### PR TITLE
feat: add support for OpenAI tool type, local_shell

### DIFF
--- a/codex-rs/core/src/conversation_history.rs
+++ b/codex-rs/core/src/conversation_history.rs
@@ -41,8 +41,9 @@ impl ConversationHistory {
 fn is_api_message(message: &ResponseItem) -> bool {
     match message {
         ResponseItem::Message { role, .. } => role.as_str() != "system",
-        ResponseItem::FunctionCall { .. } => true,
-        ResponseItem::FunctionCallOutput { .. } => true,
-        _ => false,
+        ResponseItem::FunctionCallOutput { .. }
+        | ResponseItem::FunctionCall { .. }
+        | ResponseItem::LocalShellCall { .. } => true,
+        ResponseItem::Reasoning { .. } | ResponseItem::Other => false,
     }
 }

--- a/codex-rs/core/src/models.rs
+++ b/codex-rs/core/src/models.rs
@@ -1,3 +1,5 @@
+use std::collections::HashMap;
+
 use base64::Engine;
 use serde::Deserialize;
 use serde::Serialize;
@@ -37,6 +39,14 @@ pub enum ResponseItem {
         id: String,
         summary: Vec<ReasoningItemReasoningSummary>,
     },
+    LocalShellCall {
+        /// Set when using the chat completions API.
+        id: Option<String>,
+        /// Set when using the Responses API.
+        call_id: Option<String>,
+        status: LocalShellStatus,
+        action: LocalShellAction,
+    },
     FunctionCall {
         name: String,
         // The Responses API returns the function call arguments as a *string* that contains
@@ -69,6 +79,29 @@ impl From<ResponseInputItem> for ResponseItem {
             }
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LocalShellStatus {
+    Completed,
+    InProgress,
+    Incomplete,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum LocalShellAction {
+    Exec(LocalShellExecAction),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LocalShellExecAction {
+    pub command: Vec<String>,
+    pub timeout_ms: Option<u64>,
+    pub working_directory: Option<String>,
+    pub env: Option<HashMap<String, String>>,
+    pub user: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/codex-rs/core/src/rollout.rs
+++ b/codex-rs/core/src/rollout.rs
@@ -115,6 +115,7 @@ impl RolloutRecorder {
                 // "fully qualified MCP tool calls," so we could consider
                 // reformatting them in that case.
                 ResponseItem::Message { .. }
+                | ResponseItem::LocalShellCall { .. }
                 | ResponseItem::FunctionCall { .. }
                 | ResponseItem::FunctionCallOutput { .. } => {}
                 ResponseItem::Reasoning { .. } | ResponseItem::Other => {


### PR DESCRIPTION
The new `codex-mini-latest` model expects a new tool with `{"type": "local_shell"}`. Its contract is similar to the existing `function` tool with `"name": "shell"`, so this takes the `local_shell` tool call into `ExecParams` and sends it through the existing `handle_container_exec_with_params()` code path.

This also adds the following logic when adding the default set of tools to a request:

```rust
let default_tools = if self.model.starts_with("codex") {
    &DEFAULT_CODEX_MODEL_TOOLS
} else {
    &DEFAULT_TOOLS
};
```

That is, if the model name starts with `"codex"`, we add `{"type": "local_shell"}` to the list of tools; otherwise, we add the aforementioned `shell` tool.

To test this, I ran the TUI with `-m codex-mini-latest` and verified that it used the `local_shell` tool. Though I also had some entries in `[mcp_servers]` in my personal `config.toml`. The `codex-mini-latest` model seemed eager to try the tools from the MCP servers first, so I have personally commented them out for now, so keep an eye out if you're testing `codex-mini-latest`!

Perhaps we should include more details with `{"type": "local_shell"}` or update the following:

https://github.com/openai/codex/blob/fd0b1b020818dfe8aaf7eb68425f09e86ab1b819/codex-rs/core/prompt.md

For reference, the corresponding change in the TypeScript CLI is https://github.com/openai/codex/pull/951.

