### PR TITLE
feat: add support for commands in the Rust TUI

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -632,6 +632,8 @@ dependencies = [
  "ratatui",
  "serde_json",
  "shlex",
+ "strum 0.27.1",
+ "strum_macros 0.27.1",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -2711,7 +2713,7 @@ dependencies = [
  "itertools 0.13.0",
  "lru",
  "paste",
- "strum",
+ "strum 0.26.3",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
@@ -3482,14 +3484,33 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
 ]
+
+[[package]]
+name = "strum"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 
 [[package]]
 name = "strum_macros"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.100",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c77a8c5abcaf0f9ce05d62342b7d298c346515365c36b673df4ebe3ced01fde8"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -29,6 +29,8 @@ ratatui = { version = "0.29.0", features = [
 ] }
 serde_json = "1"
 shlex = "1.3.0"
+strum = "0.27.1"
+strum_macros = "0.27.1"
 tokio = { version = "1", features = [
     "io-std",
     "macros",

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -3,6 +3,7 @@ use crate::chatwidget::ChatWidget;
 use crate::git_warning_screen::GitWarningOutcome;
 use crate::git_warning_screen::GitWarningScreen;
 use crate::scroll_event_helper::ScrollEventHelper;
+use crate::slash_command::SlashCommand;
 use crate::tui;
 use codex_core::config::Config;
 use codex_core::protocol::Event;
@@ -177,6 +178,14 @@ impl App<'_> {
                         let _ = self.chat_widget.update_latest_log(line);
                     }
                 }
+                AppEvent::DispatchCommand(command) => match command {
+                    SlashCommand::Clear => {
+                        let _ = self.chat_widget.clear_conversation_history();
+                    }
+                    SlashCommand::Quit => {
+                        break;
+                    }
+                },
             }
         }
         terminal.clear()?;

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -1,6 +1,8 @@
 use codex_core::protocol::Event;
 use crossterm::event::KeyEvent;
 
