### PR TITLE
Bug: ignore Azure OpenAI content filter streaming response

### DIFF
--- a/codex-cli/src/utils/responses.ts
+++ b/codex-cli/src/utils/responses.ts
@@ -491,6 +491,9 @@ async function* streamResponses(
     if (!choice) {
       continue;
     }
+    if ("content_filter_results" in choice) {
+      continue;
+    }
     if (
       !isToolCall &&
       (("tool_calls" in choice.delta && choice.delta.tool_calls) ||


### PR DESCRIPTION
## Summary

Fix `TypeError: Cannot use 'in' operator to search for 'tool_calls' in undefined` error that occurs when Azure OpenAI returns content filter streaming responses.

## Problem

When using Azure OpenAI, content filter responses can cause a TypeError because the streaming response format differs from standard OpenAI responses, leading to undefined object property checks.

## Solution

Added logic to ignore Azure OpenAI content filter streaming responses, preventing the TypeError from occurring during response processing.

## References

- [Azure OpenAI Content Filter](https://learn.microsoft.com/ja-jp/azure/ai-services/openai/concepts/content-streaming)

## Related Issues

Fixes #1077