### PR TITLE
Remove `README.md` and `bin` from `package.json#files` field

### DIFF
--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -26,8 +26,6 @@
     "release": "pnpm run release:readme && pnpm run release:version && pnpm install && pnpm run release:build-and-publish"
   },
   "files": [
-    "README.md",
-    "bin",
     "dist",
     "src"
   ],


### PR DESCRIPTION
This PR removes always included files and folders from the [`package.json#files` field](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files):

> Certain files are always included, regardless of settings:
> - package.json
> - README
> - LICENSE / LICENCE
> - The file in the "main" field
> - The file(s) in the "bin" field

Validated by running `pnpm i && cd codex-cli && pnpm build && pnpm release:readme && pnpm pack` and confirming both the `README.md` file and `bin` directory are still included in the tarball:

<img width="227" alt="image" src="https://github.com/user-attachments/assets/ecd90a07-73c7-4940-8c83-cb1d51dfcf96" />
