### PR TITLE
Improve SSE event test structure

### DIFF
--- a/codex-rs/core/tests/fixtures/stream_retry.json
+++ b/codex-rs/core/tests/fixtures/stream_retry.json
@@ -1,0 +1,14 @@
+{
+  "first": [
+    {
+      "type": "response.output_item.done",
+      "item": { "type": "message", "role": "assistant", "content": [] }
+    }
+  ],
+  "second": [
+    {
+      "type": "response.completed",
+      "response": { "id": "resp_ok", "output": [] }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add table-driven tests for SSE event variants
- load SSE retry sequences from JSON fixtures
- rework `stream_no_completed` test to use JSON fixtures

## Testing
- `cargo clippy --all -- -D warnings`
- `cargo test --workspace --exclude codex-linux-sandbox`
- `pnpm --filter @openai/codex run lint`
- `pnpm --filter @openai/codex run test` *(fails: Process with PID ... failed to terminate within 500ms)*

------
https://chatgpt.com/codex/tasks/task_i_68717468c3e48321b51c9ecac6ba0f09