### PR TITLE
fix: apply patch issue when using different cwd

### DIFF
--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -171,12 +171,7 @@ pub fn maybe_parse_apply_patch_verified(argv: &[String], cwd: &Path) -> MaybeApp
                 let path = hunk.resolve_path(cwd);
                 match hunk {
                     Hunk::AddFile { contents, .. } => {
-                        changes.insert(
-                            path,
-                            ApplyPatchFileChange::Add {
-                                content: contents.clone(),
-                            },
-                        );
+                        changes.insert(path, ApplyPatchFileChange::Add { content: contents });
                     }
                     Hunk::DeleteFile { .. } => {
                         changes.insert(path, ApplyPatchFileChange::Delete);
@@ -1168,7 +1163,7 @@ g
         let session_dir = tempdir().unwrap();
         let relative_path = "source.txt";
 
-        // Note that we need this file to exists for the patch to be "verified"
+        // Note that we need this file to exist for the patch to be "verified"
         // and parsed correctly.
         let session_file_path = session_dir.path().join(relative_path);
         fs::write(&session_file_path, "session directory content\n").unwrap();
@@ -1189,17 +1184,21 @@ g
         // Verify the patch contents - as otherwise we may have pulled contents
         // from the wrong file (as we're using relative paths)
         assert_eq!(
-            result, 
-            MaybeApplyPatchVerified::Body(
-                ApplyPatchAction {
-                    changes: HashMap::from([(
-                        session_dir.path().join(relative_path),
-                        ApplyPatchFileChange::Update {
-                            unified_diff: "@@ -1 +1 @@\n-session directory content\n+updated session directory content\n".to_string(),
-                            move_path: None,
-                            new_content: "updated session directory content\n".to_string(),
-                        },
-                    )]),
-                }));
+            result,
+            MaybeApplyPatchVerified::Body(ApplyPatchAction {
+                changes: HashMap::from([(
+                    session_dir.path().join(relative_path),
+                    ApplyPatchFileChange::Update {
+                        unified_diff: r#"@@ -1 +1 @@
+-session directory content
++updated session directory content
+"#
+                        .to_string(),
+                        move_path: None,
+                        new_content: "updated session directory content\n".to_string(),
+                    },
+                )]),
+            })
+        );
     }
 }

--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -159,17 +159,18 @@ pub fn maybe_parse_apply_patch_verified(argv: &[String], cwd: &Path) -> MaybeApp
                         move_path,
                         chunks,
                     } => {
+                        let absolute_path = cwd.join(path);
                         let ApplyPatchFileUpdate {
                             unified_diff,
                             content: contents,
-                        } = match unified_diff_from_chunks(&path, &chunks) {
+                        } = match unified_diff_from_chunks(&absolute_path, &chunks) {
                             Ok(diff) => diff,
                             Err(e) => {
                                 return MaybeApplyPatchVerified::CorrectnessError(e);
                             }
                         };
                         changes.insert(
-                            cwd.join(path),
+                            absolute_path,
                             ApplyPatchFileChange::Update {
                                 unified_diff,
                                 move_path: move_path.map(|p| cwd.join(p)),

--- a/codex-rs/apply-patch/src/parser.rs
+++ b/codex-rs/apply-patch/src/parser.rs
@@ -64,6 +64,17 @@ pub enum Hunk {
         chunks: Vec<UpdateFileChunk>,
     },
 }
+
+impl Hunk {
+    pub fn resolve_path(&self, cwd: &PathBuf) -> PathBuf {
+        match self {
+            Hunk::AddFile { path, .. } => cwd.join(path),
+            Hunk::DeleteFile { path } => cwd.join(path),
+            Hunk::UpdateFile { path, .. } => cwd.join(path),
+        }
+    }
+}
+
 use Hunk::*;
 
 #[derive(Debug, PartialEq)]

--- a/codex-rs/apply-patch/src/parser.rs
+++ b/codex-rs/apply-patch/src/parser.rs
@@ -22,6 +22,7 @@
 //!
 //! The parser below is a little more lenient than the explicit spec and allows for
 //! leading/trailing whitespace around patch markers.
+use std::path::Path;
 use std::path::PathBuf;
 
 use thiserror::Error;
@@ -66,7 +67,7 @@ pub enum Hunk {
 }
 
 impl Hunk {
-    pub fn resolve_path(&self, cwd: &PathBuf) -> PathBuf {
+    pub fn resolve_path(&self, cwd: &Path) -> PathBuf {
         match self {
             Hunk::AddFile { path, .. } => cwd.join(path),
             Hunk::DeleteFile { path } => cwd.join(path),


### PR DESCRIPTION
If you run a codex instance outside of the current working directory from where you launched the codex binary it won't be able to apply patches correctly, even if the sandbox policy allows it. This manifests weird behaviours, such as

* Reading the same filename in the binary working directory, and overwriting it in the session working directory. e.g. if you have a `readme` in both folders it will overwrite the readme in the session working directory with the readme in the binary working directory *applied with the suggested patch*.
* The LLM ends up in weird loops trying to verify and debug why the apply_patch won't work, and it can result in it applying patches by manually writing python or javascript if it figures out that either is supported by the system instead. 

I added a test-case to ensure that the patch contents are based on the cwd.

## Issue: mixing relative & absolute paths in apply_patch

1. The apply_patch tool use relative paths based on the session working directory.
2. `unified_diff_from_chunks` eventually ends up [reading the source file](https://github.com/reflectionai/codex/blob/main/codex-rs/apply-patch/src/lib.rs#L410) to figure out what the diff is, by using the relative path.
3. The changes are targeted using an absolute path derived from the current working directory.

The end-result in case session working directory differs from the binary working directory: we get the diff for a file relative to the binary working directory, and apply it on a file in the session working directory.
 