### PR TITLE
Fixes issue #726 by adding config to configToSave object

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -168,6 +168,7 @@ const cli = meow(
 
       disableResponseStorage: {
         type: "boolean",
+        default: undefined,
         description:
           "Disable server-side response storage (sends full conversation context with every request)",
       },
@@ -297,7 +298,7 @@ config = {
   disableResponseStorage:
     cli.flags.disableResponseStorage !== undefined
       ? Boolean(cli.flags.disableResponseStorage)
-      : config.disableResponseStorage,
+      : (config.disableResponseStorage ?? false),
 };
 
 // Check for updates after loading config. This is important because we write state file in

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -294,6 +294,12 @@ if (!apiKey && !NO_API_KEY_REQUIRED.has(provider.toLowerCase())) {
   process.exit(1);
 }
 
+const flagPresent = Object.hasOwn(cli.flags, "disableResponseStorage");
+
+const disableResponseStorage = flagPresent
+  ? Boolean(cli.flags.disableResponseStorage) // value user actually passed
+  : (config.disableResponseStorage ?? false); // fall back to YAML, default to false
+
 config = {
   apiKey,
   ...config,
@@ -303,10 +309,7 @@ config = {
     (cli.flags.reasoning as ReasoningEffort | undefined) ?? "high",
   flexMode: Boolean(cli.flags.flexMode),
   provider,
-  disableResponseStorage:
-    cli.flags.disableResponseStorage !== undefined
-      ? Boolean(cli.flags.disableResponseStorage)
-      : (config.disableResponseStorage ?? false),
+  disableResponseStorage,
 };
 
 // Check for updates after loading config. This is important because we write state file in

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -175,7 +175,6 @@ const cli = meow(
 
       disableResponseStorage: {
         type: "boolean",
-        default: undefined,
         description:
           "Disable server-side response storage (sends full conversation context with every request)",
       },

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -480,6 +480,7 @@ export const saveConfig = (
     provider: config.provider,
     providers: config.providers,
     approvalMode: config.approvalMode,
+    disableResponseStorage: config.disableResponseStorage,
   };
 
   // Add history settings if they exist

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -316,6 +316,22 @@ export const loadConfig = (
     }
   }
 
+  if (
+    storedConfig.disableResponseStorage !== undefined &&
+    typeof storedConfig.disableResponseStorage !== "boolean"
+  ) {
+    if (storedConfig.disableResponseStorage === "true") {
+      storedConfig.disableResponseStorage = true;
+    } else if (storedConfig.disableResponseStorage === "false") {
+      storedConfig.disableResponseStorage = false;
+    } else {
+      log(
+        `[codex] Warning: 'disableResponseStorage' in config is not a boolean (got '${storedConfig.disableResponseStorage}'). Ignoring this value.`,
+      );
+      delete storedConfig.disableResponseStorage;
+    }
+  }
+
   const instructionsFilePathResolved =
     instructionsPath ?? INSTRUCTIONS_FILEPATH;
   const userInstructions = existsSync(instructionsFilePathResolved)

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -365,7 +365,7 @@ export const loadConfig = (
     instructions: combinedInstructions,
     notify: storedConfig.notify === true,
     approvalMode: storedConfig.approvalMode,
-    disableResponseStorage: storedConfig.disableResponseStorage ?? false,
+    disableResponseStorage: storedConfig.disableResponseStorage === true,
   };
 
   // -----------------------------------------------------------------------

--- a/codex-cli/tests/disableResponseStorage.agentLoop.test.ts
+++ b/codex-cli/tests/disableResponseStorage.agentLoop.test.ts
@@ -8,11 +8,9 @@
 import { describe, it, expect, vi } from "vitest";
 import { AgentLoop } from "../src/utils/agent/agent-loop";
 import type { AppConfig } from "../src/utils/config";
-import type { ReviewDecision } from "../src/utils/agent/types";
-// If you have a ReviewDecision type or enum, import it here:
-// import type { ReviewDecision } from "../src/utils/agent/types";
+import { ReviewDecision } from "../src/utils/agent/review";
 
-/* ─────────── 1.  Spy + module mock ──────────────────────────────── */
+/* ─────────── 1.  Spy + module mock ─────────────────────────────── */
 const createSpy = vi.fn().mockResolvedValue({
   data: { id: "resp_123", status: "completed", output: [] },
 });
@@ -52,9 +50,7 @@ describe.each([
       additionalWritableRoots: [],
       onItem() {},
       onLoading() {},
-      getCommandConfirmation: async () => ({
-        review: "approved" as ReviewDecision,
-      }),
+      getCommandConfirmation: async () => ({ review: ReviewDecision.YES }),
       onLastResponseId() {},
     });
 
@@ -68,26 +64,22 @@ describe.each([
 
     expect(createSpy).toHaveBeenCalledTimes(1);
 
-    const payload = createSpy.mock.calls[0][0];
+    const payload: any = createSpy.mock.calls[0][0];
 
     if (flag) {
       /* behaviour when ZDR is *on* */
       expect(payload).not.toHaveProperty("previous_response_id");
-      if (payload.input) {
-        payload.input.forEach((m: any) =>
-          expect(m.store === undefined ? false : m.store).toBe(false),
-        );
-      }
+      payload.input?.forEach((m: any) =>
+        expect(m.store === undefined ? false : m.store).toBe(false),
+      );
     } else {
       /* behaviour when ZDR is *off* */
       expect(payload).toHaveProperty("previous_response_id");
-      if (payload.input) {
-        payload.input.forEach((m: any) => {
-          if ("store" in m) {
-            expect(m.store).not.toBe(false);
-          }
-        });
-      }
+      payload.input?.forEach((m: any) => {
+        if ("store" in m) {
+          expect(m.store).not.toBe(false);
+        }
+      });
     }
   });
 });

