### PR TITLE
fix: guard against missing choices

### DIFF
--- a/codex-cli/src/utils/responses.ts
+++ b/codex-cli/src/utils/responses.ts
@@ -487,7 +487,7 @@ async function* streamResponses(
   let isToolCall = false;
   for await (const chunk of completion as AsyncIterable<OpenAI.ChatCompletionChunk>) {
     // console.error('\nCHUNK: ', JSON.stringify(chunk));
-    const choice = chunk.choices[0];
+    const choice = chunk.choices?.[0];
     if (!choice) {
       continue;
     }


### PR DESCRIPTION
- Fixes guard by using optional chaining to safely check chunk.choices?.[0] before accessing.
- Currently, accessing chunk.choices[0] without checking could throw if choices was missing from the chunk.