### PR TITLE
feat: add support for @ to do file search

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -770,6 +770,7 @@ dependencies = [
  "codex-ansi-escape",
  "codex-common",
  "codex-core",
+ "codex-file-search",
  "codex-linux-sandbox",
  "codex-login",
  "color-eyre",

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -25,6 +25,7 @@ codex-common = { path = "../common", features = [
     "elapsed",
     "sandbox_summary",
 ] }
+codex-file-search = { path = "../file-search" }
 codex-linux-sandbox = { path = "../linux-sandbox" }
 codex-login = { path = "../login" }
 color-eyre = "0.6.3"

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -28,4 +28,17 @@ pub(crate) enum AppEvent {
     /// Dispatch a recognized slash command from the UI (composer) to the app
     /// layer so it can be handled centrally.
     DispatchCommand(SlashCommand),
+
+    /// Kick off an asynchronous file search for the given query (text after
+    /// the `@`). Previous searches may be cancelled by the app layer so there
+    /// is at most one in-flight search.
+    StartFileSearch(String),
+
+    /// Result of a completed asynchronous file search. The `query` echoes the
+    /// original search term so the UI can decide whether the results are
+    /// still relevant.
+    FileSearchResult {
+        query: String,
+        matches: Vec<String>,
+    },
 }

--- a/codex-rs/tui/src/bottom_pane/file_search_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/file_search_popup.rs
@@ -1,0 +1,159 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::prelude::Constraint;
+use ratatui::style::Color;
+use ratatui::style::Style;
+use ratatui::widgets::Block;
+use ratatui::widgets::BorderType;
+use ratatui::widgets::Borders;
+use ratatui::widgets::Cell;
+use ratatui::widgets::Row;
+use ratatui::widgets::Table;
+use ratatui::widgets::Widget;
+use ratatui::widgets::WidgetRef;
+
+/// Maximum number of suggestions shown in the popup.
+const MAX_RESULTS: usize = 8;
+
+/// Visual state for the file-search popup.
+pub(crate) struct FileSearchPopup {
+    /// Query corresponding to the `matches` currently shown.
+    display_query: String,
+    /// Latest query typed by the user. May differ from `display_query` when
+    /// a search is still in-flight.
+    pending_query: String,
+    /// When `true` we are still waiting for results for `pending_query`.
+    waiting: bool,
+    /// Cached matches; paths relative to the search dir.
+    matches: Vec<String>,
+    /// Currently selected index inside `matches` (if any).
+    selected_idx: Option<usize>,
+}
+
+impl FileSearchPopup {
+    pub(crate) fn new() -> Self {
+        Self {
+            display_query: String::new(),
+            pending_query: String::new(),
+            waiting: true,
+            matches: Vec::new(),
+            selected_idx: None,
+        }
+    }
+
+    /// Update the query and reset state to *waiting*.
+    pub(crate) fn set_query(&mut self, query: &str) {
+        if query == self.pending_query {
+            return;
+        }
+
+        // Determine if current matches are still relevant.
+        let keep_existing = query.starts_with(&self.display_query);
+
+        self.pending_query.clear();
+        self.pending_query.push_str(query);
+
+        self.waiting = true; // waiting for new results
+
+        if !keep_existing {
+            self.matches.clear();
+            self.selected_idx = None;
+        }
+    }
+
+    /// Replace matches when a `FileSearchResult` arrives.
+    /// Replace matches. Only applied when `query` matches `pending_query`.
+    pub(crate) fn set_matches(&mut self, query: &str, matches: Vec<String>) {
+        if query != self.pending_query {
+            return; // stale
+        }
+
+        self.display_query = query.to_string();
+        self.matches = matches;
+        self.waiting = false;
+        self.selected_idx = if self.matches.is_empty() {
+            None
+        } else {
+            Some(0)
+        };
+    }
+
+    /// Move selection cursor up.
+    pub(crate) fn move_up(&mut self) {
+        if let Some(idx) = self.selected_idx {
+            if idx > 0 {
+                self.selected_idx = Some(idx - 1);
+            }
+        }
+    }
+
+    /// Move selection cursor down.
+    pub(crate) fn move_down(&mut self) {
+        if let Some(idx) = self.selected_idx {
+            if idx + 1 < self.matches.len() {
+                self.selected_idx = Some(idx + 1);
+            }
+        } else if !self.matches.is_empty() {
+            self.selected_idx = Some(0);
+        }
+    }
+
+    pub(crate) fn selected_match(&self) -> Option<&str> {
+        self.selected_idx
+            .and_then(|idx| self.matches.get(idx))
+            .map(String::as_str)
+    }
+
+    /// Preferred height (rows) including border.
+    pub(crate) fn calculate_required_height(&self, _area: &Rect) -> u16 {
+        // Row count depends on whether we already have matches. If no matches
+        // yet (e.g. initial search or query with no results) reserve a single
+        // row so the popup is still visible. When matches are present we show
+        // up to MAX_RESULTS regardless of the waiting flag so the list
+        // remains stable while a newer search is in-flight.
+        let rows = if self.matches.is_empty() {
+            1
+        } else {
+            self.matches.len().clamp(1, MAX_RESULTS)
+        } as u16;
+        rows + 2 // border
+    }
+}
+
+impl WidgetRef for &FileSearchPopup {
+    fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        // Prepare rows.
+        let rows: Vec<Row> = if self.matches.is_empty() {
+            vec![Row::new(vec![Cell::from(" no matches ")])]
+        } else {
+            self.matches
+                .iter()
+                .take(MAX_RESULTS)
+                .enumerate()
+                .map(|(i, p)| {
+                    let mut cell = Cell::from(p.as_str());
+                    if Some(i) == self.selected_idx {
+                        cell = cell.style(Style::default().fg(Color::Yellow));
+                    }
+                    Row::new(vec![cell])
+                })
+                .collect()
+        };
+
+        let mut title = format!(" @{} ", self.pending_query);
+        if self.waiting {
+            title.push_str(" (searching …)");
+        }
+
+        let table = Table::new(rows, vec![Constraint::Percentage(100)])
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .title(title),
+            )
+            .widths([Constraint::Percentage(100)]);
+
+        table.render(area, buf);
+    }
+}

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -17,6 +17,7 @@ mod bottom_pane_view;
 mod chat_composer;
 mod chat_composer_history;
 mod command_popup;
