### PR TITLE
chore: script to create a Rust release

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -469,7 +469,7 @@ dependencies = [
 
 [[package]]
 name = "codex-cli"
-version = "0.0.2504301132"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -523,7 +523,7 @@ dependencies = [
 
 [[package]]
 name = "codex-exec"
-version = "0.0.2504301132"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.0.2504301132"
+version = "0.0.0"
 
 [profile.release]
 lto = "fat"

--- a/codex-rs/scripts/create_github_release.sh
+++ b/codex-rs/scripts/create_github_release.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# Change to the root of the Cargo workspace.
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# Cancel if there are uncommitted changes.
+if ! git diff --quiet || ! git diff --cached --quiet || [ -n "$(git ls-files --others --exclude-standard)" ]; then
+  echo "ERROR: You have uncommitted or untracked changes." >&2
+  exit 1
+fi
+
+# Fail if in a detached HEAD state.
+CURRENT_BRANCH=$(git symbolic-ref --short -q HEAD)
+
+# Create a new branch for the release and make a commit with the new version.
+VERSION=$(printf '0.0.%d' "$(date +%y%m%d%H%M)")
+TAG="rust-v$VERSION"
+git checkout -b "$TAG"
+perl -i -pe "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
+git add Cargo.toml
+git commit -m "Release $VERSION"
+git tag -a "$TAG" -m "Release $VERSION"
+git push origin "refs/tags/$TAG"
+git checkout "$CURRENT_BRANCH"


### PR DESCRIPTION
For now, keep things simple such that we never update the `version` in the `Cargo.toml` for the workspace root on the `main` branch. Instead, create a new branch for a release, push one commit that updates the `version`, and then tag that branch to kick off a release.

To test, I ran this script and created this release job:

https://github.com/openai/codex/actions/runs/14762580641