### PR TITLE
feat: don't show warning when folder is managed by git, hg or sl

### DIFF
--- a/codex-cli/src/app.tsx
+++ b/codex-cli/src/app.tsx
@@ -4,7 +4,7 @@ import type { ResponseItem } from "openai/resources/responses/responses";
 
 import TerminalChat from "./components/chat/terminal-chat";
 import TerminalChatPastRollout from "./components/chat/terminal-chat-past-rollout";
-import { checkInGit } from "./utils/check-in-git";
+import { checkInVcs } from "./utils/check-in-vcs";
 import { CLI_VERSION, type TerminalChatSession } from "./utils/session.js";
 import { onExit } from "./utils/terminal";
 import { ConfirmInput } from "@inkjs/ui";
@@ -37,8 +37,8 @@ export default function App({
 }: Props): JSX.Element {
   const app = useApp();
   const [accepted, setAccepted] = useState(() => false);
-  const [cwd, inGitRepo] = useMemo(
-    () => [process.cwd(), checkInGit(process.cwd())],
+  const [cwd, inVcsRepo] = useMemo(
+    () => [process.cwd(), checkInVcs(process.cwd())],
     [],
   );
   const { internal_eventEmitter } = useStdin();
@@ -53,7 +53,7 @@ export default function App({
     );
   }
 
-  if (!inGitRepo && !accepted) {
+  if (!inVcsRepo && !accepted) {
     return (
       <Box flexDirection="column">
         <Box borderStyle="round" paddingX={1} width={64}>
@@ -72,8 +72,8 @@ export default function App({
         >
           <Text>
             <Text color="yellow">Warning!</Text> It can be dangerous to run a
-            coding agent outside of a git repo in case there are changes that
-            you want to revert. Do you want to continue?
+            coding agent outside of a source control managed folder in case
+            there are changes that you want to revert. Do you want to continue?
           </Text>
           <Text>{cwd}</Text>
           <ConfirmInput
@@ -83,7 +83,7 @@ export default function App({
               onExit();
               // eslint-disable-next-line
               console.error(
-                "Quitting! Run again to accept or from inside a git repo",
+                "Quitting! Run again to accept or from inside a source control managed folder",
               );
             }}
             onConfirm={() => setAccepted(true)}

--- a/codex-cli/src/utils/check-in-vcs.ts
+++ b/codex-cli/src/utils/check-in-vcs.ts
@@ -29,3 +29,45 @@ export function checkInGit(workdir: string): boolean {
     return false;
   }
 }
+
+/**
+ * Returns true if the given directory is part of a Mercurial (hg) repository.
+ *
+ * Uses the canonical Mercurial command `hg root` which exits with status 0
+ * when executed anywhere inside a working tree (including the repo root) and
+ * exits with a non-zero status otherwise. We only rely on the exit code.
+ */
+export function checkInHg(workdir: string): boolean {
+  try {
+    execSync("hg root", { cwd: workdir, stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+/**
+ * Returns true if the given directory is part of a Sapling (sl) repository.
+ *
+ * Uses the Sapling command `sl root` which exits with status 0 when executed
+ * anywhere inside a working tree and exits with a non-zero status otherwise.
+ */
+export function checkInSapling(workdir: string): boolean {
+  try {
+    execSync("sl root", { cwd: workdir, stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns true if the given directory is part of a supported version control system
+ * (Git, Mercurial, or Sapling).
+ */
+export function checkInVcs(workdir: string): boolean {
+  return (
+    checkInGit(workdir) ||
+    checkInHg(workdir) ||
+    checkInSapling(workdir)
+  );
+}


### PR DESCRIPTION
## Summary

Running codex from a folder managed by source control system other  than git (hg https://www.mercurial-scm.org/, sl https://sapling-scm.com) results in a warning. We add few more tests to the check-in-git utility, rename it reflect the change and update the error message


## Test Plan:

### Before

#### Running from a sl-managed folder:

```sh
$ codex
╭──────────────────────────────────────────────────────────────╮
│ ● OpenAI Codex (research preview) v0.1.2504172351            │
╰──────────────────────────────────────────────────────────────╯
╭──────────────────────────────────────────────────────────────────────────╮
│Warning! It can be dangerous to run a coding agent outside of a git repo  │
│in case there are changes that you want to revert. Do you want to         │
│continue?                                                                 │
│                                                                          │
│/Users/zats/Documents/Xcode/Scratchpad/AnthropicTest                      │
│                                                                          │
│y/N                                                                       │
╰──────────────────────────────────────────────────────────────────────────╯
```

### After

#### Running from sl-managed folder

```sh
$ node ~/Documents/code/codex/codex-cli/bin/codex.js
╭──────────────────────────────────────────────────────────────╮
│ ● OpenAI Codex (research preview) v0.1.2504211509            │
╰──────────────────────────────────────────────────────────────╯
╭──────────────────────────────────────────────────────────────╮
│ localhost session: 2e0a7027fa4e4466ab71ca8a8e7e48fc          │
│ ↳ workdir: ~/.../Xcode/Scratchpad/AnthropicTest              │
│ ↳ model: o4-mini                                             │
│ ↳ provider: openai                                           │
│ ↳ approval: suggest                                          │
╰──────────────────────────────────────────────────────────────╯
╭──────────────────────────────────────────────────────────────────────────╮
│                                                                          │
╰──────────────────────────────────────────────────────────────────────────╯
  try: explain this codebase to me | fix any build errors | are there any
  bugs in my code?
```

#### Running from a non-source-control-managed folder

```
$ ~/Documents/code/codex/codex-cli/bin/codex.js
╭──────────────────────────────────────────────────────────────╮
│ ● OpenAI Codex (research preview) v0.1.2504211509            │
╰──────────────────────────────────────────────────────────────╯
╭──────────────────────────────────────────────────────────────────────────╮
│Warning! It can be dangerous to run a coding agent outside of a source    │
│control managed folder in case there are changes that you want to revert. │
│Do you want to continue?                                                  │
│                                                                          │
│/Users/zats/Documents/Xcode/Scratchpad                                    │
│                                                                          │
│y/N                                                                       │
╰──────────────────────────────────────────────────────────────────────────╯
```