### PR TITLE
feat(bin): support bun fallback runtime for codex CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,8 @@ Below are a few bite‑size examples you can copy‑paste. Replace the text in q
 npm install -g @openai/codex
 # or
 yarn global add @openai/codex
+# or
+bun install -g @openai/codex
 ```
 
 </details>

--- a/codex-cli/bin/codex
+++ b/codex-cli/bin/codex
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+# resolve script path in case of symlink
+SOURCE="$0"
+while [ -h "$SOURCE" ]; do
+  DIR=$(dirname "$SOURCE")
+  SOURCE=$(readlink "$SOURCE")
+  case "$SOURCE" in
+    /*) ;;  # absolute path
+    *) SOURCE="$DIR/$SOURCE" ;;  # relative path
+  esac
+done
+DIR=$(cd "$(dirname "$SOURCE")" && pwd)
+if command -v node >/dev/null 2>&1; then
+  exec node "$DIR/../dist/cli.js" "$@"
+elif command -v bun >/dev/null 2>&1; then
+  exec bun "$DIR/../dist/cli.js" "$@"
+else
+  echo "Error: node or bun is required to run codex" >&2
+  exit 1
+fi

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2504161510",
   "license": "Apache-2.0",
   "bin": {
-    "codex": "dist/cli.js"
+    "codex": "bin/codex"
   },
   "type": "module",
   "engines": {
@@ -28,6 +28,7 @@
   },
   "files": [
     "README.md",
+    "bin",
     "dist",
     "src"
   ],


### PR DESCRIPTION
This PR adds a shell wrapper in `codex-cli/bin/codex` to detect node or bun as the runtime.

It updates:
- `package.json` bin entry
- published files list to include bin/
- README install instructions to include `bun install -g @openai/codex`
