### PR TITLE
chore: install `just` in the devcontainer for Linux development

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 # enable 'universe' because musl-tools & clang live there
@@ -11,20 +11,17 @@ RUN apt-get update && \
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     build-essential curl git ca-certificates \
-    pkg-config clang musl-tools libssl-dev && \
+    pkg-config clang musl-tools libssl-dev just && \
     rm -rf /var/lib/apt/lists/*
 
-# non-root dev user
-ARG USER=dev
-ARG UID=1000
-RUN useradd -m -u $UID $USER
-USER $USER
+# Ubuntu 24.04 ships with user 'ubuntu' already created with UID 1000.
+USER ubuntu
 
 # install Rust + musl target as dev user
 RUN curl -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal && \
     ~/.cargo/bin/rustup target add aarch64-unknown-linux-musl && \
     ~/.cargo/bin/rustup component add clippy rustfmt
 
-ENV PATH="/home/${USER}/.cargo/bin:${PATH}"
+ENV PATH="/home/ubuntu/.cargo/bin:${PATH}"
 
 WORKDIR /workspace

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,15 +15,13 @@
     "CARGO_TARGET_DIR": "${containerWorkspaceFolder}/codex-rs/target-arm64"
   },
 
-  "remoteUser": "dev",
+  "remoteUser": "ubuntu",
   "customizations": {
     "vscode": {
       "settings": {
-          "terminal.integrated.defaultProfile.linux": "bash"
+        "terminal.integrated.defaultProfile.linux": "bash"
       },
-      "extensions": [
-          "rust-lang.rust-analyzer"
-      ],
+      "extensions": ["rust-lang.rust-analyzer"]
     }
   }
 }


### PR DESCRIPTION
Apparently `just` was added to `apt` in Ubuntu 24, so this required updating the Ubuntu version in the `Dockerfile` to make it so we could simply `apt install just`.

Though then that caused a conflict with the custom `dev` user we were using, though the end result seems simpler since now we just use the default `ubuntu` user provided by Ubuntu 24.