### PR TITLE
Fix Gemini model prefix handling in Codex CLI (resolves 400 errors)

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -808,13 +808,19 @@ export class AgentLoop {
                       this.oai,
                       params as ResponseCreateParams & { stream: true },
                     );
+            // Fix for Gemini: ensure model name has "models/" prefix
+            let modelName = this.model;
+            if (this.provider.toLowerCase() === "gemini" && !modelName.startsWith("models/")) {
+              modelName = `models/${modelName}`;
+            }
+
             log(
               `instructions (length ${mergedInstructions.length}): ${mergedInstructions}`,
             );
 
             // eslint-disable-next-line no-await-in-loop
             stream = await responseCall({
-              model: this.model,
+              model: modelName,
               instructions: mergedInstructions,
               input: turnInput,
               stream: true,
@@ -1197,13 +1203,19 @@ export class AgentLoop {
                         params as ResponseCreateParams & { stream: true },
                       );
 
+              // Fix for Gemini: ensure model name has "models/" prefix
+              let retryModelName = this.model;
+              if (this.provider.toLowerCase() === "gemini" && !retryModelName.startsWith("models/")) {
+                retryModelName = `models/${retryModelName}`;
+              }
+
               log(
                 "agentLoop.run(): responseCall(1): turnInput: " +
                   JSON.stringify(turnInput),
               );
               // eslint-disable-next-line no-await-in-loop
               stream = await responseCall({
-                model: this.model,
+                model: retryModelName,
                 instructions: mergedInstructions,
                 input: turnInput,
                 stream: true,


### PR DESCRIPTION

## Summary

This PR resolves persistent 400 errors when using Gemini models directly with the Codex CLI, enabling cost-effective integration without relying on OpenRouter as an intermediary.

## Problem

When attempting to use Gemini models directly via Codex CLI (to avoid OpenRouter's additional fees on top of Gemini API costs), I encountered 400 errors. The open-codex fork worked as expected, but the official Codex CLI consistently failed.

## Root Cause

- `model-utils.ts` strips the 'models/' prefix from Gemini model names for display purposes  
- `agent-loop.ts` does not re-add this prefix during actual API requests  
- Gemini's API requires model names to be fully qualified (e.g., 'models/gemini-2.5-pro-preview-05-06')

## Solution

- Detect when the provider is `gemini`  
- Add the required 'models/' prefix if not already present  
- Apply the fix in both:
  - Primary request logic (~line 813)
  - Retry logic (~line 1207)

## Testing

Tested and confirmed working on macOS with the following configuration:

```json
{
  "provider": "gemini",
  "model": "gemini-2.5-pro-preview-05-06",
  "providers": {
    "gemini": {
      "name": "Gemini",
      "baseURL": "https://generativelanguage.googleapis.com/v1beta/openai",
      "envKey": "GEMINI_API_KEY"
    }
  }
}
```

## Benefits

- Enables direct and cost-efficient use of Gemini models  
- Avoids OpenRouter as a required intermediary (reducing overhead and cost)  
- Maintains compatibility with OpenAI and other providers  
- Introduces no breaking changes to existing functionality

## Changes

- `codex-cli/src/utils/agent/agent-loop.ts`: Add Gemini model prefix handling in both request and retry paths
