### PR TITLE
fix: update bug report template - there is no --revision flag

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.yml
@@ -19,7 +19,7 @@ body:
     id: version
     attributes:
       label: What version of Codex is running?
-      description: Copy the output of `codex --revision`
+      description: Copy the output of `codex --version`
   - type: input
     id: model
     attributes:


### PR DESCRIPTION
I think there was a wrong word; --revision seems not to exist in help and does nothing.