### PR TITLE
docs: readme correction, global instructions currently at ~/.codex/instructions.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ Key flags: `--model/-m`, `--approval-mode/-a`, `--quiet/-q`, and `--notify`.
 
 You can give Codex extra instructions and guidance using `AGENTS.md` files. Codex looks for `AGENTS.md` files in the following places, and merges them top-down:
 
-1. `~/.codex/AGENTS.md` - personal global guidance
+1. `~/.codex/instructions.md` - personal global guidance
 2. `AGENTS.md` at repo root - shared project notes
 3. `AGENTS.md` in the current working directory - sub-folder/feature specifics
 


### PR DESCRIPTION
fixes #960 

Codex currently pulls from `~/.codex/instructions.md` for global instructions. 

This PR adjusts the `README.md` to better reflect current state of code and hopefully reduce setup confusion.