### PR TITLE
bump(version): 0.1.2504211509

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,38 @@
 
 You can install any of these versions: `npm install -g codex@version`
 
+## `0.1.2504211509`
+
+### 🚀 Features
+
+- Support multiple providers via Responses-Completion transformation (#247)
+- Add user-defined safe commands configuration and approval logic #380 (#386)
+- Allow switching approval modes when prompted to approve an edit/command (#400)
+- Add support for `/diff` command autocomplete in TerminalChatInput (#431)
+- Auto-open model selector if user selects deprecated model (#427)
+- Read approvalMode from config file (#298)
+- `/diff` command to view git diff (#426)
+- Tab completions for file paths (#279)
+- Add /command autocomplete (#317)
+- Allow multi-line input (#438)
+
+### 🐛 Bug Fixes
+
+- `full-auto` support in quiet mode (#374)
+- Enable shell option for child process execution (#391)
+- Configure husky and lint-staged for pnpm monorepo (#384)
+- Command pipe execution by improving shell detection (#437)
+- Name of the file not matching the name of the component (#354)
+- Allow proper exit from new Switch approval mode dialog (#453)
+- Ensure /clear resets context and exclude system messages from approximateTokenUsed count (#443)
+- `/clear` now clears terminal screen and resets context left indicator (#425)
+- Correct fish completion function name in CLI script (#485)
+- Auto-open model-selector when model is not found (#448)
+- Remove unnecessary isLoggingEnabled() checks (#420)
+- Improve test reliability for `raw-exec` (#434)
+- Unintended tear down of agent loop (#483)
+- Remove extraneous type casts (#462)
+
 ## `0.1.2504181820`
 
 ### 🚀 Features

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex",
-  "version": "0.1.2504181820",
+  "version": "0.1.2504211509",
   "license": "Apache-2.0",
   "bin": {
     "codex": "bin/codex.js"

--- a/codex-cli/src/utils/session.ts
+++ b/codex-cli/src/utils/session.ts
@@ -1,4 +1,4 @@
-export const CLI_VERSION = "0.1.2504181820"; // Must be in sync with package.json.
+export const CLI_VERSION = "0.1.2504211509"; // Must be in sync with package.json.
 export const ORIGIN = "codex_cli_ts";
 
 export type TerminalChatSession = {


### PR DESCRIPTION
## `0.1.2504211509`

### 🚀 Features

- Support multiple providers via Responses-Completion transformation (#247)
- Add user-defined safe commands configuration and approval logic #380 (#386)
- Allow switching approval modes when prompted to approve an edit/command (#400)
- Add support for `/diff` command autocomplete in TerminalChatInput (#431)
- Auto-open model selector if user selects deprecated model (#427)
- Read approvalMode from config file (#298)
- `/diff` command to view git diff (#426)
- Tab completions for file paths (#279)
- Add /command autocomplete (#317)
- Allow multi-line input (#438)

### 🐛 Bug Fixes

- `full-auto` support in quiet mode (#374)
- Enable shell option for child process execution (#391)
- Configure husky and lint-staged for pnpm monorepo (#384)
- Command pipe execution by improving shell detection (#437)
- Name of the file not matching the name of the component (#354)
- Allow proper exit from new Switch approval mode dialog (#453)
- Ensure /clear resets context and exclude system messages from approximateTokenUsed count (#443)
- `/clear` now clears terminal screen and resets context left indicator (#425)
- Correct fish completion function name in CLI script (#485)
- Auto-open model-selector when model is not found (#448)
- Remove unnecessary isLoggingEnabled() checks (#420)
- Improve test reliability for `raw-exec` (#434)
- Unintended tear down of agent loop (#483)
- Remove extraneous type casts (#462)