### PR TITLE
fix: auto-open model-selector when model is not found

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat-response-item.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-response-item.tsx
@@ -117,7 +117,7 @@ function TerminalChatResponseMessage({
       const systemMessage = message.content.find(
         (c) => c.type === "input_text",
       )?.text;
-      if (systemMessage?.includes("has been deprecated")) {
+      if (systemMessage?.includes("model_not_found")) {
         setOverlayMode?.("model");
       }
     }


### PR DESCRIPTION
Change the check from checking if the model has been deprecated to check if the model_not_found

https://github.com/user-attachments/assets/ad0f7daf-5eb4-4e4b-89e5-04240044c64f

