### PR TITLE
chore: mark Rust releases as "prerelease"

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -142,11 +142,9 @@ jobs:
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           files: dist/**
-          # TODO(ragona): I'm going to leave these as draft for now.
-          # It gives us 1) clarity that these are not yet a stable version, and
-          # 2) allows a human step to review the release before publishing the draft.
-          prerelease: false
-          draft: true
+          # For now, tag releases as "prerelease" because we are not claiming
+          # the Rust CLI is stable yet.
+          prerelease: true
 
       - uses: facebook/dotslash-publish-release@v2
         env:


### PR DESCRIPTION
Apparently the URLs for draft releases cannot be downloaded using unauthenticated `curl`, which means the DotSlash file only works for users who are authenticated with `gh`. According to chat, prereleases _can_ be fetched with unauthenticated `curl`, so let's try that.