### PR TITLE
adding ability to run custom providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ export OPENAI_API_KEY="your-api-key-here"
 > export <provider>_API_KEY="your-api-key-here"
 > ```
 >
-> You can setup custom providers by setting the base url environment variable as:
+> You can set up custom providers by setting the base url environment variable as:
 >
 > ```shell
 > export <provider>_BASE_URL="provider-base-url-here"

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ export OPENAI_API_KEY="your-api-key-here"
 > ```shell
 > export <provider>_API_KEY="your-api-key-here"
 > ```
+>
+> You can setup custom providers by setting the base url environment variable as:
+>
+> ```shell
+> export <provider>_BASE_URL="provider-base-url-here"
+> ```
+>
+> Example: setting CEREBRAS_API_KEY and CEREBRAS_BASE_URL would allow you to run with --provider cerebras
 
 </details>
 <br />

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -80,6 +80,11 @@ export function getApiKey(provider: string = "openai"): string | undefined {
   if (OPENAI_API_KEY !== "") {
     return OPENAI_API_KEY;
   }
+  // Check for a PROVIDER-specific override: e.g. CEREBRAS_API_KEY
+  const envKey = `${provider.toUpperCase()}_API_KEY`;
+  if (process.env[envKey]) {
+    return process.env[envKey];
+  }
 
   return undefined;
 }


### PR DESCRIPTION
Adding functionality to run custom api providers without having to keep adding new providers or custom hosted solutions of users/orgs
example usage:
<img width="1071" alt="image" src="https://github.com/user-attachments/assets/3d1688ef-8b19-4352-a34a-124ef77d9d79" />
