### PR TITLE
[codex-rs] Improve linux sandbox timeouts

### DIFF
--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -22,6 +22,14 @@ pub enum SandboxErr {
     #[error("seccomp backend error")]
     SeccompBackend(#[from] seccompiler::BackendError),
 
+    /// Command timed out
+    #[error("command timed out")]
+    Timeout,
+
+    /// Command was killed by a signal
+    #[error("command was killed by a signal")]
+    Signal(i32),
+
     /// Error from linux landlock
     #[error("Landlock was not able to fully enforce all sandbox rules")]
     LandlockRestrict,

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -20,16 +20,16 @@ use crate::error::Result;
 use crate::error::SandboxErr;
 use crate::protocol::SandboxPolicy;
 
-/// Maximum we send for each stream, which is either:
-/// - 10KiB OR
-/// - 256 lines
+// Maximum we send for each stream, which is either:
+// - 10KiB OR
+// - 256 lines
 const MAX_STREAM_OUTPUT: usize = 10 * 1024;
 const MAX_STREAM_OUTPUT_LINES: usize = 256;
 
 const DEFAULT_TIMEOUT_MS: u64 = 10_000;
 
-/// Hardcode this since it does not seem worth including the libc craate just
-/// for this.
+// Hardcode these since it does not seem worth including the libc crate just
+// for these.
 const SIGKILL_CODE: i32 = 9;
 const TIMEOUT_CODE: i32 = 64;
 


### PR DESCRIPTION
* Fixes flaking rust unit test
* Adds explicit sandbox exec timeout handling