### PR TITLE
fix: increase timeout for test_dev_null_write

### DIFF
--- a/codex-rs/core/src/landlock.rs
+++ b/codex-rs/core/src/landlock.rs
@@ -194,7 +194,14 @@ mod tests {
 
     #[tokio::test]
     async fn test_dev_null_write() {
-        run_cmd(&["bash", "-lc", "echo blah > /dev/null"], &[], 200).await;
+        run_cmd(
+            &["bash", "-lc", "echo blah > /dev/null"],
+            &[],
+            // We have seen timeouts when running this test in CI on GitHub,
+            // so we are using a generous timeout until we can diagnose further.
+            1_000,
+        )
+        .await;
     }
 
     #[tokio::test]


### PR DESCRIPTION
After updating this test in https://github.com/openai/codex/pull/923, I have been getting some timeouts with this test in CI, so increasing the timeout to match that of `test_writable_root`:

https://github.com/openai/codex/blob/327cf41f0ff7f0816a141a260704270ed38c9fa4/codex-rs/core/src/landlock.rs#L211-L213