### PR TITLE
fix: add extra debugging to GitHub Action

### DIFF
--- a/.github/actions/codex/src/post-comment.ts
+++ b/.github/actions/codex/src/post-comment.ts
@@ -17,6 +17,7 @@ export async function postComment(
   const bodyWithFooter = footer ? `${commentBody}${footer}` : commentBody;
 
   const octokit = ctx.getOctokit();
+  console.info("Got Octokit instance for posting comment");
   const { owner, repo } = github.context.repo;
   const issueNumber = github.context.issue.number;
 
@@ -28,6 +29,7 @@ export async function postComment(
   }
 
   try {
+    console.info("Calling octokit.rest.issues.createComment()");
     await octokit.rest.issues.createComment({
       owner,
       repo,


### PR DESCRIPTION
https://github.com/openai/codex/actions/runs/15352839832/job/43205041563 appeared to fail around `postComment()`, but I don't see the output from `fail()` in the logs. Adding a bit more info.