### PR TITLE
fix: handle invalid commands

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -238,7 +238,7 @@ export default function TerminalChatInput({
         // Any other input, including those starting with '/' but containing spaces
         // (e.g., "/command arg"), will fall through and be treated as a regular prompt.
         const trimmed = inputValue.trim();
-        
+
         if (/^\/\S+$/.test(trimmed)) {
           setInput("");
           setItems((prev) => [

--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -232,6 +232,32 @@ export default function TerminalChatInput({
         );
 
         return;
+      } else if (inputValue.startsWith("/")) {
+        // Handle invalid/unrecognized commands.
+        // Only single-word inputs starting with '/' (e.g., /command) that are not recognized are caught here.
+        // Any other input, including those starting with '/' but containing spaces
+        // (e.g., "/command arg"), will fall through and be treated as a regular prompt.
+        const trimmed = inputValue.trim();
+        
+        if (/^\/\S+$/.test(trimmed)) {
+          setInput("");
+          setItems((prev) => [
+            ...prev,
+            {
+              id: `invalidcommand-${Date.now()}`,
+              type: "message",
+              role: "system",
+              content: [
+                {
+                  type: "input_text",
+                  text: `Invalid command "${trimmed}". Use /help to retrieve the list of commands.`,
+                },
+              ],
+            },
+          ]);
+
+          return;
+        }
       }
 
       // detect image file paths for dynamic inclusion


### PR DESCRIPTION
### What is added?

I extend the if-else blocks with an additional condition where the commands validity is checked. This only applies for entered inputs that start with '/' and are a single word. This isn't necessarily restrictive from the previous behavior of the program. When an invalid command is detected, an error message is printed with a direction to retrieve command list. 

### Why is it added?

There are three main reasons for this change 

**1. Model Hallucination**: When invalid commands are passed as prompts to models, models hallucinate behavior.  Since there was a fall through in invalid commands, the models took these as prompts and hallucinated that they completed the prompted task. An example of this behavior is below. In the case of this example, the model though they had access to `/clearhistory` tool where in reality that isn't the case.
A before and after effect of this tool is below:
![img](https://github.com/user-attachments/assets/3166f151-d5d0-46d6-9ba7-c7e64ff35e4a)
![img2](https://github.com/user-attachments/assets/69934306-af68-423d-a5f0-9d922be01d27)


**2. Saves Users Credits and Time**: Since false commands and invalid commands aren't processed by the model, the user doesn't spend money on stuff that could have been mitigated much easily. The time argument is especially applicable for reasoning models. 

**3. Saves GPU Time**: GPU time is valuable, and it is not necessary to spend it on unnecessary/invalid requests. 

### Code Explanation

If no command is matched, we check if the inputValue start with `/` which indicated the input is a command (I will address the case where it is isn't below). If the inputValue start with `/` we enter the else if statement. I used a nested if statement for readability and further extendability in the future.

There are alternative ways to check besides regex, but regex is a short code and looks clean. 

**Check Conditions**: The reason why I only check single word(command) case is that to allow prompts where the user might decide to start with `/` and aren't commands. The nested if statements also come in handy where in the future other contributors might want to extend this checking. 

The code passes type, lint and test checks. 
