### PR TITLE
Add GitHub issue templates for project management

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,0 +1,218 @@
+name: 🐛 Bug Resolution
+description: Comprehensive bug resolution with impact assessment and root cause analysis
+title: “[BUG]: “
+labels: [“type:bug”]
+assignees: []
+body:
+
+- type: dropdown
+  id: domain
+  attributes:
+  label: Domain
+  description: Which domain is affected by this bug?
+  options:
+    - backend
+    - frontend
+    - shared
+    - cross_domain
+    - business_domain
+    - technical_domain
+  validations:
+  required: true
+- type: dropdown
+  id: tech_primary
+  attributes:
+  label: Primary Technology
+  description: Primary technology stack where the bug occurs
+  options:
+    - supabase
+    - svelte
+    - typescript
+    - javascript
+    - python
+    - deno
+    - react
+    - node
+    - other
+  validations:
+  required: true
+- type: dropdown
+  id: component_type
+  attributes:
+  label: Component Type
+  description: Type of component affected by the bug
+  options:
+    - ui_component
+    - api_endpoint
+    - edge_function
+    - database_function
+    - page_component
+    - store_module
+    - business_logic
+    - integration
+    - other
+  validations:
+  required: true
+- type: dropdown
+  id: severity
+  attributes:
+  label: Severity
+  description: Bug severity level
+  options:
+    - critical
+    - high
+    - medium
+    - low
+  validations:
+  required: true
+- type: dropdown
+  id: priority
+  attributes:
+  label: Priority
+  description: Bug resolution priority
+  options:
+    - critical
+    - high
+    - medium
+    - low
+  validations:
+  required: true
+- type: dropdown
+  id: estimated_effort
+  attributes:
+  label: Estimated Effort
+  description: Estimated effort to resolve
+  options:
+    - 1-2 hours
+    - half-day
+    - 1 day
+    - 2-3 days
+    - 1 week
+    - 2+ weeks
+  validations:
+  required: true
+- type: textarea
+  id: problem_description
+  attributes:
+  label: Problem Description
+  description: Clear description of the bug, its symptoms, and impact on domain functionality
+  placeholder: Describe the bug, what’s happening vs what should happen…
+  validations:
+  required: true
+- type: textarea
+  id: impact_assessment
+  attributes:
+  label: Impact Assessment
+  description: Comprehensive impact analysis
+  placeholder: |
+    **Domain Impact**: How this affects domain mission and capabilities
+    **User Impact**: Effect on stakeholders and user experience
+    **Business Impact**: Business consequences if not resolved
+    **System Impact**: Technical system effects and risks
+  validations:
+  required: true
+- type: textarea
+  id: bug_details
+  attributes:
+  label: Bug Details
+  description: Detailed bug information
+  placeholder: |
+    **Frequency**: Always/Often/Sometimes/Rare
+    **Environment**: Where the bug occurs (dev/staging/production)
+    **First Observed**: When first noticed
+    **Related Issues**: Any related bugs or issues
+  validations:
+  required: true
+- type: textarea
+  id: reproduction_steps
+  attributes:
+  label: Reproduction Steps
+  description: Step-by-step instructions to reproduce the bug
+  placeholder: |
+    1. Step 1
+    2. Step 2
+    3. Step 3
+    4. **Expected behavior**: What should happen
+    5. **Actual behavior**: What actually happens
+  validations:
+  required: true
+- type: textarea
+  id: technical_context
+  attributes:
+  label: Technical Context
+  description: Technical context and relevant system information
+  placeholder: |
+    **Domain Boundaries**: How this relates to domain boundaries
+    **Business Rules**: Relevant domain business rules
+    **Integration Points**: Cross-domain interactions involved
+    **Technology Components**: Specific tech stack components affected
+  validations:
+  required: true
+- type: textarea
+  id: root_cause_analysis
+  attributes:
+  label: Root Cause Analysis
+  description: Analysis of underlying cause (to be filled during investigation)
+  placeholder: |
+    **Investigation Areas**:
+    - [ ] Domain business rule validation
+    - [ ] Technology stack component behavior
+    - [ ] Cross-domain integration points
+    - [ ] Data consistency and validation
+    - [ ] Error handling and edge cases
+- type: textarea
+  id: resolution_approach
+  attributes:
+  label: Resolution Approach
+  description: Technical approach to fix the bug while maintaining domain integrity
+  placeholder: |
+    **Fix Strategy**:
+    - Root Cause Address: How to fix the underlying cause
+    - Domain Pattern Compliance: Ensure fix follows domain patterns
+    - Regression Prevention: How to prevent similar issues
+- type: textarea
+  id: cross_domain_considerations
+  attributes:
+  label: Cross-Domain Considerations
+  description: If bug affects multiple domains or integration points
+  placeholder: Impact on other domains and coordination requirements…
+- type: checkboxes
+  id: testing_requirements
+  attributes:
+  label: Testing Requirements
+  description: Comprehensive testing approach
+  options:
+  - label: Reproduce bug in test environment
+  - label: Verify fix resolves the issue
+  - label: Test domain business rule compliance
+  - label: Validate cross-domain integration (if applicable)
+  - label: Regression testing for related functionality
+  - label: Performance impact validation
+- type: checkboxes
+  id: definition_of_done
+  attributes:
+  label: Definition of Done
+  description: Bug resolution completion criteria
+  options:
+  - label: Root cause identified and documented
+  - label: Fix implemented following domain patterns
+  - label: Bug reproduction confirmed resolved
+  - label: Domain business rules validated
+  - label: Unit tests updated/added for bug scenario
+  - label: Integration tests validated (if cross-domain)
+  - label: Regression tests added
+  - label: Documentation updated
+  - label: Code review completed
+  - label: Fix validated in production-like environment
+- type: textarea
+  id: prevention_measures
+  attributes:
+  label: Prevention Measures
+  description: Steps to prevent similar bugs in the future
+  placeholder: What can be done to prevent this type of bug from happening again…
+- type: textarea
+  id: notes
+  attributes:
+  label: Additional Notes
+  description: Additional context, workarounds, or related issues
+  placeholder: Include any workarounds, related issues, or additional context…

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,0 +1,168 @@
+name: 🚀 Feature Development
+description: Comprehensive feature development with domain context and business impact
+title: “[FEATURE]: “
+labels: [“type:feature”]
+assignees: []
+body:
+
+- type: dropdown
+  id: domain
+  attributes:
+  label: Domain
+  description: Which domain does this feature belong to?
+  options:
+    - backend
+    - frontend
+    - shared
+    - cross_domain
+    - business_domain
+    - technical_domain
+  validations:
+  required: true
+- type: dropdown
+  id: tech_primary
+  attributes:
+  label: Primary Technology
+  description: Primary technology stack for this feature
+  options:
+    - supabase
+    - svelte
+    - typescript
+    - javascript
+    - python
+    - deno
+    - react
+    - node
+    - other
+  validations:
+  required: true
+- type: dropdown
+  id: component_type
+  attributes:
+  label: Component Type
+  description: Type of component being developed
+  options:
+    - ui_component
+    - api_endpoint
+    - edge_function
+    - database_function
+    - page_component
+    - store_module
+    - business_logic
+    - integration
+    - other
+  validations:
+  required: true
+- type: dropdown
+  id: priority
+  attributes:
+  label: Priority
+  description: Feature priority level
+  options:
+    - critical
+    - high
+    - medium
+    - low
+  validations:
+  required: true
+- type: dropdown
+  id: estimated_effort
+  attributes:
+  label: Estimated Effort
+  description: Estimated development effort
+  options:
+    - 1-2 hours
+    - half-day
+    - 1 day
+    - 2-3 days
+    - 1 week
+    - 2+ weeks
+  validations:
+  required: true
+- type: input
+  id: depends_on
+  attributes:
+  label: Dependencies
+  description: List any task dependencies (comma-separated issue numbers or task names)
+  placeholder: |
+    #123, #456, task_name
+- type: textarea
+  id: description
+  attributes:
+  label: Feature Description
+  description: Clear description of the feature and its business value to the domain and stakeholders
+  placeholder: Describe what this feature does and why it’s valuable…
+  validations:
+  required: true
+- type: textarea
+  id: business_context
+  attributes:
+  label: Business Context
+  description: How this feature advances domain mission and provides stakeholder value
+  placeholder: |
+    **Domain Impact**: How this feature advances the domain mission
+    **Stakeholder Value**: What value this provides to users/systems
+    **Success Metrics**: How success will be measured
+  validations:
+  required: true
+- type: textarea
+  id: acceptance_criteria
+  attributes:
+  label: Acceptance Criteria
+  description: Specific measurable criteria that define when this feature is complete
+  placeholder: |
+    - [ ] Specific measurable criterion 1
+    - [ ] Specific measurable criterion 2
+    - [ ] Performance requirements if applicable
+    - [ ] Security requirements if applicable
+  validations:
+  required: true
+- type: textarea
+  id: technical_approach
+  attributes:
+  label: Technical Approach
+  description: High-level technical implementation approach
+  placeholder: |
+    **Domain Considerations**:
+    - Domain Boundaries: How this respects domain boundaries
+    - Business Rules: Domain business rules that apply
+    - Architecture Patterns: Domain architecture patterns to follow
+
+    **Technology Implementation**:
+    - Primary Technology: Technology stack components to use
+    - Performance Targets: Specific performance requirements
+    - Security Requirements: Security patterns and requirements
+
+  validations:
+  required: true
+- type: textarea
+  id: integration_points
+  attributes:
+  label: Integration Points
+  description: Cross-domain integration requirements or coordination needs
+  placeholder: |
+  **Dependencies**:
+  - Internal Dependencies: Dependencies within this domain
+  - Cross-Domain Dependencies: Dependencies on other domains
+  - External Dependencies: External services or systems
+- type: checkboxes
+  id: definition_of_done
+  attributes:
+  label: Definition of Done
+  description: Comprehensive completion criteria
+  options:
+  - label: Implementation completed following domain patterns
+  - label: Unit tests written and passing
+  - label: Integration tests for cross-domain interactions (if applicable)
+  - label: Documentation updated (code comments, domain context)
+  - label: Code review completed
+  - label: Domain business rules validated
+  - label: Performance targets met
+  - label: Security requirements validated
+  - label: Integration contracts maintained (if applicable)
+- type: textarea
+  id: notes
+  attributes:
+  label: Additional Notes
+  description: Any additional context, constraints, or considerations for implementation
+  placeholder: Include any architectural decisions, constraints, or future considerations…

