### PR TITLE
fix: add empty vite config file to prevent resolving to parent

### DIFF
--- a/codex-cli/vite.config.ts
+++ b/codex-cli/vite.config.ts
@@ -1,0 +1,4 @@
+import { defineConfig } from 'vite';
+
+// Provide a stub Vite config in the CLI package to avoid resolving a parent-level vite.config.js
+export default defineConfig({});


### PR DESCRIPTION
Hi, when I tried to run the tests in the cloned repo I got an error from vitest trying to get the vite.config.ts from the parent folder. I don't know why this it not happening to more people but this fixed it, so maybe it is useful for someone else.