### PR TITLE
feat: add LightLLM provider support

### DIFF
--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -44,7 +44,7 @@ export const providers: Record<
   },
   lightllm: {
     name: "LightLLM",
-    baseURL: process.env["LIGHTLLM_BASE_URL"] || "http://35.166.170.146:9080",
+    baseURL: process.env["LIGHTLLM_BASE_URL"] || "",
     envKey: "LIGHTLLM_API_KEY",
   },
 };

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -42,4 +42,9 @@ export const providers: Record<
     baseURL: "https://api.groq.com/openai/v1",
     envKey: "GROQ_API_KEY",
   },
+  lightllm: {
+    name: "LightLLM",
+    baseURL: process.env["LIGHTLLM_BASE_URL"] || "http://35.166.170.146:9080",
+    envKey: "LIGHTLLM_API_KEY",
+  },
 };


### PR DESCRIPTION
With this change, you can specify a LightLLM provider for Codex.

Command line:

export LIGHTLLM_API_KEY=<sk-xxx>
export LIGHTLLM_BASE_URL=http://xxx.xxx.xxx.xxx:port 

node ./codex-cli/dist/cli.js --provider lightllm --model claude-3-7-sonnet --fullAuto
or:
codex --provider lightllm --model claude-3-7-sonnet --fullAuto

config.yaml 
The example LightLLM configuration file:
model_list:
  - model_name: claude-3-7-sonnet
    litellm_params:
      model: bedrock/us.anthropic.claude-3-7-sonnet-20250219-v1:0
      aws_access_key_id: <ak>
      aws_secret_access_key: <sk>
      aws_region_name: us-east-1
      api_key: <sk-xxx>

LightLLM Deploy: 
docker run -d -v /tmp/litellm/config.yaml:/app/config/config.yaml -p 9080:4000 ghcr.io/berriai/litellm:main-latest --config /app/config/config.yaml --detailed_debug

Test: 
- codex can run against lightLLM with claude-3-7-sonnet as backend model normally.


////
I have read the CLA Document and I hereby sign the CLA
