### PR TITLE
feat: update README and config to support custom providers with API k…

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,18 @@ export OPENAI_API_KEY="your-api-key-here"
 > - deepseek
 > - xai
 > - groq
+> - any other provider that is compatible with the OpenAI API
 >
 > If you use a provider other than OpenAI, you will need to set the API key for the provider in the config file or in the environment variable as:
 >
 > ```shell
 > export <provider>_API_KEY="your-api-key-here"
+> ```
+>
+> If you use a provider not listed above, you must also set the base URL for the provider:
+>
+> ```shell
+> export <provider>_BASE_URL="https://your-provider-api-base-url"
 > ```
 
 </details>

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -76,6 +76,12 @@ export function getApiKey(provider: string = "openai"): string | undefined {
     return process.env[providerInfo.envKey];
   }
 
+  // Checking `PROVIDER_API_KEY feels more intuitive with a custom provider.
+  const customApiKey = process.env[`${provider.toUpperCase()}_API_KEY`];
+  if (customApiKey) {
+    return customApiKey;
+  }
+
   // If the provider not found in the providers list and `OPENAI_API_KEY` is set, use it
   if (OPENAI_API_KEY !== "") {
     return OPENAI_API_KEY;


### PR DESCRIPTION
When using a non-built-in provider with the `--provider` option, users are prompted:

```
Set the environment variable <provider>_API_KEY and re-run this command.
You can create a <provider>_API_KEY in the <provider> dashboard.
```

However, many users are confused because, even after correctly setting `<provider>_API_KEY`, authentication may still fail unless `OPENAI_API_KEY` is _also_ present in the environment. This is not intuitive and leads to ambiguity about which API key is actually required and used as a fallback, especially when using custom or third-party (non-listed) providers.

Furthermore, the original README/documentation did not mention the requirement to set `<provider>_BASE_URL` for non-built-in providers, which is necessary for proper client behavior. This omission made the configuration process more difficult for users trying to integrate with custom endpoints.
