### PR TITLE
(feat) add better request error details

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -636,9 +636,16 @@ export class AgentLoop {
                           }>
                         )?.requestId;
 
+                      const errorDetails = [
+                        `Status: ${status || "unknown"}`,
+                        `Code: ${errCtx.code || "unknown"}`,
+                        `Type: ${errCtx.type || "unknown"}`,
+                        `Message: ${errCtx.message || "unknown"}`,
+                      ].join(", ");
+
                       return `⚠️  OpenAI rejected the request${
                         reqId ? ` (request ID: ${reqId})` : ""
-                      }. Please verify your settings and try again.`;
+                      }. Error details: ${errorDetails}. Please verify your settings and try again.`;
                     })(),
                   },
                 ],


### PR DESCRIPTION
If there's an error (like requiring verification) then the responses are opaque, for example: https://x.com/juanstoppa/status/1912563974123741641