### PR TITLE
fix: update model names to current OpenAI API standards

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.yml
@@ -25,7 +25,7 @@ body:
   - type: input
     attributes:
       label: Which model were you using?
-      description: Like `gpt-4.1`, `o4-mini`, `o3`, etc.
+      description: Like `gpt-4.1`, `o4-mini-2025-04-16`, `o3-2025-04-16`, etc.
   - type: input
     attributes:
       label: What platform is your computer?

--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Codex looks for config files in **`~/.codex/`**.
 
 ```yaml
 # ~/.codex/config.yaml
-model: o4-mini # Default model
+model: o4-mini-2025-04-16 # Default model
 fullAutoErrorMode: ask-user # or ignore-and-continue
 notify: true # Enable desktop notifications for responses
 ```
@@ -307,11 +307,11 @@ In 2021, OpenAI released Codex, an AI system designed to generate code from natu
 <details>
 <summary>Which models are supported?</summary>
 
-Any model available with [Responses API](https://platform.openai.com/docs/api-reference/responses). The default is `o4-mini`, but pass `--model gpt-4.1` or set `model: gpt-4.1` in your config file to override.
+Any model available with [Responses API](https://platform.openai.com/docs/api-reference/responses). The default is `o4-mini-2025-04-16`, but pass `--model gpt-4.1` or set `model: gpt-4.1` in your config file to override.
 
 </details>
 <details>
-<summary>Why does <code>o3</code> or <code>o4-mini</code> not work for me?</summary>
+<summary>Why does <code>o3-2025-04-16</code> or <code>o4-mini-2025-04-16</code> not work for me?</summary>
 
 It's possible that your [API account needs to be verified](https://help.openai.com/en/articles/10910291-api-organization-verification) in order to start streaming responses and seeing chain of thought summaries from the API. If you're still running into issues, please let us know!
 

--- a/codex-cli/examples/camerascii/template/screenshot_details.md
+++ b/codex-cli/examples/camerascii/template/screenshot_details.md
@@ -9,7 +9,7 @@ The image is a full–page screenshot of a single post on the social‑media sit
 2. **Tweet body text**
    * Below the header, in regular type, the author writes:
 
-     “Okay, OpenAI’s o3 is insane. Spent an hour messing with it and built an image‑to‑ASCII art converter, the exact tool I’ve always wanted. And it works so well”
+     “Okay, OpenAI’s o3-2025-04-16 is insane. Spent an hour messing with it and built an image‑to‑ASCII art converter, the exact tool I’ve always wanted. And it works so well”
 
 3. **Embedded media**
    * The majority of the screenshot is occupied by an embedded 12‑second video of the converter UI.  The video window has rounded corners and a dark theme.
@@ -31,4 +31,4 @@ The image is a full–page screenshot of a single post on the social‑media sit
    * A small black badge showing **“0:12”** overlays the bottom‑left corner of the media frame, indicating the video’s duration.
    * In the top‑right area of the media window are two pill‑shaped buttons: a heart‑shaped “Save” button and a cog‑shaped “Settings” button.
 
-Overall, the screenshot shows the user excitedly announcing the success of their custom “Image to ASCII” converter created with OpenAI’s “o3”, accompanied by a short video demonstration of the tool converting a palm‑tree photo into ASCII art.
+Overall, the screenshot shows the user excitedly announcing the success of their custom “Image to ASCII” converter created with OpenAI’s “o3-2025-04-16”, accompanied by a short video demonstration of the tool converting a palm‑tree photo into ASCII art.

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -54,7 +54,7 @@ const cli = meow(
 
   Options
     -h, --help                      Show usage and exit
-    -m, --model <model>             Model to use for completions (default: o4-mini)
+    -m, --model <model>             Model to use for completions (default: o4-mini-2025-04-16)
     -i, --image <path>              Path(s) to image files to include as input
     -v, --view <rollout>            Inspect a previously saved rollout instead of starting a session
     -q, --quiet                     Non-interactive mode that only prints the assistant's final output

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -495,7 +495,7 @@ export class AgentLoop {
             let reasoning: Reasoning | undefined;
             if (this.model.startsWith("o")) {
               reasoning = { effort: "high" };
-              if (this.model === "o3" || this.model === "o4-mini") {
+              if (this.model === "o3-2025-04-16" || this.model === "o4-mini-2025-04-16") {
                 // @ts-expect-error waiting for API type update
                 reasoning.summary = "auto";
               }

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -15,7 +15,7 @@ import { load as loadYaml, dump as dumpYaml } from "js-yaml";
 import { homedir } from "os";
 import { dirname, join, extname, resolve as resolvePath } from "path";
 
-export const DEFAULT_AGENTIC_MODEL = "o4-mini";
+export const DEFAULT_AGENTIC_MODEL = "o4-mini-2025-04-16";
 export const DEFAULT_FULL_CONTEXT_MODEL = "gpt-4.1";
 export const DEFAULT_APPROVAL_MODE = AutoApprovalMode.SUGGEST;
 export const DEFAULT_INSTRUCTIONS = "";

--- a/codex-cli/src/utils/model-utils.ts
+++ b/codex-cli/src/utils/model-utils.ts
@@ -2,7 +2,7 @@ import { OPENAI_API_KEY } from "./config";
 import OpenAI from "openai";
 
 const MODEL_LIST_TIMEOUT_MS = 2_000; // 2 seconds
-export const RECOMMENDED_MODELS: Array<string> = ["o4-mini", "o3"];
+export const RECOMMENDED_MODELS: Array<string> = ["o4-mini-2025-04-16", "o3-2025-04-16"];
 
 /**
  * Background model loader / cache.

--- a/codex-cli/tests/agent-project-doc.test.ts
+++ b/codex-cli/tests/agent-project-doc.test.ts
@@ -113,7 +113,7 @@ describe("AgentLoop", () => {
 
     const agent = new AgentLoop({
       additionalWritableRoots: [],
-      model: "o3", // arbitrary
+      model: "o3-2025-04-16", // arbitrary
       instructions: config.instructions,
       config,
       approvalPolicy: { mode: "suggest" } as any,

--- a/codex-cli/tests/config.test.tsx
+++ b/codex-cli/tests/config.test.tsx
@@ -60,7 +60,7 @@ test("loads default config if files don't exist", () => {
   });
   // Keep the test focused on just checking that default model and instructions are loaded
   // so we need to make sure we check just these properties
-  expect(config.model).toBe("o4-mini");
+  expect(config.model).toBe("o4-mini-2025-04-16");
   expect(config.instructions).toBe("");
 });
 

--- a/codex-cli/tests/model-utils-network-error.test.ts
+++ b/codex-cli/tests/model-utils-network-error.test.ts
@@ -44,7 +44,7 @@ describe("model-utils – offline resilience", () => {
       "../src/utils/model-utils.js"
     );
 
-    const supported = await isModelSupportedForResponses("o4-mini");
+    const supported = await isModelSupportedForResponses("o4-mini-2025-04-16");
     expect(supported).toBe(true);
   });
 


### PR DESCRIPTION
Update default model names to include date suffixes for compatibility with the latest OpenAI Responses API:
* Change o4-mini to o4-mini-2025-04-16
* Change o3 to o3-2025-04-16 

This resolves errors encountered when using previous model names that are no longer supported by the OpenAI API.