### PR TITLE
feat: enhance toCodePoints to prevent potential unicode 14 errors

### DIFF
--- a/codex-cli/src/text-buffer.ts
+++ b/codex-cli/src/text-buffer.ts
@@ -34,6 +34,10 @@ function clamp(v: number, min: number, max: number): number {
  * ---------------------------------------------------------------------- */
 
 function toCodePoints(str: string): Array<string> {
+  if (typeof Intl !== 'undefined' && 'Segmenter' in Intl) {
+    const seg = new Intl.Segmenter()
+    return [...seg.segment(str)].map((seg) => seg.segment)
+  }
   // [...str] or Array.from both iterate by UTF‑32 code point, handling
   // surrogate pairs correctly.
   return Array.from(str);

--- a/codex-cli/src/text-buffer.ts
+++ b/codex-cli/src/text-buffer.ts
@@ -34,9 +34,9 @@ function clamp(v: number, min: number, max: number): number {
  * ---------------------------------------------------------------------- */
 
 function toCodePoints(str: string): Array<string> {
-  if (typeof Intl !== 'undefined' && 'Segmenter' in Intl) {
-    const seg = new Intl.Segmenter()
-    return [...seg.segment(str)].map((seg) => seg.segment)
+  if (typeof Intl !== "undefined" && "Segmenter" in Intl) {
+    const seg = new Intl.Segmenter();
+    return [...seg.segment(str)].map((seg) => seg.segment);
   }
   // [...str] or Array.from both iterate by UTF‑32 code point, handling
   // surrogate pairs correctly.


### PR DESCRIPTION
## Description

`Array.from` may fail when handling certain characters newly added in Unicode 14. Where possible, it seems better to use `Intl.Segmenter` for more reliable processing.

![image](https://github.com/user-attachments/assets/2cbd779d-69d3-448e-b76a-d793cb639d96)
