### PR TITLE
fix: Adjust blocking formatting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,12 +148,12 @@ Both approaches are _transparent_ to everyday usage – you still run `codex` fr
 
 ## CLI Reference
 
-| Command        | Purpose                             | Example                              |
-| -------------- | ----------------------------------- | ------------------------------------ |
-| `codex`        | Interactive REPL                    | `codex`                              |
-| `codex "…"`    | Initial prompt for interactive REPL | `codex "fix lint errors"`            |
-| `codex -q "…"` | Non‑interactive "quiet mode"        | `codex -q --json "explain utils.ts"` |
-| `codex completion <bash|zsh|fish>` | Print shell completion script    | `codex completion bash`               |
+| Command                 | Purpose                             | Example                              |
+| ----------------------- | ----------------------------------- | ------------------------------------ | ----------------------------- | ----------------------- |
+| `codex`                 | Interactive REPL                    | `codex`                              |
+| `codex "…"`             | Initial prompt for interactive REPL | `codex "fix lint errors"`            |
+| `codex -q "…"`          | Non‑interactive "quiet mode"        | `codex -q --json "explain utils.ts"` |
+| `codex completion <bash | zsh                                 | fish>`                               | Print shell completion script | `codex completion bash` |
 
 Key flags: `--model/-m`, `--approval-mode/-a`, and `--quiet/-q`.
 


### PR DESCRIPTION
This PR aims to resolve the CI failure introduced in https://github.com/openai/codex/commit/33d0d73b822abeae87cec07f2c2901ff900e434f / #138 by modifying the README.md to adhere to `prettier`.