### PR TITLE
feat: add user-defined safe commands configuration and approval logic #380

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,6 +283,9 @@ Codex looks for config files in **`~/.codex/`**.
 model: o4-mini # Default model
 fullAutoErrorMode: ask-user # or ignore-and-continue
 notify: true # Enable desktop notifications for responses
+safeCommands:
+  - npm test # Automatically approve npm test
+  - yarn lint # Automatically approve yarn lint
 ```
 
 You can also define custom instructions:

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -56,6 +56,8 @@ export type StoredConfig = {
     saveHistory?: boolean;
     sensitivePatterns?: Array<string>;
   };
+  /** User-defined safe commands */
+  safeCommands?: Array<string>;
 };
 
 // Minimal config written on first run.  An *empty* model string ensures that
@@ -84,6 +86,8 @@ export type AppConfig = {
     saveHistory: boolean;
     sensitivePatterns: Array<string>;
   };
+  /** User-defined safe commands */
+  safeCommands?: Array<string>;
 };
 
 // ---------------------------------------------------------------------------
@@ -268,6 +272,7 @@ export const loadConfig = (
         : DEFAULT_AGENTIC_MODEL),
     instructions: combinedInstructions,
     notify: storedConfig.notify === true,
+    safeCommands: storedConfig.safeCommands ?? [],
   };
 
   // -----------------------------------------------------------------------
@@ -345,6 +350,13 @@ export const loadConfig = (
     };
   }
 
+  // Load user-defined safe commands
+  if (Array.isArray(storedConfig.safeCommands)) {
+    config.safeCommands = storedConfig.safeCommands.map(String);
+  } else {
+    config.safeCommands = [];
+  }
+
   return config;
 };
 
@@ -385,6 +397,10 @@ export const saveConfig = (
       saveHistory: config.history.saveHistory,
       sensitivePatterns: config.history.sensitivePatterns,
     };
+  }
+  // Save: User-defined safe commands
+  if (config.safeCommands && config.safeCommands.length > 0) {
+    configToSave.safeCommands = config.safeCommands;
   }
 
   if (ext === ".yaml" || ext === ".yml") {

--- a/codex-cli/tests/approvals.test.ts
+++ b/codex-cli/tests/approvals.test.ts
@@ -1,7 +1,13 @@
 import type { SafetyAssessment } from "../src/approvals";
 
 import { canAutoApprove } from "../src/approvals";
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
+
+vi.mock("../src/utils/config", () => ({
+  loadConfig: () => ({
+    safeCommands: ["npm test", "sl"],
+  }),
+}));
 
 describe("canAutoApprove()", () => {
   const env = {
@@ -88,5 +94,28 @@ describe("canAutoApprove()", () => {
     expect(check(["pytest"])).toEqual({ type: "ask-user" });
 
     expect(check(["cargo", "build"])).toEqual({ type: "ask-user" });
+  });
+
+  test("commands in safeCommands config should be safe", async () => {
+    expect(check(["npm", "test"])).toEqual({
+      type: "auto-approve",
+      reason: "User-defined safe command",
+      group: "User config",
+      runInSandbox: false,
+    });
+
+    expect(check(["sl"])).toEqual({
+      type: "auto-approve",
+      reason: "User-defined safe command",
+      group: "User config",
+      runInSandbox: false,
+    });
+
+    expect(check(["npm", "test", "--watch"])).toEqual({
+      type: "auto-approve",
+      reason: "User-defined safe command",
+      group: "User config",
+      runInSandbox: false,
+    });
   });
 });


### PR DESCRIPTION
This pull request adds a feature that allows users to configure auto-approved commands via a `safeCommands` array in the configuration file.

## Related Issue
#380 

## Changes
- Added loading and validation of the `safeCommands` array in `src/utils/config.ts`
- Implemented auto-approval logic for commands matching `safeCommands` prefixes in `src/approvals.ts`
- Added test cases in `src/tests/approvals.test.ts` to verify `safeCommands` behavior
- Updated documentation with examples and explanations of the configuration

