### PR TITLE
fix(docs): Fix the <details> misplace in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,6 @@ In 2021, OpenAI released Codex, an AI system designed to generate code from natu
 </details>
 
 <details>
-<details>
 <summary>Which models are supported?</summary>
 
 Any model available with [Responses API](https://platform.openai.com/docs/api-reference/responses). The default is `o4-mini`, but pass `--model gpt-4.1` or set `model: gpt-4.1` in your config file to override.
@@ -316,6 +315,8 @@ Any model available with [Responses API](https://platform.openai.com/docs/api-re
 It's possible that your [API account needs to be verified](https://help.openai.com/en/articles/10910291-api-organization-verification) in order to start streaming responses and seeing chain of thought summaries from the API. If you're still running into issues, please let us know!
 
 </details>
+
+<details>
 <summary>How do I stop Codex from editing my files?</summary>
 
 Codex runs model-generated commands in a sandbox. If a proposed command or file change doesn't look right, you can simply type **n** to deny the command or give the model feedback.


### PR DESCRIPTION
#291 Fixes

Fix the misplace of `<details>`

**BEFORE**
<img width="876" alt="image" src="https://github.com/user-attachments/assets/254de872-d08d-4bca-875a-36bf793e3cd3" />



**AFTER**
<img width="600" alt="image" src="https://github.com/user-attachments/assets/337e3759-0c7b-4660-a9a6-c688cacf4c9d" />

