### PR TITLE
fix: increase timeout of test_writable_root

### DIFF
--- a/codex-rs/core/src/linux.rs
+++ b/codex-rs/core/src/linux.rs
@@ -225,7 +225,9 @@ mod tests_linux {
                 &format!("echo blah > {}", file_path.to_string_lossy()),
             ],
             &[tmpdir.path().to_path_buf()],
-            500,
+            // We have seen timeouts when running this test in CI on GitHub,
+            // so we are using a generous timeout until we can diagnose further.
+            1_000,
         )
         .await;
     }


### PR DESCRIPTION
Although we made some promising fixes in https://github.com/openai/codex/pull/662, we are still seeing some flakiness in `test_writable_root()`. If this continues to flake with the more generous timeout, we should try something other than simply increasing the timeout.