### PR TITLE
fix: tighten up check for /usr/bin/sandbox-exec

### DIFF
--- a/codex-cli/src/utils/agent/sandbox/macos-seatbelt.ts
+++ b/codex-cli/src/utils/agent/sandbox/macos-seatbelt.ts
@@ -12,6 +12,14 @@ function getCommonRoots() {
   ];
 }
 
+/**
+ * When working with `sandbox-exec`, only consider `sandbox-exec` in `/usr/bin`
+ * to defend against an attacker trying to inject a malicious version on the
+ * PATH. If /usr/bin/sandbox-exec has been tampered with, then the attacker
+ * already has root access.
+ */
+export const PATH_TO_SEATBELT_EXECUTABLE = "/usr/bin/sandbox-exec";
+
 export function execWithSeatbelt(
   cmd: Array<string>,
   opts: SpawnOptions,
@@ -57,7 +65,7 @@ export function execWithSeatbelt(
   );
 
   const fullCommand = [
-    "sandbox-exec",
+    PATH_TO_SEATBELT_EXECUTABLE,
     "-p",
     fullPolicy,
     ...policyTemplateParams,

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -35,6 +35,12 @@ const TIMEOUT_CODE: i32 = 64;
 
 const MACOS_SEATBELT_READONLY_POLICY: &str = include_str!("seatbelt_readonly_policy.sbpl");
 
+/// When working with `sandbox-exec`, only consider `sandbox-exec` in `/usr/bin`
+/// to defend against an attacker trying to inject a malicious version on the
+/// PATH. If /usr/bin/sandbox-exec has been tampered with, then the attacker
+/// already has root access.
+const MACOS_PATH_TO_SEATBELT_EXECUTABLE: &str = "/usr/bin/sandbox-exec";
+
 #[derive(Deserialize, Debug, Clone)]
 pub struct ExecParams {
     pub command: Vec<String>,
@@ -186,7 +192,7 @@ pub fn create_seatbelt_command(
     };
 
     let mut seatbelt_command: Vec<String> = vec![
-        "sandbox-exec".to_string(),
+        MACOS_PATH_TO_SEATBELT_EXECUTABLE.to_string(),
         "-p".to_string(),
         full_policy.to_string(),
     ];


### PR DESCRIPTION
* In both TypeScript and Rust, we now invoke `/usr/bin/sandbox-exec` explicitly rather than whatever `sandbox-exec` happens to be on the `PATH`.
* Changed `isSandboxExecAvailable` to use `access()` rather than `command -v` so that:
  *  We only do the check once over the lifetime of the Codex process.
  * The check is specific to `/usr/bin/sandbox-exec`.
  * We now do a syscall rather than incur the overhead of spawning a process, dealing with timeouts, etc.

I think there is still room for improvement here where we should move the `isSandboxExecAvailable` check earlier in the CLI, ideally right after we do arg parsing to verify that we can provide the Seatbelt sandbox if that is what the user has requested.