### PR TITLE
fix: update Dockerfile base image to node:22-slim

### DIFF
--- a/codex-cli/Dockerfile
+++ b/codex-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-slim
+FROM node:22-slim
 
 ARG TZ
 ENV TZ="$TZ"


### PR DESCRIPTION
`codex` does not run on Node 20 (anymore). Updating the base image to `node:22-slim` made it the Docker image work for me.