### PR TITLE
feat: added arceeai as a provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ export OPENAI_API_KEY="your-api-key-here"
 > - deepseek
 > - xai
 > - groq
+> - arceeai
 > - any other provider that is compatible with the OpenAI API
 >
 > If you use a provider other than OpenAI, you will need to set the API key for the provider in the config file or in the environment variable as:
@@ -428,6 +429,11 @@ Below is a comprehensive example of `config.json` with multiple custom providers
       "name": "Groq",
       "baseURL": "https://api.groq.com/openai/v1",
       "envKey": "GROQ_API_KEY"
+    },
+    "arceeai": {
+      "name": "ArceeAI",
+      "baseURL": "https://conductor.arcee.ai/v1",
+      "envKey": "ARCEEAI_API_KEY"
     }
   },
   "history": {

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -42,4 +42,9 @@ export const providers: Record<
     baseURL: "https://api.groq.com/openai/v1",
     envKey: "GROQ_API_KEY",
   },
+  arceeai: {
+    name: "ArceeAI",
+    baseURL: "https://conductor.arcee.ai/v1",
+    envKey: "ARCEEAI_API_KEY",
+  },
 };


### PR DESCRIPTION
- Added ArceeAI as a provider  - https://conductor.arcee.ai/v1
- Compatible with ArceeAI SLMs (Virtuoso, Maestro)
- Works with ArceeAI's Conductor auto‑router models (auto, auto‑tool), once #817 is merged
