### PR TITLE
feat: introduce CellWidget trait

### DIFF
--- a/codex-rs/tui/src/cell_widget.rs
+++ b/codex-rs/tui/src/cell_widget.rs
@@ -1,0 +1,20 @@
+use ratatui::prelude::*;
+
+/// Trait implemented by every type that can live inside the conversation
+/// history list.  It provides two primitives that the parent scroll-view
+/// needs: how *tall* the widget is at a given width and how to render an
+/// arbitrary contiguous *window* of that widget.
+///
+/// The `first_visible_line` argument to [`render_window`] allows partial
+/// rendering when the top of the widget is scrolled off-screen.  The caller
+/// guarantees that `first_visible_line + area.height as usize` never exceeds
+/// the total height previously returned by [`height`].
+pub(crate) trait CellWidget {
+    /// Total height measured in wrapped terminal lines when drawn with the
+    /// given *content* width (no scrollbar column included).
+    fn height(&self, width: u16) -> usize;
+
+    /// Render a *window* that starts `first_visible_line` lines below the top
+    /// of the widget. The window’s size is given by `area`.
+    fn render_window(&self, first_visible_line: usize, area: Rect, buf: &mut Buffer);
+}

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -19,6 +19,7 @@ mod app;
 mod app_event;
 mod app_event_sender;
 mod bottom_pane;
+mod cell_widget;
 mod chatwidget;
 mod citation_regex;
 mod cli;
@@ -32,6 +33,7 @@ mod mouse_capture;
 mod scroll_event_helper;
 mod slash_command;
 mod status_indicator_widget;
+mod text_block;
 mod tui;
 mod user_approval_widget;
 

--- a/codex-rs/tui/src/text_block.rs
+++ b/codex-rs/tui/src/text_block.rs
@@ -1,0 +1,32 @@
+use crate::cell_widget::CellWidget;
+use ratatui::prelude::*;
+
+/// A simple widget that just displays a list of `Line`s via a `Paragraph`.
+/// This is the default rendering backend for most `HistoryCell` variants.
+#[derive(Clone)]
+pub(crate) struct TextBlock {
+    pub(crate) lines: Vec<Line<'static>>,
+}
+
+impl TextBlock {
+    pub(crate) fn new(lines: Vec<Line<'static>>) -> Self {
+        Self { lines }
+    }
+}
+
+impl CellWidget for TextBlock {
+    fn height(&self, width: u16) -> usize {
+        // Use the same wrapping configuration as ConversationHistoryWidget so
+        // measurement stays in sync with rendering.
+        ratatui::widgets::Paragraph::new(self.lines.clone())
+            .wrap(crate::conversation_history_widget::wrap_cfg())
+            .line_count(width)
+    }
+
+    fn render_window(&self, first_visible_line: usize, area: Rect, buf: &mut Buffer) {
+        ratatui::widgets::Paragraph::new(self.lines.clone())
+            .wrap(crate::conversation_history_widget::wrap_cfg())
+            .scroll((first_visible_line as u16, 0))
+            .render(area, buf);
+    }
+}


### PR DESCRIPTION
The motivation behind this PR is to make it so a `HistoryCell` is more like a `WidgetRef` that knows how to render itself into a `Rect` so that it can be backed by something other than a `Vec<Line>`. Because a `HistoryCell` is intended to appear in a scrollable list, we want to ensure the stack of cells can be scrolled one `Line` at a time even if the `HistoryCell` is not backed by a `Vec<Line>` itself.

To this end, we introduce the `CellWidget` trait whose key method is:

```
fn render_window(&self, first_visible_line: usize, area: Rect, buf: &mut Buffer);
```

The `first_visible_line` param is what differs from `WidgetRef::render_ref()`, as a `CellWidget` needs to know the offset into its "full view" at which it should start rendering.

The bookkeeping in `ConversationHistoryWidget` has been updated accordingly to ensure each `CellWidget` in the history is rendered appropriately.