### PR TITLE
chore: expose codex_home via Config

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -610,7 +610,7 @@ async fn submission_loop(
                 // `instructions` value into the Session struct.
                 let session_id = Uuid::new_v4();
                 let rollout_recorder =
-                    match RolloutRecorder::new(session_id, instructions.clone()).await {
+                    match RolloutRecorder::new(&config, session_id, instructions.clone()).await {
                         Ok(r) => Some(r),
                         Err(e) => {
                             tracing::warn!("failed to initialise rollout recorder: {e}");

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -1,12 +1,11 @@
 //! Root of the `codex-core` library.
 
 // Prevent accidental direct writes to stdout/stderr in library code. All
-// user‑visible output must go through the appropriate abstraction (e.g.,
+// user-visible output must go through the appropriate abstraction (e.g.,
 // the TUI or the tracing stack).
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 
 mod chat_completions;
-
 mod client;
 mod client_common;
 pub mod codex;

--- a/codex-rs/core/src/project_doc.rs
+++ b/codex-rs/core/src/project_doc.rs
@@ -137,7 +137,8 @@ mod tests {
     #![allow(clippy::expect_used, clippy::unwrap_used)]
 
     use super::*;
-    use crate::config::Config;
+    use crate::config::ConfigOverrides;
+    use crate::config::ConfigToml;
     use std::fs;
     use tempfile::TempDir;
 
@@ -147,12 +148,19 @@ mod tests {
     /// value is cleared to mimic a scenario where no system instructions have
     /// been configured.
     fn make_config(root: &TempDir, limit: usize, instructions: Option<&str>) -> Config {
-        let mut cfg = Config::load_default_config_for_test();
-        cfg.cwd = root.path().to_path_buf();
-        cfg.project_doc_max_bytes = limit;
+        let codex_home = TempDir::new().unwrap();
+        let mut config = Config::load_from_base_config_with_overrides(
+            ConfigToml::default(),
+            ConfigOverrides::default(),
+            codex_home.path().to_path_buf(),
+        )
+        .expect("defaults for test should always succeed");
 
-        cfg.instructions = instructions.map(ToOwned::to_owned);
-        cfg
+        config.cwd = root.path().to_path_buf();
+        config.project_doc_max_bytes = limit;
+
+        config.instructions = instructions.map(ToOwned::to_owned);
+        config
     }
 
     /// AGENTS.md missing – should yield `None`.

--- a/codex-rs/core/src/rollout.rs
+++ b/codex-rs/core/src/rollout.rs
@@ -17,7 +17,7 @@ use tokio::sync::mpsc::Sender;
 use tokio::sync::mpsc::{self};
 use uuid::Uuid;
 
-use crate::config::codex_dir;
+use crate::config::Config;
 use crate::models::ResponseItem;
 
 /// Folder inside `~/.codex` that holds saved rollouts.
@@ -49,12 +49,16 @@ impl RolloutRecorder {
     /// Attempt to create a new [`RolloutRecorder`]. If the sessions directory
     /// cannot be created or the rollout file cannot be opened we return the
     /// error so the caller can decide whether to disable persistence.
-    pub async fn new(uuid: Uuid, instructions: Option<String>) -> std::io::Result<Self> {
+    pub async fn new(
+        config: &Config,
+        uuid: Uuid,
+        instructions: Option<String>,
+    ) -> std::io::Result<Self> {
         let LogFileInfo {
             file,
             session_id,
             timestamp,
-        } = create_log_file(uuid)?;
+        } = create_log_file(config, uuid)?;
 
         // Build the static session metadata JSON first.
         let timestamp_format: &[FormatItem] = format_description!(
@@ -154,9 +158,9 @@ struct LogFileInfo {
     timestamp: OffsetDateTime,
 }
 
-fn create_log_file(session_id: Uuid) -> std::io::Result<LogFileInfo> {
+fn create_log_file(config: &Config, session_id: Uuid) -> std::io::Result<LogFileInfo> {
     // Resolve ~/.codex/sessions and create it if missing.
-    let mut dir = codex_dir()?;
+    let mut dir = config.codex_home.clone();
     dir.push(SESSIONS_SUBDIR);
     fs::create_dir_all(&dir)?;
 

--- a/codex-rs/core/tests/live_agent.rs
+++ b/codex-rs/core/tests/live_agent.rs
@@ -20,13 +20,15 @@
 use std::time::Duration;
 
 use codex_core::Codex;
-use codex_core::config::Config;
 use codex_core::error::CodexErr;
 use codex_core::protocol::AgentMessageEvent;
 use codex_core::protocol::ErrorEvent;
 use codex_core::protocol::EventMsg;
 use codex_core::protocol::InputItem;
 use codex_core::protocol::Op;
+mod test_support;
+use tempfile::TempDir;
+use test_support::load_default_config_for_test;
 use tokio::sync::Notify;
 use tokio::time::timeout;
 
@@ -57,7 +59,8 @@ async fn spawn_codex() -> Result<Codex, CodexErr> {
         std::env::set_var("OPENAI_STREAM_MAX_RETRIES", "2");
     }
 
-    let config = Config::load_default_config_for_test();
+    let codex_home = TempDir::new().unwrap();
+    let config = load_default_config_for_test(&codex_home);
     let (agent, _init_id) = Codex::spawn(config, std::sync::Arc::new(Notify::new())).await?;
 
     Ok(agent)

--- a/codex-rs/core/tests/previous_response_id.rs
+++ b/codex-rs/core/tests/previous_response_id.rs
@@ -2,13 +2,15 @@ use std::time::Duration;
 
 use codex_core::Codex;
 use codex_core::ModelProviderInfo;
-use codex_core::config::Config;
 use codex_core::exec::CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR;
 use codex_core::protocol::ErrorEvent;
 use codex_core::protocol::EventMsg;
 use codex_core::protocol::InputItem;
 use codex_core::protocol::Op;
+mod test_support;
 use serde_json::Value;
+use tempfile::TempDir;
+use test_support::load_default_config_for_test;
 use tokio::time::timeout;
 use wiremock::Match;
 use wiremock::Mock;
@@ -108,7 +110,8 @@ async fn keeps_previous_response_id_between_tasks() {
     };
 
     // Init session
-    let mut config = Config::load_default_config_for_test();
+    let codex_home = TempDir::new().unwrap();
+    let mut config = load_default_config_for_test(&codex_home);
     config.model_provider = model_provider;
     let ctrl_c = std::sync::Arc::new(tokio::sync::Notify::new());
     let (codex, _init_id) = Codex::spawn(config, ctrl_c.clone()).await.unwrap();

--- a/codex-rs/core/tests/stream_no_completed.rs
+++ b/codex-rs/core/tests/stream_no_completed.rs
@@ -5,10 +5,12 @@ use std::time::Duration;
 
 use codex_core::Codex;
 use codex_core::ModelProviderInfo;
-use codex_core::config::Config;
 use codex_core::exec::CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR;
 use codex_core::protocol::InputItem;
 use codex_core::protocol::Op;
+mod test_support;
+use tempfile::TempDir;
+use test_support::load_default_config_for_test;
 use tokio::time::timeout;
 use wiremock::Mock;
 use wiremock::MockServer;
@@ -96,7 +98,8 @@ async fn retries_on_early_close() {
     };
 
     let ctrl_c = std::sync::Arc::new(tokio::sync::Notify::new());
-    let mut config = Config::load_default_config_for_test();
+    let codex_home = TempDir::new().unwrap();
+    let mut config = load_default_config_for_test(&codex_home);
     config.model_provider = model_provider;
     let (codex, _init_id) = Codex::spawn(config, ctrl_c).await.unwrap();
 

--- a/codex-rs/core/tests/test_support.rs
+++ b/codex-rs/core/tests/test_support.rs
@@ -1,0 +1,23 @@
+#![allow(clippy::expect_used)]
+
+// Helpers shared by the integration tests.  These are located inside the
+// `tests/` tree on purpose so they never become part of the public API surface
+// of the `codex-core` crate.
+
+use tempfile::TempDir;
+
+use codex_core::config::Config;
+use codex_core::config::ConfigOverrides;
+use codex_core::config::ConfigToml;
+
+/// Returns a default `Config` whose on-disk state is confined to the provided
+/// temporary directory. Using a per-test directory keeps tests hermetic and
+/// avoids clobbering a developer’s real `~/.codex`.
+pub fn load_default_config_for_test(codex_home: &TempDir) -> Config {
+    Config::load_from_base_config_with_overrides(
+        ConfigToml::default(),
+        ConfigOverrides::default(),
+        codex_home.path().to_path_buf(),
+    )
+    .expect("defaults for test should always succeed")
+}

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -69,7 +69,7 @@ pub fn run_main(cli: Cli) -> std::io::Result<()> {
         }
     };
 
-    let log_dir = codex_core::config::log_dir()?;
+    let log_dir = codex_core::config::log_dir(&config)?;
     std::fs::create_dir_all(&log_dir)?;
     // Open (or create) your log file, appending to it.
     let mut log_file_opts = OpenOptions::new();


### PR DESCRIPTION
To ensure the same directory that was used as "codex home" to create the `Config` is used throughout the same session, make `codex_dir()` private to `codex.rs` and expose the directory as `codex_home` on `Config` itself so all readers must get the value through `Config`. For example, `log_dir()` now takes `cfg: &Config` as a param to derive the path to the logs folder.

Note this is particularly important for things like unit tests to ensure they use a temporary directory for "codex home" so that running the tests does not modify the user's real "codex home."

As part of this PR, this also does something I have been meaning to do for awhile, which is support the `CODEX_HOME` env variable as a way to override the default of `~/.codex`.