### PR TITLE
feat: Add per-repo memory file support & /settings command

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,12 +228,12 @@ Key flags: `--model/-m`, `--approval-mode/-a`, `--quiet/-q`, and `--notify`.
 
 ## Memory & project docs
 
-Codex merges Markdown and memory in this order:
+You can give Codex extra instructions and guidance using `AGENTS.md` files. Codex looks for `AGENTS.md` files in the following places, and merges them top-down:
 
-1. `~/.codex/instructions.md` – personal global guidance
+1. `~/.codex/AGENTS.md` - personal global guidance
 2. `~/.codex/memory/<repo-hash>.memory.md` – repository memory (past conversations & commands, enable in /settings)
-3. `codex.md` at repo root – shared project notes
-4. `codex.md` in cwd – sub-package specifics
+3. `AGENTS.md` at repo root - shared project notes
+4. `AGENTS.md` in the current working directory - sub-folder/feature specifics
 
 Disable loading of these files with `--no-project-doc` or the environment variable `CODEX_DISABLE_PROJECT_DOC=1`.
 

--- a/README.md
+++ b/README.md
@@ -228,11 +228,12 @@ Key flags: `--model/-m`, `--approval-mode/-a`, `--quiet/-q`, and `--notify`.
 
 ## Memory & project docs
 
-You can give Codex extra instructions and guidance using `AGENTS.md` files. Codex looks for `AGENTS.md` files in the following places, and merges them top-down:
+Codex merges Markdown and memory in this order:
 
-1. `~/.codex/AGENTS.md` - personal global guidance
-2. `AGENTS.md` at repo root - shared project notes
-3. `AGENTS.md` in the current working directory - sub-folder/feature specifics
+1. `~/.codex/instructions.md` – personal global guidance
+2. `~/.codex/memory/<repo-hash>.memory.md` – repository memory (past conversations & commands, enable in /settings)
+3. `codex.md` at repo root – shared project notes
+4. `codex.md` in cwd – sub-package specifics
 
 Disable loading of these files with `--no-project-doc` or the environment variable `CODEX_DISABLE_PROJECT_DOC=1`.
 

