### PR TITLE
chore(build): cleanup dist before build

### DIFF
--- a/codex-cli/build.mjs
+++ b/codex-cli/build.mjs
@@ -1,6 +1,8 @@
 import * as esbuild from "esbuild";
 import * as fs from "fs";
 import * as path from "path";
+
+const OUT_DIR = 'dist'
 /**
  * ink attempts to import react-devtools-core in an ESM-unfriendly way:
  *
@@ -39,6 +41,11 @@ const isDevBuild =
 
 const plugins = [ignoreReactDevToolsPlugin];
 
+// Build Hygiene, ensure we drop previous dist dir and any leftover files
+const outPath = path.resolve(OUT_DIR);
+if (fs.existsSync(outPath)) {
+  fs.rmSync(outPath, { recursive: true, force: true });
+}
 
 // Add a shebang that enables source‑map support for dev builds so that stack
 // traces point to the original TypeScript lines without requiring callers to
@@ -50,7 +57,7 @@ if (isDevBuild) {
     name: "dev-shebang",
     setup(build) {
       build.onEnd(async () => {
-        const outFile = path.resolve(isDevBuild ? "dist/cli-dev.js" : "dist/cli.js");
+        const outFile = path.resolve(isDevBuild ? `${OUT_DIR}/cli-dev.js` : `${OUT_DIR}/cli.js`);
         let code = await fs.promises.readFile(outFile, "utf8");
         if (code.startsWith("#!")) {
           code = code.replace(/^#!.*\n/, devShebangLine);
@@ -69,7 +76,7 @@ esbuild
     format: "esm",
     platform: "node",
     tsconfig: "tsconfig.json",
-    outfile: isDevBuild ? "dist/cli-dev.js" : "dist/cli.js",
+    outfile: isDevBuild ? `${OUT_DIR}/cli-dev.js` : `${OUT_DIR}/cli.js`,
     minify: !isDevBuild,
     sourcemap: isDevBuild ? "inline" : true,
     plugins,


### PR DESCRIPTION
Another one that I noticed.

The dist structure is very simple rn, so unlikely to run into orphaned files as you're emitting a single built artifact which wil be overwritten on build, but I always prefer to do clean builds as "hygiene".

I had a dirty dist personally after local development and testing some things, as an example.

Alternatives could be to create a `clean` script with cross platform `rimraf dist`