### PR TITLE
chore: normalize repository.url in package.json

### DIFF
--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -84,6 +84,6 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/openai/codex"
+    "url": "git+https://github.com/openai/codex.git"
   }
 }


### PR DESCRIPTION
I got this as a warning when doing `npm publish --dry-run`, so I ran `npm pkg fix` to create this PR, as instructed.