### PR TITLE
fix: update regex to better match the retry error messages

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -599,7 +599,7 @@ export class AgentLoop {
 
                 // Parse suggested retry time from error message, e.g., "Please try again in 1.3s"
                 const msg = errCtx?.message ?? "";
-                const m = /retry again in ([\d.]+)s/i.exec(msg);
+                const m = /(?:retry|try) again in ([\d.]+)s/i.exec(msg);
                 if (m && m[1]) {
                   const suggested = parseFloat(m[1]) * 1000;
                   if (!Number.isNaN(suggested)) {


### PR DESCRIPTION
I think the retry issue is just that the regex is wrong, checkout the reported error messages folks are seeing:

>     message: 'Rate limit reached for o4-mini in organization org-{redacted} on tokens per min (TPM): Limit 200000, Used 152566, Requested 60651. Please try again in 3.965s. Visit https://platform.openai.com/account/rate-limits to learn more.',

The error message uses `try again` not `retry again`

peep this regexpal: https://www.regexpal.com/?fam=155648