### PR TITLE
feat: configurable notifications in the Rust CLI 

### DIFF
--- a/codex-rs/core/src/codex_wrapper.rs
+++ b/codex-rs/core/src/codex_wrapper.rs
@@ -25,6 +25,7 @@ pub async fn init_codex(config: Config) -> anyhow::Result<(CodexWrapper, Event, 
             approval_policy: config.approval_policy,
             sandbox_policy: config.sandbox_policy,
             disable_response_storage: config.disable_response_storage,
+            notify: config.notify.clone(),
         })
         .await?;
 

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -30,6 +30,28 @@ pub struct Config {
 
     /// System instructions.
     pub instructions: Option<String>,
+
+    /// Optional external notifier command. When set, Codex will spawn this
+    /// program after each completed *turn* (i.e. when the agent finishes
+    /// processing a user submission). The value must be the full command
+    /// broken into argv tokens **without** the trailing JSON argument - Codex
+    /// appends one extra argument containing a JSON payload describing the
+    /// event.
+    ///
+    /// Example `~/.codex/config.toml` snippet:
+    ///
+    /// ```toml
+    /// notify = ["notify-send", "Codex"]
+    /// ```
+    ///
+    /// which will be invoked as:
+    ///
+    /// ```shell
+    /// notify-send Codex '{"type":"agent-turn-complete","turn-id":"12345"}'
+    /// ```
+    ///
+    /// If unset the feature is disabled.
+    pub notify: Option<Vec<String>>,
 }
 
 /// Base config deserialized from ~/.codex/config.toml.
@@ -51,6 +73,10 @@ pub struct ConfigToml {
     /// context with every request). Currently necessary for OpenAI customers
     /// who have opted into Zero Data Retention (ZDR).
     pub disable_response_storage: Option<bool>,
+
+    /// Optional external command to spawn for end-user notifications.
+    #[serde(default)]
+    pub notify: Option<Vec<String>>,
 
     /// System instructions.
     pub instructions: Option<String>,
@@ -161,6 +187,7 @@ impl Config {
             disable_response_storage: disable_response_storage
                 .or(cfg.disable_response_storage)
                 .unwrap_or(false),
+            notify: cfg.notify,
             instructions,
         }
     }

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod linux;
 mod models;
 pub mod protocol;
 mod safety;
+mod user_notification;
 pub mod util;
 mod zdr_transcript;
 

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -36,6 +36,13 @@ pub enum Op {
         /// Disable server-side response storage (send full context each request)
         #[serde(default)]
         disable_response_storage: bool,
+
+        /// Optional external notifier command tokens. Present only when the
+        /// client wants the agent to spawn a program after each completed
+        /// turn.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        #[serde(default)]
+        notify: Option<Vec<String>>,
     },
 
     /// Abort current task.

--- a/codex-rs/core/src/user_notification.rs
+++ b/codex-rs/core/src/user_notification.rs
@@ -1,0 +1,40 @@
+use serde::Serialize;
+
+/// User can configure a program that will receive notifications. Each
+/// notification is serialized as JSON and passed as an argument to the
+/// program.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(tag = "type", rename_all = "kebab-case")]
+pub(crate) enum UserNotification {
+    #[serde(rename_all = "kebab-case")]
+    AgentTurnComplete {
+        turn_id: String,
+
+        /// Messages that the user sent to the agent to initiate the turn.
+        input_messages: Vec<String>,
+
+        /// The last message sent by the assistant in the turn.
+        last_assistant_message: Option<String>,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_user_notification() {
+        let notification = UserNotification::AgentTurnComplete {
+            turn_id: "12345".to_string(),
+            input_messages: vec!["Rename `foo` to `bar` and update the callsites.".to_string()],
+            last_assistant_message: Some(
+                "Rename complete and verified `cargo build` succeeds.".to_string(),
+            ),
+        };
+        let serialized = serde_json::to_string(&notification).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"type":"agent-turn-complete","turn-id":"12345","input-messages":["Rename `foo` to `bar` and update the callsites."],"last-assistant-message":"Rename complete and verified `cargo build` succeeds."}"#
+        );
+    }
+}

--- a/codex-rs/core/tests/live_agent.rs
+++ b/codex-rs/core/tests/live_agent.rs
@@ -57,6 +57,7 @@ async fn spawn_codex() -> Codex {
                 approval_policy: config.approval_policy,
                 sandbox_policy: SandboxPolicy::new_read_only_policy(),
                 disable_response_storage: false,
+                notify: None,
             },
         })
         .await

--- a/codex-rs/core/tests/previous_response_id.rs
+++ b/codex-rs/core/tests/previous_response_id.rs
@@ -97,6 +97,7 @@ async fn keeps_previous_response_id_between_tasks() {
                 approval_policy: config.approval_policy,
                 sandbox_policy: SandboxPolicy::new_read_only_policy(),
                 disable_response_storage: false,
+                notify: None,
             },
         })
         .await

--- a/codex-rs/core/tests/stream_no_completed.rs
+++ b/codex-rs/core/tests/stream_no_completed.rs
@@ -80,6 +80,7 @@ async fn retries_on_early_close() {
                 approval_policy: config.approval_policy,
                 sandbox_policy: SandboxPolicy::new_read_only_policy(),
                 disable_response_storage: false,
+                notify: None,
             },
         })
         .await


### PR DESCRIPTION
With this change, you can specify a program that will be executed to get notified about events generated by Codex. The notification info will be packaged as a JSON object. The supported notification types are defined by the `UserNotification` enum introduced in this PR. Initially, it contains only one variant, `AgentTurnComplete`:

```rust
pub(crate) enum UserNotification {
    #[serde(rename_all = "kebab-case")]
    AgentTurnComplete {
        turn_id: String,

        /// Messages that the user sent to the agent to initiate the turn.
        input_messages: Vec<String>,

        /// The last message sent by the assistant in the turn.
        last_assistant_message: Option<String>,
    },
}
```

This is intended to support the common case when a "turn" ends, which often means it is now your chance to give Codex further instructions.

For example, I have the following in my `~/.codex/config.toml`:

```toml
notify = ["python3", "/Users/mbolin/.codex/notify.py"]
```

I created my own custom notifier script that calls out to [terminal-notifier](https://github.com/julienXX/terminal-notifier) to show a desktop push notification on macOS. Contents of `notify.py`:

```python
#!/usr/bin/env python3

import json
import subprocess
import sys


def main() -> int:
    if len(sys.argv) != 2:
        print("Usage: notify.py <NOTIFICATION_JSON>")
        return 1

    try:
        notification = json.loads(sys.argv[1])
    except json.JSONDecodeError:
        return 1

    match notification_type := notification.get("type"):
        case "agent-turn-complete":
            assistant_message = notification.get("last-assistant-message")
            if assistant_message:
                title = f"Codex: {assistant_message}"
            else:
                title = "Codex: Turn Complete!"
            input_messages = notification.get("input_messages", [])
            message = " ".join(input_messages)
            title += message
        case _:
            print(f"not sending a push notification for: {notification_type}")
            return 0

    subprocess.check_output(
        [
            "terminal-notifier",
            "-title",
            title,
            "-message",
            message,
            "-group",
            "codex",
            "-ignoreDnD",
            "-activate",
            "com.googlecode.iterm2",
        ]
    )

    return 0


if __name__ == "__main__":
    sys.exit(main())
```

For reference, here are related PRs that tried to add this functionality to the TypeScript version of the Codex CLI:

* https://github.com/openai/codex/pull/160
* https://github.com/openai/codex/pull/498