### PR TITLE
restructure flake for codex-rs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,7 @@ yarn.lock
 package.json-e
 session.ts-e
 CHANGELOG.ignore.md
+
+# nix related
+.direnv
+.envrc

--- a/README.md
+++ b/README.md
@@ -655,7 +655,9 @@ Prerequisite: Nix >= 2.4 with flakes enabled (`experimental-features = nix-comma
 Enter a Nix development shell:
 
 ```bash
-nix develop
+# Use either one of the commands according to which implementation you want to work with
+nix develop .#codex-cli # For entering codex-cli specific shell
+nix develop .#codex-rs # For entering codex-rs specific shell
 ```
 
 This shell includes Node.js, installs dependencies, builds the CLI, and provides a `codex` command alias.
@@ -663,15 +665,29 @@ This shell includes Node.js, installs dependencies, builds the CLI, and provides
 Build and run the CLI directly:
 
 ```bash
-nix build
+# Use either one of the commands according to which implementation you want to work with
+nix build .#codex-cli # For building codex-cli
+nix build .#codex-rs # For building codex-rs
 ./result/bin/codex --help
 ```
 
 Run the CLI via the flake app:
 
 ```bash
-nix run .#codex
+# Use either one of the commands according to which implementation you want to work with
+nix run .#codex-cli # For running codex-cli
+nix run .#codex-rs # For running codex-rs
 ```
+
+##### Use direnv with flakes
+
+If you have direnv installed, you can use the following `.envrc` to automatically enter the Nix shell when you `cd` into the project directory:
+
+```bash
+cd codex-rs
+echo "use flake ../flake.nix#codex-cli" >> .envrc && direnv allow
+cd codex-cli
+echo "use flake ../flake.nix#codex-rs" >> .envrc && direnv allow
 
 ---
 
@@ -684,3 +700,4 @@ Have you discovered a vulnerability or have concerns about model output? Please 
 ## License
 
 This repository is licensed under the [Apache-2.0 License](LICENSE).
+```

--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ nix run .#codex-cli # For running codex-cli
 nix run .#codex-rs # For running codex-rs
 ```
 
-##### Use direnv with flakes
+#### Use direnv with flakes
 
 If you have direnv installed, you can use the following `.envrc` to automatically enter the Nix shell when you `cd` into the project directory:
 
@@ -688,6 +688,7 @@ cd codex-rs
 echo "use flake ../flake.nix#codex-cli" >> .envrc && direnv allow
 cd codex-cli
 echo "use flake ../flake.nix#codex-rs" >> .envrc && direnv allow
+```
 
 ---
 
@@ -700,4 +701,3 @@ Have you discovered a vulnerability or have concerns about model output? Please 
 ## License
 
 This repository is licensed under the [Apache-2.0 License](LICENSE).
-```

--- a/README.md
+++ b/README.md
@@ -679,7 +679,7 @@ nix run .#codex-cli # For running codex-cli
 nix run .#codex-rs # For running codex-rs
 ```
 
-#### Use direnv with flakes
+Use direnv with flakes
 
 If you have direnv installed, you can use the following `.envrc` to automatically enter the Nix shell when you `cd` into the project directory:
 

--- a/codex-cli/default.nix
+++ b/codex-cli/default.nix
@@ -36,10 +36,8 @@ rec {
     '';
   };
   app = {
-    codex = {
-      type    = "app";
-      program = "${package}/bin/codex";
-    };
+    type    = "app";
+    program = "${package}/bin/codex";
   };
 }
 

--- a/codex-cli/default.nix
+++ b/codex-cli/default.nix
@@ -1,0 +1,45 @@
+{ pkgs, monorep-deps ? [], ... }:
+let
+  node = pkgs.nodejs_22;
+in
+rec {
+  package = pkgs.buildNpmPackage {
+    pname       = "codex-cli";
+    version     = "0.1.0";
+    src         = ./.;
+    npmDepsHash = "sha256-3tAalmh50I0fhhd7XreM+jvl0n4zcRhqygFNB1Olst8";
+    nodejs      = node;
+    npmInstallFlags = [ "--frozen-lockfile" ];
+    meta = with pkgs.lib; {
+      description = "OpenAI Codex command‑line interface";
+      license     = licenses.asl20;
+      homepage    = "https://github.com/openai/codex";
+    };
+  };
+  devShell = pkgs.mkShell {
+    name        = "codex-cli-dev";
+    buildInputs = monorep-deps ++ [
+      node
+      pkgs.pnpm
+    ];
+    shellHook = ''
+      echo "Entering development shell for codex-cli"
+      # cd codex-cli
+      if [ -f package-lock.json ]; then
+        pnpm ci || echo "npm ci failed"
+      else
+        pnpm install || echo "npm install failed"
+      fi
+      npm run build || echo "npm build failed"
+      export PATH=$PWD/node_modules/.bin:$PATH
+      alias codex="node $PWD/dist/cli.js"
+    '';
+  };
+  app = {
+    codex = {
+      type    = "app";
+      program = "${package}/bin/codex";
+    };
+  };
+}
+

--- a/codex-rs/default.nix
+++ b/codex-rs/default.nix
@@ -36,9 +36,7 @@ rec {
     '';
   };
   app = {
-    codex = {
-      type = "app";
-      program = "${package}/bin/codex";
-    };
+    type = "app";
+    program = "${package}/bin/codex";
   };
 }

--- a/codex-rs/default.nix
+++ b/codex-rs/default.nix
@@ -1,0 +1,44 @@
+{ pkgs, monorep-deps ? [], ... }:
+let
+  env = {
+    PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig:$PKG_CONFIG_PATH";
+  };
+in
+rec {
+  package = pkgs.rustPlatform.buildRustPackage {
+    inherit env;
+    pname = "codex-rs";
+    version = "0.1.0";
+    cargoLock.lockFile = ./Cargo.lock;
+    doCheck = false;
+    src = ./.;
+    nativeBuildInputs = with pkgs; [
+      pkg-config
+      openssl
+    ];
+    meta = with pkgs.lib; {
+      description = "OpenAI Codex command‑line interface rust implementation";
+      license = licenses.asl20;
+      homepage = "https://github.com/openai/codex";
+    };
+  };
+  devShell = pkgs.mkShell {
+    inherit env;
+    name = "codex-rs-dev";
+    packages = monorep-deps ++ [
+      pkgs.cargo
+      package
+    ];
+    shellHook = ''
+      echo "Entering development shell for codex-rs"
+      alias codex="cd ${package.src}/tui; cargo run; cd -"
+      ${pkgs.rustPlatform.cargoSetupHook}
+    '';
+  };
+  app = {
+    codex = {
+      type = "app";
+      program = "${package}/bin/codex";
+    };
+  };
+}

--- a/flake.lock
+++ b/flake.lock
@@ -37,7 +37,28 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1746844454,
+        "narHash": "sha256-GcUWDQUDRYrD34ol90KGUpjbVcOfUNbv0s955jPecko=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "be092436d4c0c303b654e4007453b69c0e33009e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -4,48 +4,52 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, flake-utils, ... }: 
-    flake-utils.lib.eachDefaultSystem (system: let
-      pkgs = import nixpkgs { inherit system; };
-      node = pkgs.nodejs_22;
-    in rec {
-      packages = {
-        codex-cli = pkgs.buildNpmPackage rec {
-          pname       = "codex-cli";
-          version     = "0.1.0";
-          src         = self + "/codex-cli";
-          npmDepsHash = "sha256-riVXC7T9zgUBUazH5Wq7+MjU1FepLkp9kHLSq+ZVqbs=";
-          nodejs      = node;
-          npmInstallFlags = [ "--frozen-lockfile" ];
-          meta = with pkgs.lib; {
-            description = "OpenAI Codex command‑line interface";
-            license     = licenses.asl20;
-            homepage    = "https://github.com/openai/codex";
-          };
+  outputs = { nixpkgs, flake-utils, rust-overlay, ... }: 
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
         };
-      };
-      defaultPackage = packages.codex-cli;
-      devShell = pkgs.mkShell {
-        name        = "codex-cli-dev";
-        buildInputs = [
-          node
+        pkgsWithRust = import nixpkgs {
+          inherit system;
+          overlays = [ rust-overlay.overlays.default ];
+        };
+        monorepo-dep = with pkgs; [
+          pnpm # for precommit hook
         ];
-        shellHook = ''
-          echo "Entering development shell for codex-cli"
-          cd codex-cli
-          npm ci
-          npm run build
-          export PATH=$PWD/node_modules/.bin:$PATH
-          alias codex="node $PWD/dist/cli.js"
-        '';
-      };
-      apps = {
-        codex = {
-          type    = "app";
-          program = "${packages.codex-cli}/bin/codex";
+        codex-cli = import ./codex-cli {
+          inherit pkgs monorepo-dep;
         };
-      };
-    });
+        codex-rs = import ./codex-rs {
+          pkgs = pkgsWithRust;
+          inherit monorepo-dep;
+        };
+      in
+      rec {
+        packages = {
+          codex-cli = codex-cli.package;
+          codex-rs = codex-rs.package;
+        };
+
+        devShells = {
+          codex-cli = codex-cli.devShell;
+          codex-rs = codex-rs.devShell;
+        };
+
+        apps = {
+          codex-cli = codex-cli.app;
+          codex-rs = codex-rs.app;
+        };
+
+        defaultPackage = packages.codex-cli;
+        defaultApp = apps.codex-cli;
+        defaultDevShell = devShells.codex-cli;
+      }
+    );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -20,15 +20,17 @@
           inherit system;
           overlays = [ rust-overlay.overlays.default ];
         };
-        monorepo-dep = with pkgs; [
-          pnpm # for precommit hook
+        monorepo-deps = with pkgs; [
+          # for precommit hook
+          pnpm
+          husky
         ];
         codex-cli = import ./codex-cli {
-          inherit pkgs monorepo-dep;
+          inherit pkgs monorepo-deps;
         };
         codex-rs = import ./codex-rs {
           pkgs = pkgsWithRust;
-          inherit monorepo-dep;
+          inherit monorepo-deps;
         };
       in
       rec {


### PR DESCRIPTION
Right now since the repo is having two different implementations of codex, flake was updated to work with both typescript implementation and rust implementation