+mod file_search_popup;
 mod status_indicator_view;
 
 pub(crate) use chat_composer::ChatComposer;
@@ -201,9 +202,9 @@ impl BottomPane<'_> {
         self.app_event_tx.send(AppEvent::Redraw)
     }
 
-    /// Returns true when the slash-command popup inside the composer is visible.
-    pub(crate) fn is_command_popup_visible(&self) -> bool {
-        self.active_view.is_none() && self.composer.is_command_popup_visible()
+    /// Returns true when a popup inside the composer is visible.
+    pub(crate) fn is_popup_visible(&self) -> bool {
+        self.active_view.is_none() && self.composer.is_popup_visible()
     }
 
     // --- History helpers ---
@@ -225,6 +226,11 @@ impl BottomPane<'_> {
         if updated {
             self.request_redraw();
         }
+    }
+
+    pub(crate) fn on_file_search_result(&mut self, query: String, matches: Vec<String>) {
+        self.composer.on_file_search_result(query, matches);
+        self.request_redraw();
     }
 }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -143,7 +143,7 @@ impl ChatWidget<'_> {
         // However, when the slash-command popup is visible we forward the key
         // to the bottom pane so it can handle auto-completion.
         if matches!(key_event.code, crossterm::event::KeyCode::Tab)
-            && !self.bottom_pane.is_command_popup_visible()
+            && !self.bottom_pane.is_popup_visible()
         {
             self.input_focus = match self.input_focus {
                 InputFocus::HistoryPane => InputFocus::BottomPane,
@@ -402,6 +402,11 @@ impl ChatWidget<'_> {
         };
         self.conversation_history.scroll(magnified_scroll_delta);
         self.request_redraw();
+    }
+
+    /// Forward file-search results to the bottom pane.
+    pub(crate) fn apply_file_search_result(&mut self, query: String, matches: Vec<String>) {
+        self.bottom_pane.on_file_search_result(query, matches);
     }
 
     /// Handle Ctrl-C key press.

