### PR TITLE
feat: update position of cursor when navigating input history with arrow keys to the end of the text

### DIFF
--- a/codex-cli/src/components/vendor/ink-text-input.tsx
+++ b/codex-cli/src/components/vendor/ink-text-input.tsx
@@ -105,8 +105,7 @@ function TextInput({
       }
 
       const newValue = originalValue || "";
-
-      if (previousState.cursorOffset > newValue.length - 1) {
+      if (previousState.cursorOffset === 0 || previousState.cursorOffset > newValue.length - 1) {
         return {
           cursorOffset: newValue.length,
           cursorWidth: 0,

--- a/codex-cli/src/components/vendor/ink-text-input.tsx
+++ b/codex-cli/src/components/vendor/ink-text-input.tsx
@@ -105,7 +105,11 @@ function TextInput({
       }
 
       const newValue = originalValue || "";
-      if (previousState.cursorOffset === 0 || previousState.cursorOffset > newValue.length - 1) {
+      // Sets the cursor to the end of the line if the value is empty or the cursor is at the end of the line.
+      if (
+        previousState.cursorOffset === 0 ||
+        previousState.cursorOffset > newValue.length - 1
+      ) {
         return {
           cursorOffset: newValue.length,
           cursorWidth: 0,


### PR DESCRIPTION
Updated the position of the cursor on the user input box to be at the end of the text when the user uses the arrow keys to navigate through the input history in order to better match the behavior of a terminal.