### PR TITLE
fix: lint-staged error

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ".github/workflows/*.yml": "prettier --write",
     "**/*.{js,ts,tsx}": [
       "pnpm --filter @openai/codex run lint",
-      "pnpm --filter @openai/codex run typecheck"
+      "cd codex-cli && pnpm run typecheck"
     ]
   },
   "packageManager": "pnpm@10.8.1"


### PR DESCRIPTION
## Description

In a recent commit, the command `"cd codex-cli && pnpm run typecheck"` was updated to `"pnpm --filter @openai/codex run typecheck"`. 

However, this change introduces an issue: 
when running `pnpm --filter @openai/codex run typecheck`, it executes `tsc --noEmit somefile.ts` directly, bypassing the `tsconfig.json` configuration. As a result, numerous type errors are triggered, preventing successful commits.

Close: #619
