### PR TITLE
feat: experimental side-by-side diff mode in single-pass (WIP)

### DIFF
--- a/codex-cli/examples/build-codex-demo/run.sh
+++ b/codex-cli/examples/build-codex-demo/run.sh
@@ -59,7 +59,14 @@ fi
 
 cd "run_$new_run_number"
 
-# Launch Codex
+# Launch Codex (prefer local build)
 echo "Launching..."
 description=$(yq -o=json '.' ../../task.yaml | jq -r '.description')
-codex "$description"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLI="$SCRIPT_DIR/../../dist/cli.js"
+if [ -f "$CLI" ]; then
+  # use single-pass full-context mode to see side-by-side diffs
+  node "$CLI" --full-context "$description"
+else
+  codex --full-context "$description"
+fi

--- a/codex-cli/examples/camerascii/run.sh
+++ b/codex-cli/examples/camerascii/run.sh
@@ -62,7 +62,13 @@ fi
 
 cd "run_$new_run_number"
 
-# Launch Codex
+# Launch Codex (prefer local build)
 echo "Launching..."
 description=$(yq -o=json '.' ../../task.yaml | jq -r '.description')
-codex "$description"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLI="$SCRIPT_DIR/../../dist/cli.js"
+if [ -f "$CLI" ]; then
+  node "$CLI" --full-context "$description"
+else
+  codex --full-context "$description"
+fi

--- a/codex-cli/examples/prompt-analyzer/run.sh
+++ b/codex-cli/examples/prompt-analyzer/run.sh
@@ -62,7 +62,13 @@ fi
 
 cd "run_$new_run_number"
 
-# Launch Codex
+# Launch Codex (prefer local build)
 echo "Launching..."
 description=$(yq -o=json '.' ../../task.yaml | jq -r '.description')
-codex "$description"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+CLI="$SCRIPT_DIR/../../dist/cli.js"
+if [ -f "$CLI" ]; then
+  node "$CLI" --full-context "$description"
+else
+  codex --full-context "$description"
+fi


### PR DESCRIPTION
## Summary of the journey

This contribution sprang from a “meta” experiment: I literally used the Codex CLI to edit the Codex CLI repo itself.

This was my first time using this tool, and in just a couple of minutes with only about **$5 in API calls**, _we_ introduced an (incomplete) alternative diff viewing experience: 
**side-by-side mode** (two columns, red for removals, green for additions), complementing the classic unified diff.

<br />

**Before:**
<img src="https://github.com/user-attachments/assets/0878fad9-00fd-49e7-9857-22e694faf0dc" width="300"/>

**After:**
![image](https://github.com/user-attachments/assets/57e50fc5-212f-4fa4-96fd-e15605ee9721)

Now, by invoking `codex --full-context`, you get:
- A clear, side-by-side diff layout that neatly organizes changes into two color-coded columns 🎨.
- Continued support for the original unified diff (`generateFileDiff`) for those who prefer the classic view.
- Updated demo scripts (`examples/*/run.sh`) that seamlessly default to the new side-by-side diff view.

<br />

## Limitations / Work In Progress 🚧

- Interactive, multi-pass flow still defaults to the unified diff.
- No dedicated `--diff-format` flag yet.
- Missing integration tests and UI snapshots for this new diff view.
- Documentation for this mode is still pending.

<br />

## Why this is amazing

Hacking the tool with itself creates a fascinating loop of self-reference, highlighting the incredible potential of agents. With just a few simple prompts, Codex CLI empowered _us_ to directly contribute to an open-source project. 

If I accomplished this on my first try within just a few hours of its release, imagine how quickly people will get Codex CLI to seriously start updating itself.