### PR TITLE
Fix CLA link in workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,7 +23,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          path-to-document: docs/CLA.md
+          path-to-document: https://github.com/openai/codex/blob/main/docs/CLA.md
           path-to-signatures: signatures/cla.json
           branch: cla-signatures
           allowlist: dependabot[bot]


### PR DESCRIPTION
## Summary
- fix the CLA link posted by the bot
- docs suggest using an absolute URL: https://github.com/marketplace/actions/cla-assistant-lite
