### PR TITLE
fix: navigate initialization phase before tools/list request in MCP client

### DIFF
--- a/codex-rs/mcp-client/src/main.rs
+++ b/codex-rs/mcp-client/src/main.rs
@@ -10,10 +10,16 @@
 //! program. The utility connects, issues a `tools/list` request and prints the
 //! server's response as pretty JSON.
 
+use std::time::Duration;
+
 use anyhow::Context;
 use anyhow::Result;
 use codex_mcp_client::McpClient;
+use mcp_types::ClientCapabilities;
+use mcp_types::Implementation;
+use mcp_types::InitializeRequestParams;
 use mcp_types::ListToolsRequestParams;
+use mcp_types::MCP_SCHEMA_VERSION;
 
 #[tokio::main]
 async fn main() -> Result<()> {
@@ -32,6 +38,25 @@ async fn main() -> Result<()> {
     let client = McpClient::new_stdio_client(program, args, env)
         .await
         .with_context(|| format!("failed to spawn subprocess: {original_args:?}"))?;
+
+    let params = InitializeRequestParams {
+        capabilities: ClientCapabilities {
+            experimental: None,
+            roots: None,
+            sampling: None,
+        },
+        client_info: Implementation {
+            name: "codex-mcp-client".to_owned(),
+            version: env!("CARGO_PKG_VERSION").to_owned(),
+        },
+        protocol_version: MCP_SCHEMA_VERSION.to_owned(),
+    };
+    let initialize_notification_params = None;
+    let timeout = Some(Duration::from_secs(10));
+    let response = client
+        .initialize(params, initialize_notification_params, timeout)
+        .await?;
+    eprintln!("initialize response: {response:?}");
 
     // Issue `tools/list` request (no params).
     let timeout = None;


### PR DESCRIPTION
Apparently the MCP server implemented in JavaScript did not require the `initialize` handshake before responding to tool list/call, so I missed this. 