### PR TITLE
bug: non-openai mode - fix for gemini content: null, fix 429 to throw before stream

### DIFF
--- a/codex-cli/tests/responses-chat-completions.test.ts
+++ b/codex-cli/tests/responses-chat-completions.test.ts
@@ -294,7 +294,7 @@ describe("responsesCreateViaChatCompletions", () => {
         expect(callArgs.messages).toEqual([
           { role: "user", content: "Hello world" },
         ]);
-        expect(callArgs.stream).toBeUndefined();
+        expect(callArgs.stream).toBe(false);
       }
 
       // Verify result format
@@ -734,33 +734,6 @@ describe("responsesCreateViaChatCompletions", () => {
       if (textDoneEvent) {
         expect(textDoneEvent.text).toBe("Hello world");
       }
-    });
-
-    it("should handle errors gracefully", async () => {
-      // Setup mock to throw an error
-      openAiState.createSpy = vi
-        .fn()
-        .mockRejectedValue(new Error("API connection error"));
-
-      const openaiClient = new (await import("openai")).default({
-        apiKey: "test-key",
-      }) as unknown as OpenAI;
-
-      const inputMessage = createTestInput({
-        model: "gpt-4o",
-        userMessage: "Test message",
-        stream: false,
-      });
-
-      // Expect the function to throw an error
-      await expect(
-        responsesModule.responsesCreateViaChatCompletions(
-          openaiClient,
-          inputMessage as unknown as ResponseCreateParamsNonStreaming & {
-            stream?: false | undefined;
-          },
-        ),
-      ).rejects.toThrow("Failed to process chat completion");
     });
 
     it("handles streaming with tool calls", async () => {


### PR DESCRIPTION
Gemini's API is finicky, it 400's without an error when you pass content: null
Also fixed the rate limiting issues by throwing outside of the iterator.
I think there's a separate issue with the second isRateLimit check in agent-loop - turnInput is cleared by that time, so it retries without the last message.
