### PR TITLE
fix: read version from package.json instead of modifying session.ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ To publish a new version of the CLI, run the release scripts defined in `codex-c
 3. Bump the version and `CLI_VERSION` to current datetime: `pnpm release:version`
 4. Commit the version bump (with DCO sign-off):
    ```bash
-   git add codex-cli/src/utils/session.ts codex-cli/package.json
+   git add codex-cli/package.json
    git commit -s -m "chore(release): codex-cli v$(node -p \"require('./codex-cli/package.json').version\")"
    ```
 5. Copy README, build, and publish to npm: `pnpm release`

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -21,7 +21,7 @@
     "build": "node build.mjs",
     "build:dev": "NODE_ENV=development node build.mjs --dev && NODE_OPTIONS=--enable-source-maps node dist/cli-dev.js",
     "release:readme": "cp ../README.md ./README.md",
-    "release:version": "TS=$(date +%y%m%d%H%M) && sed -E -i'' -e \"s/\\\"0\\.1\\.[0-9]{10}\\\"/\\\"0.1.${TS}\\\"/g\" package.json src/utils/session.ts",
+    "release:version": "TS=$(date +%y%m%d%H%M) && sed -E -i'' -e \"s/\\\"0\\.1\\.[0-9]{10}\\\"/\\\"0.1.${TS}\\\"/g\" package.json",
     "release:build-and-publish": "pnpm run build && npm publish",
     "release": "pnpm run release:readme && pnpm run release:version && pnpm install && pnpm run release:build-and-publish"
   },

--- a/codex-cli/src/utils/session.ts
+++ b/codex-cli/src/utils/session.ts
@@ -1,4 +1,11 @@
-export const CLI_VERSION = "0.1.2504251709"; // Must be in sync with package.json.
+// Node ESM supports JSON imports behind an assertion. TypeScript's
+// `resolveJsonModule` takes care of the typings.
+//
+// eslint-disable-next-line @typescript-eslint/consistent-type-imports
+import pkg from "../../package.json" assert { type: "json" };
+
+// Read the version directly from package.json.
+export const CLI_VERSION: string = (pkg as { version: string }).version;
 export const ORIGIN = "codex_cli_ts";
 
 export type TerminalChatSession = {


### PR DESCRIPTION
I am working to simplify the build process. As a first step, update `session.ts` so it reads the `version` from `package.json` at runtime so we no longer have to modify it during the build process. I want to get to a place where the build looks like:

```
cd codex-cli
pnpm i
pnpm build
RELEASE_DIR=$(mktemp -d)
cp -r bin "$RELEASE_DIR/bin"
cp -r dist "$RELEASE_DIR/dist"
cp -r src "$RELEASE_DIR/src" # important if we want sourcemaps to continue to work
cp ../README.md "$RELEASE_DIR"
VERSION=$(printf '0.1.%d' $(date +%y%m%d%H%M))
jq --arg version "$VERSION" '.version = $version' package.json > "$RELEASE_DIR/package.json"
```

Then the contents of `$RELEASE_DIR` should be good to `npm publish`, no?