### PR TITLE
Feature/mount-config-dir-into-container

### DIFF
--- a/codex-cli/scripts/run_in_container.sh
+++ b/codex-cli/scripts/run_in_container.sh
@@ -2,10 +2,11 @@
 set -e
 
 # Usage:
-#   ./run_in_container.sh [--work_dir directory] "COMMAND"
+#   ./run_in_container.sh [--work-dir directory] [--config directory] "COMMAND"
 #
 #   Examples:
-#     ./run_in_container.sh --work_dir project/code "ls -la"
+#     ./run_in_container.sh --work-dir project/code --config ~/.codex "codex run"
+#     ./run_in_container.sh --work-dir project/code "ls -la"
 #     ./run_in_container.sh "echo Hello, world!"
 
 # Default the work directory to WORKSPACE_ROOT_DIR if not provided.


### PR DESCRIPTION
Fixes https://github.com/openai/codex/issues/789

## What?

This PR enhances `run_in_container.sh` by optionally mounting the user's local `.codex` configuration directory into the Docker container. This allows configuration and session persistence between container restarts.

### Key Changes:

- Adds an optional `--config` flag.
- Default configuration path: `$HOME/.codex` if `--config` not provided.
- Updates usage examples and documentation.

## Why?

* Currently, users lose Codex CLI configurations (approval modes, presets, logs) between container runs, as no persistent storage is provided. This change aligns Linux Docker behavior with other environments and improves the overall developer experience.

* Until the rust implementation will run stable with sandbox features for all OS, this improves the general experience for linux users with the containerized TS version until rust is ready.
## How?

- Implemented optional bind mount based on the existence of the provided config directory.
- Ensured backward compatibility: no breaking changes for existing users who do not provide a config path.

## Manual Testing Steps:

1. Build the container:
    ```bash
    ./codex-cli/scripts/build_container.sh
    ```

2. Execute Codex CLI with config mounted:
    ```bash
    ./codex-cli/scripts/run_in_container.sh \
      --work-dir "$(pwd)" \
      --config ~/.codex \
      "COMMAND"
      
      ./codex-cli/scripts/run_in_container.sh \
      "COMMAND"
    ```

3. Confirm that the mounted config is active (e.g., correct approval mode loaded).

Tested locally with success.

## Checklist:
- [x] Implementation
- [x] Local testing: `pnpm test && pnpm lint && pnpm typecheck` -> Passed: [log](https://app.warp.dev/block/5R65Q1I94TdTJi8MZYVvsQ)
- [x] Manual testing done: 
    - `~/.codex/config.yml` contains: `model: o4-mini & approvalMode: suggest`, as you can see in the screenshot below the config is mounted and used correctly in the local conatiner run. 
        
        
        ![image](https://github.com/user-attachments/assets/c5f50d41-5fa3-41da-9b4a-de1dbbb5f625)

- [x] Examples updated in [run_in_container.sh](https://github.com/braun-viathan/codex-cli/blob/feature/mount-config-dir-into-container/codex-cli/scripts/run_in_container.sh)
### Open Question:
- Awaiting feedback if further unit or e2e are needed either to run locally or in ci before merging this one.
