### PR TITLE
fix: support pre-release identifiers in tags

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -15,9 +15,6 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
-env:
-  TAG_REGEX: '^rust-v[0-9]+\.[0-9]+\.[0-9]+$'
-
 jobs:
   tag-check:
     runs-on: ubuntu-latest
@@ -33,8 +30,8 @@ jobs:
           # 1. Must be a tag and match the regex
           [[ "${GITHUB_REF_TYPE}" == "tag" ]] \
             || { echo "❌  Not a tag push"; exit 1; }
-          [[ "${GITHUB_REF_NAME}" =~ ${TAG_REGEX} ]] \
-            || { echo "❌  Tag '${GITHUB_REF_NAME}' != ${TAG_REGEX}"; exit 1; }
+          [[ "${GITHUB_REF_NAME}" =~ ^rust-v[0-9]+\.[0-9]+\.[0-9]+(-(alpha|beta)(\.[0-9]+)?)?$ ]] \
+            || { echo "❌  Tag '${GITHUB_REF_NAME}' doesn't match expected format"; exit 1; }
 
           # 2. Extract versions
           tag_ver="${GITHUB_REF_NAME#rust-v}"

--- a/codex-rs/scripts/create_github_release.sh
+++ b/codex-rs/scripts/create_github_release.sh
@@ -2,6 +2,13 @@
 
 set -euo pipefail
 
+# By default, this script uses a version based on the current date and time.
+# If you want to specify a version, pass it as the first argument. Example:
+#
+#     ./scripts/create_github_release.sh 0.1.0-alpha.4
+#
+# The value will be used to update the `version` field in `Cargo.toml`.
+
 # Change to the root of the Cargo workspace.
 cd "$(dirname "${BASH_SOURCE[0]}")/.."
 
@@ -15,7 +22,11 @@ fi
 CURRENT_BRANCH=$(git symbolic-ref --short -q HEAD)
 
 # Create a new branch for the release and make a commit with the new version.
-VERSION=$(printf '0.0.%d' "$(date +%y%m%d%H%M)")
+if [ $# -ge 1 ]; then
+  VERSION="$1"
+else
+  VERSION=$(printf '0.0.%d' "$(date +%y%m%d%H%M)")
+fi
 TAG="rust-v$VERSION"
 git checkout -b "$TAG"
 perl -i -pe "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml


### PR DESCRIPTION
Had to update the regex in the GitHub workflow to allow suffixes like `-alpha.4`.

Successfully ran:

```
./scripts/create_github_release.sh 0.1.0-alpha.4
```

to create https://github.com/openai/codex/releases/tag/codex-rs-b289c9207090b2e27494545d7b5404e063bd86f3-1-rust-v0.1.0-alpha.4

and verified that when I run `codex --version`, it prints `codex-cli 0.1.0-alpha.4`.