### PR TITLE
Catch the exception when command is not found

### DIFF
--- a/codex-cli/src/utils/agent/sandbox/raw-exec.ts
+++ b/codex-cli/src/utils/agent/sandbox/raw-exec.ts
@@ -72,7 +72,22 @@ export function exec(
     detached: true,
   };
 
-  const child: ChildProcess = spawn(prog, command.slice(1), fullOptions);
+  // Declare `child` here so it's in scope for abort handlers and callbacks
+  let child: ChildProcess;
+  try {
+    child = spawn(prog, command.slice(1), fullOptions);
+  } catch (err) {
+    if (isLoggingEnabled()) {
+      log(`raw-exec: spawn failed for command ${command.join(" ")} - ${String(err)}`);
+    }
+
+    return Promise.resolve({
+      stdout: "",
+      stderr: String(err),
+      exitCode: 1,
+    })
+  }
+
   // If an AbortSignal is provided, ensure the spawned process is terminated
   // when the signal is triggered so that cancellations propagate down to any
   // long‑running child processes. We default to SIGTERM to give the process a


### PR DESCRIPTION
Seems to work now, codex itself wrote the code :)

```
user
run command mcp

    thinking for 4s

    command

    $ mcp

    command.stdout (code: 1, duration: 0s)

    Error: spawn mcp ENOENT

    codex
    It looks like the mcp command wasn’t found in this environment (ENOENT). Could you let me know what mcp refers to or where it’s expected to be? If it’s part of a toolchain or a script in the repo, we may need to install it or adjust your PATH.
```