### PR TITLE
[codex-rs] Add `service_tier` CLI option

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -150,7 +150,11 @@ impl ModelClient {
         let model = model.to_string();
         let client = reqwest::Client::new();
         let service_tier = service_tier.to_string();
-        Self { model, client, service_tier }
+        Self {
+            model,
+            client,
+            service_tier,
+        }
     }
 
     pub async fn stream(&mut self, prompt: &Prompt) -> Result<ResponseStream> {

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -75,6 +75,7 @@ struct Payload<'a> {
     /// true when using the Responses API.
     store: bool,
     stream: bool,
+    service_tier: &'a str,
 }
 
 #[derive(Debug, Serialize)]
@@ -141,13 +142,15 @@ static DEFAULT_TOOLS: LazyLock<Vec<ResponsesApiTool>> = LazyLock::new(|| {
 pub struct ModelClient {
     model: String,
     client: reqwest::Client,
+    service_tier: String,
 }
 
 impl ModelClient {
-    pub fn new(model: impl ToString) -> Self {
+    pub fn new(model: impl ToString, service_tier: impl ToString) -> Self {
         let model = model.to_string();
         let client = reqwest::Client::new();
-        Self { model, client }
+        let service_tier = service_tier.to_string();
+        Self { model, client, service_tier }
     }
 
     pub async fn stream(&mut self, prompt: &Prompt) -> Result<ResponseStream> {
@@ -186,6 +189,7 @@ impl ModelClient {
             previous_response_id: prompt.prev_id.clone(),
             store: prompt.store,
             stream: true,
+            service_tier: &self.service_tier,
         };
 
         let url = format!("{}/v1/responses", *OPENAI_API_BASE);

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -547,6 +547,7 @@ async fn submission_loop(
                 disable_response_storage,
                 notify,
                 cwd,
+                service_tier,
             } => {
                 info!(model, "Configuring session");
                 if !cwd.is_absolute() {
@@ -562,7 +563,7 @@ async fn submission_loop(
                     return;
                 }
 
-                let client = ModelClient::new(model.clone());
+                let client = ModelClient::new(model.clone(), service_tier);
 
                 // abort any current running session and clone its state
                 let state = match sess.take() {

--- a/codex-rs/core/src/codex_wrapper.rs
+++ b/codex-rs/core/src/codex_wrapper.rs
@@ -27,6 +27,7 @@ pub async fn init_codex(config: Config) -> anyhow::Result<(CodexWrapper, Event, 
             disable_response_storage: config.disable_response_storage,
             notify: config.notify.clone(),
             cwd: config.cwd.clone(),
+            service_tier: config.service_tier.clone(),
         })
         .await?;
 

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -18,6 +18,8 @@ const EMBEDDED_INSTRUCTIONS: &str = include_str!("../prompt.md");
 pub struct Config {
     /// Optional override of model selection.
     pub model: String,
+    
+    pub service_tier: String,
 
     /// Approval policy for executing commands.
     pub approval_policy: AskForApproval,
@@ -68,6 +70,7 @@ pub struct Config {
 pub struct ConfigToml {
     /// Optional override of model selection.
     pub model: Option<String>,
+    pub service_tier: Option<String>,   
 
     /// Default approval policy for executing commands.
     pub approval_policy: Option<AskForApproval>,
@@ -152,6 +155,7 @@ pub struct ConfigOverrides {
     pub approval_policy: Option<AskForApproval>,
     pub sandbox_policy: Option<SandboxPolicy>,
     pub disable_response_storage: Option<bool>,
+    pub service_tier: Option<String>,
 }
 
 impl Config {
@@ -176,6 +180,7 @@ impl Config {
             approval_policy,
             sandbox_policy,
             disable_response_storage,
+            service_tier,
         } = overrides;
 
         let sandbox_policy = match sandbox_policy {
@@ -195,6 +200,7 @@ impl Config {
 
         Self {
             model: model.or(cfg.model).unwrap_or_else(default_model),
+            service_tier: service_tier.or(cfg.service_tier).unwrap_or_else(|| "auto".to_string()),
             cwd: cwd.map_or_else(
                 || {
                     tracing::info!("cwd not set, using current dir");

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -18,7 +18,7 @@ const EMBEDDED_INSTRUCTIONS: &str = include_str!("../prompt.md");
 pub struct Config {
     /// Optional override of model selection.
     pub model: String,
-    
+
     pub service_tier: String,
 
     /// Approval policy for executing commands.
@@ -70,7 +70,7 @@ pub struct Config {
 pub struct ConfigToml {
     /// Optional override of model selection.
     pub model: Option<String>,
-    pub service_tier: Option<String>,   
+    pub service_tier: Option<String>,
 
     /// Default approval policy for executing commands.
     pub approval_policy: Option<AskForApproval>,
@@ -200,7 +200,9 @@ impl Config {
 
         Self {
             model: model.or(cfg.model).unwrap_or_else(default_model),
-            service_tier: service_tier.or(cfg.service_tier).unwrap_or_else(|| "auto".to_string()),
+            service_tier: service_tier
+                .or(cfg.service_tier)
+                .unwrap_or_else(|| "auto".to_string()),
             cwd: cwd.map_or_else(
                 || {
                     tracing::info!("cwd not set, using current dir");

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -29,6 +29,7 @@ pub enum Op {
     ConfigureSession {
         /// If not specified, server will use its default model.
         model: String,
+        service_tier: String,
         /// Model instructions
         instructions: Option<String>,
         /// When to escalate for approval for execution

--- a/codex-rs/core/tests/live_agent.rs
+++ b/codex-rs/core/tests/live_agent.rs
@@ -68,6 +68,7 @@ async fn spawn_codex() -> Codex {
                 disable_response_storage: false,
                 notify: None,
                 cwd: std::env::current_dir().unwrap(),
+                service_tier: config.service_tier,
             },
         })
         .await

--- a/codex-rs/core/tests/previous_response_id.rs
+++ b/codex-rs/core/tests/previous_response_id.rs
@@ -103,6 +103,7 @@ async fn keeps_previous_response_id_between_tasks() {
                 disable_response_storage: false,
                 notify: None,
                 cwd: std::env::current_dir().unwrap(),
+                service_tier: config.service_tier,
             },
         })
         .await

--- a/codex-rs/core/tests/stream_no_completed.rs
+++ b/codex-rs/core/tests/stream_no_completed.rs
@@ -91,6 +91,7 @@ async fn retries_on_early_close() {
                 disable_response_storage: false,
                 notify: None,
                 cwd: std::env::current_dir().unwrap(),
+                service_tier: config.service_tier,
             },
         })
         .await

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -14,6 +14,10 @@ pub struct Cli {
     #[arg(long, short = 'm')]
     pub model: Option<String>,
 
+    /// Service tier for request, defaults to auto, use flex to enable Flex Processing.
+    #[arg(long)]
+    pub service_tier: Option<String>,
+
     /// Convenience alias for low-friction sandboxed automatic execution (network-disabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -34,6 +34,7 @@ pub async fn run_main(cli: Cli) -> anyhow::Result<()> {
         disable_response_storage,
         color,
         prompt,
+        service_tier,
     } = cli;
 
     let (stdout_with_ansi, stderr_with_ansi) = match color {
@@ -56,6 +57,7 @@ pub async fn run_main(cli: Cli) -> anyhow::Result<()> {
     // Load configuration and determine approval policy
     let overrides = ConfigOverrides {
         model,
+        service_tier,
         // This CLI is intended to be headless and has no affordances for asking
         // the user for approval.
         approval_policy: Some(AskForApproval::Never),

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -163,7 +163,7 @@ impl CodexToolCallParam {
             approval_policy: approval_policy.map(Into::into),
             sandbox_policy,
             disable_response_storage,
-            service_tier
+            service_tier,
         };
 
         let cfg = codex_core::config::Config::load_with_overrides(overrides)?;

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -22,6 +22,10 @@ pub(crate) struct CodexToolCallParam {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
 
+    /// Optional override for the service tier for request
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<String>,
+
     /// Working directory for the session. If relative, it is resolved against
     /// the server process's current working directory.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -146,6 +150,7 @@ impl CodexToolCallParam {
             approval_policy,
             sandbox_permissions,
             disable_response_storage,
+            service_tier,
         } = self;
         let sandbox_policy = sandbox_permissions.map(|perms| {
             SandboxPolicy::from(perms.into_iter().map(Into::into).collect::<Vec<_>>())
@@ -158,6 +163,7 @@ impl CodexToolCallParam {
             approval_policy: approval_policy.map(Into::into),
             sandbox_policy,
             disable_response_storage,
+            service_tier
         };
 
         let cfg = codex_core::config::Config::load_with_overrides(overrides)?;

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -17,6 +17,10 @@ pub struct Cli {
     #[arg(long, short = 'm')]
     pub model: Option<String>,
 
+    /// Service tier for request, defaults to auto, use flex to enable Flex Processing.
+    #[arg(long)]
+    pub service_tier: Option<String>,
+
     /// Configure when the model requires human approval before executing a command.
     #[arg(long = "ask-for-approval", short = 'a')]
     pub approval_policy: Option<ApprovalModeCliArg>,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -50,6 +50,7 @@ pub fn run_main(cli: Cli) -> std::io::Result<()> {
         // Load configuration and support CLI overrides.
         let overrides = ConfigOverrides {
             model: cli.model.clone(),
+            service_tier: cli.service_tier.clone(),
             approval_policy,
             sandbox_policy,
             disable_response_storage: if cli.disable_response_storage {


### PR DESCRIPTION
Defaults to auto to preserve existing default behavior in the API. Allows users to switch to Flex Processing, saving considerable cost.

This is literally the first Rust code I have ever written so please read/review it with that in mind ❤️ 

It still seems like model, service_tier, and probably more, should be stored in some kind of model object, but I am piggybacking on the existing structures since I am very much new to Rust.