### PR TITLE
feat: show notifications on non-macos clients

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -375,6 +375,9 @@ export default function TerminalChat({
             `display notification "${safePreview}" with title "${title}" subtitle "${cwd}" sound name "Ping"`,
           ]);
         }
+      } else {
+        // Non-macOS: ring terminal bell twice before prompt
+        process.stdout.write('\u0007\u0007'); // ... two here
       }
     }
     prevLoadingRef.current = loading;

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -377,7 +377,7 @@ export default function TerminalChat({
         }
       } else {
         // Non-macOS: ring terminal bell twice before prompt
-        process.stdout.write('\u0007\u0007'); // ... two here
+        process.stdout.write("\u0007\u0007"); // ... two here
       }
     }
     prevLoadingRef.current = loading;


### PR DESCRIPTION
Use 2 bells (ctrl-g) if --notify and non-mac client. Currently there is no-op for non Mac. Found this to be useful both for non-mac and for running in a docker container while on a Mac. 