### PR TITLE
feat(cli): support --output json and --all-events in quiet mode

### DIFF
--- a/codex-cli/tests/text-buffer-boundary.test.ts
+++ b/codex-cli/tests/text-buffer-boundary.test.ts
@@ -1,0 +1,45 @@
+import TextBuffer from "../src/text-buffer";
+import { describe, it, expect } from "vitest";
+
+describe("TextBuffer – boundary tests", () => {
+  describe("extremely long lines", () => {
+    it("should handle very long single line", () => {
+      const longLine = "a".repeat(10000);
+      const buf = new TextBuffer(longLine);
+      
+      // Test cursor movement in long line
+      buf.move("end");
+      expect(buf.getCursor()).toEqual([0, 10000]);
+      
+      // Test insert in middle of long line
+      buf.move("left");
+      buf.insert("b");
+      expect(buf.getText().length).toBe(10001);
+      
+      // Test delete in long line
+      buf.del();
+      expect(buf.getText().length).toBe(10000);
+    });
+  });
+
+  describe("large number of lines", () => {
+    it("should handle buffer with many lines", () => {
+      const manyLines = Array(1000).fill("test").join("\n");
+      const buf = new TextBuffer(manyLines);
+      
+      // Test cursor movement through many lines
+      buf.move("end");
+      expect(buf.getCursor()[0]).toBe(999);
+      
+      // Test insert at end of many lines
+      buf.insert("x");
+      expect(buf.getLines().length).toBe(1000);
+      
+      // Test newline in middle of many lines
+      buf.move("up");
+      buf.move("end");
+      buf.insert("\n");
+      expect(buf.getLines().length).toBe(1001);
+    });
+  });
+}); 


### PR DESCRIPTION
### What
- Add --output json flag to quiet mode: only outputs the final assistant reply as JSON by default.
- Add --all-events flag: with --output json, outputs all agent events as NDJSON (one JSON object per line).

### Why
- Makes CLI output more machine-friendly for automation, scripting, and downstream processing.
- Allows advanced users to inspect the full agent reasoning and event flow if needed.

### Usage
1. ```codex-cli codex -q -o json "hello world"```
2. ```codex-cli codex -q -o json --all-events -- "hello world"```

### Example Output
1. {"id":"msg_683561194e28819886651b6cea6aa3f60c7c92b173cc6465","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"text":"Hello there! 👋 How can I help you today?"}],"role":"assistant"}
2. {"role":"user","content":[{"type":"input_text","text":"hello world"}],"type":"message"}
{"id":"rs_683561543bcc8198ad27c87039cf441507307a072af725fc","type":"reasoning","summary":[],"duration_ms":4358}
{"id":"lsh_683561571b588198843c06db911d897107307a072af725fc","type":"local_shell_call","status":"completed","action":{"type":"exec","command":["bash","-lc","node --version"],"env":{},"timeout_ms":1200000,"user":"root","working_directory":"/"},"call_id":"call_HwfgtOBCPDpXgfCykTVQHB9h"}
{"type":"local_shell_call_output","call_id":"call_HwfgtOBCPDpXgfCykTVQHB9h","output":"{\"output\":\"aborted\",\"metadata\":{}}"}
{"type":"message","role":"user","content":[{"type":"input_text","text":"No, don't do that — keep going though."}]}
{"id":"rs_68356158a004819884ea5fe1406ca16807307a072af725fc","type":"reasoning","summary":[],"duration_ms":9333}
{"id":"msg_6835615c0a7c8198b936af36db325ecf07307a072af725fc","type":"message","status":"completed","content":[{"type":"output_text","annotations":[],"text":"Hello, world! 👋 What can I help you with today?"}],"role":"assistant"}

