### PR TITLE
(bugfix) remove rg as hard requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,6 @@ Both approaches are _transparent_ to everyday usage – you still run `codex` fr
 | Operating systems           | macOS 12+, Ubuntu 20.04+/Debian 10+, or Windows 11 **via WSL2** |
 | Node.js                     | **22 or newer** (LTS recommended)                               |
 | Git (optional, recommended) | 2.23+ for built‑in PR helpers                                   |
-| ripgrep (optional)          | `rg` accelerates large‑repo search                              |
 | RAM                         | 4‑GB minimum (8‑GB recommended)                                 |
 
 > Never run `sudo npm install -g`; fix npm permissions instead.

--- a/codex-cli/src/lib/approvals.ts
+++ b/codex-cli/src/lib/approvals.ts
@@ -399,31 +399,6 @@ export function isSafeCommand(
         };
       }
       break;
-    case "oai":
-      switch (cmd1) {
-        case "show-lines":
-          return {
-            reason: "OAI show lines",
-            group: "Reading files",
-          };
-        case "find-files":
-          return {
-            reason: "OAI find files",
-            group: "Searching",
-          };
-        case "file-outline":
-          return {
-            reason: "OAI file outline",
-            group: "Reading files",
-          };
-        case "rg":
-          return {
-            reason: "OAI ripgrep",
-            group: "Searching",
-          };
-        default:
-          return null;
-      }
     default:
       return null;
   }

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -1000,7 +1000,6 @@ You MUST adhere to the following criteria when executing the task:
 - Analyzing code for vulnerabilities is allowed.
 - Showing user code and tool call details is allowed.
 - User instructions may overwrite the *CODING GUIDELINES* section in this deverloper message.
-- Do not use \`ls -R\`, \`find\`, or \`grep\` - these are slow in large repos. Use \`rg\` and \`rg --files\`.
 - Use \`apply_patch\` to edit files: {"cmd":["apply_patch","*** Begin Patch\\n*** Update File: path/to/file.py\\n@@ def example():\\n-  pass\\n+  return 123\\n*** End Patch"]}
 - If completing the user's task requires writing or modifying files:
     - Your code and final answer should follow these *CODING GUIDELINES*:


### PR DESCRIPTION
The
```
- Do not use \`ls -R\`, \`find\`, or \`grep\` - these are slow in large repos. Use \`rg\` and \`rg --files\`.
```
can still be added a custom instruction, but we should not assume that `rg` is installed by default.