### PR TITLE
feat: add todo function 

### DIFF
--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -29,6 +29,7 @@ import { initLogger } from "./utils/logger/log";
 import { isModelSupportedForResponses } from "./utils/model-utils.js";
 import { parseToolCall } from "./utils/parsers";
 import { onExit, setInkRenderer } from "./utils/terminal";
+import { loadTodos, saveTodos } from "./utils/todo";
 import chalk from "chalk";
 import { spawnSync } from "child_process";
 import fs from "fs";
@@ -224,6 +225,97 @@ complete -c codex -a '(__fish_complete_path)' -d 'file path'`,
   }
   // eslint-disable-next-line no-console
   console.log(script);
+  process.exit(0);
+}
+
+// Handle 'todo' subcommand before any prompting or API calls
+if (cli.input[0] === "todo") {
+  const subcommand = cli.input[1];
+  const todos = loadTodos();
+
+  switch (subcommand) {
+    case "list":
+    case "ls": {
+      if (todos.length === 0) {
+        // eslint-disable-next-line no-console
+        console.log("🗒️  No todos yet.");
+      } else {
+        // eslint-disable-next-line no-console
+        console.log("🗒️  Todo list:");
+        // eslint-disable-next-line no-console
+        todos.forEach((todo, i) => console.log(`  ${i + 1}. ${todo}`));
+      }
+      break;
+    }
+
+    case "add": {
+      const todoText = cli.input.slice(2).join(" ");
+      if (!todoText) {
+        // eslint-disable-next-line no-console
+        console.error(
+          '❌ Please provide a todo description: codex todo add "your todo"',
+        );
+        process.exit(1);
+      }
+      todos.push(todoText);
+      saveTodos(todos);
+      // eslint-disable-next-line no-console
+      console.log(`✅ Added todo: ${todoText}`);
+      break;
+    }
+
+    case "remove":
+    case "rm":
+    case "delete": {
+      const indexStr = cli.input[2];
+      if (!indexStr) {
+        // eslint-disable-next-line no-console
+        console.error(
+          "❌ Please provide a todo number: codex todo remove <number>",
+        );
+        process.exit(1);
+      }
+      const index = parseInt(indexStr, 10) - 1;
+      if (isNaN(index) || index < 0 || index >= todos.length) {
+        // eslint-disable-next-line no-console
+        console.error(
+          `❌ Invalid todo number. Use a number between 1 and ${todos.length}`,
+        );
+        process.exit(1);
+      }
+      const removed = todos.splice(index, 1)[0];
+      saveTodos(todos);
+      // eslint-disable-next-line no-console
+      console.log(`🗑️  Removed todo: ${removed}`);
+      break;
+    }
+
+    case "clear": {
+      saveTodos([]);
+      // eslint-disable-next-line no-console
+      console.log("🧹 Cleared all todos");
+      break;
+    }
+
+    default: {
+      // eslint-disable-next-line no-console
+      console.log(`Usage: codex todo <command>
+
+Commands:
+  list, ls           Show all todos
+  add <text>         Add a new todo
+  remove <number>    Remove a todo by number
+  clear              Remove all todos
+
+Examples:
+  codex todo list
+  codex todo add "Fix the login bug"
+  codex todo remove 1
+  codex todo clear`);
+      break;
+    }
+  }
+
   process.exit(0);
 }
 

--- a/codex-cli/src/cli.tsx
+++ b/codex-cli/src/cli.tsx
@@ -301,17 +301,17 @@ if (cli.input[0] === "todo") {
       // eslint-disable-next-line no-console
       console.log(`Usage: codex todo <command>
 
-Commands:
-  list, ls           Show all todos
-  add <text>         Add a new todo
-  remove <number>    Remove a todo by number
-  clear              Remove all todos
+      Commands:
+        list, ls           Show all todos
+        add <text>         Add a new todo
+        remove <number>    Remove a todo by number
+        clear              Remove all todos
 
-Examples:
-  codex todo list
-  codex todo add "Fix the login bug"
-  codex todo remove 1
-  codex todo clear`);
+      Examples:
+        codex todo list
+        codex todo add "Fix the login bug"
+        codex todo remove 1
+        codex todo clear`);
       break;
     }
   }

--- a/codex-cli/src/utils/todo.ts
+++ b/codex-cli/src/utils/todo.ts
@@ -1,0 +1,20 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+const todoFile = path.join(os.homedir(), ".codex", "todo.json");
+
+export function loadTodos(): Array<string> {
+  try {
+    if (fs.existsSync(todoFile)) {
+      return JSON.parse(fs.readFileSync(todoFile, "utf-8"));
+    }
+  } catch (e) {
+    // ignore errors
+  }
+  return [];
+}
+export function saveTodos(todos: Array<string>): void {
+  fs.mkdirSync(path.dirname(todoFile), { recursive: true });
+  fs.writeFileSync(todoFile, JSON.stringify(todos, null, 2));
+}


### PR DESCRIPTION
## Goals
- Enable users to create and manage todo items via CLI.
- Provide persistent local storage of todos.
- Support basic task management operations: add, list, mark as done, delete.
## User Stories
- As a developer, I want to quickly add a note to myself without leaving the terminal.
- As a contributor, I want to list unfinished tasks before submitting a patch.
## CLI Commands
```
codex todo add "Fix bug when input is null"
codex todo list
```
## Sample JSON structure (.codex/todo.json)
```
[
  {
    "id": 1,
    "task": "Fix bug when input is null",
    "done": false,
    "created_at": "2025-05-26T22:00:00Z"
  },
  {
    "id": 2,
    "task": "Refactor utils module",
    "done": true,
    "created_at": "2025-05-26T22:05:00Z"
  }
]
```
## File Structure
```
.codex/
  └── todo.json
```