### PR TITLE
fix: ensuring quiet mode only outputs final message

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -9,7 +9,10 @@ import type { AppRollout } from "./app";
 import type { ApprovalPolicy } from "./approvals";
 import type { CommandConfirmation } from "./utils/agent/agent-loop";
 import type { AppConfig } from "./utils/config";
-import type { ResponseItem, ResponseOutputMessage } from "openai/resources/responses/responses";
+import type {
+  ResponseItem,
+  ResponseOutputMessage,
+} from "openai/resources/responses/responses";
 
 import App from "./app";
 import { runSinglePass } from "./cli-singlepass";
@@ -424,15 +427,20 @@ const instance = render(
 setInkRenderer(instance);
 
 // Type guard to check if an item is the final completed assistant message
-function isResponseOutputMessage(item: ResponseItem): item is ResponseOutputMessage {
+function isResponseOutputMessage(
+  item: ResponseItem,
+): item is ResponseOutputMessage {
   return (
-    item.type === 'message' &&
-    'role' in item && item.role === 'assistant' &&
-    'status' in item && item.status === 'completed' &&
-    'content' in item && Array.isArray(item.content) &&
+    item.type === "message" &&
+    "role" in item &&
+    item.role === "assistant" &&
+    "status" in item &&
+    item.status === "completed" &&
+    "content" in item &&
+    Array.isArray(item.content) &&
     // Ensure content only contains output_text or refusal types
-    item.content.every(c => 
-      ('type' in c && (c.type === 'output_text' || c.type === 'refusal'))
+    item.content.every(
+      (c) => "type" in c && (c.type === "output_text" || c.type === "refusal"),
     )
   );
 }


### PR DESCRIPTION
# Fix Quiet Mode to Only Show Final Output

Fixing #585

## Problem
When using the Codex in quiet mode, it was showing all response items including internal debugging information like reasoning steps, function calls, and their outputs. In quiet mode, users should only see the final response message from the assistant.

## Changes
Added a type guard function that checks if a response item is a final output message or a refusal message. Added a filter to prevent all other types of messages from being printed in quiet mode. 

I'm not sure if this is the cleanest way to filter final messages. Open to alternative suggestions for a more elegant implementation here. 

## Testing
I verified that running the CLI with the `-q` flag now only shows the final output:

```bash
pnpm build && node ./dist/cli.js -q "explain this project"
```

## Final Notes
I noticed that quiet mode right now defaults to JSON outputs. I don't think this is intended behavior as there is a separate flag to specify if the user wants to output JSON. However, I believe this should be addressed in a separate PR

