### PR TITLE
Fix: Correct API key prompt logic for non-OpenAI providers

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -41,6 +41,7 @@ import {
   getApiKey as fetchApiKey,
   maybeRedeemCredits,
 } from "./utils/get-api-key";
+import { providers } from "./utils/providers";
 import { createInputItem } from "./utils/input-utils";
 import { initLogger } from "./utils/logger/log";
 import { isModelSupportedForResponses } from "./utils/model-utils.js";
@@ -319,8 +320,11 @@ try {
       ? new Date(data.last_refresh).getTime()
       : 0;
     const expired = Date.now() - lastRefreshTime > 28 * 24 * 60 * 60 * 1000;
-    if (data.OPENAI_API_KEY && !expired) {
-      apiKey = data.OPENAI_API_KEY;
+    if (provider.toLowerCase() === "openai") { // Only use auth.json key if provider is openai
+      if (data.OPENAI_API_KEY && !expired) {
+        apiKey = data.OPENAI_API_KEY; // This will be used by fetchApiKey for openai
+                                      // or potentially used directly if fetchApiKey is skipped
+      }
     }
   }
 } catch {
@@ -328,7 +332,8 @@ try {
 }
 
 if (cli.flags.login) {
-  apiKey = await fetchApiKey(client.issuer, client.client_id);
+  // Force login means we always call fetchApiKey
+  apiKey = await fetchApiKey(provider, client.issuer, client.client_id, true);
   try {
     const home = os.homedir();
     const authDir = path.join(home, ".codex");
@@ -340,52 +345,57 @@ if (cli.flags.login) {
   } catch {
     /* ignore */
   }
-} else if (!apiKey) {
-  apiKey = await fetchApiKey(client.issuer, client.client_id);
+} else if (!process.env[providers[provider]?.envKey ?? ''] && !apiKey && !NO_API_KEY_REQUIRED.has(provider.toLowerCase())) {
+  // If not login, not already in env, and (if openai) not pre-loaded from auth.json, then fetch.
+  apiKey = await fetchApiKey(provider, client.issuer, client.client_id, false);
 }
-// Ensure the API key is available as an environment variable for legacy code
-process.env["OPENAI_API_KEY"] = apiKey;
+// process.env["OPENAI_API_KEY"] = apiKey; // This line is removed. fetchApiKey handles setting the correct env var.
 
 if (cli.flags.free) {
   // eslint-disable-next-line no-console
   console.log(`${chalk.bold("codex --free")} attempting to redeem credits...`);
-  if (!savedTokens?.refresh_token) {
-    apiKey = await fetchApiKey(client.issuer, client.client_id, true);
-    // fetchApiKey includes credit redemption as the end of the flow
+  if (provider.toLowerCase() === "openai") {
+    if (!savedTokens?.refresh_token) {
+      // apiKey will be set by fetchApiKey, which also handles env var
+      await fetchApiKey(provider, client.issuer, client.client_id, true);
+      // fetchApiKey includes credit redemption as the end of the flow
+    } else {
+      await maybeRedeemCredits(
+        client.issuer,
+        client.client_id,
+        savedTokens.refresh_token,
+        savedTokens.id_token,
+      );
+    }
   } else {
-    await maybeRedeemCredits(
-      client.issuer,
-      client.client_id,
-      savedTokens.refresh_token,
-      savedTokens.id_token,
-    );
+    // eslint-disable-next-line no-console
+    console.log(chalk.yellow(`The --free flag is only applicable for the OpenAI provider.`));
   }
 }
 
 // Set of providers that don't require API keys
 const NO_API_KEY_REQUIRED = new Set(["ollama"]);
 
-// Skip API key validation for providers that don't require an API key
-if (!apiKey && !NO_API_KEY_REQUIRED.has(provider.toLowerCase())) {
+// Check if the API key is in the environment after all potential fetch/set operations
+const currentProviderEnvKey = providers[provider]?.envKey;
+if (!currentProviderEnvKey || (!process.env[currentProviderEnvKey] && !NO_API_KEY_REQUIRED.has(provider.toLowerCase()))) {
+  const providerName = providers[provider]?.name ?? provider;
+  const envKeyToSet = currentProviderEnvKey ?? `${provider.toUpperCase()}_API_KEY`;
   // eslint-disable-next-line no-console
   console.error(
-    `\n${chalk.red(`Missing ${provider} API key.`)}\n\n` +
-      `Set the environment variable ${chalk.bold(
-        `${provider.toUpperCase()}_API_KEY`,
-      )} ` +
-      `and re-run this command.\n` +
+    `\n${chalk.red(`Missing ${providerName} API key.`)}\n\n` +
+      `Set the environment variable ${chalk.bold(envKeyToSet)} ` +
+      `and re-run this command, or run with --login if you are using OpenAI.\n` +
       `${
         provider.toLowerCase() === "openai"
           ? `You can create a key here: ${chalk.bold(
               chalk.underline("https://platform.openai.com/account/api-keys"),
             )}\n`
           : provider.toLowerCase() === "gemini"
-            ? `You can create a ${chalk.bold(
-                `${provider.toUpperCase()}_API_KEY`,
-              )} ` + `in the ${chalk.bold(`Google AI Studio`)}.\n`
-            : `You can create a ${chalk.bold(
-                `${provider.toUpperCase()}_API_KEY`,
-              )} ` + `in the ${chalk.bold(`${provider}`)} dashboard.\n`
+            ? `You can create a ${chalk.bold(envKeyToSet)} ` +
+              `in the ${chalk.bold("Google AI Studio")}.\n`
+            : `You can create a ${chalk.bold(envKeyToSet)} ` +
+              `in the ${chalk.bold(providerName)} dashboard.\n`
       }`,
   );
   process.exit(1);
@@ -398,7 +408,11 @@ const disableResponseStorage = flagPresent
   : (config.disableResponseStorage ?? false); // fall back to YAML, default to false
 
 config = {
-  apiKey,
+  // apiKey is no longer the source of truth here for all providers.
+  // Environment variables are set by fetchApiKey.
+  // For OpenAI, if apiKey was loaded from auth.json, it might be used.
+  // For other providers, it's whatever is in their specific env var.
+  apiKey: process.env[providers[provider]?.envKey ?? ''] ?? (provider.toLowerCase() === 'openai' ? apiKey : ''),
   ...config,
   model: model ?? config.model,
   notify: Boolean(cli.flags.notify),

--- a/codex-cli/src/utils/get-api-key-components.tsx
+++ b/codex-cli/src/utils/get-api-key-components.tsx
@@ -8,8 +8,12 @@ export type Choice = { type: "signin" } | { type: "apikey"; key: string };
 
 export function ApiKeyPrompt({
   onDone,
+  providerName,
+  providerEnvKey,
 }: {
   onDone: (choice: Choice) => void;
+  providerName: string;
+  providerEnvKey: string;
 }): JSX.Element {
   const [step, setStep] = useState<"select" | "paste">("select");
   const [apiKey, setApiKey] = useState("");
@@ -18,20 +22,36 @@ export function ApiKeyPrompt({
     return (
       <Box flexDirection="column" gap={1}>
         <Box flexDirection="column">
-          <Text>
-            Sign in with ChatGPT to generate an API key or paste one you already
-            have.
-          </Text>
+          {providerName === "OpenAI" ? (
+            <Text>
+              Sign in with {providerName} to generate an API key or paste one
+              you already have.
+            </Text>
+          ) : (
+            <Text>
+              Paste your {providerName} API key or set it as an environment
+              variable.
+            </Text>
+          )}
           <Text dimColor>[use arrows to move, enter to select]</Text>
         </Box>
         <SelectInput
-          items={[
-            { label: "Sign in with ChatGPT", value: "signin" },
-            {
-              label: "Paste an API key (or set as OPENAI_API_KEY)",
-              value: "paste",
-            },
-          ]}
+          items={
+            providerName === "OpenAI"
+              ? [
+                  { label: `Sign in with ${providerName}`, value: "signin" },
+                  {
+                    label: `Paste an API key (or set as ${providerEnvKey})`,
+                    value: "paste",
+                  },
+                ]
+              : [
+                  {
+                    label: `Paste an API key (or set as ${providerEnvKey})`,
+                    value: "paste",
+                  },
+                ]
+          }
           onSelect={(item: { value: string }) => {
             if (item.value === "signin") {
               onDone({ type: "signin" });
@@ -46,7 +66,9 @@ export function ApiKeyPrompt({
 
   return (
     <Box flexDirection="column">
-      <Text>Paste your OpenAI API key and press &lt;Enter&gt;:</Text>
+      <Text>
+        Paste your {providerName} API key and press &lt;Enter&gt;:
+      </Text>
       <TextInput
         value={apiKey}
         onChange={setApiKey}

--- a/codex-cli/src/utils/get-api-key.tsx
+++ b/codex-cli/src/utils/get-api-key.tsx
@@ -1,7 +1,8 @@
 import type { Choice } from "./get-api-key-components";
 import type { Request, Response } from "express";
-import { providers } from "./providers";
+
 import { ApiKeyPrompt, WaitingForAuth } from "./get-api-key-components";
+import { providers } from "./providers";
 import chalk from "chalk";
 import express from "express";
 import fs from "fs/promises";
@@ -748,9 +749,7 @@ export async function getApiKey(
   let provider = providers[providerId];
   if (!provider) {
     // eslint-disable-next-line no-console
-    console.warn(
-      `Provider "${providerId}" not found, defaulting to OpenAI.`,
-    );
+    console.warn(`Provider "${providerId}" not found, defaulting to OpenAI.`);
     provider = providers["openai"];
   }
 

--- a/codex-cli/src/utils/get-api-key.tsx
+++ b/codex-cli/src/utils/get-api-key.tsx
@@ -1,6 +1,6 @@
 import type { Choice } from "./get-api-key-components";
 import type { Request, Response } from "express";
-
+import { providers } from "./providers";
 import { ApiKeyPrompt, WaitingForAuth } from "./get-api-key-components";
 import chalk from "chalk";
 import express from "express";
@@ -13,7 +13,10 @@ import os from "os";
 import path from "path";
 import React from "react";
 
-function promptUserForChoice(): Promise<Choice> {
+function promptUserForChoice(
+  providerName: string,
+  providerEnvKey: string,
+): Promise<Choice> {
   return new Promise<Choice>((resolve) => {
     const instance = render(
       <ApiKeyPrompt
@@ -21,6 +24,8 @@ function promptUserForChoice(): Promise<Choice> {
           resolve(choice);
           instance.unmount();
         }}
+        providerName={providerName}
+        providerEnvKey={providerEnvKey}
       />,
     );
   });
@@ -735,29 +740,52 @@ async function signInFlow(issuer: string, clientId: string): Promise<string> {
 }
 
 export async function getApiKey(
+  providerId: string,
   issuer: string,
   clientId: string,
   forceLogin: boolean = false,
 ): Promise<string> {
-  if (!forceLogin && process.env["OPENAI_API_KEY"]) {
-    return process.env["OPENAI_API_KEY"]!;
+  let provider = providers[providerId];
+  if (!provider) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `Provider "${providerId}" not found, defaulting to OpenAI.`,
+    );
+    provider = providers["openai"];
   }
-  const choice = await promptUserForChoice();
+
+  const { name: providerName, envKey: providerEnvKey } = provider;
+
+  if (!forceLogin && process.env[providerEnvKey]) {
+    return process.env[providerEnvKey]!;
+  }
+  const choice = await promptUserForChoice(providerName, providerEnvKey);
   if (choice.type === "apikey") {
-    process.env["OPENAI_API_KEY"] = choice.key;
+    process.env[providerEnvKey] = choice.key;
     return choice.key;
   }
-  const spinner = render(<WaitingForAuth />);
-  try {
-    const key = await signInFlow(issuer, clientId);
-    spinner.clear();
-    spinner.unmount();
-    process.env["OPENAI_API_KEY"] = key;
-    return key;
-  } catch (err) {
-    spinner.clear();
-    spinner.unmount();
-    throw err;
+
+  // Only trigger signInFlow for OpenAI
+  if (providerId === "openai") {
+    const spinner = render(<WaitingForAuth />);
+    try {
+      const key = await signInFlow(issuer, clientId);
+      spinner.clear();
+      spinner.unmount();
+      process.env[providerEnvKey] = key;
+      return key;
+    } catch (err) {
+      spinner.clear();
+      spinner.unmount();
+      throw err;
+    }
+  } else {
+    // For other providers, if key is not in env and user didn't paste, throw error.
+    // The ApiKeyPrompt already handles not showing "Sign in" for non-OpenAI providers.
+    // So, if we reach here, it means the user didn't paste a key.
+    throw new Error(
+      `API key for ${providerName} not found. Please set the ${providerEnvKey} environment variable or paste the key when prompted.`,
+    );
   }
 }
 


### PR DESCRIPTION
The application was incorrectly prompting for OpenAI credentials (API key or login) even when a different provider (e.g., Gemini) was selected and its corresponding API key (e.g., GEMINI_API_KEY) was set.

This commit addresses the issue by:

1.  **Generalizing API Key Components:**
    *   The `ApiKeyPrompt` component in `codex-cli/src/utils/get-api-key-components.tsx` now accepts `providerName` and `providerEnvKey` props.
    *   It dynamically displays provider-specific messages and options. The "Sign in" option is now only shown for OpenAI.

2.  **Making API Key Retrieval Provider-Aware:**
    *   The `getApiKey` function in `codex-cli/src/utils/get-api-key.tsx` now accepts a `providerId`.
    *   It uses this `providerId` to look up the correct API key environment variable (e.g., `GEMINI_API_KEY`) from `providers.ts`.
    *   It passes the correct provider name and environment key to the `ApiKeyPrompt`.
    *   The OpenAI-specific sign-in flow (`signInFlow`) is only triggered if the provider is "openai".
    *   Sets the correct provider-specific environment variable (e.g., `process.env.GEMINI_API_KEY`) when a key is pasted.

3.  **Updating Call Sites:**
    *   The main CLI entry point (`codex-cli/src/cli.tsx`) now passes the selected `provider` to `fetchApiKey` (the imported name for `getApiKey`).
    *   It relies on `fetchApiKey` to handle setting the correct provider-specific environment variable.
    *   The logic for checking for missing API keys and displaying error messages has been updated to use the current provider's specific environment variable name and display name.
    *   Loading keys from `auth.json` is now correctly scoped to the OpenAI provider.
    *   Flags like `--free` and `--login` are now handled correctly, showing messages or errors when used with non-OpenAI providers.

These changes ensure that you are prompted for the correct API key based on your selected provider and that provider-specific environment variables are respected.