### PR TITLE
chore: update release scripts for the TypeScript CLI

### DIFF
--- a/codex-cli/scripts/install_native_deps.sh
+++ b/codex-cli/scripts/install_native_deps.sh
@@ -65,7 +65,7 @@ mkdir -p "$BIN_DIR"
 # Until we start publishing stable GitHub releases, we have to grab the binaries
 # from the GitHub Action that created them. Update the URL below to point to the
 # appropriate workflow run:
-WORKFLOW_URL="https://github.com/openai/codex/actions/runs/15483730027"
+WORKFLOW_URL="https://github.com/openai/codex/actions/runs/15981617627"
 WORKFLOW_ID="${WORKFLOW_URL##*/}"
 
 ARTIFACTS_DIR="$(mktemp -d)"

--- a/codex-cli/scripts/stage_release.sh
+++ b/codex-cli/scripts/stage_release.sh
@@ -30,11 +30,12 @@ set -euo pipefail
 
 usage() {
   cat <<EOF
-Usage: $(basename "$0") [--tmp DIR] [--native]
+Usage: $(basename "$0") [--tmp DIR] [--native] [--version VERSION]
 
 Options
   --tmp DIR   Use DIR to stage the release (defaults to a fresh mktemp dir)
   --native    Bundle Rust binaries for Linux (fat package)
+  --version   Specify the version to release (defaults to a timestamp-based version)
   -h, --help  Show this help
 
 Legacy positional argument: the first non-flag argument is still interpreted
@@ -45,6 +46,8 @@ EOF
 
 TMPDIR=""
 INCLUDE_NATIVE=0
+# Default to a timestamp-based version (keep same scheme as before)
+VERSION="$(printf '0.1.%d' "$(date +%y%m%d%H%M)")"
 
 # Manual flag parser - Bash getopts does not handle GNU long options well.
 while [[ $# -gt 0 ]]; do
@@ -58,6 +61,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     --native)
       INCLUDE_NATIVE=1
+      ;;
+    --version)
+      shift || { echo "--version requires an argument"; usage 1; }
+      VERSION="$1"
       ;;
     -h|--help)
       usage 0
@@ -107,9 +114,6 @@ cp -r bin/codex.js "$TMPDIR/bin/codex.js"
 cp -r dist "$TMPDIR/dist"
 cp -r src "$TMPDIR/src" # keep source for TS sourcemaps
 cp ../README.md "$TMPDIR" || true # README is one level up - ignore if missing
-
-# Derive a timestamp-based version (keep same scheme as before)
-VERSION="$(printf '0.1.%d' "$(date +%y%m%d%H%M)")"
 
 # Modify package.json - bump version and optionally add the native directory to
 # the files array so that the binaries are published to npm.


### PR DESCRIPTION
This introduces two changes to make a quick fix so we can deploy the Rust CLI for `0.2.0` of `@openai/codex` on npm:

- Updates `WORKFLOW_URL` to point to https://github.com/openai/codex/actions/runs/15981617627, which is the GitHub workflow run used to create the binaries for the `0.2.0` release we published to Homebrew.
- Adds a `--version` option to `stage_release.sh` to specify what the `version` field in the `package.json` will be.

Locally, I ran the following:

```
./codex-cli/scripts/stage_release.sh --native --version 0.2.0
```

Previously, we only used the `--native` flag to publish to the `native` tag of `@openai/codex` (e.g., `npm publish --tag native`), but we should just publish this as the default tag for `0.2.0` to be consistent with what is in Homebrew.

We can still publish one "final" version of the TypeScript CLI as 0.1.x later.

Under the hood, this release will still contain `dist/cli.js`, `bin/codex-linux-sandbox-x64`, and `bin/codex-x86_64-apple-darwin`, which are not strictly necessary, but we'll fix that in `0.3.0`.