### PR TITLE
fix: flex-mode via config/flag

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -307,7 +307,7 @@ config = {
   notify: Boolean(cli.flags.notify),
   reasoningEffort:
     (cli.flags.reasoning as ReasoningEffort | undefined) ?? "high",
-  flexMode: Boolean(cli.flags.flexMode),
+  flexMode: cli.flags.flexMode || (config.flexMode ?? false),
   provider,
   disableResponseStorage,
 };
@@ -321,15 +321,19 @@ try {
 }
 
 // For --flex-mode, validate and exit if incorrect.
-if (cli.flags.flexMode) {
+if (config.flexMode) {
   const allowedFlexModels = new Set(["o3", "o4-mini"]);
   if (!allowedFlexModels.has(config.model)) {
-    // eslint-disable-next-line no-console
-    console.error(
-      `The --flex-mode option is only supported when using the 'o3' or 'o4-mini' models. ` +
-        `Current model: '${config.model}'.`,
-    );
-    process.exit(1);
+    if (cli.flags.flexMode) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `The --flex-mode option is only supported when using the 'o3' or 'o4-mini' models. ` +
+          `Current model: '${config.model}'.`,
+      );
+      process.exit(1);
+    } else {
+      config.flexMode = false;
+    }
   }
 }
 

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -139,6 +139,7 @@ export type StoredConfig = {
   notify?: boolean;
   /** Disable server-side response storage (send full transcript each request) */
   disableResponseStorage?: boolean;
+  flexMode?: boolean;
   providers?: Record<string, { name: string; baseURL: string; envKey: string }>;
   history?: {
     maxSize?: number;
@@ -451,6 +452,10 @@ export const loadConfig = (
   }
   // Notification setting: enable desktop notifications when set in config
   config.notify = storedConfig.notify === true;
+  // Flex-mode setting: enable the flex-mode service tier when set in config
+  if (storedConfig.flexMode !== undefined) {
+    config.flexMode = storedConfig.flexMode;
+  }
 
   // Add default history config if not provided
   if (storedConfig.history !== undefined) {
@@ -505,6 +510,7 @@ export const saveConfig = (
     providers: config.providers,
     approvalMode: config.approvalMode,
     disableResponseStorage: config.disableResponseStorage,
+    flexMode: config.flexMode,
     reasoningEffort: config.reasoningEffort,
   };
 


### PR DESCRIPTION
* Add flexMode to stored config, and use it during config loading unless the flag is explicitly passed.
* If the config asks for flexMode and the model doesn't support it, silently disable flexMode.

Resolves #803 