### PR TITLE
docs: add tracing instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,14 @@ Run Codex head‑less in pipelines. Example GitHub Action step:
 
 Set `CODEX_QUIET_MODE=1` to silence interactive UI noise.
 
+## Tracing / Verbose Logging
+
+Setting the environment variable `DEBUG=true` prints full API request and response details:
+
+```shell
+DEBUG=true codex
+```
+
 ---
 
 ## Recipes


### PR DESCRIPTION
**What**?
Add a `Tracing / Verbose Logging` section to the README

**Why**?
Enable easier troubleshooting by logging full API requests, responses, and prompt details used during code generation.

**How**?

Inserted the new section between `Non‑interactive / CI mode` and `FAQ`.