### PR TITLE
fix: Initialize environment variables for the active non-OpenAI provider

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -36,6 +36,7 @@ import {
   loadConfig,
   PRETTY_PRINT,
   INSTRUCTIONS_FILEPATH,
+  getApiKey,
 } from "./utils/config";
 import {
   getApiKey as fetchApiKey,
@@ -307,20 +308,27 @@ let savedTokens:
     }
   | undefined;
 
-// Try to load existing auth file if present
 try {
-  const home = os.homedir();
-  const authDir = path.join(home, ".codex");
-  const authFile = path.join(authDir, "auth.json");
-  if (fs.existsSync(authFile)) {
-    const data = JSON.parse(fs.readFileSync(authFile, "utf-8"));
-    savedTokens = data.tokens;
-    const lastRefreshTime = data.last_refresh
-      ? new Date(data.last_refresh).getTime()
-      : 0;
-    const expired = Date.now() - lastRefreshTime > 28 * 24 * 60 * 60 * 1000;
-    if (data.OPENAI_API_KEY && !expired) {
-      apiKey = data.OPENAI_API_KEY;
+  if (config.provider?.toLowerCase() === "openai") {
+    // Try to load existing auth file if present
+    const home = os.homedir();
+    const authDir = path.join(home, ".codex");
+    const authFile = path.join(authDir, "auth.json");
+    if (fs.existsSync(authFile)) {
+      const data = JSON.parse(fs.readFileSync(authFile, "utf-8"));
+      savedTokens = data.tokens;
+      const lastRefreshTime = data.last_refresh
+        ? new Date(data.last_refresh).getTime()
+        : 0;
+      const expired = Date.now() - lastRefreshTime > 28 * 24 * 60 * 60 * 1000;
+      if (data.OPENAI_API_KEY && !expired) {
+        apiKey = data.OPENAI_API_KEY;
+      }
+    }
+  } else {
+    const providerApiKey = getApiKey(config.provider);
+    if (providerApiKey) {
+      apiKey = providerApiKey;
     }
   }
 } catch {

--- a/codex-cli/src/utils/get-api-key-components.tsx
+++ b/codex-cli/src/utils/get-api-key-components.tsx
@@ -1,3 +1,4 @@
+import { loadConfig, saveConfig } from "./config.js";
 import SelectInput from "../components/select-input/select-input.js";
 import Spinner from "../components/vendor/ink-spinner.js";
 import TextInput from "../components/vendor/ink-text-input.js";
@@ -11,7 +12,7 @@ export function ApiKeyPrompt({
 }: {
   onDone: (choice: Choice) => void;
 }): JSX.Element {
-  const [step, setStep] = useState<"select" | "paste">("select");
+  const [step, setStep] = useState<"select" | "paste" | "exit">("select");
   const [apiKey, setApiKey] = useState("");
 
   if (step === "select") {
@@ -31,16 +32,43 @@ export function ApiKeyPrompt({
               label: "Paste an API key (or set as OPENAI_API_KEY)",
               value: "paste",
             },
+            {
+              label: "Use a different provider (e.g. Azure, edit config file)",
+              value: "other",
+            },
           ]}
           onSelect={(item: { value: string }) => {
-            if (item.value === "signin") {
-              onDone({ type: "signin" });
-            } else {
-              setStep("paste");
+            switch (item.value) {
+              case "signin":
+                onDone({ type: "signin" });
+                break;
+              case "paste":
+                setStep("paste");
+                break;
+              case "other":
+                saveConfig({
+                  ...loadConfig(),
+                  provider: "openai",
+                });
+                setStep("exit");
+
+                setTimeout(() => process.exit(0), 60);
+                break;
+              default:
+                break;
             }
           }}
         />
       </Box>
+    );
+  }
+
+  if (step === "exit") {
+    return (
+      <Text>
+        Please edit ~/.codex/config.json with your provider's API key, then
+        restart codex.
+      </Text>
     );
   }
 


### PR DESCRIPTION
Fixes #975

This PR addresses issue #975 by correcting an initialization problem for non-OpenAI providers. It also adds a new option to the initial setup prompt to guide users who wish to configure alternative providers (e.g., Azure) via the `~/.codex/config.json` file, aiming to make this process more straightforward for newcomers.
For instance, when I first tried to use Azure, I followed the README using the `--provider` option, but was still prompted for OpenAI login, which was a bit confusing. This new prompt option is intended to prevent such initial hurdles.

Similar improvements may have been addressed in [PR #990](https://github.com/openai/codex/pull/990). If that PR sufficiently covers the necessary changes, please feel free to close this one.