### PR TITLE
fix(agent-loop): notify type

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -141,7 +141,7 @@ export default function TerminalChat({
   additionalWritableRoots,
   fullStdout,
 }: Props): React.ReactElement {
-  const notify = config.notify;
+  const notify = Boolean(config.notify);
   const [model, setModel] = useState<string>(config.model);
   const [provider, setProvider] = useState<string>(config.provider || "openai");
   const [lastResponseId, setLastResponseId] = useState<string | null>(null);

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -276,8 +276,8 @@ export class AgentLoop {
       config ??
       ({
         model,
-        instructions: instructions ?? "",
-      } as AppConfig);
+        instructions: instructions ?? ""
+      });
     this.additionalWritableRoots = additionalWritableRoots;
     this.onItem = onItem;
     this.onLoading = onLoading;

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -272,12 +272,10 @@ export class AgentLoop {
     // defined object.  We purposefully copy over the `model` and
     // `instructions` that have already been passed explicitly so that
     // downstream consumers (e.g. telemetry) still observe the correct values.
-    this.config =
-      config ??
-      ({
-        model,
-        instructions: instructions ?? ""
-      });
+    this.config = config ?? {
+      model,
+      instructions: instructions ?? "",
+    };
     this.additionalWritableRoots = additionalWritableRoots;
     this.onItem = onItem;
     this.onLoading = onLoading;

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -126,7 +126,7 @@ export type AppConfig = {
   fullAutoErrorMode?: FullAutoErrorMode;
   memory?: MemoryConfig;
   /** Whether to enable desktop notifications for responses */
-  notify: boolean;
+  notify?: boolean;
 
   /** Disable server-side response storage (send full transcript each request) */
   disableResponseStorage?: boolean;


### PR DESCRIPTION
## Description

The `as AppConfig` type assertion in the constructor may introduce potential type safety risks. Removing the assertion and making `notify` an optional parameter could enhance type robustness and prevent unexpected runtime errors.

close: #605