### PR TITLE
docs: add ZDR org limitation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@
   - [Releasing `codex`](#releasing-codex)
 - [Security \& Responsible AI](#securityresponsibleai)
 - [License](#license)
-- [⚠️ Zero Data Retention (ZDR) Organization Limitation](#zero-data-retention-zdr-organization-limitation)
+- [Zero Data Retention (ZDR) Organization Limitation](#zero-data-retention-zdr-organization-limitation)
 
 </details>
 
@@ -308,7 +308,7 @@ Any model available with [Responses API](https://platform.openai.com/docs/api-re
 
 ---
 
-## ⚠️ Zero Data Retention (ZDR) Organization Limitation
+## Zero Data Retention (ZDR) Organization Limitation
 
 > **Note:** Codex CLI does **not** currently support OpenAI organizations with [Zero Data Retention (ZDR)](https://platform.openai.com/docs/guides/your-data#zero-data-retention) enabled.
 
@@ -321,7 +321,7 @@ OpenAI rejected the request. Error details: Status: 400, Code: unsupported_param
 **Why?**
 
 - Codex CLI relies on the Responses API with `store:true` to enable internal reasoning steps.
-- The Responses API requires a 30-day retention period by default, or when `store:true` is set.
+- As noted in the [docs](https://platform.openai.com/docs/guides/your-data#responses-api), the Responses API requires a 30-day retention period by default, or when the store parameter is set to true.
 - ZDR organizations cannot use `store:true`, so requests will fail.
 
 **What can I do?**

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@
   - [Releasing `codex`](#releasing-codex)
 - [Security \& Responsible AI](#securityresponsibleai)
 - [License](#license)
+- [⚠️ Zero Data Retention (ZDR) Organization Limitation](#zero-data-retention-zdr-organization-limitation)
 
 </details>
 
@@ -304,6 +305,29 @@ Not directly. It requires [Windows Subsystem for Linux (WSL2)](https://learn.mic
 Any model available with [Responses API](https://platform.openai.com/docs/api-reference/responses). The default is `o4-mini`, but pass `--model gpt-4o` or set `model: gpt-4o` in your config file to override.
 
 </details>
+
+---
+
+## ⚠️ Zero Data Retention (ZDR) Organization Limitation
+
+> **Note:** Codex CLI does **not** currently support OpenAI organizations with [Zero Data Retention (ZDR)](https://platform.openai.com/docs/guides/your-data#zero-data-retention) enabled.
+
+If your OpenAI organization has Zero Data Retention enabled, you may encounter errors such as:
+
+```
+OpenAI rejected the request. Error details: Status: 400, Code: unsupported_parameter, Type: invalid_request_error, Message: 400 Previous response cannot be used for this organization due to Zero Data Retention.
+```
+
+**Why?**
+
+- Codex CLI relies on the Responses API with `store:true` to enable internal reasoning steps.
+- The Responses API requires a 30-day retention period by default, or when `store:true` is set.
+- ZDR organizations cannot use `store:true`, so requests will fail.
+
+**What can I do?**
+
+- If you are part of a ZDR organization, Codex CLI will not work until support is added.
+- We are tracking this limitation and will update the documentation if support becomes available.
 
 ---
 


### PR DESCRIPTION
**What?**
Add a section to the README documenting the current limitation for Codex with Zero Data Retention (ZDR) organizations.

**Why?**
Users from ZDR organizations encounter errors due to the Responses API’s requirement for `store:true`, which is incompatible with ZDR policies. See #106 for more info.

**How?**
- Added a new section in the README, after FAQ and before Funding. 
- Explained the error message and reason.
- Linked to documentation as linked in the issue. 