### PR TITLE
fix(utils): save config

### DIFF
--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -458,7 +458,9 @@ export const saveConfig = (
   }
 
   if (config.instructions.includes(PROJECT_DOC_SEPARATOR)) {
-    const userInstructions = config.instructions.split(PROJECT_DOC_SEPARATOR)[0];
+    const userInstructions = config.instructions.split(
+      PROJECT_DOC_SEPARATOR,
+    )[0];
     if (userInstructions !== undefined) {
       writeFileSync(instructionsPath, userInstructions, "utf-8");
     }

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -151,6 +151,7 @@ export const PRETTY_PRINT = Boolean(process.env["PRETTY_PRINT"] || "");
 export const PROJECT_DOC_MAX_BYTES = 32 * 1024; // 32 kB
 
 const PROJECT_DOC_FILENAMES = ["codex.md", ".codex.md", "CODEX.md"];
+const PROJECT_DOC_SEPARATOR = "\n\n--- project-doc ---\n\n";
 
 export function discoverProjectDocPath(startDir: string): string | null {
   const cwd = resolvePath(startDir);
@@ -305,7 +306,7 @@ export const loadConfig = (
 
   const combinedInstructions = [userInstructions, projectDoc]
     .filter((s) => s && s.trim() !== "")
-    .join("\n\n--- project-doc ---\n\n");
+    .join(PROJECT_DOC_SEPARATOR);
 
   // Treat empty string ("" or whitespace) as absence so we can fall back to
   // the latest DEFAULT_MODEL.
@@ -456,5 +457,12 @@ export const saveConfig = (
     writeFileSync(targetPath, JSON.stringify(configToSave, null, 2), "utf-8");
   }
 
-  writeFileSync(instructionsPath, config.instructions, "utf-8");
+  if (config.instructions.includes(PROJECT_DOC_SEPARATOR)) {
+    const userInstructions = config.instructions.split(PROJECT_DOC_SEPARATOR)[0];
+    if (userInstructions !== undefined) {
+      writeFileSync(instructionsPath, userInstructions, "utf-8");
+    }
+  } else {
+    writeFileSync(instructionsPath, config.instructions, "utf-8");
+  }
 };

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -458,6 +458,6 @@ export const saveConfig = (
   }
 
   // Take everything before the first PROJECT_DOC_SEPARATOR (or the whole string if none).
-  const [userInstructions] = config.instructions.split(PROJECT_DOC_SEPARATOR);
+  const [userInstructions = ""] = config.instructions.split(PROJECT_DOC_SEPARATOR);
   writeFileSync(instructionsPath, userInstructions, "utf-8");
 };

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -458,6 +458,8 @@ export const saveConfig = (
   }
 
   // Take everything before the first PROJECT_DOC_SEPARATOR (or the whole string if none).
-  const [userInstructions = ""] = config.instructions.split(PROJECT_DOC_SEPARATOR);
+  const [userInstructions = ""] = config.instructions.split(
+    PROJECT_DOC_SEPARATOR,
+  );
   writeFileSync(instructionsPath, userInstructions, "utf-8");
 };

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -457,14 +457,7 @@ export const saveConfig = (
     writeFileSync(targetPath, JSON.stringify(configToSave, null, 2), "utf-8");
   }
 
-  if (config.instructions.includes(PROJECT_DOC_SEPARATOR)) {
-    const userInstructions = config.instructions.split(
-      PROJECT_DOC_SEPARATOR,
-    )[0];
-    if (userInstructions !== undefined) {
-      writeFileSync(instructionsPath, userInstructions, "utf-8");
-    }
-  } else {
-    writeFileSync(instructionsPath, config.instructions, "utf-8");
-  }
+  // Take everything before the first PROJECT_DOC_SEPARATOR (or the whole string if none).
+  const [userInstructions] = config.instructions.split(PROJECT_DOC_SEPARATOR);
+  writeFileSync(instructionsPath, userInstructions, "utf-8");
 };

--- a/codex-cli/tests/config.test.tsx
+++ b/codex-cli/tests/config.test.tsx
@@ -234,3 +234,44 @@ test("loads and saves providers correctly", () => {
     expect(mergedConfig.providers["openai"]).toBeDefined();
   }
 });
+
+test("saves and loads instructions with project doc separator correctly", () => {
+  const userInstructions = "user specific instructions";
+  const projectDoc = "project specific documentation";
+  const combinedInstructions = `${userInstructions}\n\n--- project-doc ---\n\n${projectDoc}`;
+
+  const testConfig = {
+    model: "test-model",
+    instructions: combinedInstructions,
+    notify: false,
+  };
+
+  saveConfig(testConfig, testConfigPath, testInstructionsPath);
+
+  expect(memfs[testInstructionsPath]).toBe(userInstructions);
+
+  const loadedConfig = loadConfig(testConfigPath, testInstructionsPath, {
+    disableProjectDoc: true,
+  });
+  expect(loadedConfig.instructions).toBe(userInstructions);
+});
+
+test("handles empty user instructions when saving with project doc separator", () => {
+  const projectDoc = "project specific documentation";
+  const combinedInstructions = `\n\n--- project-doc ---\n\n${projectDoc}`;
+
+  const testConfig = {
+    model: "test-model",
+    instructions: combinedInstructions,
+    notify: false,
+  };
+
+  saveConfig(testConfig, testConfigPath, testInstructionsPath);
+
+  expect(memfs[testInstructionsPath]).toBe("");
+
+  const loadedConfig = loadConfig(testConfigPath, testInstructionsPath, {
+    disableProjectDoc: true,
+  });
+  expect(loadedConfig.instructions).toBe("");
+});


### PR DESCRIPTION
## Description

When `saveConfig` is called, the project doc is incorrectly saved into user instructions. This change ensures that only user instructions are saved to `instructions.md` during saveConfig, preventing data corruption.

close: #576