### PR TITLE
Add reasoningEffort display to terminal-header

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -482,6 +482,7 @@ export default function TerminalChat({
               agent,
               initialImagePaths,
               flexModeEnabled: Boolean(config.flexMode),
+              reasoningEffort: config.reasoningEffort,
             }}
           />
         ) : (

--- a/codex-cli/src/components/chat/terminal-header.tsx
+++ b/codex-cli/src/components/chat/terminal-header.tsx
@@ -1,4 +1,5 @@
 import type { AgentLoop } from "../../utils/agent/agent-loop.js";
+import type { ReasoningEffort } from "openai/resources.mjs";
 
 import { Box, Text } from "ink";
 import path from "node:path";
@@ -15,6 +16,7 @@ export interface TerminalHeaderProps {
   agent?: AgentLoop;
   initialImagePaths?: Array<string>;
   flexModeEnabled?: boolean;
+  reasoningEffort?: ReasoningEffort;
 }
 
 const TerminalHeader: React.FC<TerminalHeaderProps> = ({
@@ -28,6 +30,7 @@ const TerminalHeader: React.FC<TerminalHeaderProps> = ({
   agent,
   initialImagePaths,
   flexModeEnabled = false,
+  reasoningEffort,
 }) => {
   return (
     <>
@@ -81,6 +84,12 @@ const TerminalHeader: React.FC<TerminalHeaderProps> = ({
               <Text dimColor>
                 <Text color="blueBright">↳</Text> flex-mode:{" "}
                 <Text bold>enabled</Text>
+              </Text>
+            )}
+            {model.startsWith("o") && (
+              <Text dimColor>
+                <Text color="blueBright">↳</Text> reasoning-effort:{" "}
+                <Text bold>{reasoningEffort}</Text>
               </Text>
             )}
             {initialImagePaths?.map((img, idx) => (


### PR DESCRIPTION
I don't love the `model.startsWith("o")` pattern, but it appears to be common elsewhere in the codebase. Seems like metadata on the model (and its provenance e.g. OpenAI or Ollama) should determine things like this, but the codebase doesn't support that yet.