### PR TITLE
Update default model in `--help` to o4-mini

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -43,7 +43,7 @@ const cli = meow(
 
   Options
     -h, --help                 Show usage and exit
-    -m, --model <model>        Model to use for completions (default: o3)
+    -m, --model <model>        Model to use for completions (default: o4-mini)
     -i, --image <path>         Path(s) to image files to include as input
     -v, --view <rollout>       Inspect a previously saved rollout instead of starting a session
     -q, --quiet                Non-interactive mode that only prints the assistant's final output


### PR DESCRIPTION
Old docs had o3 as the default