### PR TITLE
feat(bug-report): print bug report URL in terminal instead of opening browser (#510)

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -470,16 +470,12 @@ export default function TerminalChatInput({
         setInput("");
 
         try {
-          // Dynamically import dependencies to avoid unnecessary bundle size.
           const os = await import("node:os");
-
-          // Lazy import CLI_VERSION to avoid circular deps.
           const { CLI_VERSION } = await import("../../utils/session.js");
           const { buildBugReportUrl } = await import(
             "../../utils/bug-report.js"
           );
 
-          // Construct the bug report URL.
           const url = buildBugReportUrl({
             items: items ?? [],
             cliVersion: CLI_VERSION,
@@ -489,7 +485,6 @@ export default function TerminalChatInput({
               .join(" | "),
           });
 
-          // Display the URL in the chat history.
           setItems((prev) => [
             ...prev,
             {

--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -470,16 +470,16 @@ export default function TerminalChatInput({
         setInput("");
 
         try {
-          // Dynamically import only OS info to build the report URL
+          // Dynamically import dependencies to avoid unnecessary bundle size.
           const os = await import("node:os");
 
-          // Lazy import CLI_VERSION and URL builder
+          // Lazy import CLI_VERSION to avoid circular deps.
           const { CLI_VERSION } = await import("../../utils/session.js");
           const { buildBugReportUrl } = await import(
             "../../utils/bug-report.js"
           );
 
-          // Construct the bug report URL
+          // Construct the bug report URL.
           const url = buildBugReportUrl({
             items: items ?? [],
             cliVersion: CLI_VERSION,
@@ -489,7 +489,7 @@ export default function TerminalChatInput({
               .join(" | "),
           });
 
-          // Display the URL in the chat history for users in terminal-only sessions
+          // Display the URL in the chat history.
           setItems((prev) => [
             ...prev,
             {
@@ -505,7 +505,7 @@ export default function TerminalChatInput({
             },
           ]);
         } catch (error) {
-          // If anything went wrong, notify the user
+          // If anything went wrong, notify the user.
           setItems((prev) => [
             ...prev,
             {

--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -470,19 +470,16 @@ export default function TerminalChatInput({
         setInput("");
 
         try {
-          // Dynamically import dependencies to avoid unnecessary bundle size
-          const [{ default: open }, os] = await Promise.all([
-            import("open"),
-            import("node:os"),
-          ]);
+          // Dynamically import only OS info to build the report URL
+          const os = await import("node:os");
 
-          // Lazy import CLI_VERSION to avoid circular deps
+          // Lazy import CLI_VERSION and URL builder
           const { CLI_VERSION } = await import("../../utils/session.js");
-
           const { buildBugReportUrl } = await import(
             "../../utils/bug-report.js"
           );
 
+          // Construct the bug report URL
           const url = buildBugReportUrl({
             items: items ?? [],
             cliVersion: CLI_VERSION,
@@ -492,10 +489,7 @@ export default function TerminalChatInput({
               .join(" | "),
           });
 
-          // Open the URL in the user's default browser
-          await open(url, { wait: false });
-
-          // Inform the user in the chat history
+          // Display the URL in the chat history for users in terminal-only sessions
           setItems((prev) => [
             ...prev,
             {
@@ -505,7 +499,7 @@ export default function TerminalChatInput({
               content: [
                 {
                   type: "input_text",
-                  text: "📋 Opened browser to file a bug report. Please include any context that might help us fix the issue!",
+                  text: `🔗 Bug report URL: ${url}`,
                 },
               ],
             },

--- a/codex-cli/src/components/help-overlay.tsx
+++ b/codex-cli/src/components/help-overlay.tsx
@@ -53,7 +53,7 @@ export default function HelpOverlay({
           <Text color="cyan">/clearhistory</Text> – clear command history
         </Text>
         <Text>
-          <Text color="cyan">/bug</Text> – file a bug report with session log
+          <Text color="cyan">/bug</Text> – generate a prefilled GitHub issue URL with session log
         </Text>
         <Text>
           <Text color="cyan">/diff</Text> – view working tree git diff

--- a/codex-cli/src/components/help-overlay.tsx
+++ b/codex-cli/src/components/help-overlay.tsx
@@ -53,7 +53,8 @@ export default function HelpOverlay({
           <Text color="cyan">/clearhistory</Text> – clear command history
         </Text>
         <Text>
-          <Text color="cyan">/bug</Text> – generate a prefilled GitHub issue URL with session log
+          <Text color="cyan">/bug</Text> – generate a prefilled GitHub issue URL
+          with session log
         </Text>
         <Text>
           <Text color="cyan">/diff</Text> – view working tree git diff

--- a/codex-cli/src/utils/slash-commands.ts
+++ b/codex-cli/src/utils/slash-commands.ts
@@ -23,7 +23,10 @@ export const SLASH_COMMANDS: Array<SlashCommand> = [
   { command: "/help", description: "Show list of commands" },
   { command: "/model", description: "Open model selection panel" },
   { command: "/approval", description: "Open approval mode selection panel" },
-  { command: "/bug", description: "Generate a prefilled GitHub issue URL with session log" },
+  {
+    command: "/bug",
+    description: "Generate a prefilled GitHub issue URL with session log",
+  },
   {
     command: "/diff",
     description:

--- a/codex-cli/src/utils/slash-commands.ts
+++ b/codex-cli/src/utils/slash-commands.ts
@@ -23,7 +23,7 @@ export const SLASH_COMMANDS: Array<SlashCommand> = [
   { command: "/help", description: "Show list of commands" },
   { command: "/model", description: "Open model selection panel" },
   { command: "/approval", description: "Open approval mode selection panel" },
-  { command: "/bug", description: "Generate a prefilled GitHub bug report" },
+  { command: "/bug", description: "Generate a prefilled GitHub issue URL with session log" },
   {
     command: "/diff",
     description:


### PR DESCRIPTION
Solves #510 
This PR changes the `/bug` command to print the URL into the terminal (so it works in headless sessions) instead of trying to open a browser.