### PR TITLE
fix: for now, only run rust-ci.yml on PRs that modify files in codex-rs

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -1,7 +1,13 @@
 name: rust-ci
 on:
-  pull_request: { branches: [main] }
-  push: { branches: [main] }
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "codex-rs/**"
+  push:
+    branches:
+      - main
 
 # For CI, we build in debug (`--profile dev`) rather than release mode so we
 # get signal faster.


### PR DESCRIPTION
The `rust-ci.yml` build appears to be a bit flaky (we're looking into it...), so to save TypeScript contributors some noise, restrict the `rust-ci.yml` job so that it only runs on PRs that touch files in `codex-rs/`.