### PR TITLE
feat: support custom HTTP headers for model providers

### DIFF
--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -76,6 +76,22 @@ env_key = "AZURE_OPENAI_API_KEY"  # Or "OPENAI_API_KEY", whichever you use.
 query_params = { api-version = "2025-04-01-preview" }
 ```
 
+It is also possible to configure a provider to include extra HTTP headers with a request. These can be hardcoded values (`http_headers`) or values read from environment variables (`env_http_headers`):
+
+```toml
+[model_providers.example]
+# name, base_url, ...
+
+# This will add the HTTP header `X-Example-Header` with value `example-value`
+# to each request to the model provider.
+http_headers = { "X-Example-Header" = "example-value" }
+
+# This will add the HTTP header `X-Example-Features` with the value of the
+# `EXAMPLE_FEATURES` environment variable to each request to the model provider
+# _if_ the environment variable is set and its value is non-empty.
+env_http_headers = { "X-Example-Features": "EXAMPLE_FEATURES" }
+```
+
 ## model_provider
 
 Identifies which provider to use from the `model_providers` map. Defaults to `"openai"`.

--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -114,22 +114,18 @@ pub(crate) async fn stream_chat_completions(
         "tools": tools_json,
     });
 
-    let url = provider.get_full_url();
-
     debug!(
-        "POST to {url}: {}",
+        "POST to {}: {}",
+        provider.get_full_url(),
         serde_json::to_string_pretty(&payload).unwrap_or_default()
     );
 
-    let api_key = provider.api_key()?;
     let mut attempt = 0;
     loop {
         attempt += 1;
 
-        let mut req_builder = client.post(&url);
-        if let Some(api_key) = &api_key {
-            req_builder = req_builder.bearer_auth(api_key.clone());
-        }
+        let req_builder = provider.create_request_builder(client)?;
+
         let res = req_builder
             .header(reqwest::header::ACCEPT, "text/event-stream")
             .json(&payload)

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -659,6 +659,8 @@ disable_response_storage = true
             wire_api: crate::WireApi::Chat,
             env_key_instructions: None,
             query_params: None,
+            http_headers: None,
+            env_http_headers: None,
         };
         let model_provider_map = {
             let mut model_provider_map = built_in_model_providers();

--- a/codex-rs/core/tests/previous_response_id.rs
+++ b/codex-rs/core/tests/previous_response_id.rs
@@ -108,6 +108,8 @@ async fn keeps_previous_response_id_between_tasks() {
         env_key_instructions: None,
         wire_api: codex_core::WireApi::Responses,
         query_params: None,
+        http_headers: None,
+        env_http_headers: None,
     };
 
     // Init session

--- a/codex-rs/core/tests/stream_no_completed.rs
+++ b/codex-rs/core/tests/stream_no_completed.rs
@@ -97,6 +97,8 @@ async fn retries_on_early_close() {
         env_key_instructions: None,
         wire_api: codex_core::WireApi::Responses,
         query_params: None,
+        http_headers: None,
+        env_http_headers: None,
     };
 
     let ctrl_c = std::sync::Arc::new(tokio::sync::Notify::new());


### PR DESCRIPTION
This adds support for two new model provider config options:

- `http_headers` for hardcoded (key, value) pairs
- `env_http_headers` for headers whose values should be read from environment variables

This also updates the built-in `openai` provider to use this feature to set the following headers:

- `originator` => `codex_cli_rs`
- `version` => [CLI version]
- `OpenAI-Organization` => `OPENAI_ORGANIZATION` env var
- `OpenAI-Project` => `OPENAI_PROJECT` env var

for consistency with the TypeScript implementation:

https://github.com/openai/codex/blob/bd5a9e8ba96c7d9c58ecaf5e61ec62d14ac6378d/codex-cli/src/utils/agent/agent-loop.ts#L321-L329

While here, this also consolidates some logic that was duplicated across `client.rs` and `chat_completions.rs` by introducing `ModelProviderInfo.create_request_builder()`.

Resolves https://github.com/openai/codex/discussions/1152