### PR TITLE
feat: add ZDR support to Rust implementation

### DIFF
--- a/codex-rs/core/src/codex_wrapper.rs
+++ b/codex-rs/core/src/codex_wrapper.rs
@@ -21,6 +21,7 @@ use tracing::debug;
 pub async fn init_codex(
     approval_policy: AskForApproval,
     sandbox_policy: SandboxPolicy,
+    disable_response_storage: bool,
     model_override: Option<String>,
 ) -> anyhow::Result<(CodexWrapper, Event, Arc<Notify>)> {
     let ctrl_c = notify_on_sigint();
@@ -33,6 +34,7 @@ pub async fn init_codex(
             instructions: config.instructions,
             approval_policy,
             sandbox_policy,
+            disable_response_storage,
         })
         .await?;
 

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -19,6 +19,7 @@ mod models;
 pub mod protocol;
 mod safety;
 pub mod util;
+mod zdr_transcript;
 
 pub use codex::Codex;
 

--- a/codex-rs/core/src/models.rs
+++ b/codex-rs/core/src/models.rs
@@ -56,6 +56,17 @@ pub enum ResponseItem {
     Other,
 }
 
+impl From<ResponseInputItem> for ResponseItem {
+    fn from(item: ResponseInputItem) -> Self {
+        match item {
+            ResponseInputItem::Message { role, content } => Self::Message { role, content },
+            ResponseInputItem::FunctionCallOutput { call_id, output } => {
+                Self::FunctionCallOutput { call_id, output }
+            }
+        }
+    }
+}
+
 impl From<Vec<InputItem>> for ResponseInputItem {
     fn from(items: Vec<InputItem>) -> Self {
         Self::Message {

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -33,6 +33,9 @@ pub enum Op {
         approval_policy: AskForApproval,
         /// How to sandbox commands executed in the system
         sandbox_policy: SandboxPolicy,
+        /// Disable server-side response storage (send full context each request)
+        #[serde(default)]
+        disable_response_storage: bool,
     },
 
     /// Abort current task.

--- a/codex-rs/core/src/zdr_transcript.rs
+++ b/codex-rs/core/src/zdr_transcript.rs
@@ -1,0 +1,46 @@
+use crate::models::ResponseItem;
+
+/// Transcript that needs to be maintained for ZDR clients for which
+/// previous_response_id is not available, so we must include the transcript
+/// with every API call. This must include each `function_call` and its
+/// corresponding `function_call_output`.
+#[derive(Debug, Clone)]
+pub(crate) struct ZdrTranscript {
+    /// The oldest items are at the beginning of the vector.
+    items: Vec<ResponseItem>,
+}
+
+impl ZdrTranscript {
+    pub(crate) fn new() -> Self {
+        Self { items: Vec::new() }
+    }
+
+    /// Returns a clone of the contents in the transcript.
+    pub(crate) fn contents(&self) -> Vec<ResponseItem> {
+        self.items.clone()
+    }
+
+    /// `items` is ordered from oldest to newest.
+    pub(crate) fn record_items<I>(&mut self, items: I)
+    where
+        I: IntoIterator<Item = ResponseItem>,
+    {
+        for item in items {
+            if is_api_message(&item) {
+                // Note agent-loop.ts also does filtering on some of the fields.
+                self.items.push(item.clone());
+            }
+        }
+    }
+}
+
+/// Anything that is not a system message or "reasoning" message is considered
+/// an API message.
+fn is_api_message(message: &ResponseItem) -> bool {
+    match message {
+        ResponseItem::Message { role, .. } => role.as_str() != "system",
+        ResponseItem::FunctionCall { .. } => true,
+        ResponseItem::FunctionCallOutput { .. } => true,
+        _ => false,
+    }
+}

--- a/codex-rs/core/tests/live_agent.rs
+++ b/codex-rs/core/tests/live_agent.rs
@@ -55,6 +55,7 @@ async fn spawn_codex() -> Codex {
                 instructions: None,
                 approval_policy: AskForApproval::OnFailure,
                 sandbox_policy: SandboxPolicy::NetworkAndFileWriteRestricted,
+                disable_response_storage: false,
             },
         })
         .await

--- a/codex-rs/core/tests/previous_response_id.rs
+++ b/codex-rs/core/tests/previous_response_id.rs
@@ -95,6 +95,7 @@ async fn keeps_previous_response_id_between_tasks() {
                 instructions: None,
                 approval_policy: AskForApproval::OnFailure,
                 sandbox_policy: SandboxPolicy::NetworkAndFileWriteRestricted,
+                disable_response_storage: false,
             },
         })
         .await

