### PR TITLE
fix: respect repo default branch

### DIFF
--- a/.github/actions/codex/src/git-helpers.ts
+++ b/.github/actions/codex/src/git-helpers.ts
@@ -112,7 +112,7 @@ export async function maybePublishPRForIssue(
 
   const sanitizedMessage = lastMessage.replace(/\u2022/g, "-");
   const [summaryLine] = sanitizedMessage.split(/\r?\n/);
-  const branch = ensureOnBranch(issueNumber, [defaultBranch, "master"], summaryLine);
+  const branch = ensureOnBranch(issueNumber, [defaultBranch], summaryLine);
   commitIfNeeded(issueNumber);
   pushBranch(branch, githubToken, ctx);
 


### PR DESCRIPTION
### Description of bug
-When connecting a GitHub repo to Codex, setup fails with the error:
-Provided git ref master does not exist

### Expected behavior
Codex should:
	•	Detect the repo’s actual default branch (usually main)
	•	Or allow selecting the desired Git ref during setup
	•	Or provide a more helpful error suggesting that master is missing

### Additional context
GitHub changed the default branch from master to main in 2020. Many tools now use main as standard, and hardcoding a master ref leads to unnecessary setup failures.
	