### PR TITLE
chore: fix errors in .github/workflows/rust-release.yml and prep 0.0.2504292006 release

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -106,10 +106,11 @@ jobs:
           cp target/${{ matrix.target }}/release/codex-exec "$dest/codex-exec-${{ matrix.target }}"
           cp target/${{ matrix.target }}/release/codex "$dest/codex-${{ matrix.target }}"
 
-      - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }} || ${{ matrix.target == 'aarch64-unknown-linux-gnu' }}
+      - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-gnu' }}
         name: Stage Linux-only artifacts
         shell: bash
         run: |
+          dest="dist/${{ matrix.target }}"
           cp target/${{ matrix.target }}/release/codex-linux-sandbox "$dest/codex-linux-sandbox-${{ matrix.target }}"
 
       - name: Compress artifacts

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cli"
-version = "0.0.2504291954"
+version = "0.0.2504292006"
 dependencies = [
  "anyhow",
  "clap",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec"
-version = "0.0.2504291954"
+version = "0.0.2504292006"
 dependencies = [
  "anyhow",
  "chrono",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "codex-repl"
-version = "0.0.2504291954"
+version = "0.0.2504292006"
 dependencies = [
  "anyhow",
  "clap",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.2504291954"
+version = "0.0.2504292006"
 
 [profile.release]
 lto = "fat"


### PR DESCRIPTION
Apparently I made two key mistakes in https://github.com/openai/codex/pull/740 (fixed in this PR):

* I forgot to redefine `$dest` in the `Stage Linux-only artifacts` step
* I did not define the `if` check correctly in the `Stage Linux-only artifacts` step

This fixes both of those issues and bumps the workspace version to `0.0.2504292006` in preparation for another release attempt.