### PR TITLE
Add reasoning effort option to CLI help text

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -79,6 +79,8 @@ const cli = meow(
     --flex-mode               Use "flex-mode" processing mode for the request (only supported
                               with models o3 and o4-mini)
 
+    --reasoning <effort>      Set the reasoning effort level (low, medium, high) (default: high)
+
   Dangerous options
     --dangerously-auto-approve-everything
                                Skip all confirmation prompts and execute commands without


### PR DESCRIPTION
Reasoning effort was already available, but not expressed into the help text, so it was non-discoverable.

Other issues discovered, but will fix in separate PR since they are larger:
* #816 reasoningEffort isn't displayed in the terminal-header, making it rather hard to see the state of configuration
* I don't think the config file setting works, as the CLI option always "wins" and overwrites it