### PR TITLE
feat: hide sensitive files

### DIFF
--- a/codex-cli/src/components/singlepass-cli-app.tsx
+++ b/codex-cli/src/components/singlepass-cli-app.tsx
@@ -365,7 +365,7 @@ export function SinglePassApp({
   /* ---------------------------- Load file context --------------------------- */
   useEffect(() => {
     (async () => {
-      const ignorePats = loadIgnorePatterns();
+      const ignorePats = loadIgnorePatterns(rootPath);
       const fileContents = await getFileContents(rootPath, ignorePats);
       setFiles(fileContents);
     })();


### PR DESCRIPTION
# What
This PR prevents codex read users' .gitignore, which contains where users' secret tokens are. 

This PR resolves #85 

# Why
Users do not like to leak their secret tokens and keys to OPENAI. After resolve this, users who have sensitive files concern will start to use codex

# How

1. codex will load `.gitignore` in users' projects
2. parse patterns in `.gitignore` to Regex
3. codex will skip files that match Regex patterns
