### PR TITLE
codex-rs: have ctrl+D only quit if input buffer is empty

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -202,13 +202,22 @@ impl<'a> App<'a> {
                                 }
                             }
                         }
-                        KeyEvent {
+                        key_event @ KeyEvent {
                             code: KeyCode::Char('d'),
                             modifiers: crossterm::event::KeyModifiers::CONTROL,
                             ..
-                        } => {
-                            self.app_event_tx.send(AppEvent::ExitRequest);
-                        }
+                        } => match &self.app_state {
+                            AppState::Chat { widget } => {
+                                if widget.is_input_empty() {
+                                    self.app_event_tx.send(AppEvent::ExitRequest);
+                                } else {
+                                    self.dispatch_key_event(key_event);
+                                }
+                            }
+                            _ => {
+                                self.app_event_tx.send(AppEvent::ExitRequest);
+                            }
+                        },
                         _ => {
                             self.dispatch_key_event(key_event);
                         }

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -267,8 +267,10 @@ impl ChatComposer<'_> {
 
         let bs = if has_focus {
             BlockState {
-                right_title: Line::from("Enter to send | Ctrl+D to quit | Ctrl+J for newline")
-                    .alignment(Alignment::Right),
+                right_title: Line::from(
+                    "Enter to send | Ctrl+D to quit if input empty | Ctrl+J for newline",
+                )
+                .alignment(Alignment::Right),
                 border_style: Style::default(),
             }
         } else {
@@ -289,6 +291,11 @@ impl ChatComposer<'_> {
 
     pub(crate) fn is_command_popup_visible(&self) -> bool {
         self.command_popup.is_some()
+    }
+
+    /// Returns true if the current input buffer is empty.
+    pub(crate) fn is_input_empty(&self) -> bool {
+        self.textarea.lines().iter().all(|line| line.is_empty())
     }
 }
 

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -187,6 +187,11 @@ impl BottomPane<'_> {
             self.request_redraw();
         }
     }
+
+    /// Returns true if the current input buffer is empty.
+    pub(crate) fn is_input_empty(&self) -> bool {
+        self.composer.is_input_empty()
+    }
 }
 
 impl WidgetRef for &BottomPane<'_> {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -397,6 +397,13 @@ impl ChatWidget<'_> {
     }
 }
 
+impl ChatWidget<'_> {
+    /// Returns true if the bottom pane's input buffer is empty.
+    pub(crate) fn is_input_empty(&self) -> bool {
+        self.bottom_pane.is_input_empty()
+    }
+}
+
 impl WidgetRef for &ChatWidget<'_> {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
         let bottom_height = self.bottom_pane.calculate_required_height(&area);


### PR DESCRIPTION
I am used to using ctrl+d to delete the character to the right of the cursor (this is a default emacs keybind, and works on most terminals), and I keep accidentally killing my codex windows. This change fixes this (and allows the use of ctrl-d to delete a character to the right of the cursor as well).

This is slightly related to issue #1245, which discusses using ctrl+c (twice) as a method of quitting.