### PR TITLE
Fix nix run and nix develop by using pnpm-lock.yaml

### DIFF
--- a/codex-cli/default.nix
+++ b/codex-cli/default.nix
@@ -1,35 +1,62 @@
 { pkgs, monorep-deps ? [], ... }:
 let
   node = pkgs.nodejs_22;
+  pnpm = pkgs.pnpm_10;                 
 in
 rec {
-  package = pkgs.buildNpmPackage {
-    pname       = "codex-cli";
-    version     = "0.1.0";
-    src         = ./.;
-    npmDepsHash = "sha256-3tAalmh50I0fhhd7XreM+jvl0n4zcRhqygFNB1Olst8";
-    nodejs      = node;
-    npmInstallFlags = [ "--frozen-lockfile" ];
+  package = pkgs.stdenv.mkDerivation (final: {
+    pname   = "codex-cli";
+    version = "0.1.0";
+    src     = ./..;                      
+
+    pnpmDeps = pnpm.fetchDeps {
+      inherit (final) pname version src;
+      hash = "sha256-SyKP++eeOyoVBFscYi+Q7IxCphcEeYgpuAj70+aCdNA=";
+    };
+
+    nativeBuildInputs = [
+      node 
+      pnpm 
+      pnpm.configHook         
+      pkgs.jq                          
+      pkgs.makeWrapper
+    ];
+
+    pnpmInstallFlags = [ "--frozen-lockfile" ];
+
+    buildPhase = ''
+      runHook preBuild
+      pnpm install --offline --frozen-lockfile
+      pnpm --filter ./codex-cli... run build
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      pkgRoot=$out/lib/node_modules/${final.pname}
+      mkdir -p $pkgRoot
+      cp -R codex-cli/* $pkgRoot/
+
+      path=$(jq -r '.bin.codex' codex-cli/package.json)
+      mkdir -p $out/bin
+      makeWrapper ${node}/bin/node $out/bin/codex --add-flags "$pkgRoot/$path"
+
+      runHook postInstall
+    '';
+
     meta = with pkgs.lib; {
       description = "OpenAI Codex command‑line interface";
       license     = licenses.asl20;
       homepage    = "https://github.com/openai/codex";
     };
-  };
+  });
   devShell = pkgs.mkShell {
     name        = "codex-cli-dev";
-    buildInputs = monorep-deps ++ [
-      node
-      pkgs.pnpm
-    ];
+    buildInputs = monorep-deps ++ [ node pnpm ];
     shellHook = ''
-      echo "Entering development shell for codex-cli"
-      # cd codex-cli
-      if [ -f package-lock.json ]; then
-        pnpm ci || echo "npm ci failed"
-      else
-        pnpm install || echo "npm install failed"
-      fi
+      echo >&2 "Entering development shell for codex-cli"
+      pnpm install && echo "pnpm install succeded" || echo "npm install failed"
       npm run build || echo "npm build failed"
       export PATH=$PWD/node_modules/.bin:$PATH
       alias codex="node $PWD/dist/cli.js"

--- a/flake.nix
+++ b/flake.nix
@@ -37,21 +37,20 @@
         packages = {
           codex-cli = codex-cli.package;
           codex-rs = codex-rs.package;
+          default = codex-cli.package;
         };
 
         devShells = {
           codex-cli = codex-cli.devShell;
           codex-rs = codex-rs.devShell;
+          default = codex-cli.devShell;
         };
 
         apps = {
           codex-cli = codex-cli.app;
           codex-rs = codex-rs.app;
+          default = codex-cli.app;
         };
-
-        defaultPackage = packages.codex-cli;
-        defaultApp = apps.codex-cli;
-        defaultDevShell = devShells.codex-cli;
       }
     );
 }


### PR DESCRIPTION
Looks like the flakes for codex-cli are broken right now, `nix run github:openai/codex` doesn't work because package-lock.json is missing. 

In this PR I'm making the nix flake use pnpm-lock.yaml instead. This makes `nix run github:scanhex/codex` run fine - and fixes the same issue with `nix develop`.