### PR TITLE
fix: fix border style for BottomPane

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -252,10 +252,7 @@ impl ChatWidget<'_> {
                     cwd,
                     reason,
                 };
-                let needs_redraw = self.bottom_pane.push_approval_request(request);
-                if needs_redraw {
-                    self.request_redraw()?;
-                }
+                self.bottom_pane.push_approval_request(request)?;
             }
             EventMsg::ApplyPatchApprovalRequest {
                 changes,
@@ -284,8 +281,7 @@ impl ChatWidget<'_> {
                     reason,
                     grant_root,
                 };
-                let _needs_redraw = self.bottom_pane.push_approval_request(request);
-                // Redraw is always need because the history has changed.
+                self.bottom_pane.push_approval_request(request)?;
                 self.request_redraw()?;
             }
             EventMsg::ExecCommandBegin {

--- a/codex-rs/tui/src/status_indicator_widget.rs
+++ b/codex-rs/tui/src/status_indicator_widget.rs
@@ -120,7 +120,7 @@ impl WidgetRef for StatusIndicatorWidget {
             .padding(Padding::new(1, 0, 0, 0))
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)
-            .border_style(widget_style);
+            .border_style(widget_style.dim());
         // Animated 3‑dot pattern inside brackets. The *active* dot is bold
         // white, the others are dim.
         const DOT_COUNT: usize = 3;


### PR DESCRIPTION
This PR fixes things so that:

* when the `BottomPane` is in the `StatusIndicator` state, the border should be dim
* when the `BottomPane` does not have input focus, the border should be dim

To make it easier to enforce this invariant, this PR introduces `BottomPane::set_state()` that will:

* update `self.state`
* call `update_border_for_input_focus()`
* request a repaint

This should make it easier to enforce other updates for state changes going forward.