### PR TITLE
fix: use os-specific env var to locate .cargo folder

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -38,6 +38,8 @@ jobs:
     defaults:
       run:
         working-directory: codex-rs
+    env:
+      CARGO_HOME: ${{ runner.os == 'Windows' && format('{0}\\.cargo', env.USERPROFILE) || format('{0}/.cargo', env.HOME) }}
 
     strategy:
       fail-fast: false
@@ -65,10 +67,10 @@ jobs:
       - uses: actions/cache@v4
         with:
           path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
+            ${{ env.CARGO_HOME }}/bin/
+            ${{ env.CARGO_HOME }}/registry/index/
+            ${{ env.CARGO_HOME }}/registry/cache/
+            ${{ env.CARGO_HOME }}/git/db/
             ${{ github.workspace }}/codex-rs/target/
           key: cargo-${{ matrix.runner }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
 


### PR DESCRIPTION
https://github.com/openai/codex/pull/665 added support for building Windows in CI, but it seemed a bit sluggish, so I was curious if there was an issue using `~/.cargo` for the paths because of the `~`. Though PowerShell seems to understand `~` whereas Command Prompt does not.