### PR TITLE
o3 instead of o3-mini 

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -486,7 +486,7 @@ export class AgentLoop {
             let reasoning: Reasoning | undefined;
             if (this.model.startsWith("o")) {
               reasoning = { effort: "high" };
-              if (this.model === "o3-mini" || this.model === "o4-mini") {
+              if (this.model === "o3" || this.model === "o4-mini") {
                 // @ts-expect-error waiting for API type update
                 reasoning.summary = "auto";
               }

--- a/codex-cli/tests/agent-project-doc.test.ts
+++ b/codex-cli/tests/agent-project-doc.test.ts
@@ -112,7 +112,7 @@ describe("AgentLoop", () => {
     expect(config.instructions).toContain("Hello docs!");
 
     const agent = new AgentLoop({
-      model: "o3-mini", // arbitrary
+      model: "o3", // arbitrary
       instructions: config.instructions,
       config,
       approvalPolicy: { mode: "suggest" } as any,


### PR DESCRIPTION
as mentioned here
https://github.com/openai/codex/blob/26d551e303bc6ba59ca70b961f58d1b8f48a1c44/codex-cli/src/utils/model-utils.ts#L5

export const RECOMMENDED_MODELS: Array<string> = ["o4-mini", "o3"];


issue #17 
