### PR TITLE
feat: add CLI –version flag

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -13,7 +13,6 @@ import type { ResponseItem } from "openai/resources/responses/responses";
 
 import App from "./app";
 import { runSinglePass } from "./cli-singlepass";
-import { version } from "../package.json";
 import { AgentLoop } from "./utils/agent/agent-loop";
 import { ReviewDecision } from "./utils/agent/review";
 import { AutoApprovalMode } from "./utils/auto-approval-mode";
@@ -203,13 +202,6 @@ complete -c codex -a '(__fish_complete_path)' -d 'file path'`,
   }
   // eslint-disable-next-line no-console
   console.log(script);
-  process.exit(0);
-}
-
-// Handle --version flag
-if (cli.flags.version) {
-  // eslint-disable-next-line no-console
-  console.log(version);
   process.exit(0);
 }
 

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -52,8 +52,9 @@ const cli = meow(
     $ codex completion <bash|zsh|fish>
 
   Options
-    -h, --help                      Show usage and exit
     --version                       Print version and exit
+
+    -h, --help                      Show usage and exit
     -m, --model <model>             Model to use for completions (default: o4-mini)
     -p, --provider <provider>       Provider to use for completions (default: openai)
     -i, --image <path>              Path(s) to image files to include as input

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -13,6 +13,7 @@ import type { ResponseItem } from "openai/resources/responses/responses";
 
 import App from "./app";
 import { runSinglePass } from "./cli-singlepass";
+import { version } from "../package.json";
 import { AgentLoop } from "./utils/agent/agent-loop";
 import { ReviewDecision } from "./utils/agent/review";
 import { AutoApprovalMode } from "./utils/auto-approval-mode";
@@ -35,7 +36,6 @@ import { render } from "ink";
 import meow from "meow";
 import path from "path";
 import React from "react";
-import { version } from "../package.json";
 
 // Call this early so `tail -F "$TMPDIR/oai-codex/codex-cli-latest.log"` works
 // immediately. This must be run with DEBUG=1 for logging to work.
@@ -208,6 +208,7 @@ complete -c codex -a '(__fish_complete_path)' -d 'file path'`,
 
 // Handle --version flag
 if (cli.flags.version) {
+  // eslint-disable-next-line no-console
   console.log(version);
   process.exit(0);
 }

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -35,6 +35,7 @@ import { render } from "ink";
 import meow from "meow";
 import path from "path";
 import React from "react";
+import { version } from "../package.json";
 
 // Call this early so `tail -F "$TMPDIR/oai-codex/codex-cli-latest.log"` works
 // immediately. This must be run with DEBUG=1 for logging to work.
@@ -53,6 +54,7 @@ const cli = meow(
 
   Options
     -h, --help                      Show usage and exit
+    --version                       Print version and exit
     -m, --model <model>             Model to use for completions (default: o4-mini)
     -i, --image <path>              Path(s) to image files to include as input
     -v, --view <rollout>            Inspect a previously saved rollout instead of starting a session
@@ -93,6 +95,7 @@ const cli = meow(
     flags: {
       // misc
       help: { type: "boolean", aliases: ["h"] },
+      version: { type: "boolean", description: "Print version and exit" },
       view: { type: "string" },
       model: { type: "string", aliases: ["m"] },
       provider: { type: "string", aliases: ["p"] },
@@ -200,6 +203,12 @@ complete -c codex -a '(__fish_complete_path)' -d 'file path'`,
   }
   // eslint-disable-next-line no-console
   console.log(script);
+  process.exit(0);
+}
+
+// Handle --version flag
+if (cli.flags.version) {
+  console.log(version);
   process.exit(0);
 }
 


### PR DESCRIPTION
Adds a new flag to cli `--version` that prints the current version and exits