### PR TITLE
fix: remove errant eslint-disable so `pnpm run lint` passes again

### DIFF
--- a/codex-cli/src/utils/session.ts
+++ b/codex-cli/src/utils/session.ts
@@ -1,7 +1,5 @@
 // Node ESM supports JSON imports behind an assertion. TypeScript's
 // `resolveJsonModule` takes care of the typings.
-//
-// eslint-disable-next-line @typescript-eslint/consistent-type-imports
 import pkg from "../../package.json" assert { type: "json" };
 
 // Read the version directly from package.json.


### PR DESCRIPTION
My bad: introduced in https://github.com/openai/codex/pull/753.