### PR TITLE
feat(cli): Implement readline-style reverse search and screen clear shortcuts

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -325,10 +325,13 @@ export default function TerminalChatInput({
               newIndex = Math.max(0, historyIndex - 1);
             }
             setHistoryIndex(newIndex);
+
             setInput(history[newIndex]?.command ?? "");
+            // Re-mount the editor so it picks up the new initialText
             setEditorKey((k) => k + 1);
-            return;
+            return; // handled
           }
+          // Otherwise let it propagate.
         }
 
         if (_key.downArrow) {
@@ -347,6 +350,7 @@ export default function TerminalChatInput({
             }
             return; // handled
           }
+          // Otherwise let it propagate
         }
 
         if (_key.tab) {

--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -140,16 +140,20 @@ export default function TerminalChatInput({
             setReverseQuery("");
             setReverseResults([]);
             setReverseIndex(0);
-            setEditorKey((k: number) => k + 1);
+            setEditorKey((k) => k + 1);
           }
           return;
         }
         if (_key.upArrow) {
-          setReverseIndex((i: number) => (i <= 0 ? reverseResults.length - 1 : i - 1));
+          setReverseIndex((i: number) =>
+            i <= 0 ? reverseResults.length - 1 : i - 1,
+          );
           return;
         }
         if (_key.downArrow) {
-          setReverseIndex((i: number) => (i >= reverseResults.length - 1 ? 0 : i + 1));
+          setReverseIndex((i: number) =>
+            i >= reverseResults.length - 1 ? 0 : i + 1,
+          );
           return;
         }
         if (_key.backspace || _input === "\x7f") {
@@ -157,7 +161,7 @@ export default function TerminalChatInput({
           setReverseQuery(newQuery);
           setReverseIndex(0);
           setReverseResults(
-            history.filter((h) => h.command.includes(newQuery)).reverse()
+            history.filter((h) => h.command.includes(newQuery)).reverse(),
           );
           return;
         }
@@ -166,7 +170,7 @@ export default function TerminalChatInput({
           setReverseQuery(newQuery);
           setReverseIndex(0);
           setReverseResults(
-            history.filter((h) => h.command.includes(newQuery)).reverse()
+            history.filter((h) => h.command.includes(newQuery)).reverse(),
           );
           return;
         }
@@ -296,7 +300,7 @@ export default function TerminalChatInput({
               const newText = words.join(" ");
               setInput(newText);
               // Force remount of the editor with the new text
-              setEditorKey((k: number) => k + 1);
+              setEditorKey((k) => k + 1);
 
               // We need to move the cursor to the end after editor remounts
               setTimeout(() => {
@@ -322,7 +326,7 @@ export default function TerminalChatInput({
             }
             setHistoryIndex(newIndex);
             setInput(history[newIndex]?.command ?? "");
-            setEditorKey((k: number) => k + 1);
+            setEditorKey((k) => k + 1);
             return;
           }
         }
@@ -335,13 +339,13 @@ export default function TerminalChatInput({
             if (newIndex >= history.length) {
               setHistoryIndex(null);
               setInput(draftInput);
-              setEditorKey((k: number) => k + 1);
+              setEditorKey((k) => k + 1);
             } else {
               setHistoryIndex(newIndex);
               setInput(history[newIndex]?.command ?? "");
-              setEditorKey((k: number) => k + 1);
+              setEditorKey((k) => k + 1);
             }
-            return;
+            return; // handled
           }
         }
 
@@ -695,12 +699,21 @@ export default function TerminalChatInput({
   // Reverse search overlay UI
   if (reverseSearch) {
     return (
-      <Box flexDirection="column" borderStyle="round" borderColor="cyan" paddingX={1}>
+      <Box
+        flexDirection="column"
+        borderStyle="round"
+        borderColor="cyan"
+        paddingX={1}
+      >
         <Text color="cyan">(reverse-i-search): {reverseQuery}_</Text>
         {reverseResults.length > 0 ? (
           <Box flexDirection="column">
             {reverseResults.slice(0, 5).map((h: HistoryEntry, idx: number) => (
-              <Text key={h.timestamp} backgroundColor={idx === reverseIndex ? "cyan" : undefined} color={idx === reverseIndex ? "black" : undefined}>
+              <Text
+                key={h.timestamp}
+                backgroundColor={idx === reverseIndex ? "cyan" : undefined}
+                color={idx === reverseIndex ? "black" : undefined}
+              >
                 {h.command}
               </Text>
             ))}
@@ -708,7 +721,9 @@ export default function TerminalChatInput({
         ) : (
           <Text dimColor>No matches</Text>
         )}
-        <Text dimColor>esc to cancel | enter to select | up/down to navigate</Text>
+        <Text dimColor>
+          esc to cancel | enter to select | up/down to navigate
+        </Text>
       </Box>
     );
   }
@@ -753,7 +768,7 @@ export default function TerminalChatInput({
               focus={active}
               onSubmit={(txt) => {
                 onSubmit(txt);
-                setEditorKey((k: number) => k + 1);
+                setEditorKey((k) => k + 1);
                 setInput("");
                 setHistoryIndex(null);
                 setDraftInput("");

--- a/codex-cli/src/components/help-overlay.tsx
+++ b/codex-cli/src/components/help-overlay.tsx
@@ -85,6 +85,12 @@ export default function HelpOverlay({
           <Text color="yellow">Up/Down</Text> – scroll prompt history
         </Text>
         <Text>
+          <Text color="yellow">Ctrl+R</Text> – reverse search command history
+        </Text>
+        <Text>
+          <Text color="yellow">Ctrl+L</Text> – clear the screen
+        </Text>
+        <Text>
           <Text color="yellow">
             Esc<Text dimColor>(✕2)</Text>
           </Text>{" "}


### PR DESCRIPTION
Fixes: #534

- **Reverse-i-search (Ctrl+R) Overlay**
  - Pressing Ctrl+R opens a visual overlay for interactively searching command history.
  - Type to filter, use up/down to select, and press Enter to insert a previous command.
- **Ctrl+L to Clear Screen**
  - Instantly clears the terminal screen, just like in bash/zsh.
- **Improved History Navigation**
  - Up/Down arrow navigation for command history is now more robust and intuitive.
  - Navigation works reliably at the start/end of the input, regardless of cursor position.

<img width="735" alt="Screenshot 2025-04-29 at 11 37 59 PM" src="https://github.com/user-attachments/assets/d22e44e0-f263-4a88-83b8-bc8780d8af4d" />
