### PR TITLE
feat: add custom headers support for API requests

### DIFF
--- a/codex-cli/src/utils/agent/agent-loop.ts
+++ b/codex-cli/src/utils/agent/agent-loop.ts
@@ -22,6 +22,7 @@ import {
 } from "../config.js";
 import { log } from "../logger/log.js";
 import { parseToolCallArguments } from "../parsers.js";
+import { providers, getCustomHeaders } from "../providers.js";
 import { responsesCreateViaChatCompletions } from "../responses.js";
 import {
   ORIGIN,
@@ -309,6 +310,12 @@ export class AgentLoop {
     const apiKey = this.config.apiKey ?? process.env["OPENAI_API_KEY"] ?? "";
     const baseURL = getBaseUrl(this.provider);
 
+    // Get custom headers from provider config and environment variables
+    const providerInfo = providers[this.provider.toLowerCase()];
+    const customHeaders = providerInfo
+      ? getCustomHeaders(providerInfo, this.provider.toLowerCase())
+      : {};
+
     this.oai = new OpenAI({
       // The OpenAI JS SDK only requires `apiKey` when making requests against
       // the official API.  When running unit‑tests we stub out all network
@@ -326,6 +333,7 @@ export class AgentLoop {
           ? { "OpenAI-Organization": OPENAI_ORGANIZATION }
           : {}),
         ...(OPENAI_PROJECT ? { "OpenAI-Project": OPENAI_PROJECT } : {}),
+        ...customHeaders,
       },
       httpAgent: PROXY_URL ? new HttpsProxyAgent(PROXY_URL) : undefined,
       ...(timeoutMs !== undefined ? { timeout: timeoutMs } : {}),
@@ -344,6 +352,7 @@ export class AgentLoop {
             ? { "OpenAI-Organization": OPENAI_ORGANIZATION }
             : {}),
           ...(OPENAI_PROJECT ? { "OpenAI-Project": OPENAI_PROJECT } : {}),
+          ...customHeaders,
         },
         httpAgent: PROXY_URL ? new HttpsProxyAgent(PROXY_URL) : undefined,
         ...(timeoutMs !== undefined ? { timeout: timeoutMs } : {}),

--- a/codex-cli/src/utils/openai-client.ts
+++ b/codex-cli/src/utils/openai-client.ts
@@ -8,6 +8,7 @@ import {
   OPENAI_ORGANIZATION,
   OPENAI_PROJECT,
 } from "./config.js";
+import { providers, getCustomHeaders } from "./providers.js";
 import OpenAI, { AzureOpenAI } from "openai";
 
 type OpenAIClientConfig = {
@@ -30,6 +31,14 @@ export function createOpenAIClient(
   }
   if (OPENAI_PROJECT) {
     headers["OpenAI-Project"] = OPENAI_PROJECT;
+  }
+
+  // Add custom headers from provider config and environment variables.
+  const providerName = config.provider?.toLowerCase() || "openai";
+  const providerInfo = providers[providerName];
+  if (providerInfo) {
+    const customHeaders = getCustomHeaders(providerInfo, providerName);
+    Object.assign(headers, customHeaders);
   }
 
   if (config.provider?.toLowerCase() === "azure") {

--- a/codex-cli/tests/custom-headers.test.ts
+++ b/codex-cli/tests/custom-headers.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import {
+  parseCustomHeadersFromEnv,
+  getCustomHeaders,
+  type ProviderInfo,
+} from "../src/utils/providers.js";
+
+describe("Custom Headers", () => {
+  let originalEnvVars: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    // Store original environment variables
+    const envVarNames = [
+      "OPENAI_CUSTOM_HEADERS",
+      "AZURE_CUSTOM_HEADERS",
+      "TEST_CUSTOM_HEADERS",
+    ];
+    for (const envVar of envVarNames) {
+      originalEnvVars[envVar] = process.env[envVar];
+      delete process.env[envVar];
+    }
+  });
+
+  afterEach(() => {
+    // Restore original environment variables
+    for (const [envVar, value] of Object.entries(originalEnvVars)) {
+      if (value !== undefined) {
+        process.env[envVar] = value;
+      } else {
+        delete process.env[envVar];
+      }
+    }
+    originalEnvVars = {};
+  });
+
+  describe("parseCustomHeadersFromEnv", () => {
+    it("returns empty object when provider-specific env var is not set", () => {
+      const headers = parseCustomHeadersFromEnv("openai");
+      expect(headers).toEqual({});
+    });
+
+    it("parses single header correctly", () => {
+      process.env["OPENAI_CUSTOM_HEADERS"] = "X-Test-Header: test-value";
+      const headers = parseCustomHeadersFromEnv("openai");
+      expect(headers).toEqual({
+        "X-Test-Header": "test-value",
+      });
+    });
+
+    it("parses multiple headers correctly", () => {
+      process.env["AZURE_CUSTOM_HEADERS"] =
+        "X-Custom-Auth: Bearer token123\nX-App-Version: 2.0.0\nX-Extra: some value";
+      const headers = parseCustomHeadersFromEnv("azure");
+      expect(headers).toEqual({
+        "X-Custom-Auth": "Bearer token123",
+        "X-App-Version": "2.0.0",
+        "X-Extra": "some value",
+      });
+    });
+
+    it("handles headers with extra whitespace", () => {
+      process.env["TEST_CUSTOM_HEADERS"] =
+        "  X-Header1  :  value1  \n  X-Header2:value2\n";
+      const headers = parseCustomHeadersFromEnv("test");
+      expect(headers).toEqual({
+        "X-Header1": "value1",
+        "X-Header2": "value2",
+      });
+    });
+
+    it("ignores empty lines", () => {
+      process.env["TEST_CUSTOM_HEADERS"] =
+        "X-Header1: value1\n\n\nX-Header2: value2\n";
+      const headers = parseCustomHeadersFromEnv("test");
+      expect(headers).toEqual({
+        "X-Header1": "value1",
+        "X-Header2": "value2",
+      });
+    });
+
+    it("ignores lines without colons", () => {
+      process.env["TEST_CUSTOM_HEADERS"] =
+        "X-Header1: value1\ninvalid-line-without-colon\nX-Header2: value2";
+      const headers = parseCustomHeadersFromEnv("test");
+      expect(headers).toEqual({
+        "X-Header1": "value1",
+        "X-Header2": "value2",
+      });
+    });
+
+    it("ignores lines with empty keys", () => {
+      process.env["TEST_CUSTOM_HEADERS"] =
+        "X-Header1: value1\n: empty-key\nX-Header2: value2";
+      const headers = parseCustomHeadersFromEnv("test");
+      expect(headers).toEqual({
+        "X-Header1": "value1",
+        "X-Header2": "value2",
+      });
+    });
+
+    it("handles values with colons", () => {
+      process.env["TEST_CUSTOM_HEADERS"] =
+        "X-Auth: Bearer token:with:colons\nX-URL: https://example.com:8080";
+      const headers = parseCustomHeadersFromEnv("test");
+      expect(headers).toEqual({
+        "X-Auth": "Bearer token:with:colons",
+        "X-URL": "https://example.com:8080",
+      });
+    });
+  });
+
+  describe("getCustomHeaders", () => {
+    it("returns empty object when provider has no custom headers and no env var", () => {
+      const provider: ProviderInfo = {
+        name: "Test Provider",
+        baseURL: "https://api.example.com",
+        envKey: "TEST_KEY",
+      };
+      const headers = getCustomHeaders(provider, "test");
+      expect(headers).toEqual({});
+    });
+
+    it("returns provider headers when no env var is set", () => {
+      const provider: ProviderInfo = {
+        name: "Test Provider",
+        baseURL: "https://api.example.com",
+        envKey: "TEST_KEY",
+        customHeaders: {
+          "X-Provider-Header": "provider-value",
+          "X-Provider-Version": "1.0.0",
+        },
+      };
+      const headers = getCustomHeaders(provider, "test");
+      expect(headers).toEqual({
+        "X-Provider-Header": "provider-value",
+        "X-Provider-Version": "1.0.0",
+      });
+    });
+
+    it("returns env headers when provider has no custom headers", () => {
+      process.env["OPENAI_CUSTOM_HEADERS"] =
+        "X-Env-Header: env-value\nX-Env-Version: 2.0.0";
+      const provider: ProviderInfo = {
+        name: "OpenAI",
+        baseURL: "https://api.openai.com/v1",
+        envKey: "OPENAI_API_KEY",
+      };
+      const headers = getCustomHeaders(provider, "openai");
+      expect(headers).toEqual({
+        "X-Env-Header": "env-value",
+        "X-Env-Version": "2.0.0",
+      });
+    });
+
+    it("merges provider and env headers with env taking precedence", () => {
+      process.env["AZURE_CUSTOM_HEADERS"] =
+        "X-Shared-Header: env-value\nX-Env-Only: env-only";
+      const provider: ProviderInfo = {
+        name: "AzureOpenAI",
+        baseURL: "https://test.openai.azure.com/openai",
+        envKey: "AZURE_OPENAI_API_KEY",
+        customHeaders: {
+          "X-Shared-Header": "provider-value",
+          "X-Provider-Only": "provider-only",
+        },
+      };
+      const headers = getCustomHeaders(provider, "azure");
+      expect(headers).toEqual({
+        "X-Shared-Header": "env-value", // env takes precedence
+        "X-Provider-Only": "provider-only",
+        "X-Env-Only": "env-only",
+      });
+    });
+  });
+});

--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -34,6 +34,7 @@ pub(crate) async fn stream_chat_completions(
     model: &str,
     client: &reqwest::Client,
     provider: &ModelProviderInfo,
+    provider_name: &str,
 ) -> Result<ResponseStream> {
     // Build messages array
     let mut messages = Vec::<serde_json::Value>::new();
@@ -130,8 +131,14 @@ pub(crate) async fn stream_chat_completions(
         if let Some(api_key) = &api_key {
             req_builder = req_builder.bearer_auth(api_key.clone());
         }
+        req_builder = req_builder.header(reqwest::header::ACCEPT, "text/event-stream");
+
+        // Add custom headers
+        for (key, value) in provider.get_custom_headers(provider_name) {
+            req_builder = req_builder.header(key, value);
+        }
+
         let res = req_builder
-            .header(reqwest::header::ACCEPT, "text/event-stream")
             .json(&payload)
             .send()
             .await;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -108,6 +108,7 @@ impl Codex {
         let instructions = get_user_instructions(&config).await;
         let configure_session = Op::ConfigureSession {
             provider: config.model_provider.clone(),
+            provider_name: config.model_provider_id.clone(),
             model: config.model.clone(),
             model_reasoning_effort: config.model_reasoning_effort,
             model_reasoning_summary: config.model_reasoning_summary,
@@ -561,6 +562,7 @@ async fn submission_loop(
             }
             Op::ConfigureSession {
                 provider,
+                provider_name,
                 model,
                 model_reasoning_effort,
                 model_reasoning_summary,
@@ -588,6 +590,7 @@ async fn submission_loop(
                 let client = ModelClient::new(
                     model.clone(),
                     provider.clone(),
+                    provider_name.clone(),
                     model_reasoning_effort,
                     model_reasoning_summary,
                 );

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -659,6 +659,7 @@ disable_response_storage = true
             wire_api: crate::WireApi::Chat,
             env_key_instructions: None,
             query_params: None,
+            custom_headers: None,
         };
         let model_provider_map = {
             let mut model_provider_map = built_in_model_providers();

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -38,6 +38,9 @@ pub enum Op {
         /// Provider identifier ("openai", "openrouter", ...).
         provider: ModelProviderInfo,
 
+        /// Provider name/key used for environment variable lookup
+        provider_name: String,
+
         /// If not specified, server will use its default model.
         model: String,
 

--- a/codex-rs/core/tests/previous_response_id.rs
+++ b/codex-rs/core/tests/previous_response_id.rs
@@ -108,6 +108,7 @@ async fn keeps_previous_response_id_between_tasks() {
         env_key_instructions: None,
         wire_api: codex_core::WireApi::Responses,
         query_params: None,
+        custom_headers: None,
     };
 
     // Init session

--- a/codex-rs/core/tests/stream_no_completed.rs
+++ b/codex-rs/core/tests/stream_no_completed.rs
@@ -97,6 +97,7 @@ async fn retries_on_early_close() {
         env_key_instructions: None,
         wire_api: codex_core::WireApi::Responses,
         query_params: None,
+        custom_headers: None,
     };
 
     let ctrl_c = std::sync::Arc::new(tokio::sync::Notify::new());


### PR DESCRIPTION
Add support for custom headers in API requests via:
- custom_headers field in ModelProviderInfo config
- CODEX_CUSTOM_HEADERS environment variable with format "key: value\nkey2: value2"

Headers from both sources are merged, with env var taking precedence. Both Chat Completions and Responses APIs now include custom headers.

Resolves https://github.com/openai/codex/discussions/1152