--- a/codex-cli/tests/disableResponseStorage.agentLoop.test.ts
+++ b/codex-cli/tests/disableResponseStorage.agentLoop.test.ts
@@ -8,6 +8,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { AgentLoop } from "../src/utils/agent/agent-loop";
 import type { AppConfig } from "../src/utils/config";
+import type { ReviewDecision } from "../src/utils/agent/types";
 // If you have a ReviewDecision type or enum, import it here:
 // import type { ReviewDecision } from "../src/utils/agent/types";
 
@@ -51,7 +52,9 @@ describe.each([
       additionalWritableRoots: [],
       onItem() {},
       onLoading() {},
-      getCommandConfirmation: async () => ({ review: "approved" }),
+      getCommandConfirmation: async () => ({
+        review: "approved" as ReviewDecision,
+      }),
       onLastResponseId() {},
     });
 
@@ -70,17 +73,21 @@ describe.each([
     if (flag) {
       /* behaviour when ZDR is *on* */
       expect(payload).not.toHaveProperty("previous_response_id");
-      payload.input?.forEach((m: any) =>
-        expect(m.store === undefined ? false : m.store).toBe(false),
-      );
+      if (payload.input) {
+        payload.input.forEach((m: any) =>
+          expect(m.store === undefined ? false : m.store).toBe(false),
+        );
+      }
     } else {
       /* behaviour when ZDR is *off* */
       expect(payload).toHaveProperty("previous_response_id");
-      payload.input?.forEach((m: any) => {
-        if ("store" in m) {
-          expect(m.store).not.toBe(false);
-        }
-      });
+      if (payload.input) {
+        payload.input.forEach((m: any) => {
+          if ("store" in m) {
+            expect(m.store).not.toBe(false);
+          }
+        });
+      }
     }
   });
 });

--- a/codex-cli/tests/disableResponseStorage.agentLoop.test.ts
+++ b/codex-cli/tests/disableResponseStorage.agentLoop.test.ts
@@ -58,7 +58,8 @@ describe.each([
     await loop.run([
       {
         type: "message",
-        content: [{ type: "text", text: "hello" }],
+        role: "user",
+        content: [{ type: "input_text", text: "hello" }],
       },
     ]);
 
@@ -69,23 +70,17 @@ describe.each([
     if (flag) {
       /* behaviour when ZDR is *on* */
       expect(payload).not.toHaveProperty("previous_response_id");
-      if (payload.input) {
-        payload.input.forEach((m: any) =>
-          expect(m.store === undefined ? false : m.store).toBe(false),
-        );
-      }
+      payload.input?.forEach((m: any) =>
+        expect(m.store === undefined ? false : m.store).toBe(false),
+      );
     } else {
       /* behaviour when ZDR is *off* */
       expect(payload).toHaveProperty("previous_response_id");
-      if (payload.input) {
-        // first user message is usually non-stored; assistant messages will be stored
-        // so here we just assert the property is not forcibly set to false
-        payload.input.forEach((m: any) => {
-          if ("store" in m) {
-            expect(m.store).not.toBe(false);
-          }
-        });
-      }
+      payload.input?.forEach((m: any) => {
+        if ("store" in m) {
+          expect(m.store).not.toBe(false);
+        }
+      });
     }
   });
 });

