### PR TITLE
feat: enable Shift+Enter to insert a newline for multi-line input without submitting.

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -102,6 +102,11 @@ export default function TerminalChatInput({
 
   useInput(
     (_input, _key) => {
+      // Support Shift+Enter for new line
+      if (_key.shift && _key.return) {
+        setInput((prev) => prev + "\n");
+        return;
+      }
       // Slash command navigation: up/down to select, enter to fill
       if (!confirmationPrompt && !loading && input.trim().startsWith("/")) {
         const prefix = input.trim();


### PR DESCRIPTION
## What
- Detect `Shift+Enter` in the input prompt and append a newline for multi-line input

**Closes** #344
**Closes** #441 