### PR TITLE
feat: make cwd a required field of Config so we stop assuming std::env::current_dir() in a session

### DIFF
--- a/codex-rs/cli/src/landlock.rs
+++ b/codex-rs/cli/src/landlock.rs
@@ -18,7 +18,8 @@ pub fn run_landlock(command: Vec<String>, sandbox_policy: SandboxPolicy) -> anyh
 
     // Spawn a new thread and apply the sandbox policies there.
     let handle = std::thread::spawn(move || -> anyhow::Result<ExitStatus> {
-        codex_core::linux::apply_sandbox_policy_to_current_thread(sandbox_policy)?;
+        let cwd = std::env::current_dir()?;
+        codex_core::linux::apply_sandbox_policy_to_current_thread(sandbox_policy, &cwd)?;
         let status = Command::new(&command[0]).args(&command[1..]).status()?;
         Ok(status)
     });

--- a/codex-rs/cli/src/seatbelt.rs
+++ b/codex-rs/cli/src/seatbelt.rs
@@ -5,7 +5,8 @@ pub async fn run_seatbelt(
     command: Vec<String>,
     sandbox_policy: SandboxPolicy,
 ) -> anyhow::Result<()> {
-    let seatbelt_command = create_seatbelt_command(command, &sandbox_policy);
+    let cwd = std::env::current_dir().expect("failed to get cwd");
+    let seatbelt_command = create_seatbelt_command(command, &sandbox_policy, &cwd);
     let status = tokio::process::Command::new(seatbelt_command[0].clone())
         .args(&seatbelt_command[1..])
         .spawn()

--- a/codex-rs/core/src/codex_wrapper.rs
+++ b/codex-rs/core/src/codex_wrapper.rs
@@ -26,6 +26,7 @@ pub async fn init_codex(config: Config) -> anyhow::Result<(CodexWrapper, Event, 
             sandbox_policy: config.sandbox_policy,
             disable_response_storage: config.disable_response_storage,
             notify: config.notify.clone(),
+            cwd: config.cwd.clone(),
         })
         .await?;
 

--- a/codex-rs/core/src/linux.rs
+++ b/codex-rs/core/src/linux.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 use std::io;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -48,7 +49,7 @@ pub async fn exec_linux(
             .expect("Failed to create runtime");
 
         rt.block_on(async {
-            apply_sandbox_policy_to_current_thread(sandbox_policy)?;
+            apply_sandbox_policy_to_current_thread(sandbox_policy, &params.cwd)?;
             exec(params, ctrl_c_copy).await
         })
     })
