### PR TITLE
fix: is_inside_git_repo should take the directory as a param

### DIFF
--- a/codex-rs/core/src/util.rs
+++ b/codex-rs/core/src/util.rs
@@ -5,6 +5,8 @@ use rand::Rng;
 use tokio::sync::Notify;
 use tracing::debug;
 
+use crate::config::Config;
+
 const INITIAL_DELAY_MS: u64 = 200;
 const BACKOFF_FACTOR: f64 = 1.3;
 
@@ -33,26 +35,20 @@ pub(crate) fn backoff(attempt: u64) -> Duration {
     Duration::from_millis((base as f64 * jitter) as u64)
 }
 
-/// Return `true` if the current working directory is inside a Git repository.
+/// Return `true` if the project folder specified by the `Config` is inside a
+/// Git repository.
 ///
-/// The check walks up the directory hierarchy looking for a `.git` folder. This
+/// The check walks up the directory hierarchy looking for a `.git` file or
+/// directory (note `.git` can be a file that contains a `gitdir` entry). This
 /// approach does **not** require the `git` binary or the `git2` crate and is
-/// therefore fairly lightweight.  It intentionally only looks for the
-/// presence of a *directory* named `.git` – this is good enough for regular
-/// work‑trees and bare repos that live inside a work‑tree (common for
-/// developers running Codex locally).
+/// therefore fairly lightweight.
 ///
 /// Note that this does **not** detect *work‑trees* created with
 /// `git worktree add` where the checkout lives outside the main repository
-/// directory.  If you need Codex to work from such a checkout simply pass the
+/// directory. If you need Codex to work from such a checkout simply pass the
 /// `--allow-no-git-exec` CLI flag that disables the repo requirement.
-pub fn is_inside_git_repo() -> bool {
-    // Best‑effort: any IO error is treated as "not a repo" – the caller can
-    // decide what to do with the result.
-    let mut dir = match std::env::current_dir() {
-        Ok(d) => d,
-        Err(_) => return false,
-    };
+pub fn is_inside_git_repo(config: &Config) -> bool {
+    let mut dir = config.cwd.to_path_buf();
 
     loop {
         if dir.join(".git").exists() {

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -114,7 +114,7 @@ pub fn run_main(cli: Cli) -> std::io::Result<()> {
     // modal. The flag is shown when the current working directory is *not*
     // inside a Git repository **and** the user did *not* pass the
     // `--allow-no-git-exec` flag.
-    let show_git_warning = !cli.skip_git_repo_check && !is_inside_git_repo();
+    let show_git_warning = !cli.skip_git_repo_check && !is_inside_git_repo(&config);
 
     try_run_ratatui_app(cli, config, show_git_warning, log_rx);
     Ok(())


### PR DESCRIPTION
https://github.com/openai/codex/pull/800 made `cwd` a property of `Config` and made it so the `cwd` is not necessarily `std::env::current_dir()`. As such, `is_inside_git_repo()` should check `Config.cwd` rather than `std::env::current_dir()`.

This PR updates `is_inside_git_repo()` to take `Config` instead of an arbitrary `PathBuf` to force the check to operate on a `Config` where `cwd` has been resolved to what the user specified.