### PR TITLE
fix: tolerate out-of-order patches for the same file

### DIFF
--- a/codex-cli/src/utils/agent/apply-patch.ts
+++ b/codex-cli/src/utils/agent/apply-patch.ts
@@ -280,12 +280,22 @@ class Parser {
         this.lines,
         this.index,
       );
-      const [newIndex, fuzz] = find_context(
-        fileLines,
-        nextChunkContext,
-        index,
-        eof,
-      );
+      let [newIndex, fuzz] = find_context(
+				fileLines,
+				nextChunkContext,
+				index,
+				eof,
+			);
+			if (newIndex === -1) {
+				// The model sometimes returns patches out of order,
+				// so try searching for context from the beginning of the file.
+				[newIndex, fuzz] = find_context(
+					fileLines,
+					nextChunkContext,
+					0,
+					eof,
+				);
+			}
       if (newIndex === -1) {
         const ctxText = nextChunkContext.join("\n");
         if (eof) {

--- a/codex-cli/tests/apply-patch.test.ts
+++ b/codex-cli/tests/apply-patch.test.ts
@@ -161,6 +161,26 @@ test("process_patch - move file (rename)", () => {
   expect(fs.removals).toEqual(["old.txt"]);
 });
 
+test("process_patch - tolerate out-of-order patch sections", () => {
+  const patch = `*** Begin Patch
+*** Update File: a.txt
+@@
+-world
++world hello
+@@
+-hello
++hello world
+*** End Patch`;
+  const fs = createInMemoryFS({
+    "a.txt": "hello\nworld",
+    "c.txt": "to be removed",
+  });
+  process_patch(patch, fs.openFn, fs.writeFn, fs.removeFn);
+  expect(fs.writes).toEqual({
+    "a.txt": "hello world\nworld hello",
+  });
+});
+
 test("process_patch - combined add, update, delete", () => {
   const patch = `*** Begin Patch
 *** Add File: added.txt


### PR DESCRIPTION
Patches can contain multiple hunks for the same file to be edited. The TS parser will throw for the case where the model provides two hunks for a single file, and the first hunk comes later in the file, which seems to happen reasonably often for certain files in my testing:

```
*** Begin Patch
*** Update File: foo.ts
@@
-[old code] // corresponds to line 10
+[new code]
@@
-[old code] // corresponds to line 5
+[new code]
*** End Patch
```

The proposed fix in this PR is to retain the existing optimization logic for the common case, but add a slow pass that scans for context matches from the start of the file.