### PR TITLE
fix: add optional timeout to McpClient::send_request()

### DIFF
--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use tracing::error;
 
 use crate::codex::Session;
@@ -15,6 +17,7 @@ pub(crate) async fn handle_mcp_tool_call(
     server: String,
     tool_name: String,
     arguments: String,
+    timeout: Option<Duration>,
 ) -> ResponseInputItem {
     // Parse the `arguments` as JSON. An empty string is OK, but invalid JSON
     // is not.
@@ -45,25 +48,27 @@ pub(crate) async fn handle_mcp_tool_call(
     notify_mcp_tool_call_event(sess, sub_id, tool_call_begin_event).await;
 
     // Perform the tool call.
-    let (tool_call_end_event, tool_call_err) =
-        match sess.call_tool(&server, &tool_name, arguments_value).await {
-            Ok(result) => (
-                EventMsg::McpToolCallEnd {
-                    call_id,
-                    success: !result.is_error.unwrap_or(false),
-                    result: Some(result),
-                },
-                None,
-            ),
-            Err(e) => (
-                EventMsg::McpToolCallEnd {
-                    call_id,
-                    success: false,
-                    result: None,
-                },
-                Some(e),
-            ),
-        };
+    let (tool_call_end_event, tool_call_err) = match sess
+        .call_tool(&server, &tool_name, arguments_value, timeout)
+        .await
+    {
+        Ok(result) => (
+            EventMsg::McpToolCallEnd {
+                call_id,
+                success: !result.is_error.unwrap_or(false),
+                result: Some(result),
+            },
+            None,
+        ),
+        Err(e) => (
+            EventMsg::McpToolCallEnd {
+                call_id,
+                success: false,
+                result: None,
+            },
+            Some(e),
+        ),
+    };
 
     notify_mcp_tool_call_event(sess, sub_id, tool_call_end_event.clone()).await;
     let EventMsg::McpToolCallEnd {

--- a/codex-rs/mcp-client/Cargo.toml
+++ b/codex-rs/mcp-client/Cargo.toml
@@ -16,6 +16,7 @@ tokio = { version = "1", features = [
     "process",
     "rt-multi-thread",
     "sync",
+    "time",
 ] }
 
 [dev-dependencies]

--- a/codex-rs/mcp-client/src/main.rs
+++ b/codex-rs/mcp-client/src/main.rs
@@ -34,8 +34,9 @@ async fn main() -> Result<()> {
         .with_context(|| format!("failed to spawn subprocess: {original_args:?}"))?;
 
     // Issue `tools/list` request (no params).
+    let timeout = None;
     let tools = client
-        .list_tools(None::<ListToolsRequestParams>)
+        .list_tools(None::<ListToolsRequestParams>, timeout)
         .await
         .context("tools/list request failed")?;
 


### PR DESCRIPTION
We now impose a 10s timeout on the initial `tools/list` request to an MCP server. We do not apply a timeout for other types of requests yet, but we should start enforcing those, as well.