### PR TITLE
chore: consolidate patch prefix constants in apply‑patch.ts

### DIFF
--- a/codex-cli/src/parse-apply-patch.ts
+++ b/codex-cli/src/parse-apply-patch.ts
@@ -22,13 +22,14 @@ export type ApplyPatchOp =
   | ApplyPatchDeleteFileOp
   | ApplyPatchUpdateFileOp;
 
-const PATCH_PREFIX = "*** Begin Patch\n";
-const PATCH_SUFFIX = "\n*** End Patch";
-const ADD_FILE_PREFIX = "*** Add File: ";
-const DELETE_FILE_PREFIX = "*** Delete File: ";
-const UPDATE_FILE_PREFIX = "*** Update File: ";
-const END_OF_FILE_PREFIX = "*** End of File";
-const HUNK_ADD_LINE_PREFIX = "+";
+export const PATCH_PREFIX = "*** Begin Patch\n";
+export const PATCH_SUFFIX = "\n*** End Patch";
+export const ADD_FILE_PREFIX = "*** Add File: ";
+export const DELETE_FILE_PREFIX = "*** Delete File: ";
+export const UPDATE_FILE_PREFIX = "*** Update File: ";
+export const MOVE_FILE_TO_PREFIX = "*** Move to: ";
+export const END_OF_FILE_PREFIX = "*** End of File";
+export const HUNK_ADD_LINE_PREFIX = "+";
 
 /**
  * @returns null when the patch is invalid


### PR DESCRIPTION
This PR replaces all hard‑coded patch markers in apply‑patch.ts with the corresponding constants (now) exported from parse‑apply‑patch.ts.

Changes
	•	Import PATCH_PREFIX, PATCH_SUFFIX, ADD_FILE_PREFIX, DELETE_FILE_PREFIX, UPDATE_FILE_PREFIX, MOVE_FILE_TO_PREFIX, END_OF_FILE_PREFIX, and HUNK_ADD_LINE_PREFIX from parse‑apply‑patch.ts.
	•	Remove duplicate string literals for patch markers in apply‑patch.ts.
   •  Changed is_done() to trim the input to account for the slight difference between the variables. 

Why
	•	DRY & Consistency: Ensures a single source of truth for patch prefixes.
	•	Maintainability: Simplifies future updates to prefix values by centralizing them.
	•	Readability: Makes the code more declarative and self‑documenting.

All tests are passing, lint and format was ran. 