### PR TITLE
feat: add specific instructions for creating API keys in error msg

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -271,6 +271,10 @@ if (!apiKey && !NO_API_KEY_REQUIRED.has(provider.toLowerCase())) {
           ? `You can create a key here: ${chalk.bold(
               chalk.underline("https://platform.openai.com/account/api-keys"),
             )}\n`
+          : provider.toLowerCase() === "gemini"
+          ? `You can create a ${chalk.bold(
+              `${provider.toUpperCase()}_API_KEY`,
+            )} ` + `in the ${chalk.bold(`Google AI Studio`)}.\n`
           : `You can create a ${chalk.bold(
               `${provider.toUpperCase()}_API_KEY`,
             )} ` + `in the ${chalk.bold(`${provider}`)} dashboard.\n`


### PR DESCRIPTION
Updates the error message for missing Gemini API keys to reference "Google AI Studio" instead of the generic "GEMINI dashboard". This provides users with more accurate information about where to obtain their Gemini API keys.

This could be extended to other providers as well.