### PR TITLE
fix: add another place where $dest was missing in rust-release.yml

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -116,6 +116,7 @@ jobs:
       - name: Compress artifacts
         shell: bash
         run: |
+          dest="dist/${{ matrix.target }}"
           zstd -T0 -19 --rm "$dest"/*
 
       - uses: actions/upload-artifact@v4

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cli"
-version = "0.0.2504292006"
+version = "0.0.2504292236"
 dependencies = [
  "anyhow",
  "clap",
@@ -524,7 +524,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec"
-version = "0.0.2504292006"
+version = "0.0.2504292236"
 dependencies = [
  "anyhow",
  "chrono",
@@ -559,7 +559,7 @@ dependencies = [
 
 [[package]]
 name = "codex-repl"
-version = "0.0.2504292006"
+version = "0.0.2504292236"
 dependencies = [
  "anyhow",
  "clap",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.2504292006"
+version = "0.0.2504292236"
 
 [profile.release]
 lto = "fat"


### PR DESCRIPTION
I thought https://github.com/openai/codex/pull/745 was the last fix I needed, but apparently not.