### PR TITLE
feat: add support for -c/--config to override individual config items

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -506,6 +506,8 @@ version = "0.0.0"
 dependencies = [
  "clap",
  "codex-core",
+ "serde",
+ "toml",
 ]
 
 [[package]]
@@ -634,6 +636,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]

--- a/codex-rs/cli/src/lib.rs
+++ b/codex-rs/cli/src/lib.rs
@@ -3,6 +3,7 @@ mod exit_status;
 pub mod proto;
 
 use clap::Parser;
+use codex_common::CliConfigOverrides;
 use codex_common::SandboxPermissionOption;
 
 #[derive(Debug, Parser)]
@@ -13,6 +14,9 @@ pub struct SeatbeltCommand {
 
     #[clap(flatten)]
     pub sandbox: SandboxPermissionOption,
+
+    #[clap(skip)]
+    pub config_overrides: CliConfigOverrides,
 
     /// Full command args to run under seatbelt.
     #[arg(trailing_var_arg = true)]
@@ -27,6 +31,9 @@ pub struct LandlockCommand {
 
     #[clap(flatten)]
     pub sandbox: SandboxPermissionOption,
+
+    #[clap(skip)]
+    pub config_overrides: CliConfigOverrides,
 
     /// Full command args to run under landlock.
     #[arg(trailing_var_arg = true)]

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -2,6 +2,7 @@ use clap::Parser;
 use codex_cli::LandlockCommand;
 use codex_cli::SeatbeltCommand;
 use codex_cli::proto;
+use codex_common::CliConfigOverrides;
 use codex_exec::Cli as ExecCli;
 use codex_tui::Cli as TuiCli;
 use std::path::PathBuf;
@@ -19,6 +20,9 @@ use crate::proto::ProtoCli;
     subcommand_negates_reqs = true
 )]
 struct MultitoolCli {
+    #[clap(flatten)]
+    pub config_overrides: CliConfigOverrides,
+
     #[clap(flatten)]
     interactive: TuiCli,
 
@@ -73,28 +77,34 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
 
     match cli.subcommand {
         None => {
-            codex_tui::run_main(cli.interactive, codex_linux_sandbox_exe)?;
+            let mut tui_cli = cli.interactive;
+            prepend_config_flags(&mut tui_cli.config_overrides, cli.config_overrides);
+            codex_tui::run_main(tui_cli, codex_linux_sandbox_exe)?;
         }
-        Some(Subcommand::Exec(exec_cli)) => {
+        Some(Subcommand::Exec(mut exec_cli)) => {
+            prepend_config_flags(&mut exec_cli.config_overrides, cli.config_overrides);
             codex_exec::run_main(exec_cli, codex_linux_sandbox_exe).await?;
         }
         Some(Subcommand::Mcp) => {
             codex_mcp_server::run_main(codex_linux_sandbox_exe).await?;
         }
-        Some(Subcommand::Proto(proto_cli)) => {
+        Some(Subcommand::Proto(mut proto_cli)) => {
+            prepend_config_flags(&mut proto_cli.config_overrides, cli.config_overrides);
             proto::run_main(proto_cli).await?;
         }
         Some(Subcommand::Debug(debug_args)) => match debug_args.cmd {
-            DebugCommand::Seatbelt(seatbelt_command) => {
+            DebugCommand::Seatbelt(mut seatbelt_cli) => {
+                prepend_config_flags(&mut seatbelt_cli.config_overrides, cli.config_overrides);
                 codex_cli::debug_sandbox::run_command_under_seatbelt(
-                    seatbelt_command,
+                    seatbelt_cli,
                     codex_linux_sandbox_exe,
                 )
                 .await?;
             }
-            DebugCommand::Landlock(landlock_command) => {
+            DebugCommand::Landlock(mut landlock_cli) => {
+                prepend_config_flags(&mut landlock_cli.config_overrides, cli.config_overrides);
                 codex_cli::debug_sandbox::run_command_under_landlock(
-                    landlock_command,
+                    landlock_cli,
                     codex_linux_sandbox_exe,
                 )
                 .await?;
@@ -103,4 +113,15 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
     }
 
     Ok(())
+}
+
+/// Prepend root-level overrides so they have lower precedence than
+/// CLI-specific ones specified after the subcommand (if any).
+fn prepend_config_flags(
+    subcommand_config_overrides: &mut CliConfigOverrides,
+    cli_config_overrides: CliConfigOverrides,
+) {
+    subcommand_config_overrides
+        .raw_overrides
+        .splice(0..0, cli_config_overrides.raw_overrides);
 }

--- a/codex-rs/common/Cargo.toml
+++ b/codex-rs/common/Cargo.toml
@@ -9,8 +9,10 @@ workspace = true
 [dependencies]
 clap = { version = "4", features = ["derive", "wrap_help"], optional = true }
 codex-core = { path = "../core" }
+toml = { version = "0.8", optional = true }
+serde = { version = "1", optional = true }
 
 [features]
 # Separate feature so that `clap` is not a mandatory dependency.
-cli = ["clap"]
+cli = ["clap", "toml", "serde"]
 elapsed = []

--- a/codex-rs/common/src/config_override.rs
+++ b/codex-rs/common/src/config_override.rs
@@ -1,0 +1,170 @@
+//! Support for `-c key=value` overrides shared across Codex CLI tools.
+//!
+//! This module provides a [`CliConfigOverrides`] struct that can be embedded
+//! into a `clap`-derived CLI struct using `#[clap(flatten)]`. Each occurrence
+//! of `-c key=value` (or `--config key=value`) will be collected as a raw
+//! string. Helper methods are provided to convert the raw strings into
+//! key/value pairs as well as to apply them onto a mutable
+//! `serde_json::Value` representing the configuration tree.
+
+use clap::ArgAction;
+use clap::Parser;
+use serde::de::Error as SerdeError;
+use toml::Value;
+
+/// CLI option that captures arbitrary configuration overrides specified as
+/// `-c key=value`. It intentionally keeps both halves **unparsed** so that the
+/// calling code can decide how to interpret the right-hand side.
+#[derive(Parser, Debug, Default, Clone)]
+pub struct CliConfigOverrides {
+    /// Override a configuration value that would otherwise be loaded from
+    /// `~/.codex/config.toml`. Use a dotted path (`foo.bar.baz`) to override
+    /// nested values. The `value` portion is parsed as JSON. If it fails to
+    /// parse as JSON, the raw string is used as a literal.
+    ///
+    /// Examples:
+    ///   - `-c model="o4-mini"`
+    ///   - `-c 'sandbox_permissions=["disk-full-read-access"]'`
+    ///   - `-c shell_environment_policy.inherit=all`
+    #[arg(
+        short = 'c',
+        long = "config",
+        value_name = "key=value",
+        action = ArgAction::Append,
+        global = true,
+    )]
+    pub raw_overrides: Vec<String>,
+}
+
+impl CliConfigOverrides {
+    /// Parse the raw strings captured from the CLI into a list of `(path,
+    /// value)` tuples where `value` is a `serde_json::Value`.
+    pub fn parse_overrides(&self) -> Result<Vec<(String, Value)>, String> {
+        self.raw_overrides
+            .iter()
+            .map(|s| {
+                // Only split on the *first* '=' so values are free to contain
+                // the character.
+                let mut parts = s.splitn(2, '=');
+                let key = match parts.next() {
+                    Some(k) => k.trim(),
+                    None => return Err("Override missing key".to_string()),
+                };
+                let value_str = parts
+                    .next()
+                    .ok_or_else(|| format!("Invalid override (missing '='): {s}"))?
+                    .trim();
+
+                if key.is_empty() {
+                    return Err(format!("Empty key in override: {s}"));
+                }
+
+                // Attempt to parse as JSON. If that fails, treat it as a raw
+                // string. This allows convenient usage such as
+                // `-c model=o4-mini` without the quotes.
+                let value: Value = match parse_toml_value(value_str) {
+                    Ok(v) => v,
+                    Err(_) => Value::String(value_str.to_string()),
+                };
+
+                Ok((key.to_string(), value))
+            })
+            .collect()
+    }
+
+    /// Apply all parsed overrides onto `target`. Intermediate objects will be
+    /// created as necessary. Values located at the destination path will be
+    /// replaced.
+    pub fn apply_on_value(&self, target: &mut Value) -> Result<(), String> {
+        let overrides = self.parse_overrides()?;
+        for (path, value) in overrides {
+            apply_single_override(target, &path, value);
+        }
+        Ok(())
+    }
+}
+
+/// Apply a single override onto `root`, creating intermediate objects as
+/// necessary.
+fn apply_single_override(root: &mut Value, path: &str, value: Value) {
+    use toml::value::Table;
+
+    let parts: Vec<&str> = path.split('.').collect();
+    let mut current = root;
+
+    for (i, part) in parts.iter().enumerate() {
+        let is_last = i == parts.len() - 1;
+
+        if is_last {
+            match current {
+                Value::Table(tbl) => {
+                    tbl.insert((*part).to_string(), value);
+                }
+                _ => {
+                    let mut tbl = Table::new();
+                    tbl.insert((*part).to_string(), value);
+                    *current = Value::Table(tbl);
+                }
+            }
+            return;
+        }
+
+        // Traverse or create intermediate table.
+        match current {
+            Value::Table(tbl) => {
+                current = tbl
+                    .entry((*part).to_string())
+                    .or_insert_with(|| Value::Table(Table::new()));
+            }
+            _ => {
+                *current = Value::Table(Table::new());
+                if let Value::Table(tbl) = current {
+                    current = tbl
+                        .entry((*part).to_string())
+                        .or_insert_with(|| Value::Table(Table::new()));
+                }
+            }
+        }
+    }
+}
+
+fn parse_toml_value(raw: &str) -> Result<Value, toml::de::Error> {
+    let wrapped = format!("_x_ = {raw}");
+    let table: toml::Table = toml::from_str(&wrapped)?;
+    table
+        .get("_x_")
+        .cloned()
+        .ok_or_else(|| SerdeError::custom("missing sentinel key"))
+}
+
+#[cfg(all(test, feature = "cli"))]
+#[allow(clippy::expect_used, clippy::unwrap_used)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_basic_scalar() {
+        let v = parse_toml_value("42").expect("parse");
+        assert_eq!(v.as_integer(), Some(42));
+    }
+
+    #[test]
+    fn fails_on_unquoted_string() {
+        assert!(parse_toml_value("hello").is_err());
+    }
+
+    #[test]
+    fn parses_array() {
+        let v = parse_toml_value("[1, 2, 3]").expect("parse");
+        let arr = v.as_array().expect("array");
+        assert_eq!(arr.len(), 3);
+    }
+
+    #[test]
+    fn parses_inline_table() {
+        let v = parse_toml_value("{a = 1, b = 2}").expect("parse");
+        let tbl = v.as_table().expect("table");
+        assert_eq!(tbl.get("a").unwrap().as_integer(), Some(1));
+        assert_eq!(tbl.get("b").unwrap().as_integer(), Some(2));
+    }
+}

--- a/codex-rs/common/src/lib.rs
+++ b/codex-rs/common/src/lib.rs
@@ -8,3 +8,9 @@ pub mod elapsed;
 pub use approval_mode_cli_arg::ApprovalModeCliArg;
 #[cfg(feature = "cli")]
 pub use approval_mode_cli_arg::SandboxPermissionOption;
+
+#[cfg(any(feature = "cli", test))]
+mod config_override;
+
+#[cfg(feature = "cli")]
+pub use config_override::CliConfigOverrides;

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -89,7 +89,7 @@ pub struct Tui {
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]
-
+#[serde(rename_all = "kebab-case")]
 pub enum ShellEnvironmentPolicyInherit {
     /// "Core" environment variables for the platform. On UNIX, this would
     /// include HOME, LOGNAME, PATH, SHELL, and USER, among others.

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use clap::ValueEnum;
+use codex_common::CliConfigOverrides;
 use codex_common::SandboxPermissionOption;
 use std::path::PathBuf;
 
@@ -33,9 +34,8 @@ pub struct Cli {
     #[arg(long = "skip-git-repo-check", default_value_t = false)]
     pub skip_git_repo_check: bool,
 
-    /// Disable server‑side response storage (sends the full conversation context with every request)
-    #[arg(long = "disable-response-storage", default_value_t = false)]
-    pub disable_response_storage: bool,
+    #[clap(skip)]
+    pub config_overrides: CliConfigOverrides,
 
     /// Specifies color settings for use in the output.
     #[arg(long = "color", value_enum, default_value_t = Color::Auto)]

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -34,10 +34,10 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         sandbox,
         cwd,
         skip_git_repo_check,
-        disable_response_storage,
         color,
         last_message_file,
         prompt,
+        config_overrides,
     } = cli;
 
     let (stdout_with_ansi, stderr_with_ansi) = match color {
@@ -63,16 +63,20 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         // the user for approval.
         approval_policy: Some(AskForApproval::Never),
         sandbox_policy,
-        disable_response_storage: if disable_response_storage {
-            Some(true)
-        } else {
-            None
-        },
         cwd: cwd.map(|p| p.canonicalize().unwrap_or(p)),
         model_provider: None,
         codex_linux_sandbox_exe,
     };
-    let config = Config::load_with_overrides(overrides)?;
+    // Parse `-c` overrides.
+    let cli_kv_overrides = match config_overrides.parse_overrides() {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("Error parsing -c overrides: {e}");
+            std::process::exit(1);
+        }
+    };
+
+    let config = Config::load_with_cli_overrides(cli_kv_overrides, overrides)?;
     // Print the effective configuration so users can see what Codex is using.
     print_config_summary(&config, stdout_with_ansi);
 

--- a/codex-rs/exec/src/main.rs
+++ b/codex-rs/exec/src/main.rs
@@ -10,13 +10,30 @@
 //! This allows us to ship a completely separate set of functionality as part
 //! of the `codex-exec` binary.
 use clap::Parser;
+use codex_common::CliConfigOverrides;
 use codex_exec::Cli;
 use codex_exec::run_main;
 
+#[derive(Parser, Debug)]
+struct TopCli {
+    #[clap(flatten)]
+    config_overrides: CliConfigOverrides,
+
+    #[clap(flatten)]
+    inner: Cli,
+}
+
 fn main() -> anyhow::Result<()> {
     codex_linux_sandbox::run_with_sandbox(|codex_linux_sandbox_exe| async move {
-        let cli = Cli::parse();
-        run_main(cli, codex_linux_sandbox_exe).await?;
+        let top_cli = TopCli::parse();
+        // Merge root-level overrides into inner CLI struct so downstream logic remains unchanged.
+        let mut inner = top_cli.inner;
+        inner
+            .config_overrides
+            .raw_overrides
+            .splice(0..0, top_cli.config_overrides.raw_overrides);
+
+        run_main(inner, codex_linux_sandbox_exe).await?;
         Ok(())
     })
 }

--- a/codex-rs/mcp-server/Cargo.toml
+++ b/codex-rs/mcp-server/Cargo.toml
@@ -22,6 +22,7 @@ mcp-types = { path = "../mcp-types" }
 schemars = "0.8.22"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "0.8"
 tracing = { version = "0.1.41", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 tokio = { version = "1", features = [

--- a/codex-rs/mcp-server/src/json_to_toml.rs
+++ b/codex-rs/mcp-server/src/json_to_toml.rs
@@ -1,0 +1,84 @@
+use serde_json::Value as JsonValue;
+use toml::Value as TomlValue;
+
+/// Convert a `serde_json::Value` into a semantically equivalent `toml::Value`.
+pub(crate) fn json_to_toml(v: JsonValue) -> TomlValue {
+    match v {
+        JsonValue::Null => TomlValue::String(String::new()),
+        JsonValue::Bool(b) => TomlValue::Boolean(b),
+        JsonValue::Number(n) => {
+            if let Some(i) = n.as_i64() {
+                TomlValue::Integer(i)
+            } else if let Some(f) = n.as_f64() {
+                TomlValue::Float(f)
+            } else {
+                TomlValue::String(n.to_string())
+            }
+        }
+        JsonValue::String(s) => TomlValue::String(s),
+        JsonValue::Array(arr) => TomlValue::Array(arr.into_iter().map(json_to_toml).collect()),
+        JsonValue::Object(map) => {
+            let tbl = map
+                .into_iter()
+                .map(|(k, v)| (k, json_to_toml(v)))
+                .collect::<toml::value::Table>();
+            TomlValue::Table(tbl)
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(clippy::unwrap_used)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+
+    #[test]
+    fn json_number_to_toml() {
+        let json_value = json!(123);
+        assert_eq!(TomlValue::Integer(123), json_to_toml(json_value));
+    }
+
+    #[test]
+    fn json_array_to_toml() {
+        let json_value = json!([true, 1]);
+        assert_eq!(
+            TomlValue::Array(vec![TomlValue::Boolean(true), TomlValue::Integer(1)]),
+            json_to_toml(json_value)
+        );
+    }
+
+    #[test]
+    fn json_bool_to_toml() {
+        let json_value = json!(false);
+        assert_eq!(TomlValue::Boolean(false), json_to_toml(json_value));
+    }
+
+    #[test]
+    fn json_float_to_toml() {
+        let json_value = json!(1.25);
+        assert_eq!(TomlValue::Float(1.25), json_to_toml(json_value));
+    }
+
+    #[test]
+    fn json_null_to_toml() {
+        let json_value = serde_json::Value::Null;
+        assert_eq!(TomlValue::String(String::new()), json_to_toml(json_value));
+    }
+
+    #[test]
+    fn json_object_nested() {
+        let json_value = json!({ "outer": { "inner": 2 } });
+        let expected = {
+            let mut inner = toml::value::Table::new();
+            inner.insert("inner".into(), TomlValue::Integer(2));
+
+            let mut outer = toml::value::Table::new();
+            outer.insert("outer".into(), TomlValue::Table(inner));
+            TomlValue::Table(outer)
+        };
+
+        assert_eq!(json_to_toml(json_value), expected);
+    }
+}

--- a/codex-rs/mcp-server/src/lib.rs
+++ b/codex-rs/mcp-server/src/lib.rs
@@ -16,6 +16,7 @@ use tracing::info;
 
 mod codex_tool_config;
 mod codex_tool_runner;
+mod json_to_toml;
 mod message_processor;
 
 use crate::message_processor::MessageProcessor;

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use codex_common::ApprovalModeCliArg;
+use codex_common::CliConfigOverrides;
 use codex_common::SandboxPermissionOption;
 use std::path::PathBuf;
 
@@ -40,7 +41,6 @@ pub struct Cli {
     #[arg(long = "skip-git-repo-check", default_value_t = false)]
     pub skip_git_repo_check: bool,
 
-    /// Disable server‑side response storage (sends the full conversation context with every request)
-    #[arg(long = "disable-response-storage", default_value_t = false)]
-    pub disable_response_storage: bool,
+    #[clap(skip)]
+    pub config_overrides: CliConfigOverrides,
 }

--- a/codex-rs/tui/src/main.rs
+++ b/codex-rs/tui/src/main.rs
@@ -1,11 +1,26 @@
 use clap::Parser;
+use codex_common::CliConfigOverrides;
 use codex_tui::Cli;
 use codex_tui::run_main;
 
+#[derive(Parser, Debug)]
+struct TopCli {
+    #[clap(flatten)]
+    config_overrides: CliConfigOverrides,
+
+    #[clap(flatten)]
+    inner: Cli,
+}
+
 fn main() -> anyhow::Result<()> {
     codex_linux_sandbox::run_with_sandbox(|codex_linux_sandbox_exe| async move {
-        let cli = Cli::parse();
-        run_main(cli, codex_linux_sandbox_exe)?;
+        let top_cli = TopCli::parse();
+        let mut inner = top_cli.inner;
+        inner
+            .config_overrides
+            .raw_overrides
+            .splice(0..0, top_cli.config_overrides.raw_overrides);
+        run_main(inner, codex_linux_sandbox_exe)?;
         Ok(())
     })
 }


### PR DESCRIPTION
This PR introduces support for `-c`/`--config` so users can override individual config values on the command line using `--config name=value`. Example:

```
codex --config model=o4-mini
```

Making it possible to set arbitrary config values on the command line results in a more flexible configuration scheme and makes it easier to provide single-line examples that can be copy-pasted from documentation.

Effectively, it means there are four levels of configuration for some values:

- Default value (e.g., `model` currently defaults to `o4-mini`)
- Value in `config.toml` (e.g., user could override the default to be `model = "o3"` in their `config.toml`)
- Specifying `-c` or `--config` to override `model` (e.g., user can include `-c model=o3` in their list of args to Codex)
- If available, a config-specific flag can be used, which takes precedence over `-c` (e.g., user can specify `--model o3` in their list of args to Codex)

Now that it is possible to specify anything that could be configured in `config.toml` on the command line using `-c`, we do not need to have a custom flag for every possible config option (which can clutter the output of `--help`). To that end, as part of this PR, we drop support for the `--disable-response-storage` flag, as users can now specify `-c disable_response_storage=true` to get the equivalent functionality.

Under the hood, this works by loading the `config.toml` into a `toml::Value`. Then for each `key=value`, we create a small synthetic TOML file with `value` so that we can run the TOML parser to get the equivalent `toml::Value`. We then parse `key` to determine the point in the original `toml::Value` to do the insert/replace. Once all of the overrides from `-c` args have been applied, the `toml::Value` is deserialized into a `ConfigToml` and then the `ConfigOverrides` are applied, as before.
