### PR TITLE
fix: enable shell option for child process execution

### DIFF
--- a/codex-cli/src/utils/agent/exec.ts
+++ b/codex-cli/src/utils/agent/exec.ts
@@ -33,6 +33,7 @@ export function exec(
 
   const opts: SpawnOptions = {
     timeout: timeoutInMillis || DEFAULT_TIMEOUT_MS,
+    shell: true,
     ...(workdir ? { cwd: workdir } : {}),
   };
   // Merge default writable roots with any user-specified ones.

--- a/codex-cli/src/utils/agent/exec.ts
+++ b/codex-cli/src/utils/agent/exec.ts
@@ -1,5 +1,6 @@
 import type { ExecInput, ExecResult } from "./sandbox/interface.js";
 import type { SpawnOptions } from "child_process";
+import type { ParseEntry } from "shell-quote";
 
 import { process_patch } from "./apply-patch.js";
 import { SandboxType } from "./sandbox/interface.js";
@@ -8,8 +9,16 @@ import { exec as rawExec } from "./sandbox/raw-exec.js";
 import { formatCommandForDisplay } from "../../format-command.js";
 import fs from "fs";
 import os from "os";
+import { parse } from "shell-quote";
 
 const DEFAULT_TIMEOUT_MS = 10_000; // 10 seconds
+
+function requiresShell(cmd: Array<string>): boolean {
+  return cmd.some((arg) => {
+    const tokens = parse(arg) as Array<ParseEntry>;
+    return tokens.some((token) => typeof token === "object" && "op" in token);
+  });
+}
 
 /**
  * This function should never return a rejected promise: errors should be
@@ -33,7 +42,7 @@ export function exec(
 
   const opts: SpawnOptions = {
     timeout: timeoutInMillis || DEFAULT_TIMEOUT_MS,
-    shell: true,
+    ...(requiresShell(cmd) ? { shell: true } : {}),
     ...(workdir ? { cwd: workdir } : {}),
   };
   // Merge default writable roots with any user-specified ones.

--- a/codex-cli/src/utils/agent/sandbox/raw-exec.ts
+++ b/codex-cli/src/utils/agent/sandbox/raw-exec.ts
@@ -47,15 +47,6 @@ export function exec(
     });
   }
 
-  if (prog.includes(" ")) {
-    return Promise.resolve({
-      stdout: "",
-      stderr:
-        "command[0] contains spaces: arguments must be separate array elements",
-      exitCode: 1,
-    });
-  }
-
   // We use spawn() instead of exec() or execFile() so that we can set the
   // stdio options to "ignore" for stdin. Ripgrep has a heuristic where it
   // may try to read from stdin as explained here:

--- a/codex-cli/src/utils/agent/sandbox/raw-exec.ts
+++ b/codex-cli/src/utils/agent/sandbox/raw-exec.ts
@@ -47,6 +47,15 @@ export function exec(
     });
   }
 
+  if (prog.includes(" ")) {
+    return Promise.resolve({
+      stdout: "",
+      stderr:
+        "command[0] contains spaces: arguments must be separate array elements",
+      exitCode: 1,
+    });
+  }
+
   // We use spawn() instead of exec() or execFile() so that we can set the
   // stdio options to "ignore" for stdin. Ripgrep has a heuristic where it
   // may try to read from stdin as explained here:


### PR DESCRIPTION
## Changes

- Added a `requiresShell` function to detect when a command contains shell operators  
- In the `exec` function, enabled the `shell: true` option if shell operators are present  

## Why This Is Necessary

See the discussion in this issue comment:  
https://github.com/openai/codex/issues/320#issuecomment-2816528014

## Code Explanation

The `requiresShell` function parses the command arguments and checks for any shell‑specific operators. If it finds shell operators, it adds the `shell: true` option when running the command so that it’s executed through a shell interpreter.  
