### PR TITLE
[Rust] Allow resuming a session that was killed with ctrl + c

### DIFF
--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -413,7 +413,12 @@ where
 
                     // Nothing aggregated – forward Completed directly.
                     return Poll::Ready(Some(Ok(ResponseEvent::Completed { response_id })));
-                } // No other `Ok` variants exist at the moment, continue polling.
+                }
+                Poll::Ready(Some(Ok(ResponseEvent::Created { .. }))) => {
+                    // These events are exclusive to the Responses API and
+                    // will never appear in a Chat Completions stream.
+                    continue;
+                }
             }
         }
     }

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use tokio::sync::mpsc;
 use tokio::time::timeout;
 use tokio_util::io::ReaderStream;
-use tracing::{debug, info};
+use tracing::debug;
 use tracing::trace;
 use tracing::warn;
 
@@ -197,46 +197,6 @@ impl ModelClient {
             }
         }
     }
-
-    /// Cancels an in-progress Responses API request using the
-    /// `/responses/{id}/cancel` endpoint.  This is a **best-effort** helper –
-    /// failures are surfaced to the caller so they can be logged, but should
-    /// not crash the agent.
-    pub async fn cancel_response(&self, response_id: &str) -> Result<()> {
-        if self.provider.wire_api != WireApi::Responses {
-            // Only the experimental Responses API supports server-side
-            // cancellations. For Chat completions (and other providers) we
-            // simply return Ok so callers do not need to special-case.
-            return Ok(());
-        }
-
-        let base_url = self.provider.base_url.trim_end_matches('/');
-        let url = format!("{}/responses/{}/cancel", base_url, response_id);
-
-        let api_key = self.provider.api_key()?.ok_or_else(|| {
-            CodexErr::EnvVar(EnvVarError {
-                var: self.provider.env_key.clone().unwrap_or_default(),
-                instructions: None,
-            })
-        })?;
-
-        let res = self
-            .client
-            .post(&url)
-            .bearer_auth(api_key)
-            .header("OpenAI-Beta", "responses=experimental")
-            .send()
-            .await
-            .map_err(CodexErr::Reqwest)?;
-
-        if res.status().is_success() {
-            Ok(())
-        } else {
-            let status = res.status();
-            let body = res.text().await.unwrap_or_default();
-            Err(CodexErr::UnexpectedStatus(status, body))
-        }
-    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -248,7 +208,10 @@ struct SseEvent {
 }
 
 #[derive(Debug, Deserialize)]
-struct ResponseId {
+struct ResponseCreated {}
+
+#[derive(Debug, Deserialize)]
+struct ResponseCompleted {
     id: String,
 }
 
@@ -314,7 +277,7 @@ where
             // duplicated `output` array embedded in the `response.completed`
             // payload.  That produced two concrete issues:
             //   1. No real‑time streaming – the user only saw output after the
-            //      entire turn had finished, which broke the "typing" UX and
+            //      entire turn had finished, which broke the “typing” UX and
             //      made long‑running turns look stalled.
             //   2. Duplicate `function_call_output` items – both the
             //      individual *and* the completed array were forwarded, which
@@ -336,10 +299,15 @@ where
                     return;
                 }
             }
+            "response.created" => {
+                if let Some(_) = event.response {
+                    let _ = tx_event.send(Ok(ResponseEvent::Created {})).await;
+                }
+            }
             // Final response completed – includes array of output items & id
             "response.completed" => {
                 if let Some(resp_val) = event.response {
-                    match serde_json::from_value::<ResponseId>(resp_val) {
+                    match serde_json::from_value::<ResponseCompleted>(resp_val) {
                         Ok(r) => {
                             response_id = Some(r.id);
                         }
@@ -349,24 +317,6 @@ where
                         }
                     };
                 };
-            }
-            "response.created" => {
-                if let Some(resp_val) = event.response {
-                    match serde_json::from_value::<ResponseId>(resp_val) {
-                        Ok(r) => {
-                            let id = r.id;
-                            response_id.get_or_insert(id.clone());
-                            // Forward to downstream so the agent can cancel if needed.
-                            let _ = tx_event
-                                .send(Ok(ResponseEvent::Created { response_id: id }))
-                                .await;
-                        }
-                        Err(e) => {
-                            debug!("failed to parse ResponseCreated: {e}");
-                            continue;
-                        }
-                    }
-                }
             }
             "response.content_part.done"
             | "response.function_call_arguments.delta"

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -12,7 +12,7 @@ use serde_json::Value;
 use tokio::sync::mpsc;
 use tokio::time::timeout;
 use tokio_util::io::ReaderStream;
-use tracing::debug;
+use tracing::{debug, info};
 use tracing::trace;
 use tracing::warn;
 
@@ -167,7 +167,7 @@ impl ModelClient {
                     // negligible.
                     if !(status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error()) {
                         // Surface the error body to callers. Use `unwrap_or_default` per Clippy.
-                        let body = (res.text().await).unwrap_or_default();
+                        let body = res.text().await.unwrap_or_default();
                         return Err(CodexErr::UnexpectedStatus(status, body));
                     }
 
@@ -197,6 +197,46 @@ impl ModelClient {
             }
         }
     }
