### PR TITLE
Fix: Ensure custom instructions have proper markdown formatting

### DIFF
--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -311,7 +311,15 @@ export const loadConfig = (
 
   const combinedInstructions = [userInstructions, projectDoc]
     .filter((s) => s && s.trim() !== "")
-    .join("\n\n--- project-doc ---\n\n");
+    .map((content, index) => {
+      // Add a clear section header for the content type
+      const sectionName = index === 0 ? "## Custom Instructions" : "## Project Documentation";
+      
+      // Ensure the content starts with a proper section header and newlines
+      // This prevents list items from bleeding across sections
+      return `${sectionName}\n\n${content}`;
+    })
+    .join("\n\n<!-- Section Separator -->\n\n");
 
   // Treat empty string ("" or whitespace) as absence so we can fall back to
   // the latest DEFAULT_MODEL.


### PR DESCRIPTION
### Fix: Ensure Custom Instructions Have Proper Markdown Formatting

#### **Issue**

When custom instructions were placed in `~/.codex/instructions.md`, they incorrectly merged with the last list item of the main prompt instead of appearing as a separate section. This caused formatting issues, especially when the main prompt ended with a list.

#### **Solution**

The `combinedInstructions` function in `config.ts` was modified to:

- Add clear section headers for each content type (such as **Custom Instructions** and **Project Documentation**).
- Ensure proper markdown separation between sections with consistent spacing.
- Add HTML comments as explicit section separators.
- Properly structure markdown headings to prevent list formatting from bleeding across sections.

#### **Testing**

This fix ensures that when custom instructions are placed in `~/.codex/instructions.md`, they will appear as a properly formatted, separate section in the prompt, maintaining their intended structure and preventing markdown formatting issues.