@@ -66,13 +67,16 @@ pub async fn exec_linux(
 
 /// Apply sandbox policies inside this thread so only the child inherits
 /// them, not the entire CLI process.
-pub fn apply_sandbox_policy_to_current_thread(sandbox_policy: SandboxPolicy) -> Result<()> {
+pub fn apply_sandbox_policy_to_current_thread(
+    sandbox_policy: SandboxPolicy,
+    cwd: &Path,
+) -> Result<()> {
     if !sandbox_policy.has_full_network_access() {
         install_network_seccomp_filter_on_current_thread()?;
     }
 
     if !sandbox_policy.has_full_disk_write_access() {
-        let writable_roots = sandbox_policy.get_writable_roots();
+        let writable_roots = sandbox_policy.get_writable_roots_with_cwd(cwd);
         install_filesystem_landlock_rules_on_current_thread(writable_roots)?;
     }
 
@@ -189,7 +193,7 @@ mod tests_linux {
     async fn run_cmd(cmd: &[&str], writable_roots: &[PathBuf], timeout_ms: u64) {
         let params = ExecParams {
             command: cmd.iter().map(|elm| elm.to_string()).collect(),
-            workdir: None,
+            cwd: std::env::current_dir().expect("cwd should exist"),
             timeout_ms: Some(timeout_ms),
         };
 
@@ -262,7 +266,7 @@ mod tests_linux {
     async fn assert_network_blocked(cmd: &[&str]) {
         let params = ExecParams {
             command: cmd.iter().map(|s| s.to_string()).collect(),
-            workdir: None,
+            cwd: std::env::current_dir().expect("cwd should exist"),
             // Give the tool a generous 2‑second timeout so even slow DNS timeouts
             // do not stall the suite.
             timeout_ms: Some(2_000),

--- a/codex-rs/core/src/models.rs
+++ b/codex-rs/core/src/models.rs
@@ -102,6 +102,20 @@ impl From<Vec<InputItem>> for ResponseInputItem {
     }
 }
 
+/// If the `name` of a `ResponseItem::FunctionCall` is either `container.exec`
+/// or shell`, the `arguments` field should deserialize to this struct.
+#[derive(Deserialize, Debug, Clone, PartialEq)]
+pub struct ShellToolCallParams {
+    pub command: Vec<String>,
+    pub workdir: Option<String>,
+
+    /// This is the maximum time in seconds that the command is allowed to run.
+    #[serde(rename = "timeout")]
+    // The wire format uses `timeout`, which has ambiguous units, so we use
+    // `timeout_ms` as the field name so it is clear in code.
+    pub timeout_ms: Option<u64>,
+}
+
 #[expect(dead_code)]
 #[derive(Deserialize, Debug, Clone)]
 pub struct FunctionCallOutputPayload {
@@ -182,5 +196,24 @@ mod tests {
         let v: serde_json::Value = serde_json::from_str(&json).unwrap();
 
         assert_eq!(v.get("output").unwrap().as_str().unwrap(), "bad");
+    }
+
+    #[test]
+    fn deserialize_shell_tool_call_params() {
+        let json = r#"{
+            "command": ["ls", "-l"],
+            "workdir": "/tmp",
+            "timeout": 1000
+        }"#;
+
+        let params: ShellToolCallParams = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            ShellToolCallParams {
+                command: vec!["ls".to_string(), "-l".to_string()],
+                workdir: Some("/tmp".to_string()),
+                timeout_ms: Some(1000),
+            },
+            params
+        );
     }
 }

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -4,6 +4,7 @@
 //! between user and agent.
 
 use std::collections::HashMap;
+use std::path::Path;
 use std::path::PathBuf;
 
 use serde::Deserialize;
@@ -43,6 +44,15 @@ pub enum Op {
         #[serde(skip_serializing_if = "Option::is_none")]
         #[serde(default)]
         notify: Option<Vec<String>>,
+
+        /// Working directory that should be treated as the *root* of the
+        /// session. All relative paths supplied by the model as well as the
+        /// execution sandbox are resolved against this directory **instead**
+        /// of the process-wide current working directory. CLI front-ends are
+        /// expected to expand this to an absolute path before sending the
+        /// `ConfigureSession` operation so that the business-logic layer can
+        /// operate deterministically.
+        cwd: std::path::PathBuf,
     },
 
     /// Abort current task.
@@ -157,7 +167,7 @@ impl SandboxPolicy {
             .any(|perm| matches!(perm, SandboxPermission::NetworkFullAccess))
     }
 
-    pub fn get_writable_roots(&self) -> Vec<PathBuf> {
+    pub fn get_writable_roots_with_cwd(&self, cwd: &Path) -> Vec<PathBuf> {
         let mut writable_roots = Vec::<PathBuf>::new();
         for perm in &self.permissions {
             use SandboxPermission::*;
@@ -193,12 +203,9 @@ impl SandboxPolicy {
                         writable_roots.push(PathBuf::from("/tmp"));
                     }
                 }
-                DiskWriteCwd => match std::env::current_dir() {
-                    Ok(cwd) => writable_roots.push(cwd),
-                    Err(err) => {
-                        tracing::error!("Failed to get current working directory: {err}");
-                    }
-                },
+                DiskWriteCwd => {
+                    writable_roots.push(cwd.to_path_buf());
+                }
                 DiskWriteFolder { folder } => {
                     writable_roots.push(folder.clone());
                 }
@@ -317,7 +324,7 @@ pub enum EventMsg {
         command: Vec<String>,
         /// The command's working directory if not the default cwd for the
         /// agent.
-        cwd: String,
+        cwd: PathBuf,
     },
 
     ExecCommandEnd {

--- a/codex-rs/core/tests/live_agent.rs
+++ b/codex-rs/core/tests/live_agent.rs
@@ -58,6 +58,7 @@ async fn spawn_codex() -> Codex {
                 sandbox_policy: SandboxPolicy::new_read_only_policy(),
                 disable_response_storage: false,
                 notify: None,
+                cwd: std::env::current_dir().unwrap(),
             },
         })
         .await

--- a/codex-rs/core/tests/previous_response_id.rs
+++ b/codex-rs/core/tests/previous_response_id.rs
@@ -98,6 +98,7 @@ async fn keeps_previous_response_id_between_tasks() {
                 sandbox_policy: SandboxPolicy::new_read_only_policy(),
                 disable_response_storage: false,
                 notify: None,
+                cwd: std::env::current_dir().unwrap(),
             },
         })
         .await

--- a/codex-rs/core/tests/stream_no_completed.rs
+++ b/codex-rs/core/tests/stream_no_completed.rs
@@ -81,6 +81,7 @@ async fn retries_on_early_close() {
                 sandbox_policy: SandboxPolicy::new_read_only_policy(),
                 disable_response_storage: false,
                 notify: None,
+                cwd: std::env::current_dir().unwrap(),
             },
         })
         .await

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -21,6 +21,10 @@ pub struct Cli {
     #[clap(flatten)]
     pub sandbox: SandboxPermissionOption,
 
+    /// Tell the agent to use the specified directory as its working root.
+    #[clap(long = "cd", short = 'C', value_name = "DIR")]
+    pub cwd: Option<PathBuf>,
+
     /// Allow running Codex outside a Git repository.
     #[arg(long = "skip-git-repo-check", default_value_t = false)]
     pub skip_git_repo_check: bool,

--- a/codex-rs/exec/src/event_processor.rs
+++ b/codex-rs/exec/src/event_processor.rs
@@ -113,7 +113,7 @@ impl EventProcessor {
                     "{} {} in {}",
                     "exec".style(self.magenta),
                     escape_command(&command).style(self.bold),
-                    cwd,
+                    cwd.to_string_lossy(),
                 );
             }
             EventMsg::ExecCommandEnd {

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -29,6 +29,7 @@ pub async fn run_main(cli: Cli) -> anyhow::Result<()> {
         model,
         full_auto,
         sandbox,
+        cwd,
         skip_git_repo_check,
         disable_response_storage,
         color,
@@ -81,6 +82,7 @@ pub async fn run_main(cli: Cli) -> anyhow::Result<()> {
         } else {
             None
         },
+        cwd: cwd.map(|p| p.canonicalize().unwrap_or(p)),
     };
     let config = Config::load_with_overrides(overrides)?;
     let (codex_wrapper, event, ctrl_c) = codex_wrapper::init_codex(config).await?;

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -28,6 +28,10 @@ pub struct Cli {
     #[clap(flatten)]
     pub sandbox: SandboxPermissionOption,
 
+    /// Tell the agent to use the specified directory as its working root.
+    #[clap(long = "cd", short = 'C', value_name = "DIR")]
+    pub cwd: Option<PathBuf>,
+
     /// Allow running Codex outside a Git repository.
     #[arg(long = "skip-git-repo-check", default_value_t = false)]
     pub skip_git_repo_check: bool,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -56,6 +56,7 @@ pub fn run_main(cli: Cli) -> std::io::Result<()> {
             } else {
                 None
             },
+            cwd: cli.cwd.clone().map(|p| p.canonicalize().unwrap_or(p)),
         };
         #[allow(clippy::print_stderr)]
         match Config::load_with_overrides(overrides) {


### PR DESCRIPTION
In order to expose Codex via an MCP server, I realized that we should be taking `cwd` as a parameter rather than assuming `std::env::current_dir()` as the `cwd`. Specifically, the user may want to start a session in a directory other than the one where the MCP server has been started.

This PR makes `cwd: PathBuf` a required field of `Session` and threads it all the way through, though I think there is still an issue with not honoring `workdir` for `apply_patch`, which is something we also had to fix in the TypeScript version: https://github.com/openai/codex/pull/556.

This also adds `-C`/`--cd` to change the cwd via the command line.

To test, I ran:

```
cargo run --bin codex -- exec -C /tmp 'show the output of ls'
```

and verified it showed the contents of my `/tmp` folder instead of `$PWD`.