### PR TITLE
chore: upgrade prettier to v3

### DIFF
--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -71,7 +71,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "husky": "^9.1.7",
     "ink-testing-library": "^3.0.0",
-    "prettier": "^2.8.7",
+    "prettier": "^3.5.3",
     "punycode": "^2.3.1",
     "semver": "^7.7.1",
     "ts-node": "^10.9.1",

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -272,12 +272,12 @@ if (!apiKey && !NO_API_KEY_REQUIRED.has(provider.toLowerCase())) {
               chalk.underline("https://platform.openai.com/account/api-keys"),
             )}\n`
           : provider.toLowerCase() === "gemini"
-          ? `You can create a ${chalk.bold(
-              `${provider.toUpperCase()}_API_KEY`,
-            )} ` + `in the ${chalk.bold(`Google AI Studio`)}.\n`
-          : `You can create a ${chalk.bold(
-              `${provider.toUpperCase()}_API_KEY`,
-            )} ` + `in the ${chalk.bold(`${provider}`)} dashboard.\n`
+            ? `You can create a ${chalk.bold(
+                `${provider.toUpperCase()}_API_KEY`,
+              )} ` + `in the ${chalk.bold(`Google AI Studio`)}.\n`
+            : `You can create a ${chalk.bold(
+                `${provider.toUpperCase()}_API_KEY`,
+              )} ` + `in the ${chalk.bold(`${provider}`)} dashboard.\n`
       }`,
   );
   process.exit(1);
