### PR TITLE
chore: drop codex-cli from dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,9 +24,3 @@ updates:
     directory: /
     schedule:
       interval: weekly
-  - package-ecosystem: npm
-    directories:
-      - /
-      - codex-cli
-    schedule:
-      interval: weekly


### PR DESCRIPTION
We are not actively developing `codex-cli`, so I would rather leave the existing `pnpm-lock.yaml` files as-is.