### PR TITLE
fix: Normalize paths in resolvePathAgainstWorkdir to prevent path traversal vulnerability

### DIFF
--- a/codex-cli/src/approvals.ts
+++ b/codex-cli/src/approvals.ts
@@ -281,12 +281,14 @@ export function resolvePathAgainstWorkdir(
   candidatePath: string,
   workdir: string | undefined,
 ): string {
-  if (path.isAbsolute(candidatePath)) {
-    return candidatePath;
+  // Normalize candidatePath to prevent path traversal attacks
+  const normalizedCandidatePath = path.normalize(candidatePath);
+  if (path.isAbsolute(normalizedCandidatePath)) {
+    return normalizedCandidatePath;
   } else if (workdir != null) {
-    return path.resolve(workdir, candidatePath);
+    return path.resolve(workdir, normalizedCandidatePath);
   } else {
-    return path.resolve(candidatePath);
+    return path.resolve(normalizedCandidatePath);
   }
 }
 


### PR DESCRIPTION
This PR fixes a potential path traversal vulnerability by ensuring all paths are properly normalized in the `resolvePathAgainstWorkdir` function.

## Changes
- Added path normalization for both absolute and relative paths
- Ensures normalized paths are used in all subsequent operations
- Prevents potential path traversal attacks through non-normalized paths

This minimal change addresses the security concern without adding unnecessary complexity, while maintaining compatibility with existing code.