### PR TITLE
chore: pin Rust version to 1.86 and use io::Error::other to prepare for 1.87

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -26,7 +26,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.86
+        with:
+          components: rustfmt
       - name: cargo fmt
         run: cargo fmt -- --config imports_granularity=Item --check
 
@@ -58,9 +60,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.86
         with:
           targets: ${{ matrix.target }}
+          components: clippy
 
       - uses: actions/cache@v4
         with:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -74,7 +74,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.86
         with:
           targets: ${{ matrix.target }}
 

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -349,14 +349,12 @@ pub(crate) async fn consume_truncated_output(
     // we treat it as an exceptional I/O error
 
     let stdout_reader = child.stdout.take().ok_or_else(|| {
-        CodexErr::Io(io::Error::new(
-            io::ErrorKind::Other,
+        CodexErr::Io(io::Error::other(
             "stdout pipe was unexpectedly not available",
         ))
     })?;
     let stderr_reader = child.stderr.take().ok_or_else(|| {
-        CodexErr::Io(io::Error::new(
-            io::ErrorKind::Other,
+        CodexErr::Io(io::Error::other(
             "stderr pipe was unexpectedly not available",
         ))
     })?;

--- a/codex-rs/core/src/exec_linux.rs
+++ b/codex-rs/core/src/exec_linux.rs
@@ -51,10 +51,9 @@ pub fn exec_linux(
     match tool_call_output {
         Ok(Ok(output)) => Ok(output),
         Ok(Err(e)) => Err(e),
-        Err(e) => Err(CodexErr::Io(io::Error::new(
-            io::ErrorKind::Other,
-            format!("thread join failed: {e:?}"),
-        ))),
+        Err(e) => Err(CodexErr::Io(io::Error::other(format!(
+            "thread join failed: {e:?}"
+        )))),
     }
 }
 

--- a/codex-rs/mcp-client/src/mcp_client.rs
+++ b/codex-rs/mcp-client/src/mcp_client.rs
@@ -99,12 +99,14 @@ impl McpClient {
             .kill_on_drop(true)
             .spawn()?;
 
-        let stdin = child.stdin.take().ok_or_else(|| {
-            std::io::Error::new(std::io::ErrorKind::Other, "failed to capture child stdin")
-        })?;
-        let stdout = child.stdout.take().ok_or_else(|| {
-            std::io::Error::new(std::io::ErrorKind::Other, "failed to capture child stdout")
-        })?;
+        let stdin = child
+            .stdin
+            .take()
+            .ok_or_else(|| std::io::Error::other("failed to capture child stdin"))?;
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| std::io::Error::other("failed to capture child stdout"))?;
 
         let (outgoing_tx, mut outgoing_rx) = mpsc::channel::<JSONRPCMessage>(CHANNEL_CAPACITY);
         let pending: Arc<Mutex<HashMap<i64, PendingSender>>> = Arc::new(Mutex::new(HashMap::new()));


### PR DESCRIPTION
Previously, our GitHub actions specified the Rust toolchain as `dtolnay/rust-toolchain@stable`, which meant the version could change out from under us. In this case, the move from 1.86 to 1.87 introduced new clippy warnings, causing build failures.

Because it will take a little time to fix all the new clippy warnings, this PR pins things to 1.86 for now to unbreak the build.

It also replaces `io::Error::new(io::ErrorKind::Other)` with `io::Error::other()` in preparation for 1.87.