+
+    /// Cancels an in-progress Responses API request using the
+    /// `/responses/{id}/cancel` endpoint.  This is a **best-effort** helper –
+    /// failures are surfaced to the caller so they can be logged, but should
+    /// not crash the agent.
+    pub async fn cancel_response(&self, response_id: &str) -> Result<()> {
+        if self.provider.wire_api != WireApi::Responses {
+            // Only the experimental Responses API supports server-side
+            // cancellations. For Chat completions (and other providers) we
+            // simply return Ok so callers do not need to special-case.
+            return Ok(());
+        }
+
+        let base_url = self.provider.base_url.trim_end_matches('/');
+        let url = format!("{}/responses/{}/cancel", base_url, response_id);
+
+        let api_key = self.provider.api_key()?.ok_or_else(|| {
+            CodexErr::EnvVar(EnvVarError {
+                var: self.provider.env_key.clone().unwrap_or_default(),
+                instructions: None,
+            })
+        })?;
+
+        let res = self
+            .client
+            .post(&url)
+            .bearer_auth(api_key)
+            .header("OpenAI-Beta", "responses=experimental")
+            .send()
+            .await
+            .map_err(CodexErr::Reqwest)?;
+
+        if res.status().is_success() {
+            Ok(())
+        } else {
+            let status = res.status();
+            let body = res.text().await.unwrap_or_default();
+            Err(CodexErr::UnexpectedStatus(status, body))
+        }
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -208,7 +248,7 @@ struct SseEvent {
 }
 
 #[derive(Debug, Deserialize)]
-struct ResponseCompleted {
+struct ResponseId {
     id: String,
 }
 
@@ -274,7 +314,7 @@ where
             // duplicated `output` array embedded in the `response.completed`
             // payload.  That produced two concrete issues:
             //   1. No real‑time streaming – the user only saw output after the
-            //      entire turn had finished, which broke the “typing” UX and
+            //      entire turn had finished, which broke the "typing" UX and
             //      made long‑running turns look stalled.
             //   2. Duplicate `function_call_output` items – both the
             //      individual *and* the completed array were forwarded, which
@@ -299,7 +339,7 @@ where
             // Final response completed – includes array of output items & id
             "response.completed" => {
                 if let Some(resp_val) = event.response {
-                    match serde_json::from_value::<ResponseCompleted>(resp_val) {
+                    match serde_json::from_value::<ResponseId>(resp_val) {
                         Ok(r) => {
                             response_id = Some(r.id);
                         }
@@ -310,8 +350,25 @@ where
                     };
                 };
             }
+            "response.created" => {
+                if let Some(resp_val) = event.response {
+                    match serde_json::from_value::<ResponseId>(resp_val) {
+                        Ok(r) => {
+                            let id = r.id;
+                            response_id.get_or_insert(id.clone());
+                            // Forward to downstream so the agent can cancel if needed.
+                            let _ = tx_event
+                                .send(Ok(ResponseEvent::Created { response_id: id }))
+                                .await;
+                        }
+                        Err(e) => {
+                            debug!("failed to parse ResponseCreated: {e}");
+                            continue;
+                        }
+                    }
+                }
+            }
             "response.content_part.done"
-            | "response.created"
             | "response.function_call_arguments.delta"
             | "response.in_progress"
             | "response.output_item.added"

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -300,7 +300,7 @@ where
                 }
             }
             "response.created" => {
-                if let Some(_) = event.response {
+                if event.response.is_some() {
                     let _ = tx_event.send(Ok(ResponseEvent::Created {})).await;
                 }
             }

--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -50,8 +50,17 @@ impl Prompt {
 
 #[derive(Debug)]
 pub enum ResponseEvent {
+    /// Emitted when the OpenAI Responses API acknowledges creation of a new in-progress
+    /// response and provides the response `id`. This variant is currently only emitted
+    /// when using the experimental Responses API.
+    /// Chat Completions streams will never produce it.
+    Created {
+        response_id: String,
+    },
     OutputItemDone(ResponseItem),
-    Completed { response_id: String },
+    Completed {
+        response_id: String,
+    },
 }
 
 #[derive(Debug, Serialize)]

--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -50,7 +50,7 @@ impl Prompt {
 
 #[derive(Debug)]
 pub enum ResponseEvent {
-    Created {},
+    Created,
     OutputItemDone(ResponseItem),
     Completed { response_id: String },
 }

--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -50,17 +50,9 @@ impl Prompt {
 
 #[derive(Debug)]
 pub enum ResponseEvent {
-    /// Emitted when the OpenAI Responses API acknowledges creation of a new in-progress
-    /// response and provides the response `id`. This variant is currently only emitted
-    /// when using the experimental Responses API.
-    /// Chat Completions streams will never produce it.
-    Created {
-        response_id: String,
-    },
+    Created {},
     OutputItemDone(ResponseItem),
-    Completed {
-        response_id: String,
-    },
+    Completed { response_id: String },
 }
 
 #[derive(Debug, Serialize)]


### PR DESCRIPTION
Previously, if you ctrl+c'd a conversation, all subsequent turns would 400 because the Responses API never got a response for one of its call ids. This ensures that if we aren't sending a call id by hand, we generate a synthetic aborted call.

Fixes #1244 

https://github.com/user-attachments/assets/5126354f-b970-45f5-8c65-f811bca8294a


