### PR TITLE
[codex-rs] Add rust-release action

### DIFF
--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -1,0 +1,22 @@
+{
+    "outputs": {
+      "codex-repl": {
+        "platforms": {
+          "macos-aarch64": { "regex": "^codex-repl-aarch64-apple-darwin$", "path": "codex-repl" },
+          "macos-x86_64":  { "regex": "^codex-repl-x86_64-apple-darwin$", "path": "codex-repl" },
+          "linux-x86_64":  { "regex": "^codex-repl-x86_64-unknown-linux-musl$", "path": "codex-repl" },
+          "linux-aarch64": { "regex": "^codex-repl-aarch64-unknown-linux-gnu$",  "path": "codex-repl" }
+        }
+      },
+  
+      "codex-tui": {
+        "platforms": {
+          "macos-aarch64": { "regex": "^codex-tui-aarch64-apple-darwin$", "path": "codex-tui" },
+          "macos-x86_64":  { "regex": "^codex-tui-x86_64-apple-darwin$", "path": "codex-tui" },
+          "linux-x86_64":  { "regex": "^codex-tui-x86_64-unknown-linux-musl$", "path": "codex-tui" },
+          "linux-aarch64": { "regex": "^codex-tui-aarch64-unknown-linux-gnu$",  "path": "codex-tui" }
+        }
+      }
+    }
+  }
+  

--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -9,12 +9,21 @@
       }
     },
 
-    "codex-tui": {
+    "codex-exec": {
       "platforms": {
-        "macos-aarch64":  { "regex": "^codex-tui-aarch64-apple-darwin\\.zst$",           "path": "codex-tui" },
-        "macos-x86_64":   { "regex": "^codex-tui-x86_64-apple-darwin\\.zst$",            "path": "codex-tui" },
-        "linux-x86_64":   { "regex": "^codex-tui-x86_64-unknown-linux-musl\\.zst$",      "path": "codex-tui" },
-        "linux-aarch64":  { "regex": "^codex-tui-aarch64-unknown-linux-gnu\\.zst$",      "path": "codex-tui" }
+        "macos-aarch64":  { "regex": "^codex-exec-aarch64-apple-darwin\\.zst$",          "path": "codex-exec" },
+        "macos-x86_64":   { "regex": "^codex-exec-x86_64-apple-darwin\\.zst$",           "path": "codex-exec" },
+        "linux-x86_64":   { "regex": "^codex-exec-x86_64-unknown-linux-musl\\.zst$",     "path": "codex-exec" },
+        "linux-aarch64":  { "regex": "^codex-exec-aarch64-unknown-linux-gnu\\.zst$",     "path": "codex-exec" }
+      }
+    },
+
+    "codex-cli": {
+      "platforms": {
+        "macos-aarch64":  { "regex": "^codex-cli-aarch64-apple-darwin\\.zst$",          "path": "codex-cli" },
+        "macos-x86_64":   { "regex": "^codex-cli-x86_64-apple-darwin\\.zst$",           "path": "codex-cli" },
+        "linux-x86_64":   { "regex": "^codex-cli-x86_64-unknown-linux-musl\\.zst$",     "path": "codex-cli" },
+        "linux-aarch64":  { "regex": "^codex-cli-aarch64-unknown-linux-gnu\\.zst$",     "path": "codex-cli" }
       }
     }
   }

