### PR TITLE
fix: drop d as keyboard shortcut for scrolling in the TUI

### DIFF
--- a/codex-rs/tui/src/conversation_history_widget.rs
+++ b/codex-rs/tui/src/conversation_history_widget.rs
@@ -48,11 +48,11 @@ impl ConversationHistoryWidget {
                 self.scroll_down(1);
                 true
             }
-            KeyCode::PageUp | KeyCode::Char('b') | KeyCode::Char('u') | KeyCode::Char('U') => {
+            KeyCode::PageUp | KeyCode::Char('b') => {
                 self.scroll_page_up();
                 true
             }
-            KeyCode::PageDown | KeyCode::Char(' ') | KeyCode::Char('d') | KeyCode::Char('D') => {
+            KeyCode::PageDown | KeyCode::Char(' ') => {
                 self.scroll_page_down();
                 true
             }
@@ -238,7 +238,7 @@ impl WidgetRef for ConversationHistoryWidget {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
         let (title, border_style) = if self.has_input_focus {
             (
-                "Messages (↑/↓ or j/k = line,  b/u = PgUp, space/d = PgDn)",
+                "Messages (↑/↓ or j/k = line,  b/space = page)",
                 Style::default().fg(Color::LightYellow),
             )
         } else {


### PR DESCRIPTION
The existing `b` and `space` are sufficient and `d` and `u` default to half-page scrolling in `less`, so the way we supported `d` and `u` wasn't faithful to that, anyway:

https://man7.org/linux/man-pages/man1/less.1.html

If we decide to bring `d` and `u` back, they should probably match `less`?