### PR TITLE
feat: highlight matching characters in fuzzy file search

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -1,4 +1,5 @@
 use codex_core::protocol::Event;
+use codex_file_search::FileMatch;
 use crossterm::event::KeyEvent;
 
 use crate::slash_command::SlashCommand;
@@ -39,6 +40,6 @@ pub(crate) enum AppEvent {
     /// still relevant.
     FileSearchResult {
         query: String,
-        matches: Vec<String>,
+        matches: Vec<FileMatch>,
     },
 }

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -20,6 +20,7 @@ use super::file_search_popup::FileSearchPopup;
 
 use crate::app_event::AppEvent;
 use crate::app_event_sender::AppEventSender;
+use codex_file_search::FileMatch;
 
 /// Minimum number of visible text rows inside the textarea.
 const MIN_TEXTAREA_ROWS: usize = 1;
@@ -129,7 +130,7 @@ impl ChatComposer<'_> {
     }
 
     /// Integrate results from an asynchronous file search.
-    pub(crate) fn on_file_search_result(&mut self, query: String, matches: Vec<String>) {
+    pub(crate) fn on_file_search_result(&mut self, query: String, matches: Vec<FileMatch>) {
         // Only apply if user is still editing a token starting with `query`.
         let current_opt = Self::current_at_token(&self.textarea);
         let Some(current_token) = current_opt else {

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -1,16 +1,16 @@
 //! Bottom pane: shows the ChatComposer or a BottomPaneView, if one is active.
 
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+use crate::user_approval_widget::ApprovalRequest;
 use bottom_pane_view::BottomPaneView;
 use bottom_pane_view::ConditionalUpdate;
 use codex_core::protocol::TokenUsage;
+use codex_file_search::FileMatch;
 use crossterm::event::KeyEvent;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::widgets::WidgetRef;
-
-use crate::app_event::AppEvent;
-use crate::app_event_sender::AppEventSender;
-use crate::user_approval_widget::ApprovalRequest;
 
 mod approval_modal_view;
 mod bottom_pane_view;
@@ -228,7 +228,7 @@ impl BottomPane<'_> {
         }
     }
 
-    pub(crate) fn on_file_search_result(&mut self, query: String, matches: Vec<String>) {
+    pub(crate) fn on_file_search_result(&mut self, query: String, matches: Vec<FileMatch>) {
         self.composer.on_file_search_result(query, matches);
         self.request_redraw();
     }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -38,6 +38,7 @@ use crate::bottom_pane::InputResult;
 use crate::conversation_history_widget::ConversationHistoryWidget;
 use crate::history_cell::PatchEventType;
 use crate::user_approval_widget::ApprovalRequest;
+use codex_file_search::FileMatch;
 
 pub(crate) struct ChatWidget<'a> {
     app_event_tx: AppEventSender,
@@ -405,7 +406,7 @@ impl ChatWidget<'_> {
     }
 
     /// Forward file-search results to the bottom pane.
-    pub(crate) fn apply_file_search_result(&mut self, query: String, matches: Vec<String>) {
+    pub(crate) fn apply_file_search_result(&mut self, query: String, matches: Vec<FileMatch>) {
         self.bottom_pane.on_file_search_result(query, matches);
     }
 

--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -165,7 +165,7 @@ impl FileSearchManager {
         cancellation_token: Arc<AtomicBool>,
         search_state: Arc<Mutex<SearchState>>,
     ) {
-        let compute_indices = false;
+        let compute_indices = true;
         std::thread::spawn(move || {
             let matches = file_search::run(
                 &query,
@@ -176,12 +176,7 @@ impl FileSearchManager {
                 cancellation_token.clone(),
                 compute_indices,
             )
-            .map(|res| {
-                res.matches
-                    .into_iter()
-                    .map(|m| m.path)
-                    .collect::<Vec<String>>()
-            })
+            .map(|res| res.matches)
             .unwrap_or_default();
 
             let is_cancelled = cancellation_token.load(Ordering::Relaxed);


### PR DESCRIPTION
Using the new file-search API introduced in https://github.com/openai/codex/pull/1419, matching characters are now shown in bold in the TUI:

https://github.com/user-attachments/assets/8bbcc6c6-75a3-493f-8ea4-b2a063e09b3a

Fixes https://github.com/openai/codex/issues/1261