### PR TITLE
Improve SSE tests

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -391,3 +391,108 @@ async fn stream_from_fixture(path: impl AsRef<Path>) -> Result<ResponseStream> {
     tokio::spawn(process_sse(stream, tx_event));
     Ok(ResponseStream { rx_event })
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::expect_used, clippy::unwrap_used)]
+    use super::*;
+    use serde_json::json;
+
+    async fn run_sse(events: Vec<serde_json::Value>) -> Vec<ResponseEvent> {
+        let mut body = String::new();
+        for e in events {
+            let kind = e
+                .get("type")
+                .and_then(|v| v.as_str())
+                .expect("fixture event missing type");
+            if e.as_object().map(|o| o.len() == 1).unwrap_or(false) {
+                body.push_str(&format!("event: {kind}\n\n"));
+            } else {
+                body.push_str(&format!("event: {kind}\ndata: {e}\n\n"));
+            }
+        }
+        let (tx, mut rx) = mpsc::channel::<Result<ResponseEvent>>(8);
+        let stream = ReaderStream::new(std::io::Cursor::new(body)).map_err(CodexErr::Io);
+        tokio::spawn(process_sse(stream, tx));
+        let mut out = Vec::new();
+        while let Some(ev) = rx.recv().await {
+            out.push(ev.expect("channel closed"));
+        }
+        out
+    }
+
+    #[tokio::test]
+    async fn table_driven_event_kinds() {
+        struct Case {
+            name: &'static str,
+            event: serde_json::Value,
+            expect_first: fn(&ResponseEvent) -> bool,
+            expected_len: usize,
+        }
+
+        fn is_created(ev: &ResponseEvent) -> bool {
+            matches!(ev, ResponseEvent::Created)
+        }
+
+        fn is_output(ev: &ResponseEvent) -> bool {
+            matches!(ev, ResponseEvent::OutputItemDone(_))
+        }
+
+        fn is_completed(ev: &ResponseEvent) -> bool {
+            matches!(ev, ResponseEvent::Completed { .. })
+        }
+
+        let completed = json!({
+            "type": "response.completed",
+            "response": {
+                "id": "c",
+                "usage": {
+                    "input_tokens": 0,
+                    "input_tokens_details": null,
+                    "output_tokens": 0,
+                    "output_tokens_details": null,
+                    "total_tokens": 0
+                },
+                "output": []
+            }
+        });
+
+        let cases = vec![
+            Case {
+                name: "created",
+                event: json!({"type": "response.created", "response": {}}),
+                expect_first: is_created,
+                expected_len: 2,
+            },
+            Case {
+                name: "output_item.done",
+                event: json!({
+                    "type": "response.output_item.done",
+                    "item": {
+                        "type": "message",
+                        "role": "assistant",
+                        "content": [
+                            {"type": "output_text", "text": "hi"}
+                        ]
+                    }
+                }),
+                expect_first: is_output,
+                expected_len: 2,
+            },
+            Case {
+                name: "unknown",
+                event: json!({"type": "response.new_tool_event"}),
+                expect_first: is_completed,
+                expected_len: 1,
+            },
+        ];
+
+        for case in cases {
+            let mut evs = vec![case.event];
+            evs.push(completed.clone());
+            let out = run_sse(evs).await;
+            assert_eq!(out.len(), case.expected_len, "case {}", case.name);
+            assert!((case.expect_first)(&out[0]), "case {}", case.name);
+        }
+    }
+}

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -421,9 +421,17 @@ mod tests {
         out
     }
 
