### PR TITLE
chore: ensure next Node.js release includes musl binaries for arm64 Linux

### DIFF
--- a/codex-cli/scripts/install_native_deps.sh
+++ b/codex-cli/scripts/install_native_deps.sh
@@ -65,7 +65,7 @@ mkdir -p "$BIN_DIR"
 # Until we start publishing stable GitHub releases, we have to grab the binaries
 # from the GitHub Action that created them. Update the URL below to point to the
 # appropriate workflow run:
-WORKFLOW_URL="https://github.com/openai/codex/actions/runs/15483216943"
+WORKFLOW_URL="https://github.com/openai/codex/actions/runs/15483730027"
 WORKFLOW_ID="${WORKFLOW_URL##*/}"
 
 ARTIFACTS_DIR="$(mktemp -d)"


### PR DESCRIPTION
Target a workflow with more recent binary artifacts.