### PR TITLE
feat: add TensorZero provider

### DIFF
--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -55,6 +55,9 @@ export function getApiKey(provider: string): string | undefined {
     if (providerInfo.name === "Ollama") {
       return process.env[providerInfo.envKey] ?? "dummy";
     }
+    if (providerInfo.name === "TensorZero") {
+      return process.env[providerInfo.envKey] ?? "dummy";
+    }
     return process.env[providerInfo.envKey];
   }
 

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -42,4 +42,9 @@ export const providers: Record<
     baseURL: "https://api.groq.com/openai/v1",
     envKey: "GROQ_API_KEY",
   },
+  tensorzero: {
+    name: "TensorZero",
+    baseURL: "http://localhost:3000/openai/v1",
+    envKey: "TENSORZERO_API_KEY",
+  },
 };


### PR DESCRIPTION
This PR adds TensorZero as a provider.

TensorZero is an open-source (Apache 2.0) framework for building and optimizing LLM applications:

https://github.com/tensorzero/tensorzero

This will enable Codex users to access different models, manage their data in a local database, run optimization experiments, and more.

Please let me know if you have any questions. Thanks!

## Usage

Assuming the TensorZero Gateway ([Quick Start](https://www.tensorzero.com/docs/quickstart/)) is running locally on port 3000 (default), you can use Codex (built from source) like:

```
node codex-cli/dist/cli.js -p tensorzero -m tensorzero::model_name::openai::gpt-4o-mini
```

You can use any model or function that would be available through our OpenAI-compatible inference API (i.e. `tensorzero::model_name::xxx` or `tensorzero::function_name::xxx`).