### PR TITLE
docs: mention dotenv support in Quickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,13 @@ Next, set your OpenAI API key as an environment variable:
 export OPENAI_API_KEY="your-api-key-here"
 ```
 
-> **Note:** This command sets the key only for your current terminal session. To make it permanent, add the `export` line to your shell's configuration file (e.g., `~/.zshrc`).
+ > **Note:** This command sets the key only for your current terminal session. To make it permanent, add the `export` line to your shell's configuration file (e.g., `~/.zshrc`).
+ >
+ > **Tip:** You can also place your API key into a `.env` file at the root of your project:
+ > ```env
+ > OPENAI_API_KEY=your-api-key-here
+ > ```
+ > The CLI will automatically load variables from `.env` (via `dotenv/config`).
 
 Run interactively:
 


### PR DESCRIPTION
Add a note in Quickstart that you can drop your API key into a `.env` file
(since dotenv support was introduced in 40266be #122).

✅ Ran `npm test && npm run lint && npm run typecheck` locally

I have read the CLA Document and I hereby sign the CLA