### PR TITLE
bump(version): 0.1.2504220136

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 You can install any of these versions: `npm install -g codex@version`
 
+## `0.1.2504220136`
+
+### 🚀 Features
+
+- Add support for ZDR orgs (#481)
+- Include fractional portion of chunk that exceeds stdout/stderr limit (#497)
+
 ## `0.1.2504211509`
 
 ### 🚀 Features

--- a/cliff.toml
+++ b/cliff.toml
@@ -38,7 +38,7 @@ commit_parsers = [
   { message = "^fix",  group = "<!-- 1 -->🐛 Bug Fixes" },
   { message = "^bump", group = "<!-- 6 -->🛳️ Release" },
   # Fallback – skip anything that didn't match the above rules.
-  { message = ".*",  group = "<!-- 10 -->💼 Other", skip = true },
+  { message = ".*",  group = "<!-- 10 -->💼 Other" },
 ]
 
 filter_unconventional = false

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex",
-  "version": "0.1.2504211509",
+  "version": "0.1.2504220136",
   "license": "Apache-2.0",
   "bin": {
     "codex": "bin/codex.js"

--- a/codex-cli/src/utils/session.ts
+++ b/codex-cli/src/utils/session.ts
@@ -1,4 +1,4 @@
-export const CLI_VERSION = "0.1.2504211509"; // Must be in sync with package.json.
+export const CLI_VERSION = "0.1.2504220136"; // Must be in sync with package.json.
 export const ORIGIN = "codex_cli_ts";
 
 export type TerminalChatSession = {


### PR DESCRIPTION
## `0.1.2504220136`

### 🚀 Features

- Add support for ZDR orgs (#481)
- Include fractional portion of chunk that exceeds stdout/stderr limit (#497)
