### PR TITLE
fix: update package-lock.json name to codex

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "codex-internal",
+  "name": "codex",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
## Changes
- Update project name in package-lock.json from `codex-internal` to `codex`

## Background
- After running `npm i`, detected a diff in package-lock.json
- Updated the project name to match the actual project name