### PR TITLE
Improve error message for outdated Node

### DIFF
--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -81,6 +81,18 @@ if (wantsNative) {
   process.exit(exitCode);
 }
 
+// Ensure a compatible Node version before falling back to the JavaScript CLI.
+const pkgJsonPath = path.join(__dirname, "../package.json");
+const { engines } = JSON.parse(fs.readFileSync(pkgJsonPath, "utf8"));
+const requiredNodeMajor = Number.parseInt(engines.node.match(/\d+/)[0], 10);
+const currentMajor = Number.parseInt(process.versions.node.split(".")[0], 10);
+if (currentMajor < requiredNodeMajor) {
+  console.error(
+    `Codex CLI requires Node.js ${requiredNodeMajor} or newer. Detected ${process.version}. Please upgrade your Node.js installation.`
+  );
+  process.exit(1);
+}
+
 // Fallback: execute the original JavaScript CLI.
 
 // Resolve the path to the compiled CLI bundle


### PR DESCRIPTION
## Summary
- gracefully fail before loading CLI if Node is <22 by checking `process.versions.node`
- print a clear message telling the user to upgrade Node
- derive required Node version from package.json instead of hardcoding

## Testing
- `pnpm test` *(fails: Error: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-10.8.1.tgz)*


------
https://chatgpt.com/codex/tasks/task_i_683e5b70d24c832099295100ae72afbe