### PR TITLE
fix(run_in_container): drop hardcoded --full-auto flag

### DIFF
--- a/codex-cli/scripts/run_in_container.sh
+++ b/codex-cli/scripts/run_in_container.sh
@@ -92,4 +92,4 @@ quoted_args=""
 for arg in "$@"; do
   quoted_args+=" $(printf '%q' "$arg")"
 done
-docker exec -it "$CONTAINER_NAME" bash -c "cd \"/app$WORK_DIR\" && codex --full-auto ${quoted_args}"
+docker exec -it "$CONTAINER_NAME" bash -c "cd \"/app$WORK_DIR\" && codex ${quoted_args}"


### PR DESCRIPTION
In run_in_container.sh Codex was started with hardcoded --full-Auto which makes it impossible for users to supply other
--approval-mode parameters. 

Removing the flag lets Codex in a container respect CLI options on Linux the same way it does without the container.

Fixes: https://github.com/openai/codex/issues/781


## PR-Checklist:
* [x] local test passed:  -> see: https://app.warp.dev/block/Q70dnGHPlWMwesy2uXZqDb
* [x] branch is up-to-date
* [x] Issue fixed: 
        
![image](https://github.com/user-attachments/assets/ce126f7e-30bb-4d14-b50a-7897663a0105)