@@ -381,8 +381,8 @@ if (cli.flags.quiet) {
     cli.flags.fullAuto || cli.flags.approvalMode === "full-auto"
       ? AutoApprovalMode.FULL_AUTO
       : cli.flags.autoEdit || cli.flags.approvalMode === "auto-edit"
-      ? AutoApprovalMode.AUTO_EDIT
-      : config.approvalMode || AutoApprovalMode.SUGGEST;
+        ? AutoApprovalMode.AUTO_EDIT
+        : config.approvalMode || AutoApprovalMode.SUGGEST;
 
   await runQuietMode({
     prompt,
@@ -412,8 +412,8 @@ const approvalPolicy: ApprovalPolicy =
   cli.flags.fullAuto || cli.flags.approvalMode === "full-auto"
     ? AutoApprovalMode.FULL_AUTO
     : cli.flags.autoEdit || cli.flags.approvalMode === "auto-edit"
-    ? AutoApprovalMode.AUTO_EDIT
-    : config.approvalMode || AutoApprovalMode.SUGGEST;
+      ? AutoApprovalMode.AUTO_EDIT
+      : config.approvalMode || AutoApprovalMode.SUGGEST;
 
 const instance = render(
   <App

--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -135,8 +135,8 @@ export default function TerminalChatInput({
                 ? len - 1
                 : selectedSlashSuggestion - 1
               : selectedSlashSuggestion >= len - 1
-              ? 0
-              : selectedSlashSuggestion + 1;
+                ? 0
+                : selectedSlashSuggestion + 1;
             setSelectedSlashSuggestion(nextIdx);
             // Autocomplete the command in the input
             const match = matches[nextIdx];

--- a/codex-cli/src/components/chat/terminal-chat-response-item.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-response-item.tsx
@@ -135,14 +135,14 @@ function TerminalChatResponseMessage({
               c.type === "output_text"
                 ? c.text
                 : c.type === "refusal"
-                ? c.refusal
-                : c.type === "input_text"
-                ? c.text
-                : c.type === "input_image"
-                ? "<Image>"
-                : c.type === "input_file"
-                ? c.filename
-                : "", // unknown content type
+                  ? c.refusal
+                  : c.type === "input_text"
+                    ? c.text
+                    : c.type === "input_image"
+                      ? "<Image>"
+                      : c.type === "input_file"
+                        ? c.filename
+                        : "", // unknown content type
           )
           .join(" ")}
       </Markdown>

--- a/codex-cli/src/components/history-overlay.tsx
+++ b/codex-cli/src/components/history-overlay.tsx
@@ -148,8 +148,8 @@ function formatHistoryForDisplay(items: Array<ResponseItem>): {
     const cmdArray: Array<string> | undefined = Array.isArray(argsObj?.["cmd"])
       ? (argsObj!["cmd"] as Array<string>)
       : Array.isArray(argsObj?.["command"])
-      ? (argsObj!["command"] as Array<string>)
-      : undefined;
+        ? (argsObj!["command"] as Array<string>)
+        : undefined;
 
     if (cmdArray && cmdArray.length > 0) {
       commands.push(processCommandArray(cmdArray, filesSet));

--- a/codex-cli/src/utils/agent/apply-patch.ts
+++ b/codex-cli/src/utils/agent/apply-patch.ts
@@ -219,8 +219,8 @@ class Parser {
           s.normalize("NFC").replace(
             /./gu,
             (c) =>
-              ((
-                {
+              (
+                ({
                   "-": "-",
                   "\u2010": "-",
                   "\u2011": "-",
@@ -240,8 +240,8 @@ class Parser {
                   "\u201B": "'",
                   "\u00A0": " ",
                   "\u202F": " ",
-                } as Record<string, string>
-              )[c] ?? c),
+                }) as Record<string, string>
+              )[c] ?? c,
           );
 
         if (

--- a/codex-cli/tests/agent-cancel-early.test.ts
+++ b/codex-cli/tests/agent-cancel-early.test.ts
@@ -67,7 +67,7 @@ vi.mock("openai", () => {
 vi.mock("../src/approvals.js", () => ({
   __esModule: true,
   alwaysApprovedCommands: new Set<string>(),
-  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false } as any),
+  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false }) as any,
 }));
 
 vi.mock("../src/format-command.js", () => ({
@@ -94,7 +94,7 @@ describe("cancel before first function_call", () => {
       approvalPolicy: { mode: "auto" } as any,
       onItem: () => {},
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
       config: { model: "any", instructions: "", notify: false },
     });

--- a/codex-cli/tests/agent-cancel-prev-response.test.ts
+++ b/codex-cli/tests/agent-cancel-prev-response.test.ts
@@ -74,7 +74,7 @@ vi.mock("openai", () => {
 vi.mock("../src/approvals.js", () => ({
   __esModule: true,
   alwaysApprovedCommands: new Set<string>(),
-  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false } as any),
+  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false }) as any,
 }));
 
 vi.mock("../src/format-command.js", () => ({
@@ -102,7 +102,7 @@ describe("cancel clears previous_response_id", () => {
       additionalWritableRoots: [],
       onItem: () => {},
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
       config: { model: "any", instructions: "", notify: false },
     });

--- a/codex-cli/tests/agent-cancel-race.test.ts
+++ b/codex-cli/tests/agent-cancel-race.test.ts
@@ -99,7 +99,7 @@ describe("Agent cancellation race", () => {
       approvalPolicy: { mode: "auto" } as any,
       onItem: (i) => items.push(i),
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 

--- a/codex-cli/tests/agent-cancel.test.ts
+++ b/codex-cli/tests/agent-cancel.test.ts
@@ -52,7 +52,7 @@ vi.mock("../src/approvals.js", () => {
     __esModule: true,
     alwaysApprovedCommands: new Set<string>(),
     canAutoApprove: () =>
-      ({ type: "auto-approve", runInSandbox: false } as any),
+      ({ type: "auto-approve", runInSandbox: false }) as any,
     isSafeCommand: () => null,
   };
 });
@@ -96,7 +96,7 @@ describe("Agent cancellation", () => {
         received.push(item);
       },
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 
@@ -144,7 +144,7 @@ describe("Agent cancellation", () => {
       approvalPolicy: { mode: "auto" } as any,
       onItem: (item) => received.push(item),
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 

--- a/codex-cli/tests/agent-function-call-id.test.ts
+++ b/codex-cli/tests/agent-function-call-id.test.ts
@@ -91,7 +91,7 @@ vi.mock("openai", () => {
 vi.mock("../src/approvals.js", () => ({
   __esModule: true,
   alwaysApprovedCommands: new Set<string>(),
-  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false } as any),
+  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false }) as any,
   isSafeCommand: () => null,
 }));
 
@@ -121,7 +121,7 @@ describe("function_call_output includes original call ID", () => {
       additionalWritableRoots: [],
       onItem: () => {},
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 

--- a/codex-cli/tests/agent-generic-network-error.test.ts
+++ b/codex-cli/tests/agent-generic-network-error.test.ts
@@ -26,7 +26,7 @@ vi.mock("openai", () => {
 vi.mock("../src/approvals.js", () => ({
   __esModule: true,
   alwaysApprovedCommands: new Set<string>(),
-  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false } as any),
+  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false }) as any,
   isSafeCommand: () => null,
 }));
 
@@ -62,7 +62,7 @@ describe("AgentLoop – generic network/server errors", () => {
       approvalPolicy: { mode: "auto" } as any,
       onItem: (i) => received.push(i),
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 
@@ -106,7 +106,7 @@ describe("AgentLoop – generic network/server errors", () => {
       approvalPolicy: { mode: "auto" } as any,
       onItem: (i) => received.push(i),
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 

--- a/codex-cli/tests/agent-interrupt-continue.test.ts
+++ b/codex-cli/tests/agent-interrupt-continue.test.ts
@@ -47,7 +47,7 @@ describe("Agent interrupt and continue", () => {
       onLoading: (loading) => {
         loadingState = loading;
       },
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 

--- a/codex-cli/tests/agent-invalid-request-error.test.ts
+++ b/codex-cli/tests/agent-invalid-request-error.test.ts
@@ -25,7 +25,7 @@ vi.mock("openai", () => {
 vi.mock("../src/approvals.js", () => ({
   __esModule: true,
   alwaysApprovedCommands: new Set<string>(),
-  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false } as any),
+  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false }) as any,
   isSafeCommand: () => null,
 }));
 
@@ -61,7 +61,7 @@ describe("AgentLoop – invalid request / 4xx errors", () => {
       additionalWritableRoots: [],
       onItem: (i) => received.push(i),
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 

--- a/codex-cli/tests/agent-max-tokens-error.test.ts
+++ b/codex-cli/tests/agent-max-tokens-error.test.ts
@@ -25,7 +25,7 @@ vi.mock("openai", () => {
 vi.mock("../src/approvals.js", () => ({
   __esModule: true,
   alwaysApprovedCommands: new Set<string>(),
-  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false } as any),
+  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false }) as any,
   isSafeCommand: () => null,
 }));
 
@@ -64,7 +64,7 @@ describe("AgentLoop – max_tokens too large error", () => {
       approvalPolicy: { mode: "auto" } as any,
       onItem: (i) => received.push(i),
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 

--- a/codex-cli/tests/agent-network-errors.test.ts
+++ b/codex-cli/tests/agent-network-errors.test.ts
@@ -45,7 +45,7 @@ vi.mock("openai", () => {
 vi.mock("../src/approvals.js", () => ({
   __esModule: true,
   alwaysApprovedCommands: new Set<string>(),
-  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false } as any),
+  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false }) as any,
   isSafeCommand: () => null,
 }));
 
@@ -112,7 +112,7 @@ describe("AgentLoop – network resilience", () => {
       additionalWritableRoots: [],
       onItem: (i) => received.push(i),
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 
@@ -154,7 +154,7 @@ describe("AgentLoop – network resilience", () => {
       additionalWritableRoots: [],
       onItem: (i) => received.push(i),
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 

--- a/codex-cli/tests/agent-project-doc.test.ts
+++ b/codex-cli/tests/agent-project-doc.test.ts
@@ -56,7 +56,7 @@ vi.mock("../src/approvals.js", () => {
     __esModule: true,
     alwaysApprovedCommands: new Set<string>(),
     canAutoApprove: () =>
-      ({ type: "auto-approve", runInSandbox: false } as any),
+      ({ type: "auto-approve", runInSandbox: false }) as any,
     isSafeCommand: () => null,
   };
 });
@@ -119,7 +119,7 @@ describe("AgentLoop", () => {
       approvalPolicy: { mode: "suggest" } as any,
       onItem: () => {},
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 

--- a/codex-cli/tests/agent-rate-limit-error.test.ts
+++ b/codex-cli/tests/agent-rate-limit-error.test.ts
@@ -37,7 +37,7 @@ vi.mock("openai", () => {
 vi.mock("../src/approvals.js", () => ({
   __esModule: true,
   alwaysApprovedCommands: new Set<string>(),
-  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false } as any),
+  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false }) as any,
   isSafeCommand: () => null,
 }));
 
@@ -82,7 +82,7 @@ describe("AgentLoop – rate‑limit handling", () => {
         additionalWritableRoots: [],
         onItem: (i) => received.push(i),
         onLoading: () => {},
-        getCommandConfirmation: async () => ({ review: "yes" } as any),
+        getCommandConfirmation: async () => ({ review: "yes" }) as any,
         onLastResponseId: () => {},
       });
 

--- a/codex-cli/tests/agent-server-retry.test.ts
+++ b/codex-cli/tests/agent-server-retry.test.ts
@@ -35,7 +35,7 @@ vi.mock("openai", () => {
 vi.mock("../src/approvals.js", () => ({
   __esModule: true,
   alwaysApprovedCommands: new Set<string>(),
-  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false } as any),
+  canAutoApprove: () => ({ type: "auto-approve", runInSandbox: false }) as any,
   isSafeCommand: () => null,
 }));
 
@@ -100,7 +100,7 @@ describe("AgentLoop – automatic retry on 5xx errors", () => {
       additionalWritableRoots: [],
       onItem: (i) => received.push(i),
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 
@@ -138,7 +138,7 @@ describe("AgentLoop – automatic retry on 5xx errors", () => {
       additionalWritableRoots: [],
       onItem: (i) => received.push(i),
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 

--- a/codex-cli/tests/agent-terminate.test.ts
+++ b/codex-cli/tests/agent-terminate.test.ts
@@ -54,7 +54,7 @@ vi.mock("../src/approvals.js", () => {
     __esModule: true,
     alwaysApprovedCommands: new Set<string>(),
     canAutoApprove: () =>
-      ({ type: "auto-approve", runInSandbox: false } as any),
+      ({ type: "auto-approve", runInSandbox: false }) as any,
     isSafeCommand: () => null,
   };
 });
@@ -116,7 +116,7 @@ describe("Agent terminate (hard cancel)", () => {
       additionalWritableRoots: [],
       onItem: (item) => received.push(item),
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 
@@ -152,7 +152,7 @@ describe("Agent terminate (hard cancel)", () => {
       additionalWritableRoots: [],
       onItem: () => {},
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 

--- a/codex-cli/tests/agent-thinking-time.test.ts
+++ b/codex-cli/tests/agent-thinking-time.test.ts
@@ -110,7 +110,7 @@ describe("thinking time counter", () => {
       additionalWritableRoots: [],
       onItem: (i) => items.push(i),
       onLoading: () => {},
-      getCommandConfirmation: async () => ({ review: "yes" } as any),
+      getCommandConfirmation: async () => ({ review: "yes" }) as any,
       onLastResponseId: () => {},
     });
 

--- a/codex-cli/tests/invalid-command-handling.test.ts
+++ b/codex-cli/tests/invalid-command-handling.test.ts
@@ -26,7 +26,7 @@ vi.mock("../src/approvals.js", () => {
   return {
     __esModule: true,
     canAutoApprove: () =>
-      ({ type: "auto-approve", runInSandbox: false } as any),
+      ({ type: "auto-approve", runInSandbox: false }) as any,
     isSafeCommand: () => null,
   };
 });
@@ -51,7 +51,7 @@ describe("handleExecCommand – invalid executable", () => {
     const execInput = { cmd: ["git show"] } as any;
     const config = { model: "any", instructions: "" } as any;
     const policy = { mode: "auto" } as any;
-    const getConfirmation = async () => ({ review: "yes" } as any);
+    const getConfirmation = async () => ({ review: "yes" }) as any;
 
     const additionalWritableRoots: Array<string> = [];
     const { outputText, metadata } = await handleExecCommand(

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "*.md": "prettier --write",
     ".github/workflows/*.yml": "prettier --write",
     "**/*.{js,ts,tsx}": [
+      "prettier --write",
       "pnpm --filter @openai/codex run lint",
       "cd codex-cli && pnpm run typecheck"
     ]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,8 +150,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0(@types/react@18.3.20)
       prettier:
-        specifier: ^2.8.7
-        version: 2.8.8
+        specifier: ^3.5.3
+        version: 3.5.3
       punycode:
         specifier: ^2.3.1
         version: 2.3.1
@@ -1747,6 +1747,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-emoji@2.2.0:
     resolution: {integrity: sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==}
@@ -1925,11 +1926,6 @@ packages:
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
-
-  prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
 
   prettier@3.5.3:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
@@ -4319,8 +4315,6 @@ snapshots:
       source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
-
-  prettier@2.8.8: {}
 
   prettier@3.5.3: {}
 


### PR DESCRIPTION
## Description

This PR addresses the following improvements:

**Unify Prettier Version**: Currently, the Prettier version used in `/package.json` and `/codex-cli/package.json` are different. In this PR, we're updating both to use Prettier v3.

-  Prettier v3 introduces improved support for JavaScript and TypeScript. (e.g. the formatting scenario shown in the image below. This is more aligned with the TypeScript indentation standard). 

<img width="1126" alt="image" src="https://github.com/user-attachments/assets/6e237eb8-4553-4574-b336-ed9561c55370" />

**Add Prettier Auto-Formatting in lint-staged**: We've added a step to automatically run prettier --write on JavaScript and TypeScript files as part of the lint-staged process, before the ESLint checks.

- This will help ensure that all committed code is properly formatted according to the project's Prettier configuration.