--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -1,0 +1,204 @@
+//! Helper that owns the debounce/cancellation logic for `@` file searches.
+//!
+//! `ChatComposer` publishes *every* change of the `@token` as
+//! `AppEvent::StartFileSearch(query)`.
+//! This struct receives those events and decides when to actually spawn the
+//! expensive search (handled in the main `App` thread). It tries to ensure:
+//!
+//! - Even when the user types long text quickly, they will start seeing results
+//!   after a short delay using an early version of what they typed.
+//! - At most one search is in-flight at any time.
+//!
+//! It works as follows:
+//!
+//! 1. First query starts a debounce timer.
+//! 2. While the timer is pending, the latest query from the user is stored.
+//! 3. When the timer fires, it is cleared, and a search is done for the most
+//!    recent query.
+//! 4. If there is a in-flight search that is not a prefix of the latest thing
+//!    the user typed, it is cancelled.
+
+use codex_file_search as file_search;
+use std::num::NonZeroUsize;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::thread;
+use std::time::Duration;
+
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+
+#[allow(clippy::unwrap_used)]
+const MAX_FILE_SEARCH_RESULTS: NonZeroUsize = NonZeroUsize::new(8).unwrap();
+
+#[allow(clippy::unwrap_used)]
+const NUM_FILE_SEARCH_THREADS: NonZeroUsize = NonZeroUsize::new(2).unwrap();
+
+/// How long to wait after a keystroke before firing the first search when none
+/// is currently running. Keeps early queries more meaningful.
+const FILE_SEARCH_DEBOUNCE: Duration = Duration::from_millis(100);
+
+const ACTIVE_SEARCH_COMPLETE_POLL_INTERVAL: Duration = Duration::from_millis(20);
+
+/// State machine for file-search orchestration.
+pub(crate) struct FileSearchManager {
+    /// Unified state guarded by one mutex.
+    state: Arc<Mutex<SearchState>>,
+
+    search_dir: PathBuf,
+    app_tx: AppEventSender,
+}
+
+struct SearchState {
+    /// Latest query typed by user (updated every keystroke).
+    latest_query: String,
+
+    /// true if a search is currently scheduled.
+    is_search_scheduled: bool,
+
+    /// If there is an active search, this will be the query being searched.
+    active_search: Option<ActiveSearch>,
+}
+
+struct ActiveSearch {
+    query: String,
+    cancellation_token: Arc<AtomicBool>,
+}
+
+impl FileSearchManager {
+    pub fn new(search_dir: PathBuf, tx: AppEventSender) -> Self {
+        Self {
+            state: Arc::new(Mutex::new(SearchState {
+                latest_query: String::new(),
+                is_search_scheduled: false,
+                active_search: None,
+            })),
+            search_dir,
+            app_tx: tx,
+        }
+    }
+
+    /// Call whenever the user edits the `@` token.
+    pub fn on_user_query(&self, query: String) {
+        {
+            #[allow(clippy::unwrap_used)]
+            let mut st = self.state.lock().unwrap();
+            if query == st.latest_query {
+                // No change, nothing to do.
+                return;
+            }
+
+            // Update latest query.
+            st.latest_query.clear();
+            st.latest_query.push_str(&query);
+
+            // If there is an in-flight search that is definitely obsolete,
+            // cancel it now.
+            if let Some(active_search) = &st.active_search {
+                if !query.starts_with(&active_search.query) {
+                    active_search
+                        .cancellation_token
+                        .store(true, Ordering::Relaxed);
+                    st.active_search = None;
+                }
+            }
+
+            // Schedule a search to run after debounce.
+            if !st.is_search_scheduled {
+                st.is_search_scheduled = true;
+            } else {
+                return;
+            }
+        }
+
+        // If we are here, we set `st.is_search_scheduled = true` before
+        // dropping the lock. This means we are the only thread that can spawn a
+        // debounce timer.
+        let state = self.state.clone();
+        let search_dir = self.search_dir.clone();
+        let tx_clone = self.app_tx.clone();
+        thread::spawn(move || {
+            // Always do a minimum debounce, but then poll until the
+            // `active_search` is cleared.
+            thread::sleep(FILE_SEARCH_DEBOUNCE);
+            loop {
+                #[allow(clippy::unwrap_used)]
+                if state.lock().unwrap().active_search.is_none() {
+                    break;
+                }
+                thread::sleep(ACTIVE_SEARCH_COMPLETE_POLL_INTERVAL);
+            }
+
+            // The debounce timer has expired, so start a search using the
+            // latest query.
+            let cancellation_token = Arc::new(AtomicBool::new(false));
+            let token = cancellation_token.clone();
+            let query = {
+                #[allow(clippy::unwrap_used)]
+                let mut st = state.lock().unwrap();
+                let query = st.latest_query.clone();
+                st.is_search_scheduled = false;
+                st.active_search = Some(ActiveSearch {
+                    query: query.clone(),
+                    cancellation_token: token,
+                });
+                query
+            };
+
+            FileSearchManager::spawn_file_search(
+                query,
+                search_dir,
+                tx_clone,
+                cancellation_token,
+                state,
+            );
+        });
+    }
+
+    fn spawn_file_search(
+        query: String,
+        search_dir: PathBuf,
+        tx: AppEventSender,
+        cancellation_token: Arc<AtomicBool>,
+        search_state: Arc<Mutex<SearchState>>,
+    ) {
+        std::thread::spawn(move || {
+            let matches = file_search::run(
+                &query,
+                MAX_FILE_SEARCH_RESULTS,
+                &search_dir,
+                Vec::new(),
+                NUM_FILE_SEARCH_THREADS,
+                cancellation_token.clone(),
+            )
+            .map(|res| {
+                res.matches
+                    .into_iter()
+                    .map(|(_, p)| p)
+                    .collect::<Vec<String>>()
+            })
+            .unwrap_or_default();
+
+            let is_cancelled = cancellation_token.load(Ordering::Relaxed);
+            if !is_cancelled {
+                tx.send(AppEvent::FileSearchResult { query, matches });
+            }
+
+            // Reset the active search state. Do a pointer comparison to verify
+            // that we are clearing the ActiveSearch that corresponds to the
+            // cancellation token we were given.
+            {
+                #[allow(clippy::unwrap_used)]
+                let mut st = search_state.lock().unwrap();
+                if let Some(active_search) = &st.active_search {
+                    if Arc::ptr_eq(&active_search.cancellation_token, &cancellation_token) {
+                        st.active_search = None;
+                    }
+                }
+            }
+        });
+    }
+}

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -29,6 +29,7 @@ mod citation_regex;
 mod cli;
 mod conversation_history_widget;
 mod exec_command;
