### PR TITLE
fix: 400 error when using other providers after logging into OpenAI

### DIFF
--- a/codex-cli/src/utils/get-api-key-components.tsx
+++ b/codex-cli/src/utils/get-api-key-components.tsx
@@ -8,11 +8,20 @@ export type Choice = { type: "signin" } | { type: "apikey"; key: string };
 
 export function ApiKeyPrompt({
   onDone,
+  provider = "openai",
 }: {
   onDone: (choice: Choice) => void;
+  provider?: string;
 }): JSX.Element {
-  const [step, setStep] = useState<"select" | "paste">("select");
+  const isOpenAI = provider.toLowerCase() === "openai";
+
+  const [step, setStep] = useState<"select" | "paste">(
+    isOpenAI ? "select" : "paste",
+  );
   const [apiKey, setApiKey] = useState("");
+
+  const providerName = provider.charAt(0).toUpperCase() + provider.slice(1);
+  const envVarName = `${provider.toUpperCase()}_API_KEY`;
 
   if (step === "select") {
     return (
@@ -28,7 +37,7 @@ export function ApiKeyPrompt({
           items={[
             { label: "Sign in with ChatGPT", value: "signin" },
             {
-              label: "Paste an API key (or set as OPENAI_API_KEY)",
+              label: `Paste an API key (or set as ${envVarName})`,
               value: "paste",
             },
           ]}
@@ -46,7 +55,7 @@ export function ApiKeyPrompt({
 
   return (
     <Box flexDirection="column">
-      <Text>Paste your OpenAI API key and press &lt;Enter&gt;:</Text>
+      <Text>Paste your {providerName} API key and press &lt;Enter&gt;:</Text>
       <TextInput
         value={apiKey}
         onChange={setApiKey}
@@ -55,7 +64,7 @@ export function ApiKeyPrompt({
             onDone({ type: "apikey", key: value.trim() });
           }
         }}
-        placeholder="sk-..."
+        placeholder={isOpenAI ? "sk-..." : "Enter your API key..."}
         mask="*"
       />
     </Box>

--- a/codex-cli/src/utils/get-api-key.tsx
+++ b/codex-cli/src/utils/get-api-key.tsx
@@ -13,10 +13,11 @@ import os from "os";
 import path from "path";
 import React from "react";
 
-function promptUserForChoice(): Promise<Choice> {
+function promptUserForChoice(provider: string = "openai"): Promise<Choice> {
   return new Promise<Choice>((resolve) => {
     const instance = render(
       <ApiKeyPrompt
+        provider={provider}
         onDone={(choice: Choice) => {
           resolve(choice);
           instance.unmount();
@@ -740,13 +741,17 @@ export async function getApiKey(
   issuer: string,
   clientId: string,
   forceLogin: boolean = false,
+  provider: string = "openai",
 ): Promise<string> {
-  if (!forceLogin && process.env["OPENAI_API_KEY"]) {
-    return process.env["OPENAI_API_KEY"]!;
+  const providerUpper = provider.toUpperCase();
+  const envVarName = `${providerUpper}_API_KEY`;
+
+  if (!forceLogin && process.env[envVarName]) {
+    return process.env[envVarName]!;
   }
-  const choice = await promptUserForChoice();
+  const choice = await promptUserForChoice(provider);
   if (choice.type === "apikey") {
-    process.env["OPENAI_API_KEY"] = choice.key;
+    process.env[envVarName] = choice.key;
     return choice.key;
   }
   const spinner = render(<WaitingForAuth />);


### PR DESCRIPTION
If the user is logged into openai, i.e., the `~/.codex/auth.json` file exists, and the user switches to other providers, the openai key is still used, which will cause a request error. Related issues: https://github.com/openai/codex/issues/987

![bug image](https://github.com/user-attachments/assets/9995aed8-b611-4fcc-8a2c-da23c4ef1fb6)

This modification mainly includes the following points:
1. Fix the logic of reading the key, and change it to reading the key based on the provider
2. When `~/.codex/auth.json` does not exist:
- Currently: Regardless of the current provider, whether the corresponding key exists in the `env`, it will display "Login to ChatGPT" and "Enter OpenAI key".
- After the change:
    - If the current provider is `OpenAI`, it will display 1) Login to ChatGPT 2) Manually enter OpenAI key.
    - If the current provider is not OpenAI
      - If the key corresponding to the provider exists in the `env`, it is used directly.
      - If it does not exist in the `env`, only manually enter `provider key`.
3. Optimized the logic for obtaining `savedTokens`, abstracting it into the `loadAuth` method.
4. Optimized the assignment logic for `process.env["OPENAI_API_KEY"]` to prioritize fetching the value from process.env; if it's not there, it will fetch from `auth.json`.