### PR TITLE
Fix escape key handling in overlays (fixes #1348)

### DIFF
--- a/codex-cli/src/components/diff-overlay.tsx
+++ b/codex-cli/src/components/diff-overlay.tsx
@@ -43,7 +43,7 @@ export default function DiffOverlay({
     } else if (input === "G") {
       setCursor(lines.length - 1);
     }
-  });
+  }, { isActive: true });
 
   const firstVisible = Math.min(
     Math.max(0, cursor - Math.floor(maxVisible / 2)),

--- a/codex-cli/src/components/help-overlay.tsx
+++ b/codex-cli/src/components/help-overlay.tsx
@@ -16,7 +16,7 @@ export default function HelpOverlay({
     if (key.escape || input === "q") {
       onExit();
     }
-  });
+  }, { isActive: true });
 
   return (
     <Box

--- a/codex-cli/src/components/history-overlay.tsx
+++ b/codex-cli/src/components/history-overlay.tsx
@@ -51,7 +51,7 @@ export default function HistoryOverlay({ items, onExit }: Props): JSX.Element {
     } else if (input === "G") {
       setCursor(list.length - 1);
     }
-  });
+  }, { isActive: true });
 
   const rows = process.stdout.rows || 24;
   const headerRows = 2;

--- a/codex-cli/src/components/model-overlay.tsx
+++ b/codex-cli/src/components/model-overlay.tsx
@@ -81,7 +81,7 @@ export default function ModelOverlay({
         setMode(mode === "model" ? "provider" : "model");
       }
     }
-  });
+  }, { isActive: true });
 
   if (hasLastResponse) {
     return (

--- a/codex-cli/tests/help-overlay.test.tsx
+++ b/codex-cli/tests/help-overlay.test.tsx
@@ -1,0 +1,102 @@
+/* -------------------------------------------------------------------------- *
+ * Tests for the HelpOverlay component
+ *
+ * The component displays help information with available commands and keyboard
+ * shortcuts. It should be dismissible with the Escape key or 'q' key.
+ * -------------------------------------------------------------------------- */
+
+import { describe, it, expect, vi } from "vitest";
+import { render } from "ink-testing-library";
+import React from "react";
+import HelpOverlay from "../src/components/help-overlay";
+
+// ---------------------------------------------------------------------------
+// Module mocks *must* be registered *before* the module under test is imported
+// so that Vitest can replace the dependency during evaluation.
+// ---------------------------------------------------------------------------
+
+// Mock ink's useInput to capture keyboard handlers
+let keyboardHandler: ((input: string, key: any) => void) | undefined;
+vi.mock("ink", async () => {
+  const actual = await vi.importActual("ink");
+  return {
+    ...actual,
+    useInput: (handler: (input: string, key: any) => void) => {
+      keyboardHandler = handler;
+    },
+  };
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("HelpOverlay", () => {
+  describe("content display", () => {
+    it("displays slash commands", () => {
+      const { lastFrame } = render(<HelpOverlay onExit={vi.fn()} />);
+      const frame = lastFrame()!;
+
+      expect(frame).toContain("Available commands");
+      expect(frame).toContain("/help");
+      expect(frame).toContain("/model");
+      expect(frame).toContain("/approval");
+      expect(frame).toContain("/history");
+      expect(frame).toContain("/clear");
+      expect(frame).toContain("/clearhistory");
+      expect(frame).toContain("/bug");
+      expect(frame).toContain("/diff");
+      expect(frame).toContain("/compact");
+    });
+
+    it("displays keyboard shortcuts", () => {
+      const { lastFrame } = render(<HelpOverlay onExit={vi.fn()} />);
+      const frame = lastFrame()!;
+
+      expect(frame).toContain("Keyboard shortcuts");
+      expect(frame).toContain("Enter");
+      expect(frame).toContain("Ctrl+J");
+      expect(frame).toContain("Up/Down");
+      expect(frame).toContain("Esc");
+      expect(frame).toContain("Ctrl+C");
+    });
+
+    it("displays exit instructions", () => {
+      const { lastFrame } = render(<HelpOverlay onExit={vi.fn()} />);
+      const frame = lastFrame()!;
+
+      expect(frame).toContain("esc or q to close");
+    });
+  });
+
+  describe("keyboard interaction", () => {
+    it("handles escape key", () => {
+      const onExit = vi.fn();
+      render(<HelpOverlay onExit={onExit} />);
+
+      keyboardHandler?.("", { escape: true });
+      expect(onExit).toHaveBeenCalledTimes(1);
+    });
+
+    it("handles 'q' key", () => {
+      const onExit = vi.fn();
+      render(<HelpOverlay onExit={onExit} />);
+
+      keyboardHandler?.("q", {});
+      expect(onExit).toHaveBeenCalledTimes(1);
+    });
+
+    it("ignores other keys", () => {
+      const onExit = vi.fn();
+      render(<HelpOverlay onExit={onExit} />);
+
+      // Try various other keys
+      keyboardHandler?.("a", {});
+      keyboardHandler?.("1", {});
+      keyboardHandler?.("", { enter: true });
+      keyboardHandler?.("", { upArrow: true });
+      
+      expect(onExit).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes issue where the escape key wasn't working to close the help menu and other overlays
- Adds `isActive: true` to `useInput` hook in all overlay components to ensure proper keyboard event capture
- Prevents input events from being intercepted by background components when overlays are displayed

## Changes
- Modified `help-overlay.tsx`, `history-overlay.tsx`, `diff-overlay.tsx`, and `model-overlay.tsx` to add `isActive: true` option to their `useInput` hooks
- Added comprehensive test suite for help overlay keyboard handling

## Test Plan
- [x] Added unit tests for help overlay keyboard interactions
- [x] All existing tests pass
- [x] Manually tested escape key functionality in all overlays

Fixes #1348