### PR TITLE
feat: redesign sandbox config

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -697,7 +697,6 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
- "codex-common",
  "codex-core",
  "landlock",
  "libc",

--- a/codex-rs/cli/src/lib.rs
+++ b/codex-rs/cli/src/lib.rs
@@ -5,16 +5,12 @@ pub mod proto;
 
 use clap::Parser;
 use codex_common::CliConfigOverrides;
-use codex_common::SandboxPermissionOption;
 
 #[derive(Debug, Parser)]
 pub struct SeatbeltCommand {
     /// Convenience alias for low-friction sandboxed automatic execution (network-disabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
-
-    #[clap(flatten)]
-    pub sandbox: SandboxPermissionOption,
 
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,
@@ -29,9 +25,6 @@ pub struct LandlockCommand {
     /// Convenience alias for low-friction sandboxed automatic execution (network-disabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
-
-    #[clap(flatten)]
-    pub sandbox: SandboxPermissionOption,
 
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,

--- a/codex-rs/common/src/approval_mode_cli_arg.rs
+++ b/codex-rs/common/src/approval_mode_cli_arg.rs
@@ -1,13 +1,9 @@
 //! Standard type to use with the `--approval-mode` CLI option.
 //! Available when the `cli` feature is enabled for the crate.
 
-use clap::ArgAction;
-use clap::Parser;
 use clap::ValueEnum;
 
-use codex_core::config::parse_sandbox_permission_with_base_path;
 use codex_core::protocol::AskForApproval;
-use codex_core::protocol::SandboxPermission;
 
 #[derive(Clone, Copy, Debug, ValueEnum)]
 #[value(rename_all = "kebab-case")]
@@ -35,39 +31,4 @@ impl From<ApprovalModeCliArg> for AskForApproval {
             ApprovalModeCliArg::Never => AskForApproval::Never,
         }
     }
-}
-
-#[derive(Parser, Debug)]
-pub struct SandboxPermissionOption {
-    /// Specify this flag multiple times to specify the full set of permissions
-    /// to grant to Codex.
-    ///
-    /// ```shell
-    /// codex -s disk-full-read-access \
-    ///       -s disk-write-cwd \
-    ///       -s disk-write-platform-user-temp-folder \
-    ///       -s disk-write-platform-global-temp-folder
-    /// ```
-    ///
-    /// Note disk-write-folder takes a value:
-    ///
-    /// ```shell
-    ///     -s disk-write-folder=$HOME/.pyenv/shims
-    /// ```
-    ///
-    /// These permissions are quite broad and should be used with caution:
-    ///
-    /// ```shell
-    ///     -s disk-full-write-access
-    ///     -s network-full-access
-    /// ```
-    #[arg(long = "sandbox-permission", short = 's', action = ArgAction::Append, value_parser = parse_sandbox_permission)]
-    pub permissions: Option<Vec<SandboxPermission>>,
-}
-
-/// Custom value-parser so we can keep the CLI surface small *and*
-/// still handle the parameterised `disk-write-folder` case.
-fn parse_sandbox_permission(raw: &str) -> std::io::Result<SandboxPermission> {
-    let base_path = std::env::current_dir()?;
-    parse_sandbox_permission_with_base_path(raw, base_path)
 }

--- a/codex-rs/common/src/lib.rs
+++ b/codex-rs/common/src/lib.rs
@@ -6,8 +6,6 @@ pub mod elapsed;
 
 #[cfg(feature = "cli")]
 pub use approval_mode_cli_arg::ApprovalModeCliArg;
-#[cfg(feature = "cli")]
-pub use approval_mode_cli_arg::SandboxPermissionOption;
 
 #[cfg(any(feature = "cli", test))]
 mod config_override;

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -1,7 +1,6 @@
 use clap::Parser;
 use clap::ValueEnum;
 use codex_common::CliConfigOverrides;
-use codex_common::SandboxPermissionOption;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -22,9 +21,6 @@ pub struct Cli {
     /// Convenience alias for low-friction sandboxed automatic execution (network-disabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
-
-    #[clap(flatten)]
-    pub sandbox: SandboxPermissionOption,
 
     /// Tell the agent to use the specified directory as its working root.
     #[clap(long = "cd", short = 'C', value_name = "DIR")]

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -31,7 +31,6 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         model,
         config_profile,
         full_auto,
-        sandbox,
         cwd,
         skip_git_repo_check,
         color,
@@ -85,9 +84,9 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
     };
 
     let sandbox_policy = if full_auto {
-        Some(SandboxPolicy::new_full_auto_policy())
+        Some(SandboxPolicy::new_workspace_write_policy())
     } else {
-        sandbox.permissions.clone().map(Into::into)
+        None
     };
 
     // Load configuration and determine approval policy

