### PR TITLE
feat: add shell completion subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ Both approaches are _transparent_ to everyday usage – you still run `codex` fr
 | `codex`        | Interactive REPL                    | `codex`                              |
 | `codex "…"`    | Initial prompt for interactive REPL | `codex "fix lint errors"`            |
 | `codex -q "…"` | Non‑interactive "quiet mode"        | `codex -q --json "explain utils.ts"` |
+| `codex completion <bash|zsh|fish>` | Print shell completion script    | `codex completion bash`               |
 
 Key flags: `--model/-m`, `--approval-mode/-a`, and `--quiet/-q`.
 


### PR DESCRIPTION
Why
---
Improves the usability of the `codex` CLI by adding shell completion for file paths. This allows users to quickly complete file arguments using tab completion in bash, zsh, and fish shells. Enable via `eval "$(codex completion <shell>)"`.