### PR TITLE
fix: yq doesn't need a -o=json argument

### DIFF
--- a/codex-cli/examples/build-codex-demo/run.sh
+++ b/codex-cli/examples/build-codex-demo/run.sh
@@ -20,7 +20,7 @@ auto_mode=false
 cd runs || exit 1
 
 # Grab task name for logging
-task_name=$(yq -o=json '.' ../task.yaml | jq -r '.name')
+task_name=$(yq '.' ../task.yaml | jq -r '.name')
 echo "Checking for runs for task: $task_name"
 
 # Find existing run_N directories
@@ -61,5 +61,5 @@ cd "run_$new_run_number"
 
 # Launch Codex
 echo "Launching..."
-description=$(yq -o=json '.' ../../task.yaml | jq -r '.description')
+description=$(yq '.' ../../task.yaml | jq -r '.description')
 codex "$description"

--- a/codex-cli/examples/camerascii/run.sh
+++ b/codex-cli/examples/camerascii/run.sh
@@ -23,7 +23,7 @@ mkdir -p runs
 cd runs || exit 1
 
 # Grab task name for logging
-task_name=$(yq -o=json '.' ../task.yaml | jq -r '.name')
+task_name=$(yq '.' ../task.yaml | jq -r '.name')
 echo "Checking for runs for task: $task_name"
 
 # Find existing run_N directories
@@ -64,5 +64,5 @@ cd "run_$new_run_number"
 
 # Launch Codex
 echo "Launching..."
-description=$(yq -o=json '.' ../../task.yaml | jq -r '.description')
+description=$(yq '.' ../../task.yaml | jq -r '.description')
 codex "$description"

--- a/codex-cli/examples/impossible-pong/run.sh
+++ b/codex-cli/examples/impossible-pong/run.sh
@@ -23,7 +23,7 @@ mkdir -p runs
 cd runs || exit 1
 
 # Grab task name for logging
-task_name=$(yq -o=json '.' ../task.yaml | jq -r '.name')
+task_name=$(yq '.' ../task.yaml | jq -r '.name')
 echo "Checking for runs for task: $task_name"
 
 # Find existing run_N directories
@@ -64,5 +64,5 @@ cd "run_$new_run_number"
 
 # Launch Codex
 echo "Launching..."
-description=$(yq -o=json '.' ../../task.yaml | jq -r '.description')
+description=$(yq '.' ../../task.yaml | jq -r '.description')
 codex "$description"

--- a/codex-cli/examples/prompt-analyzer/run.sh
+++ b/codex-cli/examples/prompt-analyzer/run.sh
@@ -23,7 +23,7 @@ mkdir -p runs
 cd runs || exit 1
 
 # Grab task name for logging
-task_name=$(yq -o=json '.' ../task.yaml | jq -r '.name')
+task_name=$(yq '.' ../task.yaml | jq -r '.name')
 echo "Checking for runs for task: $task_name"
 
 # Find existing run_N directories
@@ -64,5 +64,5 @@ cd "run_$new_run_number"
 
 # Launch Codex
 echo "Launching..."
-description=$(yq -o=json '.' ../../task.yaml | jq -r '.description')
+description=$(yq '.' ../../task.yaml | jq -r '.description')
 codex "$description"


### PR DESCRIPTION
This pull request updates several `run.sh` scripts across multiple Codex CLI examples to simplify the usage of the `yq` command by removing the `-o=json` option. This change ensures consistent handling of YAML files without explicitly converting them to JSON.

### Updates to `yq` Command Usage:

* Removed the `-o=json` option from the `yq` command when extracting the `task_name` in `codex-cli/examples/build-codex-demo/run.sh`.
* Removed the `-o=json` option from the `yq` command when extracting the `description` in `codex-cli/examples/build-codex-demo/run.sh`.
* Applied the same updates to `codex-cli/examples/camerascii/run.sh`, `codex-cli/examples/impossible-pong/run.sh`, and `codex-cli/examples/prompt-analyzer/run.sh` for both `task_name` and `description` extraction. [[1]](diffhunk://#diff-bf643ab09e6a7ad0e0fe9f5eab5708353cda8ee2e768f4de5416cb66970d6ccdL26-R26) [[2]](diffhunk://#diff-bf643ab09e6a7ad0e0fe9f5eab5708353cda8ee2e768f4de5416cb66970d6ccdL67-R67)