### PR TITLE
Make sonnet 3.7 the default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ Codex looks for config files in **`~/.codex/`**.
 
 ```yaml
 # ~/.codex/config.yaml
-model: o4-mini # Default model
+model: claude-3-7-sonnet-latest # Default model
 fullAutoErrorMode: ask-user # or ignore-and-continue
 ```
 
@@ -284,7 +284,7 @@ Not directly. It requires [Windows Subsystem for Linux (WSL2)](https://learn.mic
 <details>
 <summary>Which models are supported?</summary>
 
-Any model available with [Responses API](https://platform.openai.com/docs/api-reference/responses). The default is `o4-mini`, but pass `--model gpt-4o` or set `model: gpt-4o` in your config file to override.
+Any model available with [Responses API](https://platform.openai.com/docs/api-reference/responses). The default is `claude-3-7-sonnet-latest`, but pass `--model gpt-4o` or set `model: gpt-4o` in your config file to override.
 
 </details>
 

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -43,7 +43,7 @@ const cli = meow(
 
   Options
     -h, --help                 Show usage and exit
-    -m, --model <model>        Model to use for completions (default: o4-mini)
+    -m, --model <model>        Model to use for completions (default: claude-3-7-sonnet-latest)
     -i, --image <path>         Path(s) to image files to include as input
     -v, --view <rollout>       Inspect a previously saved rollout instead of starting a session
     -q, --quiet                Non-interactive mode that only prints the assistant's final output

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -15,8 +15,8 @@ import { load as loadYaml, dump as dumpYaml } from "js-yaml";
 import { homedir } from "os";
 import { dirname, join, extname, resolve as resolvePath } from "path";
 
-export const DEFAULT_AGENTIC_MODEL = "o4-mini";
-export const DEFAULT_FULL_CONTEXT_MODEL = "gpt-4.1";
+export const DEFAULT_AGENTIC_MODEL = "claude-3-7-sonnet-latest";
+export const DEFAULT_FULL_CONTEXT_MODEL = "claude-3-7-sonnet-latest";
 export const DEFAULT_APPROVAL_MODE = AutoApprovalMode.SUGGEST;
 export const DEFAULT_INSTRUCTIONS = "";
 

--- a/codex-cli/src/utils/model-utils.ts
+++ b/codex-cli/src/utils/model-utils.ts
@@ -2,7 +2,7 @@ import { OPENAI_API_KEY } from "./config";
 import OpenAI from "openai";
 
 const MODEL_LIST_TIMEOUT_MS = 2_000; // 2 seconds
-export const RECOMMENDED_MODELS: Array<string> = ["o4-mini", "o3"];
+export const RECOMMENDED_MODELS: Array<string> = ["claude-3-7-sonnet-latest"];
 
 /**
  * Background model loader / cache.


### PR DESCRIPTION
I've been having a bit more success using Sonnet 3.7. This PR makes 3.7 the default model. Steps to use:

1. Set `OPENAI_API_KEY` to your `ANTHROPIC_API_KEY`.
2. Set `OPENAI_BASE_URL` to `https://api.anthropic.com/v1/`.

I hope this helps anybody else who was having trouble using codex! Thanks to the amazing team at OpenAI for making this possible!