### PR TITLE
feat: Check Nix package is working as part of the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,3 +78,10 @@ jobs:
         run: ./scripts/asciicheck.py README.md
       - name: Check README ToC
         run: python3 scripts/readme_toc.py README.md
+
+  build-nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cachix/install-nix-action@v31
+      - run: nix build


### PR DESCRIPTION
This PR does not directly address the issue #515 reported with the Nix build, which has already been addressed in a separate PR #1051; rather, it adds a check to the existing CI workflow to make it easier to identify issues with the Nix build.

**Note:** The `build-nix` job is expected to fail because the Nix package is currently broken on `main`.