--- a/codex-cli/tests/disableResponseStorage.agentLoop.test.ts
+++ b/codex-cli/tests/disableResponseStorage.agentLoop.test.ts
@@ -69,17 +69,21 @@ describe.each([
     if (flag) {
       /* behaviour when ZDR is *on* */
       expect(payload).not.toHaveProperty("previous_response_id");
-      payload.input?.forEach((m: any) =>
-        expect(m.store === undefined ? false : m.store).toBe(false),
-      );
+      if (payload.input) {
+        payload.input.forEach((m: any) =>
+          expect(m.store === undefined ? false : m.store).toBe(false),
+        );
+      }
     } else {
       /* behaviour when ZDR is *off* */
       expect(payload).toHaveProperty("previous_response_id");
-      payload.input?.forEach((m: any) => {
-        if ("store" in m) {
-          expect(m.store).not.toBe(false);
-        }
-      });
+      if (payload.input) {
+        payload.input.forEach((m: any) => {
+          if ("store" in m) {
+            expect(m.store).not.toBe(false);
+          }
+        });
+      }
     }
   });
 });

--- a/codex-cli/tests/disableResponseStorage.agentLoop.test.ts
+++ b/codex-cli/tests/disableResponseStorage.agentLoop.test.ts
@@ -1,0 +1,79 @@
+/**
+ * codex-cli/tests/disableResponseStorage.agentLoop.test.ts
+ *
+ * Verifies AgentLoop's request-building logic for both values of
+ * disableResponseStorage.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { AgentLoop } from "../src/utils/agent/agent-loop";
+import type { AppConfig } from "../src/utils/config";
+
+/* ─────────── 1.  Spy + module mock ──────────────────────────────── */
+const createSpy = vi.fn().mockResolvedValue({
+  data: { id: "resp_123", status: "completed", output: [] },
+});
+
+vi.mock("openai", () => ({
+  default: class {
+    public responses = { create: createSpy };
+  },
+  APIConnectionTimeoutError: class extends Error {},
+}));
+
+/* ─────────── 2.  Parametrised tests ─────────────────────────────── */
+describe.each([
+  { flag: true, title: "omits previous_response_id & sets store:false" },
+  { flag: false, title: "sends previous_response_id & allows store:true" },
+])("AgentLoop with disableResponseStorage=%s", ({ flag, title }) => {
+  /* build a fresh config for each case */
+  const cfg: AppConfig = {
+    model: "o4-mini",
+    provider: "openai",
+    instructions: "",
+    disableResponseStorage: flag,
+    notify: false,
+  };
+
+  it(title, async () => {
+    /* reset spy per iteration */
+    createSpy.mockClear();
+
+    const loop = new AgentLoop({
+      model: cfg.model,
+      provider: cfg.provider,
+      config: cfg,
+      instructions: "",
+      approvalPolicy: "suggest",
+      disableResponseStorage: flag,
+      additionalWritableRoots: [],
+      onItem() {},
+      onLoading() {},
+      getCommandConfirmation: async () => ({ review: "approve" }),
+      onLastResponseId() {},
+    });
+
+    await loop.run([{ type: "text", content: "hello" }]);
+    expect(createSpy).toHaveBeenCalledTimes(1);
+
+    const payload = createSpy.mock.calls[0][0];
+
+    if (flag) {
+      /* behaviour when ZDR is *on* */
+      expect(payload).not.toHaveProperty("previous_response_id");
+      payload.input.forEach((m: any) =>
+        expect(m.store === undefined ? false : m.store).toBe(false),
+      );
+    } else {
+      /* behaviour when ZDR is *off* */
+      expect(payload).toHaveProperty("previous_response_id");
+      // first user message is usually non-stored; assistant messages will be stored
+      // so here we just assert the property is not forcibly set to false
+      payload.input.forEach((m: any) => {
+        if ("store" in m) {
+          expect(m.store).not.toBe(false);
+        }
+      });
+    }
+  });
+});

