### PR TITLE
feat: update McpClient::new_stdio_client() to accept an env

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -561,7 +561,6 @@ name = "codex-mcp-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "codex-core",
  "mcp-types",
  "pretty_assertions",
  "serde",

--- a/codex-rs/mcp-client/Cargo.toml
+++ b/codex-rs/mcp-client/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1"
-codex-core = { path = "../core", features = ["cli"] }
 mcp-types = { path = "../mcp-types" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/codex-rs/mcp-client/src/main.rs
+++ b/codex-rs/mcp-client/src/main.rs
@@ -18,17 +18,20 @@ use mcp_types::ListToolsRequestParams;
 #[tokio::main]
 async fn main() -> Result<()> {
     // Collect command-line arguments excluding the program name itself.
-    let cmd_args: Vec<String> = std::env::args().skip(1).collect();
+    let mut args: Vec<String> = std::env::args().skip(1).collect();
 
-    if cmd_args.is_empty() || cmd_args[0] == "--help" || cmd_args[0] == "-h" {
+    if args.is_empty() || args[0] == "--help" || args[0] == "-h" {
         eprintln!("Usage: mcp-client <program> [args..]\n\nExample: mcp-client codex-mcp-server");
         std::process::exit(1);
     }
+    let original_args = args.clone();
 
     // Spawn the subprocess and connect the client.
-    let client = McpClient::new_stdio_client(cmd_args.clone())
+    let program = args.remove(0);
+    let env = None;
+    let client = McpClient::new_stdio_client(program, args, env)
         .await
-        .with_context(|| format!("failed to spawn subprocess: {:?}", cmd_args))?;
+        .with_context(|| format!("failed to spawn subprocess: {original_args:?}"))?;
 
     // Issue `tools/list` request (no params).
     let tools = client


### PR DESCRIPTION
Cleans up the signature for `new_stdio_client()` to more closely mirror how MCP servers are declared in config files (`command`, `args`, `env`). Also takes a cue from Claude Code where the MCP server is launched with a restricted `env` so that it only includes "safe" things like `USER` and `PATH` (see the `create_env_for_mcp_server()` function introduced in this PR for details) by default, as it is common for developers to have sensitive API keys present in their environment that should only be forwarded to the MCP server when the user has explicitly configured it to do so.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/831).
* #829
* __->__ #831