### PR TITLE
fix: write logs to ~/.codex/log instead of /tmp

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use dirs::home_dir;
 use serde::Deserialize;
 
@@ -28,15 +30,36 @@ impl Config {
     }
 
     fn load_from_toml() -> Option<Self> {
-        let mut p = home_dir()?;
-        p.push(".codex/config.toml");
+        let mut p = codex_dir().ok()?;
+        p.push("config.toml");
         let contents = std::fs::read_to_string(&p).ok()?;
         toml::from_str(&contents).ok()
     }
 
     fn load_instructions() -> Option<String> {
-        let mut p = home_dir()?;
-        p.push(".codex/instructions.md");
+        let mut p = codex_dir().ok()?;
+        p.push("instructions.md");
         std::fs::read_to_string(&p).ok()
     }
+}
+
+/// Returns the path to the Codex configuration directory, which is `~/.codex`.
+/// Does not verify that the directory exists.
+pub fn codex_dir() -> std::io::Result<PathBuf> {
+    let mut p = home_dir().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            "Could not find home directory",
+        )
+    })?;
+    p.push(".codex");
+    Ok(p)
+}
+
+/// Returns the path to the folder where Codex logs are stored. Does not verify
+/// that the directory exists.
+pub fn log_dir() -> std::io::Result<PathBuf> {
+    let mut p = codex_dir()?;
+    p.push("log");
+    Ok(p)
 }


### PR DESCRIPTION
Previously, the Rust TUI was writing log files to `/tmp`, which is world-readable and not available on Windows, so that isn't great.

This PR tries to clean things up by adding a function that provides the path to the "Codex config dir," e.g., `~/.codex` (though I suppose we could support `$CODEX_HOME` to override this?) and then defines other paths in terms of the result of `codex_dir()`.

For example, `log_dir()` returns the folder where log files should be written which is defined in terms of `codex_dir()`. I updated the TUI to use this function. On UNIX, we even go so far as to `chmod 600` the log file by default, though as noted in a comment, it's a bit tedious to do the equivalent on Windows, so we just let that go for now.

This also changes the default logging level to `info` for `codex_core` and `codex_tui` when `RUST_LOG` is not specified. I'm not really sure if we should use a more verbose default (it may be helpful when debugging user issues), though if so, we should probably also set up log rotation?