### PR TITLE
feat: Allow pasting newlines

### DIFF
--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -21,7 +21,7 @@ codex-ansi-escape = { path = "../ansi-escape" }
 codex-core = { path = "../core" }
 codex-common = { path = "../common", features = ["cli", "elapsed"] }
 color-eyre = "0.6.3"
-crossterm = "0.28.1"
+crossterm = { version = "0.28.1", features = ["bracketed-paste"] }
 mcp-types = { path = "../mcp-types" }
 ratatui = { version = "0.29.0", features = [
     "unstable-widget-ref",

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -2,7 +2,9 @@ use std::io::Stdout;
 use std::io::stdout;
 use std::io::{self};
 
+use crossterm::event::DisableBracketedPaste;
 use crossterm::event::DisableMouseCapture;
+use crossterm::event::EnableBracketedPaste;
 use crossterm::event::EnableMouseCapture;
 use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
@@ -19,6 +21,7 @@ pub type Tui = Terminal<CrosstermBackend<Stdout>>;
 pub fn init() -> io::Result<Tui> {
     execute!(stdout(), EnterAlternateScreen)?;
     execute!(stdout(), EnableMouseCapture)?;
+    execute!(stdout(), EnableBracketedPaste)?;
     enable_raw_mode()?;
     set_panic_hook();
     Terminal::new(CrosstermBackend::new(stdout()))
@@ -35,6 +38,7 @@ fn set_panic_hook() {
 /// Restore the terminal to its original state
 pub fn restore() -> io::Result<()> {
     execute!(stdout(), DisableMouseCapture)?;
+    execute!(stdout(), DisableBracketedPaste)?;
     execute!(stdout(), LeaveAlternateScreen)?;
     disable_raw_mode()?;
     Ok(())


### PR DESCRIPTION
Noticed that when pasting multi-line blocks, each newline was treated like a new submission.
Update tui to handle Paste directly and map newlines to shift+enter.

# Test

Copied this into clipboard:
```
Do nothing.
Explain this repo to me.
```

Pasted in and saw multi-line input. Hitting Enter then submitted the full block.