### PR TITLE
feat: read `model_provider` and `model_providers` from config.toml

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -80,6 +80,7 @@ impl Codex {
         let (tx_sub, rx_sub) = async_channel::bounded(64);
         let (tx_event, rx_event) = async_channel::bounded(64);
         let configure_session = Op::ConfigureSession {
+            provider: config.model_provider.clone(),
             model: config.model.clone(),
             instructions: config.instructions.clone(),
             approval_policy: config.approval_policy,
@@ -504,6 +505,7 @@ async fn submission_loop(
                 sess.abort();
             }
             Op::ConfigureSession {
+                provider,
                 model,
                 instructions,
                 approval_policy,
@@ -512,7 +514,7 @@ async fn submission_loop(
                 notify,
                 cwd,
             } => {
-                info!(model, "Configuring session");
+                info!("Configuring session: model={model}; provider={provider:?}");
                 if !cwd.is_absolute() {
                     let message = format!("cwd is not absolute: {cwd:?}");
                     error!(message);
@@ -526,7 +528,7 @@ async fn submission_loop(
                     return;
                 }
 
-                let client = ModelClient::new(model.clone());
+                let client = ModelClient::new(model.clone(), provider.clone());
 
                 // abort any current running session and clone its state
                 let state = match sess.take() {

--- a/codex-rs/core/src/flags.rs
+++ b/codex-rs/core/src/flags.rs
@@ -2,12 +2,11 @@ use std::time::Duration;
 
 use env_flags::env_flags;
 
-use crate::error::CodexErr;
-use crate::error::Result;
-
 env_flags! {
     pub OPENAI_DEFAULT_MODEL: &str = "o3";
-    pub OPENAI_API_BASE: &str = "https://api.openai.com";
+    pub OPENAI_API_BASE: &str = "https://api.openai.com/v1";
+
+    /// Fallback when the provider-specific key is not set.
     pub OPENAI_API_KEY: Option<&str> = None;
     pub OPENAI_TIMEOUT_MS: Duration = Duration::from_millis(300_000), |value| {
         value.parse().map(Duration::from_millis)
@@ -21,9 +20,6 @@ env_flags! {
         value.parse().map(Duration::from_millis)
     };
 
+    /// Fixture path for offline tests (see client.rs).
     pub CODEX_RS_SSE_FIXTURE: Option<&str> = None;
-}
-
-pub fn get_api_key() -> Result<&'static str> {
-    OPENAI_API_KEY.ok_or_else(|| CodexErr::EnvVar("OPENAI_API_KEY"))
 }

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -7,6 +7,7 @@
 
 mod client;
 pub mod codex;
+pub use codex::Codex;
 pub mod codex_wrapper;
 pub mod config;
 pub mod error;
@@ -18,6 +19,8 @@ pub mod linux;
 mod mcp_connection_manager;
 pub mod mcp_server_config;
 mod mcp_tool_call;
+mod model_provider_info;
+pub use model_provider_info::ModelProviderInfo;
 mod models;
 pub mod protocol;
 mod rollout;
@@ -25,5 +28,3 @@ mod safety;
 mod user_notification;
 pub mod util;
 mod zdr_transcript;
-
-pub use codex::Codex;

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -1,0 +1,103 @@
+//! Registry of model providers supported by Codex.
+//!
+//! Providers can be defined in two places:
+//!   1. Built-in defaults compiled into the binary so Codex works out-of-the-box.
+//!   2. User-defined entries inside `~/.codex/config.toml` under the `model_providers`
+//!      key. These override or extend the defaults at runtime.
+
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::HashMap;
+
+/// Serializable representation of a provider definition.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ModelProviderInfo {
+    /// Friendly display name.
+    pub name: String,
+    /// Base URL for the provider's OpenAI-compatible API.
+    pub base_url: String,
+    /// Environment variable that stores the user's API key for this provider.
+    pub env_key: String,
+}
+
+impl ModelProviderInfo {
+    /// Returns the API key for this provider if present in the environment.
+    pub fn api_key(&self) -> Option<String> {
+        std::env::var(&self.env_key).ok()
+    }
+}
+
+/// Built-in default provider list.
+pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
+    use ModelProviderInfo as P;
+
+    [
+        (
+            "openai",
+            P {
+                name: "OpenAI".into(),
+                base_url: "https://api.openai.com/v1".into(),
+                env_key: "OPENAI_API_KEY".into(),
+            },
+        ),
+        (
+            "openrouter",
+            P {
+                name: "OpenRouter".into(),
+                base_url: "https://openrouter.ai/api/v1".into(),
+                env_key: "OPENROUTER_API_KEY".into(),
+            },
+        ),
+        (
+            "gemini",
+            P {
+                name: "Gemini".into(),
+                base_url: "https://generativelanguage.googleapis.com/v1beta/openai".into(),
+                env_key: "GEMINI_API_KEY".into(),
+            },
+        ),
+        (
+            "ollama",
+            P {
+                name: "Ollama".into(),
+                base_url: "http://localhost:11434/v1".into(),
+                env_key: "OLLAMA_API_KEY".into(),
+            },
+        ),
+        (
+            "mistral",
+            P {
+                name: "Mistral".into(),
+                base_url: "https://api.mistral.ai/v1".into(),
+                env_key: "MISTRAL_API_KEY".into(),
+            },
+        ),
+        (
+            "deepseek",
+            P {
+                name: "DeepSeek".into(),
+                base_url: "https://api.deepseek.com".into(),
+                env_key: "DEEPSEEK_API_KEY".into(),
+            },
+        ),
+        (
+            "xai",
+            P {
+                name: "xAI".into(),
+                base_url: "https://api.x.ai/v1".into(),
+                env_key: "XAI_API_KEY".into(),
+            },
+        ),
+        (
+            "groq",
+            P {
+                name: "Groq".into(),
+                base_url: "https://api.groq.com/openai/v1".into(),
+                env_key: "GROQ_API_KEY".into(),
+            },
+        ),
+    ]
+    .into_iter()
+    .map(|(k, v)| (k.to_string(), v))
+    .collect()
+}

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -11,6 +11,8 @@ use mcp_types::CallToolResult;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::model_provider_info::ModelProviderInfo;
+
 /// Submission Queue Entry - requests from user
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct Submission {
@@ -27,6 +29,9 @@ pub struct Submission {
 pub enum Op {
     /// Configure the model session.
     ConfigureSession {
+        /// Provider identifier ("openai", "openrouter", ...).
+        provider: ModelProviderInfo,
+
         /// If not specified, server will use its default model.
         model: String,
         /// Model instructions

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -66,6 +66,7 @@ pub async fn run_main(cli: Cli) -> anyhow::Result<()> {
             None
         },
         cwd: cwd.map(|p| p.canonicalize().unwrap_or(p)),
+        provider: None,
     };
     let config = Config::load_with_overrides(overrides)?;
 

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -158,6 +158,7 @@ impl CodexToolCallParam {
             approval_policy: approval_policy.map(Into::into),
             sandbox_policy,
             disable_response_storage,
+            provider: None,
         };
 
         let cfg = codex_core::config::Config::load_with_overrides(overrides)?;

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -58,6 +58,7 @@ pub fn run_main(cli: Cli) -> std::io::Result<()> {
                 None
             },
             cwd: cli.cwd.clone().map(|p| p.canonicalize().unwrap_or(p)),
+            provider: None,
         };
         #[allow(clippy::print_stderr)]
         match Config::load_with_overrides(overrides) {


### PR DESCRIPTION
This is the first step in supporting other model providers in the Rust CLI. Specifically, this PR adds support for the new entries in `Config` and `ConfigOverrides` to specify a `ModelProviderInfo`, which is the basic config needed for an LLM provider. This PR does not get us all the way there yet because `client.rs` still categorically appends `/responses` to the URL and expects the endpoint to support the OpenAI Responses API. Will fix that next!