### PR TITLE
Fix timeout overflow warning

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -305,7 +305,8 @@ export class AgentLoop {
     this.disableResponseStorage = disableResponseStorage ?? false;
     this.sessionId = getSessionId() || randomUUID().replaceAll("-", "");
     // Configure OpenAI client with optional timeout (ms) from environment
-    const timeoutMs = OPENAI_TIMEOUT_MS;
+    // Ensure timeout doesn't exceed max safe integer for Node.js timeouts (prevent TimeoutOverflowWarning)
+    const timeoutMs = OPENAI_TIMEOUT_MS && OPENAI_TIMEOUT_MS < 2147483647 ? OPENAI_TIMEOUT_MS : undefined;
     const apiKey = this.config.apiKey ?? process.env["OPENAI_API_KEY"] ?? "";
     const baseURL = getBaseUrl(this.provider);
 
@@ -347,6 +348,7 @@ export class AgentLoop {
         },
         httpAgent: PROXY_URL ? new HttpsProxyAgent(PROXY_URL) : undefined,
         ...(timeoutMs !== undefined ? { timeout: timeoutMs } : {}),
+        // Timeout is already validated above
       });
     }
 

--- a/codex-cli/src/utils/agent/sandbox/raw-exec.ts
+++ b/codex-cli/src/utils/agent/sandbox/raw-exec.ts
@@ -120,6 +120,7 @@ export function exec(
       killTarget("SIGTERM");
 
       // Escalate to SIGKILL if the group refuses to die.
+      // Use a reasonable timeout value (2 seconds) to avoid Node.js TimeoutOverflowWarning
       setTimeout(() => {
         if (!child.killed) {
           killTarget("SIGKILL");

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -63,8 +63,13 @@ export const CONFIG_YML_FILEPATH = join(CONFIG_DIR, "config.yml");
 export const CONFIG_FILEPATH = CONFIG_JSON_FILEPATH;
 export const INSTRUCTIONS_FILEPATH = join(CONFIG_DIR, "instructions.md");
 
-export const OPENAI_TIMEOUT_MS =
-  parseInt(process.env["OPENAI_TIMEOUT_MS"] || "0", 10) || undefined;
+// Cap timeout to avoid Node.js TimeoutOverflowWarning (max safe 32-bit signed integer)
+const MAX_SAFE_TIMEOUT = 2147483647;
+export const OPENAI_TIMEOUT_MS = (() => {
+  const parsed = parseInt(process.env["OPENAI_TIMEOUT_MS"] || "0", 10);
+  if (!parsed) return undefined;
+  return parsed > MAX_SAFE_TIMEOUT ? MAX_SAFE_TIMEOUT : parsed;
+})();
 export const OPENAI_BASE_URL = process.env["OPENAI_BASE_URL"] || "";
 export let OPENAI_API_KEY = process.env["OPENAI_API_KEY"] || "";
 


### PR DESCRIPTION
This PR fixes the TimeoutOverflowWarning by adding safeguards for large timeout values that exceed Node.js 32-bit integer limit.