### PR TITLE
feat: add repository-specific configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ The hardening mechanism Codex uses depends on your OS:
 | `codex -q "…"`                       | Non‑interactive "quiet mode"        | `codex -q --json "explain utils.ts"` |
 | `codex completion <bash\|zsh\|fish>` | Print shell completion script       | `codex completion bash`              |
 
-Key flags: `--model/-m`, `--approval-mode/-a`, `--quiet/-q`, and `--notify`.
+Key flags: `--model/-m`, `--approval-mode/-a`, `--quiet/-q`, `--no-repo-config`, and `--notify`.
 
 ---
 
@@ -281,7 +281,11 @@ pnpm link
 
 ## Configuration
 
-Codex looks for config files in **`~/.codex/`** (either YAML or JSON format).
+Codex supports both global and repository-specific configuration files in YAML or JSON format.
+
+### Global Configuration
+
+Global configuration is stored in **`~/.codex/`**:
 
 ```yaml
 # ~/.codex/config.yaml
@@ -303,6 +307,24 @@ safeCommands:
   "notify": true
 }
 ```
+
+### Repository-Specific Configuration
+
+You can also define repository-specific configuration in **`./.codex/config.json`** or **`./.codex/config.yaml`** within your project:
+
+```yaml
+# ./.codex/config.yaml
+model: gpt-4.1 # Override model for this repository
+approvalMode: auto-edit # Different approval mode for this project
+safeCommands:
+  - npm run build # Project-specific safe commands
+```
+
+Repository-specific configuration takes precedence over global configuration. Codex will look for config files in the current directory first, then walk up to the Git root directory.
+
+You can disable repository-specific configuration with the `--no-repo-config` flag.
+
+### Custom Instructions
 
 You can also define custom instructions:
 

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -68,6 +68,7 @@ const cli = meow(
 
     --no-project-doc           Do not automatically include the repository's 'codex.md'
     --project-doc <file>       Include an additional markdown file at <file> as context
+    --no-repo-config           Do not load repository-specific configuration from .codex/config.json
     --full-stdout              Do not truncate stdout/stderr from command outputs
     --notify                   Enable desktop notifications for responses
 
@@ -142,6 +143,10 @@ const cli = meow(
       projectDoc: {
         type: "string",
         description: "Path to a markdown file to include as project doc",
+      },
+      noRepoConfig: {
+        type: "boolean",
+        description: "Disable repository-specific configuration",
       },
       flexMode: {
         type: "boolean",
@@ -248,6 +253,7 @@ let config = loadConfig(undefined, undefined, {
   disableProjectDoc: Boolean(cli.flags.noProjectDoc),
   projectDocPath: cli.flags.projectDoc as string | undefined,
   isFullContext: fullContextMode,
+  disableRepoConfig: Boolean(cli.flags.noRepoConfig),
 });
 
 const prompt = cli.input[0];

--- a/codex-cli/tests/config.test.tsx
+++ b/codex-cli/tests/config.test.tsx
@@ -1,6 +1,12 @@
 import type * as fsType from "fs";
 
-import { loadConfig, saveConfig, saveRepoConfig, discoverRepoConfigPath, REPO_CONFIG_JSON_FILEPATH } from "../src/utils/config.js"; // parent import first
+import {
+  loadConfig,
+  saveConfig,
+  saveRepoConfig,
+  discoverRepoConfigPath,
+  REPO_CONFIG_JSON_FILEPATH,
+} from "../src/utils/config.js"; // parent import first
 import { AutoApprovalMode } from "../src/utils/auto-approval-mode.js";
 import { tmpdir } from "os";
 import { join } from "path";


### PR DESCRIPTION
## Description
This PR implements repository-specific configuration support, addressing issue #430. Users can now define configuration specific to a repository in `./.codex/config.json` or `./.codex/config.yaml`, which takes precedence over global configuration.

## Changes
- Added support for loading configuration from `./.codex/config.json` or `./.codex/config.yaml`
- Implemented a merging strategy that allows repository-specific configuration to override global configuration
- Added support for walking up to the Git root to find repository configuration
- Added a `--no-repo-config` flag to disable repository-specific configuration
- Updated documentation to explain the new feature
- Added comprehensive tests for the new functionality

## Testing
- Added new tests specifically for repository-specific configuration
- All existing tests continue to pass
- Verified proper merging of global and repository-specific configurations
- Tested the `--no-repo-config` flag to ensure it correctly disables repository-specific configuration

## Documentation
- Updated README.md with detailed information about repository-specific configuration
- Added examples of how to use the feature
- Updated CLI help text to include the new `--no-repo-config` flag

Fixes #430