### PR TITLE
ci: build Rust on Windows as part of CI

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -5,6 +5,7 @@ on:
       - main
     paths:
       - "codex-rs/**"
+      - ".github/**"
   push:
     branches:
       - main
@@ -41,6 +42,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # Note: While Codex CLI does not support Windows today, we include
+        # Windows in CI to ensure the code at least builds there.
         include:
           - runner: macos-14
             target: aarch64-apple-darwin
@@ -50,6 +53,8 @@ jobs:
             target: x86_64-unknown-linux-musl
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+          - runner: windows-latest
+            target: x86_64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
While we aren't ready to provide Windows binaries of Codex CLI, it seems like a good idea to ensure we guard platform-specific code appropriately.