### PR TITLE
fix: use o4-mini as the default model

### DIFF
--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -32,7 +32,7 @@ The `config.toml` file supports the following options:
 The model that Codex should use.
 
 ```toml
-model = "o3"  # overrides the default of "codex-mini-latest"
+model = "o3"  # overrides the default of "o4-mini"
 ```
 
 ### model_provider

--- a/codex-rs/core/src/flags.rs
+++ b/codex-rs/core/src/flags.rs
@@ -3,7 +3,7 @@ use std::time::Duration;
 use env_flags::env_flags;
 
 env_flags! {
-    pub OPENAI_DEFAULT_MODEL: &str = "codex-mini-latest";
+    pub OPENAI_DEFAULT_MODEL: &str = "o4-mini";
     pub OPENAI_API_BASE: &str = "https://api.openai.com/v1";
 
     /// Fallback when the provider-specific key is not set.


### PR DESCRIPTION
Rollback of https://github.com/openai/codex/pull/972.