### PR TITLE
bump(version): 0.1.2504221401

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ You can install any of these versions: `npm install -g codex@version`
 ### 🐛 Bug Fixes
 
 - Agent loop for ZDR (`disableResponseStorage`) (#543)
+- Fix relative `workdir` check for `apply_patch` (#556)
 - Minimal mid-stream #429 retry loop using existing back-off (#506)
 - Inconsistent usage of base URL and API key (#507)
 - Remove requirement for api key for ollama (#546)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 You can install any of these versions: `npm install -g codex@version`
 
+## `0.1.2504221401`
+
+### 🚀 Features
+
+- Show actionable errors when api keys are missing (#523)
+- Add CLI `--version` flag (#492)
+
+### 🐛 Bug Fixes
+
+- Agent loop for ZDR (`disableResponseStorage`) (#543)
+- Minimal mid-stream #429 retry loop using existing back-off (#506)
+- Inconsistent usage of base URL and API key (#507)
+- Remove requirement for api key for ollama (#546)
+- Support `[provider]_BASE_URL` (#542)
+
 ## `0.1.2504220136`
 
 ### 🚀 Features

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex",
-  "version": "0.1.2504220136",
+  "version": "0.1.2504221401",
   "license": "Apache-2.0",
   "bin": {
     "codex": "bin/codex.js"

--- a/codex-cli/src/utils/session.ts
+++ b/codex-cli/src/utils/session.ts
@@ -1,4 +1,4 @@
-export const CLI_VERSION = "0.1.2504220136"; // Must be in sync with package.json.
+export const CLI_VERSION = "0.1.2504221401"; // Must be in sync with package.json.
 export const ORIGIN = "codex_cli_ts";
 
 export type TerminalChatSession = {


### PR DESCRIPTION
## `0.1.2504221401`

### 🚀 Features

- Show actionable errors when api keys are missing (#523)
- Add CLI `--version` flag (#492)

### 🐛 Bug Fixes

- Agent loop for ZDR (`disableResponseStorage`) (#543)
- Fix relative `workdir` check for `apply_patch` (#556)
- Minimal mid-stream #429 retry loop using existing back-off (#506)
- Inconsistent usage of base URL and API key (#507)
- Remove requirement for api key for ollama (#546)
- Support `[provider]_BASE_URL` (#542)