### PR TITLE
fix(provider): Enable provider Base URL configuration via environment variables

### DIFF
--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -44,7 +44,7 @@ export function setApiKey(apiKey: string): void {
 export function getBaseUrl(provider: string): string | undefined {
   const providerInfo = providers[provider.toLowerCase()];
   if (providerInfo) {
-    return providerInfo.baseURL;
+    return process.env[providerInfo.envBaseURLKey] ?? providerInfo.baseURL;
   }
   return undefined;
 }

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -1,45 +1,60 @@
+import * as process from "process";
+
 export const providers: Record<
   string,
-  { name: string; baseURL: string; envKey: string }
+  {
+    name: string;
+    baseURL: string;
+    envKey: string;
+    envBaseURLKey: string;
+  }
 > = {
   openai: {
     name: "OpenAI",
     baseURL: "https://api.openai.com/v1",
     envKey: "OPENAI_API_KEY",
+    envBaseURLKey: "OPENAI_BASE_URL",
   },
   openrouter: {
     name: "OpenRouter",
     baseURL: "https://openrouter.ai/api/v1",
     envKey: "OPENROUTER_API_KEY",
+    envBaseURLKey: "OPENROUTER_BASE_URL",
   },
   gemini: {
     name: "Gemini",
-    baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
+    baseURL: "https://generativelanguage.googleapis.com/v1beta",
     envKey: "GEMINI_API_KEY",
+    envBaseURLKey: "GEMINI_BASE_URL",
   },
   ollama: {
     name: "Ollama",
     baseURL: "http://localhost:11434/v1",
     envKey: "OLLAMA_API_KEY",
+    envBaseURLKey: "GEMINI_BASE_URL",
   },
   mistral: {
     name: "Mistral",
     baseURL: "https://api.mistral.ai/v1",
     envKey: "MISTRAL_API_KEY",
+    envBaseURLKey: "MISTRAL_BASE_URL",
   },
   deepseek: {
     name: "DeepSeek",
-    baseURL: "https://api.deepseek.com",
+    baseURL: "https://api.deepseek.com/v1",
     envKey: "DEEPSEEK_API_KEY",
+    envBaseURLKey: "DEEPSEEK_BASE_URL",
   },
   xai: {
     name: "xAI",
     baseURL: "https://api.x.ai/v1",
     envKey: "XAI_API_KEY",
+    envBaseURLKey: "XAI_BASE_URL",
   },
   groq: {
     name: "Groq",
     baseURL: "https://api.groq.com/openai/v1",
     envKey: "GROQ_API_KEY",
+    envBaseURLKey: "GROQ_BASE_URL",
   },
 };

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -23,7 +23,7 @@ export const providers: Record<
   },
   gemini: {
     name: "Gemini",
-    baseURL: "https://generativelanguage.googleapis.com/v1beta",
+    baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
     envKey: "GEMINI_API_KEY",
     envBaseURLKey: "GEMINI_BASE_URL",
   },
@@ -41,7 +41,7 @@ export const providers: Record<
   },
   deepseek: {
     name: "DeepSeek",
-    baseURL: "https://api.deepseek.com/v1",
+    baseURL: "https://api.deepseek.com",
     envKey: "DEEPSEEK_API_KEY",
     envBaseURLKey: "DEEPSEEK_BASE_URL",
   },

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -1,5 +1,3 @@
-import * as process from "process";
-
 export const providers: Record<
   string,
   {


### PR DESCRIPTION
Setting the OPENAI_BASE_URL environment variables worked fine for running Codex until two days ago, but it has no effect because getBaseUrl (from #247) doesn't check for them.

This PR updates getBaseUrl to read the corresponding environment variable, similar to how getApiKey works, falling back to the default value if the variable is not set.