### PR TITLE
feat(tui-rs): add support for mousewheel scrolling

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -3,8 +3,15 @@ use crossterm::event::KeyEvent;
 
 pub(crate) enum AppEvent {
     CodexEvent(Event),
+
     Redraw,
+
     KeyEvent(KeyEvent),
+
+    /// Scroll event with a value representing the "scroll delta" as the net
+    /// scroll up/down events within a short time window.
+    Scroll(i32),
+
     /// Request to exit the application gracefully.
     ExitRequest,
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -364,6 +364,23 @@ impl ChatWidget<'_> {
         Ok(())
     }
 
+    pub(crate) fn handle_scroll_delta(
+        &mut self,
+        scroll_delta: i32,
+    ) -> std::result::Result<(), std::sync::mpsc::SendError<AppEvent>> {
+        // If the user is trying to scroll exactly one line, we let them, but
+        // otherwise we assume they are trying to scroll in larger increments.
+        let magnified_scroll_delta = if scroll_delta == 1 {
+            1
+        } else {
+            // Play with this: perhaps it should be non-linear?
+            scroll_delta * 2
+        };
+        self.conversation_history.scroll(magnified_scroll_delta);
+        self.request_redraw()?;
+        Ok(())
+    }
+
     /// Forward an `Op` directly to codex.
     pub(crate) fn submit_op(&self, op: Op) {
         if let Err(e) = self.codex_op_tx.send(op) {

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -21,6 +21,7 @@ mod exec_command;
 mod git_warning_screen;
 mod history_cell;
 mod log_layer;
+mod scroll_event_helper;
 mod status_indicator_widget;
 mod tui;
 mod user_approval_widget;

--- a/codex-rs/tui/src/scroll_event_helper.rs
+++ b/codex-rs/tui/src/scroll_event_helper.rs
@@ -1,0 +1,77 @@
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicI32;
+use std::sync::atomic::Ordering;
+use std::sync::mpsc::Sender;
+use std::sync::Arc;
+
+use tokio::runtime::Handle;
+use tokio::time::sleep;
+use tokio::time::Duration;
+
+use crate::app_event::AppEvent;
+
+pub(crate) struct ScrollEventHelper {
+    app_event_tx: Sender<AppEvent>,
+    scroll_delta: Arc<AtomicI32>,
+    timer_scheduled: Arc<AtomicBool>,
+    runtime: Handle,
+}
+
+/// How long to wait after the first scroll event before sending the
+/// accumulated scroll delta to the main thread.
+const DEBOUNCE_WINDOW: Duration = Duration::from_millis(100);
+
+/// Utility to debounce scroll events so we can determine the **magnitude** of
+/// each scroll burst by accumulating individual wheel events over a short
+/// window.  The debounce timer now runs on Tokio so we avoid spinning up a new
+/// operating-system thread for every burst.
+impl ScrollEventHelper {
+    pub(crate) fn new(app_event_tx: Sender<AppEvent>) -> Self {
+        Self {
+            app_event_tx,
+            scroll_delta: Arc::new(AtomicI32::new(0)),
+            timer_scheduled: Arc::new(AtomicBool::new(false)),
+            runtime: Handle::current(),
+        }
+    }
+
+    pub(crate) fn scroll_up(&self) {
+        self.scroll_delta.fetch_sub(1, Ordering::Relaxed);
+        self.schedule_notification();
+    }
+
+    pub(crate) fn scroll_down(&self) {
+        self.scroll_delta.fetch_add(1, Ordering::Relaxed);
+        self.schedule_notification();
+    }
+
+    /// Starts a one-shot timer **only once** per burst of wheel events.
+    fn schedule_notification(&self) {
+        // If the timer is already scheduled, do nothing.
+        if self
+            .timer_scheduled
+            .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+            .is_err()
+        {
+            return;
+        }
+
+        // Otherwise, schedule a new timer.
+        let tx = self.app_event_tx.clone();
+        let delta = Arc::clone(&self.scroll_delta);
+        let timer_flag = Arc::clone(&self.timer_scheduled);
+
+        // Use self.runtime instead of tokio::spawn() because the calling thread
+        // in app.rs is not part of the Tokio runtime: it is a plain OS thread.
+        self.runtime.spawn(async move {
+            sleep(DEBOUNCE_WINDOW).await;
+
+            let accumulated = delta.swap(0, Ordering::SeqCst);
+            if accumulated != 0 {
+                let _ = tx.send(AppEvent::Scroll(accumulated));
+            }
+
+            timer_flag.store(false, Ordering::SeqCst);
+        });
+    }
+}

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -2,6 +2,8 @@ use std::io::stdout;
 use std::io::Stdout;
 use std::io::{self};
 
+use crossterm::event::DisableMouseCapture;
+use crossterm::event::EnableMouseCapture;
 use ratatui::backend::CrosstermBackend;
 use ratatui::crossterm::execute;
 use ratatui::crossterm::terminal::disable_raw_mode;
@@ -16,6 +18,7 @@ pub type Tui = Terminal<CrosstermBackend<Stdout>>;
 /// Initialize the terminal
 pub fn init() -> io::Result<Tui> {
     execute!(stdout(), EnterAlternateScreen)?;
+    execute!(stdout(), EnableMouseCapture)?;
     enable_raw_mode()?;
     set_panic_hook();
     Terminal::new(CrosstermBackend::new(stdout()))
@@ -31,6 +34,7 @@ fn set_panic_hook() {
 
 /// Restore the terminal to its original state
 pub fn restore() -> io::Result<()> {
+    execute!(stdout(), DisableMouseCapture)?;
     execute!(stdout(), LeaveAlternateScreen)?;
     disable_raw_mode()?;
     Ok(())


### PR DESCRIPTION
It is intuitive to try to scroll the conversation history using the mouse in the TUI, but prior to this change, we only supported scrolling via keyboard events.

This PR enables mouse capture upon initialization (and disables it on exit) such that we get `ScrollUp` and `ScrollDown` events in `codex-rs/tui/src/app.rs`. I initially mapped each event to scrolling by one line, but that felt sluggish. I decided to introduce `ScrollEventHelper` so we could debounce scroll events and measure the number of scroll events in a 100ms window to determine the "magnitude" of the scroll event. I put in a basic heuristic to start, but perhaps someone more motivated can play with it over time.

`ScrollEventHelper` takes care of handling the atomic fields and thread management to ensure an `AppEvent::Scroll` event is pumped back through the event loop at the appropriate time with the accumulated delta.