### PR TITLE
fix: model selection

### DIFF
--- a/codex-cli/src/components/model-overlay.tsx
+++ b/codex-cli/src/components/model-overlay.tsx
@@ -153,10 +153,10 @@ export default function ModelOverlay({
       }
       initialItems={items}
       currentValue={currentModel}
-      onSelect={() =>
+      onSelect={(selectedModel) =>
         onSelect(
           items?.map((m) => m.value),
-          currentModel,
+          selectedModel,
         )
       }
       onExit={onExit}


### PR DESCRIPTION
fix: pass correct selected model in ModelOverlay

The ModelOverlay component was incorrectly passing the current model instead of the newly selected model to its onSelect callback. This prevented model changes from being applied properly.

The fix ensures that when a user selects a new model, the parent component receives the correct newly selected model value, allowing model changes to work as intended.