### PR TITLE
fix: update outdated repo setup in codex.yml

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -47,9 +47,22 @@ jobs:
         with:
           node-version: 22
 
-      - name: Install dependencies (codex-cli)
-        working-directory: codex-cli
-        run: npm ci
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "store_path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store_path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install
 
       - uses: dtolnay/rust-toolchain@1.87
         with:


### PR DESCRIPTION
We should do some work to share the setup logic across `codex.yml`, `ci.yml`, and `rust-ci.yml`.