### PR TITLE
feat: command whitelists

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,14 +147,16 @@ Codex lets you decide _how much autonomy_ the agent receives and auto-approval p
 | **Auto Edit**             | • Read **and** apply‑patch writes to files                                                         | • **All** shell commands                                                                        |
 | **Full Auto**             | • Read/write files <br>• Execute shell commands (network disabled, writes limited to your workdir) | –                                                                                               |
 
-In **Full Auto** every command is run **network‑disabled** and confined to the
+In **Full Auto** every command is run **network‑disabled** and confined to the
 current working directory (plus temporary files) for defense‑in‑depth. Codex
 will also show a warning/confirmation if you start in **auto‑edit** or
 **full‑auto** while the directory is _not_ tracked by Git, so you always have a
 safety net.
 
-Coming soon: you’ll be able to whitelist specific commands to auto‑execute with
-the network enabled, once we’re confident in additional safeguards.
+You can whitelist specific commands to auto-approve without prompting by adding them to
+the `commandWhitelist` in your config file. This is useful for trusted commands like
+editors (`vim`, `code`) or common Git operations. Whitelisted commands still respect
+the network and sandbox restrictions of your chosen approval mode.
 
 ### Platform sandboxing details
 
@@ -310,6 +312,10 @@ model: o4-mini # Default model
 approvalMode: suggest # or auto-edit, full-auto
 fullAutoErrorMode: ask-user # or ignore-and-continue
 notify: true # Enable desktop notifications for responses
+commandWhitelist: # List of trusted commands to auto-approve
+  - "vim"
+  - "code"
+  - "git commit -m"
 ```
 
 ```json
@@ -318,7 +324,8 @@ notify: true # Enable desktop notifications for responses
   "model": "o4-mini",
   "approvalMode": "suggest",
   "fullAutoErrorMode": "ask-user",