--- a/codex-cli/tests/disableResponseStorage.agentLoop.test.ts
+++ b/codex-cli/tests/disableResponseStorage.agentLoop.test.ts
@@ -64,15 +64,19 @@ describe.each([
 
     expect(createSpy).toHaveBeenCalledTimes(1);
 
-    const payload: any = createSpy.mock.calls[0][0];
+    const call = createSpy.mock.calls[0];
+    if (!call) {
+      throw new Error("Expected createSpy to have been called at least once");
+    }
+    const payload: any = call[0];
 
     if (flag) {
       /* behaviour when ZDR is *on* */
       expect(payload).not.toHaveProperty("previous_response_id");
       if (payload.input) {
-        payload.input.forEach((m: any) =>
-          expect(m.store === undefined ? false : m.store).toBe(false),
-        );
+        payload.input.forEach((m: any) => {
+          expect(m.store === undefined ? false : m.store).toBe(false);
+        });
       }
     } else {
       /* behaviour when ZDR is *off* */

--- a/codex-cli/tests/disableResponseStorage.test.ts
+++ b/codex-cli/tests/disableResponseStorage.test.ts
@@ -1,0 +1,42 @@
+/**
+ * codex/codex-cli/tests/disableResponseStorage.test.ts
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import { loadConfig, saveConfig } from "../src/utils/config";
+
+const sandboxHome = mkdtempSync(join(tmpdir(), "codex-home-"));
+const codexDir = join(sandboxHome, ".codex");
+const yamlPath = join(codexDir, "config.yaml");
+
+describe("disableResponseStorage persistence", () => {
+  beforeAll(() => {
+    // mkdir -p ~/.codex inside the sandbox
+    rmSync(codexDir, { recursive: true, force: true });
+    require("fs").mkdirSync(codexDir, { recursive: true });
+
+    // seed YAML with ZDR enabled
+    writeFileSync(yamlPath, "model: o4-mini\ndisableResponseStorage: true\n");
+  });
+
+  afterAll(() => {
+    rmSync(sandboxHome, { recursive: true, force: true });
+  });
+
+  it("keeps disableResponseStorage=true across load/save cycle", async () => {
+    // 1️⃣ explicitly load the sandbox file
+    const cfg1 = loadConfig(yamlPath);
+    expect(cfg1.disableResponseStorage).toBe(true);
+
+    // 2️⃣ save right back to the same file
+    await saveConfig(cfg1, yamlPath);
+
+    // 3️⃣ reload and re-assert
+    const cfg2 = loadConfig(yamlPath);
+    expect(cfg2.disableResponseStorage).toBe(true);
+  });
+});

--- a/codex-cli/tests/disableResponseStorage.test.ts
+++ b/codex-cli/tests/disableResponseStorage.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -17,7 +17,7 @@ describe("disableResponseStorage persistence", () => {
   beforeAll(() => {
     // mkdir -p ~/.codex inside the sandbox
     rmSync(codexDir, { recursive: true, force: true });
-    require("fs").mkdirSync(codexDir, { recursive: true });
+    mkdirSync(codexDir, { recursive: true });
 
     // seed YAML with ZDR enabled
     writeFileSync(yamlPath, "model: o4-mini\ndisableResponseStorage: true\n");

--- a/codex-cli/tests/disableResponseStorage.test.ts
+++ b/codex-cli/tests/disableResponseStorage.test.ts
@@ -8,13 +8,14 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 
 import { loadConfig, saveConfig } from "../src/utils/config";
+import type { AppConfig } from "../src/utils/config";
 
-const sandboxHome = mkdtempSync(join(tmpdir(), "codex-home-"));
-const codexDir = join(sandboxHome, ".codex");
-const yamlPath = join(codexDir, "config.yaml");
+const sandboxHome: string = mkdtempSync(join(tmpdir(), "codex-home-"));
+const codexDir: string = join(sandboxHome, ".codex");
+const yamlPath: string = join(codexDir, "config.yaml");
 
 describe("disableResponseStorage persistence", () => {
-  beforeAll(() => {
+  beforeAll((): void => {
     // mkdir -p ~/.codex inside the sandbox
     rmSync(codexDir, { recursive: true, force: true });
     mkdirSync(codexDir, { recursive: true });
@@ -23,20 +24,20 @@ describe("disableResponseStorage persistence", () => {
     writeFileSync(yamlPath, "model: o4-mini\ndisableResponseStorage: true\n");
   });
 
-  afterAll(() => {
+  afterAll((): void => {
     rmSync(sandboxHome, { recursive: true, force: true });
   });
 
-  it("keeps disableResponseStorage=true across load/save cycle", async () => {
+  it("keeps disableResponseStorage=true across load/save cycle", async (): Promise<void> => {
     // 1️⃣ explicitly load the sandbox file
-    const cfg1 = loadConfig(yamlPath);
+    const cfg1: AppConfig = loadConfig(yamlPath);
     expect(cfg1.disableResponseStorage).toBe(true);
 
     // 2️⃣ save right back to the same file
     await saveConfig(cfg1, yamlPath);
 
     // 3️⃣ reload and re-assert
-    const cfg2 = loadConfig(yamlPath);
+    const cfg2: AppConfig = loadConfig(yamlPath);
     expect(cfg2.disableResponseStorage).toBe(true);
   });
 });


### PR DESCRIPTION
The saveConfig() function only includes a hardcoded subset of properties when writing the config file. Any property not explicitly listed (like disableResponseStorage) will be dropped.
I have added `disableResponseStorage` to the `configToSave` object as the immediate fix.

[Linking Issue this fixes.](https://github.com/openai/codex/issues/726)