### PR TITLE
fix: include codex-linux-sandbox-aarch64-unknown-linux-musl in the set of release artifacts

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -107,7 +107,10 @@ jobs:
           cp target/${{ matrix.target }}/release/codex-exec "$dest/codex-exec-${{ matrix.target }}"
           cp target/${{ matrix.target }}/release/codex "$dest/codex-${{ matrix.target }}"
 
-      - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-gnu' }}
+        # After https://github.com/openai/codex/pull/1228 is merged and a new
+        # release is cut with an artifacts built after that PR, the `-gnu`
+        # variants can go away as we will only use the `-musl` variants.
+      - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-musl' }}
         name: Stage Linux-only artifacts
         shell: bash
         run: |


### PR DESCRIPTION
This was missed in https://github.com/openai/codex/pull/1225. Once we create a new GitHub Release with this change, we can use the URL from the workflow that triggered the release in https://github.com/openai/codex/pull/1228.