### PR TITLE
fix: realpathSafe to safely resolve symlinks for seatbelt

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,12 +104,18 @@ importers:
       '@types/shell-quote':
         specifier: ^1.7.5
         version: 1.7.5
+      '@types/which':
+        specifier: ^3.0.4
+        version: 3.0.4
       '@typescript-eslint/eslint-plugin':
         specifier: ^7.18.0
         version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)
       '@typescript-eslint/parser':
         specifier: ^7.18.0
         version: 7.18.0(eslint@8.57.1)(typescript@5.8.3)
+      boxen:
+        specifier: ^8.0.1
+        version: 8.0.1
       esbuild:
         specifier: ^0.25.2
         version: 0.25.2
@@ -152,6 +158,9 @@ importers:
       whatwg-url:
         specifier: ^14.2.0
         version: 14.2.0
+      which:
+        specifier: ^5.0.0
+        version: 5.0.0
 
 packages:
 
@@ -542,6 +551,9 @@ packages:
   '@types/shell-quote@1.7.5':
     resolution: {integrity: sha512-+UE8GAGRPbJVQDdxi16dgadcBfQ+KG2vgZhV1+3A1XmHbmwcdwhCUwIdy+d3pAGrbvgRoVSjeI9vOWyq376Yzw==}
 
+  '@types/which@3.0.4':
+    resolution: {integrity: sha512-liyfuo/106JdlgSchJzXEQCVArk0CvevqPote8F8HgWgJ3dRCcTHgJIsLDuee0kxk/mhbInzIZk3QWSZJ8R+2w==}
+
   '@typescript-eslint/eslint-plugin@7.18.0':
     resolution: {integrity: sha512-94EQTWZ40mzBc42ATNIBimBEDltSJ9RQHCC8vc/PDbxi4k8dVwUAv4o98dk50M1zB+JGFxp43FP7f8+FP8R6Sw==}
     engines: {node: ^18.18.0 || >=20.0.0}
@@ -657,6 +669,9 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ansi-align@3.0.1:
+    resolution: {integrity: sha512-IOfwwBF5iczOjp/WeY4YxyjqAFMQoZufdQWDd19SEExbVLNXqvpzSJ/M7Za4/sCPmQ0+GRquoA7bGcINcxew6w==}
+
   ansi-escapes@7.0.0:
     resolution: {integrity: sha512-GdYO7a61mR0fOlAsvC9/rIHf7L96sBc6dEWzeOu+KAea5bZyQRPIpojrVoI4AXGJS/ycu/fBTdLrUkA4ODrvjw==}
     engines: {node: '>=18'}
@@ -744,6 +759,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  boxen@8.0.1:
+    resolution: {integrity: sha512-F3PH5k5juxom4xktynS7MoFY+NUWH5LC4CnH11YB8NPew+HLpmBLCybSAEyb2F+4pRXhuhWqFesoQd6DAyc2hw==}
+    engines: {node: '>=18'}
+
   brace-expansion@1.1.11:
     resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
 
@@ -777,6 +796,10 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  camelcase@8.0.0:
+    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
+    engines: {node: '>=16'}
 
   chai@5.2.0:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
@@ -1547,6 +1570,10 @@ packages:
 
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  isexe@3.1.1:
+    resolution: {integrity: sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ==}
+    engines: {node: '>=16'}
 
   iterator.prototype@1.1.5:
     resolution: {integrity: sha512-H0dkQoCa3b2VEeKQBOxFph+JAbcrQdE7KC0UkqwpLmv2EC4P41QXP+rqo9wYodACiG5/WM5s9oDApTU8utwj9g==}
@@ -2384,6 +2411,11 @@ packages:
     engines: {node: '>= 8'}
     hasBin: true
 
