### PR TITLE
fix #376: Allow Outbound from Container

### DIFF
--- a/codex-cli/scripts/init_firewall.sh
+++ b/codex-cli/scripts/init_firewall.sh
@@ -3,7 +3,7 @@ set -euo pipefail  # Exit on error, undefined vars, and pipeline failures
 IFS=$'\n\t'       # Stricter word splitting
 # Optional flag to allow outbound traffic without restrictions
 ALLOW_OUTBOUND=false
-if [ "${1:-}" = "--allow-outbound" ]; then
+if [ "${1:-}" = "--dangerously-allow-network-outbound" ]; then
   ALLOW_OUTBOUND=true
   shift
 fi
@@ -96,7 +96,7 @@ iptables -A FORWARD -p udp -j REJECT --reject-with icmp-port-unreachable
 echo "Firewall configuration complete"
 # Skip verification if outbound is allowed
 if [ "$ALLOW_OUTBOUND" = true ]; then
-  echo "Allow-outbound flag set; skipping firewall verification"
+  echo "DANGEROUS Allow-outbound flag set; skipping firewall verification"
   exit 0
 fi
 echo "Verifying firewall rules..."

--- a/codex-cli/scripts/run_in_container.sh
+++ b/codex-cli/scripts/run_in_container.sh
@@ -2,7 +2,7 @@
 set -e
 
 # Usage:
-#   ./run_in_container.sh [--allow-outbound] [--work_dir directory] "COMMAND"
+#   ./run_in_container.sh [--dangerously-allow-network-outbound] [--work_dir directory] "COMMAND"
 #
 #   Examples:
 #     ./run_in_container.sh --work_dir project/code "ls -la"
@@ -13,10 +13,10 @@ WORK_DIR="${WORKSPACE_ROOT_DIR:-$(pwd)}"
 # By default, do not disable outbound firewall
 ALLOW_OUTBOUND=false
 
-# Parse optional flags: --allow-outbound and --work_dir
+# Parse optional flags: --dangerously-allow-network-outbound and --work_dir
 while [ "$#" -gt 0 ]; do
   case "$1" in
-    --allow-outbound)
+    --dangerously-allow-network-outbound)
       ALLOW_OUTBOUND=true
       shift
       ;;
@@ -48,7 +48,7 @@ trap cleanup EXIT
 
 # Ensure a command is provided.
 if [ "$#" -eq 0 ]; then
-  echo "Usage: $0 [--allow-outbound] [--work_dir directory] \"COMMAND\""
+  echo "Usage: $0 [--dangerously-allow-network-outbound] [--work_dir directory] \"COMMAND\""
   exit 1
 fi
 
@@ -73,7 +73,7 @@ docker run --name "$CONTAINER_NAME" -d \
 # Initialize the firewall inside the container, passing allow-outbound if requested
 if [ "$ALLOW_OUTBOUND" = true ]; then
   echo "Initializing firewall inside container (allowing outbound traffic)..."
-  docker exec "$CONTAINER_NAME" bash -c "sudo /usr/local/bin/init_firewall.sh --allow-outbound"
+  docker exec "$CONTAINER_NAME" bash -c "sudo /usr/local/bin/init_firewall.sh --dangerously-allow-network-outbound"
 else
   echo "Initializing firewall inside container..."
   docker exec "$CONTAINER_NAME" bash -c "sudo /usr/local/bin/init_firewall.sh"


### PR DESCRIPTION
While I can't think of any good reason why codex running in a docker container shouldn't be able to contact the larger web, I can think of reasons why it should (npm install, uploading test reports, research tasks). I can think of some good reasons why it shouldn't be able to connect to the host computer, but that's another diff perhaps? Assuming there is some good reason for disabling www access while running in a container, I decided to make it a flag.

## Change

Added --allow-outbound flag to the run_in_container.sh script tree, if set, outbound firewall rules won't be turned on allowing container to connect to things like npm, run tests, perform git actions etc.

## Testing

`run_in_container.sh --allow-outbound "ping google"` succeeds!
`run_in_container.sh "ping google"` fails as expected

Resolves: #376 