--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -2,19 +2,19 @@
   "outputs": {
     "codex-repl": {
       "platforms": {
-        "macos-aarch64":  { "regex": "^codex-repl-aarch64-apple-darwin$",          "format": null, "path": "codex-repl" },
-        "macos-x86_64":   { "regex": "^codex-repl-x86_64-apple-darwin$",           "format": null, "path": "codex-repl" },
-        "linux-x86_64":   { "regex": "^codex-repl-x86_64-unknown-linux-musl$",     "format": null, "path": "codex-repl" },
-        "linux-aarch64":  { "regex": "^codex-repl-aarch64-unknown-linux-gnu$",     "format": null, "path": "codex-repl" }
+        "macos-aarch64":  { "regex": "^codex-repl-aarch64-apple-darwin\\.zst$",          "path": "codex-repl" },
+        "macos-x86_64":   { "regex": "^codex-repl-x86_64-apple-darwin\\.zst$",           "path": "codex-repl" },
+        "linux-x86_64":   { "regex": "^codex-repl-x86_64-unknown-linux-musl\\.zst$",     "path": "codex-repl" },
+        "linux-aarch64":  { "regex": "^codex-repl-aarch64-unknown-linux-gnu\\.zst$",     "path": "codex-repl" }
       }
     },
 
     "codex-tui": {
       "platforms": {
-        "macos-aarch64":  { "regex": "^codex-tui-aarch64-apple-darwin$",           "format": null, "path": "codex-tui" },
-        "macos-x86_64":   { "regex": "^codex-tui-x86_64-apple-darwin$",            "format": null, "path": "codex-tui" },
-        "linux-x86_64":   { "regex": "^codex-tui-x86_64-unknown-linux-musl$",      "format": null, "path": "codex-tui" },
-        "linux-aarch64":  { "regex": "^codex-tui-aarch64-unknown-linux-gnu$",      "format": null, "path": "codex-tui" }
+        "macos-aarch64":  { "regex": "^codex-tui-aarch64-apple-darwin\\.zst$",           "path": "codex-tui" },
+        "macos-x86_64":   { "regex": "^codex-tui-x86_64-apple-darwin\\.zst$",            "path": "codex-tui" },
+        "linux-x86_64":   { "regex": "^codex-tui-x86_64-unknown-linux-musl\\.zst$",      "path": "codex-tui" },
+        "linux-aarch64":  { "regex": "^codex-tui-aarch64-unknown-linux-gnu\\.zst$",      "path": "codex-tui" }
       }
     }
   }

