### PR TITLE
fix: remove wrapping in Rust TUI that was incompatible with scrolling math

### DIFF
--- a/codex-rs/tui/src/conversation_history_widget.rs
+++ b/codex-rs/tui/src/conversation_history_widget.rs
@@ -377,9 +377,12 @@ impl WidgetRef for ConversationHistoryWidget {
         // second time by the widget – which manifested as the entire block
         // drifting off‑screen when the user attempted to scroll.
 
-        let paragraph = Paragraph::new(visible_lines)
-            .block(block)
-            .wrap(Wrap { trim: false });
+        // Currently, we do not use the `wrap` method on the `Paragraph` widget
+        // because it messes up our scrolling math above that assumes each Line
+        // contributes one line of height to the widget. Admittedly, this is
+        // bad because users cannot see content that is clipped without
+        // resizing the terminal.
+        let paragraph = Paragraph::new(visible_lines).block(block);
         paragraph.render(area, buf);
 
         let needs_scrollbar = num_lines > viewport_height;


### PR DESCRIPTION
I noticed that sometimes I would enter a new message, but it would not show up in the conversation history. Even if I focused the conversation history and tried to scroll it to the bottom, I could not bring it into view. At first, I was concerned that messages were not making it to the UI layer, but I added debug statements and verified that was not the issue.

It turned out that, previous to this PR, lines that are wider than the viewport take up multiple lines of vertical space because `wrap()` was set on the `Paragraph` inside the scroll pane. Unfortunately, that broke our "scrollbar math" that assumed each `Line` contributes one line of height in the UI.

This PR removes the `wrap()`, but introduces a new issue, which is that now you cannot see long lines without resizing your terminal window. For now, I filed an issue here:

https://github.com/openai/codex/issues/869

I think the long-term fix is to fix our math so it calculates the height of a `Line` after it is wrapped given the current width of the viewport.