### PR TITLE
fix: duplicated message on model change

### DIFF
--- a/codex-cli/src/components/typeahead-overlay.tsx
+++ b/codex-cli/src/components/typeahead-overlay.tsx
@@ -128,15 +128,18 @@ export default function TypeaheadOverlay({
           value={value}
           onChange={setValue}
           onSubmit={(submitted) => {
-            // Prefer the first visible item; otherwise fall back to whatever
-            // the user typed so they can switch to a model that wasn't in the
-            // pre‑fetched list.
-            const target = selectItems[0]?.value ?? submitted.trim();
-            if (target) {
-              onSelect(target);
-            } else {
-              onExit();
+            // If there are items in the SelectInput, let its onSelect handle the submission.
+            // Only submit from TextInput if the list is empty.
+            if (selectItems.length === 0) {
+              const target = submitted.trim();
+              if (target) {
+                onSelect(target);
+              } else {
+                // If submitted value is empty and list is empty, just exit.
+                onExit();
+              }
             }
+            // If selectItems.length > 0, do nothing here; SelectInput's onSelect will handle Enter.
           }}
         />
         {selectItems.length > 0 && (


### PR DESCRIPTION
Problem:
Pressing "Enter" could trigger the selection logic twice—once from the text box and once from the list of options—causing the model to switch twice.

Fix:
Now, the text box only handles "Enter" if there are no options in the list. If options are present, only the list handles "Enter." This prevents the selection from happening twice.

before:

https://github.com/user-attachments/assets/ae02f864-2f33-42c0-bd99-dee2d0d107ad

after:

https://github.com/user-attachments/assets/b656ed19-32a2-4218-917b-9af630a4fb2f