+mod file_search;
 mod get_git_diff;
 mod git_warning_screen;
 mod history_cell;


### PR DESCRIPTION
Introduces support for `@` to trigger a fuzzy-filename search in the composer. Under the hood, this leverages https://crates.io/crates/nucleo-matcher to do the fuzzy matching and https://crates.io/crates/ignore to build up the list of file candidates (so that it respects `.gitignore`).

For simplicity (at least for now), we do not do any caching between searches like VS Code does for its file search:

https://github.com/microsoft/vscode/blob/1d89ed699b2e924d418c856318a3e12bca67ff3a/src/vs/workbench/services/search/node/rawSearchService.ts#L212-L218

Because we do not do any caching, I saw queries take up to three seconds on large repositories with hundreds of thousands of files. To that end, we do not perform searches synchronously on each keystroke, but instead dispatch an event to do the search on a background thread that asynchronously reports back to the UI when the results are available. This is largely handled by the `FileSearchManager` introduced in this PR, which also has logic for debouncing requests so there is at most one search in flight at a time.

While we could potentially polish and tune this feature further, it may already be overengineered for how it will be used, in practice, so we can improve things going forward if it turns out that this is not "good enough" in the wild.

Note this feature does not work like `@` in the TypeScript CLI, which was more like directory-based tab completion. In the Rust CLI, `@` triggers a full-repo fuzzy-filename search.

Fixes https://github.com/openai/codex/issues/1261.