### PR TITLE
fix: Support Azure OpenAI Responses API

### DIFF
--- a/codex-cli/src/components/chat/terminal-chat.tsx
+++ b/codex-cli/src/components/chat/terminal-chat.tsx
@@ -426,6 +426,9 @@ export default function TerminalChat({
   // ────────────────────────────────────────────────────────────────
   useEffect(() => {
     (async () => {
+      if (provider.toLowerCase() === "azure") {
+        return;
+      }
       const available = await getAvailableModels(provider);
       if (model && available.length > 0 && !available.includes(model)) {
         setItems((prev) => [

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -800,7 +800,8 @@ export class AgentLoop {
 
             const responseCall =
               !this.config.provider ||
-              this.config.provider?.toLowerCase() === "openai"
+              this.config.provider?.toLowerCase() === "openai" ||
+              this.config.provider?.toLowerCase() === "azure"
                 ? (params: ResponseCreateParams) =>
                     this.oai.responses.create(params)
                 : (params: ResponseCreateParams) =>
@@ -1188,7 +1189,8 @@ export class AgentLoop {
 
               const responseCall =
                 !this.config.provider ||
-                this.config.provider?.toLowerCase() === "openai"
+                this.config.provider?.toLowerCase() === "openai" ||
+                this.config.provider?.toLowerCase() === "azure"
                   ? (params: ResponseCreateParams) =>
                       this.oai.responses.create(params)
                   : (params: ResponseCreateParams) =>


### PR DESCRIPTION
This pull request introduces support for the Azure provider in the `codex-cli` project by adding conditional logic to handle Azure-specific cases in both the `TerminalChat` component and the `AgentLoop` utility class.

### Changes related to Azure provider support:

* [`codex-cli/src/components/chat/terminal-chat.tsx`](diffhunk://#diff-3ca20e3e19776666dbd4236fed974b3091250c64d2eead5c1f37f694736cb046R429-R431): Added a condition in the `useEffect` hook to bypass fetching available models if the provider is Azure. In [Azure OpenAI Responses API (Preview)](https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/responses?WT.mc_id=DT-MVP-4015686&tabs=python-secure), the endpoint doesn't include the deployment name. So the model in the request payload means "Deployment Name". So This warning can be ignored when using Azure OpenAI using Reponses API.
* [`codex-cli/src/utils/agent/agent-loop.ts`](diffhunk://#diff-b15957eac2720c3f1f55aa32f172cdd0ac6969caf4e7be87983df747a9f97083L803-R804): Updated the logic in two instances to include Azure as a valid provider for response creation, alongside OpenAI. [[1]](diffhunk://#diff-b15957eac2720c3f1f55aa32f172cdd0ac6969caf4e7be87983df747a9f97083L803-R804) [[2]](diffhunk://#diff-b15957eac2720c3f1f55aa32f172cdd0ac6969caf4e7be87983df747a9f97083L1191-R1193)

related #11

fixes #1010
