### PR TITLE
Add chat completions SSE parser test

### DIFF
--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -494,7 +494,9 @@ mod tests {
         let mut text = String::new();
         for i in 0..2 {
             match &events[i] {
-                ResponseEvent::OutputItemDone(ResponseItem::Message { role, content }) if role == "assistant" => {
+                ResponseEvent::OutputItemDone(ResponseItem::Message { role, content })
+                    if role == "assistant" =>
+                {
                     if let Some(ContentItem::OutputText { text: t }) = content.get(0) {
                         text.push_str(t);
                     }
@@ -505,7 +507,11 @@ mod tests {
         assert_eq!(text, "Hello world");
 
         match &events[2] {
-            ResponseEvent::OutputItemDone(ResponseItem::FunctionCall { name, arguments, call_id }) => {
+            ResponseEvent::OutputItemDone(ResponseItem::FunctionCall {
+                name,
+                arguments,
+                call_id,
+            }) => {
                 assert_eq!(name, "foo");
                 assert_eq!(call_id, "call1");
                 assert_eq!(arguments, "{\"a\": 1}");

--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -486,18 +486,21 @@ mod tests {
 
         let mut events = Vec::new();
         while let Some(ev) = rx.recv().await {
-            events.push(ev.expect("stream error"));
+            match ev {
+                Ok(event) => events.push(event),
+                Err(e) => panic!("stream error: {e}"),
+            }
         }
 
         assert_eq!(events.len(), 4);
 
         let mut text = String::new();
-        for i in 0..2 {
-            match &events[i] {
+        for (i, event) in events.iter().take(2).enumerate() {
+            match event {
                 ResponseEvent::OutputItemDone(ResponseItem::Message { role, content })
                     if role == "assistant" =>
                 {
-                    if let Some(ContentItem::OutputText { text: t }) = content.get(0) {
+                    if let Some(ContentItem::OutputText { text: t }) = content.first() {
                         text.push_str(t);
                     }
                 }


### PR DESCRIPTION
## Summary
- add regression test to ensure streaming Chat Completions SSE deltas are merged correctly

## Testing
- `cargo test -p codex-core --quiet`

------
https://chatgpt.com/codex/tasks/task_i_687158a285808321837a9bd12930f0a1