### PR TITLE
chore: replace regex with regex-lite, where appropriate

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -567,7 +567,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "pretty_assertions",
- "regex",
  "serde_json",
  "similar",
  "tempfile",
@@ -682,7 +681,7 @@ dependencies = [
  "log",
  "multimap",
  "path-absolutize",
- "regex",
+ "regex-lite",
  "serde",
  "serde_json",
  "serde_with",
@@ -757,7 +756,7 @@ dependencies = [
  "pretty_assertions",
  "ratatui",
  "ratatui-image",
- "regex",
+ "regex-lite",
  "serde_json",
  "shlex",
  "strum 0.27.1",
@@ -3322,6 +3321,12 @@ dependencies = [
  "memchr",
  "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
 
 [[package]]
 name = "regex-syntax"

--- a/codex-rs/apply-patch/Cargo.toml
+++ b/codex-rs/apply-patch/Cargo.toml
@@ -12,7 +12,6 @@ workspace = true
 
 [dependencies]
 anyhow = "1"
-regex = "1.11.1"
 serde_json = "1.0.110"
 similar = "2.7.0"
 thiserror = "2.0.12"

--- a/codex-rs/execpolicy/Cargo.toml
+++ b/codex-rs/execpolicy/Cargo.toml
@@ -24,7 +24,7 @@ env_logger = "0.11.5"
 log = "0.4"
 multimap = "0.10.0"
 path-absolutize = "3.1.1"
-regex = "1.11.1"
+regex-lite = "0.1"
 serde = { version = "1.0.194", features = ["derive"] }
 serde_json = "1.0.110"
 serde_with = { version = "3", features = ["macros"] }

--- a/codex-rs/execpolicy/src/policy.rs
+++ b/codex-rs/execpolicy/src/policy.rs
@@ -1,6 +1,6 @@
 use multimap::MultiMap;
-use regex::Error as RegexError;
-use regex::Regex;
+use regex_lite::Error as RegexError;
+use regex_lite::Regex;
 
 use crate::ExecCall;
 use crate::Forbidden;
@@ -29,7 +29,7 @@ impl Policy {
         } else {
             let escaped_substrings = forbidden_substrings
                 .iter()
-                .map(|s| regex::escape(s))
+                .map(|s| regex_lite::escape(s))
                 .collect::<Vec<_>>()
                 .join("|");
             Some(Regex::new(&format!("({escaped_substrings})"))?)

--- a/codex-rs/execpolicy/src/policy_parser.rs
+++ b/codex-rs/execpolicy/src/policy_parser.rs
@@ -7,7 +7,7 @@ use crate::arg_matcher::ArgMatcher;
 use crate::opt::OptMeta;
 use log::info;
 use multimap::MultiMap;
-use regex::Regex;
+use regex_lite::Regex;
 use starlark::any::ProvidesStaticType;
 use starlark::environment::GlobalsBuilder;
 use starlark::environment::LibraryExtension;
@@ -73,7 +73,7 @@ impl PolicyParser {
 
 #[derive(Debug)]
 pub struct ForbiddenProgramRegex {
-    pub regex: regex::Regex,
+    pub regex: regex_lite::Regex,
     pub reason: String,
 }
 
@@ -93,7 +93,7 @@ impl PolicyBuilder {
         }
     }
 
-    fn build(self) -> Result<Policy, regex::Error> {
+    fn build(self) -> Result<Policy, regex_lite::Error> {
         let programs = self.programs.into_inner();
         let forbidden_program_regexes = self.forbidden_program_regexes.into_inner();
         let forbidden_substrings = self.forbidden_substrings.into_inner();
@@ -207,7 +207,7 @@ fn policy_builtins(builder: &mut GlobalsBuilder) {
             .unwrap()
             .downcast_ref::<PolicyBuilder>()
             .unwrap();
-        let compiled_regex = regex::Regex::new(&regex)?;
+        let compiled_regex = regex_lite::Regex::new(&regex)?;
         policy_builder.add_forbidden_program_regex(compiled_regex, reason);
         Ok(NoneType)
     }

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -33,7 +33,7 @@ ratatui = { version = "0.29.0", features = [
     "unstable-rendered-line-info",
 ] }
 ratatui-image = "8.0.0"
-regex = "1"
+regex-lite = "0.1"
 serde_json = "1"
 shlex = "1.3.0"
 strum = "0.27.1"

--- a/codex-rs/tui/src/citation_regex.rs
+++ b/codex-rs/tui/src/citation_regex.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::expect_used)]
 
-use regex::Regex;
+use regex_lite::Regex;
 
 // This is defined in its own file so we can limit the scope of
 // `allow(clippy::expect_used)` because we cannot scope it to the `lazy_static!`

--- a/codex-rs/tui/src/markdown.rs
+++ b/codex-rs/tui/src/markdown.rs
@@ -71,7 +71,7 @@ fn rewrite_file_citations<'a>(
         None => return Cow::Borrowed(src),
     };
 
-    CITATION_REGEX.replace_all(src, |caps: &regex::Captures<'_>| {
+    CITATION_REGEX.replace_all(src, |caps: &regex_lite::Captures<'_>| {
         let file = &caps[1];
         let start_line = &caps[2];
 


### PR DESCRIPTION
As explained on https://crates.io/crates/regex-lite, `regex-lite` is a lighter alternative to `regex` and seems to be sufficient for our purposes.