### PR TITLE
re-enable Prettier check for codex-cli in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,11 @@ jobs:
 
       # Run all tasks using workspace filters
 
-      - name: Check formatting
+      - name: Check TypeScript code formatting
+        working-directory: codex-cli
+        run: pnpm run format
+
+      - name: Check Markdown and config file formatting
         run: pnpm run format
 
       - name: Run tests

--- a/codex-cli/src/components/chat/terminal-chat-command-review.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-command-review.tsx
@@ -121,46 +121,47 @@ export function TerminalChatCommandReview({
 
   useInput(
     (input, key) => {
-    if (mode === "select") {
-      if (input === "y") {
-        onReviewCommand(ReviewDecision.YES);
-      } else if (input === "x") {
-        onReviewCommand(ReviewDecision.EXPLAIN);
-      } else if (input === "e") {
-        setMode("input");
-      } else if (input === "n") {
-        onReviewCommand(
-          ReviewDecision.NO_CONTINUE,
-          "Don't do that, keep going though",
-        );
-      } else if (input === "a" && showAlwaysApprove) {
-        onReviewCommand(ReviewDecision.ALWAYS);
-      } else if (input === "s") {
-        // switch approval mode
-        onSwitchApprovalMode();
-      } else if (key.escape) {
-        onReviewCommand(ReviewDecision.NO_EXIT);
+      if (mode === "select") {
+        if (input === "y") {
+          onReviewCommand(ReviewDecision.YES);
+        } else if (input === "x") {
+          onReviewCommand(ReviewDecision.EXPLAIN);
+        } else if (input === "e") {
+          setMode("input");
+        } else if (input === "n") {
+          onReviewCommand(
+            ReviewDecision.NO_CONTINUE,
+            "Don't do that, keep going though",
+          );
+        } else if (input === "a" && showAlwaysApprove) {
+          onReviewCommand(ReviewDecision.ALWAYS);
+        } else if (input === "s") {
+          // switch approval mode
+          onSwitchApprovalMode();
+        } else if (key.escape) {
+          onReviewCommand(ReviewDecision.NO_EXIT);
+        }
+      } else if (mode === "explanation") {
+        // When in explanation mode, any key returns to select mode
+        if (key.return || key.escape || input === "x") {
+          setMode("select");
+        }
+      } else {
+        // text entry mode
+        if (key.return) {
+          // if user hit enter on empty msg, fall back to DEFAULT_DENY_MESSAGE
+          const custom = msg.trim() === "" ? DEFAULT_DENY_MESSAGE : msg;
+          onReviewCommand(ReviewDecision.NO_CONTINUE, custom);
+        } else if (key.escape) {
+          // treat escape as denial with default message as well
+          onReviewCommand(
+            ReviewDecision.NO_CONTINUE,
+            msg.trim() === "" ? DEFAULT_DENY_MESSAGE : msg,
+          );
+        }
       }
-    } else if (mode === "explanation") {
-      // When in explanation mode, any key returns to select mode
-      if (key.return || key.escape || input === "x") {
-        setMode("select");
-      }
-    } else {
-      // text entry mode
-      if (key.return) {
-        // if user hit enter on empty msg, fall back to DEFAULT_DENY_MESSAGE
-        const custom = msg.trim() === "" ? DEFAULT_DENY_MESSAGE : msg;
-        onReviewCommand(ReviewDecision.NO_CONTINUE, custom);
-      } else if (key.escape) {
-        // treat escape as denial with default message as well
-        onReviewCommand(
-          ReviewDecision.NO_CONTINUE,
-          msg.trim() === "" ? DEFAULT_DENY_MESSAGE : msg,
-        );
-      }
-    }
-    }, { isActive }
+    },
+    { isActive },
   );
 
   return (

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -300,15 +300,10 @@ export default function TerminalChat({
       agentRef.current = undefined;
       forceUpdate(); // re‑render after teardown too
     };
-  // We intentionally omit 'approvalPolicy' and 'confirmationPrompt' from the deps
-  // so switching modes or showing confirmation dialogs doesn’t tear down the loop.
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    model,
-    config,
-    requestConfirmation,
-    additionalWritableRoots,
-  ]);
+    // We intentionally omit 'approvalPolicy' and 'confirmationPrompt' from the deps
+    // so switching modes or showing confirmation dialogs doesn’t tear down the loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [model, config, requestConfirmation, additionalWritableRoots]);
 
   // whenever loading starts/stops, reset or start a timer — but pause the
   // timer while a confirmation overlay is displayed so we don't trigger a
@@ -597,7 +592,11 @@ export default function TerminalChat({
               setApprovalPolicy(newMode as ApprovalPolicy);
               // update existing AgentLoop instance
               if (agentRef.current) {
-                (agentRef.current as unknown as { approvalPolicy: ApprovalPolicy }).approvalPolicy = newMode as ApprovalPolicy;
+                (
+                  agentRef.current as unknown as {
+                    approvalPolicy: ApprovalPolicy;
+                  }
+                ).approvalPolicy = newMode as ApprovalPolicy;
               }
               setItems((prev) => [
                 ...prev,

--- a/codex-cli/tests/input-utils.test.ts
+++ b/codex-cli/tests/input-utils.test.ts
@@ -14,9 +14,13 @@ describe("createInputItem", () => {
 
   it("includes image content for existing file", async () => {
     const fakeBuffer = Buffer.from("fake image content");
-    const readSpy = vi.spyOn(fs, "readFile").mockResolvedValue(fakeBuffer as any);
+    const readSpy = vi
+      .spyOn(fs, "readFile")
+      .mockResolvedValue(fakeBuffer as any);
     const result = await createInputItem("hello", ["dummy-path"]);
-    const expectedUrl = `data:application/octet-stream;base64,${fakeBuffer.toString("base64")}`;
+    const expectedUrl = `data:application/octet-stream;base64,${fakeBuffer.toString(
+      "base64",
+    )}`;
     expect(result.role).toBe("user");
     expect(result.type).toBe("message");
     expect(result.content.length).toBe(2);


### PR DESCRIPTION
This check was lost in https://github.com/openai/codex/pull/287. Both the root folder and `codex-cli/` have their own `pnpm format` commands that check the formatting of different things.

Also ran `pnpm format:fix` to fix the formatting violations that got in while this was disabled in CI.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/417).
* #420
* #419
* #416
* __->__ #417