### PR TITLE
feat: add LM Studio as a provider + bugfix for command explanation with alternative providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ export OPENAI_API_KEY="your-api-key-here"
 > - openrouter
 > - gemini
 > - ollama
+> - lmstudio
 > - mistral
 > - deepseek
 > - xai

--- a/codex-cli/src/utils/compact-summary.ts
+++ b/codex-cli/src/utils/compact-summary.ts
@@ -1,6 +1,6 @@
 import type { ResponseItem } from "openai/resources/responses/responses.mjs";
 
-import { OPENAI_BASE_URL } from "./config.js";
+import { getApiKey, getBaseUrl, OPENAI_BASE_URL } from "./config.js";
 import OpenAI from "openai";
 
 /**
@@ -11,19 +11,24 @@ import OpenAI from "openai";
  */
 /**
  * Generate a condensed summary of the conversation items.
+ * @param provider The provider to use for the API request
  * @param items The list of conversation items to summarize
  * @param model The model to use for generating the summary
  * @param flexMode Whether to use the flex-mode service tier
  * @returns A concise structured summary string
  */
 export async function generateCompactSummary(
+  provider: string,
   items: Array<ResponseItem>,
   model: string,
   flexMode = false,
 ): Promise<string> {
+  const apiKey = getApiKey(provider) ?? process.env["OPENAI_API_KEY"];
+  const baseURL = getBaseUrl(provider) ?? OPENAI_BASE_URL;
+      
   const oai = new OpenAI({
-    apiKey: process.env["OPENAI_API_KEY"],
-    baseURL: OPENAI_BASE_URL,
+    apiKey,
+    baseURL
   });
 
   const conversationText = items

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -55,6 +55,9 @@ export function getApiKey(provider: string): string | undefined {
     if (providerInfo.name === "Ollama") {
       return process.env[providerInfo.envKey] ?? "dummy";
     }
+    if (providerInfo.name === "LM Studio") {
+      return process.env[providerInfo.envKey] ?? "dummy";
+    }
     return process.env[providerInfo.envKey];
   }
 

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -22,6 +22,11 @@ export const providers: Record<
     baseURL: "http://localhost:11434/v1",
     envKey: "OLLAMA_API_KEY",
   },
+  lmstudio: {
+    name: "LM Studio",
+    baseURL: "http://localhost:1234/v1",
+    envKey: "LMSTUDIO_API_KEY",
+  },
   mistral: {
     name: "Mistral",
     baseURL: "https://api.mistral.ai/v1",


### PR DESCRIPTION
This PR adds LM Studio as a local LLM provider. Additionally it fixes `generateCommandExplanation` and `generateCompactSummary` to also support non-openai providers.

Testing / usage:
Requires LM Studio 0.3.15b9, which is currently in Beta (try it [here](https://lmstudio.ai/beta-releases)). Expected to be released in stable tomorrow.