### PR TITLE
chore: git ignore unwanted package managers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,8 @@ Thumbs.db
 Icon?
 .Spotlight-V100/
 
+# Unwanted package managers
+.yarn/
+yarn.lock
+pnpm-lock.yaml
+


### PR DESCRIPTION
https://github.com/openai/codex/blob/main/package-lock.json

Considering that the current repository uses `npm` as the package manager, the related files for `yarn` and `pnpm` are therefore ignored.