### PR TITLE
bump(version): 0.1.2505140839

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 You can install any of these versions: `npm install -g codex@version`
 
+## `0.1.2505140839`
+
+### 🪲 Bug Fixes
+
+- Gpt-4.1 apply_patch handling (#930)
+- Add support for fileOpener in config.json (#911)
+- Patch in #366 and #367 for marked-terminal (#916)
+- Remember to set lastIndex = 0 on shared RegExp (#918)
+- Always load version from package.json at runtime (#909)
+- Tweak the label for citations for better rendering (#919)
+- Tighten up some logic around session timestamps and ids (#922)
+- Change EventMsg enum so every variant takes a single struct (#925)
+- Reasoning default to medium, show workdir when supplied (#931)
+- Test_dev_null_write() was not using echo as intended (#923)
+
 ## `0.1.2504301751`
 
 ### 🚀 Features


### PR DESCRIPTION
## `0.1.2505140839`

### 🪲 Bug Fixes

- Gpt-4.1 apply_patch handling (#930)
- Add support for fileOpener in config.json (#911)
- Patch in #366 and #367 for marked-terminal (#916)
- Remember to set lastIndex = 0 on shared RegExp (#918)
- Always load version from package.json at runtime (#909)
- Tweak the label for citations for better rendering (#919)
- Tighten up some logic around session timestamps and ids (#922)
- Change EventMsg enum so every variant takes a single struct (#925)
- Reasoning default to medium, show workdir when supplied (#931)
- Test_dev_null_write() was not using echo as intended (#923)