### PR TITLE
fix: test_dev_null_write() was not using echo as intended

### DIFF
--- a/codex-rs/core/src/landlock.rs
+++ b/codex-rs/core/src/landlock.rs
@@ -194,7 +194,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_dev_null_write() {
-        run_cmd(&["echo", "blah", ">", "/dev/null"], &[], 200).await;
+        run_cmd(&["bash", "-lc", "echo blah > /dev/null"], &[], 200).await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
I believe this test meant to verify that echoing content to `/dev/null` succeeded, but instead, I believe it was testing the equivalent to `echo 'blah > /dev/null'`.