### PR TITLE
Requesty as Provider like Openrouter

### DIFF
--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -12,6 +12,11 @@ export const providers: Record<
     baseURL: "https://openrouter.ai/api/v1",
     envKey: "OPENROUTER_API_KEY",
   },
+  requesty: {
+    name: "Requesty",
+    baseURL: "https://router.requesty.ai/v1",
+    envKey: "REQUESTY_API_KEY",
+  },
   azure: {
     name: "AzureOpenAI",
     baseURL: "https://YOUR_PROJECT_NAME.openai.azure.com/openai",

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -97,6 +97,16 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
             },
         ),
         (
+            "requesty",
+            P {
+                name: "Requesty".into(),
+                base_url: "https://router.requesty.ai/v1".into(),
+                env_key: Some("REQUESTY_API_KEY".into()),
+                env_key_instructions: None,
+                wire_api: WireApi::Chat,
+            },
+        ),
+        (
             "gemini",
             P {
                 name: "Gemini".into(),


### PR DESCRIPTION
Description:

This PR adds Requesty as a new AI provider to Codex, allowing users to access Requesty's models through the same interface as other providers. Requesty currently has over 15k developers using the Gateway.

Changes
Added requesty to the providers list in the TypeScript implementation (codex-cli/src/utils/providers.ts)
Added requesty to the built-in model providers list in the Rust implementation (codex-rs/core/src/model_provider_info.rs)

Configured Requesty to use the Chat API format, similar to OpenRouter
