### PR TITLE
fix: Improper spawn of sh on Windows Powershell

### DIFF
--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+// Unified entry point for Codex CLI on all platforms
+// Dynamically loads the compiled ESM bundle in dist/cli.js
+
+import path from 'path';
+import { fileURLToPath, pathToFileURL } from 'url';
+
+// Determine this script's directory
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+// Resolve the path to the compiled CLI bundle
+const cliPath = path.resolve(__dirname, '../dist/cli.js');
+const cliUrl = pathToFileURL(cliPath).href;
+
+// Load and execute the CLI
+(async () => {
+  try {
+    await import(cliUrl);
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.2504172351",
   "license": "Apache-2.0",
   "bin": {
-    "codex": "bin/codex"
+    "codex": "bin/codex.js"
   },
   "type": "module",
   "engines": {


### PR DESCRIPTION
# Fix CLI launcher on Windows by replacing `sh`-based entrypoint with cross-platform Node script

## What's changed

* This PR attempts to replace the sh-based entry point with a node script that works on all platforms including Windows Powershell and CMD

## Why 

* Previously, when installing Codex globally via `npm i -g @openai/codex`, Windows resulted in a broken CLI issue due to the `ps1` launcher trying to execute `sh.exe`.

* If users don't have Unix-style shell, running the command will fail as seen below since `sh.exe` can't be found

* Output:
 ``` 
& : The term 'sh.exe' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the
spelling of the name, or if a path was included, verify that the path is correct and try again.
At C:\Users\{user}\AppData\Roaming\npm\codex.ps1:24 char:7
+     & "sh$exe"  "$basedir/node_modules/@openai/codex/bin/codex" $args
+       ~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (sh.exe:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```



## How
* By using a Node based entry point that resolves the path to the compiled ESM bundle and dynamically loads it using native ESM

* Removed dependency on platform-specific launchers allowing a single entrypoint to work everywhere Node.js runs.


## Result

Codex CLI now supports cross-platform and launches correctly via:
* macOS / Linux
* Windows PowerShell
* GitBash
* CMD
* WSL

Directly addresses #316 

![image](https://github.com/user-attachments/assets/85faaca4-24bc-47c9-8160-4e30df6da4c3)


![image](https://github.com/user-attachments/assets/a13f7adc-52c1-4c0e-af02-e35a35dc45d4)




