### PR TITLE
Adds support for provider Docker Model Runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ export OPENAI_API_KEY="your-api-key-here"
 > - deepseek
 > - xai
 > - groq
+> - dmr (Docker Model Runner)
 >
 > If you use a provider other than OpenAI, you will need to set the API key for the provider in the config file or in the environment variable as:
 >

--- a/codex-cli/src/utils/config.ts
+++ b/codex-cli/src/utils/config.ts
@@ -52,7 +52,7 @@ export function getBaseUrl(provider: string): string | undefined {
 export function getApiKey(provider: string): string | undefined {
   const providerInfo = providers[provider.toLowerCase()];
   if (providerInfo) {
-    if (providerInfo.name === "Ollama") {
+    if (providerInfo.name === "Ollama" || providerInfo.name === "Docker Model Runner") {
       return process.env[providerInfo.envKey] ?? "dummy";
     }
     return process.env[providerInfo.envKey];

--- a/codex-cli/src/utils/providers.ts
+++ b/codex-cli/src/utils/providers.ts
@@ -42,4 +42,9 @@ export const providers: Record<
     baseURL: "https://api.groq.com/openai/v1",
     envKey: "GROQ_API_KEY",
   },
+  dmr: {
+    name: "Docker Model Runner",
+    baseURL: "http://localhost:12434/engines/v1",
+    envKey: "DMR",
+  },
 };


### PR DESCRIPTION
## Add Docker Model Runner (DMR) Integration

### Overview
This PR adds support for Docker Model Runner (DMR) as a new provider in Codex. DMR allows users to run AI models locally using Docker.

### Changes
- Added DMR as a new provider in the providers configuration
- Set up DMR endpoint to use the local Docker Model Runner API (http://localhost:12434/engines/v1)
- Updated documentation to include DMR in the supported providers list

### Benefits
- Local Model Execution: Users can now run AI models directly on their machines using Docker's infrastructure
- Resource Control: Better control over computational resources and model execution
- Privacy: Data stays local and doesn't leave the user's machine
- Cost Effective: No per-token charges when using local models

### Requirements
Users need to:
- Have Docker Desktop installed with Docker Model Runner enabled (Beta features)
- Pull their desired model using docker model pull
- Ensure the Docker Model Runner service is running on port 12434

### Related Documentation
For more details on Docker Model Runner setup and configuration, users can refer to:
https://docs.docker.com/ai/model-runner/
Let me know if you would like me to expand on any part of this PR description or add more details about specific aspects of the implementation.