### PR TITLE
feat: add new config option: model_supports_reasoning_summaries

### DIFF
--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -206,6 +206,14 @@ To disable reasoning summaries, set `model_reasoning_summary` to `"none"` in you
 model_reasoning_summary = "none"  # disable reasoning summaries
 ```
 
+## model_supports_reasoning_summaries
+
+By default, `reasoning` is only set on requests to OpenAI models that are known to support them. To force `reasoning` to set on requests to the current model, you can force this behavior by setting the following in `config.toml`:
+
+```toml
+model_supports_reasoning_summaries = true
+```
+
 ## sandbox_mode
 
 Codex executes model-generated shell commands inside an OS-level sandbox.

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -586,7 +586,7 @@ async fn submission_loop(
                 }
 
                 let client = ModelClient::new(
-                    model.clone(),
+                    config.clone(),
                     provider.clone(),
                     model_reasoning_effort,
                     model_reasoning_summary,

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -130,6 +130,10 @@ pub struct Config {
     /// If not "none", the value to use for `reasoning.summary` when making a
     /// request using the Responses API.
     pub model_reasoning_summary: ReasoningSummary,
+
+    /// When set to `true`, overrides the default heuristic and forces
+    /// `model_supports_reasoning_summaries()` to return `true`.
+    pub model_supports_reasoning_summaries: bool,
 }
 
 impl Config {
@@ -308,6 +312,9 @@ pub struct ConfigToml {
 
     pub model_reasoning_effort: Option<ReasoningEffort>,
     pub model_reasoning_summary: Option<ReasoningSummary>,
+
+    /// Override to force-enable reasoning summaries for the configured model.
+    pub model_supports_reasoning_summaries: Option<bool>,
 }
 
 impl ConfigToml {
@@ -472,6 +479,10 @@ impl Config {
                 .model_reasoning_summary
                 .or(cfg.model_reasoning_summary)
                 .unwrap_or_default(),
+
+            model_supports_reasoning_summaries: cfg
+                .model_supports_reasoning_summaries
+                .unwrap_or(false),
         };
         Ok(config)
     }
@@ -776,6 +787,7 @@ disable_response_storage = true
                 hide_agent_reasoning: false,
                 model_reasoning_effort: ReasoningEffort::High,
                 model_reasoning_summary: ReasoningSummary::Detailed,
+                model_supports_reasoning_summaries: false,
             },
             o3_profile_config
         );
@@ -820,6 +832,7 @@ disable_response_storage = true
             hide_agent_reasoning: false,
             model_reasoning_effort: ReasoningEffort::default(),
             model_reasoning_summary: ReasoningSummary::default(),
+            model_supports_reasoning_summaries: false,
         };
 
         assert_eq!(expected_gpt3_profile_config, gpt3_profile_config);
@@ -879,6 +892,7 @@ disable_response_storage = true
             hide_agent_reasoning: false,
             model_reasoning_effort: ReasoningEffort::default(),
             model_reasoning_summary: ReasoningSummary::default(),
+            model_supports_reasoning_summaries: false,
         };
 
         assert_eq!(expected_zdr_profile_config, zdr_profile_config);

--- a/codex-rs/exec/src/event_processor.rs
+++ b/codex-rs/exec/src/event_processor.rs
@@ -139,7 +139,7 @@ impl EventProcessor {
             ("sandbox", summarize_sandbox_policy(&config.sandbox_policy)),
         ];
         if config.model_provider.wire_api == WireApi::Responses
-            && model_supports_reasoning_summaries(&config.model)
+            && model_supports_reasoning_summaries(config)
         {
             entries.push((
                 "reasoning effort",

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -159,7 +159,7 @@ impl HistoryCell {
                 ("sandbox", summarize_sandbox_policy(&config.sandbox_policy)),
             ];
             if config.model_provider.wire_api == WireApi::Responses
-                && model_supports_reasoning_summaries(&config.model)
+                && model_supports_reasoning_summaries(config)
             {
                 entries.push((
                     "reasoning effort",


### PR DESCRIPTION
As noted in the updated docs, this makes it so that you can set:

```toml
model_supports_reasoning_summaries = true
```

as a way of overriding the existing heuristic for when to set the `reasoning` field on a sampling request:

https://github.com/openai/codex/blob/341c091c5b09dc706ab5c7d629516e6ef5aaf902/codex-rs/core/src/client_common.rs#L152-L166