+use crate::slash_command::SlashCommand;
+
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum AppEvent {
     CodexEvent(Event),
@@ -22,4 +24,8 @@ pub(crate) enum AppEvent {
 
     /// Latest formatted log line emitted by `tracing`.
     LatestLog(String),
+
+    /// Dispatch a recognized slash command from the UI (composer) to the app
+    /// layer so it can be handled centrally.
+    DispatchCommand(SlashCommand),
 }

--- a/codex-rs/tui/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/command_popup.rs
@@ -1,0 +1,191 @@
+use std::collections::HashMap;
+
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Color;
+use ratatui::style::Style;
+use ratatui::widgets::Block;
+use ratatui::widgets::BorderType;
+use ratatui::widgets::Borders;
+use ratatui::widgets::Cell;
+use ratatui::widgets::Row;
+use ratatui::widgets::Table;
+use ratatui::widgets::Widget;
+use ratatui::widgets::WidgetRef;
+
+use crate::slash_command::SlashCommand;
+use crate::slash_command::built_in_slash_commands;
+
+const MAX_POPUP_ROWS: usize = 5;
+
+use ratatui::style::Modifier;
+
+pub(crate) struct CommandPopup {
+    command_filter: String,
+    all_commands: HashMap<&'static str, SlashCommand>,
+    selected_idx: Option<usize>,
+}
+
+impl CommandPopup {
+    pub(crate) fn new() -> Self {
+        Self {
+            command_filter: String::new(),
+            all_commands: built_in_slash_commands(),
+            selected_idx: None,
+        }
+    }
+
+    /// Update the filter string based on the current composer text. The text
+    /// passed in is expected to start with a leading '/'. Everything after the
+    /// *first* '/" on the *first* line becomes the active filter that is used
+    /// to narrow down the list of available commands.
+    pub(crate) fn on_composer_text_change(&mut self, text: String) {
+        let first_line = text.lines().next().unwrap_or("");
+
+        if let Some(stripped) = first_line.strip_prefix('/') {
+            // Extract the *first* token (sequence of non-whitespace
+            // characters) after the slash so that `/clear something` still
+            // shows the help for `/clear`.
+            let token = stripped.trim_start();
+            let cmd_token = token.split_whitespace().next().unwrap_or("");
+
+            // Update the filter keeping the original case (commands are all
+            // lower-case for now but this may change in the future).
+            self.command_filter = cmd_token.to_string();
+        } else {
+            // The composer no longer starts with '/'. Reset the filter so the
+            // popup shows the *full* command list if it is still displayed
+            // for some reason.
+            self.command_filter.clear();
+        }
+
+        // Reset or clamp selected index based on new filtered list.
+        let matches_len = self.filtered_commands().len();
+        self.selected_idx = match matches_len {
+            0 => None,
+            _ => Some(self.selected_idx.unwrap_or(0).min(matches_len - 1)),
+        };
+    }
+
+    /// Determine the preferred height of the popup. This is the number of
+    /// rows required to show **at most** `MAX_POPUP_ROWS` commands plus the
+    /// table/border overhead (one line at the top and one at the bottom).
+    pub(crate) fn calculate_required_height(&self, _area: &Rect) -> u16 {
+        let matches = self.filtered_commands();
+        let row_count = matches.len().clamp(1, MAX_POPUP_ROWS) as u16;
+        // Account for the border added by the Block that wraps the table.
+        // 2 = one line at the top, one at the bottom.
+        row_count + 2
+    }
+
+    /// Return the list of commands that match the current filter. Matching is
+    /// performed using a *prefix* comparison on the command name.
+    fn filtered_commands(&self) -> Vec<&SlashCommand> {
+        let mut cmds: Vec<&SlashCommand> = self
+            .all_commands
+            .values()
+            .filter(|cmd| {
+                if self.command_filter.is_empty() {
+                    true
+                } else {
+                    cmd.command()
+                        .starts_with(&self.command_filter.to_ascii_lowercase())
+                }
+            })
+            .collect();
+
+        // Sort the commands alphabetically so the order is stable and
+        // predictable.
+        cmds.sort_by(|a, b| a.command().cmp(b.command()));
+        cmds
+    }
+
+    /// Move the selection cursor one step up.
+    pub(crate) fn move_up(&mut self) {
+        if let Some(len) = self.filtered_commands().len().checked_sub(1) {
+            if len == usize::MAX {
+                return;
+            }
+        }
+
+        if let Some(idx) = self.selected_idx {
+            if idx > 0 {
+                self.selected_idx = Some(idx - 1);
+            }
+        } else if !self.filtered_commands().is_empty() {
+            self.selected_idx = Some(0);
+        }
+    }
+
+    /// Move the selection cursor one step down.
+    pub(crate) fn move_down(&mut self) {
+        let matches_len = self.filtered_commands().len();
+        if matches_len == 0 {
+            self.selected_idx = None;
+            return;
+        }
+
+        match self.selected_idx {
+            Some(idx) if idx + 1 < matches_len => {
+                self.selected_idx = Some(idx + 1);
+            }
+            None => {
+                self.selected_idx = Some(0);
+            }
+            _ => {}
+        }
+    }
+
+    /// Return currently selected command, if any.
+    pub(crate) fn selected_command(&self) -> Option<&SlashCommand> {
+        let matches = self.filtered_commands();
+        self.selected_idx.and_then(|idx| matches.get(idx).copied())
+    }
+}
+
+impl WidgetRef for CommandPopup {
+    fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        let style = Style::default().bg(Color::Blue).fg(Color::White);
+
+        let matches = self.filtered_commands();
+
+        let mut rows: Vec<Row> = Vec::new();
+        let visible_matches: Vec<&SlashCommand> =
+            matches.into_iter().take(MAX_POPUP_ROWS).collect();
+
+        if visible_matches.is_empty() {
+            rows.push(Row::new(vec![
+                Cell::from("").style(style),
+                Cell::from("No matching commands").style(style.add_modifier(Modifier::ITALIC)),
+            ]));
+        } else {
+            for (idx, cmd) in visible_matches.iter().enumerate() {
+                let highlight = Style::default().bg(Color::White).fg(Color::Blue);
+                let cmd_style = if Some(idx) == self.selected_idx {
+                    highlight
+                } else {
+                    style
+                };
+
+                rows.push(Row::new(vec![
+                    Cell::from(cmd.command().to_string()).style(cmd_style),
+                    Cell::from(cmd.description().to_string()).style(style),
+                ]));
+            }
+        }
+
+        use ratatui::layout::Constraint;
+
+        let table = Table::new(rows, [Constraint::Length(15), Constraint::Min(10)])
+            .style(style)
+            .column_spacing(1)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .style(style),
+            );
+
+        table.render(area, buf);
+    }
+}

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -15,6 +15,7 @@ use crate::user_approval_widget::ApprovalRequest;
 mod approval_modal_view;
 mod bottom_pane_view;
 mod chat_composer;
