### PR TITLE
Fix Docker container scripts

### DIFF
--- a/codex-cli/.dockerignore
+++ b/codex-cli/.dockerignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/codex-cli/Dockerfile
+++ b/codex-cli/Dockerfile
@@ -4,22 +4,24 @@ ARG TZ
 ENV TZ="$TZ"
 
 # Install basic development tools and iptables/ipset
-RUN apt update && apt install -y less \
+RUN apt update && apt install -y \
+  aggregate \
+  dnsutils \
+  fzf \
+  gh \
   git \
+  gnupg2 \
+  iproute2 \
+  ipset \
+  iptables \
+  jq \
+  less \
+  man-db \
   procps \
   sudo \
-  fzf \
-  zsh \
-  man-db \
   unzip \
-  gnupg2 \
-  gh \
-  iptables \
-  ipset \
-  iproute2 \
-  dnsutils \
-  aggregate \
-  jq
+  ripgrep \
+  zsh 
 
 # Ensure default node user has access to /usr/local/share
 RUN mkdir -p /usr/local/share/npm-global && \

--- a/codex-cli/Dockerfile
+++ b/codex-cli/Dockerfile
@@ -35,8 +35,7 @@ ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
 ENV PATH=$PATH:/usr/local/share/npm-global/bin
 
 # Install codex
-COPY dist/codex.tgz codex.tgz
-RUN npm install -g codex.tgz
+RUN npm install -i -g @openai/codex
 
 # Copy and set up firewall script
 COPY scripts/init_firewall.sh /usr/local/bin/

--- a/codex-cli/Dockerfile
+++ b/codex-cli/Dockerfile
@@ -35,7 +35,8 @@ ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
 ENV PATH=$PATH:/usr/local/share/npm-global/bin
 
 # Install codex
-RUN npm install -i -g @openai/codex
+COPY dist/codex.tgz codex.tgz
+RUN npm install -g codex.tgz
 
 # Copy and set up firewall script
 COPY scripts/init_firewall.sh /usr/local/bin/

--- a/codex-cli/scripts/build_container.sh
+++ b/codex-cli/scripts/build_container.sh
@@ -1,9 +1,16 @@
 #!/bin/bash
 
+set -euo pipefail
+
 SCRIPT_DIR=$(realpath "$(dirname "$0")")
 trap "popd >> /dev/null" EXIT
 pushd "$SCRIPT_DIR/.." >> /dev/null || {
   echo "Error: Failed to change directory to $SCRIPT_DIR/.."
   exit 1
 }
+npm install
+npm run build
+rm -rf ./dist/openai-codex-*.tgz
+npm pack --pack-destination ./dist
+mv ./dist/openai-codex-*.tgz ./dist/codex.tgz
 docker build -t codex -f "./Dockerfile" .

--- a/codex-cli/scripts/build_container.sh
+++ b/codex-cli/scripts/build_container.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
 
-docker build -t codex -f codex-cli/Dockerfile codex-cli
+SCRIPT_DIR=$(realpath "$(dirname "$0")")
+trap "popd >> /dev/null" EXIT
+pushd "$SCRIPT_DIR/.." >> /dev/null || {
+  echo "Error: Failed to change directory to $SCRIPT_DIR/.."
+  exit 1
+}
+docker build -t codex -f "./Dockerfile" .

--- a/codex-cli/scripts/run_in_container.sh
+++ b/codex-cli/scripts/run_in_container.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 # Usage:
 #   ./run_in_container.sh [--work_dir directory] "COMMAND"
@@ -8,7 +9,7 @@
 #     ./run_in_container.sh "echo Hello, world!"
 
 # Default the work directory to WORKSPACE_ROOT_DIR if not provided.
-WORK_DIR="${WORKSPACE_ROOT_DIR}"
+WORK_DIR="${WORKSPACE_ROOT_DIR:-$(pwd)}"
 
 # Parse optional flag.
 if [ "$1" = "--work_dir" ]; then
@@ -35,14 +36,14 @@ if [ -z "$WORK_DIR" ]; then
 fi
 
 # Remove any existing container named 'codex'.
-docker rm -f codex || true
+docker rm -f codex 2>/dev/null || true
 
 # Run the container with the specified directory mounted at the same path inside the container.
 docker run --name codex -d \
   -e OPENAI_API_KEY \
   --cap-add=NET_ADMIN \
   --cap-add=NET_RAW \
-  -v "$WORK_DIR:$WORK_DIR" \
+  -v "$WORK_DIR:/app$WORK_DIR" \
   codex \
   sleep infinity
 
@@ -56,4 +57,4 @@ quoted_args=""
 for arg in "$@"; do
   quoted_args+=" $(printf '%q' "$arg")"
 done
-docker exec codex bash -c "cd \"$WORK_DIR\" && codex --dangerously-auto-approve-everything -q ${quoted_args}"
+docker exec -it codex bash -c "cd \"/app$WORK_DIR\" && codex --full-auto ${quoted_args}"

--- a/codex-cli/scripts/run_in_container.sh
+++ b/codex-cli/scripts/run_in_container.sh
@@ -20,6 +20,8 @@ if [ "$1" = "--work_dir" ]; then
   shift 2
 fi
 
+WORK_DIR=$(realpath "$WORK_DIR")
+
 # Ensure a command is provided.
 if [ "$#" -eq 0 ]; then
   echo "Usage: $0 [--work_dir directory] \"COMMAND\""
@@ -49,4 +51,9 @@ docker exec codex bash -c "sudo /usr/local/bin/init_firewall.sh"
 
 # Execute the provided command in the container, ensuring it runs in the work directory.
 # We use a parameterized bash command to safely handle the command and directory.
-docker exec codex bash -c "cd \"$WORK_DIR\" && codex --dangerously-auto-approve-everything -q \"$@\""
+
+quoted_args=""
+for arg in "$@"; do
+  quoted_args+=" $(printf '%q' "$arg")"
+done
+docker exec codex bash -c "cd \"$WORK_DIR\" && codex --dangerously-auto-approve-everything -q ${quoted_args}"


### PR DESCRIPTION
###### Why/Context/Summary

Fix the `build_container.sh` and `run_in_container.sh` scripts.

* Use public npm installation of codex
* Control where the build script executes
* Use the `realpath` of the workdir
* Make sure we properly quote all the args to `codex`

Fixes https://github.com/openai/codex/issues/22