### PR TITLE
fix: remove requirement for api key for ollama

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ export OPENAI_API_KEY="your-api-key-here"
 > ```shell
 > export <provider>_API_KEY="your-api-key-here"
 > ```
+>
+> Note that Ollama (for local LLM usage) does not require an API key.
 
 </details>
 <br />

--- a/README.md
+++ b/README.md
@@ -95,8 +95,6 @@ export OPENAI_API_KEY="your-api-key-here"
 > ```shell
 > export <provider>_API_KEY="your-api-key-here"
 > ```
->
-> Note that Ollama (for local LLM usage) does not require an API key.
 
 </details>
 <br />

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -254,14 +254,17 @@ const imagePaths = cli.flags.image;
 const provider = cli.flags.provider ?? config.provider ?? "openai";
 const apiKey = getApiKey(provider);
 
-if (!apiKey) {
+// Set of providers that don't require API keys
+const NO_API_KEY_REQUIRED = new Set(["ollama"]);
+
+if (!apiKey && !NO_API_KEY_REQUIRED.has(provider.toLowerCase())) {
   // eslint-disable-next-line no-console
   console.error(
     `\n${chalk.red(`Missing ${provider} API key.`)}\n\n` +
       `Set the environment variable ${chalk.bold("OPENAI_API_KEY")} ` +
       `and re-run this command.\n` +
-      `You can create a key here: ${chalk.bold(
-        chalk.underline("https://platform.openai.com/account/api-keys"),
+        `You can create a key here: ${chalk.bold(
+          chalk.underline("https://platform.openai.com/account/api-keys"),
       )}\n`,
   );
   process.exit(1);

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -257,14 +257,15 @@ const apiKey = getApiKey(provider);
 // Set of providers that don't require API keys
 const NO_API_KEY_REQUIRED = new Set(["ollama"]);
 
+// Skip API key validation for providers that don't require an API key
 if (!apiKey && !NO_API_KEY_REQUIRED.has(provider.toLowerCase())) {
   // eslint-disable-next-line no-console
   console.error(
     `\n${chalk.red(`Missing ${provider} API key.`)}\n\n` +
       `Set the environment variable ${chalk.bold("OPENAI_API_KEY")} ` +
       `and re-run this command.\n` +
-        `You can create a key here: ${chalk.bold(
-          chalk.underline("https://platform.openai.com/account/api-keys"),
+      `You can create a key here: ${chalk.bold(
+        chalk.underline("https://platform.openai.com/account/api-keys"),
       )}\n`,
   );
   process.exit(1);


### PR DESCRIPTION
Fixes #540 
# Skip API key validation for Ollama provider

## Description
This PR modifies the CLI to not require an API key when using Ollama as the provider

## Changes
- Modified the validation logic to skip API key checks for these providers
- Updated the README to clarify that Ollama doesn't require an API key

