### PR TITLE
chore: update install_native_deps.sh to use rust-v0.0.2505171051

### DIFF
--- a/codex-cli/scripts/install_native_deps.sh
+++ b/codex-cli/scripts/install_native_deps.sh
@@ -65,7 +65,7 @@ mkdir -p "$BIN_DIR"
 # Until we start publishing stable GitHub releases, we have to grab the binaries
 # from the GitHub Action that created them. Update the URL below to point to the
 # appropriate workflow run:
-WORKFLOW_URL="https://github.com/openai/codex/actions/runs/14950726936"
+WORKFLOW_URL="https://github.com/openai/codex/actions/runs/15087655786"
 WORKFLOW_ID="${WORKFLOW_URL##*/}"
 
 ARTIFACTS_DIR="$(mktemp -d)"


### PR DESCRIPTION
Use a more recent built of the Rust binaries to include with the Node module.