### PR TITLE
add: `codex --login` + `codex --free`

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -24,7 +24,10 @@ import {
   PRETTY_PRINT,
   INSTRUCTIONS_FILEPATH,
 } from "./utils/config";
-import { getApiKey as fetchApiKey } from "./utils/get-api-key";
+import {
+  getApiKey as fetchApiKey,
+  maybeRedeemCredits,
+} from "./utils/get-api-key";
 import { createInputItem } from "./utils/input-utils";
 import { initLogger } from "./utils/logger/log";
 import { isModelSupportedForResponses } from "./utils/model-utils.js";
@@ -63,6 +66,8 @@ const cli = meow(
     -i, --image <path>              Path(s) to image files to include as input
     -v, --view <rollout>            Inspect a previously saved rollout instead of starting a session
     --history                       Browse previous sessions
+    --login                         Start a new sign in flow
+    --free                          Retry redeeming free credits
     -q, --quiet                     Non-interactive mode that only prints the assistant's final output
     -c, --config                    Open the instructions file in your editor
     -w, --writable-root <path>      Writable folder for sandbox in full-auto mode (can be specified multiple times)
@@ -108,6 +113,8 @@ const cli = meow(
       version: { type: "boolean", description: "Print version and exit" },
       view: { type: "string" },
       history: { type: "boolean", description: "Browse previous sessions" },
+      login: { type: "boolean", description: "Force a new sign in flow" },
+      free: { type: "boolean", description: "Retry redeeming free credits" },
       model: { type: "string", aliases: ["m"] },
       provider: { type: "string", aliases: ["p"] },
       image: { type: "string", isMultiple: true, aliases: ["i"] },
@@ -279,6 +286,7 @@ const client = {
 };
 
 let apiKey = "";
+let savedTokens: { id_token?: string; access_token?: string } | undefined;
 
 // Try to load existing auth file if present
 try {
@@ -287,6 +295,7 @@ try {
   const authFile = path.join(authDir, "auth.json");
   if (fs.existsSync(authFile)) {
     const data = JSON.parse(fs.readFileSync(authFile, "utf-8"));
+    savedTokens = data.tokens;
     const lastRefreshTime = data.last_refresh
       ? new Date(data.last_refresh).getTime()
       : 0;
@@ -299,11 +308,32 @@ try {
   // ignore errors
 }
 
-if (!apiKey) {
+if (cli.flags.login) {
+  apiKey = await fetchApiKey(client.issuer, client.client_id);
+  try {
+    const home = os.homedir();
+    const authDir = path.join(home, ".codex");
+    const authFile = path.join(authDir, "auth.json");
+    if (fs.existsSync(authFile)) {
+      const data = JSON.parse(fs.readFileSync(authFile, "utf-8"));
+      savedTokens = data.tokens;
+    }
+  } catch {
+    /* ignore */
+  }
+} else if (!apiKey) {
   apiKey = await fetchApiKey(client.issuer, client.client_id);
 }
 // Ensure the API key is available as an environment variable for legacy code
 process.env["OPENAI_API_KEY"] = apiKey;
+
+if (cli.flags.free && savedTokens?.id_token && savedTokens?.access_token) {
+  await maybeRedeemCredits(
+    client.issuer,
+    savedTokens.id_token,
+    savedTokens.access_token,
+  );
+}
 
 // Set of providers that don't require API keys
 const NO_API_KEY_REQUIRED = new Set(["ollama"]);

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -286,7 +286,13 @@ const client = {
 };
 
 let apiKey = "";
-let savedTokens: { id_token?: string; access_token?: string } | undefined;
+let savedTokens:
+  | {
+      id_token?: string;
+      access_token?: string;
+      refresh_token: string;
+    }
+  | undefined;
 
 // Try to load existing auth file if present
 try {
@@ -331,7 +337,9 @@ if (cli.flags.free && savedTokens?.id_token && savedTokens?.access_token) {
   await maybeRedeemCredits(
     client.issuer,
     savedTokens.id_token,
+    savedTokens.refresh_token,
     savedTokens.access_token,
+    client.client_id,
   );
 }
 

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -333,13 +333,14 @@ if (cli.flags.login) {
 // Ensure the API key is available as an environment variable for legacy code
 process.env["OPENAI_API_KEY"] = apiKey;
 
-if (cli.flags.free && savedTokens?.id_token && savedTokens?.access_token) {
+if (cli.flags.free && savedTokens?.refresh_token) {
+  // eslint-disable-next-line no-console
+  console.log(`${chalk.bold("codex --free")} attempting to redeem credits...`);
   await maybeRedeemCredits(
     client.issuer,
-    savedTokens.id_token,
-    savedTokens.refresh_token,
-    savedTokens.access_token,
     client.client_id,
+    savedTokens.refresh_token,
+    savedTokens.id_token,
   );
 }
 

--- a/codex-cli/src/utils/get-api-key.tsx
+++ b/codex-cli/src/utils/get-api-key.tsx
@@ -101,18 +101,15 @@ async function maybeRedeemCredits(
     // Validate ID token expiration; if expired, attempt token-exchange for a fresh ID token
     if (Date.now() >= idClaims.exp * 1000) {
       try {
-        const oidcConfig = await getOidcConfiguration(issuer);
-        const exchangeParams = new URLSearchParams({
-          grant_type: "urn:ietf:params:oauth:grant-type:token-exchange",
-          client_id: clientId,
-          subject_token: refreshToken,
-          subject_token_type: "urn:ietf:params:oauth:token-type:refresh_token",
-          requested_token_type: "urn:ietf:params:oauth:token-type:id_token",
-        });
-        const refreshRes = await fetch(oidcConfig.token_endpoint, {
+        const refreshRes = await fetch("https://auth.openai.com/oauth/token", {
           method: "POST",
-          headers: { "Content-Type": "application/x-www-form-urlencoded" },
-          body: exchangeParams.toString(),
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            client_id: clientId,
+            grant_type: "refresh_token",
+            refresh_token: refreshToken,
+            scope: "openid profile email",
+          }),
         });
         if (!refreshRes.ok) {
           // eslint-disable-next-line no-console

--- a/codex-cli/src/utils/get-api-key.tsx
+++ b/codex-cli/src/utils/get-api-key.tsx
@@ -156,14 +156,18 @@ async function maybeRedeemCredits(
     ) {
       // eslint-disable-next-line no-console
       console.warn(
-        "Sorry, your subscription must be active for more than 7 days to redeem credits.\nMore info: https://help.openai.com/en/articles/11381614\nPlease try again on: " +
-          new Date(
-            new Date(subStart).getTime() + 7 * 24 * 60 * 60 * 1000,
-          ).toLocaleDateString() +
-          " " +
-          new Date(
-            new Date(subStart).getTime() + 7 * 24 * 60 * 60 * 1000,
-          ).toLocaleTimeString(),
+        "Sorry, your subscription must be active for more than 7 days to redeem credits.\nMore info: " +
+          chalk.dim("https://help.openai.com/en/articles/11381614") +
+          chalk.bold(
+            "\nPlease try again on " +
+              new Date(
+                new Date(subStart).getTime() + 7 * 24 * 60 * 60 * 1000,
+              ).toLocaleDateString() +
+              " " +
+              new Date(
+                new Date(subStart).getTime() + 7 * 24 * 60 * 60 * 1000,
+              ).toLocaleTimeString(),
+          ),
       );
       return;
     }
@@ -180,6 +184,11 @@ async function maybeRedeemCredits(
       ?.chatgpt_plan_type as string | undefined;
 
     if (needsSetup || !(planType === "plus" || planType === "pro")) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        "Users with Plus or Pro subscriptions can redeem free API credits.\nMore info: " +
+          chalk.dim("https://help.openai.com/en/articles/11381614"),
+      );
       return;
     }
 
@@ -716,10 +725,12 @@ export async function getApiKey(
   const spinner = render(<WaitingForAuth />);
   try {
     const key = await signInFlow(issuer, clientId);
+    spinner.clear();
     spinner.unmount();
     process.env["OPENAI_API_KEY"] = key;
     return key;
   } catch (err) {
+    spinner.clear();
     spinner.unmount();
     throw err;
   }

--- a/codex-cli/src/utils/get-api-key.tsx
+++ b/codex-cli/src/utils/get-api-key.tsx
@@ -2,7 +2,6 @@ import type { Choice } from "./get-api-key-components";
 import type { Request, Response } from "express";
 
 import { ApiKeyPrompt, WaitingForAuth } from "./get-api-key-components";
-import { clearTerminal } from "./terminal";
 import chalk from "chalk";
 import express from "express";
 import fs from "fs/promises";
@@ -212,9 +211,30 @@ async function maybeRedeemCredits(
         // eslint-disable-next-line no-console
         console.log(
           chalk.green(
-            `\u2728  Granted ${planType === "plus" ? "$5" : "$50"} in API credits for being a ChatGPT ${
-              planType === "plus" ? "Plus" : "Pro"
-            } subscriber!`,
+            `${chalk.bold(
+              `Thanks for being a ChatGPT ${
+                planType === "plus" ? "Plus" : "Pro"
+              } subscriber!`,
+            )}\nIf you haven't already redeemed, you should receive ${
+              planType === "plus" ? "$5" : "$50"
+            } in API credits\nCredits: ${chalk.dim(chalk.underline("https://platform.openai.com/settings/organization/billing/credit-grants"))}\nMore info: ${chalk.dim(chalk.underline("https://help.openai.com/en/articles/11381614"))}`,
+          ),
+        );
+      } else {
+        // eslint-disable-next-line no-console
+        console.log(
+          chalk.green(
+            `It looks like no credits were granted:\n${JSON.stringify(
+              redeemData,
+              null,
+              2,
+            )}\nCredits: ${chalk.dim(
+              chalk.underline(
+                "https://platform.openai.com/settings/organization/billing/credit-grants",
+              ),
+            )}\nMore info: ${chalk.dim(
+              chalk.underline("https://help.openai.com/en/articles/11381614"),
+            )}`,
           ),
         );
       }
@@ -697,7 +717,6 @@ export async function getApiKey(
   try {
     const key = await signInFlow(issuer, clientId);
     spinner.unmount();
-    clearTerminal();
     process.env["OPENAI_API_KEY"] = key;
     return key;
   } catch (err) {


### PR DESCRIPTION
## Summary
- add `--login` and `--free` flags to cli help
- handle `--login` and `--free` logic in cli
- factor out redeem flow into `maybeRedeemCredits`
- call new helper from login callback