### PR TITLE
fix: ensure the first user message always displays after the session info

### DIFF
--- a/codex-rs/tui/src/conversation_history_widget.rs
+++ b/codex-rs/tui/src/conversation_history_widget.rs
@@ -175,8 +175,18 @@ impl ConversationHistoryWidget {
     /// Note `model` could differ from `config.model` if the agent decided to
     /// use a different model than the one requested by the user.
     pub fn add_session_info(&mut self, config: &Config, event: SessionConfiguredEvent) {
-        let is_first_event = self.entries.is_empty();
-        self.add_to_history(HistoryCell::new_session_info(config, event, is_first_event));
+        // In practice, SessionConfiguredEvent should always be the first entry
+        // in the history, but it is possible that an error could be sent
+        // before the session info.
+        let has_welcome_message = self
+            .entries
+            .iter()
+            .any(|entry| matches!(entry.cell, HistoryCell::WelcomeMessage { .. }));
+        self.add_to_history(HistoryCell::new_session_info(
+            config,
+            event,
+            !has_welcome_message,
+        ));
     }
 
     pub fn add_user_message(&mut self, message: String) {


### PR DESCRIPTION
Previously, if the first user message was sent with the command invocation, e.g.:

```
$ cargo run --bin codex 'hello'
```

Then the user message was added as the first entry in the history and then `is_first_event` would be `false` here:

https://github.com/openai/codex/blob/031df77dfb9248fe47b40ec52bf8b05052231722/codex-rs/tui/src/conversation_history_widget.rs#L178-L179

which would prevent the "welcome" message with things like the the model version from displaying.

The fix in this PR is twofold:

* Reorganize the logic so the `ChatWidget` constructor stores `initial_user_message` rather than sending it right away. Now inside `handle_codex_event()`, it waits for the `SessionConfigured` event and sends the `initial_user_message`, if it exists.
* In `conversation_history_widget.rs`, `add_session_info()` checks to see whether a `WelcomeMessage` exists in the history when determining the value of `has_welcome_message`. By construction, we expect that `WelcomeMessage` is always the first message (in which case the existing `let is_first_event = self.entries.is_empty();` logic would be sound), but we decide to be extra defensive in case an `EventMsg::Error` is processed before `EventMsg::SessionConfigured`.