### PR TITLE
fix: broken invariants in agent-loop, "400 No tool output found"

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -119,8 +119,6 @@ export class AgentLoop {
       return;
     }
 
-    // Reset the current stream to allow new requests
-    this.currentStream = null;
     log(
       `AgentLoop.cancel() invoked – currentStream=${Boolean(
         this.currentStream,
@@ -131,6 +129,9 @@ export class AgentLoop {
     (
       this.currentStream as { controller?: { abort?: () => void } } | null
     )?.controller?.abort?.();
+
+    // Reset the current stream to allow new requests
+    this.currentStream = null;
 
     this.canceled = true;
 

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -860,13 +860,16 @@ export class AgentLoop {
               this.onItem(item);
             }
           }
+          // guarading clear
+          // because we may still enter this after abort
+          this.pendingAborts.clear();
         }
 
         // At this point the turn finished without the user invoking
         // `cancel()`.  Any outstanding function‑calls must therefore have been
         // satisfied, so we can safely clear the set that tracks pending aborts
         // to avoid emitting duplicate synthetic outputs in subsequent runs.
-        this.pendingAborts.clear();
+        // this.pendingAborts.clear();
         // Now emit system messages recording the per‑turn *and* cumulative
         // thinking times so UIs and tests can surface/verify them.
         // const thinkingEnd = Date.now();


### PR DESCRIPTION
### I'm not certain this fully fixes the issue, but these changes address several clear problems in the current cancellation flow

This is a draft because I think we can do better still, and I welcome pushes to this PR or publishing if yall wanna run with it.

There is an issue of broken invariants, where we are running logic such as `flush` even though the code as written expects it will not run after `cancel`.

related to #114 aka `400 No tool output found for function call`.

## Problem 1: Abort Controller is null

Upon cancel, we attempt to abort the stream via abortController. 

After #178 we are nulling out the handle to the stream BEFORE we call the abort method on its controller.  TS assertions hide that fact from the compiler, giving us a silent no-op instead of an abort:
https://github.com/openai/codex/blob/09f0ae3899910995ac9659504739e16363d7176c/codex-cli/src/utils/agent/agent-loop.ts#L122-L133

This means cancel will not abort the stream, and we continue processing events.

## Problem 2: Broken control flow expectations

Problem 1 is an issue, but not one that should lead to the `400 No tool output found for function call`.

The agent loop is written in such a way that it appears to expect to break out of the async iterator loop when the stream is aborted. **That never actually happens even after fixing Problem 1** and you can confirm that w/ a console.log in the catch handler.

https://github.com/openai/codex/blob/09f0ae3899910995ac9659504739e16363d7176c/codex-cli/src/utils/agent/agent-loop.ts#L790-L800

That is the broken invariant. When we do not break out of the loop on abort, we continue processing events, and our cleanup code later runs.

"Fix Problem 1, and Problem 2 heals itself then" you may say. Under testing, it does not! I have not observed the `catch` executing in response to a proper abort.

> The implementation of the Stream in the openai sdk does not seem to bubble up aborts, but will instead return silently. (assuming that i've located the codepath correctly here) https://github.com/openai/openai-node/blob/2785c1186b528e4ab3a2a7c9282e041aaa4c13f6/src/streaming.ts#L82-L85

## Problem 3 -- Inconsistent State Guards

There are inconsistent `canceled` state guards in the event processing and leads to state drift when we realize that:
1. Problem 1 meant we continue to process the stream
2. Problem 2 means that we will run cleanup code `flush` even though we may have `this.canceled === true` impacting the processing of events.

With probelm 2 being the broken invariant, the rest of the flow gets unpredictable. Most places are guarded, like
https://github.com/openai/codex/blob/09f0ae3899910995ac9659504739e16363d7176c/codex-cli/src/utils/agent/agent-loop.ts#L1112-L1121

**But we will still increment the `lastReponseId` even when we are in a cancel situation, and stopped processing function calls.**

I focused on the `flush` code. It will unconditionally clear the `pendingAborts` array, despite it expecting that we are in a cancel free state. I didn't trace the exact specifics to limit my brain running out of context space for while debugging these async flows.

## Solution

Well, I ran out of time to really come up with a bullet proof solution. Testing this is difficult, as it relies on timing. Asking to prefix tool runs w/ sleep can help a bit, but I had a harder time reproing today vs last week.

**For now, ensuring Abort actually is triggered, and guarding the flush is an improvement**

Ideally, we can get the throw to happen on an abort, or otherwise return early from the processing. That's the smallest surgical fix until this logic can be reworked to be entirely signal aware. I propose that in the near future instead of a canceled flag,  we observe the AbortSignal as the single source of truth for cancellation state and esnure it propogates consistently through all operations.

### bugbears

Stream processing can be finicky, as you may still receive buffered events after a stream has been canceled. Idk how this maps exactly to async generators

Once the abort is successful, assuming we have no more events that leak out, we can't easily break from the loop and return early. I wasn't able to consistently repro today getting another event even when we are in the canceled state, but throwing a manually constructed `AbortError` if we process an event during `this.canceled === true` would fix the control flow.

>  p.s. I include this note whenever I’ve spent significant time on a contribution to a project I don’t maintain. It’s part disclosure, part invitation. ❤️
>
> this investigation took a few days of work to fully unwind and validate. working on open source full-time has given me the freedom to do the kind of deep, slow, careful work that rarely fits into a sprint. that freedom made this fix possible.
>
> if this kind of work resonates with you, or you want to connect about open source systems work more broadly, feel free to reach out.