### PR TITLE
feat: add `debug landlock` subcommand comparable to `debug seatbelt`

### DIFF
--- a/codex-rs/cli/src/landlock.rs
+++ b/codex-rs/cli/src/landlock.rs
@@ -1,0 +1,51 @@
+//! `debug landlock` implementation for the Codex CLI.
+//!
+//! On Linux the command is executed inside a Landlock + seccomp sandbox by
+//! calling the low-level `exec_linux` helper from `codex_core::linux`.
+
+use codex_core::protocol::SandboxPolicy;
+use std::os::unix::process::ExitStatusExt;
+use std::path::PathBuf;
+use std::process;
+use std::process::Command;
+use std::process::ExitStatus;
+
+/// Execute `command` in a Linux sandbox (Landlock + seccomp) the way Codex
+/// would.
+pub(crate) fn run_landlock(
+    command: Vec<String>,
+    sandbox_policy: SandboxPolicy,
+    writable_roots: Vec<PathBuf>,
+) -> anyhow::Result<()> {
+    if command.is_empty() {
+        anyhow::bail!("command args are empty");
+    }
+
+    // Spawn a new thread and apply the sandbox policies there.
+    let handle = std::thread::spawn(move || -> anyhow::Result<ExitStatus> {
+        // Apply sandbox policies inside this thread so only the child inherits
+        // them, not the entire CLI process.
+        if sandbox_policy.is_network_restricted() {
+            codex_core::linux::install_network_seccomp_filter_on_current_thread()?;
+        }
+
+        if sandbox_policy.is_file_write_restricted() {
+            codex_core::linux::install_filesystem_landlock_rules_on_current_thread(writable_roots)?;
+        }
+
+        let status = Command::new(&command[0]).args(&command[1..]).status()?;
+        Ok(status)
+    });
+    let status = handle
+        .join()
+        .map_err(|e| anyhow::anyhow!("Failed to join thread: {e:?}"))??;
+
+    // Use ExitStatus to derive the exit code.
+    if let Some(code) = status.code() {
+        process::exit(code);
+    } else if let Some(signal) = status.signal() {
+        process::exit(128 + signal);
+    } else {
+        process::exit(1);
+    }
+}

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -14,7 +14,7 @@ pub mod exec;
 mod flags;
 mod is_safe_command;
 #[cfg(target_os = "linux")]
-mod linux;
+pub mod linux;
 mod models;
 pub mod protocol;
 mod safety;

--- a/codex-rs/core/src/linux.rs
+++ b/codex-rs/core/src/linux.rs
@@ -72,7 +72,15 @@ pub async fn exec_linux(
     }
 }
 
-fn install_filesystem_landlock_rules_on_current_thread(writable_roots: Vec<PathBuf>) -> Result<()> {
+/// Installs Landlock file-system rules on the current thread allowing read
+/// access to the entire file-system while restricting write access to
+/// `/dev/null` and the provided list of `writable_roots`.
+///
+/// # Errors
+/// Returns [`CodexErr::Sandbox`] variants when the ruleset fails to apply.
+pub fn install_filesystem_landlock_rules_on_current_thread(
+    writable_roots: Vec<PathBuf>,
+) -> Result<()> {
     let abi = ABI::V5;
     let access_rw = AccessFs::from_all(abi);
     let access_ro = AccessFs::from_read(abi);
@@ -98,7 +106,9 @@ fn install_filesystem_landlock_rules_on_current_thread(writable_roots: Vec<PathB
     Ok(())
 }
 
-fn install_network_seccomp_filter_on_current_thread() -> std::result::Result<(), SandboxErr> {
+/// Installs a seccomp filter that blocks outbound network access except for
+/// AF_UNIX domain sockets.
+pub fn install_network_seccomp_filter_on_current_thread() -> std::result::Result<(), SandboxErr> {
     // Build rule map.
     let mut rules: BTreeMap<i64, Vec<SeccompRule>> = BTreeMap::new();
 


### PR DESCRIPTION
This PR adds a `debug landlock` subcommand to the Codex CLI for testing how Codex would execute a command using the specified sandbox policy.

Built and ran this code in the `rust:latest` Docker container. In the container, hitting the network with vanilla `curl` succeeds:

```
$ curl google.com
<HTML><HEAD><meta http-equiv="content-type" content="text/html;charset=utf-8">
<TITLE>301 Moved</TITLE></HEAD><BODY>
<H1>301 Moved</H1>
The document has moved
<A HREF="http://www.google.com/">here</A>.
</BODY></HTML>
```

whereas this fails, as expected:

```
$ cargo run -- debug landlock -s network-restricted -- curl google.com
curl: (6) getaddrinfo() thread failed to start
```
