### PR TITLE
fix: remember to set lastIndex = 0 on shared RegExp

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat-response-item.tsx
+++ b/codex-cli/src/components/chat/terminal-chat-response-item.tsx
@@ -330,6 +330,7 @@ function rewriteFileCitations(
     return markdown;
   }
 
+  citationRegex.lastIndex = 0;
   return markdown.replace(citationRegex, (_match, file, start, _end) => {
     const absPath = path.resolve(cwd, file);
     const uri = `${fileOpener}://file${absPath}:${start}`;


### PR DESCRIPTION
I had not observed an issue in the wild because of this yet, but it feels like it was only a matter of time...