### PR TITLE
Add a PowerShell script that can better support Windows

### DIFF
--- a/codex-cli/scripts/build_container.ps1
+++ b/codex-cli/scripts/build_container.ps1
@@ -1,0 +1,23 @@
+#!/usr/bin/env pwsh
+# PowerShell 7.5
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+# Get the script's directory and navigate to the parent directory.
+$scriptDir = Split-Path $MyInvocation.MyCommand.Definition -Parent
+Push-Location (Join-Path $scriptDir '..')
+try {
+    & npm install
+    & npm run build
+    Remove-Item ./dist/openai-codex-*.tgz -Recurse -Force -ErrorAction Ignore
+    & npm pack --pack-destination ./dist
+    Move-Item ./dist/openai-codex-*.tgz ./dist/codex.tgz -Force
+
+    # Dockerfile Patch to Resolve Permission Issues on Windows
+    echo 'git config --global --add safe.directory /app' >> ./Dockerfile
+
+    & docker build -t codex -f './Dockerfile' .
+}
+finally {
+    Pop-Location
+}

--- a/codex-cli/scripts/run_in_container.ps1
+++ b/codex-cli/scripts/run_in_container.ps1
@@ -1,0 +1,56 @@
+#!/usr/bin/env pwsh
+# PowerShell 7.5
+<#
+Usage:
+  .\run_in_container.ps1 [-WorkDir <directory>] -- <PROMPT>
+Example:
+  .\run_in_container.ps1 -WorkDir G:\Projects\demo1 -- "explain this codebase to me"
+  .\run_in_container.ps1
+#>
+
+param(
+    [string]$WorkDir = (Get-Location).ProviderPath,
+    [string]$OPENAI_API_KEY,
+    [Parameter(ValueFromRemainingArguments)] [string[]]$Args
+)
+
+$WorkDir = (Get-Item $WorkDir).FullName
+$containerName = 'codex_' + ($WorkDir -replace '[\\/]', '_' -replace '[^0-9A-Za-z_-]', '')
+
+# Check whether OPENAI_API_KEY has been passed as a parameter or set in environment variables.
+if (-not $OPENAI_API_KEY) {
+    if (-not $env:OPENAI_API_KEY) {
+        Write-Error 'An OPENAI_API_KEY parameter or an environment variable must be provided.'
+        exit 1
+    }
+} else {
+    $env:OPENAI_API_KEY = $OPENAI_API_KEY
+}
+
+function Cleanup {
+    docker rm -f $containerName 2> $null
+}
+
+function Quote-BashArg {
+    param([string]$Value)
+    return "'$($Value -replace "'", "''\'''")'"
+}
+
+try {
+    Cleanup  # Remove old container
+
+    docker run --name $containerName -d `
+        -e OPENAI_API_KEY `
+        --cap-add=NET_ADMIN --cap-add=NET_RAW `
+        -v "${WorkDir}:/app" `
+        codex sleep infinity | Out-Null
+
+    docker exec $containerName bash -c 'sudo /usr/local/bin/init_firewall.sh'
+
+    $quoted = ($Args | ForEach-Object { Quote-BashArg $_ }) -join ' '
+
+    docker exec -it $containerName bash -c "cd '/app' && codex --full-auto $quoted"
+}
+finally {
+    Register-EngineEvent PowerShell.Exiting -Action { Cleanup } | Out-Null
+}


### PR DESCRIPTION
This pull request introduces two new PowerShell scripts to streamline the workflow for building and running the `codex` container. These scripts aim to simplify container management and improve usability, especially for Windows users. Below are the key changes:

### New Build Script (`build_container.ps1`)

* Added a PowerShell script to automate the build process for the `codex` container. It includes steps for dependency installation, packaging, and Docker image creation, along with a patch to resolve permission issues on Windows.

### New Run Script (`run_in_container.ps1`)

* Added a PowerShell script to facilitate running the `codex` container. It supports setting the working directory, handling the `OPENAI_API_KEY` via parameters or environment variables, and passing prompts to the containerized application. The script also includes cleanup logic for old containers and utilities for argument quoting.