### PR TITLE
fix: adapt Go commands for macOS sandbox compatibility

### DIFF
--- a/codex-cli/src/utils/agent/platform-commands.ts
+++ b/codex-cli/src/utils/agent/platform-commands.ts
@@ -3,8 +3,8 @@
  */
 
 import { log, isLoggingEnabled } from "./log.js";
-import * as path from "path";
 import * as fs from "fs";
+import * as path from "path";
 
 /**
  * Map of Unix commands to their Windows equivalents
@@ -101,9 +101,15 @@ export function adaptCommandForPlatform(command: Array<string>): Array<string> {
  * @param command The command array to adapt
  * @returns The adapted command array or null if no adaptation is needed
  */
-function adaptGoCommandForSandbox(command: Array<string>): Array<string> | null {
+function adaptGoCommandForSandbox(
+  command: Array<string>,
+): Array<string> | null {
   // Only adapt on macOS and when the command is Go-related
-  if (process.platform !== "darwin" || command.length === 0 || command[0] !== "go") {
+  if (
+    process.platform !== "darwin" ||
+    command.length === 0 ||
+    command[0] !== "go"
+  ) {
     return null;
   }
 

--- a/codex-cli/tests/platform-commands.test.ts
+++ b/codex-cli/tests/platform-commands.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { adaptCommandForPlatform } from "../src/utils/agent/platform-commands.js";
+import * as path from "path";
+import * as fs from "fs";
+
+// Mock the platform and filesystem modules
+vi.mock("path", () => ({
+  join: vi.fn(),
+}));
+
+vi.mock("fs", () => ({
+  existsSync: vi.fn(),
+  mkdirSync: vi.fn(),
+}));
+
+describe("platform-commands", () => {
+  const originalPlatform = process.platform;
+  const mockCwd = "/mock/cwd";
+  const mockTmpDir = "/mock/cwd/.tmp";
+
+  beforeEach(() => {
+    // Reset all mocks
+    vi.resetAllMocks();
+
+    // Mock process.cwd()
+    vi.spyOn(process, "cwd").mockReturnValue(mockCwd);
+
+    // Mock path.join
+    vi.mocked(path.join).mockReturnValue(mockTmpDir);
+  });
+
+  afterEach(() => {
+    // Restore the original platform
+    Object.defineProperty(process, "platform", {
+      value: originalPlatform,
+    });
+  });
+
+  describe("adaptCommandForPlatform", () => {
+    describe("Windows platform adaptations", () => {
+      beforeEach(() => {
+        // Mock Windows platform
+        Object.defineProperty(process, "platform", {
+          value: "win32",
+        });
+      });
+
+      it("should adapt ls command to dir on Windows", () => {
+        const command = ["ls"];
+        const adapted = adaptCommandForPlatform(command);
+        expect(adapted).toEqual(["dir"]);
+      });
+
+      it("should adapt ls -l to dir /p on Windows", () => {
+        const command = ["ls", "-l"];
+        const adapted = adaptCommandForPlatform(command);
+        expect(adapted).toEqual(["dir", "/p"]);
+      });
+
+      it("should not modify commands that don't need adaptation", () => {
+        const command = ["echo", "hello"];
+        const adapted = adaptCommandForPlatform(command);
+        expect(adapted).toEqual(["echo", "hello"]);
+      });
+
+      it("should handle empty command arrays", () => {
+        const command: Array<string> = [];
+        const adapted = adaptCommandForPlatform(command);
+        expect(adapted).toEqual([]);
+      });
+    });
+
+    describe("macOS Go command adaptations", () => {
+      beforeEach(() => {
+        // Mock macOS platform
+        Object.defineProperty(process, "platform", {
+          value: "darwin",
+        });
+      });
+
+      it("should adapt go build command on macOS", () => {
+        // Mock fs.existsSync to return false (directory doesn't exist)
+        vi.mocked(fs.existsSync).mockReturnValue(false);
+
+        const command = ["go", "build"];
+        const adapted = adaptCommandForPlatform(command);
+
+        // Verify tmp directory creation was attempted
+        expect(fs.existsSync).toHaveBeenCalledWith(mockTmpDir);
+        expect(fs.mkdirSync).toHaveBeenCalledWith(mockTmpDir, {
+          recursive: true,
+        });
+
+        // Verify command adaptation
+        expect(adapted).toEqual([
+          "env",
+          `GOTMPDIR=${mockTmpDir}`,
+          "go",
+          "build",
+        ]);
+      });
+
+      it("should not create tmp directory if it already exists", () => {
+        // Mock fs.existsSync to return true (directory exists)
+        vi.mocked(fs.existsSync).mockReturnValue(true);
+
+        const command = ["go", "run", "main.go"];
+        const adapted = adaptCommandForPlatform(command);
+
+        // Verify tmp directory creation was not attempted
+        expect(fs.existsSync).toHaveBeenCalledWith(mockTmpDir);
+        expect(fs.mkdirSync).not.toHaveBeenCalled();
+
+        // Verify command adaptation
+        expect(adapted).toEqual([
+          "env",
+          `GOTMPDIR=${mockTmpDir}`,
+          "go",
+          "run",
+          "main.go",
+        ]);
+      });
+
+      it("should not adapt non-Go commands on macOS", () => {
+        const command = ["echo", "hello"];
+        const adapted = adaptCommandForPlatform(command);
+
+        // Verify no tmp directory checks or creation
+        expect(fs.existsSync).not.toHaveBeenCalled();
+        expect(fs.mkdirSync).not.toHaveBeenCalled();
+
+        // Command should be unchanged
+        expect(adapted).toEqual(["echo", "hello"]);
+      });
+    });
+
+    describe("Linux platform", () => {
+      beforeEach(() => {
+        // Mock Linux platform
+        Object.defineProperty(process, "platform", {
+          value: "linux",
+        });
+      });
+
+      it("should not adapt commands on Linux", () => {
+        const command = ["ls", "-l"];
+        const adapted = adaptCommandForPlatform(command);
+        expect(adapted).toEqual(["ls", "-l"]);
+      });
+
+      it("should not adapt Go commands on Linux", () => {
+        const command = ["go", "build"];
+        const adapted = adaptCommandForPlatform(command);
+
+        // Verify no tmp directory checks or creation
+        expect(fs.existsSync).not.toHaveBeenCalled();
+        expect(fs.mkdirSync).not.toHaveBeenCalled();
+
+        // Command should be unchanged
+        expect(adapted).toEqual(["go", "build"]);
+      });
+    });
+  });
+});


### PR DESCRIPTION
# Fix: Adapt Go commands for macOS sandbox compatibility

## Issue
This PR addresses issue #207 "Full auto mode cannot build Go code" where users on macOS encounter permission errors when running Go commands in full-auto mode: go: creating work dir: mkdir /var/folders/zv/b1sjg_v16tn6dpgblz8v4ls40000gn/T/go-build3375040063: operation not permitted


## Root Cause
The issue occurs because:
1. Codex CLI uses Apple Seatbelt (`sandbox-exec`) on macOS for sandboxing
2. The sandbox restricts write access to system directories
3. Go attempts to create temporary build directories in system locations by default
4. This operation is blocked by the sandbox, causing the build to fail

## Solution
This PR implements a platform-specific adaptation for Go commands on macOS:

1. Detects when a Go command is being executed on macOS
2. Creates a `.tmp` directory in the current working directory (which is writable in the sandbox)
3. Sets the `GOTMPDIR` environment variable to point to this directory
4. Go will use this directory for temporary build files instead of system locations

## Implementation Details
- Added a new `adaptGoCommandForSandbox` function in `platform-commands.ts`
- Modified the existing `adaptCommandForPlatform` function to check for Go commands first
- Added comprehensive unit tests for the new functionality

## Testing
- Added unit tests that verify the behavior on different platforms
- **Note**: I developed this on Windows and haven't been able to test it directly on macOS. The solution is based on Go's documented behavior regarding the `GOTMPDIR` environment variable.

## Additional Notes
This approach:
- Is non-intrusive and only affects Go commands on macOS
- Maintains sandbox security by only using directories that are already writable
- Follows the same pattern as existing platform adaptations
- Is well-tested and documented

## Screenshots
N/A

## Checklist
- [x] Added or updated tests
- [x] Added comments and documentation
- [x] Tested on Windows
- [ ] Tested on macOS (not available)
- [x] Follows project coding standards