### PR TITLE
fix: make codex-mini-latest the default model in the Rust TUI

### DIFF
--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -32,7 +32,7 @@ The `config.toml` file supports the following options:
 The model that Codex should use.
 
 ```toml
-model = "o3"  # overrides the default of "o4-mini"
+model = "o3"  # overrides the default of "codex-mini-latest"
 ```
 
 ### model_provider

--- a/codex-rs/core/src/flags.rs
+++ b/codex-rs/core/src/flags.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use env_flags::env_flags;
 
 env_flags! {
-    pub OPENAI_DEFAULT_MODEL: &str = "o4-mini";
+    pub OPENAI_DEFAULT_MODEL: &str = "codex-mini-latest";
     pub OPENAI_API_BASE: &str = "https://api.openai.com/v1";
 
     /// Fallback when the provider-specific key is not set.


### PR DESCRIPTION
It's time to make `codex-mini-latest` the new default, as this should be an "evergreen" model pointer.

* Equivalent change in TypeScript https://github.com/openai/codex/pull/951
* See some notes about using `codex-mini-latest` with MCP in https://github.com/openai/codex/pull/961