+mod command_popup;
 mod status_indicator_view;
 
 pub(crate) use chat_composer::ChatComposer;
@@ -45,7 +46,7 @@ pub(crate) struct BottomPaneParams {
 impl BottomPane<'_> {
     pub fn new(params: BottomPaneParams) -> Self {
         Self {
-            composer: ChatComposer::new(params.has_input_focus),
+            composer: ChatComposer::new(params.has_input_focus, params.app_event_tx.clone()),
             active_view: None,
             app_event_tx: params.app_event_tx,
             has_input_focus: params.has_input_focus,
@@ -167,6 +168,11 @@ impl BottomPane<'_> {
 
     pub(crate) fn request_redraw(&self) -> Result<(), SendError<AppEvent>> {
         self.app_event_tx.send(AppEvent::Redraw)
+    }
+
+    /// Returns true when the slash-command popup inside the composer is visible.
+    pub(crate) fn is_command_popup_visible(&self) -> bool {
+        self.active_view.is_none() && self.composer.is_command_popup_visible()
     }
 }
 

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -26,6 +26,7 @@ mod history_cell;
 mod log_layer;
 mod markdown;
 mod scroll_event_helper;
+mod slash_command;
 mod status_indicator_widget;
 mod tui;
 mod user_approval_widget;

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -1,0 +1,36 @@
+use std::collections::HashMap;
+
+use strum::IntoEnumIterator;
+use strum_macros::AsRefStr; // derive macro
+use strum_macros::EnumIter;
+use strum_macros::EnumString;
+use strum_macros::IntoStaticStr;
+
+/// Commands that can be invoked by starting a message with a leading slash.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, EnumString, EnumIter, AsRefStr, IntoStaticStr)]
+#[strum(serialize_all = "kebab-case")]
+pub enum SlashCommand {
+    Clear,
+    Quit,
+}
+
+impl SlashCommand {
+    /// User-visible description shown in the popup.
+    pub fn description(self) -> &'static str {
+        match self {
+            SlashCommand::Clear => "Clear the chat history.",
+            SlashCommand::Quit => "Exit the application.",
+        }
+    }
+
+    /// Command string without the leading '/'. Provided for compatibility with
+    /// existing code that expects a method named `command()`.
+    pub fn command(self) -> &'static str {
+        self.into()
+    }
+}
+
+/// Return all built-in commands in a HashMap keyed by their command string.
+pub fn built_in_slash_commands() -> HashMap<&'static str, SlashCommand> {
+    SlashCommand::iter().map(|c| (c.command(), c)).collect()
+}


### PR DESCRIPTION
Introduces support for slash commands like in the TypeScript CLI. We do not support the full set of commands yet, but the core abstraction is there now.

In particular, we have a `SlashCommand` enum and due to thoughtful use of the [strum](https://crates.io/crates/strum) crate, it requires minimal boilerplate to add a new command to the list.

The key new piece of UI is `CommandPopup`, though the keyboard events are still handled by `ChatComposer`. The behavior is roughly as follows:

* if the first character in the composer is `/`, the command popup is displayed (if you really want to send a message to Codex that starts with a `/`, simply put a space before the `/`)
* while the popup is displayed, up/down can be used to change the selection of the popup
* if there is a selection, hitting tab completes the command, but does not send it
* if there is a selection, hitting enter sends the command
* if the prefix of the composer matches a command, the command will be visible in the popup so the user can see the description (commands could take arguments, so additional text may appear after the command name itself)

https://github.com/user-attachments/assets/39c3e6ee-eeb7-4ef7-a911-466d8184975f

Incidentally, Codex wrote almost all the code for this PR!