### PR TITLE
fix: remove unreachable "disableResponseStorage" logic flow introduced in #543

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -543,22 +543,6 @@ export class AgentLoop {
         );
       } else {
         turnInput = [...abortOutputs, ...input].map(stripInternalFields);
-
-        // When response storage is disabled we have to maintain our own
-        // running transcript so that the next request still contains the
-        // full conversational history.  We skipped the transcript update in
-        // the branch above – ensure we do it here as well.
-        if (this.disableResponseStorage) {
-          const newUserItems: Array<ResponseInputItem> = input.filter((it) => {
-            if (it.type === "message" && it.role === "system") {
-              return false;
-            } else if (it.type === "reasoning") {
-              return false;
-            }
-            return true;
-          });
-          this.transcript.push(...newUserItems.map(stripInternalFields));
-        }
       }
 
       this.onLoading(true);


### PR DESCRIPTION
This PR cleans up unreachable code that was added as a result of https://github.com/openai/codex/pull/543.

The code being removed is already being handled above:
https://github.com/openai/codex/blob/23f0887df3323a2b2a5bd87780c8845776b56bba/codex-cli/src/utils/agent/agent-loop.ts#L535-L539