### PR TITLE
Allow running without a sandbox if the user has explicitly marked the environment as already being sufficiently locked-down.

### DIFF
--- a/codex-cli/src/utils/agent/handle-exec-command.ts
+++ b/codex-cli/src/utils/agent/handle-exec-command.ts
@@ -293,7 +293,11 @@ const isSandboxExecAvailable: Promise<boolean> = fs
 
 async function getSandbox(runInSandbox: boolean): Promise<SandboxType> {
   if (runInSandbox) {
-    if (process.platform === "darwin") {
+    if (CODEX_UNSAFE_ALLOW_NO_SANDBOX) {
+      // Allow running without a sandbox if the user has explicitly marked the
+      // environment as already being sufficiently locked-down.
+      return SandboxType.NONE;
+    } else if (process.platform === "darwin") {
       // On macOS we rely on the system-provided `sandbox-exec` binary to
       // enforce the Seatbelt profile.  However, starting with macOS 14 the
       // executable may be removed from the default installation or the user
@@ -313,10 +317,6 @@ async function getSandbox(runInSandbox: boolean): Promise<SandboxType> {
       // using Landlock in a Linux Docker container from a macOS host may not
       // work.
       return SandboxType.LINUX_LANDLOCK;
-    } else if (CODEX_UNSAFE_ALLOW_NO_SANDBOX) {
-      // Allow running without a sandbox if the user has explicitly marked the
-      // environment as already being sufficiently locked-down.
-      return SandboxType.NONE;
     }
 
     // For all else, we hard fail if the user has requested a sandbox and none is available.


### PR DESCRIPTION
This pull request modifies the sandbox selection logic in the `getSandbox` function to prioritize a new environment variable, `CODEX_UNSAFE_ALLOW_NO_SANDBOX`, for improved flexibility in sandbox behavior. The most important changes include reordering condition checks and removing redundant code.

### Sandbox logic updates:

* [`codex-cli/src/utils/agent/handle-exec-command.ts`](diffhunk://#diff-1b37fa9d56af38298f4d5e6e3d921d39798ed533e07c417260a4b983cf2a90a3L296-R300): Added a condition to prioritize the `CODEX_UNSAFE_ALLOW_NO_SANDBOX` environment variable, allowing users to explicitly disable sandboxing if they have ensured a secure environment. This condition now appears before the macOS-specific sandbox logic.