### PR TITLE
Add codex-rs --dangerously-run-with-no-sandbox

### DIFF
--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -176,6 +176,18 @@ impl SandboxPolicy {
         }
     }
 
+    /// Unrestricted policy: allow full disk read/write and network access.
+    /// Commands will be auto-approved without sandbox enforcement.
+    pub fn new_unrestricted_policy() -> Self {
+        Self {
+            permissions: vec![
+                SandboxPermission::DiskFullReadAccess,
+                SandboxPermission::DiskFullWriteAccess,
+                SandboxPermission::NetworkFullAccess,
+            ],
+        }
+    }
+
     pub fn has_full_disk_read_access(&self) -> bool {
         self.permissions
             .iter()

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -162,9 +162,12 @@ impl SandboxPolicy {
             SandboxPolicy::Permissions(p) => p,
             SandboxPolicy::NoSandbox => Vec::new(),
         };
-        permissions.extend(writable_roots.iter().cloned().map(|folder| {
-            SandboxPermission::DiskWriteFolder { folder }
-        }));
+        permissions.extend(
+            writable_roots
+                .iter()
+                .cloned()
+                .map(|folder| SandboxPermission::DiskWriteFolder { folder }),
+        );
         SandboxPolicy::Permissions(permissions)
     }
 

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -26,11 +26,11 @@ pub struct Cli {
     /// Skip all confirmation prompts and execute commands without sandboxing.
     /// EXTREMELY DANGEROUS. Intended solely for running in environments that are externally sandboxed.
     #[arg(
-        long = "dangerously-auto-approve-and-run-without-sandbox",
+        long = "dangerously-run-with-no-sandbox",
         default_value_t = false,
         conflicts_with = "full_auto"
     )]
-    pub dangerously_auto_approve_everything: bool,
+    pub dangerously_run_with_no_sandbox: bool,
 
     #[clap(flatten)]
     pub sandbox: SandboxPermissionOption,

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -26,7 +26,7 @@ pub struct Cli {
     /// Skip all confirmation prompts and execute commands without sandboxing.
     /// EXTREMELY DANGEROUS. Intended solely for running in environments that are externally sandboxed.
     #[arg(
-        long = "dangerously-auto-approve-everything",
+        long = "dangerously-auto-approve-and-run-without-sandbox",
         default_value_t = false,
         conflicts_with = "full_auto"
     )]

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -23,6 +23,15 @@ pub struct Cli {
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
 
+    /// Skip all confirmation prompts and execute commands without sandboxing.
+    /// EXTREMELY DANGEROUS. Intended solely for running in environments that are externally sandboxed.
+    #[arg(
+        long = "dangerously-auto-approve-everything",
+        default_value_t = false,
+        conflicts_with = "full_auto"
+    )]
+    pub dangerously_auto_approve_everything: bool,
+
     #[clap(flatten)]
     pub sandbox: SandboxPermissionOption,
 

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -31,7 +31,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         model,
         config_profile,
         full_auto,
-        dangerously_auto_approve_everything,
+        dangerously_run_with_no_sandbox,
         sandbox,
         cwd,
         skip_git_repo_check,
@@ -87,7 +87,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
 
     let sandbox_policy = if full_auto {
         Some(SandboxPolicy::new_full_auto_policy())
-    } else if dangerously_auto_approve_everything {
+    } else if dangerously_run_with_no_sandbox {
         Some(SandboxPolicy::new_unrestricted_policy())
     } else {
         sandbox.permissions.clone().map(Into::into)

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -31,6 +31,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         model,
         config_profile,
         full_auto,
+        dangerously_auto_approve_everything,
         sandbox,
         cwd,
         skip_git_repo_check,
@@ -86,6 +87,8 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
 
     let sandbox_policy = if full_auto {
         Some(SandboxPolicy::new_full_auto_policy())
+    } else if dangerously_auto_approve_everything {
+        Some(SandboxPolicy::new_unrestricted_policy())
     } else {
         sandbox.permissions.clone().map(Into::into)
     };

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -32,7 +32,7 @@ pub struct Cli {
     /// Skip all confirmation prompts and execute commands without sandboxing.
     /// Intended solely for ephemeral local testing.
     #[arg(
-        long = "dangerously-auto-approve-everything",
+        long = "dangerously-auto-approve-and-run-without-sandbox",
         default_value_t = false,
         conflicts_with = "full_auto"
     )]

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -30,13 +30,13 @@ pub struct Cli {
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
     /// Skip all confirmation prompts and execute commands without sandboxing.
-    /// Intended solely for ephemeral local testing.
+    /// EXTREMELY DANGEROUS. Intended solely for running in environments that are externally sandboxed.
     #[arg(
-        long = "dangerously-auto-approve-and-run-without-sandbox",
+        long = "dangerously-run-with-no-sandbox",
         default_value_t = false,
         conflicts_with = "full_auto"
     )]
-    pub dangerously_auto_approve_everything: bool,
+    pub dangerously_run_with_no_sandbox: bool,
 
     #[clap(flatten)]
     pub sandbox: SandboxPermissionOption,

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -29,6 +29,14 @@ pub struct Cli {
     /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, network-disabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
+    /// Skip all confirmation prompts and execute commands without sandboxing.
+    /// Intended solely for ephemeral local testing.
+    #[arg(
+        long = "dangerously-auto-approve-everything",
+        default_value_t = false,
+        conflicts_with = "full_auto"
+    )]
+    pub dangerously_auto_approve_everything: bool,
 
     #[clap(flatten)]
     pub sandbox: SandboxPermissionOption,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -51,6 +51,11 @@ pub fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> std::io::
             Some(SandboxPolicy::new_full_auto_policy()),
             Some(AskForApproval::OnFailure),
         )
+    } else if cli.dangerously_auto_approve_everything {
+        (
+            Some(SandboxPolicy::new_unrestricted_policy()),
+            Some(AskForApproval::Never),
+        )
     } else {
         let sandbox_policy = cli.sandbox.permissions.clone().map(Into::into);
         (sandbox_policy, cli.approval_policy.map(Into::into))

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -51,7 +51,7 @@ pub fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> std::io::
             Some(SandboxPolicy::new_full_auto_policy()),
             Some(AskForApproval::OnFailure),
         )
-    } else if cli.dangerously_auto_approve_everything {
+    } else if cli.dangerously_run_with_no_sandbox {
         (
             Some(SandboxPolicy::new_unrestricted_policy()),
             Some(AskForApproval::Never),


### PR DESCRIPTION
This should address #1254 (and motivation/justification is available there)

In short, the sandbox, even with network+disk access, still blocks some things on osx (like access to the keychain most likely). Also, in some environments people are already fully sandboxed (externally to codex), so this gives an option in those environments.