### PR TITLE
fix: always send full instructions when using the Responses API

### DIFF
--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -25,7 +25,7 @@ pub struct Prompt {
     pub prev_id: Option<String>,
     /// Optional instructions from the user to amend to the built-in agent
     /// instructions.
-    pub instructions: Option<String>,
+    pub user_instructions: Option<String>,
     /// Whether to store response on server side (disable_response_storage = !store).
     pub store: bool,
 
@@ -37,21 +37,14 @@ pub struct Prompt {
 
 impl Prompt {
     pub(crate) fn get_full_instructions(&self, model: &str) -> Cow<str> {
-        [
-            Some(Cow::Borrowed(BASE_INSTRUCTIONS)),
-            self.instructions.as_ref().map(|s| Cow::Owned(s.clone())),
-            if model.starts_with("gpt-4.1") {
-                Some(Cow::Borrowed(APPLY_PATCH_TOOL_INSTRUCTIONS))
-            } else {
-                None
-            },
-        ]
-        .iter()
-        .filter_map(|s| s.as_ref())
-        .map(|cow| cow.as_ref())
-        .collect::<Vec<_>>()
-        .join("\n")
-        .into()
+        let mut sections: Vec<&str> = vec![BASE_INSTRUCTIONS];
+        if let Some(ref user) = self.user_instructions {
+            sections.push(user);
+        }
+        if model.starts_with("gpt-4.1") {
+            sections.push(APPLY_PATCH_TOOL_INSTRUCTIONS);
+        }
+        Cow::Owned(sections.join("\n"))
     }
 }
 

--- a/codex-rs/core/src/project_doc.rs
+++ b/codex-rs/core/src/project_doc.rs
@@ -25,7 +25,7 @@ const PROJECT_DOC_SEPARATOR: &str = "\n\n--- project-doc ---\n\n";
 
 /// Combines `Config::instructions` and `AGENTS.md` (if present) into a single
 /// string of instructions.
-pub(crate) async fn create_full_instructions(config: &Config) -> Option<String> {
+pub(crate) async fn get_user_instructions(config: &Config) -> Option<String> {
     match find_project_doc(config).await {
         Ok(Some(project_doc)) => match &config.instructions {
             Some(original_instructions) => Some(format!(
@@ -168,7 +168,7 @@ mod tests {
     async fn no_doc_file_returns_none() {
         let tmp = tempfile::tempdir().expect("tempdir");
 
-        let res = create_full_instructions(&make_config(&tmp, 4096, None)).await;
+        let res = get_user_instructions(&make_config(&tmp, 4096, None)).await;
         assert!(
             res.is_none(),
             "Expected None when AGENTS.md is absent and no system instructions provided"
@@ -182,7 +182,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         fs::write(tmp.path().join("AGENTS.md"), "hello world").unwrap();
 
-        let res = create_full_instructions(&make_config(&tmp, 4096, None))
+        let res = get_user_instructions(&make_config(&tmp, 4096, None))
             .await
             .expect("doc expected");
 
@@ -201,7 +201,7 @@ mod tests {
         let huge = "A".repeat(LIMIT * 2); // 2 KiB
         fs::write(tmp.path().join("AGENTS.md"), &huge).unwrap();
 
-        let res = create_full_instructions(&make_config(&tmp, LIMIT, None))
+        let res = get_user_instructions(&make_config(&tmp, LIMIT, None))
             .await
             .expect("doc expected");
 
@@ -233,7 +233,7 @@ mod tests {
         let mut cfg = make_config(&repo, 4096, None);
         cfg.cwd = nested;
 
-        let res = create_full_instructions(&cfg).await.expect("doc expected");
+        let res = get_user_instructions(&cfg).await.expect("doc expected");
         assert_eq!(res, "root level doc");
     }
 
@@ -243,7 +243,7 @@ mod tests {
         let tmp = tempfile::tempdir().expect("tempdir");
         fs::write(tmp.path().join("AGENTS.md"), "something").unwrap();
 
-        let res = create_full_instructions(&make_config(&tmp, 0, None)).await;
+        let res = get_user_instructions(&make_config(&tmp, 0, None)).await;
         assert!(
             res.is_none(),
             "With limit 0 the function should return None"
@@ -259,7 +259,7 @@ mod tests {
 
         const INSTRUCTIONS: &str = "base instructions";
 
-        let res = create_full_instructions(&make_config(&tmp, 4096, Some(INSTRUCTIONS)))
+        let res = get_user_instructions(&make_config(&tmp, 4096, Some(INSTRUCTIONS)))
             .await
             .expect("should produce a combined instruction string");
 
@@ -276,7 +276,7 @@ mod tests {
 
         const INSTRUCTIONS: &str = "some instructions";
 
-        let res = create_full_instructions(&make_config(&tmp, 4096, Some(INSTRUCTIONS))).await;
+        let res = get_user_instructions(&make_config(&tmp, 4096, Some(INSTRUCTIONS))).await;
 
         assert_eq!(res, Some(INSTRUCTIONS.to_string()));
     }


### PR DESCRIPTION
This fixes a longstanding error in the Rust CLI where `codex.rs` contained an errant `is_first_turn` check that would exclude the user instructions for subsequent "turns" of a conversation when using the responses API (i.e., when `previous_response_id` existed).

While here, renames `Prompt.instructions` to `Prompt.user_instructions` since we now have quite a few levels of instructions floating around. Also removed an unnecessary use of `clone()` in `Prompt.get_full_instructions()`.