### PR TITLE
docs: add FAQ clarification to OpenAI Codex (2021)

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,13 @@ You can also define custom instructions:
 ## FAQ
 
 <details>
+<summary>OpenAI released a model called Codex in 2021 - is this related?</summary>
+
+In 2021, OpenAI released Codex, an AI system designed to generate code from natural language prompts. That original Codex model was deprecated as of March 2023 and is separate from the CLI tool.
+
+</details>
+
+<details>
 <summary>How do I stop Codex from touching my repo?</summary>
 
 Codex always runs in a **sandbox first**. If a proposed command or file change looks suspicious you can simply answer **n** when prompted and nothing happens to your working tree.


### PR DESCRIPTION
**What?**
This PR adds a FAQ to the README about the difference between the [2021 OpenAI Codex](https://en.wikipedia.org/wiki/OpenAI_Codex) model and this CLI tool.

**Why?**
To reduce confusion for people searching for Codex.

**How?**
Added a `<details>`-wrapped FAQ entry under the FAQ section in `README.md` with a brief explanation.
