### PR TITLE
fix: remove clap dependency from core crate

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -516,7 +516,6 @@ dependencies = [
  "async-channel",
  "base64 0.21.7",
  "bytes",
- "clap",
  "codex-apply-patch",
  "codex-mcp-client",
  "dirs",

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -12,7 +12,6 @@ anyhow = "1"
 async-channel = "2.3.1"
 base64 = "0.21"
 bytes = "1.10.1"
-clap = { version = "4", features = ["derive", "wrap_help"], optional = true }
 codex-apply-patch = { path = "../apply-patch" }
 codex-mcp-client = { path = "../mcp-client" }
 dirs = "6"


### PR DESCRIPTION
This is no longer necessary after https://github.com/openai/codex/pull/843.