### PR TITLE
docs: Update default model value from o4-mini to codex-mini-latest in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,7 @@ Codex configuration files can be placed in the `~/.codex/` directory, supporting
 
 | Parameter           | Type    | Default    | Description                      | Available Options                                                                              |
 | ------------------- | ------- | ---------- | -------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `model`             | string  | `o4-mini`  | AI model to use                  | Any model name supporting OpenAI API                                                           |
+| `model`             | string  | `codex-mini-latest`  | AI model to use                  | Any model name supporting OpenAI API                                                           |
 | `approvalMode`      | string  | `suggest`  | AI assistant's permission mode   | `suggest` (suggestions only)<br>`auto-edit` (automatic edits)<br>`full-auto` (fully automatic) |
 | `fullAutoErrorMode` | string  | `ask-user` | Error handling in full-auto mode | `ask-user` (prompt for user input)<br>`ignore-and-continue` (ignore and proceed)               |
 | `notify`            | boolean | `true`     | Enable desktop notifications     | `true`/`false`                                                                                 |


### PR DESCRIPTION
## Why

Since version `0.1.2505160811` , the default value for the model parameter appears to have changed to `codex-mini-latest`.
However, the default value in the README parameters section remained as `o4-mini`.
Therefore, I believe it would be better to update the model's default value in the README from `o4-mini` to `codex-mini-latest` to maintain consistency.

## What

Updated the default model value in the "Basic configuration parameters" section of the README.