### PR TITLE
feat: Add general retry to agent-loop for mid-stream API errors.

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -1032,16 +1032,22 @@ export class AgentLoop {
             };
 
             if (
-              isRateLimitError(err) &&
               streamRetryAttempt < MAX_STREAM_RETRIES
             ) {
               streamRetryAttempt += 1;
 
-              const waitMs =
-                RATE_LIMIT_RETRY_WAIT_MS * 2 ** (streamRetryAttempt - 1);
-              log(
-                `OpenAI stream rate‑limited – retry ${streamRetryAttempt}/${MAX_STREAM_RETRIES} in ${waitMs} ms`,
-              );
+              let waitMs;
+              if (isRateLimitError(err)) {
+                  waitMs = RATE_LIMIT_RETRY_WAIT_MS * 2 ** (streamRetryAttempt - 1);
+                  log(
+                    `OpenAI stream rate‑limited – retry ${streamRetryAttempt}/${MAX_STREAM_RETRIES} in ${waitMs} ms`,
+                  );
+              } else {
+                  waitMs = RATE_LIMIT_RETRY_WAIT_MS;
+                  log(
+                    `OpenAI stream error "${err}" – retry ${streamRetryAttempt}/${MAX_STREAM_RETRIES} in ${waitMs} ms`,
+                  );
+              }
 
               // Give the server a breather before retrying.
               // eslint-disable-next-line no-await-in-loop


### PR DESCRIPTION
Extends https://github.com/openai/codex/pull/506 to retry any mid-stream API error. 

Particularly useful for non-openai providers which have intermittent 40x and 50x errors. 

For errors not identified as rate limit errors it doesn't use the exponential back-off but sticks to static delay.
