### PR TITLE
fix(agent-loop): send apply_patch instructions to non-OpenAI providers

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -787,7 +787,10 @@ export class AgentLoop {
               reasoning = { effort: this.config.reasoningEffort ?? "medium" };
               reasoning.summary = "auto";
             }
-            if (this.model.startsWith("gpt-4.1")) {
+            if (
+              this.config.provider?.toLowerCase() !== "openai" ||
+              this.model.startsWith("gpt-4.1")
+            ) {
               modelSpecificInstructions = applyPatchToolInstructions;
             }
             const mergedInstructions = [


### PR DESCRIPTION
Previously, only models starting with "gpt-4.1" received apply_patch tool instructions. Now, any model whose provider isn’t OpenAI (case-insensitive) will get them too. This fixes the oversight and ensures external providers get the patch-tool guidance.