### PR TITLE
Add Android platform support for Codex CLI

### DIFF
--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -41,6 +41,7 @@ if (wantsNative) {
   let targetTriple = null;
   switch (platform) {
     case "linux":
+    case "android":
       switch (arch) {
         case "x64":
           targetTriple = "x86_64-unknown-linux-musl";


### PR DESCRIPTION
## Summary
Add Android platform support to Codex CLI

## What?
- Added `android` to the list of supported platforms in `codex-cli/bin/codex.js`
- Treats Android as Linux for binary compatibility

## Why?
- Fixes "Unsupported platform: android (arm64)" error on Termux
- Enables Codex CLI usage on Android devices via Termux
- Improves platform compatibility without affecting other platforms

## How?
- Modified the platform detection switch statement to include `case "android":`
- Android falls through to the same logic as Linux, using appropriate ARM64 binaries
- Minimal change with no breaking effects on existing functionality

## Testing
- Tested on Android/Termux environment
- Verified the fix resolves the platform detection error
- Confirmed no impact on other platforms

## Related Issues
Fixes the "Unsupported platform: android (arm64)" error reported by Termux users