### PR TITLE
fix: softprops/action-gh-release@v2 should use existing tag instead of creating a new tag

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -157,9 +157,7 @@ jobs:
   release:
     needs: build
     name: release
-    runs-on: ubuntu-24.04
-    env:
-      RELEASE_TAG: codex-rs-${{ github.sha }}-${{ github.run_attempt }}-${{ github.ref_name }}
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/download-artifact@v4
@@ -169,9 +167,19 @@ jobs:
       - name: List
         run: ls -R dist/
 
-      - uses: softprops/action-gh-release@v2
+      - name: Define release name
+        id: release_name
+        run: |
+          # Extract the version from the tag name, which is in the format
+          # "rust-v0.1.0".
+          version="${GITHUB_REF_NAME#rust-v}"
+          echo "name=${version}" >> $GITHUB_OUTPUT
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ env.RELEASE_TAG }}
+          name: ${{ steps.release_name.outputs.name }}
+          tag_name: ${{ github.ref_name }}
           files: dist/**
           # For now, tag releases as "prerelease" because we are not claiming
           # the Rust CLI is stable yet.
@@ -181,5 +189,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag: ${{ env.RELEASE_TAG }}
+          tag: ${{ github.ref_name }}
           config: .github/dotslash-config.json

--- a/codex-rs/scripts/create_github_release.sh
+++ b/codex-rs/scripts/create_github_release.sh
@@ -28,19 +28,11 @@ else
   VERSION=$(printf '0.0.%d' "$(date +%y%m%d%H%M)")
 fi
 TAG="rust-v$VERSION"
-RELEASE_BRANCH="release/$TAG"
-
-git checkout -b "$RELEASE_BRANCH"
+git checkout -b "$TAG"
 perl -i -pe "s/^version = \".*\"/version = \"$VERSION\"/" Cargo.toml
 git add Cargo.toml
 git commit -m "Release $VERSION"
 git tag -a "$TAG" -m "Release $VERSION"
-
-# The commit identified by the tag must be reachable from a branch so that
-# when GitHub creates the `Source code (tar.gz)` for the release, it can find
-# the commit. This is a requirement for Homebrew to be able to install the
-# package from the tarball.
-git push origin "$RELEASE_BRANCH"
 git push origin "refs/tags/$TAG"
 
 git checkout "$CURRENT_BRANCH"


### PR DESCRIPTION
https://github.com/Homebrew/homebrew-core/pull/228521 details the issues I was having with the **Source code (tar.gz)** artifact for our GitHub releases not being quite right. I landed these PRs as stabs in the dark to fix this:

- https://github.com/openai/codex/pull/1423
- https://github.com/openai/codex/pull/1430

Based on the insights from https://github.com/Homebrew/homebrew-core/pull/228521, I think those were wrong and the real problem was this:

https://github.com/openai/codex/blob/6dad5c3b1799ac18f7c76a9612f24936682b3c1d/.github/workflows/rust-release.yml#L162

That is, I was manufacturing a new tag name on the fly instead of using the existing one.

This PR reverts #1423 and #1430 and hopefully fixes how `tag_name` is set for the `softprops/action-gh-release@v2` step so the **Source code (tar.gz)** includes the correct files. Assuming this works, this should make the Homebrew formula straightforward.