### PR TITLE
chore: set Cargo workspace to version 0.0.2504291926 to create a scratch release

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cli"
-version = "0.1.0"
+version = "0.0.2504291926"
 dependencies = [
  "anyhow",
  "clap",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec"
-version = "0.1.0"
+version = "0.0.2504291926"
 dependencies = [
  "anyhow",
  "chrono",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "codex-repl"
-version = "0.1.0"
+version = "0.0.2504291926"
 dependencies = [
  "anyhow",
  "clap",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.1.0"
+version = "0.0.2504291926"
 
 [profile.release]
 lto = "fat"


### PR DESCRIPTION
Needed to exercise the new release process in https://github.com/openai/codex/pull/671.