### PR TITLE
fix: small fixes so Codex compiles on Windows

### DIFF
--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -322,7 +322,7 @@ fn synthetic_exit_status(code: i32) -> ExitStatus {
 }
 
 #[cfg(windows)]
-fn synthetic_exit_status(code: u32) -> ExitStatus {
+fn synthetic_exit_status(code: i32) -> ExitStatus {
     use std::os::windows::process::ExitStatusExt;
-    std::process::ExitStatus::from_raw(code)
+    std::process::ExitStatus::from_raw(code.try_into().unwrap())
 }


### PR DESCRIPTION
Small fixes required:

* `ExitStatusExt` differs because UNIX expects exit code to be `i32` whereas Windows does `u32`
* Marking a file "executable only by owner" is a bit more involved on Windows. We just do something approximate for now (and add a TODO) to get things compiling.

I created this PR on my personal Windows machine and `cargo test` and `cargo clippy` succeed. Once this is in, I'll rebase https://github.com/openai/codex/pull/665 on top so Windows stays fixed!