### PR TITLE
Set provider-specific API key if using non-openai provider

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -21,9 +21,9 @@ import { AutoApprovalMode } from "./utils/auto-approval-mode";
 import { checkForUpdates } from "./utils/check-updates";
 import {
   loadConfig,
+  getApiKey,
   PRETTY_PRINT,
   INSTRUCTIONS_FILEPATH,
-  getApiKey,
 } from "./utils/config";
 import { getApiKey as fetchApiKey } from "./utils/get-api-key";
 import { createInputItem } from "./utils/input-utils";

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -23,6 +23,7 @@ import {
   loadConfig,
   PRETTY_PRINT,
   INSTRUCTIONS_FILEPATH,
+  getApiKey,
 } from "./utils/config";
 import { getApiKey as fetchApiKey } from "./utils/get-api-key";
 import { createInputItem } from "./utils/input-utils";
@@ -291,8 +292,9 @@ try {
       ? new Date(data.last_refresh).getTime()
       : 0;
     const expired = Date.now() - lastRefreshTime > 28 * 24 * 60 * 60 * 1000;
-    if (data.OPENAI_API_KEY && !expired) {
-      apiKey = data.OPENAI_API_KEY;
+    const providerApiKey = data[`${provider.toUpperCase()}_API_KEY`];
+    if (providerApiKey && !expired) {
+      apiKey = providerApiKey;
     }
   }
 } catch {
@@ -300,7 +302,11 @@ try {
 }
 
 if (!apiKey) {
-  apiKey = await fetchApiKey(client.issuer, client.client_id);
+  if (provider.toLowerCase() === "openai") {
+    apiKey = await fetchApiKey(client.issuer, client.client_id);
+  } else {
+    apiKey = getApiKey(provider) ?? "";
+  }
 }
 // Ensure the API key is available as an environment variable for legacy code
 process.env["OPENAI_API_KEY"] = apiKey;


### PR DESCRIPTION
To fix the following issues:

- https://github.com/openai/codex/issues/987
- https://github.com/openai/codex/issues/975

will also fixes #1005