### PR TITLE
bump(version): 0.1.2505021246

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 You can install any of these versions: `npm install -g codex@version`
 
+## `0.1.2505021246`
+
+### 🚀 Features
+
+- Use Landlock for sandboxing on Linux in TypeScript CLI (#763)
+- Configure HTTPS agent for proxies (#775)
+
 ## `0.1.2504301751`
 
 ### 🚀 Features

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex",
-  "version": "0.1.2504301751",
+  "version": "0.1.2505021246",
   "license": "Apache-2.0",
   "bin": {
     "codex": "bin/codex.js"


### PR DESCRIPTION
## `0.1.2505021246`

### 🚀 Features

- Use Landlock for sandboxing on Linux in TypeScript CLI (#763)
- Configure HTTPS agent for proxies (#775)