### PR TITLE
minor change in description of Build from source in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,11 @@ cd codex/codex-cli
 npm install
 npm run build
 
-# Run the locally‑built CLI directly
+# Get the usage and the options
 node ./dist/cli.js --help
+
+# Run the locally‑built CLI directly
+node ./dist/cli.js
 
 # Or link the command globally for convenience
 npm link


### PR DESCRIPTION
Separated the `node ./dist/cli.js --help ` and `node ./dist/cli.js `. The comment suggested `node ./dist/cli.js --help ` was to run the locally-built CLI but in fact it shows the usage an options. It is a minor change and clarifies the flow for new developers. 