+    /// Verifies that the SSE adapter emits the expected [`ResponseEvent`] for
+    /// a variety of `type` values from the Responses API. The test is written
+    /// table-driven style to keep additions for new event kinds trivial.
+    ///
+    /// Each `Case` supplies an input event, a predicate that must match the
+    /// *first* `ResponseEvent` produced by the adapter, and the total number
+    /// of events expected after appending a synthetic `response.completed`
+    /// marker that terminates the stream.
     #[tokio::test]
     async fn table_driven_event_kinds() {
-        struct Case {
+        struct TestCase {
             name: &'static str,
             event: serde_json::Value,
             expect_first: fn(&ResponseEvent) -> bool,
@@ -458,13 +466,13 @@ mod tests {
         });
 
         let cases = vec![
-            Case {
+            TestCase {
                 name: "created",
                 event: json!({"type": "response.created", "response": {}}),
                 expect_first: is_created,
                 expected_len: 2,
             },
-            Case {
+            TestCase {
                 name: "output_item.done",
                 event: json!({
                     "type": "response.output_item.done",
@@ -479,7 +487,7 @@ mod tests {
                 expect_first: is_output,
                 expected_len: 2,
             },
-            Case {
+            TestCase {
                 name: "unknown",
                 event: json!({"type": "response.new_tool_event"}),
                 expect_first: is_completed,

--- a/codex-rs/core/tests/fixtures/completed_template.json
+++ b/codex-rs/core/tests/fixtures/completed_template.json
@@ -1,0 +1,16 @@
+[
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "__ID__",
+      "usage": {
+        "input_tokens": 0,
+        "input_tokens_details": null,
+        "output_tokens": 0,
+        "output_tokens_details": null,
+        "total_tokens": 0
+      },
+      "output": []
+    }
+  }
+]

--- a/codex-rs/core/tests/fixtures/incomplete_sse.json
+++ b/codex-rs/core/tests/fixtures/incomplete_sse.json
@@ -1,0 +1,3 @@
+[
+  {"type": "response.output_item.done"}
+]

--- a/codex-rs/core/tests/previous_response_id.rs
+++ b/codex-rs/core/tests/previous_response_id.rs
@@ -11,6 +11,7 @@ mod test_support;
 use serde_json::Value;
 use tempfile::TempDir;
 use test_support::load_default_config_for_test;
+use test_support::load_sse_fixture_with_id;
 use tokio::time::timeout;
 use wiremock::Match;
 use wiremock::Mock;
@@ -42,12 +43,9 @@ impl Match for HasPrevId {
     }
 }
 
-/// Build minimal SSE stream with completed marker.
+/// Build minimal SSE stream with completed marker using the JSON fixture.
 fn sse_completed(id: &str) -> String {
-    format!(
-        "event: response.completed\n\
-data: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"{id}\",\"output\":[]}}}}\n\n\n"
-    )
+    load_sse_fixture_with_id("tests/fixtures/completed_template.json", id)
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/core/tests/stream_no_completed.rs
+++ b/codex-rs/core/tests/stream_no_completed.rs
@@ -12,6 +12,8 @@ use codex_core::protocol::Op;
 mod test_support;
 use tempfile::TempDir;
 use test_support::load_default_config_for_test;
+use test_support::load_sse_fixture;
+use test_support::load_sse_fixture_with_id;
 use tokio::time::timeout;
 use wiremock::Mock;
 use wiremock::MockServer;
@@ -22,15 +24,11 @@ use wiremock::matchers::method;
 use wiremock::matchers::path;
 
 fn sse_incomplete() -> String {
-    // Only a single line; missing the completed event.
-    "event: response.output_item.done\n\n".to_string()
+    load_sse_fixture("tests/fixtures/incomplete_sse.json")
 }
 
 fn sse_completed(id: &str) -> String {
-    format!(
-        "event: response.completed\n\
-data: {{\"type\":\"response.completed\",\"response\":{{\"id\":\"{id}\",\"output\":[]}}}}\n\n\n"
-    )
+    load_sse_fixture_with_id("tests/fixtures/completed_template.json", id)
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/codex-rs/core/tests/test_support.rs
+++ b/codex-rs/core/tests/test_support.rs
@@ -30,7 +30,6 @@ pub fn load_default_config_for_test(codex_home: &TempDir) -> Config {
 /// with only a `type` field results in an event with no `data:` section. This
 /// makes it trivial to extend the fixtures as OpenAI adds new event kinds or
 /// fields.
-#[allow(dead_code)]
 pub fn load_sse_fixture(path: impl AsRef<std::path::Path>) -> String {
     let events: Vec<serde_json::Value> =
         serde_json::from_reader(std::fs::File::open(path).expect("read fixture"))
@@ -51,10 +50,10 @@ pub fn load_sse_fixture(path: impl AsRef<std::path::Path>) -> String {
         .collect()
 }
 
-/// Like [`load_sse_fixture`] but substitutes the placeholder `__ID__` with the
-/// provided identifier before parsing. Useful when the test needs unique
-/// `response_id` values.
-#[allow(dead_code)]
+/// Same as [`load_sse_fixture`], but replaces the placeholder `__ID__` in the
+/// fixture template with the supplied identifier before parsing. This lets a
+/// single JSON template be reused by multiple tests that each need a unique
+/// `response_id`.
 pub fn load_sse_fixture_with_id(path: impl AsRef<std::path::Path>, id: &str) -> String {
     let raw = std::fs::read_to_string(path).expect("read fixture template");
     let replaced = raw.replace("__ID__", id);

--- a/codex-rs/core/tests/test_support.rs
+++ b/codex-rs/core/tests/test_support.rs
@@ -30,6 +30,7 @@ pub fn load_default_config_for_test(codex_home: &TempDir) -> Config {
 /// with only a `type` field results in an event with no `data:` section. This
 /// makes it trivial to extend the fixtures as OpenAI adds new event kinds or
 /// fields.
+#[allow(dead_code)]
 pub fn load_sse_fixture(path: impl AsRef<std::path::Path>) -> String {
     let events: Vec<serde_json::Value> =
         serde_json::from_reader(std::fs::File::open(path).expect("read fixture"))
@@ -53,6 +54,7 @@ pub fn load_sse_fixture(path: impl AsRef<std::path::Path>) -> String {
 /// Like [`load_sse_fixture`] but substitutes the placeholder `__ID__` with the
 /// provided identifier before parsing. Useful when the test needs unique
 /// `response_id` values.
+#[allow(dead_code)]
 pub fn load_sse_fixture_with_id(path: impl AsRef<std::path::Path>, id: &str) -> String {
     let raw = std::fs::read_to_string(path).expect("read fixture template");
     let replaced = raw.replace("__ID__", id);

--- a/codex-rs/core/tests/test_support.rs
+++ b/codex-rs/core/tests/test_support.rs
@@ -21,3 +21,55 @@ pub fn load_default_config_for_test(codex_home: &TempDir) -> Config {
     )
     .expect("defaults for test should always succeed")
 }
+
+/// Builds an SSE stream body from a JSON fixture.
+///
+/// The fixture must contain an array of objects where each object represents a
+/// single SSE event with at least a `type` field matching the `event:` value.
+/// Additional fields become the JSON payload for the `data:` line. An object
+/// with only a `type` field results in an event with no `data:` section. This
+/// makes it trivial to extend the fixtures as OpenAI adds new event kinds or
+/// fields.
+pub fn load_sse_fixture(path: impl AsRef<std::path::Path>) -> String {
+    let events: Vec<serde_json::Value> =
+        serde_json::from_reader(std::fs::File::open(path).expect("read fixture"))
+            .expect("parse JSON fixture");
+    events
+        .into_iter()
+        .map(|e| {
+            let kind = e
+                .get("type")
+                .and_then(|v| v.as_str())
+                .expect("fixture event missing type");
+            if e.as_object().map(|o| o.len() == 1).unwrap_or(false) {
+                format!("event: {kind}\n\n")
+            } else {
+                format!("event: {kind}\ndata: {e}\n\n")
+            }
+        })
+        .collect()
+}
+
+/// Like [`load_sse_fixture`] but substitutes the placeholder `__ID__` with the
+/// provided identifier before parsing. Useful when the test needs unique
+/// `response_id` values.
+pub fn load_sse_fixture_with_id(path: impl AsRef<std::path::Path>, id: &str) -> String {
+    let raw = std::fs::read_to_string(path).expect("read fixture template");
+    let replaced = raw.replace("__ID__", id);
+    let events: Vec<serde_json::Value> =
+        serde_json::from_str(&replaced).expect("parse JSON fixture");
+    events
+        .into_iter()
+        .map(|e| {
+            let kind = e
+                .get("type")
+                .and_then(|v| v.as_str())
+                .expect("fixture event missing type");
+            if e.as_object().map(|o| o.len() == 1).unwrap_or(false) {
+                format!("event: {kind}\n\n")
+            } else {
+                format!("event: {kind}\ndata: {e}\n\n")
+            }
+        })
+        .collect()
+}


### PR DESCRIPTION
## Summary
- support fixture-based SSE data in tests
- add helpers to load SSE JSON fixtures
- add table-driven SSE unit tests
- let integration tests use fixture loading
- fix clippy errors from format! calls

## Testing
- `cargo clippy --tests`
- `cargo test --workspace --exclude codex-linux-sandbox`


------
https://chatgpt.com/codex/tasks/task_i_68717468c3e48321b51c9ecac6ba0f09