### PR TITLE
feat: drop support for `q` in the Rust TUI since we already support ctrl+d

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -149,12 +149,7 @@ impl ChatWidget<'_> {
                     InputResult::Submitted(text) => {
                         // Special client‑side commands start with a leading slash.
                         let trimmed = text.trim();
-
                         match trimmed {
-                            "q" => {
-                                // Gracefully request application shutdown.
-                                let _ = self.app_event_tx.send(AppEvent::ExitRequest);
-                            }
                             "/clear" => {
                                 // Clear the current conversation history without exiting.
                                 self.conversation_history.clear();


### PR DESCRIPTION
Out of the box, we will make `/` the only official "escape sequence" for commands in the Rust TUI. We will look to support `q` (or any string you want to use as a "macro") via a plugin, but not make it part of the default experience.

Existing `q` users will have to get by with `ctrl+d` for now.