### PR TITLE
feat: add support for `/diff` command autocomplete in TerminalChatInput

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -168,6 +168,9 @@ export default function TerminalChatInput({
                 case "/approval":
                   openApprovalOverlay();
                   break;
+                case "/diff":
+                  openDiffOverlay();
+                  break;
                 case "/bug":
                   onSubmit(cmd);
                   break;


### PR DESCRIPTION
It's not working without this