### PR TITLE
fix: correct typos in thinking texts (transcendent & parroting)

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat-input-thinking.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input-thinking.tsx
@@ -28,7 +28,7 @@ const thinkingTexts = ["Thinking"]; /* [
   "Asking the oracle",
   "Detangling qubits",
   "Reading tea leaves",
-  "Pondering universal love and transcendant joy",
+  "Pondering universal love and transcendent joy",
   "Feeling the AGI",
   "Shaving the yak",
   "Escaping local minima",
@@ -61,7 +61,7 @@ const thinkingTexts = ["Thinking"]; /* [
   "Bargaining with entropy",
   "Channeling",
   "Cooking",
-  "Parrotting stochastically",
+  "Parroting stochastically",
 ]; */
 
 export default function TerminalChatInputThinking({

--- a/codex-cli/src/components/chat/terminal-chat-new-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-new-input.tsx
@@ -55,7 +55,7 @@ const thinkingTexts = ["Thinking"]; /* [
   "Asking the oracle",
   "Detangling qubits",
   "Reading tea leaves",
-  "Pondering universal love and transcendant joy",
+  "Pondering universal love and transcendent joy",
   "Feeling the AGI",
   "Shaving the yak",
   "Escaping local minima",


### PR DESCRIPTION
Ran codex on its own source code to find mistakes & commit, even though they are commented out.