### PR TITLE
fix: prevent duplicate message output in quiet mode

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -489,6 +489,9 @@ async function runQuietMode({
   additionalWritableRoots: ReadonlyArray<string>;
   config: AppConfig;
 }): Promise<void> {
+  // Keep track of processed items by their id to prevent duplicate outputs
+  const processedItemIds = new Set<string>();
+  
   const agent = new AgentLoop({
     model: config.model,
     config: config,
@@ -498,8 +501,12 @@ async function runQuietMode({
     additionalWritableRoots,
     disableResponseStorage: config.disableResponseStorage,
     onItem: (item: ResponseItem) => {
-      // eslint-disable-next-line no-console
-      console.log(formatResponseItemForQuietMode(item));
+      // Only output each item once based on its ID
+      if (item.id && !processedItemIds.has(item.id)) {
+        processedItemIds.add(item.id);
+        // eslint-disable-next-line no-console
+        console.log(formatResponseItemForQuietMode(item));
+      }
     },
     onLoading: () => {
       /* intentionally ignored in quiet mode */


### PR DESCRIPTION
This commit fixes an issue in quiet mode where messages were being printed multiple times. It adds a Set to track processed message IDs and ensures each message is only printed once, regardless of how many times the onItem callback is triggered.

🤖 Generated with [Claude Code](https://claude.ai/code)