### PR TITLE
chore: update exec crate to use std::time instead of chrono

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -503,7 +503,6 @@ dependencies = [
 name = "codex-common"
 version = "0.0.0"
 dependencies = [
- "chrono",
  "clap",
  "codex-core",
 ]

--- a/codex-rs/common/Cargo.toml
+++ b/codex-rs/common/Cargo.toml
@@ -7,11 +7,10 @@ edition = "2024"
 workspace = true
 
 [dependencies]
-chrono = { version = "0.4.40", optional = true }
 clap = { version = "4", features = ["derive", "wrap_help"], optional = true }
 codex-core = { path = "../core" }
 
 [features]
 # Separate feature so that `clap` is not a mandatory dependency.
 cli = ["clap"]
-elapsed = ["chrono"]
+elapsed = []

--- a/codex-rs/exec/src/event_processor.rs
+++ b/codex-rs/exec/src/event_processor.rs
@@ -17,6 +17,7 @@ use owo_colors::OwoColorize;
 use owo_colors::Style;
 use shlex::try_join;
 use std::collections::HashMap;
+use std::time::Instant;
 
 /// This should be configurable. When used in CI, users may not want to impose
 /// a limit so they can see the full transcript.
@@ -76,7 +77,7 @@ impl EventProcessor {
 
 struct ExecCommandBegin {
     command: Vec<String>,
-    start_time: chrono::DateTime<Utc>,
+    start_time: Instant,
 }
 
 /// Metadata captured when an `McpToolCallBegin` event is received.
@@ -84,11 +85,11 @@ struct McpToolCallBegin {
     /// Formatted invocation string, e.g. `server.tool({"city":"sf"})`.
     invocation: String,
     /// Timestamp when the call started so we can compute duration later.
-    start_time: chrono::DateTime<Utc>,
+    start_time: Instant,
 }
 
 struct PatchApplyBegin {
-    start_time: chrono::DateTime<Utc>,
+    start_time: Instant,
     auto_approved: bool,
 }
 
@@ -133,7 +134,7 @@ impl EventProcessor {
                     call_id.clone(),
                     ExecCommandBegin {
                         command: command.clone(),
-                        start_time: Utc::now(),
+                        start_time: Instant::now(),
                     },
                 );
                 ts_println!(
@@ -208,7 +209,7 @@ impl EventProcessor {
                     call_id.clone(),
                     McpToolCallBegin {
                         invocation: invocation.clone(),
-                        start_time: Utc::now(),
+                        start_time: Instant::now(),
                     },
                 );
 
@@ -263,7 +264,7 @@ impl EventProcessor {
                 self.call_id_to_patch.insert(
                     call_id.clone(),
                     PatchApplyBegin {
-                        start_time: Utc::now(),
+                        start_time: Instant::now(),
                         auto_approved,
                     },
                 );


### PR DESCRIPTION
When I originally wrote `elapsed.rs`, I realized we were using both `std::time` and `chrono` with no real benefit of having both. We should try to keep the `exec` subcommand trim (as it also buildable as a standalone executable), so this helps tighten things up.