### PR TITLE
feat: introduce --compute-indices flag to codex-file-search

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -699,6 +699,7 @@ dependencies = [
  "clap",
  "ignore",
  "nucleo-matcher",
+ "serde",
  "serde_json",
  "tokio",
 ]

--- a/codex-rs/file-search/Cargo.toml
+++ b/codex-rs/file-search/Cargo.toml
@@ -16,5 +16,6 @@ anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 ignore = "0.4.23"
 nucleo-matcher = "0.3.1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1.0.110"
 tokio = { version = "1", features = ["full"] }

--- a/codex-rs/file-search/src/cli.rs
+++ b/codex-rs/file-search/src/cli.rs
@@ -20,6 +20,10 @@ pub struct Cli {
     #[clap(long, short = 'C')]
     pub cwd: Option<PathBuf>,
 
+    /// Include matching file indices in the output.
+    #[arg(long, default_value = "false")]
+    pub compute_indices: bool,
+
     // While it is common to default to the number of logical CPUs when creating
     // a thread pool, empirically, the I/O of the filetree traversal offers
     // limited parallelism and is the bottleneck, so using a smaller number of

--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -165,6 +165,7 @@ impl FileSearchManager {
         cancellation_token: Arc<AtomicBool>,
         search_state: Arc<Mutex<SearchState>>,
     ) {
+        let compute_indices = false;
         std::thread::spawn(move || {
             let matches = file_search::run(
                 &query,
@@ -173,11 +174,12 @@ impl FileSearchManager {
                 Vec::new(),
                 NUM_FILE_SEARCH_THREADS,
                 cancellation_token.clone(),
+                compute_indices,
             )
             .map(|res| {
                 res.matches
                     .into_iter()
-                    .map(|(_, p)| p)
+                    .map(|m| m.path)
                     .collect::<Vec<String>>()
             })
             .unwrap_or_default();


### PR DESCRIPTION
This is a small quality-of-life feature, the addition of `--compute-indices` to the CLI, which, if enabled, will compute and set the `indices` field for each `FileMatch` returned by `run()`. Note we only bother to compute `indices` once we have the top N results because there could be a lot of intermediate "top N" results during the search that are ultimately discarded.

When set, the indices are included in the JSON output when `--json` is specified and the matching indices are displayed in bold when `--json` is not specified.