### PR TITLE
Fix 401 error when using OpenRouter as provider.

### DIFF
--- a/codex-cli/tests/agent-project-doc.test.ts
+++ b/codex-cli/tests/agent-project-doc.test.ts
@@ -114,8 +114,9 @@ describe("AgentLoop", () => {
     const agent = new AgentLoop({
       additionalWritableRoots: [],
       model: "o3", // arbitrary
+      provider: "openai", // explicitly set to use OpenAI responses API
       instructions: config.instructions,
-      config,
+      config: { ...config, provider: "openai" }, // ensure config also has provider set
       approvalPolicy: { mode: "suggest" } as any,
       onItem: () => {},
       onLoading: () => {},


### PR DESCRIPTION
# The Issue

Currently when using a config.json like this:

```json
{
  "model": "o4-mini",
  "provider": "openrouter",
  "providers": {
    "openrouter": {
      "name": "OpenRouter",
      "baseURL": "https://openrouter.ai/api/v1",
      "envKey": "OPENROUTER_API_KEY"
    }
  },
  "history": {
    "maxSize": 1000,
    "saveHistory": true,
    "sensitivePatterns": []
  }
}
```

and running using command:

```
codex --provider openrouter "hello"
```

Codex will show:

```
Hello test

    system
    ⚠️  OpenAI rejected the request. Error details: Status: 401, Code: 401, Type
: unknown, Message: 401 No
    auth credentials found. Please verify your settings and try again.
```

# The Root Cause and Fix

Problem: 401 authentication error when using non-OpenAI providers (specifically OpenRouter with o4-mini model), despite having correct API keys set in environment variables.

Root Cause: The codebase had hardcoded dependencies on OpenAI API keys in two critical locations, preventing proper authentication with alternative providers:

**AgentLoop Constructor Bug (agent-loop.ts):**

Hardcoded lookup: process.env["OPENAI_API_KEY"]
Issue: Always looked for OpenAI key regardless of configured provider
Impact: Even when using OpenRouter, the agent would try to authenticate with missing OpenAI credentials

**CLI Startup Logic Bug (cli.tsx):**

Only checked for OPENAI_API_KEY in auth file loading and fallback scenarios
Issue: Provider-specific keys like OPENROUTER_API_KEY were ignored during CLI initialization
Impact: CLI would trigger unnecessary login flows despite valid provider credentials being available

Fix: Replaced hardcoded OpenAI key lookups with provider-aware authentication:

1. Used getApiKey(this.provider) function that dynamically resolves the correct API key based on the configured provider
2. Added provider-specific key checks in CLI auth flow
3. Now properly supports OPENROUTER_API_KEY, GEMINI_API_KEY, etc. based on the selected provider

Result: Authentication now works correctly for all supported providers, not just OpenAI.