### PR TITLE
fix: enable clippy on tests

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -81,7 +81,7 @@ jobs:
         run: echo "FAILED=" >> $GITHUB_ENV
 
       - name: cargo clippy
-        run: cargo clippy --target ${{ matrix.target }} --all-features -- -D warnings || echo "FAILED=${FAILED:+$FAILED, }cargo clippy" >> $GITHUB_ENV
+        run: cargo clippy --target ${{ matrix.target }} --all-features --tests -- -D warnings || echo "FAILED=${FAILED:+$FAILED, }cargo clippy" >> $GITHUB_ENV
 
       # Running `cargo build` from the workspace root builds the workspace using
       # the union of all features from third-party crates. This can mask errors

--- a/codex-rs/core/src/is_safe_command.rs
+++ b/codex-rs/core/src/is_safe_command.rs
@@ -194,6 +194,7 @@ fn is_valid_sed_n_arg(arg: Option<&str>) -> bool {
 }
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
 
     fn vec_str(args: &[&str]) -> Vec<String> {

--- a/codex-rs/core/src/linux.rs
+++ b/codex-rs/core/src/linux.rs
@@ -179,7 +179,9 @@ fn install_network_seccomp_filter_on_current_thread() -> std::result::Result<(),
 }
 
 #[cfg(test)]
-mod tests_linux {
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
     use super::*;
     use crate::exec::ExecParams;
     use crate::exec::SandboxType;

--- a/codex-rs/core/src/models.rs
+++ b/codex-rs/core/src/models.rs
@@ -163,6 +163,7 @@ impl std::ops::Deref for FunctionCallOutputPayload {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
 
     #[test]

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -189,6 +189,7 @@ fn is_write_patch_constrained_to_writable_paths(
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
 
     #[test]

--- a/codex-rs/core/src/user_notification.rs
+++ b/codex-rs/core/src/user_notification.rs
@@ -20,6 +20,7 @@ pub(crate) enum UserNotification {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use super::*;
 
     #[test]

--- a/codex-rs/core/tests/live_cli.rs
+++ b/codex-rs/core/tests/live_cli.rs
@@ -15,6 +15,7 @@ fn require_api_key() -> String {
 
 /// Helper that spawns the binary inside a TempDir with minimal flags. Returns (Assert, TempDir).
 fn run_live(prompt: &str) -> (assert_cmd::assert::Assert, TempDir) {
+    #![allow(clippy::unwrap_used)]
     use std::io::Read;
     use std::io::Write;
     use std::thread;
@@ -110,6 +111,7 @@ fn run_live(prompt: &str) -> (assert_cmd::assert::Assert, TempDir) {
 #[ignore]
 #[test]
 fn live_create_file_hello_txt() {
+    #![allow(clippy::unwrap_used)]
     if std::env::var("OPENAI_API_KEY").is_err() {
         eprintln!("skipping live_create_file_hello_txt – OPENAI_API_KEY not set");
         return;

--- a/codex-rs/core/tests/previous_response_id.rs
+++ b/codex-rs/core/tests/previous_response_id.rs
@@ -48,6 +48,8 @@ data: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"{}\",\"output\":
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn keeps_previous_response_id_between_tasks() {
+    #![allow(clippy::unwrap_used)]
+
     // Mock server
     let server = MockServer::start().await;
 

--- a/codex-rs/core/tests/stream_no_completed.rs
+++ b/codex-rs/core/tests/stream_no_completed.rs
@@ -32,6 +32,8 @@ data: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"{}\",\"output\":
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn retries_on_early_close() {
+    #![allow(clippy::unwrap_used)]
+
     let server = MockServer::start().await;
 
     struct SeqResponder;

--- a/codex-rs/execpolicy/src/execv_checker.rs
+++ b/codex-rs/execpolicy/src/execv_checker.rs
@@ -140,6 +140,7 @@ fn is_executable_file(path: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::unwrap_used)]
     use tempfile::TempDir;
 
     use super::*;

--- a/codex-rs/execpolicy/tests/head.rs
+++ b/codex-rs/execpolicy/tests/head.rs
@@ -67,7 +67,10 @@ fn test_head_one_flag_one_file() -> Result<()> {
             exec: ValidExec {
                 program: "head".to_string(),
                 flags: vec![],
-                opts: vec![MatchedOpt::new("-n", "100", ArgType::PositiveInteger).unwrap()],
+                opts: vec![
+                    MatchedOpt::new("-n", "100", ArgType::PositiveInteger)
+                        .expect("should validate")
+                ],
                 args: vec![MatchedArg::new(
                     2,
                     ArgType::ReadableFile,

--- a/codex-rs/execpolicy/tests/sed.rs
+++ b/codex-rs/execpolicy/tests/sed.rs
@@ -47,7 +47,10 @@ fn test_sed_print_specific_lines_with_e_flag() -> Result<()> {
             exec: ValidExec {
                 program: "sed".to_string(),
                 flags: vec![MatchedFlag::new("-n")],
-                opts: vec![MatchedOpt::new("-e", "122,202p", ArgType::SedCommand).unwrap()],
+                opts: vec![
+                    MatchedOpt::new("-e", "122,202p", ArgType::SedCommand)
+                        .expect("should validate")
+                ],
                 args: vec![MatchedArg::new(3, ArgType::ReadableFile, "hello.txt")?],
                 system_path: vec!["/usr/bin/sed".to_string()],
             }


### PR DESCRIPTION
https://github.com/openai/codex/pull/855 added the clippy warning to disallow `unwrap()`, but apparently we were not verifying that tests were "clippy clean" in CI, so I ended up with a lot of local errors in VS Code.

This turns on the check in CI and fixes the offenders.