-  "notify": true
+  "notify": true,
+  "commandWhitelist": ["vim", "code", "git commit -m"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 - [Quickstart](#quickstart)
 - [Why Codex?](#why-codex)
 - [Security Model & Permissions](#security-model--permissions)
+  - [Whitelisting Commands](#whitelisting-commands)
   - [Platform sandboxing details](#platform-sandboxing-details)
 - [System Requirements](#system-requirements)
 - [CLI Reference](#cli-reference)

--- a/README.md
+++ b/README.md
@@ -153,10 +153,16 @@ will also show a warning/confirmation if you start in **auto‑edit** or
 **full‑auto** while the directory is _not_ tracked by Git, so you always have a
 safety net.
 
+### Whitelisting Commands
+
 You can whitelist specific commands to auto-approve without prompting by adding them to
 the `commandWhitelist` in your config file. This is useful for trusted commands like
-editors (`vim`, `code`) or common Git operations. Whitelisted commands still respect
-the network and sandbox restrictions of your chosen approval mode.
+editors (`vim`, `code`) or common Git operations. **Note**: The whitelist only takes effect
+when running in modes that would normally require approval (like `suggest` mode), not in
+`full-auto` mode where all commands are already auto-approved.
+
+> **⚠️ Security Warning**: Whitelisted commands run WITHOUT sandbox restrictions and have
+> full network access. Only whitelist commands that you fully trust.
 
 ### Platform sandboxing details
 

--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ editors (`vim`, `code`) or common Git operations. **Note**: The whitelist only t
 when running in modes that would normally require approval (like `suggest` mode), not in
 `full-auto` mode where all commands are already auto-approved.
 
-> **⚠️ Security Warning**: Whitelisted commands run WITHOUT sandbox restrictions and have
+> **⚠️ Security Warning**: Whitelisted commands run WITHOUT sandbox restrictions and may have
 > full network access. Only whitelist commands that you fully trust.
 
 ### Platform sandboxing details

--- a/README.md
+++ b/README.md
@@ -147,10 +147,10 @@ Codex lets you decide _how much autonomy_ the agent receives and auto-approval p
 | **Auto Edit**             | <li>Read **and** apply-patch writes to files                                                        | <li>**All** shell commands                                                                      |
 | **Full Auto**             | <li>Read/write files <li> Execute shell commands (network disabled, writes limited to your workdir) | -                                                                                               |
 
-In **Full Auto** every command is run **network‑disabled** and confined to the
-current working directory (plus temporary files) for defense‑in‑depth. Codex
-will also show a warning/confirmation if you start in **auto‑edit** or
-**full‑auto** while the directory is _not_ tracked by Git, so you always have a
+In **Full Auto** every command is run **network-disabled** and confined to the
+current working directory (plus temporary files) for defense-in-depth. Codex
+will also show a warning/confirmation if you start in **auto-edit** or
+**full-auto** while the directory is _not_ tracked by Git, so you always have a
 safety net.
 
 ### Whitelisting Commands

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ editors (`vim`, `code`) or common Git operations. **Note**: The whitelist only t
 when running in modes that would normally require approval (like `suggest` mode), not in
 `full-auto` mode where all commands are already auto-approved.
 
-> **⚠️ Security Warning**: Whitelisted commands run WITHOUT sandbox restrictions and may have
+> **Security Warning**: Whitelisted commands run WITHOUT sandbox restrictions and may have
 > full network access. Only whitelist commands that you fully trust.
 
 ### Platform sandboxing details

--- a/codex-cli/src/approvals.ts
+++ b/codex-cli/src/approvals.ts
@@ -1,11 +1,10 @@
-import type { AppConfig } from "./utils/config";
 import type { ParseEntry, ControlOperator } from "shell-quote";
-
 
 import {
   identify_files_added,
   identify_files_needed,
 } from "./utils/agent/apply-patch";
+import {loadConfig} from "./utils/config";
 import * as path from "path";
 import { parse } from "shell-quote";
 
@@ -75,8 +74,7 @@ export function canAutoApprove(
   command: ReadonlyArray<string>,
   policy: ApprovalPolicy,
   writableRoots: ReadonlyArray<string>,
-  env: NodeJS.ProcessEnv = process.env,
-  config?: AppConfig,
+  env: NodeJS.ProcessEnv = process.env
 ): SafetyAssessment {
   if (command[0] === "apply_patch") {
     return command.length === 2 && typeof command[1] === "string"
@@ -164,7 +162,7 @@ export function canAutoApprove(
   }
 
   // Check to see if command is whitelisted
-  const whitelistAssessment = isCommandWhitelisted(command, config);
+  const whitelistAssessment = isCommandWhitelisted(command);
   if (whitelistAssessment != null) {
     return whitelistAssessment;
   }
@@ -459,10 +457,9 @@ const UNSAFE_OPTIONS_FOR_FIND_COMMAND: ReadonlySet<string> = new Set([
 ]);
 
 function isCommandWhitelisted(
-  command: ReadonlyArray<string>,
-  config?: AppConfig,
+  command: ReadonlyArray<string>
 ): SafetyAssessment | null {
-  const whitelist = config?.commandWhitelist;
+  const whitelist = loadConfig()?.commandWhitelist;
   if (!whitelist?.length) {
     return null;
   }

--- a/codex-cli/src/approvals.ts
+++ b/codex-cli/src/approvals.ts
@@ -4,7 +4,7 @@ import {
   identify_files_added,
   identify_files_needed,
 } from "./utils/agent/apply-patch";
-import {loadConfig} from "./utils/config";
+import { loadConfig } from "./utils/config";
 import * as path from "path";
 import { parse } from "shell-quote";
 
@@ -457,7 +457,7 @@ const UNSAFE_OPTIONS_FOR_FIND_COMMAND: ReadonlySet<string> = new Set([
 ]);
 
 function isCommandWhitelisted(
-  command: ReadonlyArray<string>
+  command: ReadonlyArray<string>,
 ): SafetyAssessment | null {
   const whitelist = loadConfig()?.commandWhitelist;
   if (!whitelist?.length) {

--- a/codex-cli/src/approvals.ts
+++ b/codex-cli/src/approvals.ts
@@ -74,7 +74,7 @@ export function canAutoApprove(
   command: ReadonlyArray<string>,
   policy: ApprovalPolicy,
   writableRoots: ReadonlyArray<string>,
-  env: NodeJS.ProcessEnv = process.env
+  env: NodeJS.ProcessEnv = process.env,
 ): SafetyAssessment {
   if (command[0] === "apply_patch") {
     return command.length === 2 && typeof command[1] === "string"
@@ -471,7 +471,7 @@ function isCommandWhitelisted(
         type: "auto-approve",
         reason: "Command whitelisted by user",
         group: "Whitelisted",
-        runInSandbox: true, // Still run in sandbox for safety
+        runInSandbox: false,
       };
     }
   }

--- a/codex-cli/src/approvals.ts
+++ b/codex-cli/src/approvals.ts
@@ -1,4 +1,6 @@
+import type { AppConfig } from "./utils/config";
 import type { ParseEntry, ControlOperator } from "shell-quote";
+
 
 import {
   identify_files_added,
@@ -6,7 +8,6 @@ import {
 } from "./utils/agent/apply-patch";
 import * as path from "path";
 import { parse } from "shell-quote";
-import { AppConfig } from "./utils/config";
 
 export type SafetyAssessment = {
   /**
@@ -462,7 +463,9 @@ function isCommandWhitelisted(
   config?: AppConfig,
 ): SafetyAssessment | null {
   const whitelist = config?.commandWhitelist;
-  if (!whitelist?.length) return null;
+  if (!whitelist?.length) {
+    return null;
+  }
 
   const cmdString = command.join(" ");
   for (const pattern of whitelist) {

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -73,6 +73,8 @@ export type StoredConfig = {
   memory?: MemoryConfig;
   /** Whether to enable desktop notifications for responses */
   notify?: boolean;
+  /** List of commands that can be auto-approved without prompting */
+  commandWhitelist?: Array<string>;
   history?: {
     maxSize?: number;
     saveHistory?: boolean;
@@ -103,6 +105,8 @@ export type AppConfig = {
   memory?: MemoryConfig;
   /** Whether to enable desktop notifications for responses */
   notify: boolean;
+  /** List of commands that can be auto-approved without prompting */
+  commandWhitelist?: Array<string>;
 
   /** Enable the "flex-mode" processing mode for supported models (o3, o4-mini) */
   flexMode?: boolean;
@@ -293,6 +297,7 @@ export const loadConfig = (
     instructions: combinedInstructions,
     notify: storedConfig.notify === true,
     approvalMode: storedConfig.approvalMode,
+    commandWhitelist: storedConfig.commandWhitelist ?? [],
   };
 
   // -----------------------------------------------------------------------
@@ -403,6 +408,7 @@ export const saveConfig = (
     model: config.model,
     provider: config.provider,
     approvalMode: config.approvalMode,
+    commandWhitelist: config.commandWhitelist,
   };
 
   // Add history settings if they exist

--- a/codex-cli/tests/approvals.test.ts
+++ b/codex-cli/tests/approvals.test.ts
@@ -1,8 +1,13 @@
 import type { SafetyAssessment } from "../src/approvals";
-import type { AutoApprovalMode } from "../src/utils/auto-approval-mode";
 
 import { canAutoApprove } from "../src/approvals";
-import { describe, test, expect } from "vitest";
+import { describe, test, expect, vi } from "vitest";
+
+vi.mock("../src/utils/config", () => ({
+  loadConfig: () => ({
+    commandWhitelist: ["npm install", "pip install", "yarn add"],
+  }),
+}));
 
 describe("canAutoApprove()", () => {
   const env = {
@@ -91,49 +96,30 @@ describe("canAutoApprove()", () => {
     expect(check(["cargo", "build"])).toEqual({ type: "ask-user" });
   });
 
-  test("whitelisted commands", () => {
-    const checkWithWhitelist = (command: ReadonlyArray<string>): SafetyAssessment =>
-      canAutoApprove(command, "suggest", writeablePaths, env, {
-        model: "test-model",
-        provider: "openai",
-        instructions: "",
-        notify: false,
-        approvalMode: "suggest" as AutoApprovalMode,
-        commandWhitelist: ["npm run", "yarn test"],
-      });
-
-    // Whitelisted commands should be auto-approved
-    expect(checkWithWhitelist(["npm", "run", "test"])).toEqual({
+  test("whitelisted commands should be auto-approved", async () => {
+    expect(check(["npm", "install"])).toEqual({
       type: "auto-approve",
       reason: "Command whitelisted by user",
       group: "Whitelisted",
       runInSandbox: true,
     });
 
-    expect(checkWithWhitelist(["yarn", "test", "--coverage"])).toEqual({
+    expect(check(["pip", "install", "requests"])).toEqual({
       type: "auto-approve",
       reason: "Command whitelisted by user",
       group: "Whitelisted",
       runInSandbox: true,
     });
 
+    expect(check(["yarn", "add", "express"])).toEqual({
+      type: "auto-approve",
+      reason: "Command whitelisted by user",
+      group: "Whitelisted",
+      runInSandbox: true,
+    });
+    
     // Non-whitelisted commands should still require approval
-    expect(checkWithWhitelist(["npm", "install"])).toEqual({
-      type: "ask-user",
-    });
-
-    // Empty whitelist should behave like no whitelist
-    const checkEmptyWhitelist = (command: ReadonlyArray<string>): SafetyAssessment =>
-      canAutoApprove(command, "suggest", writeablePaths, env, {
-        model: "test-model",
-        provider: "openai",
-        instructions: "",
-        notify: false,
-        approvalMode: "suggest" as AutoApprovalMode,
-        commandWhitelist: [],
-      });
-
-    expect(checkEmptyWhitelist(["npm", "run", "test"])).toEqual({
+    expect(check(["cargo", "install"])).toEqual({
       type: "ask-user",
     });
   });

--- a/codex-cli/tests/approvals.test.ts
+++ b/codex-cli/tests/approvals.test.ts
@@ -101,21 +101,21 @@ describe("canAutoApprove()", () => {
       type: "auto-approve",
       reason: "Command whitelisted by user",
       group: "Whitelisted",
-      runInSandbox: true,
+      runInSandbox: false,
     });
 
     expect(check(["pip", "install", "requests"])).toEqual({
       type: "auto-approve",
       reason: "Command whitelisted by user",
       group: "Whitelisted",
-      runInSandbox: true,
+      runInSandbox: false,
     });
 
     expect(check(["yarn", "add", "express"])).toEqual({
       type: "auto-approve",
       reason: "Command whitelisted by user",
       group: "Whitelisted",
-      runInSandbox: true,
+      runInSandbox: false,
     });
     
     // Non-whitelisted commands should still require approval

--- a/codex-cli/tests/approvals.test.ts
+++ b/codex-cli/tests/approvals.test.ts
@@ -117,7 +117,7 @@ describe("canAutoApprove()", () => {
       group: "Whitelisted",
       runInSandbox: false,
     });
-    
+
     // Non-whitelisted commands should still require approval
     expect(check(["cargo", "install"])).toEqual({
       type: "ask-user",

--- a/codex-cli/tests/config.test.tsx
+++ b/codex-cli/tests/config.test.tsx
@@ -65,7 +65,7 @@ test("loads default config if files don't exist", () => {
   expect(config.instructions).toBe("");
 });
 
-test("saves and loads config with whitelist correctly", () => {
+test("saves and loads config correctly", () => {
   const testConfig = {
     model: "test-model",
     instructions: "test instructions",

--- a/codex-cli/tests/config.test.tsx
+++ b/codex-cli/tests/config.test.tsx
@@ -65,16 +65,20 @@ test("loads default config if files don't exist", () => {
   expect(config.instructions).toBe("");
 });
 
-test("saves and loads config correctly", () => {
+test("saves and loads config with whitelist correctly", () => {
   const testConfig = {
     model: "test-model",
     instructions: "test instructions",
     notify: false,
+    commandWhitelist: ["npm run", "yarn test"],
   };
   saveConfig(testConfig, testConfigPath, testInstructionsPath);
 
   // Our in‑memory fs should now contain those keys:
-  expect(memfs[testConfigPath]).toContain(`"model": "test-model"`);
+  // Parse the saved config to check its contents
+  const savedConfig = JSON.parse(memfs[testConfigPath] as string);
+  expect(savedConfig.model).toBe("test-model");
+  expect(savedConfig.commandWhitelist).toEqual(["npm run", "yarn test"]);
   expect(memfs[testInstructionsPath]).toBe("test instructions");
 
   const loadedConfig = loadConfig(testConfigPath, testInstructionsPath, {
@@ -83,6 +87,7 @@ test("saves and loads config correctly", () => {
   // Check just the specified properties that were saved
   expect(loadedConfig.model).toBe(testConfig.model);
   expect(loadedConfig.instructions).toBe(testConfig.instructions);
+  expect(loadedConfig.commandWhitelist).toEqual(testConfig.commandWhitelist);
 });
 
 test("loads user instructions + project doc when codex.md is present", () => {


### PR DESCRIPTION
# Add command whitelist for auto-approval

Resolves #380 and #475

Adds a whitelist feature that lets users specify trusted commands to bypass confirmation in "auto-edit" and "suggest" mode. For example, frequently used non-destructive commands like `nl` or `git status` can now be auto-approved.

## Implementation Details
- Added `commandWhitelist` to config (e.g., `["npm run", "git status"]`)
- Uses prefix matching to match whitelisted applications or specific commands
- Whitelisted commands run WITHOUT sandbox restrictions, like other commands in "auto-edit" and "suggest" mode.
- Added tests for whitelist functionality and config handling

## Example
```json
{
  "commandWhitelist": ["npm run", "nl", "git status"]
}
```

Now `npm run test` and `npm run build` will auto-approve, while `npm install` still requires confirmation when running in a non 'full-auto' mode.
