### PR TITLE
feat: add Portkey AI Gateway to list of providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ export OPENAI_API_KEY="your-api-key-here"
 > - deepseek
 > - xai
 > - groq
+> - portkey
 >
 > If you use a provider other than OpenAI, you will need to set the API key for the provider in the config file or in the environment variable as:
 >

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -42,4 +42,9 @@ export const providers: Record<
     baseURL: "https://api.groq.com/openai/v1",
     envKey: "GROQ_API_KEY",
   },
+  portkey: {
+    name: "Portkey",
+    baseURL: "https://api.portkey.ai/v1",
+    envKey: "PORTKEY_API_KEY",
+  }
 };


### PR DESCRIPTION
Portkey's API completely follow the [OpenAI API schema](https://portkey.ai/docs/api-reference/inference-api/introduction) and make them compatible with 250+ different LLMs with features for routing, observability, fallbacks, rate limiting, guardrails, and more.

This PR allows developers to leverage Portkey as a provider for Codex and implement the same functionalities across the entire Codex touchpoints.