### PR TITLE
feat: bring back -s option to specify sandbox permissions

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -504,6 +504,7 @@ dependencies = [
  "mime_guess",
  "openssl-sys",
  "patch",
+ "path-absolutize",
  "predicates",
  "rand",
  "reqwest",

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -21,6 +21,7 @@ fs-err = "3.1.0"
 futures = "0.3"
 mime_guess = "2.0"
 patch = "0.7"
+path-absolutize = "3.1.1"
 rand = "0.9"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 serde = { version = "1", features = ["derive"] }

--- a/codex-rs/core/src/approval_mode_cli_arg.rs
+++ b/codex-rs/core/src/approval_mode_cli_arg.rs
@@ -1,9 +1,14 @@
 //! Standard type to use with the `--approval-mode` CLI option.
 //! Available when the `cli` feature is enabled for the crate.
 
+use std::path::PathBuf;
+
+use clap::ArgAction;
+use clap::Parser;
 use clap::ValueEnum;
 
 use crate::protocol::AskForApproval;
+use crate::protocol::SandboxPermission;
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
 #[value(rename_all = "kebab-case")]
@@ -30,5 +35,86 @@ impl From<ApprovalModeCliArg> for AskForApproval {
             ApprovalModeCliArg::UnlessAllowListed => AskForApproval::UnlessAllowListed,
             ApprovalModeCliArg::Never => AskForApproval::Never,
         }
+    }
+}
+
+#[derive(Parser, Debug)]
+pub struct SandboxPermissionOption {
+    /// Specify this flag multiple times to specify the full set of permissions
+    /// to grant to Codex.
+    ///
+    /// ```shell
+    /// codex -s disk-full-read-access \
+    ///       -s disk-write-cwd \
+    ///       -s disk-write-platform-user-temp-folder \
+    ///       -s disk-write-platform-global-temp-folder
+    /// ```
+    ///
+    /// Note disk-write-folder takes a value:
+    ///
+    /// ```shell
+    ///     -s disk-write-folder=$HOME/.pyenv/shims
+    /// ```
+    ///
+    /// These permissions are quite broad and should be used with caution:
+    ///
+    /// ```shell
+    ///     -s disk-full-write-access
+    ///     -s network-full-access
+    /// ```
+    #[arg(long = "sandbox-permission", short = 's', action = ArgAction::Append, value_parser = parse_sandbox_permission)]
+    pub permissions: Option<Vec<SandboxPermission>>,
+}
+
+/// Custom value-parser so we can keep the CLI surface small *and*
+/// still handle the parameterised `disk-write-folder` case.
+fn parse_sandbox_permission(raw: &str) -> std::io::Result<SandboxPermission> {
+    let base_path = std::env::current_dir()?;
+    parse_sandbox_permission_with_base_path(raw, base_path)
+}
+
+pub(crate) fn parse_sandbox_permission_with_base_path(
+    raw: &str,
+    base_path: PathBuf,
+) -> std::io::Result<SandboxPermission> {
+    use SandboxPermission::*;
+
+    if let Some(path) = raw.strip_prefix("disk-write-folder=") {
+        return if path.is_empty() {
+            Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "--sandbox-permission disk-write-folder=<PATH> requires a non-empty PATH",
+            ))
+        } else {
+            use path_absolutize::*;
+
+            let file = PathBuf::from(path);
+            let absolute_path = if file.is_relative() {
+                file.absolutize_from(base_path)
+            } else {
+                file.absolutize()
+            }
+            .map(|path| path.into_owned())?;
+            Ok(DiskWriteFolder {
+                folder: absolute_path,
+            })
+        };
+    }
+
+    match raw {
+        "disk-full-read-access" => Ok(DiskFullReadAccess),
+        "disk-write-platform-user-temp-folder" => Ok(DiskWritePlatformUserTempFolder),
+        "disk-write-platform-global-temp-folder" => Ok(DiskWritePlatformGlobalTempFolder),
+        "disk-write-cwd" => Ok(DiskWriteCwd),
+        "disk-full-write-access" => Ok(DiskFullWriteAccess),
+        "network-full-access" => Ok(NetworkFullAccess),
+        _ => Err(
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!(
+                    "`{raw}` is not a recognised permission.\nRun with `--help` to see the accepted values."
+                ),
+            )
+        ),
     }
 }

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -27,3 +27,5 @@ pub use codex::Codex;
 mod approval_mode_cli_arg;
 #[cfg(feature = "cli")]
 pub use approval_mode_cli_arg::ApprovalModeCliArg;
+#[cfg(feature = "cli")]
+pub use approval_mode_cli_arg::SandboxPermissionOption;

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -132,16 +132,6 @@ impl SandboxPolicy {
         }
     }
 
