### PR TITLE
codex -v <rollout> is not working

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -124,7 +124,7 @@ const cli = meow(
       // misc
       help: { type: "boolean", aliases: ["h"] },
       version: { type: "boolean", description: "Print version and exit" },
-      view: { type: "string" },
+      view: { type: "string", aliases: ["v"] },
       history: { type: "boolean", description: "Browse previous sessions" },
       login: { type: "boolean", description: "Force a new sign in flow" },
       free: { type: "boolean", description: "Retry redeeming free credits" },


### PR DESCRIPTION

This pull request introduces a minor improvement to the `codex-cli` by adding an alias for the `view` option in the CLI. 

* [`codex-cli/src/cli.tsx`](diffhunk://#diff-d0c60208d61213d8f02913352d9a3ae13f3e4a9594cd67fcf75ffee3b8c02160L127-R127): Updated the `view` option to include an alias `-v`, making it more convenient for users to access this functionality.

fixes #1120