### PR TITLE
fix: `apply_patch` unicode characters

### DIFF
--- a/codex-cli/src/utils/agent/apply-patch.ts
+++ b/codex-cli/src/utils/agent/apply-patch.ts
@@ -238,6 +238,7 @@ class Parser {
                   "\u2018": "'",
                   "\u2019": "'",
                   "\u201B": "'",
+                  "\u00A0": " ",
                 } as Record<string, string>
               )[c] ?? c),
           );
@@ -373,6 +374,7 @@ function find_context_core(
     /* U+2018 LEFT SINGLE QUOTATION MARK */ "\u2018": "'",
     /* U+2019 RIGHT SINGLE QUOTATION MARK */ "\u2019": "'",
     /* U+201B SINGLE HIGH-REVERSED-9 QUOTATION MARK */ "\u201B": "'",
+    /* U+00A0 NO-BREAK SPACE */ "\u00A0": " ",
   };
 
   const canon = (s: string): string =>

--- a/codex-cli/src/utils/agent/apply-patch.ts
+++ b/codex-cli/src/utils/agent/apply-patch.ts
@@ -239,6 +239,7 @@ class Parser {
                   "\u2019": "'",
                   "\u201B": "'",
                   "\u00A0": " ",
+                  "\u202F": " ",
                 } as Record<string, string>
               )[c] ?? c),
           );
@@ -374,7 +375,9 @@ function find_context_core(
     /* U+2018 LEFT SINGLE QUOTATION MARK */ "\u2018": "'",
     /* U+2019 RIGHT SINGLE QUOTATION MARK */ "\u2019": "'",
     /* U+201B SINGLE HIGH-REVERSED-9 QUOTATION MARK */ "\u201B": "'",
+    // Spaces ------------------------------------------------------------------
     /* U+00A0 NO-BREAK SPACE */ "\u00A0": " ",
+    /* U+202F NARROW NO-BREAK SPACE */ "\u202F": " ",
   };
 
   const canon = (s: string): string =>


### PR DESCRIPTION
fuzzy-er matching for apply_patch to handle u00A0 and u202F spaces
