### PR TITLE
fix: check workdir before spawn

### DIFF
--- a/codex-cli/src/utils/agent/handle-exec-command.ts
+++ b/codex-cli/src/utils/agent/handle-exec-command.ts
@@ -217,7 +217,7 @@ async function execCommand(
     if (applyPatchCommand != null) {
       log("EXEC running apply_patch command");
     } else {
-      const { cmd, workdir, timeoutInMillis } = execInput;
+      const { cmd, timeoutInMillis } = execInput;
       // Seconds are a bit easier to read in log messages and most timeouts
       // are specified as multiples of 1000, anyway.
       const timeout =

--- a/codex-cli/src/utils/agent/handle-exec-command.ts
+++ b/codex-cli/src/utils/agent/handle-exec-command.ts
@@ -204,6 +204,15 @@ async function execCommand(
   runInSandbox: boolean,
   abortSignal?: AbortSignal,
 ): Promise<ExecCommandSummary> {
+  let { workdir } = execInput;
+  if (workdir) {
+    try {
+      await access(workdir);
+    } catch (e) {
+      log(`EXEC workdir=${workdir} not found, use process.cwd() instead`);
+      workdir = process.cwd();
+    }
+  }
   if (isLoggingEnabled()) {
     if (applyPatchCommand != null) {
       log("EXEC running apply_patch command");


### PR DESCRIPTION
The workdir used to spawn a agent command is provide by the agent tool, we need to ensure its existence and fallback to process.cwd when not.

fix #212