### PR TITLE
chore: Rust release, set prerelease:false and version=0.0.2504301132

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -143,10 +143,10 @@ jobs:
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           files: dist/**
-          # TODO(ragona): I'm going to leave these as prerelease/draft for now.
+          # TODO(ragona): I'm going to leave these as draft for now.
           # It gives us 1) clarity that these are not yet a stable version, and
           # 2) allows a human step to review the release before publishing the draft.
-          prerelease: true
+          prerelease: false
           draft: true
 
       - uses: facebook/dotslash-publish-release@v2

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cli"
-version = "0.0.2504292236"
+version = "0.0.2504301132"
 dependencies = [
  "anyhow",
  "clap",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec"
-version = "0.0.2504292236"
+version = "0.0.2504301132"
 dependencies = [
  "anyhow",
  "chrono",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.2504292236"
+version = "0.0.2504301132"
 
 [profile.release]
 lto = "fat"


### PR DESCRIPTION
The generated DotSlash file has URLs that refer to `https://github.com/openai/codex/releases/`, so let's set `prerelease:false` (but keep `draft:true` for now) so those URLs should work.

Also updated `version` in Cargo workspace so I will kick off a build once this lands.