### PR TITLE
feat: allow switching approval modes when prompted to approve an edit/command

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat-command-review.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-command-review.tsx
@@ -18,11 +18,15 @@ export function TerminalChatCommandReview({
   // callback to switch approval mode overlay
   onSwitchApprovalMode,
   explanation: propExplanation,
+  // whether this review Select is active (listening for keys)
+  isActive = true,
 }: {
   confirmationPrompt: React.ReactNode;
   onReviewCommand: (decision: ReviewDecision, customMessage?: string) => void;
   onSwitchApprovalMode: () => void;
   explanation?: string;
+  // when false, disable the underlying Select so it won't capture input
+  isActive?: boolean;
 }): React.ReactElement {
   const [mode, setMode] = React.useState<"select" | "input" | "explanation">(
     "select",
@@ -115,7 +119,8 @@ export function TerminalChatCommandReview({
     return opts;
   }, [showAlwaysApprove]);
 
-  useInput((input, key) => {
+  useInput(
+    (input, key) => {
     if (mode === "select") {
       if (input === "y") {
         onReviewCommand(ReviewDecision.YES);
@@ -155,7 +160,8 @@ export function TerminalChatCommandReview({
         );
       }
     }
-  });
+    }, { isActive }
+  );
 
   return (
     <Box flexDirection="column" gap={1} borderStyle="round" marginTop={1}>
@@ -203,6 +209,8 @@ export function TerminalChatCommandReview({
             <Text>Allow command?</Text>
             <Box paddingX={2} flexDirection="column" gap={1}>
               <Select
+                isDisabled={!isActive}
+                visibleOptionCount={approvalOptions.length}
                 onChange={(value: ReviewDecision | "edit" | "switch") => {
                   if (value === "edit") {
                     setMode("input");

--- a/codex-cli/src/components/chat/terminal-chat-command-review.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-command-review.tsx
@@ -103,7 +103,7 @@ export function TerminalChatCommandReview({
       },
       // allow switching approval mode
       {
-        label: "Switch approval mode (v)",
+        label: "Switch approval mode (s)",
         value: "switch",
       },
       {

--- a/codex-cli/src/components/chat/terminal-chat-command-review.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-command-review.tsx
@@ -15,10 +15,13 @@ const DEFAULT_DENY_MESSAGE =
 export function TerminalChatCommandReview({
   confirmationPrompt,
   onReviewCommand,
+  // callback to switch approval mode overlay
+  onSwitchApprovalMode,
   explanation: propExplanation,
 }: {
   confirmationPrompt: React.ReactNode;
   onReviewCommand: (decision: ReviewDecision, customMessage?: string) => void;
+  onSwitchApprovalMode: () => void;
   explanation?: string;
 }): React.ReactElement {
   const [mode, setMode] = React.useState<"select" | "input" | "explanation">(
@@ -70,6 +73,7 @@ export function TerminalChatCommandReview({
     const opts: Array<
       | { label: string; value: ReviewDecision }
       | { label: string; value: "edit" }
+      | { label: string; value: "switch" }
     > = [
       {
         label: "Yes (y)",
@@ -92,6 +96,11 @@ export function TerminalChatCommandReview({
       {
         label: "Edit or give feedback (e)",
         value: "edit",
+      },
+      // allow switching approval mode
+      {
+        label: "Switch approval mode (v)",
+        value: "switch",
       },
       {
         label: "No, and keep going (n)",
@@ -121,6 +130,9 @@ export function TerminalChatCommandReview({
         );
       } else if (input === "a" && showAlwaysApprove) {
         onReviewCommand(ReviewDecision.ALWAYS);
+      } else if (input === "v") {
+        // switch approval mode
+        onSwitchApprovalMode();
       } else if (key.escape) {
         onReviewCommand(ReviewDecision.NO_EXIT);
       }
@@ -191,9 +203,11 @@ export function TerminalChatCommandReview({
             <Text>Allow command?</Text>
             <Box paddingX={2} flexDirection="column" gap={1}>
               <Select
-                onChange={(value: ReviewDecision | "edit") => {
+                onChange={(value: ReviewDecision | "edit" | "switch") => {
                   if (value === "edit") {
                     setMode("input");
+                  } else if (value === "switch") {
+                    onSwitchApprovalMode();
                   } else {
                     onReviewCommand(value);
                   }

--- a/codex-cli/src/components/chat/terminal-chat-command-review.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-command-review.tsx
@@ -135,7 +135,7 @@ export function TerminalChatCommandReview({
         );
       } else if (input === "a" && showAlwaysApprove) {
         onReviewCommand(ReviewDecision.ALWAYS);
-      } else if (input === "v") {
+      } else if (input === "s") {
         // switch approval mode
         onSwitchApprovalMode();
       } else if (key.escape) {

--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -407,6 +407,8 @@ export default function TerminalChatInput({
       <TerminalChatCommandReview
         confirmationPrompt={confirmationPrompt}
         onReviewCommand={submitConfirmation}
+        // allow switching approval mode via 'v'
+        onSwitchApprovalMode={openApprovalOverlay}
         explanation={explanation}
       />
     );

--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -410,6 +410,8 @@ export default function TerminalChatInput({
         // allow switching approval mode via 'v'
         onSwitchApprovalMode={openApprovalOverlay}
         explanation={explanation}
+        // disable when input is inactive (e.g., overlay open)
+        isActive={active}
       />
     );
   }

--- a/codex-cli/src/components/chat/terminal-chat-new-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-new-input.tsx
@@ -346,6 +346,8 @@ export default function TerminalChatInput({
       <TerminalChatCommandReview
         confirmationPrompt={confirmationPrompt}
         onReviewCommand={submitConfirmation}
+        // allow switching approval mode via 'v'
+        onSwitchApprovalMode={openApprovalOverlay}
         explanation={explanation}
       />
     );

--- a/codex-cli/src/components/chat/terminal-chat-new-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-new-input.tsx
@@ -349,6 +349,8 @@ export default function TerminalChatInput({
         // allow switching approval mode via 'v'
         onSwitchApprovalMode={openApprovalOverlay}
         explanation={explanation}
+        // disable when input is inactive (e.g., overlay open)
+        isActive={active}
       />
     );
   }

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -205,9 +205,6 @@ export default function TerminalChat({
     );
   }
 
-  // We intentionally omit 'approvalPolicy' and 'confirmationPrompt' from the deps
-  // so switching modes or showing confirmation dialogs doesn’t tear down the loop.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     // Skip recreating the agent if awaiting a decision on a pending confirmation
     if (confirmationPrompt != null) {
@@ -303,6 +300,9 @@ export default function TerminalChat({
       agentRef.current = undefined;
       forceUpdate(); // re‑render after teardown too
     };
+  // We intentionally omit 'approvalPolicy' and 'confirmationPrompt' from the deps
+  // so switching modes or showing confirmation dialogs doesn’t tear down the loop.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     model,
     config,

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -205,6 +205,9 @@ export default function TerminalChat({
     );
   }
 
+  // We intentionally omit 'approvalPolicy' and 'confirmationPrompt' from the deps
+  // so switching modes or showing confirmation dialogs doesn’t tear down the loop.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
   useEffect(() => {
     // Skip recreating the agent if awaiting a decision on a pending confirmation
     if (confirmationPrompt != null) {
@@ -594,7 +597,7 @@ export default function TerminalChat({
               setApprovalPolicy(newMode as ApprovalPolicy);
               // update existing AgentLoop instance
               if (agentRef.current) {
-                (agentRef.current as any).approvalPolicy = newMode as ApprovalPolicy;
+                (agentRef.current as unknown as { approvalPolicy: ApprovalPolicy }).approvalPolicy = newMode as ApprovalPolicy;
               }
               setItems((prev) => [
                 ...prev,


### PR DESCRIPTION
Implements https://github.com/openai/codex/issues/392

When the user is in suggest or auto-edit mode and gets an approval request, they now have an option in the `Shell Command` dialog to: `Switch approval mode (v)`

That option brings up the standard `Switch approval mode` dialog, allowing the user to switch into the desired mode, then drops them back to the `Shell Command` dialog's `Allow command?` prompt, allowing them to approve the current command and let the agent continue doing the rest of what it was doing without interruption.
```
╭────────────────────────────────────────────────────────
│Shell Command
│                          
│$ apply_patch << 'PATCH'    
│*** Begin Patch                      
│*** Update File: foo.txt          
│@@ -1 +1 @@                         
│-foo                                          
│+bar                                         
│*** End Patch                         
│PATCH                                    
│                                                
│                                                
│Allow command?                   
│                                                
│    Yes (y)                                
│    Explain this command (x) 
│    Edit or give feedback (e)  
│    Switch approval mode (v)
│    No, and keep going (n)    
│    No, and stop for now (esc)
╰────────────────────────────────────────────────────────╭────────────────────────────────────────────────────────
│ Switch approval mode      
│ Current mode: suggest  
│                                          
│                                          
│                                          
│ ❯ suggest                        
│   auto-edit                       
│   full-auto                        
│ type to search · enter to confirm · esc to cancel 
╰────────────────────────────────────────────────────────
```
