### PR TITLE
chore: update GitHub workflow for native artifacts for npm release

### DIFF
--- a/codex-cli/scripts/install_native_deps.sh
+++ b/codex-cli/scripts/install_native_deps.sh
@@ -65,7 +65,7 @@ mkdir -p "$BIN_DIR"
 # Until we start publishing stable GitHub releases, we have to grab the binaries
 # from the GitHub Action that created them. Update the URL below to point to the
 # appropriate workflow run:
-WORKFLOW_URL="https://github.com/openai/codex/actions/runs/15280451034"
+WORKFLOW_URL="https://github.com/openai/codex/actions/runs/15334411824"
 WORKFLOW_ID="${WORKFLOW_URL##*/}"
 
 ARTIFACTS_DIR="$(mktemp -d)"


### PR DESCRIPTION
Among other things, this picks up this UI treatment fix:

https://github.com/openai/codex/pull/1161