### PR TITLE
fix(cli): respect -a/--approval-mode auto-edit alias

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -254,7 +254,7 @@ if (quietMode) {
 const approvalPolicy: ApprovalPolicy =
   cli.flags.fullAuto || cli.flags.approvalMode === "full-auto"
     ? AutoApprovalMode.FULL_AUTO
-    : cli.flags.autoEdit
+    : cli.flags.autoEdit || cli.flags.approvalMode === "auto-edit"
     ? AutoApprovalMode.AUTO_EDIT
     : AutoApprovalMode.SUGGEST;
 


### PR DESCRIPTION
Fix a bug where `-a auto-edit` (or `--approval-mode auto-edit`) is ignored and falls back to `suggest`. 