### PR TITLE
fix(cli): add approvalMode support in config

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -335,14 +335,27 @@ if (quietMode) {
 //    it is more dangerous than --fullAuto we deliberately give it lower
 //    priority so a user specifying both flags still gets the safer behaviour.
 // 3. --autoEdit – automatically approve edits, but prompt for commands.
-// 4. Default – suggest mode (prompt for everything).
+// 4. Default – use the config file's approval mode.
+// 5. If not specified, fall back to suggest mode (prompt for everything).
 
-const approvalPolicy: ApprovalPolicy =
-  cli.flags.fullAuto || cli.flags.approvalMode === "full-auto"
-    ? AutoApprovalMode.FULL_AUTO
-    : cli.flags.autoEdit || cli.flags.approvalMode === "auto-edit"
-    ? AutoApprovalMode.AUTO_EDIT
-    : AutoApprovalMode.SUGGEST;
+const approvalPolicy: ApprovalPolicy = (() => {
+  if (cli.flags.fullAuto || cli.flags.approvalMode === "full-auto") {
+    return AutoApprovalMode.FULL_AUTO;
+  }
+  if (cli.flags.autoEdit || cli.flags.approvalMode === "auto-edit") {
+    return AutoApprovalMode.AUTO_EDIT;
+  }
+  if (
+    typeof cli.flags.approvalMode === "string" &&
+    Object.values(AutoApprovalMode).includes(
+      cli.flags.approvalMode as AutoApprovalMode,
+    )
+  ) {
+    return cli.flags.approvalMode as AutoApprovalMode;
+  }
+  // Fall back to config value, then default
+  return config.approvalMode ?? AutoApprovalMode.SUGGEST;
+})();
 
 preloadModels();
 

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -46,6 +46,7 @@ export const PRETTY_PRINT = Boolean(process.env["PRETTY_PRINT"] || "");
 // Represents config as persisted in config.json.
 export type StoredConfig = {
   model?: string;
+  /** Default approval mode used when CLI flags are not provided */
   approvalMode?: AutoApprovalMode;
   fullAutoErrorMode?: FullAutoErrorMode;
   memory?: MemoryConfig;
@@ -75,6 +76,8 @@ export type AppConfig = {
   apiKey?: string;
   model: string;
   instructions: string;
+  /** Default approval mode for the CLI session when flags are absent */
+  approvalMode?: AutoApprovalMode;
   fullAutoErrorMode?: FullAutoErrorMode;
   memory?: MemoryConfig;
   /** Whether to enable desktop notifications for responses */
@@ -268,6 +271,7 @@ export const loadConfig = (
         : DEFAULT_AGENTIC_MODEL),
     instructions: combinedInstructions,
     notify: storedConfig.notify === true,
+    approvalMode: storedConfig.approvalMode ?? DEFAULT_APPROVAL_MODE,
   };
 
   // -----------------------------------------------------------------------
@@ -376,6 +380,7 @@ export const saveConfig = (
   // Create the config object to save
   const configToSave: StoredConfig = {
     model: config.model,
+    approvalMode: config.approvalMode,
   };
 
   // Add history settings if they exist

--- a/codex-cli/tests/config.test.tsx
+++ b/codex-cli/tests/config.test.tsx
@@ -1,5 +1,6 @@
 import type * as fsType from "fs";
 
+import { AutoApprovalMode } from "../src/utils/auto-approval-mode.js";
 import { loadConfig, saveConfig } from "../src/utils/config.js"; // parent import first
 import { tmpdir } from "os";
 import { join } from "path";
@@ -62,12 +63,14 @@ test("loads default config if files don't exist", () => {
   // so we need to make sure we check just these properties
   expect(config.model).toBe("o4-mini");
   expect(config.instructions).toBe("");
+  expect(config.approvalMode).toBe(AutoApprovalMode.SUGGEST);
 });
 
 test("saves and loads config correctly", () => {
   const testConfig = {
     model: "test-model",
     instructions: "test instructions",
+    approvalMode: AutoApprovalMode.AUTO_EDIT,
     notify: false,
   };
   saveConfig(testConfig, testConfigPath, testInstructionsPath);
@@ -82,6 +85,7 @@ test("saves and loads config correctly", () => {
   // Check just the specified properties that were saved
   expect(loadedConfig.model).toBe(testConfig.model);
   expect(loadedConfig.instructions).toBe(testConfig.instructions);
+  expect(loadedConfig.approvalMode).toBe(AutoApprovalMode.AUTO_EDIT);
 });
 
 test("loads user instructions + project doc when codex.md is present", () => {
@@ -89,7 +93,7 @@ test("loads user instructions + project doc when codex.md is present", () => {
   const userInstr = "here are user instructions";
   const projectDoc = "# Project Title\n\nSome project‑specific doc";
   // first, make config so loadConfig will see storedConfig
-  memfs[testConfigPath] = JSON.stringify({ model: "mymodel" }, null, 2);
+  memfs[testConfigPath] = JSON.stringify({ model: "mymodel", approvalMode: "full-auto" }, null, 2);
   // then user instructions:
   memfs[testInstructionsPath] = userInstr;
   // and now our fake codex.md in the cwd:
@@ -103,6 +107,7 @@ test("loads user instructions + project doc when codex.md is present", () => {
 
   // 3) assert we got both pieces concatenated
   expect(cfg.model).toBe("mymodel");
+  expect(cfg.approvalMode).toBe(AutoApprovalMode.FULL_AUTO);
   expect(cfg.instructions).toBe(
     userInstr + "\n\n--- project-doc ---\n\n" + projectDoc,
   );


### PR DESCRIPTION
The ~/.codex/config.json file can now specify an approvalMode.\nThis is used whenever no approve/suggest flags are passed; flags still win if provided.