--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -54,7 +54,7 @@ export default function TerminalChatInput({
   openApprovalOverlay,
   openHelpOverlay,
   openDiffOverlay,
-  openSettingsOverlay,
+  openSettingsOverlay = () => {},
   onCompact,
   interruptAgent,
   active,
@@ -78,7 +78,7 @@ export default function TerminalChatInput({
   openApprovalOverlay: () => void;
   openHelpOverlay: () => void;
   openDiffOverlay: () => void;
-  openSettingsOverlay: () => void;
+  openSettingsOverlay?: () => void;
   onCompact: () => void;
   interruptAgent: () => void;
   active: boolean;

--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -10,7 +10,7 @@ import type {
 import MultilineTextEditor from "./multiline-editor";
 import { TerminalChatCommandReview } from "./terminal-chat-command-review.js";
 import TextCompletions from "./terminal-chat-completions.js";
-import { loadConfig } from "../../utils/config.js";
+import { loadConfig, appendMemoryFile } from "../../utils/config.js";
 import { getFileSystemSuggestions } from "../../utils/file-system-suggestions.js";
 import { expandFileTags } from "../../utils/file-tag-utils";
 import { createInputItem } from "../../utils/input-utils.js";
@@ -485,7 +485,20 @@ export default function TerminalChatInput({
 
       if (!inputValue) {
         return;
-      } else if (inputValue === "/history") {
+      }
+      // Capture user input to memory if enabled
+      // Record user input in memory
+      try {
+        const cfg = loadConfig();
+        if (cfg.memory?.enabled) {
+          const cwd = process.cwd();
+          const entry = `user: ${inputValue}`;
+          appendMemoryFile(cwd, entry);
+        }
+      } catch {
+        // ignore any memory errors
+      }
+      if (inputValue === "/history") {
         setInput("");
         openOverlay();
         return;

--- a/codex-cli/src/components/chat/terminal-chat-input.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-input.tsx
@@ -54,6 +54,7 @@ export default function TerminalChatInput({
   openApprovalOverlay,
   openHelpOverlay,
   openDiffOverlay,
+  openSettingsOverlay,
   onCompact,
   interruptAgent,
   active,
@@ -77,6 +78,7 @@ export default function TerminalChatInput({
   openApprovalOverlay: () => void;
   openHelpOverlay: () => void;
   openDiffOverlay: () => void;
+  openSettingsOverlay: () => void;
   onCompact: () => void;
   interruptAgent: () => void;
   active: boolean;
@@ -294,6 +296,9 @@ export default function TerminalChatInput({
                   break;
                 case "/diff":
                   openDiffOverlay();
+                  break;
+                case "/settings":
+                  openSettingsOverlay();
                   break;
                 case "/bug":
                   onSubmit(cmd);

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -257,14 +257,18 @@ export default function TerminalChat({
         setItems((prev) => {
           const updated = uniqueById([...prev, item as ResponseItem]);
           saveRollout(sessionId, updated);
-          // Persist memory if enabled: record assistant outputs
-          if (config.memory?.enabled) {
+          // Persist memory if enabled: record assistant outputs (only items with content)
+          if (config.memory?.enabled && "content" in item) {
             try {
-              // Record assistant (codex) output
-              const content = (item as ResponseItem).content || [];
-              const texts = content
-                .filter((c) => c.type === "output_text")
-                .map((c) => (c as { text: string }).text)
+              const contentItems = item.content ?? [];
+              const texts = (
+                contentItems as Array<{ type: "output_text"; text: string }>
+              )
+                .filter(
+                  (c): c is { type: "output_text"; text: string } =>
+                    c.type === "output_text",
+                )
+                .map((c) => c.text)
                 .join(" ");
               if (texts) {
                 appendMemoryFile(process.cwd(), `codex: ${texts}`);

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -13,7 +13,7 @@ import { useTerminalSize } from "../../hooks/use-terminal-size.js";
 import { AgentLoop } from "../../utils/agent/agent-loop.js";
 import { ReviewDecision } from "../../utils/agent/review.js";
 import { generateCompactSummary } from "../../utils/compact-summary.js";
-import { saveConfig } from "../../utils/config.js";
+import { saveConfig, appendMemoryFile } from "../../utils/config.js";
 import { extractAppliedPatches as _extractAppliedPatches } from "../../utils/extract-applied-patches.js";
 import { getGitDiff } from "../../utils/get-diff.js";
 import { createInputItem } from "../../utils/input-utils.js";
@@ -32,6 +32,7 @@ import DiffOverlay from "../diff-overlay.js";
 import HelpOverlay from "../help-overlay.js";
 import HistoryOverlay from "../history-overlay.js";
 import ModelOverlay from "../model-overlay.js";
+import SettingsOverlay from "../settings-overlay.js";
 import chalk from "chalk";
 import { Box, Text } from "ink";
 import { spawn } from "node:child_process";
@@ -44,7 +45,8 @@ export type OverlayModeType =
   | "model"
   | "approval"
   | "help"
-  | "diff";
+  | "diff"
+  | "settings";
 
 type Props = {
   config: AppConfig;
@@ -149,6 +151,10 @@ export default function TerminalChat({
     initialApprovalPolicy,
   );
   const [thinkingSeconds, setThinkingSeconds] = useState(0);
+  // Repository-specific memory enabled state
+  const [memoryEnabled, setMemoryEnabled] = useState<boolean>(
+    Boolean(config.memory?.enabled),
+  );
 
   const handleCompact = async () => {
     setLoading(true);
@@ -251,6 +257,22 @@ export default function TerminalChat({
         setItems((prev) => {
           const updated = uniqueById([...prev, item as ResponseItem]);
           saveRollout(sessionId, updated);
+          // Persist memory if enabled: record assistant outputs
+          if (config.memory?.enabled) {
+            try {
+              // Collect any output_text from the item
+              const content = (item as ResponseItem).content || [];
+              const texts = content
+                .filter((c) => c.type === "output_text")
+                .map((c) => (c as { text: string }).text)
+                .join(" ");
+              if (texts) {
+                appendMemoryFile(process.cwd(), texts);
+              }
+            } catch (err) {
+              log(`Error writing memory file: ${err}`);
+            }
+          }
           return updated;
         });
       },
@@ -528,6 +550,7 @@ export default function TerminalChat({
               // Ensure no overlay is shown.
               setOverlayMode("none");
             }}
+            openSettingsOverlay={() => setOverlayMode("settings")}
             onCompact={handleCompact}
             active={overlayMode === "none"}
             interruptAgent={() => {
@@ -720,6 +743,19 @@ export default function TerminalChat({
         {overlayMode === "diff" && (
           <DiffOverlay
             diffText={diffText}
+            onExit={() => setOverlayMode("none")}
+          />
+        )}
+        {overlayMode === "settings" && (
+          <SettingsOverlay
+            currentMemory={memoryEnabled}
+            onToggle={(enabled) => {
+              setMemoryEnabled(enabled);
+              saveConfig({
+                ...config,
+                memory: { enabled },
+              });
+            }}
             onExit={() => setOverlayMode("none")}
           />
         )}

--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -260,14 +260,14 @@ export default function TerminalChat({
           // Persist memory if enabled: record assistant outputs
           if (config.memory?.enabled) {
             try {
-              // Collect any output_text from the item
+              // Record assistant (codex) output
               const content = (item as ResponseItem).content || [];
               const texts = content
                 .filter((c) => c.type === "output_text")
                 .map((c) => (c as { text: string }).text)
                 .join(" ");
               if (texts) {
-                appendMemoryFile(process.cwd(), texts);
+                appendMemoryFile(process.cwd(), `codex: ${texts}`);
               }
             } catch (err) {
               log(`Error writing memory file: ${err}`);

--- a/codex-cli/src/components/help-overlay.tsx
+++ b/codex-cli/src/components/help-overlay.tsx
@@ -43,6 +43,9 @@ export default function HelpOverlay({
           <Text color="cyan">/approval</Text> – switch auto‑approval mode
         </Text>
         <Text>
+          <Text color="cyan">/settings</Text> – open settings menu
+        </Text>
+        <Text>
           <Text color="cyan">/history</Text> – show command &amp; file history
           for this session
         </Text>

--- a/codex-cli/src/components/settings-overlay.tsx
+++ b/codex-cli/src/components/settings-overlay.tsx
@@ -1,0 +1,36 @@
+import TypeaheadOverlay from "./typeahead-overlay.js";
+import { Text } from "ink";
+import React from "react";
+
+type Props = {
+  /** Current memory enabled state */
+  currentMemory: boolean;
+  /** Toggle memory enabled, then exit */
+  onToggle: (enabled: boolean) => void;
+  /** Exit overlay without changes */
+  onExit: () => void;
+};
+
+/**
+ * Overlay to toggle repository-specific memory file usage.
+ */
+export default function SettingsOverlay({
+  currentMemory,
+  onToggle,
+  onExit,
+}: Props): JSX.Element {
+  const label = `Use memory file: ${currentMemory ? "On" : "Off"}`;
+  const items = [{ label, value: "memory" }];
+  return (
+    <TypeaheadOverlay
+      title="Settings"
+      description={<Text>Toggle repository memory feature</Text>}
+      initialItems={items}
+      currentValue="memory"
+      onSelect={() => {
+        onToggle(!currentMemory);
+      }}
+      onExit={onExit}
+    />
+  );
+}

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -18,6 +18,7 @@ import {
   getApiKey,
   getBaseUrl,
   AZURE_OPENAI_API_VERSION,
+  appendMemoryFile,
 } from "../config.js";
 import { log } from "../logger/log.js";
 import { parseToolCallArguments } from "../parsers.js";
@@ -448,6 +449,16 @@ export class AgentLoop {
         this.getCommandConfirmation,
         this.execAbortController?.signal,
       );
+      // Record command and its stdout in memory
+      try {
+        if (this.config.memory?.enabled) {
+          const cwd = args.workdir || process.cwd();
+          appendMemoryFile(cwd, `command: ${args.cmd.join(" ")}`);
+          appendMemoryFile(cwd, `command.stdout: ${outputText}`);
+        }
+      } catch (err) {
+        log(`Error writing memory file: ${err}`);
+      }
       outputItem.output = JSON.stringify({ output: outputText, metadata });
 
       if (additionalItemsFromExec) {

--- a/codex-cli/src/utils/slash-commands.ts
+++ b/codex-cli/src/utils/slash-commands.ts
@@ -32,4 +32,5 @@ export const SLASH_COMMANDS: Array<SlashCommand> = [
     description:
       "Show git diff of the working directory (or applied patches if not in git)",
   },
+  { command: "/settings", description: "Open settings menu" },
 ];

--- a/codex-cli/tests/memory-file.test.ts
+++ b/codex-cli/tests/memory-file.test.ts
@@ -1,0 +1,41 @@
+import { test, expect, vi } from "vitest";
+import fs from "fs";
+import path from "path";
+import os from "os";
+
+import {
+  loadConfig,
+  saveConfig,
+  appendMemoryFile,
+  getMemoryFilePath,
+} from "../src/utils/config";
+
+test("memory file append and load", () => {
+  // Create a temporary home directory to isolate config
+  const tmpHome = fs.mkdtempSync(path.join(os.tmpdir(), "codex-test-home-"));
+  vi.spyOn(os, "homedir").mockReturnValue(tmpHome);
+
+  // Create a temporary project directory
+  const tmpProject = fs.mkdtempSync(path.join(os.tmpdir(), "codex-test-proj-"));
+
+  // Initial load to create default config
+  const initialConfig = loadConfig(undefined, undefined, { cwd: tmpProject });
+  // Enable memory in config and save
+  initialConfig.memory = { enabled: true };
+  saveConfig(initialConfig);
+
+  // Append a memory entry
+  const testEntry = "Ran ls and saw file1.txt file2.txt";
+  appendMemoryFile(tmpProject, testEntry);
+
+  // The memory file should exist and contain the entry
+  const memPath = getMemoryFilePath(tmpProject);
+  expect(fs.existsSync(memPath)).toBe(true);
+  const memContent = fs.readFileSync(memPath, "utf-8");
+  expect(memContent).toContain(testEntry + "\n");
+
+  // Reload config with memory enabled, and ensure instructions start with the memory
+  const loadedConfig = loadConfig(undefined, undefined, { cwd: tmpProject });
+  expect(loadedConfig.memory?.enabled).toBe(true);
+  expect(loadedConfig.instructions.startsWith(testEntry)).toBe(true);
+});


### PR DESCRIPTION
## What?

This PR introduces a new repository-specific memory feature, plus a /settings command to toggle it. Memory is persisted to
`~/.codex/memory/<repo-hash>.memory.md`
and automatically merged into your prompt context alongside existing instructions and project docs.

Specifically, we now record and label:

* **User inputs** (`user:`)
* **Shell commands** and their standard output (`command:`, `command.stdout:`)
* **Assistant (Codex) outputs** (`codex:`)

All of the above are appended to the per-repo memory file when the feature is enabled.

-----------------------------------------------------------------------------

## Why?

Current Codex sessions are stateless between runs, so context is lost on exit. By persisting a lightweight “memory” of what you asked, what commands ran, and what Codex responded, we can rehydrate that history automatically on next invocation; improving continuity, reducing “Where was I?” follow-ups, and enabling richer conversations over time.

-----------------------------------------------------------------------------

## How?

### Slash-commands & UI

    * Added `"/settings"` to `SLASH_COMMANDS` for autocompletion.
    * Created `SettingsOverlay` component under `src/components/` to toggle memory on/off.
    * Extended `TerminalChatInput` and `TerminalChat` to wire up `openSettingsOverlay`, handle the new `settings` overlay mode, and include `/settings` in the help menu.
    * Updated `HelpOverlay` to list `/settings` under *Slash-commands*.

### Configuration

    * In `src/utils/config.ts`:
        * Defined `MEMORY_DIR = ~/.codex/memory` & `getMemoryFilePath(cwd)` (SHA-256 of project root).
        * Added `appendMemoryFile(cwd, text)` helper.
        * Extended `StoredConfig` & `AppConfig` to include `memory?: {enabled: boolean }`.
        * On `loadConfig()`, if `memory.enabled`, read the memory file (logged) and inject its contents *after* `~/.codex/instructions.md` but *before* `codex.md` project docs.
        * On `saveConfig()`, persist the `memory.enabled` flag alongside other settings.
        * Updated README under “Memory & project docs” to reflect the new merge order:
            1. `~/.codex/instructions.md`
            2. `~/.codex/memory/<repo-hash>.memory.md`
            3. `codex.md` at repo root
            4. `codex.md` in cwd

### Memory Capture

* **User inputs**: In `TerminalChatInput.onSubmit`, before sending, we call `appendMemoryFile(cwd, "user: <input>")` if memory is enabled.
* **Assistant outputs**: In `TerminalChat`’s `onItem` handler, we filter for `output_text`, prefix with `codex:`, and append.
* **Commands & stdout**: In `agent-loop.ts`’s `handleFunctionCall`, after running `handleExecCommand`, we append:    command: <joined argv> command.stdout: <outputText>

### Testing

    * Added `codex-cli/tests/memory-file.test.ts` which:
        1. Mocks a temp home & project dir
        2. Enables memory via `saveConfig`
        3. Appends a test entry
        4. Verifies the memory file exists and content is labeled + newline-terminated
        5. Reloads `loadConfig()` and asserts that `instructions` begins with the memory content

### Lint & Types

* Fixed duplicate imports, import ordering (per ESLint `import/order`), and removed all remaining `any` usages.
* Switched array types to `Array<string>` to satisfy `@typescript-eslint/array-type`.
* All files now pass `pnpm run lint`, `pnpm run typecheck`, and existing tests.

-----------------------------------------------------------------------------

### For Contributors

I took great care in ensuring the code quality and test coverage of this PR, but am looking for feedback from reviewers. Please take a moment to review the code, and let me know if you have any comments or suggestions.

One important point of contention I had was *how* to include the toggle for memory file usage. I settled on a quick /settings menu implementation, but realize this may not be in-line with the intentions of other maintainers of codex. If you have suggestions or preferences for an alternative, please let me know!

-----------------------------------------------------------------------------

Please run the full suite locally before reviewing:

    pnpm install
    pnpm --filter @openai/codex run lint
    pnpm --filter @openai/codex run typecheck
    pnpm --filter @openai/codex run test

Thank you for taking a close look, eager to hear your feedback!