### PR TITLE
fix: correct CLI command in error message to 'openai api models.list'

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -442,7 +442,7 @@ if (
   console.error(
     `The model "${config.model}" does not appear in the list of models ` +
       `available to your account. Double-check the spelling (use\n` +
-      `  openai models list\n` +
+      `  openai api models.list\n` +
       `to see the full list) or choose another model with the --model flag.`,
   );
   process.exit(1);


### PR DESCRIPTION
fix: correct CLI command in error message to 'openai api models.list'

The previous message suggested 'openai models list', which is not a valid command.