--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -1,22 +1,21 @@
 {
-    "outputs": {
-      "codex-repl": {
-        "platforms": {
-          "macos-aarch64": { "regex": "^codex-repl-aarch64-apple-darwin$", "path": "codex-repl" },
-          "macos-x86_64":  { "regex": "^codex-repl-x86_64-apple-darwin$", "path": "codex-repl" },
-          "linux-x86_64":  { "regex": "^codex-repl-x86_64-unknown-linux-musl$", "path": "codex-repl" },
-          "linux-aarch64": { "regex": "^codex-repl-aarch64-unknown-linux-gnu$",  "path": "codex-repl" }
-        }
-      },
-  
-      "codex-tui": {
-        "platforms": {
-          "macos-aarch64": { "regex": "^codex-tui-aarch64-apple-darwin$", "path": "codex-tui" },
-          "macos-x86_64":  { "regex": "^codex-tui-x86_64-apple-darwin$", "path": "codex-tui" },
-          "linux-x86_64":  { "regex": "^codex-tui-x86_64-unknown-linux-musl$", "path": "codex-tui" },
-          "linux-aarch64": { "regex": "^codex-tui-aarch64-unknown-linux-gnu$",  "path": "codex-tui" }
-        }
+  "outputs": {
+    "codex-repl": {
+      "platforms": {
+        "macos-aarch64":  { "regex": "^codex-repl-aarch64-apple-darwin$",          "format": null, "path": "codex-repl" },
+        "macos-x86_64":   { "regex": "^codex-repl-x86_64-apple-darwin$",           "format": null, "path": "codex-repl" },
+        "linux-x86_64":   { "regex": "^codex-repl-x86_64-unknown-linux-musl$",     "format": null, "path": "codex-repl" },
+        "linux-aarch64":  { "regex": "^codex-repl-aarch64-unknown-linux-gnu$",     "format": null, "path": "codex-repl" }
+      }
+    },
+
+    "codex-tui": {
+      "platforms": {
+        "macos-aarch64":  { "regex": "^codex-tui-aarch64-apple-darwin$",           "format": null, "path": "codex-tui" },
+        "macos-x86_64":   { "regex": "^codex-tui-x86_64-apple-darwin$",            "format": null, "path": "codex-tui" },
+        "linux-x86_64":   { "regex": "^codex-tui-x86_64-unknown-linux-musl$",      "format": null, "path": "codex-tui" },
+        "linux-aarch64":  { "regex": "^codex-tui-aarch64-unknown-linux-gnu$",      "format": null, "path": "codex-tui" }
       }
     }
   }
-  
+}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -7,6 +7,10 @@ on:
   # remove before landing
   workflow_dispatch:
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: true
+
 jobs:
   build:
     name: ${{ matrix.runner }} - ${{ matrix.target }}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,0 +1,82 @@
+name: rust-ci
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "codex-rs/**"
+  push:
+    tags:
+      - "v.*.*.*"
+
+  # remove before landing
+  workflow_dispatch:
+
+jobs:
+
+  release:
+    name: ${{ matrix.runner }} - ${{ matrix.target }}
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    defaults:
+      run:
+        working-directory: codex-rs
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: macos-14
+            target: aarch64-apple-darwin
+          - runner: macos-14
+            target: x86_64-apple-darwin
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ${{ github.workspace }}/codex-rs/target/
+          key: cargo-${{ matrix.runner }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+
+      - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+        name: Install musl build tools
+        run: |
+          sudo apt install -y musl-tools pkg-config
+
+      - name: Initialize failure flag
+        run: echo "FAILED=" >> $GITHUB_ENV
+
+      - name: cargo build
+        run: cargo build --target ${{ matrix.target }} --release --all-features -- -D warnings || echo "FAILED=${FAILED:+$FAILED, }cargo clippy" >> $GITHUB_ENV
+    
+      - name: upload
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.runner }}-${{ matrix.target }}
+          path: dist/*
+
+      - name: release
+        uses: softprops/action-gh-release@v2
+        with: { files: dist/* }
+
+      - name: Fail if any step failed
+        run: |
+          if [ -n "$FAILED" ]; then
+            echo -e "See logs above, as the following steps failed:\n$FAILED"
+            exit 1
+          fi
+        env:
+          FAILED: ${{ env.FAILED }}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -34,8 +34,6 @@ jobs:
             target: x86_64-unknown-linux-gnu
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
-          - runner: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-musl
 
     steps:
       - uses: actions/checkout@v4
@@ -57,21 +55,6 @@ jobs:
         name: Install musl build tools
         run: |
           sudo apt install -y musl-tools pkg-config
-
-      - if: matrix.target == 'aarch64-unknown-linux-musl'
-        name: Install aarch64-musl toolchain
-        run: |
-          sudo apt-get update
-          curl -LO https://musl.cc/aarch64-linux-musl-cross.tgz
-          sudo tar -C /usr/local -xzf aarch64-linux-musl-cross.tgz
-          echo "/usr/local/aarch64-linux-musl-cross/bin" >> "$GITHUB_PATH"
-
-          # tell Cargo which compiler/archiver to use
-          {
-              echo "CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc"
-              echo "AR_aarch64_unknown_linux_musl=aarch64-linux-musl-ar"
-              echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc"
-          } >> "$GITHUB_ENV"
 
       - name: Cargo build
         run: cargo build --target ${{ matrix.target }} --release --all-targets --all-features

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -5,7 +5,6 @@
 # git push origin rust-v0.1.0
 # ```
 
-
 name: rust-release
 on:
   push:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -55,7 +55,7 @@ jobs:
         run: echo "FAILED=" >> $GITHUB_ENV
 
       - name: cargo build
-        run: cargo build --target ${{ matrix.target }} --release --all-features -- -D warnings || echo "FAILED=${FAILED:+$FAILED, }cargo clippy" >> $GITHUB_ENV
+        run: cargo build --target ${{ matrix.target }} --release --all-features || echo "FAILED=${FAILED:+$FAILED, }cargo clippy" >> $GITHUB_ENV
     
       - name: upload
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -4,15 +4,35 @@ on:
     tags:
       - "rust-v.*.*.*"
 
-  # remove before landing
-  workflow_dispatch:
-
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: true
 
+env:
+  TAG_REGEX: '^rust-v\.[0-9]+\.[0-9]+\.[0-9]+$'
+
 jobs:
+  tag-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify tag format
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "::group::Tag validation"
+          echo "Ref type : ${GITHUB_REF_TYPE}"
+          echo "Ref name : ${GITHUB_REF_NAME}"
+          if [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
+            echo "❌ Not a tag push"; exit 1
+          fi
+          if [[ ! "${GITHUB_REF_NAME}" =~ ${TAG_REGEX} ]]; then
+            echo "❌ Tag '${GITHUB_REF_NAME}' does not match ${TAG_REGEX}"; exit 1
+          fi
+          echo "✅ Tag format OK"
+          echo "::endgroup::"
+
   build:
+    needs: tag-check
     name: ${{ matrix.runner }} - ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -65,11 +65,11 @@ jobs:
         shell: bash
         run: |
           dest="dist/${{ matrix.target }}"
-          ls -R
-          echo $dest
           mkdir -p "$dest"
           shopt -s nullglob
-          cp target/${{ matrix.target }}/release/codex-* "$dest/"
+          cp target/${{ matrix.target }}/release/codex-repl "$dest"
+          cp target/${{ matrix.target }}/release/codex-tui "$dest"
+          ls -R dist/
 
       - name: upload
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -8,7 +8,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   build:
     name: ${{ matrix.runner }} - ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
@@ -53,7 +52,7 @@ jobs:
 
       - name: cargo build
         run: cargo build --target ${{ matrix.target }} --release --all-targets --all-features
-      
+
       - name: stage artifacts
         shell: bash
         run: |
@@ -61,7 +60,7 @@ jobs:
           mkdir -p "$dest"
           shopt -s nullglob
           cp target/${{ matrix.target }}/release/codex-* "$dest/"
-    
+
       - name: upload
         uses: actions/upload-artifact@v4
         with:
@@ -74,6 +73,6 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-        - uses: actions:/download-artifact@v4
-          with:
-            path: dist
+      - uses: actions:/download-artifact@v4
+        with:
+          path: dist

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -86,9 +86,9 @@ jobs:
 
       - name: List
         run: ls -R dist/
-    
+
       - uses: softprops/action-gh-release@v2
-        with: 
+        with:
           files: dist/**
           prerelease: true
           draft: true

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -56,7 +56,7 @@ jobs:
       - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
         name: Install musl build tools
         run: |
-          sudo apt install -y musl-tools pkg-config
+          sudo apt install -y musl-tools pkg-config libssl-dev
 
       - name: cargo build
         run: cargo build --target ${{ matrix.target }} --release --all-targets --all-features

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -103,7 +103,8 @@ jobs:
           mkdir -p "$dest"
 
           cp target/${{ matrix.target }}/release/codex-repl "$dest/codex-repl-${{ matrix.target }}"
-          cp target/${{ matrix.target }}/release/codex-tui "$dest/codex-tui-${{ matrix.target }}"
+          cp target/${{ matrix.target }}/release/codex-exec "$dest/codex-exec-${{ matrix.target }}"
+          cp target/${{ matrix.target }}/release/codex-cli "$dest/codex-cli-${{ matrix.target }}"
 
           zstd -T0 -19 --rm "$dest"/*
 

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -56,13 +56,12 @@ jobs:
       - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
         name: Install musl build tools
         run: |
-          sudo apt install -y musl-tools pkg-config libssl-dev
-          echo "OPENSSL_STATIC=1" >> "$GITHUB_ENV"
+          sudo apt install -y musl-tools pkg-config
 
-      - name: cargo build
+      - name: Cargo build
         run: cargo build --target ${{ matrix.target }} --release --all-targets --all-features
 
-      - name: stage artifacts
+      - name: Stage artifacts
         shell: bash
         run: |
           dest="dist/${{ matrix.target }}"
@@ -88,5 +87,5 @@ jobs:
         with:
           path: dist
 
-      - name: list
+      - name: List
         run: ls dist/

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -8,8 +8,8 @@ on:
   workflow_dispatch:
 
 concurrency:
-    group: ${{ github.workflow }}-${{ github.ref }}
-    cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build:
@@ -80,6 +80,6 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           path: dist
-      
+
       - name: list
         run: ls dist/

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -69,13 +69,11 @@ jobs:
           shopt -s nullglob
           cp target/${{ matrix.target }}/release/codex-repl "$dest"
           cp target/${{ matrix.target }}/release/codex-tui "$dest"
-          ls -R dist/
 
       - name: upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.target }}
-          path: dist/${{ matrix.target }}
+          path: dist/*
 
   release:
     needs: build

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -72,15 +72,11 @@ jobs:
           cp target/${{ matrix.target }}/release/codex-tui "$dest"
           ls -lah "$dest"
 
-      - name: upload
-        uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v4
         with:
-          path: dist/${{ matrix.target }}/codex-repl
+          name: ${{ matrix.target }}
+          path: codex-rs/dist/${{ matrix.target }}/*
 
-      - name: upload
-        uses: actions/upload-artifact@v4
-        with:
-          path: dist/${{ matrix.target }}/codex-tui
 
   release:
     needs: build

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -85,4 +85,4 @@ jobs:
           path: dist
 
       - name: List
-        run: ls dist/
+        run: ls -R dist/

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -61,17 +61,17 @@ jobs:
       - if: matrix.target == 'aarch64-unknown-linux-musl'
         name: Install aarch64-musl toolchain
         run: |
-            sudo apt-get update
-            curl -LO https://musl.cc/aarch64-linux-musl-cross.tgz
-            sudo tar -C /usr/local -xzf aarch64-linux-musl-cross.tgz
-            echo "/usr/local/aarch64-linux-musl-cross/bin" >> "$GITHUB_PATH"
+          sudo apt-get update
+          curl -LO https://musl.cc/aarch64-linux-musl-cross.tgz
+          sudo tar -C /usr/local -xzf aarch64-linux-musl-cross.tgz
+          echo "/usr/local/aarch64-linux-musl-cross/bin" >> "$GITHUB_PATH"
 
-            # tell Cargo which compiler/archiver to use
-            {
-                echo "CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc"
-                echo "AR_aarch64_unknown_linux_musl=aarch64-linux-musl-ar"
-                echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc"
-            } >> "$GITHUB_ENV"
+          # tell Cargo which compiler/archiver to use
+          {
+              echo "CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc"
+              echo "AR_aarch64_unknown_linux_musl=aarch64-linux-musl-ar"
+              echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc"
+          } >> "$GITHUB_ENV"
 
       - name: Cargo build
         run: cargo build --target ${{ matrix.target }} --release --all-targets --all-features
@@ -90,7 +90,6 @@ jobs:
         with:
           name: ${{ matrix.target }}
           path: codex-rs/dist/${{ matrix.target }}/*
-
 
   release:
     needs: build

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -97,6 +97,8 @@ jobs:
           draft: true
 
       - uses: facebook/dotslash-publish-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag: ${{ env.RELEASE_TAG }}
           config: .github/dotslash-config.json

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -65,6 +65,8 @@ jobs:
         shell: bash
         run: |
           dest="dist/${{ matrix.target }}"
+          ls -R
+          echo $dest
           mkdir -p "$dest"
           shopt -s nullglob
           cp target/${{ matrix.target }}/release/codex-* "$dest/"

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -65,9 +65,8 @@ jobs:
           dest="dist/${{ matrix.target }}"
           mkdir -p "$dest"
           shopt -s nullglob
-          cp target/${{ matrix.target }}/release/codex-repl "$dest"
-          cp target/${{ matrix.target }}/release/codex-tui "$dest"
-          ls -lah "$dest"
+          cp target/${{ matrix.target }}/release/codex-repl "$dest/codex-repl-${{ matrix.target }}"
+          cp target/${{ matrix.target }}/release/codex-tui "$dest/codex-tui-${{ matrix.target }}"
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -86,3 +86,9 @@ jobs:
 
       - name: List
         run: ls -R dist/
+    
+      - uses: softprops/action-gh-release@v2
+        with: 
+          files: dist/**
+          prerelease: true
+          draft: true

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -32,6 +32,10 @@ jobs:
             target: x86_64-unknown-linux-musl
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -55,7 +55,7 @@ jobs:
         run: echo "FAILED=" >> $GITHUB_ENV
 
       - name: cargo build
-        run: cargo build --target ${{ matrix.target }} --release --all-features || echo "FAILED=${FAILED:+$FAILED, }cargo clippy" >> $GITHUB_ENV
+        run: cargo build --target ${{ matrix.target }} --release --all-features || echo "FAILED=${FAILED:+$FAILED, }cargo build" >> $GITHUB_ENV
     
       - name: upload
         uses: actions/upload-artifact@v4

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -15,20 +15,30 @@ jobs:
   tag-check:
     runs-on: ubuntu-latest
     steps:
-      - name: Verify tag format
+      - uses: actions/checkout@v4
+
+      - name: Validate tag matches Cargo.toml version
         shell: bash
         run: |
           set -euo pipefail
           echo "::group::Tag validation"
-          echo "Ref type : ${GITHUB_REF_TYPE}"
-          echo "Ref name : ${GITHUB_REF_NAME}"
-          if [[ "${GITHUB_REF_TYPE}" != "tag" ]]; then
-            echo "❌ Not a tag push"; exit 1
-          fi
-          if [[ ! "${GITHUB_REF_NAME}" =~ ${TAG_REGEX} ]]; then
-            echo "❌ Tag '${GITHUB_REF_NAME}' does not match ${TAG_REGEX}"; exit 1
-          fi
-          echo "✅ Tag format OK"
+
+          # 1. Must be a tag and match the regex
+          [[ "${GITHUB_REF_TYPE}" == "tag" ]] \
+            || { echo "❌  Not a tag push"; exit 1; }
+          [[ "${GITHUB_REF_NAME}" =~ ${TAG_REGEX} ]] \
+            || { echo "❌  Tag '${GITHUB_REF_NAME}' != ${TAG_REGEX}"; exit 1; }
+
+          # 2. Extract versions
+          tag_ver="${GITHUB_REF_NAME#rust-v.}"
+          cargo_ver="$(grep -m1 '^version' codex-rs/Cargo.toml \
+                        | sed -E 's/version *= *"([^"]+)".*/\1/')"
+
+          # 3. Compare
+          [[ "${tag_ver}" == "${cargo_ver}" ]] \
+            || { echo "❌  Tag ${tag_ver} ≠ Cargo.toml ${cargo_ver}"; exit 1; }
+
+          echo "✅  Tag and Cargo.toml agree (${tag_ver})"
           echo "::endgroup::"
 
   build:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -51,26 +51,14 @@ jobs:
         run: |
           sudo apt install -y musl-tools pkg-config
 
-      - name: Initialize failure flag
-        run: echo "FAILED=" >> $GITHUB_ENV
-
       - name: cargo build
-        run: cargo build --target ${{ matrix.target }} --release --all-features || echo "FAILED=${FAILED:+$FAILED, }cargo build" >> $GITHUB_ENV
+        run: cargo build --target ${{ matrix.target }} --release --all-features
     
       - name: upload
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
           path: dist/*
-
-      - name: Fail if any step failed
-        run: |
-          if [ -n "$FAILED" ]; then
-            echo -e "See logs above, as the following steps failed:\n$FAILED"
-            exit 1
-          fi
-        env:
-          FAILED: ${{ env.FAILED }}
 
   release:
     needs: build

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -52,13 +52,13 @@ jobs:
           sudo apt install -y musl-tools pkg-config
 
       - name: cargo build
-        run: cargo build --target ${{ matrix.target }} --release --all-features
+        run: cargo build --target ${{ matrix.target }} --release --all-targets --all-features
     
       - name: upload
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
-          path: dist/*
+          path: target/release/codex-*
 
   release:
     needs: build
@@ -69,4 +69,4 @@ jobs:
         - name: download
           uses: actions:/download-artifact@v4
           with:
-            path: dist/*
+            path: target/release/*

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,13 +1,8 @@
 name: rust-ci
 on:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "codex-rs/**"
   push:
     tags:
-      - "v.*.*.*"
+      - "rust-v.*.*.*"
 
   # remove before landing
   workflow_dispatch:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -53,12 +53,20 @@ jobs:
 
       - name: cargo build
         run: cargo build --target ${{ matrix.target }} --release --all-targets --all-features
+      
+      - name: stage artifacts
+        shell: bash
+        run: |
+          dest="dist/${{ matrix.target }}"
+          mkdir -p "$dest"
+          shopt -s nullglob
+          cp target/${{ matrix.target }}/release/codex-* "$dest/"
     
       - name: upload
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
-          path: target/release/codex-*
+          path: dist/${{ matrix.target }}
 
   release:
     needs: build
@@ -66,7 +74,6 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-        - name: download
-          uses: actions:/download-artifact@v4
+        - uses: actions:/download-artifact@v4
           with:
-            path: target/release/*
+            path: dist

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -69,11 +69,12 @@ jobs:
           shopt -s nullglob
           cp target/${{ matrix.target }}/release/codex-repl "$dest"
           cp target/${{ matrix.target }}/release/codex-tui "$dest"
+          ls -lah "$dest"
 
       - name: upload
         uses: actions/upload-artifact@v4
         with:
-          path: dist/*
+          path: dist/${{ matrix.target }}
 
   release:
     needs: build

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-        - uses: actions:/download-artifact@v4
+        - name: download
+          uses: actions:/download-artifact@v4
           with:
-            name: x86_64-unknown-linux-musl
-            path: dist/
+            path: dist/*

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -74,7 +74,12 @@ jobs:
       - name: upload
         uses: actions/upload-artifact@v4
         with:
-          path: dist/${{ matrix.target }}
+          path: dist/${{ matrix.target }}/codex-repl
+
+      - name: upload
+        uses: actions/upload-artifact@v4
+        with:
+          path: dist/${{ matrix.target }}/codex-tui
 
   release:
     needs: build

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,3 +1,11 @@
+# Release workflow for codex-rs.
+# To release, follow a workflow like:
+# ```
+# git tag -a rust-v0.1.0 -m "Release 0.1.0"
+# git push origin rust-v0.1.0
+# ```
+
+
 name: rust-release
 on:
   push:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -44,7 +44,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             ${{ github.workspace }}/codex-rs/target/
-          key: cargo-${{ matrix.runner }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-release-${{ matrix.runner }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
 
       - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
         name: Install musl build tools

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -1,4 +1,4 @@
-name: rust-ci
+name: rust-release
 on:
   push:
     tags:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: upload
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.runner }}-${{ matrix.target }}
+          name: ${{ matrix.target }}
           path: dist/*
 
       - name: Fail if any step failed
@@ -80,5 +80,5 @@ jobs:
     steps:
         - uses: actions:/download-artifact@v4
           with:
-            name: test
+            name: x86_64-unknown-linux-musl
             path: dist/

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -124,6 +124,9 @@ jobs:
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           files: dist/**
+          # TODO(ragona): I'm going to leave these as prerelease/draft for now.
+          # It gives us 1) clarity that these are not yet a stable version, and
+          # 2) allows a human step to review the release before publishing the draft.
           prerelease: true
           draft: true
 

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -78,6 +78,9 @@ jobs:
     name: release
     runs-on: ubuntu-24.04
 
+    env:
+      RELEASE_TAG: ${{ github.ref_name }}
+
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -88,6 +91,13 @@ jobs:
 
       - uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           files: dist/**
           prerelease: true
           draft: true
+
+      - uses: facebook/dotslash-publish-release@v1
+        with:
+          tag: ${{ env.RELEASE_TAG }}
+          config: .github/dotslash-config.json
+

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -77,6 +77,9 @@ jobs:
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions:/download-artifact@v4
+      - uses: actions/download-artifact@v4
         with:
           path: dist
+      
+      - name: list
+        run: ls dist/

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
 
-  release:
+  build:
     name: ${{ matrix.runner }} - ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
@@ -63,10 +63,6 @@ jobs:
           name: ${{ matrix.runner }}-${{ matrix.target }}
           path: dist/*
 
-      - name: release
-        uses: softprops/action-gh-release@v2
-        with: { files: dist/* }
-
       - name: Fail if any step failed
         run: |
           if [ -n "$FAILED" ]; then
@@ -75,3 +71,14 @@ jobs:
           fi
         env:
           FAILED: ${{ env.FAILED }}
+
+  release:
+    needs: build
+    name: release
+    runs-on: ubuntu-24.04
+
+    steps:
+        - uses: actions:/download-artifact@v4
+          with:
+            name: test
+            path: dist/

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -64,9 +64,11 @@ jobs:
         run: |
           dest="dist/${{ matrix.target }}"
           mkdir -p "$dest"
-          shopt -s nullglob
+
           cp target/${{ matrix.target }}/release/codex-repl "$dest/codex-repl-${{ matrix.target }}"
           cp target/${{ matrix.target }}/release/codex-tui "$dest/codex-tui-${{ matrix.target }}"
+
+          zstd -T0 -19 --rm "$dest"/*
 
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -57,6 +57,7 @@ jobs:
         name: Install musl build tools
         run: |
           sudo apt install -y musl-tools pkg-config libssl-dev
+          echo "OPENSSL_STATIC=1" >> "$GITHUB_ENV"
 
       - name: cargo build
         run: cargo build --target ${{ matrix.target }} --release --all-targets --all-features

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -96,10 +96,9 @@ jobs:
           prerelease: true
           draft: true
 
-      - uses: facebook/dotslash-publish-release@v1
+      - uses: facebook/dotslash-publish-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag: ${{ env.RELEASE_TAG }}
           config: .github/dotslash-config.json
-

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -58,6 +58,21 @@ jobs:
         run: |
           sudo apt install -y musl-tools pkg-config
 
+      - if: matrix.target == 'aarch64-unknown-linux-musl'
+        name: Install aarch64-musl toolchain
+        run: |
+            sudo apt-get update
+            curl -LO https://musl.cc/aarch64-linux-musl-cross.tgz
+            sudo tar -C /usr/local -xzf aarch64-linux-musl-cross.tgz
+            echo "/usr/local/aarch64-linux-musl-cross/bin" >> "$GITHUB_PATH"
+
+            # tell Cargo which compiler/archiver to use
+            {
+                echo "CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc"
+                echo "AR_aarch64_unknown_linux_musl=aarch64-linux-musl-ar"
+                echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-musl-gcc"
+            } >> "$GITHUB_ENV"
+
       - name: Cargo build
         run: cargo build --target ${{ matrix.target }} --release --all-targets --all-features
 

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -79,9 +79,8 @@ jobs:
     needs: build
     name: release
     runs-on: ubuntu-24.04
-
     env:
-      RELEASE_TAG: ${{ github.ref_name }}
+      RELEASE_TAG: codex-rs-${{ github.sha }}-${{ github.run_attempt }}-${{ github.ref_name }}
 
     steps:
       - uses: actions/download-artifact@v4

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -14,3 +14,6 @@ members = [
 
 [workspace.package]
 version = "0.1.0"
+
+[profile.release]
+lto = "fat"

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -1,4 +1,5 @@
 [workspace]
+version = "0.1.0"
 resolver = "2"
 members = [
     "ansi-escape",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -1,5 +1,4 @@
 [workspace]
-version = "0.1.0"
 resolver = "2"
 members = [
     "ansi-escape",
@@ -12,3 +11,6 @@ members = [
     "repl",
     "tui",
 ]
+
+[workspace.package]
+version = "0.1.0"

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-cli"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [[bin]]

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -49,6 +49,9 @@ seccompiler = "0.5.0"
 [target.x86_64-unknown-linux-musl.dependencies]
 openssl-sys = { version = "*", features = ["vendored"] }
 
+[target.aarch64-unknown-linux-musl.dependencies]
+openssl-sys = { version = "*", features = ["vendored"] }
+
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -49,9 +49,6 @@ seccompiler = "0.5.0"
 [target.x86_64-unknown-linux-musl.dependencies]
 openssl-sys = { version = "*", features = ["vendored"] }
 
-[target.aarch64-unknown-linux-musl.dependencies]
-openssl-sys = { version = "*", features = ["vendored"] }
-
 [dev-dependencies]
 assert_cmd = "2"
 predicates = "3"

--- a/codex-rs/exec/Cargo.toml
+++ b/codex-rs/exec/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-exec"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [[bin]]

--- a/codex-rs/repl/Cargo.toml
+++ b/codex-rs/repl/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "codex-repl"
-version = "0.1.0"
+version = { workspace = true }
 edition = "2021"
 
 [[bin]]


### PR DESCRIPTION
Taking a pass at building artifacts per platform so we can consider different distribution strategies that don't require users to install the full `cargo` toolchain. 

Right now this grabs just the `codex-repl` and `codex-tui` bins for 5 different targets and bundles them into a draft release. I think a clearly marked pre-release set of artifacts will unblock the next step of testing.