### PR TITLE
feat: add Nix flake for reproducible development environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ storybook-static/
 # ignore README for publishing
 codex-cli/README.md
 
+# ignore Nix derivation results
+result
+
 # editor
 .vscode/
 .idea/

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@
 - [Funding Opportunity](#funding-opportunity)
 - [Contributing](#contributing)
   - [Development workflow](#development-workflow)
+    - [Nix Flake Development](#nix-flake-development)
   - [Writing high‑impact code changes](#writing-highimpact-code-changes)
   - [Opening a pull request](#opening-a-pull-request)
   - [Review process](#review-process)
@@ -354,6 +355,31 @@ npm run typecheck
 # Automatically fix lint + prettier issues
 npm run lint:fix
 npm run format:fix
+```
+
+#### Nix Flake Development
+
+Prerequisite: Nix >= 2.4 with flakes enabled (`experimental-features = nix-command flakes` in `~/.config/nix/nix.conf`).
+
+Enter a Nix development shell:
+
+```bash
+nix develop
+```
+
+This shell includes Node.js, installs dependencies, builds the CLI, and provides a `codex` command alias.
+
+Build and run the CLI directly:
+
+```bash
+nix build
+./result/bin/codex --help
+```
+
+Run the CLI via the flake app:
+
+```bash
+nix run .#codex
 ```
 
 ### Writing high‑impact code changes

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1744463964,
+        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,51 @@
+{
+  description = "Development Nix flake for OpenAI Codex CLI";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }: 
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs { inherit system; };
+      node = pkgs.nodejs_22;
+    in rec {
+      packages = {
+        codex-cli = pkgs.buildNpmPackage rec {
+          pname       = "codex-cli";
+          version     = "0.1.0";
+          src         = self + "/codex-cli";
+          npmDepsHash = "sha256-Kh8Ognh1Lpd6OFSwUPMi/YHVNeTON/GjhckowS/LiKA=";
+          nodejs      = node;
+          npmInstallFlags = [ "--frozen-lockfile" ];
+          meta = with pkgs.lib; {
+            description = "OpenAI Codex command‑line interface";
+            license     = licenses.asl20;
+            homepage    = "https://github.com/openai/codex";
+          };
+        };
+      };
+      defaultPackage = packages.codex-cli;
+      devShell = pkgs.mkShell {
+        name        = "codex-cli-dev";
+        buildInputs = [
+          node
+        ];
+        shellHook = ''
+          echo "Entering development shell for codex-cli"
+          cd codex-cli
+          npm ci
+          npm run build
+          export PATH=$PWD/node_modules/.bin:$PATH
+          alias codex="node $PWD/dist/cli.js"
+        '';
+      };
+      apps = {
+        codex = {
+          type    = "app";
+          program = "${packages.codex-cli}/bin/codex";
+        };
+      };
+    });
+}

--- a/flake.nix
+++ b/flake.nix
@@ -16,7 +16,7 @@
           pname       = "codex-cli";
           version     = "0.1.0";
           src         = self + "/codex-cli";
-          npmDepsHash = "sha256-Kh8Ognh1Lpd6OFSwUPMi/YHVNeTON/GjhckowS/LiKA=";
+          npmDepsHash = "sha256-riVXC7T9zgUBUazH5Wq7+MjU1FepLkp9kHLSq+ZVqbs=";
           nodejs      = node;
           npmInstallFlags = [ "--frozen-lockfile" ];
           meta = with pkgs.lib; {


### PR DESCRIPTION
This PR introduces a Nix flake configuration to enable reproducible development environments:

- Adds flake.nix defining a devShell with necessary dependencies.
- Updates README.md with usage instructions for `nix develop`.
- Ensures CI compatibility with Nix for consistent builds.
