### PR TITLE
fix(readme): correct direnv flake instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,9 +715,9 @@ If you have direnv installed, you can use the following `.envrc` to automaticall
 
 ```bash
 cd codex-rs
-echo "use flake ../flake.nix#codex-cli" >> .envrc && direnv allow
-cd codex-cli
 echo "use flake ../flake.nix#codex-rs" >> .envrc && direnv allow
+cd codex-cli
+echo "use flake ../flake.nix#codex-cli" >> .envrc && direnv allow
 ```
 
 ---


### PR DESCRIPTION
The Quick-start section for direnv/Nix was incorrect.  
This patch switches them to the corresponding flake references:

- codex-rs  → flake codex-rs
- codex-cli → flake codex-cli