### PR TITLE
Added AiHubMix provider

### DIFF
--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -52,4 +52,10 @@ export const providers: Record<
     baseURL: "https://conductor.arcee.ai/v1",
     envKey: "ARCEEAI_API_KEY",
   },
+  // Support for AiHubMix provider
+  aihubmix: {
+    name: "AiHubMix",
+    baseURL: "https://aihubmix.com/v1",
+    envKey: "AIHUBMIX_API_KEY",
+  },
 };

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -156,6 +156,16 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
                 wire_api: WireApi::Chat,
             },
         ),
+        (
+            "aihubmix",
+            P {
+                name: "AiHubMix".into(),
+                base_url: "https://aihubmix.com/v1".into(),
+                env_key: Some("AIHUBMIX_API_KEY".into()),
+                env_key_instructions: None,
+                wire_api: WireApi::Chat,
+            },
+        ),
     ]
     .into_iter()
     .map(|(k, v)| (k.to_string(), v))


### PR DESCRIPTION
### AiHubMix Integration for Codex

This PR integrates **AiHubMix** as a new AI provider into Codex, enabling users to access AiHubMix's diverse models through the same unified interface as other providers. AiHubMix offers a wide array of specialized AI models.

---

#### Changes

* **AiHubMix** has been added to the providers list within the TypeScript implementation (`codex-cli/src/utils/providers.ts`).
* **AiHubMix** has been included in the built-in model providers list in the Rust implementation (`codex-rs/core/src/model_provider_info.rs`).
* **AiHubMix** has been configured to utilize the Chat API format, consistent with other major providers like OpenAI.