### PR TITLE
docs: fix contradictory flags in CLI reference example

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ The hardening mechanism Codex uses depends on your OS:
 | ------------------------------------ | ----------------------------------- | ------------------------------------ |
 | `codex`                              | Interactive REPL                    | `codex`                              |
 | `codex "..."`                        | Initial prompt for interactive REPL | `codex "fix lint errors"`            |
-| `codex -q "..."`                     | Non-interactive "quiet mode"        | `codex -q --json "explain utils.ts"` |
+| `codex -q "..."`                     | Non-interactive "quiet mode"        | `codex -q "explain utils.ts"`        |
 | `codex completion <bash\|zsh\|fish>` | Print shell completion script       | `codex completion bash`              |
 
 Key flags: `--model/-m`, `--approval-mode/-a`, `--quiet/-q`, and `--notify`.


### PR DESCRIPTION
Fixes #737

This PR fixes the contradictory flags in the CLI reference example. The example was using both `-q` and `--json` flags together, which are contradictory. Since the purpose of the example is to demonstrate non-interactive "quiet mode", I've kept the `-q` flag and removed the `--json` flag.

I have read the CLA Document and I hereby sign the CLA