--- a/codex-rs/linux-sandbox/Cargo.toml
+++ b/codex-rs/linux-sandbox/Cargo.toml
@@ -15,15 +15,9 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
+anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 codex-core = { path = "../core" }
-codex-common = { path = "../common", features = ["cli"] }
-
-# Used for error handling in the helper that unifies runtime dispatch across
-# binaries.
-anyhow = "1"
-# Required to construct a Tokio runtime for async execution of the caller's
-# entry-point.
 tokio = { version = "1", features = ["rt-multi-thread"] }
 
 [dev-dependencies]

--- a/codex-rs/linux-sandbox/src/linux_run_main.rs
+++ b/codex-rs/linux-sandbox/src/linux_run_main.rs
@@ -1,13 +1,16 @@
 use clap::Parser;
-use codex_common::SandboxPermissionOption;
 use std::ffi::CString;
+use std::path::PathBuf;
 
 use crate::landlock::apply_sandbox_policy_to_current_thread;
 
 #[derive(Debug, Parser)]
 pub struct LandlockCommand {
-    #[clap(flatten)]
-    pub sandbox: SandboxPermissionOption,
+    /// It is possible that the cwd used in the context of the sandbox policy
+    /// is different from the cwd of the process to spawn.
+    pub sandbox_policy_cwd: PathBuf,
+
+    pub sandbox_policy: codex_core::protocol::SandboxPolicy,
 
     /// Full command args to run under landlock.
     #[arg(trailing_var_arg = true)]
@@ -15,21 +18,13 @@ pub struct LandlockCommand {
 }
 
 pub fn run_main() -> ! {
-    let LandlockCommand { sandbox, command } = LandlockCommand::parse();
+    let LandlockCommand {
+        sandbox_policy_cwd,
+        sandbox_policy,
+        command,
+    } = LandlockCommand::parse();
 
-    let sandbox_policy = match sandbox.permissions.map(Into::into) {
-        Some(sandbox_policy) => sandbox_policy,
-        None => codex_core::protocol::SandboxPolicy::new_read_only_policy(),
-    };
-
-    let cwd = match std::env::current_dir() {
-        Ok(cwd) => cwd,
-        Err(e) => {
-            panic!("failed to getcwd(): {e:?}");
-        }
-    };
-
-    if let Err(e) = apply_sandbox_policy_to_current_thread(&sandbox_policy, &cwd) {
+    if let Err(e) = apply_sandbox_policy_to_current_thread(&sandbox_policy, &sandbox_policy_cwd) {
         panic!("error running landlock: {e:?}");
     }
 

--- a/codex-rs/linux-sandbox/tests/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/landlock.rs
@@ -46,7 +46,10 @@ async fn run_cmd(cmd: &[&str], writable_roots: &[PathBuf], timeout_ms: u64) {
         env: create_env_from_core_vars(),
     };
 
-    let sandbox_policy = SandboxPolicy::new_read_only_policy_with_writable_roots(writable_roots);
+    let sandbox_policy = SandboxPolicy::WorkspaceWrite {
+        writable_roots: writable_roots.to_vec(),
+        network_access: false,
+    };
     let sandbox_program = env!("CARGO_BIN_EXE_codex-linux-sandbox");
     let codex_linux_sandbox_exe = Some(PathBuf::from(sandbox_program));
     let ctrl_c = Arc::new(Notify::new());

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -1,7 +1,6 @@
 //! Configuration object accepted by the `codex` MCP tool-call.
 
 use codex_core::protocol::AskForApproval;
-use codex_core::protocol::SandboxPolicy;
 use mcp_types::Tool;
 use mcp_types::ToolInputSchema;
 use schemars::JsonSchema;
@@ -19,7 +18,7 @@ pub(crate) struct CodexToolCallParam {
     /// The *initial user prompt* to start the Codex conversation.
     pub prompt: String,
 
-    /// Optional override for the model name (e.g. "o3", "o4-mini")
+    /// Optional override for the model name (e.g. "o3", "o4-mini").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
 
@@ -37,22 +36,14 @@ pub(crate) struct CodexToolCallParam {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub approval_policy: Option<CodexToolCallApprovalPolicy>,
 
-    /// Sandbox permissions using the same string values accepted by the CLI
-    /// (e.g. "disk-write-cwd", "network-full-access").
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub sandbox_permissions: Option<Vec<CodexToolCallSandboxPermission>>,
-
     /// Individual config settings that will override what is in
     /// CODEX_HOME/config.toml.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub config: Option<HashMap<String, serde_json::Value>>,
 }
 
-// Create custom enums for use with `CodexToolCallApprovalPolicy` where we
-// intentionally exclude docstrings from the generated schema because they
-// introduce anyOf in the the generated JSON schema, which makes it more complex
-// without adding any real value since we aspire to use self-descriptive names.
-
+// Custom enum mirroring `AskForApproval`, but constrained to the subset we
+// expose via the tool-call schema.
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) enum CodexToolCallApprovalPolicy {
@@ -73,50 +64,12 @@ impl From<CodexToolCallApprovalPolicy> for AskForApproval {
     }
 }
 
-// TODO: Support additional writable folders via a separate property on
-// CodexToolCallParam.
-
-#[derive(Debug, Clone, Deserialize, JsonSchema)]
-#[serde(rename_all = "kebab-case")]
-pub(crate) enum CodexToolCallSandboxPermission {
-    DiskFullReadAccess,
-    DiskWriteCwd,
-    DiskWritePlatformUserTempFolder,
-    DiskWritePlatformGlobalTempFolder,
-    DiskFullWriteAccess,
-    NetworkFullAccess,
-}
-
-impl From<CodexToolCallSandboxPermission> for codex_core::protocol::SandboxPermission {
-    fn from(value: CodexToolCallSandboxPermission) -> Self {
-        match value {
-            CodexToolCallSandboxPermission::DiskFullReadAccess => {
-                codex_core::protocol::SandboxPermission::DiskFullReadAccess
-            }
-            CodexToolCallSandboxPermission::DiskWriteCwd => {
-                codex_core::protocol::SandboxPermission::DiskWriteCwd
-            }
-            CodexToolCallSandboxPermission::DiskWritePlatformUserTempFolder => {
-                codex_core::protocol::SandboxPermission::DiskWritePlatformUserTempFolder
-            }
-            CodexToolCallSandboxPermission::DiskWritePlatformGlobalTempFolder => {
-                codex_core::protocol::SandboxPermission::DiskWritePlatformGlobalTempFolder
-            }
-            CodexToolCallSandboxPermission::DiskFullWriteAccess => {
-                codex_core::protocol::SandboxPermission::DiskFullWriteAccess
-            }
-            CodexToolCallSandboxPermission::NetworkFullAccess => {
-                codex_core::protocol::SandboxPermission::NetworkFullAccess
-            }
-        }
-    }
-}
-
+/// Builds a `Tool` definition (JSON schema etc.) for the Codex tool-call.
 pub(crate) fn create_tool_for_codex_tool_call_param() -> Tool {
     let schema = SchemaSettings::draft2019_09()
         .with(|s| {
             s.inline_subschemas = true;
-            s.option_add_null_type = false
+            s.option_add_null_type = false;
         })
         .into_generator()
         .into_root_schema_for::<CodexToolCallParam>();
@@ -129,12 +82,12 @@ pub(crate) fn create_tool_for_codex_tool_call_param() -> Tool {
         serde_json::from_value::<ToolInputSchema>(schema_value).unwrap_or_else(|e| {
             panic!("failed to create Tool from schema: {e}");
         });
+
     Tool {
         name: "codex".to_string(),
         input_schema: tool_input_schema,
         description: Some(
-            "Run a Codex session. Accepts configuration parameters matching the Codex Config struct."
-                .to_string(),
+            "Run a Codex session. Accepts configuration parameters matching the Codex Config struct.".to_string(),
         ),
         annotations: None,
     }
@@ -142,7 +95,7 @@ pub(crate) fn create_tool_for_codex_tool_call_param() -> Tool {
 
 impl CodexToolCallParam {
     /// Returns the initial user prompt to start the Codex conversation and the
-    /// Config.
+    /// effective Config object generated from the supplied parameters.
     pub fn into_config(
         self,
         codex_linux_sandbox_exe: Option<PathBuf>,
@@ -153,20 +106,18 @@ impl CodexToolCallParam {
             profile,
             cwd,
             approval_policy,
-            sandbox_permissions,
             config: cli_overrides,
         } = self;
-        let sandbox_policy = sandbox_permissions.map(|perms| {
-            SandboxPolicy::from(perms.into_iter().map(Into::into).collect::<Vec<_>>())
-        });
 
-        // Build ConfigOverrides recognised by codex-core.
+        // Build the `ConfigOverrides` recognised by codex-core.
         let overrides = codex_core::config::ConfigOverrides {
             model,
             config_profile: profile,
             cwd: cwd.map(PathBuf::from),
             approval_policy: approval_policy.map(Into::into),
-            sandbox_policy,
+            // Note we may want to expose a field on CodexToolCallParam to
+            // facilitate configuring the sandbox policy.
+            sandbox_policy: None,
             model_provider: None,
             codex_linux_sandbox_exe,
         };
@@ -230,7 +181,7 @@ mod tests {
                 "type": "string"
               },
               "model": {
-                "description": "Optional override for the model name (e.g. \"o3\", \"o4-mini\")",
+                "description": "Optional override for the model name (e.g. \"o3\", \"o4-mini\").",
                 "type": "string"
               },
               "profile": {
@@ -241,21 +192,6 @@ mod tests {
                 "description": "The *initial user prompt* to start the Codex conversation.",
                 "type": "string"
               },
-              "sandbox-permissions": {
-                "description": "Sandbox permissions using the same string values accepted by the CLI (e.g. \"disk-write-cwd\", \"network-full-access\").",
-                "items": {
-                  "enum": [
-                    "disk-full-read-access",
-                    "disk-write-cwd",
-                    "disk-write-platform-user-temp-folder",
-                    "disk-write-platform-global-temp-folder",
-                    "disk-full-write-access",
-                    "network-full-access"
-                  ],
-                  "type": "string"
-                },
-                "type": "array"
-              }
             },
             "required": [
               "prompt"

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -1,7 +1,6 @@
 use clap::Parser;
 use codex_common::ApprovalModeCliArg;
 use codex_common::CliConfigOverrides;
-use codex_common::SandboxPermissionOption;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -29,9 +28,6 @@ pub struct Cli {
     /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, network-disabled sandbox that can write to cwd and TMPDIR)
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
-
-    #[clap(flatten)]
-    pub sandbox: SandboxPermissionOption,
 
     /// Tell the agent to use the specified directory as its working root.
     #[clap(long = "cd", short = 'C', value_name = "DIR")]

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -48,11 +48,11 @@ pub use cli::Cli;
 pub fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> std::io::Result<()> {
     let (sandbox_policy, approval_policy) = if cli.full_auto {
         (
-            Some(SandboxPolicy::new_full_auto_policy()),
+            Some(SandboxPolicy::new_workspace_write_policy()),
             Some(AskForApproval::OnFailure),
         )
     } else {
-        let sandbox_policy = cli.sandbox.permissions.clone().map(Into::into);
+        let sandbox_policy = None;
         (sandbox_policy, cli.approval_policy.map(Into::into))
     };
 


### PR DESCRIPTION
This is a major redesign of how sandbox configuration works and aims to fix https://github.com/openai/codex/issues/1248. Specifically, it replaces `sandbox_permissions` in `config.toml` (and the `-s`/`--sandbox-permission` CLI flags) with a "table" with effectively three variants:

```toml
# Safest option: full disk is read-only, but writes and network access are disallowed.
[sandbox]
mode = "read-only"

# The cwd of the Codex task is writable, as well as $TMPDIR on macOS.
# writable_roots can be used to specify additional writable folders.
[sandbox]
mode = "workspace-write"
writable_roots = []  # Optional, defaults to the empty list.
network_access = false  # Optional, defaults to false.

# Disable sandboxing: use at your own risk!!!
[sandbox]
mode = "danger-full-access"
```

This should make sandboxing easier to reason about. While we have dropped support for `-s`, the way it works now is:

- no flags => `read-only`
- `--full-auto` => `workspace-write`
- currently, there is no way to specify `danger-full-access` via a CLI flag, but we will revisit that as part of https://github.com/openai/codex/issues/1254

Outstanding issue:

- As noted in the `TODO` on `SandboxPolicy::is_unrestricted()`, we are still conflating sandbox preferences with approval preferences in that case, which needs to be cleaned up.
