### PR TITLE
fix: update scripts/build_container.sh to use pnpm instead of npm

### DIFF
--- a/codex-cli/scripts/build_container.sh
+++ b/codex-cli/scripts/build_container.sh
@@ -8,9 +8,9 @@ pushd "$SCRIPT_DIR/.." >> /dev/null || {
   echo "Error: Failed to change directory to $SCRIPT_DIR/.."
   exit 1
 }
-npm install
-npm run build
+pnpm install
+pnpm run build
 rm -rf ./dist/openai-codex-*.tgz
-npm pack --pack-destination ./dist
+pnpm pack --pack-destination ./dist
 mv ./dist/openai-codex-*.tgz ./dist/codex.tgz
 docker build -t codex -f "./Dockerfile" .


### PR DESCRIPTION
I suspect this is why some contributors kept accidentally including a new `codex-cli/package-lock.json` in their PRs.

Note the `Dockerfile` still uses `npm` instead of `pnpm`, but that appears to be fine. (Probably nicer to globally install as few things as possible in the image.)