### PR TITLE
fix: overhaul SandboxPolicy and config loading in Rust

### DIFF
--- a/codex-rs/cli/src/landlock.rs
+++ b/codex-rs/cli/src/landlock.rs
@@ -5,7 +5,6 @@
 
 use codex_core::protocol::SandboxPolicy;
 use std::os::unix::process::ExitStatusExt;
-use std::path::PathBuf;
 use std::process;
 use std::process::Command;
 use std::process::ExitStatus;
@@ -15,7 +14,6 @@ use std::process::ExitStatus;
 pub(crate) fn run_landlock(
     command: Vec<String>,
     sandbox_policy: SandboxPolicy,
-    writable_roots: Vec<PathBuf>,
 ) -> anyhow::Result<()> {
     if command.is_empty() {
         anyhow::bail!("command args are empty");
@@ -23,16 +21,7 @@ pub(crate) fn run_landlock(
 
     // Spawn a new thread and apply the sandbox policies there.
     let handle = std::thread::spawn(move || -> anyhow::Result<ExitStatus> {
-        // Apply sandbox policies inside this thread so only the child inherits
-        // them, not the entire CLI process.
-        if sandbox_policy.is_network_restricted() {
-            codex_core::linux::install_network_seccomp_filter_on_current_thread()?;
-        }
-
-        if sandbox_policy.is_file_write_restricted() {
-            codex_core::linux::install_filesystem_landlock_rules_on_current_thread(writable_roots)?;
-        }
-
+        codex_core::linux::apply_sandbox_policy_to_current_thread(sandbox_policy)?;
         let status = Command::new(&command[0]).args(&command[1..]).status()?;
         Ok(status)
     });

--- a/codex-rs/cli/src/seatbelt.rs
+++ b/codex-rs/cli/src/seatbelt.rs
@@ -1,13 +1,11 @@
 use codex_core::exec::create_seatbelt_command;
 use codex_core::protocol::SandboxPolicy;
-use std::path::PathBuf;
 
 pub(crate) async fn run_seatbelt(
     command: Vec<String>,
     sandbox_policy: SandboxPolicy,
-    writable_roots: Vec<PathBuf>,
 ) -> anyhow::Result<()> {
-    let seatbelt_command = create_seatbelt_command(command, sandbox_policy, &writable_roots);
+    let seatbelt_command = create_seatbelt_command(command, &sandbox_policy);
     let status = tokio::process::Command::new(seatbelt_command[0].clone())
         .args(&seatbelt_command[1..])
         .spawn()

--- a/codex-rs/core/src/approval_mode_cli_arg.rs
+++ b/codex-rs/core/src/approval_mode_cli_arg.rs
@@ -4,7 +4,6 @@
 use clap::ValueEnum;
 
 use crate::protocol::AskForApproval;
-use crate::protocol::SandboxPolicy;
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
 #[value(rename_all = "kebab-case")]
@@ -24,38 +23,12 @@ pub enum ApprovalModeCliArg {
     Never,
 }
 
-#[derive(Clone, Copy, Debug, ValueEnum)]
-#[value(rename_all = "kebab-case")]
-pub enum SandboxModeCliArg {
-    /// Network syscalls will be blocked
-    NetworkRestricted,
-    /// Filesystem writes will be restricted
-    FileWriteRestricted,
-    /// Network and filesystem writes will be restricted
-    NetworkAndFileWriteRestricted,
-    /// No restrictions; full "unsandboxed" mode
-    DangerousNoRestrictions,
-}
-
 impl From<ApprovalModeCliArg> for AskForApproval {
     fn from(value: ApprovalModeCliArg) -> Self {
         match value {
             ApprovalModeCliArg::OnFailure => AskForApproval::OnFailure,
             ApprovalModeCliArg::UnlessAllowListed => AskForApproval::UnlessAllowListed,
             ApprovalModeCliArg::Never => AskForApproval::Never,
-        }
-    }
-}
-
-impl From<SandboxModeCliArg> for SandboxPolicy {
-    fn from(value: SandboxModeCliArg) -> Self {
-        match value {
-            SandboxModeCliArg::NetworkRestricted => SandboxPolicy::NetworkRestricted,
-            SandboxModeCliArg::FileWriteRestricted => SandboxPolicy::FileWriteRestricted,
-            SandboxModeCliArg::NetworkAndFileWriteRestricted => {
-                SandboxPolicy::NetworkAndFileWriteRestricted
-            }
-            SandboxModeCliArg::DangerousNoRestrictions => SandboxPolicy::DangerousNoRestrictions,
         }
     }
 }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -861,7 +861,7 @@ async fn handle_function_call(
                 assess_command_safety(
                     &params.command,
                     sess.approval_policy,
-                    sess.sandbox_policy,
+                    &sess.sandbox_policy,
                     &state.approved_commands,
                 )
             };
@@ -916,14 +916,11 @@ async fn handle_function_call(
             )
             .await;
 
-            let roots_snapshot = { sess.writable_roots.lock().unwrap().clone() };
-
             let output_result = process_exec_tool_call(
                 params.clone(),
                 sandbox_type,
-                &roots_snapshot,
                 sess.ctrl_c.clone(),
-                sess.sandbox_policy,
+                &sess.sandbox_policy,
             )
             .await;
 
@@ -1006,16 +1003,13 @@ async fn handle_function_call(
                             )
                             .await;
 
-                            let retry_roots = { sess.writable_roots.lock().unwrap().clone() };
-
                             // This is an escalated retry; the policy will not be
                             // examined and the sandbox has been set to `None`.
                             let retry_output_result = process_exec_tool_call(
                                 params.clone(),
                                 SandboxType::None,
-                                &retry_roots,
                                 sess.ctrl_c.clone(),
-                                sess.sandbox_policy,
+                                &sess.sandbox_policy,
                             )
                             .await;
 

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1,5 +1,6 @@
 use crate::flags::OPENAI_DEFAULT_MODEL;
 use crate::protocol::AskForApproval;
+use crate::protocol::SandboxPermission;
 use crate::protocol::SandboxPolicy;
 use dirs::home_dir;
 use serde::Deserialize;
@@ -11,25 +12,66 @@ use std::path::PathBuf;
 const EMBEDDED_INSTRUCTIONS: &str = include_str!("../prompt.md");
 
 /// Application configuration loaded from disk and merged with overrides.
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Debug, Clone)]
 pub struct Config {
     /// Optional override of model selection.
-    #[serde(default = "default_model")]
     pub model: String,
-    /// Default approval policy for executing commands.
-    #[serde(default)]
+
+    /// Approval policy for executing commands.
     pub approval_policy: AskForApproval,
-    #[serde(default)]
+
     pub sandbox_policy: SandboxPolicy,
 
     /// Disable server-side response storage (sends the full conversation
     /// context with every request). Currently necessary for OpenAI customers
     /// who have opted into Zero Data Retention (ZDR).
-    #[serde(default)]
     pub disable_response_storage: bool,
 
     /// System instructions.
     pub instructions: Option<String>,
+}
+
+/// Base config deserialized from ~/.codex/config.toml.
+#[derive(Deserialize, Debug, Clone, Default)]
+pub struct ConfigToml {
+    /// Optional override of model selection.
+    pub model: Option<String>,
+
+    /// Default approval policy for executing commands.
+    pub approval_policy: Option<AskForApproval>,
+
+    pub sandbox_permissions: Option<Vec<SandboxPermission>>,
+
+    /// Disable server-side response storage (sends the full conversation
+    /// context with every request). Currently necessary for OpenAI customers
+    /// who have opted into Zero Data Retention (ZDR).
+    pub disable_response_storage: Option<bool>,
+
+    /// System instructions.
+    pub instructions: Option<String>,
+}
+
+impl ConfigToml {
+    /// Attempt to parse the file at `~/.codex/config.toml`. If it does not
+    /// exist, return a default config. Though if it exists and cannot be
+    /// parsed, report that to the user and force them to fix it.
+    fn load_from_toml() -> std::io::Result<Self> {
+        let config_toml_path = codex_dir()?.join("config.toml");
+        match std::fs::read_to_string(&config_toml_path) {
+            Ok(contents) => toml::from_str::<Self>(&contents).map_err(|e| {
+                tracing::error!("Failed to parse config.toml: {e}");
+                std::io::Error::new(std::io::ErrorKind::InvalidData, e)
+            }),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                tracing::info!("config.toml not found, using defaults");
+                Ok(Self::default())
+            }
+            Err(e) => {
+                tracing::error!("Failed to read config.toml: {e}");
+                Err(e)
+            }
+        }
+    }
 }
 
 /// Optional overrides for user configuration (e.g., from CLI flags).
@@ -46,11 +88,14 @@ impl Config {
     /// ~/.codex/config.toml, ~/.codex/instructions.md, embedded defaults, and
     /// any values provided in `overrides` (highest precedence).
     pub fn load_with_overrides(overrides: ConfigOverrides) -> std::io::Result<Self> {
-        let mut cfg: Config = Self::load_from_toml()?;
+        let cfg: ConfigToml = ConfigToml::load_from_toml()?;
         tracing::warn!("Config parsed from config.toml: {cfg:?}");
+        Ok(Self::load_from_base_config_with_overrides(cfg, overrides))
+    }
 
+    fn load_from_base_config_with_overrides(cfg: ConfigToml, overrides: ConfigOverrides) -> Self {
         // Instructions: user-provided instructions.md > embedded default.
-        cfg.instructions =
+        let instructions =
             Self::load_instructions().or_else(|| Some(EMBEDDED_INSTRUCTIONS.to_string()));
 
         // Destructure ConfigOverrides fully to ensure all overrides are applied.
@@ -61,56 +106,47 @@ impl Config {
             disable_response_storage,
         } = overrides;
 
-        if let Some(model) = model {
-            cfg.model = model;
-        }
-        if let Some(approval_policy) = approval_policy {
-            cfg.approval_policy = approval_policy;
-        }
-        if let Some(sandbox_policy) = sandbox_policy {
-            cfg.sandbox_policy = sandbox_policy;
-        }
-        if let Some(disable_response_storage) = disable_response_storage {
-            cfg.disable_response_storage = disable_response_storage;
-        }
-        Ok(cfg)
-    }
-
-    /// Attempt to parse the file at `~/.codex/config.toml` into a Config.
-    fn load_from_toml() -> std::io::Result<Self> {
-        let config_toml_path = codex_dir()?.join("config.toml");
-        match std::fs::read_to_string(&config_toml_path) {
-            Ok(contents) => toml::from_str::<Self>(&contents).map_err(|e| {
-                tracing::error!("Failed to parse config.toml: {e}");
-                std::io::Error::new(std::io::ErrorKind::InvalidData, e)
-            }),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
-                tracing::info!("config.toml not found, using defaults");
-                Ok(Self::load_default_config())
+        let sandbox_policy = match sandbox_policy {
+            Some(sandbox_policy) => sandbox_policy,
+            None => {
+                // Derive a SandboxPolicy from the permissions in the config.
+                match cfg.sandbox_permissions {
+                    // Note this means the user can explicitly set permissions
+                    // to the empty list in the config file, granting it no
+                    // permissions whatsoever.
+                    Some(permissions) => SandboxPolicy::from(permissions),
+                    // Default to read only rather than completely locked down.
+                    None => SandboxPolicy::new_read_only_policy(),
+                }
             }
-            Err(e) => {
-                tracing::error!("Failed to read config.toml: {e}");
-                Err(e)
-            }
+        };
+
+        Self {
+            model: model.or(cfg.model).unwrap_or_else(default_model),
+            approval_policy: approval_policy
+                .or(cfg.approval_policy)
+                .unwrap_or_else(AskForApproval::default),
+            sandbox_policy,
+            disable_response_storage: disable_response_storage
+                .or(cfg.disable_response_storage)
+                .unwrap_or(false),
+            instructions,
         }
-    }
-
-    /// Meant to be used exclusively for tests: load_with_overrides() should be
-    /// used in all other cases.
-    pub fn load_default_config_for_test() -> Self {
-        Self::load_default_config()
-    }
-
-    fn load_default_config() -> Self {
-        // Load from an empty string to exercise #[serde(default)] to
-        // get the default values for each field.
-        toml::from_str::<Self>("").expect("empty string should parse as TOML")
     }
 
     fn load_instructions() -> Option<String> {
         let mut p = codex_dir().ok()?;
         p.push("instructions.md");
         std::fs::read_to_string(&p).ok()
+    }
+
+    /// Meant to be used exclusively for tests: `load_with_overrides()` should
+    /// be used in all other cases.
+    pub fn load_default_config_for_test() -> Self {
+        Self::load_from_base_config_with_overrides(
+            ConfigToml::default(),
+            ConfigOverrides::default(),
+        )
     }
 }
 

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -1,7 +1,6 @@
 use std::io;
 #[cfg(target_family = "unix")]
 use std::os::unix::process::ExitStatusExt;
-use std::path::PathBuf;
 use std::process::ExitStatus;
 use std::process::Stdio;
 use std::sync::Arc;
@@ -33,7 +32,7 @@ const DEFAULT_TIMEOUT_MS: u64 = 10_000;
 const SIGKILL_CODE: i32 = 9;
 const TIMEOUT_CODE: i32 = 64;
 
-const MACOS_SEATBELT_READONLY_POLICY: &str = include_str!("seatbelt_readonly_policy.sbpl");
+const MACOS_SEATBELT_BASE_POLICY: &str = include_str!("seatbelt_base_policy.sbpl");
 
 /// When working with `sandbox-exec`, only consider `sandbox-exec` in `/usr/bin`
 /// to defend against an attacker trying to inject a malicious version on the
@@ -67,19 +66,17 @@ pub enum SandboxType {
 #[cfg(target_os = "linux")]
 async fn exec_linux(
     params: ExecParams,
-    writable_roots: &[PathBuf],
     ctrl_c: Arc<Notify>,
-    sandbox_policy: SandboxPolicy,
+    sandbox_policy: &SandboxPolicy,
 ) -> Result<RawExecToolCallOutput> {
-    crate::linux::exec_linux(params, writable_roots, ctrl_c, sandbox_policy).await
+    crate::linux::exec_linux(params, ctrl_c, sandbox_policy).await
 }
 
 #[cfg(not(target_os = "linux"))]
 async fn exec_linux(
     _params: ExecParams,
-    _writable_roots: &[PathBuf],
     _ctrl_c: Arc<Notify>,
-    _sandbox_policy: SandboxPolicy,
+    _sandbox_policy: &SandboxPolicy,
 ) -> Result<RawExecToolCallOutput> {
     Err(CodexErr::Io(io::Error::new(
         io::ErrorKind::InvalidInput,
@@ -90,9 +87,8 @@ async fn exec_linux(
 pub async fn process_exec_tool_call(
     params: ExecParams,
     sandbox_type: SandboxType,
-    writable_roots: &[PathBuf],
     ctrl_c: Arc<Notify>,
-    sandbox_policy: SandboxPolicy,
+    sandbox_policy: &SandboxPolicy,
 ) -> Result<ExecToolCallOutput> {
     let start = Instant::now();
 
@@ -104,7 +100,7 @@ pub async fn process_exec_tool_call(
                 workdir,
                 timeout_ms,
             } = params;
-            let seatbelt_command = create_seatbelt_command(command, sandbox_policy, writable_roots);
+            let seatbelt_command = create_seatbelt_command(command, sandbox_policy);
             exec(
                 ExecParams {
                     command: seatbelt_command,
@@ -115,9 +111,7 @@ pub async fn process_exec_tool_call(
             )
             .await
         }
-        SandboxType::LinuxSeccomp => {
-            exec_linux(params, writable_roots, ctrl_c, sandbox_policy).await
-        }
+        SandboxType::LinuxSeccomp => exec_linux(params, ctrl_c, sandbox_policy).await,
     };
     let duration = start.elapsed();
     match raw_output_result {
@@ -162,41 +156,61 @@ pub async fn process_exec_tool_call(
 
 pub fn create_seatbelt_command(
     command: Vec<String>,
-    sandbox_policy: SandboxPolicy,
-    writable_roots: &[PathBuf],
+    sandbox_policy: &SandboxPolicy,
 ) -> Vec<String> {
-    let (policies, cli_args): (Vec<String>, Vec<String>) = writable_roots
-        .iter()
-        .enumerate()
-        .map(|(index, root)| {
-            let param_name = format!("WRITABLE_ROOT_{index}");
-            let policy: String = format!("(subpath (param \"{param_name}\"))");
-            let cli_arg = format!("-D{param_name}={}", root.to_string_lossy());
-            (policy, cli_arg)
-        })
-        .unzip();
-
-    // TODO(ragona): The seatbelt policy should reflect the SandboxPolicy that
-    // is passed, but everything is currently hardcoded to use
-    // MACOS_SEATBELT_READONLY_POLICY.
-    // TODO(mbolin): apply_patch calls must also honor the SandboxPolicy.
-    if !matches!(sandbox_policy, SandboxPolicy::NetworkRestricted) {
-        tracing::error!("specified sandbox policy {sandbox_policy:?} will not be honroed");
-    }
-
-    let full_policy = if policies.is_empty() {
-        MACOS_SEATBELT_READONLY_POLICY.to_string()
-    } else {
-        let scoped_write_policy = format!("(allow file-write*\n{}\n)", policies.join(" "));
-        format!("{MACOS_SEATBELT_READONLY_POLICY}\n{scoped_write_policy}")
+    let (file_write_policy, extra_cli_args) = {
+        if sandbox_policy.has_full_disk_write_access() {
+            // Allegedly, this is more permissive than `(allow file-write*)`.
+            (
+                r#"(allow file-write* (regex #"^/"))"#.to_string(),
+                Vec::<String>::new(),
+            )
+        } else {
+            let writable_roots = sandbox_policy.get_writable_roots();
+            let (writable_folder_policies, cli_args): (Vec<String>, Vec<String>) = writable_roots
+                .iter()
+                .enumerate()
+                .map(|(index, root)| {
+                    let param_name = format!("WRITABLE_ROOT_{index}");
+                    let policy: String = format!("(subpath (param \"{param_name}\"))");
+                    let cli_arg = format!("-D{param_name}={}", root.to_string_lossy());
+                    (policy, cli_arg)
+                })
+                .unzip();
+            if writable_folder_policies.is_empty() {
+                ("".to_string(), Vec::<String>::new())
+            } else {
+                let file_write_policy = format!(
+                    "(allow file-write*\n{}\n)",
+                    writable_folder_policies.join(" ")
+                );
+                (file_write_policy, cli_args)
+            }
+        }
     };
 
+    let file_read_policy = if sandbox_policy.has_full_disk_read_access() {
+        "; allow read-only file operations\n(allow file-read*)"
+    } else {
+        ""
+    };
+
+    // TODO(mbolin): apply_patch calls must also honor the SandboxPolicy.
+    let network_policy = if sandbox_policy.has_full_network_access() {
+        "(allow network-outbound)\n(allow network-inbound)\n(allow system-socket)"
+    } else {
+        ""
+    };
+
+    let full_policy = format!(
+        "{MACOS_SEATBELT_BASE_POLICY}\n{file_read_policy}\n{file_write_policy}\n{network_policy}"
+    );
     let mut seatbelt_command: Vec<String> = vec![
         MACOS_PATH_TO_SEATBELT_EXECUTABLE.to_string(),
         "-p".to_string(),
-        full_policy.to_string(),
+        full_policy,
     ];
-    seatbelt_command.extend(cli_args);
+    seatbelt_command.extend(extra_cli_args);
     seatbelt_command.push("--".to_string());
     seatbelt_command.extend(command);
     seatbelt_command

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -27,5 +27,3 @@ pub use codex::Codex;
 mod approval_mode_cli_arg;
 #[cfg(feature = "cli")]
 pub use approval_mode_cli_arg::ApprovalModeCliArg;
-#[cfg(feature = "cli")]
-pub use approval_mode_cli_arg::SandboxModeCliArg;

--- a/codex-rs/core/src/seatbelt_base_policy.sbpl
+++ b/codex-rs/core/src/seatbelt_base_policy.sbpl
@@ -6,9 +6,6 @@
 ; start with closed-by-default
 (deny default)
 
-; allow read-only file operations
-(allow file-read*)
-
 ; child processes inherit the policy of their parent
 (allow process-exec)
 (allow process-fork)

--- a/codex-rs/core/tests/live_agent.rs
+++ b/codex-rs/core/tests/live_agent.rs
@@ -55,7 +55,7 @@ async fn spawn_codex() -> Codex {
                 model: config.model,
                 instructions: None,
                 approval_policy: config.approval_policy,
-                sandbox_policy: SandboxPolicy::NetworkAndFileWriteRestricted,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
                 disable_response_storage: false,
             },
         })

--- a/codex-rs/core/tests/previous_response_id.rs
+++ b/codex-rs/core/tests/previous_response_id.rs
@@ -95,7 +95,7 @@ async fn keeps_previous_response_id_between_tasks() {
                 model: config.model,
                 instructions: None,
                 approval_policy: config.approval_policy,
-                sandbox_policy: SandboxPolicy::NetworkAndFileWriteRestricted,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
                 disable_response_storage: false,
             },
         })

--- a/codex-rs/core/tests/stream_no_completed.rs
+++ b/codex-rs/core/tests/stream_no_completed.rs
@@ -78,7 +78,7 @@ async fn retries_on_early_close() {
                 model: config.model,
                 instructions: None,
                 approval_policy: config.approval_policy,
-                sandbox_policy: SandboxPolicy::NetworkAndFileWriteRestricted,
+                sandbox_policy: SandboxPolicy::new_read_only_policy(),
                 disable_response_storage: false,
             },
         })

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
 use clap::ValueEnum;
-use codex_core::SandboxModeCliArg;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -14,11 +13,9 @@ pub struct Cli {
     #[arg(long, short = 'm')]
     pub model: Option<String>,
 
-    /// Configure the process restrictions when a command is executed.
-    ///
-    /// Uses OS-specific sandboxing tools; Seatbelt on OSX, landlock+seccomp on Linux.
-    #[arg(long = "sandbox", short = 's')]
-    pub sandbox_policy: Option<SandboxModeCliArg>,
+    /// Convenience alias for low-friction sandboxed automatic execution (network-disabled sandbox that can write to cwd and TMPDIR)
+    #[arg(long = "full-auto", default_value_t = false)]
+    pub full_auto: bool,
 
     /// Allow running Codex outside a Git repository.
     #[arg(long = "skip-git-repo-check", default_value_t = false)]

--- a/codex-rs/repl/src/cli.rs
+++ b/codex-rs/repl/src/cli.rs
@@ -1,7 +1,6 @@
 use clap::ArgAction;
 use clap::Parser;
 use codex_core::ApprovalModeCliArg;
-use codex_core::SandboxModeCliArg;
 use std::path::PathBuf;
 
 /// Command‑line arguments.
@@ -37,11 +36,9 @@ pub struct Cli {
     #[arg(long = "ask-for-approval", short = 'a')]
     pub approval_policy: Option<ApprovalModeCliArg>,
 
-    /// Configure the process restrictions when a command is executed.
-    ///
-    /// Uses OS-specific sandboxing tools; Seatbelt on OSX, landlock+seccomp on Linux.
-    #[arg(long = "sandbox", short = 's')]
-    pub sandbox_policy: Option<SandboxModeCliArg>,
+    /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, network-disabled sandbox that can write to cwd and TMPDIR)
+    #[arg(long = "full-auto", default_value_t = false)]
+    pub full_auto: bool,
 
     /// Allow running Codex outside a Git repository.  By default the CLI
     /// aborts early when the current working directory is **not** inside a

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -1,6 +1,5 @@
 use clap::Parser;
 use codex_core::ApprovalModeCliArg;
-use codex_core::SandboxModeCliArg;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -21,11 +20,9 @@ pub struct Cli {
     #[arg(long = "ask-for-approval", short = 'a')]
     pub approval_policy: Option<ApprovalModeCliArg>,
 
-    /// Configure the process restrictions when a command is executed.
-    ///
-    /// Uses OS-specific sandboxing tools; Seatbelt on OSX, landlock+seccomp on Linux.
-    #[arg(long = "sandbox", short = 's')]
-    pub sandbox_policy: Option<SandboxModeCliArg>,
+    /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, network-disabled sandbox that can write to cwd and TMPDIR)
+    #[arg(long = "full-auto", default_value_t = false)]
+    pub full_auto: bool,
 
     /// Allow running Codex outside a Git repository.
     #[arg(long = "skip-git-repo-check", default_value_t = false)]
@@ -34,12 +31,4 @@ pub struct Cli {
     /// Disable server‑side response storage (sends the full conversation context with every request)
     #[arg(long = "disable-response-storage", default_value_t = false)]
     pub disable_response_storage: bool,
-
-    /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, -s network-and-file-write-restricted)
-    #[arg(long = "full-auto", default_value_t = true)]
-    pub full_auto: bool,
-
-    /// Convenience alias for supervised sandboxed execution (-a unless-allow-listed, -s network-and-file-write-restricted)
-    #[arg(long = "suggest", default_value_t = false)]
-    pub suggest: bool,
 }


### PR DESCRIPTION
Previous to this PR, `SandboxPolicy` was a bit difficult to work with:

https://github.com/openai/codex/blob/237f8a11e11fdcc793a09e787e48215676d9b95b/codex-rs/core/src/protocol.rs#L98-L108

Specifically:

* It was an `enum` and therefore options were mutually exclusive as opposed to additive.
* It defined things in terms of what the agent _could not_ do as opposed to what they _could_ do. This made things hard to support because we would prefer to build up a sandbox config by starting with something extremely restrictive and only granting permissions for things the user as explicitly allowed.

This PR changes things substantially by redefining the policy in terms of two concepts:

* A `SandboxPermission` enum that defines permissions that can be granted to the agent/sandbox.
* A `SandboxPolicy` that internally stores a `Vec<SandboxPermission>`, but externally exposes a simpler API that can be used to configure Seatbelt/Landlock.

Previous to this PR, we supported a `--sandbox` flag that effectively mapped to an enum value in `SandboxPolicy`. Though now that `SandboxPolicy` is a wrapper around `Vec<SandboxPermission>`, the single `--sandbox` flag no longer makes sense. While I could have turned it into a flag that the user can specify multiple times, I think the current values to use with such a flag are long and potentially messy, so for the moment, I have dropped support for `--sandbox` altogether and we can bring it back once we have figured out the naming thing.

Since `--sandbox` is gone, users now have to specify `--full-auto` to get a sandbox that allows writes in `cwd`. Admittedly, there is no clean way to specify the equivalent of `--full-auto` in your `config.toml` right now, so we will have to revisit that, as well.

Because `Config` presents a `SandboxPolicy` field and `SandboxPolicy` changed considerably, I had to overhaul how config loading works, as well. There are now two distinct concepts, `ConfigToml` and `Config`:

* `ConfigToml` is the deserialization of `~/.codex/config.toml`. As one might expect, every field is `Optional` and it is `#[derive(Deserialize, Default)]`. Consistent use of `Optional` makes it clear what the user has specified explicitly.
* `Config` is the "normalized config" and is produced by merging `ConfigToml` with `ConfigOverrides`. Where `ConfigToml` contains a raw `Option<Vec<SandboxPermission>>`, `Config` presents only the final `SandboxPolicy`.

The changes to `core/src/exec.rs` and `core/src/linux.rs` merit extra special attention to ensure we are faithfully mapping the `SandboxPolicy` to the Seatbelt and Landlock configs, respectively.

Also, take note that `core/src/seatbelt_readonly_policy.sbpl` has been renamed to `codex-rs/core/src/seatbelt_base_policy.sbpl` and that `(allow file-read*)` has been removed from the `.sbpl` file as now this is added to the policy in `core/src/exec.rs` when `sandbox_policy.has_full_disk_read_access()` is `true`.