### PR TITLE
chore: create a release script for the Rust CLI

### DIFF
--- a/codex-cli/.gitignore
+++ b/codex-cli/.gitignore
@@ -1,3 +1,7 @@
 # Added by ./scripts/install_native_deps.sh
+/bin/codex-aarch64-apple-darwin
+/bin/codex-aarch64-unknown-linux-musl
 /bin/codex-linux-sandbox-arm64
 /bin/codex-linux-sandbox-x64
+/bin/codex-x86_64-apple-darwin
+/bin/codex-x86_64-unknown-linux-musl

--- a/codex-cli/scripts/stage_release.sh
+++ b/codex-cli/scripts/stage_release.sh
@@ -48,6 +48,7 @@ TMPDIR=""
 INCLUDE_NATIVE=0
 # Default to a timestamp-based version (keep same scheme as before)
 VERSION="$(printf '0.1.%d' "$(date +%y%m%d%H%M)")"
+WORKFLOW_URL=""
 
 # Manual flag parser - Bash getopts does not handle GNU long options well.
 while [[ $# -gt 0 ]]; do
@@ -65,6 +66,10 @@ while [[ $# -gt 0 ]]; do
     --version)
       shift || { echo "--version requires an argument"; usage 1; }
       VERSION="$1"
+      ;;
+    --workflow-url)
+      shift || { echo "--workflow-url requires an argument"; exit 1; }
+      WORKFLOW_URL="$1"
       ;;
     -h|--help)
       usage 0
@@ -125,7 +130,7 @@ jq --arg version "$VERSION" \
 # 2. Native runtime deps (sandbox plus optional Rust binaries)
 
 if [[ "$INCLUDE_NATIVE" -eq 1 ]]; then
-  ./scripts/install_native_deps.sh "$TMPDIR" --full-native
+  ./scripts/install_native_deps.sh --full-native --workflow-url "$WORKFLOW_URL" "$TMPDIR"
   touch "${TMPDIR}/bin/use-native"
 else
   ./scripts/install_native_deps.sh "$TMPDIR"

--- a/codex-cli/scripts/stage_rust_release.py
+++ b/codex-cli/scripts/stage_rust_release.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+import argparse
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="""Stage a release for the npm module.
+
+Run this after the GitHub Release has been created and use
+`--release-version` to specify the version to release.
+"""
+    )
+    parser.add_argument(
+        "--release-version", required=True, help="Version to release, e.g., 0.3.0"
+    )
+    args = parser.parse_args()
+    version = args.release_version
+
+    gh_run = subprocess.run(
+        [
+            "gh",
+            "run",
+            "list",
+            "--branch",
+            f"rust-v{version}",
+            "--json",
+            "workflowName,url,headSha",
+            "--jq",
+            'first(.[] | select(.workflowName == "rust-release"))',
+        ],
+        stdout=subprocess.PIPE,
+        check=True,
+    )
+    gh_run.check_returncode()
+    workflow = json.loads(gh_run.stdout)
+    sha = workflow["headSha"]
+
+    print(f"should `git checkout {sha}`")
+
+    current_dir = Path(__file__).parent.resolve()
+    stage_release = subprocess.run(
+        [
+            current_dir / "stage_release.sh",
+            "--version",
+            version,
+            "--workflow-url",
+            workflow["url"],
+            "--native",
+        ]
+    )
+    stage_release.check_returncode()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
This is a stopgap solution before migrating the build for the npm release to GitHub Actions (which is ultimately what should be done to ensure hermetic builds).

The idea is that instead of continuing to create PRs like https://github.com/openai/codex/pull/1472 where I have to check in a change to the `WORKFLOW_URL`, this script uses `gh run list` to get the `WORKFLOW_URL` dynamically and then threads the value through to `install_native_deps.sh`.

To create the 0.3.0 release on npm, I ran:

```shell
./codex-cli/scripts/stage_rust_release.py --release-version 0.3.0
```

and then did `npm publish --dry-run` followed by `npm publish` in the temp directory created by `stage_rust_release.py`.