### PR TITLE
fix: support arm64 build for Linux

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,29 @@
+FROM ubuntu:22.04
+
+ARG DEBIAN_FRONTEND=noninteractive
+# enable 'universe' because musl-tools & clang live there
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    software-properties-common && \
+    add-apt-repository --yes universe
+
+# now install build deps
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    build-essential curl git ca-certificates \
+    pkg-config clang musl-tools libssl-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# non-root dev user
+ARG USER=dev
+ARG UID=1000
+RUN useradd -m -u $UID $USER
+USER $USER
+
+# install Rust + musl target as dev user
+RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && \
+    ~/.cargo/bin/rustup target add aarch64-unknown-linux-musl
+
+ENV PATH="/home/${USER}/.cargo/bin:${PATH}"
+
+WORKDIR /workspace

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,30 @@
+# Containerized Development
+
+We provide the following options to facilitate Codex development in a container. This is particularly useful for verifying the Linux build when working on a macOS host.
+
+## Docker
+
+To build the Docker image locally for x64 and then run it with the repo mounted under `/workspace`:
+
+```shell
+CODEX_DOCKER_IMAGE_NAME=codex-linux-dev
+docker build --platform=linux/amd64 -t "$CODEX_DOCKER_IMAGE_NAME" ./.devcontainer
+docker run --platform=linux/amd64 --rm -it -e CARGO_TARGET_DIR=/workspace/codex-rs/target-amd64 -v "$PWD":/workspace -w /workspace/codex-rs "$CODEX_DOCKER_IMAGE_NAME"
+```
+
+Note that `/workspace/target` will contain the binaries built for your host platform, so we include `-e CARGO_TARGET_DIR=/workspace/codex-rs/target-amd64` in the `docker run` command so that the binaries built inside your container are written to a separate directory.
+
+For arm64, specify `--platform=linux/amd64` instead for both `docker build` and `docker run`.
+
+Currently, the `Dockerfile` works for both x64 and arm64 Linux, though you need to run `rustup target add x86_64-unknown-linux-musl` yourself to install the musl toolchain for x64.
+
+## VS Code
+
+VS Code recognizes the `devcontainer.json` file and gives you the option to develop Codex in a container. Currently, `devcontainer.json` builds and runs the `arm64` flavor of the container.
+
+From the integrated terminal in VS Code, you can build either flavor of the `arm64` build (GNU or musl):
+
+```shell
+cargo build --target aarch64-unknown-linux-musl
+cargo build --target aarch64-unknown-linux-gnu
+```

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,29 @@
+{
+  "name": "Codex",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "..",
+    "platform": "linux/arm64"
+  },
+
+  /* Force VS Code to run the container as arm64 in
+     case your host is x86 (or vice-versa). */
+  "runArgs": ["--platform=linux/arm64"],
+
+  "containerEnv": {
+    "RUST_BACKTRACE": "1",
+    "CARGO_TARGET_DIR": "${containerWorkspaceFolder}/codex-rs/target-arm64"
+  },
+
+  "remoteUser": "dev",
+  "customizations": {
+    "vscode": {
+      "settings": {
+          "terminal.integrated.defaultProfile.linux": "bash"
+      },
+      "extensions": [
+          "rust-lang.rust-analyzer"
+      ],
+    }
+  }
+}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -55,6 +55,10 @@ jobs:
             target: x86_64-unknown-linux-musl
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
 
@@ -75,7 +79,7 @@ jobs:
             ${{ github.workspace }}/codex-rs/target/
           key: cargo-${{ matrix.runner }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+      - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl'}}
         name: Install musl build tools
         run: |
           sudo apt install -y musl-tools pkg-config

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -70,6 +70,8 @@ jobs:
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
           - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+          - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
 
     steps:
@@ -88,7 +90,7 @@ jobs:
             ${{ github.workspace }}/codex-rs/target/
           key: cargo-release-${{ matrix.runner }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
 
-      - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
+      - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl'}}
         name: Install musl build tools
         run: |
           sudo apt install -y musl-tools pkg-config

--- a/codex-rs/.gitignore
+++ b/codex-rs/.gitignore
@@ -1,1 +1,7 @@
 /target/
+
+# Recommended value of CARGO_TARGET_DIR when using Docker as explained in .devcontainer/README.md.
+/target-amd64/
+
+# Value of CARGO_TARGET_DIR when using .devcontainer/devcontainer.json.
+/target-arm64/

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -58,6 +58,10 @@ seccompiler = "0.5.0"
 [target.x86_64-unknown-linux-musl.dependencies]
 openssl-sys = { version = "*", features = ["vendored"] }
 
+# Build OpenSSL from source for musl builds.
+[target.aarch64-unknown-linux-musl.dependencies]
+openssl-sys = { version = "*", features = ["vendored"] }
+
 [dev-dependencies]
 assert_cmd = "2"
 maplit = "1.0.2"


### PR DESCRIPTION
Users were running into issues with glibc mismatches on arm64 linux. In the past, we did not provide a musl build for arm64 Linux because we had trouble getting the openssl dependency to build correctly. Though today I just tried the same trick in `Cargo.toml` that we were doing for `x86_64-unknown-linux-musl` (using `openssl-sys` with `features = ["vendored"]`), so I'm not sure what problem we had in the past the builds "just worked" today!

Though one tweak that did have to be made is that the integration tests for Seccomp/Landlock empirically require longer timeouts on arm64 linux, or at least on the `ubuntu-24.04-arm` GitHub Runner. As such, we change the timeouts for arm64 in `codex-rs/linux-sandbox/tests/landlock.rs`.

Though in solving this problem, I decided I needed a turnkey solution for testing the Linux build(s) from my Mac laptop, so this PR introduces `.devcontainer/Dockerfile` and `.devcontainer/devcontainer.json` to facilitate this. Detailed instructions are in `.devcontainer/README.md`.

We will update `dotslash-config.json` and other release-related scripts in a follow-up PR.