-    pub fn new_full_auto_policy_with_writable_roots(writable_roots: &[PathBuf]) -> Self {
-        let mut permissions = Self::new_full_auto_policy().permissions;
-        permissions.extend(writable_roots.iter().map(|folder| {
-            SandboxPermission::DiskWriteFolder {
-                folder: folder.clone(),
-            }
-        }));
-        Self { permissions }
-    }
-
     pub fn has_full_disk_read_access(&self) -> bool {
         self.permissions
             .iter()

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use clap::ValueEnum;
+use codex_core::SandboxPermissionOption;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -16,6 +17,9 @@ pub struct Cli {
     /// Convenience alias for low-friction sandboxed automatic execution (network-disabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
+
+    #[clap(flatten)]
+    pub sandbox: SandboxPermissionOption,
 
     /// Allow running Codex outside a Git repository.
     #[arg(long = "skip-git-repo-check", default_value_t = false)]

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -28,6 +28,7 @@ pub async fn run_main(cli: Cli) -> anyhow::Result<()> {
         images,
         model,
         full_auto,
+        sandbox,
         skip_git_repo_check,
         disable_response_storage,
         color,
@@ -65,7 +66,7 @@ pub async fn run_main(cli: Cli) -> anyhow::Result<()> {
     let sandbox_policy = if full_auto {
         Some(SandboxPolicy::new_full_auto_policy())
     } else {
-        None
+        sandbox.permissions.clone().map(Into::into)
     };
 
     // Load configuration and determine approval policy

--- a/codex-rs/repl/src/cli.rs
+++ b/codex-rs/repl/src/cli.rs
@@ -1,6 +1,7 @@
 use clap::ArgAction;
 use clap::Parser;
 use codex_core::ApprovalModeCliArg;
+use codex_core::SandboxPermissionOption;
 use std::path::PathBuf;
 
 /// Command‑line arguments.
@@ -39,6 +40,9 @@ pub struct Cli {
     /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, network-disabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
+
+    #[clap(flatten)]
+    pub sandbox: SandboxPermissionOption,
 
     /// Allow running Codex outside a Git repository.  By default the CLI
     /// aborts early when the current working directory is **not** inside a

--- a/codex-rs/repl/src/lib.rs
+++ b/codex-rs/repl/src/lib.rs
@@ -84,7 +84,8 @@ pub async fn run_main(cli: Cli) -> anyhow::Result<()> {
             Some(AskForApproval::OnFailure),
         )
     } else {
-        (None, cli.approval_policy.map(Into::into))
+        let sandbox_policy = cli.sandbox.permissions.clone().map(Into::into);
+        (sandbox_policy, cli.approval_policy.map(Into::into))
     };
 
     // Load config file and apply CLI overrides (model & approval policy)

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use codex_core::ApprovalModeCliArg;
+use codex_core::SandboxPermissionOption;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -23,6 +24,9 @@ pub struct Cli {
     /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, network-disabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
+
+    #[clap(flatten)]
+    pub sandbox: SandboxPermissionOption,
 
     /// Allow running Codex outside a Git repository.
     #[arg(long = "skip-git-repo-check", default_value_t = false)]

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -41,7 +41,8 @@ pub fn run_main(cli: Cli) -> std::io::Result<()> {
             Some(AskForApproval::OnFailure),
         )
     } else {
-        (None, cli.approval_policy.map(Into::into))
+        let sandbox_policy = cli.sandbox.permissions.clone().map(Into::into);
+        (sandbox_policy, cli.approval_policy.map(Into::into))
     };
 
     let config = {


### PR DESCRIPTION
This PR updates `core/src/approval_mode_cli_arg.rs` to have a `SandboxPermissionOption` that we can include across our CLIs via:

```rust
#[clap(flatten)]
pub sandbox: SandboxPermissionOption,
```

I then updated our CLIs so that when `Option<Vec<SandboxPermission>>` is `Some`, the permissions are used to create the corresponding `SandboxPolicy`.

To test, I updated my `~/.codex/config.toml` to be:

```toml
model = "o3"

approval_policy = "on-failure"

sandbox_permissions = [
    "disk-full-read-access",
    "disk-write-platform-user-temp-folder",
    "disk-write-platform-global-temp-folder",
    "disk-write-cwd",
]
```

And when I launch the TUI, the **codex session** details are as I expect:

<img width="977" alt="image" src="https://github.com/user-attachments/assets/2b847318-496b-4b2e-a8fd-15331bf3f891" />

Alternatively, I could also do:

```
cargo run -- -s disk-full-read-access -s disk-write-platform-user-temp-folder -s disk-write-platform-global-temp-folder -s disk-write-cwd 
```
---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/739).
* #740
* __->__ #739