### PR TITLE
Fix markdown table in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ Both approaches are _transparent_ to everyday usage – you still run `codex` fr
 | `codex`        | Interactive REPL                    | `codex`                              |
 | `codex "…"`    | Initial prompt for interactive REPL | `codex "fix lint errors"`            |
 | `codex -q "…"` | Non‑interactive "quiet mode"        | `codex -q --json "explain utils.ts"` |
-| `codex completion <bash|zsh|fish>` | Print shell completion script    | `codex completion bash`               |
+| `codex completion <bash\|zsh\|fish>` | Print shell completion script    | `codex completion bash`               |
 
 Key flags: `--model/-m`, `--approval-mode/-a`, and `--quiet/-q`.
 


### PR DESCRIPTION
Before:

<img width="909" alt="image" src="https://github.com/user-attachments/assets/8de0d798-5587-407a-9196-bda3e26c1331" />

After:

<img width="945" alt="image" src="https://github.com/user-attachments/assets/90454694-2f26-49b1-8c4b-e017237797ca" />
