### PR TITLE
refactor: improve performance of renderFilesToXml using Array.join

### DIFF
--- a/codex-cli/src/utils/singlepass/context.ts
+++ b/codex-cli/src/utils/singlepass/context.ts
@@ -51,14 +51,15 @@ export function renderTaskContext(taskContext: TaskContext): string {
  * For each file, we embed the content in a CDATA section.
  */
 function renderFilesToXml(files: Array<FileContent>): string {
-  let xmlContent = "<files>";
-  for (const fc of files) {
-    xmlContent += `
+  const fileContents = files
+    .map(
+      (fc) => `
       <file>
         <path>${fc.path}</path>
         <content><![CDATA[${fc.content}]]></content>
-      </file>`;
-  }
-  xmlContent += "\n</files>";
-  return xmlContent;
+      </file>`,
+    )
+    .join("");
+
+  return `<files>\n${fileContents}\n</files>`;
 }


### PR DESCRIPTION
### Summary

Refactored the `renderFilesToXml` function to improve performance and readability by replacing iterative string concatenation with `Array.map().join()`.

### Changes

- Replaced the `for...of` loop with `files.map(...).join('')`
- Reduced number of string mutation operations
- Preserved the existing XML structure and CDATA safety

### Why

Using `join` avoids repeated string concatenation in loops, which can improve performance, especially when rendering a large number of files. It also results in more concise and idiomatic code.


I have read the CLA Document and I hereby sign the CLA
---

Let me know if this needs any adjustments!