--- a/codex-rs/core/tests/stream_no_completed.rs
+++ b/codex-rs/core/tests/stream_no_completed.rs
@@ -78,6 +78,7 @@ async fn retries_on_early_close() {
                 instructions: None,
                 approval_policy: AskForApproval::OnFailure,
                 sandbox_policy: SandboxPolicy::NetworkAndFileWriteRestricted,
+                disable_response_storage: false,
             },
         })
         .await

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -16,6 +16,10 @@ pub struct Cli {
     #[arg(long = "skip-git-repo-check", default_value_t = false)]
     pub skip_git_repo_check: bool,
 
+    /// Disable server‑side response storage (sends the full conversation context with every request)
+    #[arg(long = "disable-response-storage", default_value_t = false)]
+    pub disable_response_storage: bool,
+
     /// Initial instructions for the agent.
     pub prompt: Option<String>,
 }

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -31,9 +31,10 @@ pub async fn run_main(cli: Cli) -> anyhow::Result<()> {
         .try_init();
 
     let Cli {
-        skip_git_repo_check,
-        model,
         images,
+        model,
+        skip_git_repo_check,
+        disable_response_storage,
         prompt,
         ..
     } = cli;
@@ -50,8 +51,13 @@ pub async fn run_main(cli: Cli) -> anyhow::Result<()> {
     // likely come from a new --execution-policy arg.
     let approval_policy = AskForApproval::Never;
     let sandbox_policy = SandboxPolicy::NetworkAndFileWriteRestricted;
-    let (codex_wrapper, event, ctrl_c) =
-        codex_wrapper::init_codex(approval_policy, sandbox_policy, model).await?;
+    let (codex_wrapper, event, ctrl_c) = codex_wrapper::init_codex(
+        approval_policy,
+        sandbox_policy,
+        disable_response_storage,
+        model,
+    )
+    .await?;
     let codex = Arc::new(codex_wrapper);
     info!("Codex initialized with event: {event:?}");
 

--- a/codex-rs/repl/src/cli.rs
+++ b/codex-rs/repl/src/cli.rs
@@ -50,6 +50,10 @@ pub struct Cli {
     #[arg(long, action = ArgAction::SetTrue, default_value_t = false)]
     pub allow_no_git_exec: bool,
 
+    /// Disable server‑side response storage (sends the full conversation context with every request)
+    #[arg(long = "disable-response-storage", default_value_t = false)]
+    pub disable_response_storage: bool,
+
     /// Record submissions into file as JSON
     #[arg(short = 'S', long)]
     pub record_submissions: Option<String>,

--- a/codex-rs/repl/src/lib.rs
+++ b/codex-rs/repl/src/lib.rs
@@ -97,6 +97,7 @@ async fn codex_main(mut cli: Cli, cfg: Config, ctrl_c: Arc<Notify>) -> anyhow::R
             instructions: cfg.instructions,
             approval_policy: cli.approval_policy.into(),
             sandbox_policy: cli.sandbox_policy.into(),
+            disable_response_storage: cli.disable_response_storage,
         },
     };
 

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -37,6 +37,7 @@ impl App<'_> {
         show_git_warning: bool,
         initial_images: Vec<std::path::PathBuf>,
         model: Option<String>,
+        disable_response_storage: bool,
     ) -> Self {
         let (app_event_tx, app_event_rx) = channel();
 
@@ -70,6 +71,7 @@ impl App<'_> {
             initial_prompt.clone(),
             initial_images,
             model,
+            disable_response_storage,
         );
 
         let app_state = if show_git_warning {

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -31,6 +31,10 @@ pub struct Cli {
     #[arg(long = "skip-git-repo-check", default_value_t = false)]
     pub skip_git_repo_check: bool,
 
+    /// Disable server‑side response storage (sends the full conversation context with every request)
+    #[arg(long = "disable-response-storage", default_value_t = false)]
+    pub disable_response_storage: bool,
+
     /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, -s network-and-file-write-restricted)
     #[arg(long = "full-auto", default_value_t = true)]
     pub full_auto: bool,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -106,6 +106,7 @@ fn run_ratatui_app(
         approval_policy,
         sandbox_policy: sandbox,
         model,
+        disable_response_storage,
         ..
     } = cli;
 
@@ -119,6 +120,7 @@ fn run_ratatui_app(
         show_git_warning,
         images,
         model,
+        disable_response_storage,
     );
 
     // Bridge log receiver into the AppEvent channel so latest log lines update the UI.


### PR DESCRIPTION
This adds support for the `--disable-response-storage` flag across our multiple Rust CLIs to support customers who have opted into Zero-Data Retention (ZDR). The analogous changes to the TypeScript CLI were:

* https://github.com/openai/codex/pull/481
* https://github.com/openai/codex/pull/543

For a client using ZDR, `previous_response_id` will never be available, so the `input` field of an API request must include the full transcript of the conversation thus far. As such, this PR changes the type of `Prompt.input` from `Vec<ResponseInputItem>` to `Vec<ResponseItem>`.

Practically speaking, `ResponseItem` was effectively a "superset" of `ResponseInputItem` already. The main difference for us is that `ResponseItem` includes the `FunctionCall` variant that we have to include as part of the conversation history in the ZDR case.

Another key change in this PR is modifying `try_run_turn()` so that it returns the `Vec<ResponseItem>` for the turn in addition to the `Vec<ResponseInputItem>` produced by `try_run_turn()`. This is because the caller of `run_turn()` needs to record the `Vec<ResponseItem>` when ZDR is enabled.

To that end, this PR introduces `ZdrTranscript` (and adds `zdr_transcript: Option<ZdrTranscript>` to `struct State` in `codex.rs`) to take responsibility for maintaining the conversation transcript in the ZDR case. 