### PR TITLE
chore: install clippy and rustfmt in the devcontainer for Linux development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -22,7 +22,8 @@ USER $USER
 
 # install Rust + musl target as dev user
 RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && \
-    ~/.cargo/bin/rustup target add aarch64-unknown-linux-musl
+    ~/.cargo/bin/rustup target add aarch64-unknown-linux-musl && \
+    ~/.cargo/bin/rustup component add clippy rustfmt
 
 ENV PATH="/home/${USER}/.cargo/bin:${PATH}"
 


### PR DESCRIPTION
I discovered it was difficult to do development in the devcontainer without these tools available.