### PR TITLE
fix: truncate auth.json file before rewriting it

### DIFF
--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -75,7 +75,7 @@ pub async fn try_read_openai_api_key(codex_home: &Path) -> std::io::Result<Strin
         auth_dot_json.last_refresh = Utc::now();
 
         let mut options = OpenOptions::new();
-        options.write(true).create(true);
+        options.truncate(true).write(true).create(true);
         #[cfg(unix)]
         {
             options.mode(0o600);


### PR DESCRIPTION
This was missed in https://github.com/openai/codex/pull/1212. Caught by @rizwankce in https://github.com/openai/codex/discussions/1174#discussioncomment-13377475.