### PR TITLE
Update README.md to not use both --json and -q (quiet) in examples cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ The hardening mechanism Codex uses depends on your OS:
 | ------------------------------------ | ----------------------------------- | ------------------------------------ |
 | `codex`                              | Interactive REPL                    | `codex`                              |
 | `codex "..."`                        | Initial prompt for interactive REPL | `codex "fix lint errors"`            |
-| `codex -q "..."`                     | Non-interactive "quiet mode"        | `codex -q --json "explain utils.ts"` |
+| `codex -q "..."`                     | Non-interactive "quiet mode"        | `codex -q        "explain utils.ts"` |
 | `codex completion <bash\|zsh\|fish>` | Print shell completion script       | `codex completion bash`              |
 
 Key flags: `--model/-m`, `--approval-mode/-a`, `--quiet/-q`, and `--notify`.


### PR DESCRIPTION
<img width="693" alt="image" src="https://github.com/user-attachments/assets/5ff253cd-3357-4e16-a603-7f94b47e989e" />

this example doesnt make sense.

also --quiet cli flag is curerntly broken and will output json logs anyways... see https://github.com/openai/codex/issues/585