### PR TITLE
Add Rust CLI suggestion functionality

### DIFF
--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -167,6 +167,16 @@ impl BottomPane<'_> {
         self.active_view.is_none() && self.composer.is_command_popup_visible()
     }
 
+    /// Get suggestion state for rendering (selected_index, suggestions_array, should_show)
+    pub(crate) fn get_suggestion_info(&self, is_conversation_new: bool) -> Option<(Option<usize>, &'static [&'static str])> {
+        if self.active_view.is_none() && is_conversation_new && self.composer.should_show_suggestions() {
+            let (selected, suggestions) = self.composer.get_suggestion_state();
+            Some((selected, suggestions))
+        } else {
+            None
+        }
+    }
+
     // --- History helpers ---
 
     pub(crate) fn set_history_metadata(&mut self, log_id: u64, entry_count: usize) {

--- a/codex-rs/tui/src/conversation_history_widget.rs
+++ b/codex-rs/tui/src/conversation_history_widget.rs
@@ -51,6 +51,12 @@ impl ConversationHistoryWidget {
         self.has_input_focus = has_input_focus;
     }
 
+    pub(crate) fn is_conversation_new(&self) -> bool {
+        !self.entries.iter().any(|entry| 
+            matches!(entry.cell, HistoryCell::UserPrompt { .. })
+        )
+    }
+
     /// Returns true if it needs a redraw.
     pub(crate) fn handle_key_event(&mut self, key_event: KeyEvent) -> bool {
         match key_event.code {


### PR DESCRIPTION
what: Adds canned prompt suggestions to the Rust CLI, similar to the existing TypeScript CLI functionality.

**Note:** Uses Left/Right arrow keys for suggestion navigation instead of Tab, since Tab is reserved for TUI focus management between panes.

why: Closes #1259 

how: 
  - Implement canned prompt suggestions similar to TypeScript CLI
  - Add suggestion detection and rendering in chat_composer.rs
  - Use Option<usize> for type-safe selection indexing
  - Auto-hide suggestions when user starts typing
  - Add comprehensive test coverage

I have read the CLA Document and I hereby sign the CLA

@bolinfest I'm happy to add in giving the user the option to hide suggestions or add their own as a follow to this PR

## video demos below

Rust CLI with suggestions (this branch)
https://github.com/user-attachments/assets/680b6b47-ff11-4fd4-a743-56d0509ef230

Rust CLI without suggestions (main branch)
https://github.com/user-attachments/assets/ecd28d00-361c-4f15-abd7-6705a769cd73

Typescript CLI on main
https://github.com/user-attachments/assets/4306c617-842a-4fc8-80cf-3868757fc5a8

<img width="1470" alt="Screenshot 2025-06-12 at 7 55 42 PM" src="https://github.com/user-attachments/assets/2ae4e7b7-3e2d-45a5-acb4-1d20c4846a79" />
