### PR TITLE
fix: introduce ExtractHeredocError that implements PartialEq

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1080,7 +1080,7 @@ async fn handle_function_call(
                     };
                 }
                 MaybeApplyPatchVerified::ShellParseError(error) => {
-                    trace!("Failed to parse shell command, {error}");
+                    trace!("Failed to parse shell command, {error:?}");
                 }
                 MaybeApplyPatchVerified::NotApplyPatch => (),
             }


### PR DESCRIPTION
https://github.com/openai/codex/pull/942 had to introduce a hand-rolled `PartialEq` implementation because `extract_heredoc_body_from_apply_patch_command()` returned `anyhow::Result`, and `anyhow::Error` was used with the `ShellParseError` variant of `MaybeApplyPatch`, which is why we could not `#[derive(PartialEq)]`.

This introduces a rich `ExtractHeredocError` enum to use instead of `anyhow::Error`, so we now remove the custom `impl PartialEq` for `MaybeApplyPatchVerified`.