### PR TITLE
fix: use aarch64-unknown-linux-musl instead of aarch64-unknown-linux-gnu

### DIFF
--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -5,7 +5,7 @@
         "macos-aarch64":  { "regex": "^codex-exec-aarch64-apple-darwin\\.zst$",          "path": "codex-exec" },
         "macos-x86_64":   { "regex": "^codex-exec-x86_64-apple-darwin\\.zst$",           "path": "codex-exec" },
         "linux-x86_64":   { "regex": "^codex-exec-x86_64-unknown-linux-musl\\.zst$",     "path": "codex-exec" },
-        "linux-aarch64":  { "regex": "^codex-exec-aarch64-unknown-linux-gnu\\.zst$",     "path": "codex-exec" }
+        "linux-aarch64":  { "regex": "^codex-exec-aarch64-unknown-linux-musl\\.zst$",     "path": "codex-exec" }
       }
     },
 
@@ -14,14 +14,14 @@
         "macos-aarch64":  { "regex": "^codex-aarch64-apple-darwin\\.zst$",          "path": "codex" },
         "macos-x86_64":   { "regex": "^codex-x86_64-apple-darwin\\.zst$",           "path": "codex" },
         "linux-x86_64":   { "regex": "^codex-x86_64-unknown-linux-musl\\.zst$",     "path": "codex" },
-        "linux-aarch64":  { "regex": "^codex-aarch64-unknown-linux-gnu\\.zst$",     "path": "codex" }
+        "linux-aarch64":  { "regex": "^codex-aarch64-unknown-linux-musl\\.zst$",     "path": "codex" }
       }
     },
 
     "codex-linux-sandbox": {
       "platforms": {
         "linux-x86_64":   { "regex": "^codex-linux-sandbox-x86_64-unknown-linux-musl\\.zst$",     "path": "codex-linux-sandbox" },
-        "linux-aarch64":  { "regex": "^codex-linux-sandbox-aarch64-unknown-linux-gnu\\.zst$",     "path": "codex-linux-sandbox" }
+        "linux-aarch64":  { "regex": "^codex-linux-sandbox-aarch64-unknown-linux-musl\\.zst$",     "path": "codex-linux-sandbox" }
       }
     }
   }

--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -46,7 +46,7 @@ if (wantsNative) {
           targetTriple = "x86_64-unknown-linux-musl";
           break;
         case "arm64":
-          targetTriple = "aarch64-unknown-linux-gnu";
+          targetTriple = "aarch64-unknown-linux-musl";
           break;
         default:
           break;

--- a/codex-cli/scripts/install_native_deps.sh
+++ b/codex-cli/scripts/install_native_deps.sh
@@ -65,7 +65,7 @@ mkdir -p "$BIN_DIR"
 # Until we start publishing stable GitHub releases, we have to grab the binaries
 # from the GitHub Action that created them. Update the URL below to point to the
 # appropriate workflow run:
-WORKFLOW_URL="https://github.com/openai/codex/actions/runs/15361005231"
+WORKFLOW_URL="https://github.com/openai/codex/actions/runs/15483216943"
 WORKFLOW_ID="${WORKFLOW_URL##*/}"
 
 ARTIFACTS_DIR="$(mktemp -d)"
@@ -78,7 +78,7 @@ gh run download --dir "$ARTIFACTS_DIR" --repo openai/codex "$WORKFLOW_ID"
 zstd -d "$ARTIFACTS_DIR/x86_64-unknown-linux-musl/codex-linux-sandbox-x86_64-unknown-linux-musl.zst" \
      -o "$BIN_DIR/codex-linux-sandbox-x64"
 
-zstd -d "$ARTIFACTS_DIR/aarch64-unknown-linux-gnu/codex-linux-sandbox-aarch64-unknown-linux-gnu.zst" \
+zstd -d "$ARTIFACTS_DIR/aarch64-unknown-linux-musl/codex-linux-sandbox-aarch64-unknown-linux-musl.zst" \
      -o "$BIN_DIR/codex-linux-sandbox-arm64"
 
 if [[ "$INCLUDE_RUST" -eq 1 ]]; then
@@ -86,8 +86,8 @@ if [[ "$INCLUDE_RUST" -eq 1 ]]; then
   zstd -d "$ARTIFACTS_DIR/x86_64-unknown-linux-musl/codex-x86_64-unknown-linux-musl.zst" \
       -o "$BIN_DIR/codex-x86_64-unknown-linux-musl"
   # ARM64 Linux
-  zstd -d "$ARTIFACTS_DIR/aarch64-unknown-linux-gnu/codex-aarch64-unknown-linux-gnu.zst" \
-      -o "$BIN_DIR/codex-aarch64-unknown-linux-gnu"
+  zstd -d "$ARTIFACTS_DIR/aarch64-unknown-linux-musl/codex-aarch64-unknown-linux-musl.zst" \
+      -o "$BIN_DIR/codex-aarch64-unknown-linux-musl"
   # x64 macOS
   zstd -d "$ARTIFACTS_DIR/x86_64-apple-darwin/codex-x86_64-apple-darwin.zst" \
       -o "$BIN_DIR/codex-x86_64-apple-darwin"

--- a/codex-cli/scripts/stage_release.sh
+++ b/codex-cli/scripts/stage_release.sh
@@ -17,7 +17,7 @@
 # When --native is supplied we copy the linux-sandbox binaries (as before) and
 # additionally fetch / unpack the two Rust targets that we currently support:
 #   - x86_64-unknown-linux-musl
-#   - aarch64-unknown-linux-gnu
+#   - aarch64-unknown-linux-musl
 #
 # NOTE: This script is intended to be run from the repository root via
 #       `pnpm --filter codex-cli stage-release ...` or inside codex-cli with the


### PR DESCRIPTION
Now that we have published a GitHub Release that contains arm64 musl artifacts for Linux, update the following scripts to take advantage of them:

- `dotslash-config.json` now uses musl artifacts for the `linux-aarch64` target
- `install_native_deps.sh` for the TypeScript CLI now includes `codex-linux-sandbox-aarch64-unknown-linux-musl` instead of `codex-linux-sandbox-aarch64-unknown-linux-gnu` for sandboxing
- `codex-cli/bin/codex.js` now checks for `aarch64-unknown-linux-musl` artifacts instead of `aarch64-unknown-linux-gnu` ones