### PR TITLE
Add support for not requiring API key for custom model configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,11 +344,13 @@ Codex configuration files can be placed in the `~/.codex/` directory, supporting
 
 In the `providers` object, you can configure multiple AI service providers. Each provider requires the following parameters:
 
-| Parameter | Type   | Description                             | Example                       |
-| --------- | ------ | --------------------------------------- | ----------------------------- |
-| `name`    | string | Display name of the provider            | `"OpenAI"`                    |
-| `baseURL` | string | API service URL                         | `"https://api.openai.com/v1"` |
-| `envKey`  | string | Environment variable name (for API key) | `"OPENAI_API_KEY"`            |
+| Parameter | Type   | Description                                      | Example                       |
+| --------- | ------ | ------------------------------------------------ | ----------------------------- |
+| `name`    | string | Display name of the provider                     | `"OpenAI"`                    |
+| `baseURL` | string | API service URL                                  | `"https://api.openai.com/v1"` |
+| `envKey`  | string | Environment variable name for API key (optional) | `"OPENAI_API_KEY"`            |
+
+If `envKey` is not set, the provider is exempt from requiring an API key.
 
 ### History configuration
 
@@ -413,8 +415,7 @@ Below is a comprehensive example of `config.json` with multiple custom providers
     },
     "ollama": {
       "name": "Ollama",
-      "baseURL": "http://localhost:11434/v1",
-      "envKey": "OLLAMA_API_KEY"
+      "baseURL": "http://localhost:11434/v1"
     },
     "mistral": {
       "name": "Mistral",

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -305,23 +305,14 @@ if (!apiKey) {
 // Ensure the API key is available as an environment variable for legacy code
 process.env["OPENAI_API_KEY"] = apiKey;
 
-// Set of providers that don't require API keys, "ollama" for backwards compat
-// and those providers which don't provide `envKey` in configuration are exempt
-const NO_API_KEY_REQUIRED = new Set([
-  "ollama",
-  ...Object.entries(config.providers ?? [])
-    .filter(([_, providerConfg]) => !providerConfg.envKey)
-    .map((entry) => entry[0]),
-]);
-
 // Skip API key validation for providers that don't require an API key
-if (!apiKey && !NO_API_KEY_REQUIRED.has(provider.toLowerCase())) {
+if (!apiKey && !config.providers?.[provider]?.envKey != null) {
+  const apiKeyEnvVarName =
+    config.providers?.[provider]?.envKey ?? `${provider.toUpperCase()}_API_KEY`;
   // eslint-disable-next-line no-console
   console.error(
     `\n${chalk.red(`Missing ${provider} API key.`)}\n\n` +
-      `Set the environment variable ${chalk.bold(
-        `${provider.toUpperCase()}_API_KEY`,
-      )} ` +
+      `Set the environment variable ${chalk.bold(`${apiKeyEnvVarName}`)} ` +
       `and re-run this command.\n` +
       `${
         provider.toLowerCase() === "openai"
@@ -329,12 +320,10 @@ if (!apiKey && !NO_API_KEY_REQUIRED.has(provider.toLowerCase())) {
               chalk.underline("https://platform.openai.com/account/api-keys"),
             )}\n`
           : provider.toLowerCase() === "gemini"
-            ? `You can create a ${chalk.bold(
-                `${provider.toUpperCase()}_API_KEY`,
-              )} ` + `in the ${chalk.bold(`Google AI Studio`)}.\n`
-            : `You can create a ${chalk.bold(
-                `${provider.toUpperCase()}_API_KEY`,
-              )} ` + `in the ${chalk.bold(`${provider}`)} dashboard.\n`
+            ? `You can create a ${chalk.bold(`${apiKeyEnvVarName}`)} ` +
+              `in the ${chalk.bold(`Google AI Studio`)}.\n`
+            : `You can create a ${chalk.bold(`${apiKeyEnvVarName}`)} ` +
+              `in the ${chalk.bold(`${provider}`)} dashboard.\n`
       }`,
   );
   process.exit(1);

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -305,8 +305,14 @@ if (!apiKey) {
 // Ensure the API key is available as an environment variable for legacy code
 process.env["OPENAI_API_KEY"] = apiKey;
 
-// Set of providers that don't require API keys
-const NO_API_KEY_REQUIRED = new Set(["ollama"]);
+// Set of providers that don't require API keys, "ollama" for backwards compat
+// and those providers which don't provide `envKey` in configuration are exempt
+const NO_API_KEY_REQUIRED = new Set([
+  "ollama",
+  ...Object.entries(config.providers ?? [])
+    .filter(([_, providerConfg]) => !providerConfg.envKey)
+    .map((entry) => entry[0]),
+]);
 
 // Skip API key validation for providers that don't require an API key
 if (!apiKey && !NO_API_KEY_REQUIRED.has(provider.toLowerCase())) {

--- a/codex-cli/src/components/model-overlay.tsx
+++ b/codex-cli/src/components/model-overlay.tsx
@@ -1,3 +1,5 @@
+import type { providers } from "src/utils/providers.js";
+
 import TypeaheadOverlay from "./typeahead-overlay.js";
 import {
   getAvailableModels,
@@ -18,7 +20,7 @@ type Props = {
   currentModel: string;
   currentProvider?: string;
   hasLastResponse: boolean;
-  providers?: Record<string, { name: string; baseURL: string; envKey: string }>;
+  providers?: typeof providers;
   onSelect: (allModels: Array<string>, model: string) => void;
   onSelectProvider?: (provider: string) => void;
   onExit: () => void;

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -114,8 +114,8 @@ export function getApiKey(provider: string = "openai"): string | undefined {
   const providersConfig = config.providers ?? providers;
   const providerInfo = providersConfig[provider.toLowerCase()];
   if (providerInfo) {
-    if (providerInfo.name === "Ollama") {
-      return process.env[providerInfo.envKey] ?? "dummy";
+    if (!providerInfo.envKey || providerInfo.name === "Ollama") {
+      return "dummy";
     }
     return process.env[providerInfo.envKey];
   }
@@ -202,7 +202,7 @@ export type AppConfig = {
 
   /** Enable the "flex-mode" processing mode for supported models (o3, o4-mini) */
   flexMode?: boolean;
-  providers?: Record<string, { name: string; baseURL: string; envKey: string }>;
+  providers?: typeof providers;
   history?: {
     maxSize: number;
     saveHistory: boolean;

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -114,7 +114,7 @@ export function getApiKey(provider: string = "openai"): string | undefined {
   const providersConfig = config.providers ?? providers;
   const providerInfo = providersConfig[provider.toLowerCase()];
   if (providerInfo) {
-    if (!providerInfo.envKey || providerInfo.name === "Ollama") {
+    if (!providerInfo.envKey) {
       return "dummy";
     }
     return process.env[providerInfo.envKey];
@@ -149,7 +149,7 @@ export type StoredConfig = {
   /** Disable server-side response storage (send full transcript each request) */
   disableResponseStorage?: boolean;
   flexMode?: boolean;
-  providers?: Record<string, { name: string; baseURL: string; envKey: string }>;
+  providers?: typeof providers;
   history?: {
     maxSize?: number;
     saveHistory?: boolean;
@@ -361,6 +361,14 @@ export const loadConfig = (
       // If parsing fails, fall back to empty config to avoid crashing.
       storedConfig = {};
     }
+  }
+  // Remove `envKey` from Ollama provider if it exists. This was previously hardcoded
+  // so removing it is necessary from old stored configs
+  if (storedConfig.providers?.["ollama"]?.envKey != null) {
+    log(
+      `[codex] Warning: 'envKey' for Ollama provider is not supported, use a custom provider instead. Ignoring this value.`,
+    );
+    delete storedConfig.providers["ollama"].envKey;
   }
 
   if (

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -1,6 +1,6 @@
 export const providers: Record<
   string,
-  { name: string; baseURL: string; envKey: string }
+  { name: string; baseURL: string; envKey?: string }
 > = {
   openai: {
     name: "OpenAI",
@@ -25,7 +25,6 @@ export const providers: Record<
   ollama: {
     name: "Ollama",
     baseURL: "http://localhost:11434/v1",
-    envKey: "OLLAMA_API_KEY",
   },
   mistral: {
     name: "Mistral",


### PR DESCRIPTION
I run a self-hosted `ollama` setup in a URL different than `http://localhost:11434` (remote host).
The non-required API key setup previously done is solely targeted
for the provider named "Ollama". I want to add something like `ollama-remote` that would not require the API key.

This PR does just that for the Node.js version by adding a `noApiKeyRequired ' field to the `config.json`.

The Rust change simply adds the `--provider` CLI flag. I used it to quickly try out and verify that I could run my setup against it. It is not necessary to merge, and I can drop this change if it is unwanted.