--- a/.github/ISSUE_TEMPLATE/infra.yaml
+++ b/.github/ISSUE_TEMPLATE/infra.yaml
@@ -1,0 +1,254 @@
+name: 🏗️ Infrastructure Enhancement
+description: Platform improvements with cross-domain considerations and operational excellence
+title: “[INFRA]: “
+labels: [“type:infrastructure”]
+assignees: []
+body:
+
+- type: dropdown
+  id: domain
+  attributes:
+  label: Domain
+  description: Which domain does this infrastructure support?
+  options:
+    - backend
+    - frontend
+    - shared
+    - cross_domain
+    - platform_wide
+    - technical_domain
+  validations:
+  required: true
+- type: dropdown
+  id: tech_primary
+  attributes:
+  label: Primary Technology
+  description: Primary technology for infrastructure implementation
+  options:
+    - supabase
+    - docker
+    - kubernetes
+    - github_actions
+    - terraform
+    - aws
+    - vercel
+    - cloudflare
+    - monitoring
+    - other
+  validations:
+  required: true
+- type: dropdown
+  id: infrastructure_scope
+  attributes:
+  label: Infrastructure Scope
+  description: Scope of infrastructure work
+  options:
+    - domain_specific
+    - cross_domain
+    - platform_wide
+    - external_integration
+  validations:
+  required: true
+- type: dropdown
+  id: infrastructure_type
+  attributes:
+  label: Infrastructure Type
+  description: Type of infrastructure enhancement
+  options:
+    - deployment
+    - monitoring
+    - security
+    - performance
+    - development
+    - backup_recovery
+    - networking
+    - storage
+    - other
+  validations:
+  required: true
+- type: dropdown
+  id: priority
+  attributes:
+  label: Priority
+  description: Infrastructure priority level
+  options:
+    - critical
+    - high
+    - medium
+    - low
+  validations:
+  required: true
+- type: dropdown
+  id: estimated_effort
+  attributes:
+  label: Estimated Effort
+  description: Estimated implementation effort
+  options:
+    - 1-2 hours
+    - half-day
+    - 1 day
+    - 2-3 days
+    - 1 week
+    - 2+ weeks
+  validations:
+  required: true
+- type: textarea
+  id: infrastructure_description
+  attributes:
+  label: Infrastructure Description
+  description: Clear description of the infrastructure work and its purpose for domain capabilities
+  placeholder: Describe what infrastructure will be implemented and why it’s needed…
+  validations:
+  required: true
+- type: textarea
+  id: infrastructure_context
+  attributes:
+  label: Infrastructure Context
+  description: Context and business justification
+  placeholder: |
+    **Domain Support**: How this infrastructure supports domain mission
+    **Scope**: Domain-specific/Cross-domain/Platform-wide
+    **Business Justification**: Why this infrastructure work is needed
+  validations:
+  required: true
+- type: textarea
+  id: current_state_analysis
+  attributes:
+  label: Current State Analysis
+  description: Assessment of current infrastructure state and limitations
+  placeholder: |
+    **Infrastructure Gaps**:
+    - Performance Issues: Current performance limitations
+    - Scalability Constraints: Scaling bottlenecks
+    - Security Concerns: Security improvements needed
+    - Operational Challenges: Operational pain points
+    - Development Friction: Developer experience issues
+  validations:
+  required: true
+- type: textarea
+  id: infrastructure_requirements
+  attributes:
+  label: Infrastructure Requirements
+  description: Detailed requirements for infrastructure enhancement
+  placeholder: |
+    **Performance Targets**: Specific performance requirements
+    **Scalability Goals**: Scaling requirements and targets
+    **Security Standards**: Security compliance and requirements
+    **Reliability Targets**: Uptime and reliability requirements
+    **Compliance Needs**: Regulatory or policy compliance
+  validations:
+  required: true
+- type: textarea
+  id: technical_approach
+  attributes:
+  label: Technical Approach
+  description: Infrastructure implementation approach aligned with domain technology patterns
+  placeholder: |
+    **Technology Stack**:
+    - Primary Technologies: Infrastructure technologies to use
+    - Integration Points: How this integrates with existing infrastructure
+    - Domain Alignment: How this supports domain technology patterns
+
+    **Architecture Considerations**:
+    - Domain Boundaries: How infrastructure respects domain boundaries
+    - Cross-Domain Impact: Effect on other domains
+    - Technology Consistency: Alignment with existing tech choices
+
+  validations:
+  required: true
+- type: textarea
+  id: implementation_plan
+  attributes:
+  label: Implementation Plan
+  description: Detailed implementation approach and phases
+  placeholder: |
+    **Phase 1: Foundation**
+    - [ ] Core infrastructure component setup
+    - [ ] Basic functionality validation
+
+    **Phase 2: Integration**
+    - [ ] Integration with existing systems
+    - [ ] Domain-specific configuration
+
+    **Phase 3: Optimization**
+    - [ ] Performance tuning and optimization
+    - [ ] Monitoring and alerting setup
+
+  validations:
+  required: true
+- type: textarea
+  id: cross_domain_considerations
+  attributes:
+  label: Cross-Domain Considerations
+  description: Impact and coordination needs with other domains
+  placeholder: |
+    **Affected Domains**:
+    - Domain A: How this affects Domain A
+    - Domain B: How this affects Domain B
+
+    **Coordination Requirements**:
+    - Cross-domain coordination needed during implementation
+    - Communication and rollout coordination
+- type: textarea
+  id: risk_assessment
+  attributes:
+  label: Risk Assessment
+  description: Analysis of infrastructure risks and mitigation strategies
+  placeholder: |
+    **Implementation Risks**: Technical risks and mitigation
+    **Operational Risks**: Operational impact and mitigation
+    **Domain Impact Risks**: Domain functionality risks and mitigation
+- type: checkboxes
+  id: testing_validation
+  attributes:
+  label: Testing & Validation
+  description: Infrastructure validation requirements
+  options:
+  - label: Infrastructure component testing
+  - label: Performance benchmark validation
+  - label: Security configuration validation
+  - label: Domain integration testing
+  - label: Cross-domain impact validation
+  - label: Disaster recovery testing (if applicable)
+  - label: Monitoring and alerting validation
+- type: checkboxes
+  id: definition_of_done
+  attributes:
+  label: Definition of Done
+  description: Infrastructure completion criteria
+  options:
+  - label: Infrastructure implemented and configured
+  - label: Performance targets validated
+  - label: Security requirements met
+  - label: Domain integration tested
+  - label: Cross-domain coordination completed
+  - label: Monitoring and alerting operational
+  - label: Documentation updated (runbooks, architecture docs)
+  - label: Team training completed (if needed)
+  - label: Rollback procedures tested
+  - label: Production readiness validated
+- type: textarea
+  id: monitoring_maintenance
+  attributes:
+  label: Monitoring & Maintenance
+  description: Ongoing monitoring, maintenance, and operational requirements
+  placeholder: |
+    **Monitoring Strategy**: How infrastructure health will be monitored
+    **Maintenance Schedule**: Regular maintenance requirements
+    **Operational Procedures**: Day-to-day operational needs
+- type: textarea
+  id: documentation_requirements
+  attributes:
+  label: Documentation Requirements
+  description: Infrastructure documentation needs
+  placeholder: |
+    - [ ] Architecture documentation updated
+    - [ ] Operational runbooks created/updated
+    - [ ] Domain-specific configuration documented
+    - [ ] Troubleshooting guides updated
+- type: textarea
+  id: notes
+  attributes:
+  label: Additional Notes
+  description: Additional context, constraints, dependencies, or operational considerations
+  placeholder: Include any architectural decisions, constraints, or operational notes…

