### PR TITLE
fix: correct fish completion function name in CLI script

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -190,7 +190,7 @@ _codex() {
 }
 _codex`,
     fish: `# fish completion for codex
-complete -c codex -a '(_fish_complete_path)' -d 'file path'`,
+complete -c codex -a '(__fish_complete_path)' -d 'file path'`,
   };
   const script = scripts[shell];
   if (!script) {


### PR DESCRIPTION
Missing an underscore.

fish function: https://github.com/fish-shell/fish-shell/blob/master/share/functions/__fish_complete_path.fish

fixes https://github.com/openai/codex/issues/469