### PR TITLE
chore: reduce docker image size

### DIFF
--- a/codex-cli/Dockerfile
+++ b/codex-cli/Dockerfile
@@ -1,11 +1,13 @@
-FROM node:20
+FROM node:20-slim
 
 ARG TZ
 ENV TZ="$TZ"
 
-# Install basic development tools and iptables/ipset
-RUN apt update && apt install -y \
+# Install basic development tools, ca-certificates, and iptables/ipset, then clean up apt cache to reduce image size
+RUN apt-get update && apt-get install -y --no-install-recommends \
   aggregate \
+  ca-certificates \
+  curl \
   dnsutils \
   fzf \
   gh \
@@ -21,7 +23,8 @@ RUN apt update && apt install -y \
   sudo \
   unzip \
   ripgrep \
-  zsh 
+  zsh \
+  && rm -rf /var/lib/apt/lists/*
 
 # Ensure default node user has access to /usr/local/share
 RUN mkdir -p /usr/local/share/npm-global && \
@@ -38,7 +41,11 @@ ENV PATH=$PATH:/usr/local/share/npm-global/bin
 
 # Install codex
 COPY dist/codex.tgz codex.tgz
-RUN npm install -g codex.tgz
+RUN npm install -g codex.tgz \
+  && npm cache clean --force \
+  && rm -rf /usr/local/share/npm-global/lib/node_modules/codex-cli/node_modules/.cache \
+  && rm -rf /usr/local/share/npm-global/lib/node_modules/codex-cli/tests \
+  && rm -rf /usr/local/share/npm-global/lib/node_modules/codex-cli/docs
 
 # Copy and set up firewall script
 COPY scripts/init_firewall.sh /usr/local/bin/


### PR DESCRIPTION
This PR makes changes in the Dockerfile to reduce the final image size. I'm sure this can be optimized further. But I didn't want to make too many changes at once. 

Original: 
```
REPOSITORY   TAG       IMAGE ID       CREATED         SIZE
codex        latest    c8f66942ded3   4 minutes ago   1.91GB
```

Now: 
```
REPOSITORY   TAG       IMAGE ID       CREATED         SIZE
codex        latest    2a6d6450609c   4 minutes ago   747MB
```