### PR TITLE
fix: allow proper exit from new Switch approval mode dialog

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -482,7 +482,7 @@ export default function TerminalChat({
             <Text color="gray">Initializing agent…</Text>
           </Box>
         )}
-        {agent && (
+        {overlayMode === "none" && agent && (
           <TerminalChatInput
             loading={loading}
             setItems={setItems}


### PR DESCRIPTION
As described in  https://github.com/openai/codex/issues/392#issuecomment-2817090022 introduced by #400 

The testing I'd done worked correctly because I was using the (s) shortcut, but selecting the same option using arrow‑key → Enter on “Switch approval mode” was preventing the user from subsequently exiting the Switch approval mode dialog, requiring a ^C to quit codex entirely. With this fix, both entry methods work correctly in my testing.

Per codex:

Issue

 - When you navigated down (↓) to “Switch approval mode (s)” in the Shell Command review dialog and pressed Enter, the ApprovalModeOverlay would open—but because the underlying `TerminalChatCommandReview` component stayed mounted (albeit disabled), its own Ink input handlers immediately re‑captured the same key events and re‑opened the overlay as soon as you hit Esc or Enter again. In practice this made it impossible to exit the submenu.

Root cause

 - We only disabled the SelectInput via `isDisabled`, but never fully unmounted the review UI when an overlay was shown, so its `useInput` and `<Select>` hooks were still active and “stealing” keys.

Fix

 - In `terminal-chat.tsx` we now only render `<TerminalChatInput>` (and by extension `TerminalChatCommandReview`) when `overlayMode === "none"`. That unmounts all of its key handlers whenever any overlay (history, model, approval, help, diff) is open, so no input leaks through.

Files changed

 - **src/components/chat/terminal-chat.tsx**: Wrapped the entire `<TerminalChatInput>` block in `overlayMode === "none" && agent`

With that in place, arrow‑key → Enter on “Switch approval mode” correctly opens the overlay, and then you can use Enter/Esc inside the overlay without getting stuck or immediately re‑opening it.
