### PR TITLE
fix: remove codex-repl from GitHub workflows

### DIFF
--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -1,14 +1,5 @@
 {
   "outputs": {
-    "codex-repl": {
-      "platforms": {
-        "macos-aarch64":  { "regex": "^codex-repl-aarch64-apple-darwin\\.zst$",          "path": "codex-repl" },
-        "macos-x86_64":   { "regex": "^codex-repl-x86_64-apple-darwin\\.zst$",           "path": "codex-repl" },
-        "linux-x86_64":   { "regex": "^codex-repl-x86_64-unknown-linux-musl\\.zst$",     "path": "codex-repl" },
-        "linux-aarch64":  { "regex": "^codex-repl-aarch64-unknown-linux-gnu\\.zst$",     "path": "codex-repl" }
-      }
-    },
-
     "codex-exec": {
       "platforms": {
         "macos-aarch64":  { "regex": "^codex-exec-aarch64-apple-darwin\\.zst$",          "path": "codex-exec" },

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -102,7 +102,6 @@ jobs:
           dest="dist/${{ matrix.target }}"
           mkdir -p "$dest"
 
-          cp target/${{ matrix.target }}/release/codex-repl "$dest/codex-repl-${{ matrix.target }}"
           cp target/${{ matrix.target }}/release/codex-exec "$dest/codex-exec-${{ matrix.target }}"
           cp target/${{ matrix.target }}/release/codex "$dest/codex-${{ matrix.target }}"
 


### PR DESCRIPTION
I missed this when doing https://github.com/openai/codex/pull/754.