### PR TITLE
bump(version): 0.1.2505171619

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 You can install any of these versions: `npm install -g codex@version`
 
+## `0.1.2505171619`
+
+- `codex --login` + `codex --free` (#998)
+
 ## `0.1.2505161800`
 
 - Sign in with chatgpt credits (#974)

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openai/codex",
-  "version": "0.1.2504301751",
+  "version": "0.0.0-dev",
   "license": "Apache-2.0",
   "bin": {
     "codex": "bin/codex.js"


### PR DESCRIPTION
## `0.1.2505171619`

- `codex --login` + `codex --free` (#998)