### PR TITLE
fix: update Gemini base URL to the correct endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ Below is a comprehensive example of `config.json` with multiple custom providers
     },
     "gemini": {
       "name": "Gemini",
-      "baseURL": "https://generativelanguage.googleapis.com/v1beta/openai",
+      "baseURL": "https://generativelanguage.googleapis.com/v1beta/models",
       "envKey": "GEMINI_API_KEY"
     },
     "ollama": {

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -14,7 +14,7 @@ export const providers: Record<
   },
   gemini: {
     name: "Gemini",
-    baseURL: "https://generativelanguage.googleapis.com/v1beta/openai",
+    baseURL: "https://generativelanguage.googleapis.com/v1beta/models",
     envKey: "GEMINI_API_KEY",
   },
   ollama: {

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -100,7 +100,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
             "gemini",
             P {
                 name: "Gemini".into(),
-                base_url: "https://generativelanguage.googleapis.com/v1beta/openai".into(),
+                base_url: "https://generativelanguage.googleapis.com/v1beta/models".into(),
                 env_key: Some("GEMINI_API_KEY".into()),
                 env_key_instructions: None,
                 wire_api: WireApi::Chat,


### PR DESCRIPTION
This pull request updates the base URL for the Gemini provider across multiple files to ensure consistency and accuracy. The changes replace the outdated URL with the correct one.

### Updates to Gemini provider configuration:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L404-R404): Updated the example configuration to use the new base URL `https://generativelanguage.googleapis.com/v1beta/models` for the Gemini provider.
* [`codex-cli/src/utils/providers.ts`](diffhunk://#diff-b5be3ee91dfdd2fdddf1d835d25e784e1c96116e126f5d2ea7d467638033a647L17-R17): Updated the `providers` record to reflect the new base URL for the Gemini provider.
* [`codex-rs/core/src/model_provider_info.rs`](diffhunk://#diff-76fcdc000bc34710c8e5e49240491bd704aab05f3cd89770d3cd65d18f36f83dL103-R103): Updated the `built_in_model_providers` function to use the new base URL for the Gemini provider.

Should fix #880 