### PR TITLE
fix: primary output of the codex-cli crate is named codex, not codex-cli

### DIFF
--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -18,12 +18,12 @@
       }
     },
 
-    "codex-cli": {
+    "codex": {
       "platforms": {
-        "macos-aarch64":  { "regex": "^codex-cli-aarch64-apple-darwin\\.zst$",          "path": "codex-cli" },
-        "macos-x86_64":   { "regex": "^codex-cli-x86_64-apple-darwin\\.zst$",           "path": "codex-cli" },
-        "linux-x86_64":   { "regex": "^codex-cli-x86_64-unknown-linux-musl\\.zst$",     "path": "codex-cli" },
-        "linux-aarch64":  { "regex": "^codex-cli-aarch64-unknown-linux-gnu\\.zst$",     "path": "codex-cli" }
+        "macos-aarch64":  { "regex": "^codex-aarch64-apple-darwin\\.zst$",          "path": "codex" },
+        "macos-x86_64":   { "regex": "^codex-x86_64-apple-darwin\\.zst$",           "path": "codex" },
+        "linux-x86_64":   { "regex": "^codex-x86_64-unknown-linux-musl\\.zst$",     "path": "codex" },
+        "linux-aarch64":  { "regex": "^codex-aarch64-unknown-linux-gnu\\.zst$",     "path": "codex" }
       }
     },
 

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -104,7 +104,7 @@ jobs:
 
           cp target/${{ matrix.target }}/release/codex-repl "$dest/codex-repl-${{ matrix.target }}"
           cp target/${{ matrix.target }}/release/codex-exec "$dest/codex-exec-${{ matrix.target }}"
-          cp target/${{ matrix.target }}/release/codex-cli "$dest/codex-cli-${{ matrix.target }}"
+          cp target/${{ matrix.target }}/release/codex "$dest/codex-${{ matrix.target }}"
 
       - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }} || ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
         name: Stage Linux-only artifacts


### PR DESCRIPTION
I just got a bunch of failures in the release workflow:

https://github.com/openai/codex/actions/runs/14745492805/job/41391926707

along the lines of:

```
cp: cannot stat 'target/aarch64-unknown-linux-gnu/release/codex-cli': No such file or directory
```