### PR TITLE
Silence deprecation warnings without NODE_OPTIONS

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -1,5 +1,9 @@
 #!/usr/bin/env node
 
+// Hack to suppress deprecation warnings (punycode)
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(process as any).noDeprecation = true;
+
 import type { AppRollout } from "./app";
 import type { ApprovalPolicy } from "./approvals";
 import type { CommandConfirmation } from "./utils/agent/agent-loop";


### PR DESCRIPTION
TIL this even works, wow, it feels like a hack though for sure.

Can override process.noDeprecations to silence warnings. This use isnt even [documented](https://nodejs.org/api/process.html#processnodeprecation), but works in local testing

> This can serve as an unblock until a better fix is landed

Specifically it was `punycode` in node 22 that is being used in the transitive dep tree, and giving deprecation warnings.

Closes https://github.com/openai/codex/issues/42