--- a/.github/ISSUE_TEMPLATE/integration.yaml
+++ b/.github/ISSUE_TEMPLATE/integration.yaml
@@ -1,0 +1,302 @@
+name: 🔄 Cross-Domain Integration
+description: Cross-domain coordination with proper boundary management and contract definition
+title: “[INTEGRATION]: “
+labels: [“type:integration”, “cross-domain”]
+assignees: []
+body:
+
+- type: dropdown
+  id: integration_type
+  attributes:
+  label: Integration Type
+  description: Type of cross-domain integration
+  options:
+    - api
+    - event
+    - data
+    - batch
+    - real_time
+    - message_queue
+    - shared_service
+    - other
+  validations:
+  required: true
+- type: dropdown
+  id: source_domain
+  attributes:
+  label: Source Domain
+  description: Domain initiating or providing the integration
+  options:
+    - backend
+    - frontend
+    - shared
+    - business_domain
+    - technical_domain
+    - external_system
+    - other
+  validations:
+  required: true
+- type: dropdown
+  id: target_domain
+  attributes:
+  label: Target Domain
+  description: Domain receiving or consuming the integration
+  options:
+    - backend
+    - frontend
+    - shared
+    - business_domain
+    - technical_domain
+    - external_system
+    - other
+  validations:
+  required: true
+- type: dropdown
+  id: tech_primary
+  attributes:
+  label: Primary Technology
+  description: Primary technology for integration implementation
+  options:
+    - rest_api
+    - graphql
+    - grpc
+    - message_queue
+    - event_stream
+    - database
+    - webhook
+    - other
+  validations:
+  required: true
+- type: dropdown
+  id: priority
+  attributes:
+  label: Priority
+  description: Integration priority level
+  options:
+    - critical
+    - high
+    - medium
+    - low
+  validations:
+  required: true
+- type: dropdown
+  id: estimated_effort
+  attributes:
+  label: Estimated Effort
+  description: Estimated integration effort
+  options:
+    - 1-2 hours
+    - half-day
+    - 1 day
+    - 2-3 days
+    - 1 week
+    - 2+ weeks
+  validations:
+  required: true
+- type: input
+  id: depends_on
+  attributes:
+  label: Dependencies
+  description: List any task dependencies (comma-separated issue numbers or task names)
+  placeholder: |
+    #123, #456, domain_setup_task
+- type: textarea
+  id: integration_description
+  attributes:
+  label: Integration Description
+  description: Clear description of the integration work and its purpose for cross-domain coordination
+  placeholder: Describe what will be integrated between domains and why…
+  validations:
+  required: true
+- type: textarea
+  id: integration_context
+  attributes:
+  label: Integration Context
+  description: Context and business purpose for integration
+  placeholder: |
+    **Business Purpose**: Why this integration is needed for business value
+    **Workflow Integration**: How domain workflows coordinate
+    **Timing Requirements**: Synchronous/Asynchronous requirements
+  validations:
+  required: true
+- type: textarea
+  id: integration_requirements
+  attributes:
+  label: Integration Requirements
+  description: Detailed requirements for cross-domain coordination
+  placeholder: |
+    **Functional Requirements**:
+    - Data Exchange: What data needs to be shared between domains
+    - Business Logic: Cross-domain business rules and validation
+    - Workflow Integration: How domain workflows coordinate
+
+    **Non-Functional Requirements**:
+    - Performance: Response time, throughput requirements
+    - Reliability: Availability, fault tolerance requirements
+    - Security: Authentication, authorization, data protection
+    - Scalability: Volume and growth requirements
+
+  validations:
+  required: true
+- type: textarea
+  id: domain_boundary_analysis
+  attributes:
+  label: Domain Boundary Analysis
+  description: Analysis of how integration respects and maintains domain boundaries
+  placeholder: |
+    **Source Domain Responsibilities**:
+    - What the source domain owns and controls
+    - What the source domain exposes to other domains
+    - Source domain integration patterns and constraints
+
+    **Target Domain Responsibilities**:
+    - What the target domain owns and controls
+    - What the target domain needs from other domains
+    - Target domain integration patterns and constraints
+
+    **Boundary Protection**:
+    - Anti-corruption layers needed
+    - Data transformation and validation requirements
+    - Error isolation and handling strategies
+
+  validations:
+  required: true
+- type: textarea
+  id: technical_integration_approach
+  attributes:
+  label: Technical Integration Approach
+  description: Technical implementation approach maintaining domain autonomy
+  placeholder: |
+    **Integration Pattern**:
+    - Pattern Type: Request-Response/Event-Driven/Data Pipeline/etc.
+    - Protocol: HTTP/GraphQL/Message Queue/etc.
+    - Data Format: JSON/XML/Protocol Buffers/etc.
+
+    **Contract Definition**:
+    ```yaml
+    integration_contract:
+      name: "domain_to_domain_integration"
+      version: "1.0.0"
+      source: "source_domain"
+      target: "target_domain"
+    \```
+
+    **Error Handling Strategy**:
+    - Error Categories: Expected error types and handling
+    - Retry Logic: Retry strategies and backoff patterns
+    - Fallback Mechanisms: What happens when integration fails
+    - Circuit Breaker: Protection against cascading failures
+
+  validations:
+  required: true
+- type: textarea
+  id: implementation_plan
+  attributes:
+  label: Implementation Plan
+  description: Detailed implementation phases maintaining domain boundaries
+  placeholder: |
+    **Phase 1: Contract Design**
+    - [ ] Define integration contract between domains
+    - [ ] Design data schemas and validation rules
+    - [ ] Plan anti-corruption layers
+    - [ ] Design error handling strategies
+
+    **Phase 2: Source Domain Implementation**
+    - [ ] Implement source domain integration points
+    - [ ] Add data transformation and validation
+    - [ ] Implement error handling and monitoring
+    - [ ] Add integration testing
+
+    **Phase 3: Target Domain Implementation**
+    - [ ] Implement target domain integration points
+    - [ ] Add anti-corruption layers if needed
+    - [ ] Implement error handling and fallback
+    - [ ] Add integration testing
+
+    **Phase 4: End-to-End Integration**
+    - [ ] Test complete integration flow
+    - [ ] Validate error scenarios
+    - [ ] Performance and load testing
+    - [ ] Security validation
+
+  validations:
+  required: true
+- type: textarea
+  id: cross_domain_coordination
+  attributes:
+  label: Cross-Domain Coordination
+  description: Coordination requirements between domain teams
+  placeholder: |
+    **Development Coordination**:
+    - How domain teams will coordinate during development
+    - Integration testing coordination
+    - Deployment coordination requirements
+
+    **Operational Coordination**:
+    - Monitoring and alerting coordination
+    - Incident response coordination
+    - Maintenance and upgrade coordination
+- type: checkboxes
+  id: testing_strategy
+  attributes:
+  label: Testing Strategy
+  description: Comprehensive integration testing approach
+  options:
+  - label: Contract testing (source domain perspective)
+  - label: Contract testing (target domain perspective)
+  - label: Integration testing (end-to-end flow)
+  - label: Error scenario testing
+  - label: Performance testing
+  - label: Security testing
+  - label: Failover and recovery testing
+- type: checkboxes
+  id: definition_of_done
+  attributes:
+  label: Definition of Done
+  description: Integration completion criteria
+  options:
+  - label: Integration contract defined and agreed upon
+  - label: Source domain integration implemented
+  - label: Target domain integration implemented
+  - label: Anti-corruption layers implemented (if needed)
+  - label: Error handling and fallback mechanisms implemented
+  - label: Contract tests passing (both domains)
+  - label: End-to-end integration tests passing
+  - label: Performance requirements validated
+  - label: Security requirements validated
+  - label: Monitoring and alerting implemented
+  - label: Documentation completed (contract, usage, troubleshooting)
+  - label: Domain context updated with integration patterns
+  - label: Operational runbooks created
+  - label: Teams trained on integration patterns
+- type: textarea
+  id: monitoring_operations
+  attributes:
+  label: Monitoring & Operations
+  description: Ongoing monitoring, maintenance, and operational requirements
+  placeholder: |
+    **Integration Health Monitoring**:
+    - Key metrics to monitor integration health
+    - Alerting on integration failures or degradation
+    - Dashboard requirements for operational visibility
+
+    **Maintenance Considerations**:
+    - Version management for integration contracts
+    - Backward compatibility strategies
+    - Migration strategies for contract changes
+- type: textarea
+  id: risk_mitigation
+  attributes:
+  label: Risk Mitigation
+  description: Integration risks and mitigation strategies
+  placeholder: |
+    **Domain Coupling Risk**: How to prevent tight coupling between domains
+    **Performance Impact**: Mitigation for performance impact on domains
+    **Failure Isolation**: How integration failures are isolated
+    **Data Consistency**: Handling eventual consistency challenges
+- type: textarea
+  id: notes
+  attributes:
+  label: Additional Notes
+  description: Additional context, constraints, architectural decisions, or operational considerations
+  placeholder: Include any architectural decisions, constraints, or operational notes…

--- a/.github/ISSUE_TEMPLATE/refactoring.yaml
+++ b/.github/ISSUE_TEMPLATE/refactoring.yaml
@@ -1,0 +1,303 @@
+name: ♻️ Code Refactoring
+description: Code improvements with safety measures, rollback plans, and domain integrity preservation
+title: “[REFACTOR]: “
+labels: [“type:refactoring”]
+assignees: []
+body:
+
+- type: dropdown
+  id: domain
+  attributes:
+  label: Domain
+  description: Which domain is being refactored?
+  options:
+    - backend
+    - frontend
+    - shared
+    - cross_domain
+    - business_domain
+    - technical_domain
+  validations:
+  required: true
+- type: dropdown
+  id: tech_primary
+  attributes:
+  label: Primary Technology
+  description: Primary technology stack being refactored
+  options:
+    - typescript
+    - javascript
+    - python
+    - deno
+    - react
+    - node
+    - other
+  validations:
+  required: true
+- type: dropdown
+  id: component_type
+  attributes:
+  label: Component Type
+  description: Type of component being refactored
+  options:
+    - ui_component
+    - api_endpoint
+    - edge_function
+    - database_function
+    - page_component
+    - store_module
+    - business_logic
+    - integration
+    - architecture
+    - other
+  validations:
+  required: true
+- type: dropdown
+  id: refactoring_scope
+  attributes:
+  label: Refactoring Scope
+  description: Scope of refactoring work
+  options:
+    - single_component
+    - module_level
+    - domain_level
+    - cross_domain
+    - architecture_wide
+  validations:
+  required: true
+- type: dropdown
+  id: priority
+  attributes:
+  label: Priority
+  description: Refactoring priority level
+  options:
+    - critical
+    - high
+    - medium
+    - low
+  validations:
+  required: true
+- type: dropdown
+  id: estimated_effort
+  attributes:
+  label: Estimated Effort
+  description: Estimated refactoring effort
+  options:
+    - 1-2 hours
+    - half-day
+    - 1 day
+    - 2-3 days
+    - 1 week
+    - 2+ weeks
+  validations:
+  required: true
+- type: input
+  id: depends_on
+  attributes:
+  label: Dependencies
+  description: List any task dependencies (comma-separated issue numbers or task names)
+  placeholder: |
+    #123, #456, feature_completion
+- type: textarea
+  id: refactoring_description
+  attributes:
+  label: Refactoring Description
+  description: Clear description of the refactoring work and its purpose for domain improvement
+  placeholder: Describe what code/architecture will be refactored and why…
+  validations:
+  required: true
+- type: textarea
+  id: current_state_analysis
+  attributes:
+  label: Current State Analysis
+  description: Assessment of current code/architecture state and why refactoring is needed
+  placeholder: |
+    **Technical Debt Assessment**:
+    - Code Quality Issues: Specific code quality problems
+    - Architecture Concerns: Architectural issues or inconsistencies
+    - Performance Problems: Performance-related technical debt
+    - Maintenance Burden: Areas causing high maintenance overhead
+    - Domain Boundary Issues: Problems with domain boundary clarity
+
+    **Business Impact of Current State**:
+    - Development Velocity: How current state slows development
+    - Bug Risk: How current state increases bug risk
+    - Feature Delivery: Impact on feature delivery capability
+    - Team Productivity: Effect on team efficiency
+
+  validations:
+  required: true
+- type: textarea
+  id: refactoring_goals
+  attributes:
+  label: Refactoring Goals
+  description: Clear goals for what the refactoring will achieve
+  placeholder: |
+    **Primary Objectives**:
+    - Code Quality: Specific code quality improvements
+    - Architecture Clarity: Architectural improvements sought
+    - Performance: Performance improvements expected
+    - Maintainability: Maintenance improvements goals
+    - Domain Boundary Clarity: Domain boundary improvements
+
+    **Success Metrics**:
+    - [ ] Measurable improvement metric 1
+    - [ ] Measurable improvement metric 2
+    - [ ] Measurable improvement metric 3
+
+  validations:
+  required: true
+- type: textarea
+  id: technical_approach
+  attributes:
+  label: Technical Approach
+  description: Refactoring approach that maintains domain integrity and business functionality
+  placeholder: |
+    **Refactoring Strategy**:
+    - Approach: Big-bang/Incremental/Strangler Pattern/etc.
+    - Domain Patterns: Domain patterns to apply during refactoring
+    - Architecture Patterns: Architecture patterns to implement
+    - Technology Considerations: Technology stack improvements
+
+    **Domain Considerations**:
+    - Business Rule Preservation: How to maintain domain business rules
+    - Domain Boundary Maintenance: Ensuring domain boundaries remain clear
+    - Integration Contract Stability: Maintaining integration contracts during refactoring
+
+  validations:
+  required: true
+- type: textarea
+  id: risk_assessment
+  attributes:
+  label: Risk Assessment
+  description: Analysis of refactoring risks and mitigation strategies
+  placeholder: |
+    **Technical Risks**:
+    - Functionality Regression: Risk of breaking existing functionality
+    - Performance Degradation: Risk of performance impact
+    - Integration Breakage: Risk of breaking cross-domain integrations
+    - Data Consistency: Risk of data inconsistency during refactoring
+
+    **Mitigation Strategies**:
+    - Specific strategies to mitigate each identified risk
+    - Rollback plans and checkpoints
+    - Testing strategies to validate refactoring
+
+  validations:
+  required: true
+- type: textarea
+  id: implementation_plan
+  attributes:
+  label: Implementation Plan
+  description: Detailed refactoring implementation approach with safety measures
+  placeholder: |
+    **Phase 1: Preparation**
+    - [ ] Comprehensive test coverage for existing functionality
+    - [ ] Domain business rule validation tests
+    - [ ] Integration contract tests
+    - [ ] Performance baseline establishment
+    - [ ] Rollback strategy definition
+
+    **Phase 2: Incremental Refactoring**
+    - [ ] Refactoring step 1 with validation
+    - [ ] Refactoring step 2 with validation
+    - [ ] Refactoring step 3 with validation
+    - [ ] Each step includes testing and validation
+
+    **Phase 3: Validation & Optimization**
+    - [ ] End-to-end functionality validation
+    - [ ] Performance validation against baseline
+    - [ ] Integration contract validation
+    - [ ] Domain business rule validation
+    - [ ] Documentation updates
+
+  validations:
+  required: true
+- type: textarea
+  id: cross_domain_impact_analysis
+  attributes:
+  label: Cross-Domain Impact Analysis
+  description: Analysis of how refactoring affects other domains and integration points
+  placeholder: |
+    **Integration Impact**:
+    - Affected Integrations: Which cross-domain integrations are affected
+    - Contract Changes: Any integration contract changes needed
+    - Coordination Requirements: Cross-domain coordination needed
+
+    **Domain Dependencies**:
+    - How other domains depend on refactored components
+    - Communication and coordination plan for dependent domains
+- type: checkboxes
+  id: testing_strategy
+  attributes:
+  label: Testing Strategy
+  description: Comprehensive testing approach to ensure refactoring safety
+  options:
+  - label: Unit test coverage for all refactored code
+  - label: Domain business rule validation tests
+  - label: Integration tests for cross-domain interactions
+  - label: Performance regression tests
+  - label: End-to-end workflow validation tests
+- type: checkboxes
+  id: definition_of_done
+  attributes:
+  label: Definition of Done
+  description: Refactoring completion criteria
+  options:
+  - label: Refactoring implementation completed
+  - label: All existing functionality preserved and validated
+  - label: Domain business rules maintained and validated
+  - label: Integration contracts maintained (no breaking changes)
+  - label: Performance targets met or improved
+  - label: Comprehensive test coverage for refactored code
+  - label: Code quality metrics improved
+  - label: Architecture documentation updated
+  - label: Domain context updated with new patterns
+  - label: Team knowledge transfer completed
+  - label: No regression issues in production
+- type: textarea
+  id: rollback_plan
+  attributes:
+  label: Rollback Plan
+  description: Detailed plan for rolling back refactoring if issues arise
+  placeholder: |
+    **Rollback Triggers**:
+    - Specific conditions that would trigger rollback
+    - Performance degradation thresholds
+    - Functionality regression criteria
+
+    **Rollback Procedure**:
+    - Step-by-step rollback process
+    - Data consistency restoration if needed
+    - Communication plan for rollback scenarios
+- type: textarea
+  id: knowledge_transfer
+  attributes:
+  label: Knowledge Transfer
+  description: Plan for sharing refactoring insights and new patterns with team
+  placeholder: |
+    **Documentation Updates**:
+    - [ ] Architecture documentation updates
+    - [ ] Code pattern documentation
+    - [ ] Domain development guidelines updates
+    - [ ] Troubleshooting guides updates
+
+    **Team Education**:
+    - Training needed on new patterns or approaches
+    - Knowledge sharing sessions planned
+- type: textarea
+  id: long_term_maintenance
+  attributes:
+  label: Long-term Maintenance
+  description: Considerations for maintaining refactored code and preventing regression
+  placeholder: |
+    **Code Quality Maintenance**:
+    - Strategies to maintain code quality improvements
+    - Automated quality gates and monitoring
+    - Regular review and maintenance schedules
+- type: textarea
+  id: notes
+  attributes:
+  label: Additional Notes
+  description: Additional context, architectural decisions, lessons learned, or future refactoring opportunities
+  placeholder: Include any architectural decisions, lessons learned, or future opportunities…

--- a/.github/config.yaml
+++ b/.github/config.yaml
@@ -1,0 +1,12 @@
+blank_issues_enabled: false
+contact_links:
+
+- name: 📚 Documentation & Context
+  url: https://github.com/your-org/your-repo/blob/main/AGENTS.md
+  about: Review domain context and development patterns before creating issues
+- name: 🤝 Cross-Domain Coordination
+  url: https://github.com/your-org/your-repo/discussions
+  about: Use discussions for cross-domain coordination and architectural decisions
+- name: 🔍 Strategic Analysis
+  url: https://github.com/your-org/your-repo/wiki
+  about: Check project wiki for strategic analysis and domain documentation


### PR DESCRIPTION
This commit introduces a set of standardized GitHub issue templates to improve consistency and detail in issue reporting and tracking.

The following templates have been added:
- bug.yaml: For reporting bugs.
- feature.yaml: For proposing new features.
- infra.yaml: For infrastructure-related tasks.
- integration.yaml: For cross-domain integration tasks.
- refactoring.yaml: For code refactoring efforts.

A config.yaml file has also been added to configure the issue template chooser.