### PR TITLE
The log file name should not use the colon character

### DIFF
--- a/codex-cli/src/utils/logger/log.ts
+++ b/codex-cli/src/utils/logger/log.ts
@@ -65,7 +65,7 @@ function now() {
   const hours = String(date.getHours()).padStart(2, "0");
   const minutes = String(date.getMinutes()).padStart(2, "0");
   const seconds = String(date.getSeconds()).padStart(2, "0");
-  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}`;
+  return `${year}-${month}-${day}T${hours}-${minutes}-${seconds}`;
 }
 
 let logger: Logger;


### PR DESCRIPTION
Windows cannot create a file if the filename contains a colon.

This pull request includes a small change to the `now` function in `codex-cli/src/utils/logger/log.ts`. The change modifies the time format in the returned string by replacing the colon (`:`) separators in the time portion with hyphens (`-`).

fixes #1003