### PR TITLE
chore: drop src from publish

### DIFF
--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -26,8 +26,7 @@
     "release": "pnpm run release:readme && pnpm run release:version && pnpm install && pnpm run release:build-and-publish"
   },
   "files": [
-    "dist",
-    "src"
+    "dist"
   ],
   "dependencies": {
     "@inkjs/ui": "^2.0.0",


### PR DESCRIPTION
Publish shouldn't need the source files published along with the distributable bin.

`src` is being shipped to the registry rn: https://www.npmjs.com/package/@openai/codex?activeTab=code

You can verify that the src is not needed by packing the project manually after removing src from the files:

```sh
# from the codex-cli dir
rm -rf dist # just for hygiene
pnpm run build
pnpm pack

mkdir /tmp/codex-tar-test
mv openai-codex-0.1.2504181820.tgz /tmp/codex-tar-test
cd /tmp/codex-tar-test

pnpm init
pnpm add ./openai-codex-0.1.2504181820.tgz /tmp/codex-tar-test
pnpm exec codex --full-auto "run a bash -c command to echo hello world"
```

The cli is operational

> noticed this when checking the screenshot included in https://github.com/openai/codex/pull/461