### PR TITLE
codex-rs: Disable ANSI escape sequences in log file

### DIFF
--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -112,6 +112,7 @@ pub fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> std::io::
     let file_layer = tracing_subscriber::fmt::layer()
         .with_writer(non_blocking)
         .with_target(false)
+        .with_ansi(false)
         .with_filter(env_filter());
 
     // Channel that carries formatted log lines to the UI.


### PR DESCRIPTION
Tiny change: [disable ANSI escape codes](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/fmt/struct.Layer.html#method.with_ansi) in the log file.

These are nice in a terminal but very noisy when the logs are viewed in a text editor:
<img width="426" alt="image" src="https://github.com/user-attachments/assets/64a8318f-0bdd-43fa-ba3b-37342e1663f1" />

After this PR:
<img width="412" alt="image" src="https://github.com/user-attachments/assets/cd13b404-02bc-45e0-939b-0ed6776d6f38" />
