### PR TITLE
feat: show actionable errors when api keys are missing

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -255,11 +255,16 @@ if (!apiKey) {
   // eslint-disable-next-line no-console
   console.error(
     `\n${chalk.red(`Missing ${provider} API key.`)}\n\n` +
-      `Set the environment variable ${chalk.bold("OPENAI_API_KEY")} ` +
-      `and re-run this command.\n` +
-      `You can create a key here: ${chalk.bold(
-        chalk.underline("https://platform.openai.com/account/api-keys"),
-      )}\n`,
+    `Set the environment variable ${chalk.bold(`${provider.toUpperCase()}_API_KEY`)} ` +
+    `and re-run this command.\n` +
+    `${
+      provider.toLowerCase() === "openai"
+        ? `You can create a key here: ${chalk.bold(
+            chalk.underline("https://platform.openai.com/account/api-keys")
+          )}\n`
+        : `You can create a ${chalk.bold(`${provider.toUpperCase()}_API_KEY`)} ` +
+          `in the ${chalk.bold(`${provider}`)} dashboard.\n`
+    }`
   );
   process.exit(1);
 }

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -255,16 +255,19 @@ if (!apiKey) {
   // eslint-disable-next-line no-console
   console.error(
     `\n${chalk.red(`Missing ${provider} API key.`)}\n\n` +
-    `Set the environment variable ${chalk.bold(`${provider.toUpperCase()}_API_KEY`)} ` +
-    `and re-run this command.\n` +
-    `${
-      provider.toLowerCase() === "openai"
-        ? `You can create a key here: ${chalk.bold(
-            chalk.underline("https://platform.openai.com/account/api-keys")
-          )}\n`
-        : `You can create a ${chalk.bold(`${provider.toUpperCase()}_API_KEY`)} ` +
-          `in the ${chalk.bold(`${provider}`)} dashboard.\n`
-    }`
+      `Set the environment variable ${chalk.bold(
+        `${provider.toUpperCase()}_API_KEY`,
+      )} ` +
+      `and re-run this command.\n` +
+      `${
+        provider.toLowerCase() === "openai"
+          ? `You can create a key here: ${chalk.bold(
+              chalk.underline("https://platform.openai.com/account/api-keys"),
+            )}\n`
+          : `You can create a ${chalk.bold(
+              `${provider.toUpperCase()}_API_KEY`,
+            )} ` + `in the ${chalk.bold(`${provider}`)} dashboard.\n`
+      }`,
   );
   process.exit(1);
 }


### PR DESCRIPTION
Change errors on missing api key of other providers from
<img width="854" alt="image" src="https://github.com/user-attachments/assets/f488a247-5040-4b02-92d6-90a2204419ff" />
(missing deepseek key but still throws error for openai)
to
<img width="854" alt="image" src="https://github.com/user-attachments/assets/8333d24a-91f8-4ba8-9a51-ed22a7e8a074" />
This should help new users figure out the issue easier and go to the right place to get api keys

OpenAI key missing would popup with the right link
<img width="854" alt="image" src="https://github.com/user-attachments/assets/0ecc9320-380f-425c-972e-4312bf610955" />
