### PR TITLE
feat: load defaults into Config and introduce ConfigOverrides

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -5,6 +5,7 @@ use std::path::PathBuf;
 
 use clap::ArgAction;
 use clap::Parser;
+use codex_core::SandboxModeCliArg;
 use codex_exec::Cli as ExecCli;
 use codex_interactive::Cli as InteractiveCli;
 use codex_repl::Cli as ReplCli;
@@ -70,6 +71,10 @@ struct SeatbeltCommand {
     #[arg(long = "writable-root", short = 'w', value_name = "DIR", action = ArgAction::Append, use_value_delimiter = false)]
     writable_roots: Vec<PathBuf>,
 
+    /// Configure the process restrictions for the command.
+    #[arg(long = "sandbox", short = 's')]
+    sandbox_policy: SandboxModeCliArg,
+
     /// Full command args to run under seatbelt.
     #[arg(trailing_var_arg = true)]
     command: Vec<String>,
@@ -101,9 +106,10 @@ async fn main() -> anyhow::Result<()> {
         Some(Subcommand::Debug(debug_args)) => match debug_args.cmd {
             DebugCommand::Seatbelt(SeatbeltCommand {
                 command,
+                sandbox_policy,
                 writable_roots,
             }) => {
-                seatbelt::run_seatbelt(command, writable_roots).await?;
+                seatbelt::run_seatbelt(command, sandbox_policy.into(), writable_roots).await?;
             }
         },
     }

--- a/codex-rs/cli/src/seatbelt.rs
+++ b/codex-rs/cli/src/seatbelt.rs
@@ -1,11 +1,13 @@
 use codex_core::exec::create_seatbelt_command;
+use codex_core::protocol::SandboxPolicy;
 use std::path::PathBuf;
 
 pub(crate) async fn run_seatbelt(
     command: Vec<String>,
+    sandbox_policy: SandboxPolicy,
     writable_roots: Vec<PathBuf>,
 ) -> anyhow::Result<()> {
-    let seatbelt_command = create_seatbelt_command(command, &writable_roots);
+    let seatbelt_command = create_seatbelt_command(command, sandbox_policy, &writable_roots);
     let status = tokio::process::Command::new(seatbelt_command[0].clone())
         .args(&seatbelt_command[1..])
         .spawn()

--- a/codex-rs/core/src/approval_mode_cli_arg.rs
+++ b/codex-rs/core/src/approval_mode_cli_arg.rs
@@ -6,7 +6,7 @@ use clap::ValueEnum;
 use crate::protocol::AskForApproval;
 use crate::protocol::SandboxPolicy;
 
-#[derive(Clone, Debug, ValueEnum)]
+#[derive(Clone, Copy, Debug, ValueEnum)]
 #[value(rename_all = "kebab-case")]
 pub enum ApprovalModeCliArg {
     /// Run all commands without asking for user approval.
@@ -24,7 +24,7 @@ pub enum ApprovalModeCliArg {
     Never,
 }
 
-#[derive(Clone, Debug, ValueEnum)]
+#[derive(Clone, Copy, Debug, ValueEnum)]
 #[value(rename_all = "kebab-case")]
 pub enum SandboxModeCliArg {
     /// Network syscalls will be blocked

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -36,7 +36,6 @@ use crate::exec::process_exec_tool_call;
 use crate::exec::ExecParams;
 use crate::exec::ExecToolCallOutput;
 use crate::exec::SandboxType;
-use crate::flags::OPENAI_DEFAULT_MODEL;
 use crate::flags::OPENAI_STREAM_MAX_RETRIES;
 use crate::models::ContentItem;
 use crate::models::FunctionCallOutputPayload;
@@ -486,7 +485,6 @@ async fn submission_loop(
                 sandbox_policy,
                 disable_response_storage,
             } => {
-                let model = model.unwrap_or_else(|| OPENAI_DEFAULT_MODEL.to_string());
                 info!(model, "Configuring session");
                 let client = ModelClient::new(model.clone());
 

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1,39 +1,98 @@
-use std::path::PathBuf;
-
+use crate::flags::OPENAI_DEFAULT_MODEL;
+use crate::protocol::AskForApproval;
+use crate::protocol::SandboxPolicy;
 use dirs::home_dir;
 use serde::Deserialize;
+use std::path::PathBuf;
 
-/// Embedded fallback instructions that mirror the TypeScript CLI’s default system prompt. These
-/// are compiled into the binary so a clean install behaves correctly even if the user has not
-/// created `~/.codex/instructions.md`.
+/// Embedded fallback instructions that mirror the TypeScript CLI’s default
+/// system prompt. These are compiled into the binary so a clean install behaves
+/// correctly even if the user has not created `~/.codex/instructions.md`.
 const EMBEDDED_INSTRUCTIONS: &str = include_str!("../prompt.md");
 
-#[derive(Default, Deserialize, Debug, Clone)]
+/// Application configuration loaded from disk and merged with overrides.
+#[derive(Deserialize, Debug, Clone)]
 pub struct Config {
-    pub model: Option<String>,
+    /// Optional override of model selection.
+    #[serde(default = "default_model")]
+    pub model: String,
+    /// Default approval policy for executing commands.
+    #[serde(default)]
+    pub approval_policy: AskForApproval,
+    #[serde(default)]
+    pub sandbox_policy: SandboxPolicy,
+    /// System instructions.
     pub instructions: Option<String>,
 }
 
+/// Optional overrides for user configuration (e.g., from CLI flags).
+#[derive(Default, Debug, Clone)]
+pub struct ConfigOverrides {
+    pub model: Option<String>,
+    pub approval_policy: Option<AskForApproval>,
+    pub sandbox_policy: Option<SandboxPolicy>,
+}
+
 impl Config {
-    /// Load ~/.codex/config.toml and ~/.codex/instructions.md (if present).
-    /// Returns `None` if neither file exists.
-    pub fn load() -> Option<Self> {
-        let mut cfg: Config = Self::load_from_toml().unwrap_or_default();
+    /// Load configuration, optionally applying overrides (CLI flags). Merges
+    /// ~/.codex/config.toml, ~/.codex/instructions.md, embedded defaults, and
+    /// any values provided in `overrides` (highest precedence).
+    pub fn load_with_overrides(overrides: ConfigOverrides) -> std::io::Result<Self> {
+        let mut cfg: Config = Self::load_from_toml()?;
+        tracing::warn!("Config parsed from config.toml: {cfg:?}");
 
-        // Highest precedence → user‑provided ~/.codex/instructions.md (if present)
-        // Fallback           → embedded default instructions baked into the binary
-
+        // Instructions: user-provided instructions.md > embedded default.
         cfg.instructions =
             Self::load_instructions().or_else(|| Some(EMBEDDED_INSTRUCTIONS.to_string()));
 
-        Some(cfg)
+        // Destructure ConfigOverrides fully to ensure all overrides are applied.
+        let ConfigOverrides {
+            model,
+            approval_policy,
+            sandbox_policy,
+        } = overrides;
+
+        if let Some(model) = model {
+            cfg.model = model;
+        }
+        if let Some(approval_policy) = approval_policy {
+            cfg.approval_policy = approval_policy;
+        }
+        if let Some(sandbox_policy) = sandbox_policy {
+            cfg.sandbox_policy = sandbox_policy;
+        }
+        Ok(cfg)
     }
 
-    fn load_from_toml() -> Option<Self> {
-        let mut p = codex_dir().ok()?;
-        p.push("config.toml");
-        let contents = std::fs::read_to_string(&p).ok()?;
-        toml::from_str(&contents).ok()
+    /// Attempt to parse the file at `~/.codex/config.toml` into a Config.
+    fn load_from_toml() -> std::io::Result<Self> {
+        let config_toml_path = codex_dir()?.join("config.toml");
+        match std::fs::read_to_string(&config_toml_path) {
+            Ok(contents) => toml::from_str::<Self>(&contents).map_err(|e| {
+                tracing::error!("Failed to parse config.toml: {e}");
+                std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+            }),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                tracing::info!("config.toml not found, using defaults");
+                Ok(Self::load_default_config())
+            }
+            Err(e) => {
+                tracing::error!("Failed to read config.toml: {e}");
+                Err(e)
+            }
+        }
+    }
+
+    /// Meant to be used exclusively for tests: load_with_overrides() should be
+    /// used in all other cases.
+    pub fn load_default_config_for_test() -> Self {
+        Self::load_default_config()
+    }
+
+    fn load_default_config() -> Self {
+        // Load from an empty string to exercise #[serde(default)] to
+        // get the default values for each field.
+        toml::from_str::<Self>("").expect("empty string should parse as TOML")
     }
 
     fn load_instructions() -> Option<String> {
@@ -41,6 +100,10 @@ impl Config {
         p.push("instructions.md");
         std::fs::read_to_string(&p).ok()
     }
+}
+
+fn default_model() -> String {
+    OPENAI_DEFAULT_MODEL.to_string()
 }
 
 /// Returns the path to the Codex configuration directory, which is `~/.codex`.

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -98,7 +98,7 @@ pub async fn process_exec_tool_call(
                 workdir,
                 timeout_ms,
             } = params;
-            let seatbelt_command = create_seatbelt_command(command, writable_roots);
+            let seatbelt_command = create_seatbelt_command(command, sandbox_policy, writable_roots);
             exec(
                 ExecParams {
                     command: seatbelt_command,
@@ -154,7 +154,11 @@ pub async fn process_exec_tool_call(
     }
 }
 
-pub fn create_seatbelt_command(command: Vec<String>, writable_roots: &[PathBuf]) -> Vec<String> {
+pub fn create_seatbelt_command(
+    command: Vec<String>,
+    sandbox_policy: SandboxPolicy,
+    writable_roots: &[PathBuf],
+) -> Vec<String> {
     let (policies, cli_args): (Vec<String>, Vec<String>) = writable_roots
         .iter()
         .enumerate()
@@ -165,6 +169,14 @@ pub fn create_seatbelt_command(command: Vec<String>, writable_roots: &[PathBuf])
             (policy, cli_arg)
         })
         .unzip();
+
+    // TODO(ragona): The seatbelt policy should reflect the SandboxPolicy that
+    // is passed, but everything is currently hardcoded to use
+    // MACOS_SEATBELT_READONLY_POLICY.
+    // TODO(mbolin): apply_patch calls must also honor the SandboxPolicy.
+    if !matches!(sandbox_policy, SandboxPolicy::NetworkRestricted) {
+        tracing::error!("specified sandbox policy {sandbox_policy:?} will not be honroed");
+    }
 
     let full_policy = if policies.is_empty() {
         MACOS_SEATBELT_READONLY_POLICY.to_string()

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -26,7 +26,7 @@ pub enum Op {
     /// Configure the model session.
     ConfigureSession {
         /// If not specified, server will use its default model.
-        model: Option<String>,
+        model: String,
         /// Model instructions
         instructions: Option<String>,
         /// When to escalate for approval for execution
@@ -66,11 +66,13 @@ pub enum Op {
 }
 
 /// Determines how liberally commands are auto‑approved by the system.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum AskForApproval {
     /// Under this policy, only “known safe” commands—as determined by
     /// `is_safe_command()`—that **only read files** are auto‑approved.
     /// Everything else will ask the user to approve.
+    #[default]
     UnlessAllowListed,
 
     /// In addition to everything allowed by **`Suggest`**, commands that
@@ -91,13 +93,15 @@ pub enum AskForApproval {
 }
 
 /// Determines execution restrictions for model shell commands
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
 pub enum SandboxPolicy {
     /// Network syscalls will be blocked
     NetworkRestricted,
     /// Filesystem writes will be restricted
     FileWriteRestricted,
     /// Network and filesystem writes will be restricted
+    #[default]
     NetworkAndFileWriteRestricted,
     /// No restrictions; full "unsandboxed" mode
     DangerousNoRestrictions,

--- a/codex-rs/core/tests/live_agent.rs
+++ b/codex-rs/core/tests/live_agent.rs
@@ -17,7 +17,7 @@
 
 use std::time::Duration;
 
-use codex_core::protocol::AskForApproval;
+use codex_core::config::Config;
 use codex_core::protocol::EventMsg;
 use codex_core::protocol::InputItem;
 use codex_core::protocol::Op;
@@ -47,13 +47,14 @@ async fn spawn_codex() -> Codex {
 
     let agent = Codex::spawn(std::sync::Arc::new(Notify::new())).unwrap();
 
+    let config = Config::load_default_config_for_test();
     agent
         .submit(Submission {
             id: "init".into(),
             op: Op::ConfigureSession {
-                model: None,
+                model: config.model,
                 instructions: None,
-                approval_policy: AskForApproval::OnFailure,
+                approval_policy: config.approval_policy,
                 sandbox_policy: SandboxPolicy::NetworkAndFileWriteRestricted,
                 disable_response_storage: false,
             },

--- a/codex-rs/core/tests/previous_response_id.rs
+++ b/codex-rs/core/tests/previous_response_id.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use codex_core::protocol::AskForApproval;
+use codex_core::config::Config;
 use codex_core::protocol::InputItem;
 use codex_core::protocol::Op;
 use codex_core::protocol::SandboxPolicy;
@@ -87,13 +87,14 @@ async fn keeps_previous_response_id_between_tasks() {
     let codex = Codex::spawn(std::sync::Arc::new(tokio::sync::Notify::new())).unwrap();
 
     // Init session
+    let config = Config::load_default_config_for_test();
     codex
         .submit(Submission {
             id: "init".into(),
             op: Op::ConfigureSession {
-                model: None,
+                model: config.model,
                 instructions: None,
-                approval_policy: AskForApproval::OnFailure,
+                approval_policy: config.approval_policy,
                 sandbox_policy: SandboxPolicy::NetworkAndFileWriteRestricted,
                 disable_response_storage: false,
             },

--- a/codex-rs/core/tests/stream_no_completed.rs
+++ b/codex-rs/core/tests/stream_no_completed.rs
@@ -3,7 +3,7 @@
 
 use std::time::Duration;
 
-use codex_core::protocol::AskForApproval;
+use codex_core::config::Config;
 use codex_core::protocol::InputItem;
 use codex_core::protocol::Op;
 use codex_core::protocol::SandboxPolicy;
@@ -70,13 +70,14 @@ async fn retries_on_early_close() {
 
     let codex = Codex::spawn(std::sync::Arc::new(tokio::sync::Notify::new())).unwrap();
 
+    let config = Config::load_default_config_for_test();
     codex
         .submit(Submission {
             id: "init".into(),
             op: Op::ConfigureSession {
-                model: None,
+                model: config.model,
                 instructions: None,
-                approval_policy: AskForApproval::OnFailure,
+                approval_policy: config.approval_policy,
                 sandbox_policy: SandboxPolicy::NetworkAndFileWriteRestricted,
                 disable_response_storage: false,
             },

--- a/codex-rs/exec/Cargo.toml
+++ b/codex-rs/exec/Cargo.toml
@@ -14,7 +14,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-codex-core = { path = "../core" }
+codex-core = { path = "../core", features = ["cli"] }
 tokio = { version = "1", features = [
     "io-std",
     "macros",

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use codex_core::SandboxModeCliArg;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -11,6 +12,12 @@ pub struct Cli {
     /// Model the agent should use.
     #[arg(long, short = 'm')]
     pub model: Option<String>,
+
+    /// Configure the process restrictions when a command is executed.
+    ///
+    /// Uses OS-specific sandboxing tools; Seatbelt on OSX, landlock+seccomp on Linux.
+    #[arg(long = "sandbox", short = 's')]
+    pub sandbox_policy: Option<SandboxModeCliArg>,
 
     /// Allow running Codex outside a Git repository.
     #[arg(long = "skip-git-repo-check", default_value_t = false)]

--- a/codex-rs/interactive/src/cli.rs
+++ b/codex-rs/interactive/src/cli.rs
@@ -21,8 +21,8 @@ pub struct Cli {
     /// Configure the process restrictions when a command is executed.
     ///
     /// Uses OS-specific sandboxing tools; Seatbelt on OSX, landlock+seccomp on Linux.
-    #[arg(long = "sandbox", short = 's', value_enum, default_value_t = SandboxModeCliArg::NetworkAndFileWriteRestricted)]
-    pub sandbox_policy: SandboxModeCliArg,
+    #[arg(long = "sandbox", short = 's')]
+    pub sandbox_policy: Option<SandboxModeCliArg>,
 
     /// Allow running Codex outside a Git repository.
     #[arg(long = "skip-git-repo-check", default_value_t = false)]

--- a/codex-rs/repl/src/cli.rs
+++ b/codex-rs/repl/src/cli.rs
@@ -34,14 +34,14 @@ pub struct Cli {
     pub no_ansi: bool,
 
     /// Configure when the model requires human approval before executing a command.
-    #[arg(long = "ask-for-approval", short = 'a', value_enum, default_value_t = ApprovalModeCliArg::OnFailure)]
-    pub approval_policy: ApprovalModeCliArg,
+    #[arg(long = "ask-for-approval", short = 'a')]
+    pub approval_policy: Option<ApprovalModeCliArg>,
 
     /// Configure the process restrictions when a command is executed.
     ///
     /// Uses OS-specific sandboxing tools; Seatbelt on OSX, landlock+seccomp on Linux.
-    #[arg(long = "sandbox", short = 's', value_enum, default_value_t = SandboxModeCliArg::NetworkAndFileWriteRestricted)]
-    pub sandbox_policy: SandboxModeCliArg,
+    #[arg(long = "sandbox", short = 's')]
+    pub sandbox_policy: Option<SandboxModeCliArg>,
 
     /// Allow running Codex outside a Git repository.  By default the CLI
     /// aborts early when the current working directory is **not** inside a

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -4,10 +4,9 @@ use crate::git_warning_screen::GitWarningOutcome;
 use crate::git_warning_screen::GitWarningScreen;
 use crate::scroll_event_helper::ScrollEventHelper;
 use crate::tui;
-use codex_core::protocol::AskForApproval;
+use codex_core::config::Config;
 use codex_core::protocol::Event;
 use codex_core::protocol::Op;
-use codex_core::protocol::SandboxPolicy;
 use color_eyre::eyre::Result;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
@@ -34,12 +33,10 @@ pub(crate) struct App<'a> {
 
 impl App<'_> {
     pub(crate) fn new(
-        approval_policy: AskForApproval,
-        sandbox_policy: SandboxPolicy,
+        config: Config,
         initial_prompt: Option<String>,
         show_git_warning: bool,
         initial_images: Vec<std::path::PathBuf>,
-        model: Option<String>,
         disable_response_storage: bool,
     ) -> Self {
         let (app_event_tx, app_event_rx) = channel();
@@ -80,12 +77,10 @@ impl App<'_> {
         }
 
         let chat_widget = ChatWidget::new(
-            approval_policy,
-            sandbox_policy,
+            config,
             app_event_tx.clone(),
             initial_prompt.clone(),
             initial_images,
-            model,
             disable_response_storage,
         );
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3,12 +3,11 @@ use std::sync::mpsc::Sender;
 use std::sync::Arc;
 
 use codex_core::codex_wrapper::init_codex;
-use codex_core::protocol::AskForApproval;
+use codex_core::config::Config;
 use codex_core::protocol::Event;
 use codex_core::protocol::EventMsg;
 use codex_core::protocol::InputItem;
 use codex_core::protocol::Op;
-use codex_core::protocol::SandboxPolicy;
 use crossterm::event::KeyEvent;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Constraint;
@@ -34,7 +33,7 @@ pub(crate) struct ChatWidget<'a> {
     conversation_history: ConversationHistoryWidget,
     bottom_pane: BottomPane<'a>,
     input_focus: InputFocus,
-    approval_policy: AskForApproval,
+    config: Config,
     cwd: std::path::PathBuf,
 }
 
@@ -46,12 +45,10 @@ enum InputFocus {
 
 impl ChatWidget<'_> {
     pub(crate) fn new(
-        approval_policy: AskForApproval,
-        sandbox_policy: SandboxPolicy,
+        config: Config,
         app_event_tx: Sender<AppEvent>,
         initial_prompt: Option<String>,
         initial_images: Vec<std::path::PathBuf>,
-        model: Option<String>,
         disable_response_storage: bool,
     ) -> Self {
         let (codex_op_tx, mut codex_op_rx) = unbounded_channel::<Op>();
@@ -63,23 +60,17 @@ impl ChatWidget<'_> {
 
         let app_event_tx_clone = app_event_tx.clone();
         // Create the Codex asynchronously so the UI loads as quickly as possible.
+        let config_for_agent_loop = config.clone();
         tokio::spawn(async move {
-            // Initialize session; storage enabled by default
-            let (codex, session_event, _ctrl_c) = match init_codex(
-                approval_policy,
-                sandbox_policy,
-                disable_response_storage,
-                model,
-            )
-            .await
-            {
-                Ok(vals) => vals,
-                Err(e) => {
-                    // TODO(mbolin): This error needs to be surfaced to the user.
-                    tracing::error!("failed to initialize codex: {e}");
-                    return;
-                }
-            };
+            let (codex, session_event, _ctrl_c) =
+                match init_codex(config_for_agent_loop, disable_response_storage).await {
+                    Ok(vals) => vals,
+                    Err(e) => {
+                        // TODO: surface this error to the user.
+                        tracing::error!("failed to initialize codex: {e}");
+                        return;
+                    }
+                };
 
             // Forward the captured `SessionInitialized` event that was consumed
             // inside `init_codex()` so it can be rendered in the UI.
@@ -115,7 +106,7 @@ impl ChatWidget<'_> {
                 has_input_focus: true,
             }),
             input_focus: InputFocus::BottomPane,
-            approval_policy,
+            config,
             cwd: cwd.clone(),
         };
 
@@ -243,11 +234,8 @@ impl ChatWidget<'_> {
         match msg {
             EventMsg::SessionConfigured { model } => {
                 // Record session information at the top of the conversation.
-                self.conversation_history.add_session_info(
-                    model,
-                    self.cwd.clone(),
-                    self.approval_policy,
-                );
+                self.conversation_history
+                    .add_session_info(&self.config, model, self.cwd.clone());
                 self.request_redraw()?;
             }
             EventMsg::AgentMessage { message } => {

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -18,14 +18,14 @@ pub struct Cli {
     pub model: Option<String>,
 
     /// Configure when the model requires human approval before executing a command.
-    #[arg(long = "ask-for-approval", short = 'a', value_enum, default_value_t = ApprovalModeCliArg::OnFailure)]
-    pub approval_policy: ApprovalModeCliArg,
+    #[arg(long = "ask-for-approval", short = 'a')]
+    pub approval_policy: Option<ApprovalModeCliArg>,
 
     /// Configure the process restrictions when a command is executed.
     ///
     /// Uses OS-specific sandboxing tools; Seatbelt on OSX, landlock+seccomp on Linux.
-    #[arg(long = "sandbox", short = 's', value_enum, default_value_t = SandboxModeCliArg::NetworkAndFileWriteRestricted)]
-    pub sandbox_policy: SandboxModeCliArg,
+    #[arg(long = "sandbox", short = 's')]
+    pub sandbox_policy: Option<SandboxModeCliArg>,
 
     /// Allow running Codex outside a Git repository.
     #[arg(long = "skip-git-repo-check", default_value_t = false)]

--- a/codex-rs/tui/src/conversation_history_widget.rs
+++ b/codex-rs/tui/src/conversation_history_widget.rs
@@ -1,6 +1,7 @@
 use crate::history_cell::CommandOutput;
 use crate::history_cell::HistoryCell;
 use crate::history_cell::PatchEventType;
+use codex_core::config::Config;
 use codex_core::protocol::FileChange;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
@@ -181,13 +182,10 @@ impl ConversationHistoryWidget {
         self.add_to_history(HistoryCell::new_patch_event(event_type, changes));
     }
 
-    pub fn add_session_info(
-        &mut self,
-        model: String,
-        cwd: std::path::PathBuf,
-        approval_policy: codex_core::protocol::AskForApproval,
-    ) {
-        self.add_to_history(HistoryCell::new_session_info(model, cwd, approval_policy));
+    /// Note `model` could differ from `config.model` if the agent decided to
+    /// use a different model than the one requested by the user.
+    pub fn add_session_info(&mut self, config: &Config, model: String, cwd: PathBuf) {
+        self.add_to_history(HistoryCell::new_session_info(config, model, cwd));
     }
 
     pub fn add_active_exec_command(&mut self, call_id: String, command: Vec<String>) {

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1,4 +1,5 @@
 use codex_ansi_escape::ansi_escape_line;
+use codex_core::config::Config;
 use codex_core::protocol::FileChange;
 use ratatui::prelude::*;
 use ratatui::style::Color;
@@ -144,9 +145,9 @@ impl HistoryCell {
     }
 
     pub(crate) fn new_session_info(
+        config: &Config,
         model: String,
         cwd: std::path::PathBuf,
-        approval_policy: codex_core::protocol::AskForApproval,
     ) -> Self {
         let mut lines: Vec<Line<'static>> = Vec::new();
 
@@ -158,7 +159,11 @@ impl HistoryCell {
         ]));
         lines.push(Line::from(vec![
             "↳ approval: ".bold(),
-            format!("{:?}", approval_policy).into(),
+            format!("{:?}", config.approval_policy).into(),
+        ]));
+        lines.push(Line::from(vec![
+            "↳ sandbox: ".bold(),
+            format!("{:?}", config.sandbox_policy).into(),
         ]));
         lines.push(Line::from(""));
 


### PR DESCRIPTION
This changes how instantiating `Config` works and also adds `approval_policy` and `sandbox_policy` as fields. The idea is:

* All fields of `Config` have appropriate default values.
* `Config` is initially loaded from `~/.codex/config.toml`, so values in `config.toml` will override those defaults.
* Clients must instantiate `Config` via `Config::load_with_overrides(ConfigOverrides)` where `ConfigOverrides` has optional overrides that are expected to be settable based on CLI flags.

The `Config` should be defined early in the program and then passed down. Now functions like `init_codex()` take fewer individual parameters because they can just take a `Config`.

Also, `Config::load()` used to fail silently if `~/.codex/config.toml` had a parse error and fell back to the default config. This seemed really bad because it wasn't clear why the values in my `config.toml` weren't getting picked up. I changed things so that `load_with_overrides()` returns `Result<Config>` and verified that the various CLIs print a reasonable error if `config.toml` is malformed.

Finally, I also updated the TUI to show which **sandbox** value is being used, as we do for other key values like **model** and **approval**. This was also a reminder that the various values of `--sandbox` are honored on Linux but not macOS today, so I added some TODOs about fixing that.
