### PR TITLE
fix: shift + enter for newlines

### DIFF
--- a/codex-cli/src/components/chat/multiline-editor.tsx
+++ b/codex-cli/src/components/chat/multiline-editor.tsx
@@ -318,6 +318,12 @@ const MultilineTextEditorInner = (
       }
 
       if (input === "\r") {
+        // Shift+Enter (fallback without modifyOtherKeys) → insert newline
+        if (key.shift) {
+          buffer.current.newline();
+          setVersion((v) => v + 1);
+          return;
+        }
         // Plain Enter – submit (works on all basic terminals).
         if (onSubmit) {
           onSubmit(buffer.current.getText());


### PR DESCRIPTION
I was excited to use shift + enter for newlines in codex but upon upgrading, and despite the message to use this, it didn't work.

I created a `task.md` as:

```markdown
# task

Somebody added support in the codex REPL for using shift + enter to create a new line (instead of submitting). the old functionality was control + J. however on my machine, the new funcitonality doens't work, only the old, despite the help message in the REPL. please investigate and fix
```

and ran `codex --full-auto "open up task.md and work on it"`

seems to work for me
