### PR TITLE
Dotenv Support

### DIFF
--- a/codex-cli/package-lock.json
+++ b/codex-cli/package-lock.json
@@ -12,6 +12,7 @@
         "@inkjs/ui": "^2.0.0",
         "chalk": "^5.2.0",
         "diff": "^7.0.0",
+        "dotenv": "^16.1.4",
         "file-type": "^20.1.0",
         "ink": "^5.2.0",
         "ink-select-input": "^6.0.0",
@@ -2433,6 +2434,17 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -33,6 +33,7 @@
     "@inkjs/ui": "^2.0.0",
     "chalk": "^5.2.0",
     "diff": "^7.0.0",
+    "dotenv": "^16.1.4",
     "file-type": "^20.1.0",
     "ink": "^5.2.0",
     "ink-select-input": "^6.0.0",

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import "dotenv/config";
 
 import type { AppRollout } from "./app";
 import type { ApprovalPolicy } from "./approvals";


### PR DESCRIPTION
This PR adds `dotenv` to enable picking up the `OPENAI_API_KEY` env var from the local repo where the client was initialized.

I have multiple projects, some where I want to use my corporate key and some where I want to use my personal key. Manually `export`ing them is pretty annoying. So I've added `dotenv` to make managing this much simpler.