### PR TITLE
chore: rename AskForApproval::UnlessAllowListed to AskForApproval::UnlessTrusted

### DIFF
--- a/codex-rs/common/src/approval_mode_cli_arg.rs
+++ b/codex-rs/common/src/approval_mode_cli_arg.rs
@@ -26,7 +26,7 @@ pub enum ApprovalModeCliArg {
 impl From<ApprovalModeCliArg> for AskForApproval {
     fn from(value: ApprovalModeCliArg) -> Self {
         match value {
-            ApprovalModeCliArg::Untrusted => AskForApproval::UnlessAllowListed,
+            ApprovalModeCliArg::Untrusted => AskForApproval::UnlessTrusted,
             ApprovalModeCliArg::OnFailure => AskForApproval::OnFailure,
             ApprovalModeCliArg::Never => AskForApproval::Never,
         }

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -731,7 +731,7 @@ disable_response_storage = true
             model: "gpt-3.5-turbo".to_string(),
             model_provider_id: "openai-chat-completions".to_string(),
             model_provider: fixture.openai_chat_completions_provider.clone(),
-            approval_policy: AskForApproval::UnlessAllowListed,
+            approval_policy: AskForApproval::UnlessTrusted,
             sandbox_policy: SandboxPolicy::new_read_only_policy(),
             shell_environment_policy: ShellEnvironmentPolicy::default(),
             disable_response_storage: false,

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -120,7 +120,7 @@ pub enum AskForApproval {
     /// Everything else will ask the user to approve.
     #[default]
     #[serde(rename = "untrusted")]
-    UnlessAllowListed,
+    UnlessTrusted,
 
     /// *All* commands are auto‑approved, but they are expected to run inside a
     /// sandbox where network access is disabled and writes are confined to a

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -36,7 +36,7 @@ pub fn assess_patch_safety(
         }
         // TODO(ragona): I'm not sure this is actually correct? I believe in this case
         // we want to continue to the writable paths check before asking the user.
-        AskForApproval::UnlessAllowListed => {
+        AskForApproval::UnlessTrusted => {
             return SafetyCheck::AskUser;
         }
     }

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -55,7 +55,7 @@ pub(crate) enum CodexToolCallApprovalPolicy {
 impl From<CodexToolCallApprovalPolicy> for AskForApproval {
     fn from(value: CodexToolCallApprovalPolicy) -> Self {
         match value {
-            CodexToolCallApprovalPolicy::Untrusted => AskForApproval::UnlessAllowListed,
+            CodexToolCallApprovalPolicy::Untrusted => AskForApproval::UnlessTrusted,
             CodexToolCallApprovalPolicy::OnFailure => AskForApproval::OnFailure,
             CodexToolCallApprovalPolicy::Never => AskForApproval::Never,
         }


### PR DESCRIPTION
We could just rename to `Untrusted` instead of `UnlessTrusted`, but I think `AskForApproval::UnlessTrusted` reads a bit better.