+  which@5.0.0:
+    resolution: {integrity: sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -2727,6 +2759,8 @@ snapshots:
 
   '@types/shell-quote@1.7.5': {}
 
+  '@types/which@3.0.4': {}
+
   '@typescript-eslint/eslint-plugin@7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -2875,6 +2909,10 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ansi-align@3.0.1:
+    dependencies:
+      string-width: 4.2.3
+
   ansi-escapes@7.0.0:
     dependencies:
       environment: 1.1.0
@@ -2976,6 +3014,17 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  boxen@8.0.1:
+    dependencies:
+      ansi-align: 3.0.1
+      camelcase: 8.0.0
+      chalk: 5.4.1
+      cli-boxes: 3.0.0
+      string-width: 7.2.0
+      type-fest: 4.40.0
+      widest-line: 5.0.0
+      wrap-ansi: 9.0.0
+
   brace-expansion@1.1.11:
     dependencies:
       balanced-match: 1.0.2
@@ -3013,6 +3062,8 @@ snapshots:
       get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
+
+  camelcase@8.0.0: {}
 
   chai@5.2.0:
     dependencies:
@@ -3914,6 +3965,8 @@ snapshots:
   isarray@2.0.5: {}
 
   isexe@2.0.0: {}
+
+  isexe@3.1.1: {}
 
   iterator.prototype@1.1.5:
     dependencies:
@@ -4826,6 +4879,10 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  which@5.0.0:
+    dependencies:
+      isexe: 3.1.1
 
   why-is-node-running@2.3.0:
     dependencies:


### PR DESCRIPTION
This is a followup to #370 and #275 

It fixes #330 

And also integrates feedback from @bolinfest (ty for the very good feedback!)

> I have concerns with this PR:
> 
> Without testing, it is not 100% clear to me that this fixes your specific problem without creating problems for a number of other people. For example, if I have a symlink like \~/myrepo, which is a symlink to one of multiple clones of my repo (~/src/myrepo1, ~/src/myrepo2, etc.) and I start Codex in ~/myrepo, will canonicalizing the path screw things up? Because the agent is likely to spawn commands with paths relative to ~/myrepo.

I tested w/ a symlinked cwd, and in both versions (w/ and w/o realpath) they succeeded for reading/writing in the cwd. Which surprised me, tbh. I expected that it would fail w/o the realpath resolution. 

Seatbelt is apparently poorly documented, or rather the implementation and policy language is considered apple internal. Im reading reverse engineer documents and bug reports to wayfind here 🤣  The bug we were fixing for originally of `/var` needed to be resolved in the policy to `/private/var` is an edgecase that I have read about (yes Im using AI to accelerate this understanding, buyer beware) and seems to be known.

Edit to add: Didnt make this clear, we are not touching userland paths. We are only altering the paths we add to the policy, for comparison against what the kernel hands to seatbelt for checking.

> This uses realpathSync(). In general, we try to avoid blocking I/O calls in our codebase.
> You call this in execWithSeatbelt(), which means the canonicalization is done every time Seatbelt is used as opposed to just doing it one time at the start of the agent loop.

addressed the sync. I did sync originally bc I missed that the function was returning `Promise<ExecResult>`, saw the lack of async keyword on the func and thought I was making the least invasive change.

As for caching it, yeah I can do that if desired. This isn't what I'd call a hotpath, but if the additional complexity is worth trimming the waste here in your mind I can do that. We have minute long network calls making up most of the latency in this application. Strong opinion held weakly on my end. 

> A workaround would be to use the new -w flag I introduced in https://github.com/openai/codex/pull/263 with -w $GOTMPDIR or -w $(realpath $GOTMPDIR) or however things work in Go. (Sorry, I don't write Go.)

**The issue here is that writing to macos tmpdir is **currently broken without the realpath** change. The agent cannot write to it, nor the software it invokes.** Im not a go dev either, but the particulars are generic to tmp dir writeability.

Try it out on a mac:
```sh
echo $TMPDIR # /var/folders/....
codex --full-auto -w $TMPDIR "Append some data to a test file in my macos tmpdir, we are testing your ability to write to it"`
```

### A targetted fix would be to realpath just the tmp dir and play whackamole as new reports come in w/ other edgecaes (which is fully valid). I can make that change if desired.