### PR TITLE
Add default config template

### DIFF
--- a/codex-rs/core/config_template.toml
+++ b/codex-rs/core/config_template.toml
@@ -1,0 +1,45 @@
+# Codex configuration template
+# See https://github.com/openai/codex/blob/main/codex-rs/config.md for details.
+# All values below represent defaults. Uncomment to override them.
+
+# model = "codex-mini-latest"
+# model_provider = "openai"
+# approval_policy = "unless-allow-listed"
+# disable_response_storage = false
+# project_doc_max_bytes = 32768
+# file_opener = "vscode"
+# hide_agent_reasoning = false
+# model_reasoning_effort = "medium"
+# model_reasoning_summary = "auto"
+
+[shell_environment_policy]
+# inherit = "core"
+# ignore_default_excludes = false
+# exclude = []
+# set = {}
+# include_only = []
+
+[sandbox]
+# mode = "read-only"
+# writable_roots = []
+# network_access = false
+
+[history]
+# persistence = "save-all"
+
+[tui]
+# disable_mouse_capture = false
+
+# Example provider override
+#[model_providers.openai]
+# name = "OpenAI"
+# base_url = "https://api.openai.com/v1"
+# env_key = "OPENAI_API_KEY"
+# wire_api = "chat"
+
+# Example profile
+#[profiles.example]
+# model = "o3"
+# model_provider = "openai"
+# approval_policy = "never"
+


### PR DESCRIPTION
## Summary
- provide a `config_template.toml` showing the defaults commented out
- write this template to `$CODEX_HOME/config.toml` if it doesn't exist

## Testing
- `cargo fmt` *(fails: rustfmt not installed)*
- `cargo test --workspace --no-run` *(fails: could not download crates)*

## CLA
I have read the CLA Document and I hereby sign the CLA
------
https://chatgpt.com/codex/tasks/task_i_6862ed404e70832d9f22548ae1345e5a