### PR TITLE
Fix command not found errors

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -33,6 +33,7 @@ import { applyPatchToolInstructions } from "./apply-patch.js";
 import { handleExecCommand } from "./handle-exec-command.js";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { spawnSync } from "node:child_process";
+import { getEnvironmentInfo } from "../platform-info.js";
 import { randomUUID } from "node:crypto";
 import OpenAI, { APIConnectionTimeoutError, AzureOpenAI } from "openai";
 import os from "os";
@@ -1599,9 +1600,12 @@ export class AgentLoop {
 // Dynamic developer message prefix: includes user, workdir, and rg suggestion.
 const userName = os.userInfo().username;
 const workdir = process.cwd();
+const { platform, shell } = getEnvironmentInfo();
 const dynamicLines: Array<string> = [
   `User: ${userName}`,
   `Workdir: ${workdir}`,
+  `Platform: ${platform}`,
+  `Shell: ${shell}`,
 ];
 if (spawnSync("rg", ["--version"], { stdio: "ignore" }).status === 0) {
   dynamicLines.push(

--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -22,6 +22,7 @@ import {
 } from "../config.js";
 import { log } from "../logger/log.js";
 import { parseToolCallArguments } from "../parsers.js";
+import { getEnvironmentInfo } from "../platform-info.js";
 import { responsesCreateViaChatCompletions } from "../responses.js";
 import {
   ORIGIN,
@@ -33,7 +34,6 @@ import { applyPatchToolInstructions } from "./apply-patch.js";
 import { handleExecCommand } from "./handle-exec-command.js";
 import { HttpsProxyAgent } from "https-proxy-agent";
 import { spawnSync } from "node:child_process";
-import { getEnvironmentInfo } from "../platform-info.js";
 import { randomUUID } from "node:crypto";
 import OpenAI, { APIConnectionTimeoutError, AzureOpenAI } from "openai";
 import os from "os";

--- a/codex-cli/src/utils/platform-info.ts
+++ b/codex-cli/src/utils/platform-info.ts
@@ -1,0 +1,9 @@
+import os from "os";
+import path from "path";
+
+export function getEnvironmentInfo(): { platform: string; shell: string } {
+  const platform = `${os.platform()} ${os.arch()} ${os.release()}`;
+  const shellPath = process.env["SHELL"] || process.env["ComSpec"] || "";
+  const shell = shellPath ? path.basename(shellPath) : "unknown";
+  return { platform, shell };
+}

--- a/codex-cli/tests/environment-info.test.ts
+++ b/codex-cli/tests/environment-info.test.ts
@@ -1,0 +1,13 @@
+import { getEnvironmentInfo } from "../src/utils/platform-info.js";
+import { test, expect } from "vitest";
+import os from "os";
+import path from "path";
+
+test("reports platform and shell", () => {
+  const info = getEnvironmentInfo();
+  const expectedPlatform = `${os.platform()} ${os.arch()} ${os.release()}`;
+  const shellPath = process.env["SHELL"] || process.env["ComSpec"] || "";
+  const expectedShell = shellPath ? path.basename(shellPath) : "unknown";
+  expect(info.platform).toBe(expectedPlatform);
+  expect(info.shell).toBe(expectedShell);
+});


### PR DESCRIPTION
Expected:

Existing commands like "git" should be executed.

Actual:

On MacOS, I noticed that simple commands like "git" would not be found.  This is similar to https://github.com/openai/codex/pull/688.

Fix:
Using that PR as inspiration, I had OpenAI Codex (SaaS) produce this more focused patch to detect the correct environment.
Tested on MacOS and Linux.
