### PR TITLE
fix: for the @native release of the Node module, use the Rust version by default

### DIFF
--- a/codex-cli/scripts/install_native_deps.sh
+++ b/codex-cli/scripts/install_native_deps.sh
@@ -65,7 +65,7 @@ mkdir -p "$BIN_DIR"
 # Until we start publishing stable GitHub releases, we have to grab the binaries
 # from the GitHub Action that created them. Update the URL below to point to the
 # appropriate workflow run:
-WORKFLOW_URL="https://github.com/openai/codex/actions/runs/15087655786"
+WORKFLOW_URL="https://github.com/openai/codex/actions/runs/15192425904"
 WORKFLOW_ID="${WORKFLOW_URL##*/}"
 
 ARTIFACTS_DIR="$(mktemp -d)"

--- a/codex-cli/scripts/stage_release.sh
+++ b/codex-cli/scripts/stage_release.sh
@@ -122,6 +122,7 @@ jq --arg version "$VERSION" \
 
 if [[ "$INCLUDE_NATIVE" -eq 1 ]]; then
   ./scripts/install_native_deps.sh "$TMPDIR" --full-native
+  touch "${TMPDIR}/bin/use-native"
 else
   ./scripts/install_native_deps.sh "$TMPDIR"
 fi
@@ -130,11 +131,12 @@ popd >/dev/null
 
 echo "Staged version $VERSION for release in $TMPDIR"
 
-echo "Test Node:"
-echo "    node ${TMPDIR}/bin/codex.js --help"
 if [[ "$INCLUDE_NATIVE" -eq 1 ]]; then
   echo "Test Rust:"
-  echo "    CODEX_RUST=1 node ${TMPDIR}/bin/codex.js --help"
+  echo "    node ${TMPDIR}/bin/codex.js --help"
+else
+  echo "Test Node:"
+  echo "    node ${TMPDIR}/bin/codex.js --help"
 fi
 
 # Print final hint for convenience


### PR DESCRIPTION
Added logic so that when we run `./scripts/stage_release.sh --native` (for the `@native` version of the Node module), we drop a `use-native` file next to `codex.js`. If present, `codex.js` will now run the Rust CLI. 

Ran `./scripts/stage_release.sh --native` and verified that when the running `codex.js` in the staged folder:

```
$ /var/folders/wm/f209bc1n2bd_r0jncn9s6j_00000gp/T/tmp.efvEvBlSN6/bin/codex.js --version
codex-cli 0.0.2505220956
```

it ran the expected Rust version of the CLI, as desired.

While here, I also updated the Rust version to one that I cut today, which includes the new shell environment policy config option: https://github.com/openai/codex/pull/1061. Note this may "break" some users if the processes spawned by Codex need extra environment variables. (We are still working to determine what the right defaults should be for this option.)