### PR TITLE
feat: show the version when starting Codex

### DIFF
--- a/codex-rs/exec/src/event_processor.rs
+++ b/codex-rs/exec/src/event_processor.rs
@@ -120,7 +120,12 @@ impl EventProcessor {
     /// for the session. This mirrors the information shown in the TUI welcome
     /// screen.
     pub(crate) fn print_config_summary(&mut self, config: &Config, prompt: &str) {
-        ts_println!(self, "OpenAI Codex (research preview)\n--------");
+        const VERSION: &str = env!("CARGO_PKG_VERSION");
+        ts_println!(
+            self,
+            "OpenAI Codex v{} (research preview)\n--------",
+            VERSION
+        );
 
         let entries = vec![
             ("workdir", config.cwd.display().to_string()),

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -130,10 +130,13 @@ impl HistoryCell {
             history_entry_count: _,
         } = event;
         if is_first_event {
+            const VERSION: &str = env!("CARGO_PKG_VERSION");
+
             let mut lines: Vec<Line<'static>> = vec![
                 Line::from(vec![
                     "OpenAI ".into(),
                     "Codex".bold(),
+                    format!(" v{}", VERSION).into(),
                     " (research preview)".dim(),
                 ]),
                 Line::from(""),


### PR DESCRIPTION
The TypeScript version of the CLI shows the version when it starts up, which is helpful when users share screenshots (and nice to know, as a user).