### PR TITLE
Remove unnecessary console log from test

### DIFF
--- a/codex-cli/tests/agent-cancel-prev-response.test.ts
+++ b/codex-cli/tests/agent-cancel-prev-response.test.ts
@@ -132,8 +132,10 @@ describe("cancel clears previous_response_id", () => {
     ] as any);
 
     const bodies = _test.getBodies();
-    // eslint-disable-next-line no-console
-    console.log(JSON.stringify(bodies, null, 2));
+    if (process.env["DEBUG"] === "true") {
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify(bodies, null, 2));
+    }
     expect(bodies.length).toBeGreaterThanOrEqual(2);
 
     // The *last* invocation belongs to the second run (after cancellation).

--- a/codex-cli/tests/agent-cancel-prev-response.test.ts
+++ b/codex-cli/tests/agent-cancel-prev-response.test.ts
@@ -132,10 +132,6 @@ describe("cancel clears previous_response_id", () => {
     ] as any);
 
     const bodies = _test.getBodies();
-    if (process.env["DEBUG"] === "true") {
-      // eslint-disable-next-line no-console
-      console.log(JSON.stringify(bodies, null, 2));
-    }
     expect(bodies.length).toBeGreaterThanOrEqual(2);
 
     // The *last* invocation belongs to the second run (after cancellation).


### PR DESCRIPTION
When running `npm test` on `codex-cli`, the test `agent-cancel-prev-response.test.ts` logs a significant body of text to console for no obvious reason. 

This is not helpful, as it makes test logs messy and far longer.

This change deletes the `console.log(...)` that produces the behavior.