### PR TITLE
fix: build with `codegen-units = 1` for profile.release

### DIFF
--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -37,3 +37,6 @@ lto = "fat"
 # Because we bundle some of these executables with the TypeScript CLI, we
 # remove everything to make the binary as small as possible.
 strip = "symbols"
+
+# See https://github.com/openai/codex/issues/1411 for details.
+codegen-units = 1


### PR DESCRIPTION
Great suggestion from @zamazan4ik on https://github.com/openai/codex/issues/1411.