### PR TITLE
Add paste summarization to Codex TUI

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -787,6 +787,7 @@ dependencies = [
  "color-eyre",
  "crossterm",
  "image",
+ "insta",
  "lazy_static",
  "mcp-types",
  "path-clean",
@@ -869,6 +870,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1229,6 +1242,12 @@ checksum = "3d248bdd43ce613d87415282f69b9bb99d947d290b10962dd6c56233312c2ad5"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "encoding_rs"
@@ -2109,6 +2128,17 @@ name = "indoc"
 version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
+
+[[package]]
+name = "insta"
+version = "1.43.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "154934ea70c58054b556dd430b99a98c2a7ff5309ac9891597e339b5c28f4371"
+dependencies = [
+ "console",
+ "once_cell",
+ "similar",
+]
 
 [[package]]
 name = "instability"

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -61,4 +61,5 @@ unicode-segmentation = "1.12.0"
 uuid = "1"
 
 [dev-dependencies]
+insta = "1.43.1"
 pretty_assertions = "1"

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -12,6 +12,9 @@ pub(crate) enum AppEvent {
 
     KeyEvent(KeyEvent),
 
+    /// Text pasted from the terminal clipboard.
+    Paste(String),
+
     /// Scroll event with a value representing the "scroll delta" as the net
     /// scroll up/down events within a short time window.
     Scroll(i32),

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -883,22 +883,26 @@ mod tests {
         let sender = AppEventSender::new(tx);
         let mut composer = ChatComposer::new(true, sender);
 
-        let mut terminal = Terminal::new(TestBackend::new(30, 4)).unwrap();
-        terminal
-            .draw(|f| f.render_widget_ref(&composer, f.area()))
-            .unwrap();
+        let mut terminal = match Terminal::new(TestBackend::new(30, 4)) {
+            Ok(t) => t,
+            Err(e) => panic!("Failed to create terminal: {}", e),
+        };
+
+        if let Err(e) = terminal.draw(|f| f.render_widget_ref(&composer, f.area())) {
+            panic!("Failed to draw empty composer: {e}");
+        }
         assert_snapshot!("empty", terminal.backend());
 
         composer.handle_paste("short".into());
-        terminal
-            .draw(|f| f.render_widget_ref(&composer, f.area()))
-            .unwrap();
+        if let Err(e) = terminal.draw(|f| f.render_widget_ref(&composer, f.area())) {
+            panic!("Failed to draw small composer: {e}");
+        }
         assert_snapshot!("small", terminal.backend());
 
         composer.handle_paste("z".repeat(LARGE_PASTE_CHAR_THRESHOLD + 5));
-        terminal
-            .draw(|f| f.render_widget_ref(&composer, f.area()))
-            .unwrap();
+        if let Err(e) = terminal.draw(|f| f.render_widget_ref(&composer, f.area())) {
+            panic!("Failed to draw large composer: {e}");
+        }
         assert_snapshot!("large", terminal.backend());
     }
 }

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -877,19 +877,19 @@ mod tests {
 
         let mut terminal = Terminal::new(TestBackend::new(30, 4)).unwrap();
         terminal
-            .draw(|f| f.render_widget_ref(&composer, f.size()))
+            .draw(|f| f.render_widget_ref(&composer, f.area()))
             .unwrap();
         assert_snapshot!("empty", terminal.backend());
 
         composer.handle_paste("short".into());
         terminal
-            .draw(|f| f.render_widget_ref(&composer, f.size()))
+            .draw(|f| f.render_widget_ref(&composer, f.area()))
             .unwrap();
         assert_snapshot!("small", terminal.backend());
 
         composer.handle_paste("z".repeat(LARGE_PASTE_CHAR_THRESHOLD + 5));
         terminal
-            .draw(|f| f.render_widget_ref(&composer, f.size()))
+            .draw(|f| f.render_widget_ref(&composer, f.area()))
             .unwrap();
         assert_snapshot!("large", terminal.backend());
     }

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -655,8 +655,10 @@ impl WidgetRef for &ChatComposer<'_> {
 
 #[cfg(test)]
 mod tests {
+    use crate::bottom_pane::AppEventSender;
+    use crate::bottom_pane::ChatComposer;
+    use crate::bottom_pane::InputResult;
     use crate::bottom_pane::chat_composer::LARGE_PASTE_CHAR_THRESHOLD;
-    use crate::bottom_pane::{AppEventSender, ChatComposer, InputResult};
     use tui_textarea::TextArea;
 
     #[test]
@@ -805,7 +807,9 @@ mod tests {
 
     #[test]
     fn handle_paste_small_inserts_text() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
 
         let (tx, _rx) = std::sync::mpsc::channel();
         let sender = AppEventSender::new(tx);
@@ -826,7 +830,9 @@ mod tests {
 
     #[test]
     fn handle_paste_large_uses_placeholder_and_replaces_on_submit() {
-        use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
 
         let large = "x".repeat(LARGE_PASTE_CHAR_THRESHOLD + 10);
         let (tx, _rx) = std::sync::mpsc::channel();
@@ -850,8 +856,9 @@ mod tests {
 
     #[test]
     fn edit_clears_pending_paste() {
+        use crossterm::event::KeyCode;
         use crossterm::event::KeyEvent;
-        use crossterm::event::{KeyCode, KeyModifiers};
+        use crossterm::event::KeyModifiers;
 
         let large = "y".repeat(LARGE_PASTE_CHAR_THRESHOLD + 1);
         let (tx, _rx) = std::sync::mpsc::channel();
@@ -869,7 +876,8 @@ mod tests {
     #[test]
     fn ui_snapshots() {
         use insta::assert_snapshot;
-        use ratatui::{Terminal, backend::TestBackend};
+        use ratatui::Terminal;
+        use ratatui::backend::TestBackend;
 
         let (tx, _rx) = std::sync::mpsc::channel();
         let sender = AppEventSender::new(tx);

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -885,7 +885,7 @@ mod tests {
 
         let mut terminal = match Terminal::new(TestBackend::new(30, 4)) {
             Ok(t) => t,
-            Err(e) => panic!("Failed to create terminal: {}", e),
+            Err(e) => panic!("Failed to create terminal: {e}"),
         };
 
         if let Err(e) = terminal.draw(|f| f.render_widget_ref(&composer, f.area())) {

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -46,7 +46,7 @@ pub(crate) struct ChatComposer<'a> {
     ctrl_c_quit_hint: bool,
     dismissed_file_popup_token: Option<String>,
     current_file_query: Option<String>,
-    pending_paste: Option<(String, String)>,
+    pending_pastes: Vec<(String, String)>,
 }
 
 /// Popup state – at most one can be visible at any time.
@@ -70,7 +70,7 @@ impl ChatComposer<'_> {
             ctrl_c_quit_hint: false,
             dismissed_file_popup_token: None,
             current_file_query: None,
-            pending_paste: None,
+            pending_pastes: Vec::new(),
         };
         this.update_border(has_input_focus);
         this
@@ -136,7 +136,7 @@ impl ChatComposer<'_> {
         if char_count > LARGE_PASTE_CHAR_THRESHOLD {
             let placeholder = format!("[Pasted Content {char_count} chars]");
             self.textarea.insert_str(&placeholder);
-            self.pending_paste = Some((placeholder, pasted));
+            self.pending_pastes.push((placeholder, pasted));
         } else {
             self.textarea.insert_str(&pasted);
         }
@@ -437,11 +437,13 @@ impl ChatComposer<'_> {
                 self.textarea.select_all();
                 self.textarea.cut();
 
-                if let Some((placeholder, actual)) = self.pending_paste.take() {
-                    if text.contains(&placeholder) {
-                        text = text.replace(&placeholder, &actual);
+                // Replace all pending pastes in the text
+                for (placeholder, actual) in &self.pending_pastes {
+                    if text.contains(placeholder) {
+                        text = text.replace(placeholder, actual);
                     }
                 }
+                self.pending_pastes.clear();
 
                 if text.is_empty() {
                     (InputResult::None, true)
@@ -468,14 +470,69 @@ impl ChatComposer<'_> {
 
     /// Handle generic Input events that modify the textarea content.
     fn handle_input_basic(&mut self, input: Input) -> (InputResult, bool) {
-        self.textarea.input(input);
-        if let Some((placeholder, _)) = &self.pending_paste {
-            let text = self.textarea.lines().join("\n");
-            if !text.contains(placeholder) {
-                self.pending_paste = None;
+        // Special handling for backspace on placeholders
+        if let Input {
+            key: Key::Backspace,
+            ..
+        } = input
+        {
+            if self.try_remove_placeholder_at_cursor() {
+                return (InputResult::None, true);
             }
         }
+
+        // Normal input handling
+        self.textarea.input(input);
+        let text_after = self.textarea.lines().join("\n");
+
+        // Check if any placeholders were removed and remove their corresponding pending pastes
+        self.pending_pastes
+            .retain(|(placeholder, _)| text_after.contains(placeholder));
+
         (InputResult::None, true)
+    }
+
+    /// Attempts to remove a placeholder if the cursor is at the end of one.
+    /// Returns true if a placeholder was removed.
+    fn try_remove_placeholder_at_cursor(&mut self) -> bool {
+        let (row, col) = self.textarea.cursor();
+        let line = self
+            .textarea
+            .lines()
+            .get(row)
+            .map(|s| s.as_str())
+            .unwrap_or("");
+
+        // Find any placeholder that ends at the cursor position
+        let placeholder_to_remove = self.pending_pastes.iter().find_map(|(ph, _)| {
+            if col < ph.len() {
+                return None;
+            }
+            let potential_ph_start = col - ph.len();
+            if line[potential_ph_start..col] == *ph {
+                Some(ph.clone())
+            } else {
+                None
+            }
+        });
+
+        if let Some(placeholder) = placeholder_to_remove {
+            // Remove the entire placeholder from the text
+            let placeholder_len = placeholder.len();
+            for _ in 0..placeholder_len {
+                self.textarea.input(Input {
+                    key: Key::Backspace,
+                    ctrl: false,
+                    alt: false,
+                    shift: false,
+                });
+            }
+            // Remove from pending pastes
+            self.pending_pastes.retain(|(ph, _)| ph != &placeholder);
+            true
+        } else {
+            false
+        }
     }
 
     /// Synchronize `self.command_popup` with the current text in the
@@ -818,7 +875,7 @@ mod tests {
         let needs_redraw = composer.handle_paste("hello".to_string());
         assert!(needs_redraw);
         assert_eq!(composer.textarea.lines(), ["hello"]);
-        assert!(composer.pending_paste.is_none());
+        assert!(composer.pending_pastes.is_empty());
 
         let (result, _) =
             composer.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
@@ -834,16 +891,18 @@ mod tests {
         use crossterm::event::KeyEvent;
         use crossterm::event::KeyModifiers;
 
-        let large = "x".repeat(LARGE_PASTE_CHAR_THRESHOLD + 10);
         let (tx, _rx) = std::sync::mpsc::channel();
         let sender = AppEventSender::new(tx);
         let mut composer = ChatComposer::new(true, sender);
 
+        let large = "x".repeat(LARGE_PASTE_CHAR_THRESHOLD + 10);
         let needs_redraw = composer.handle_paste(large.clone());
         assert!(needs_redraw);
         let placeholder = format!("[Pasted Content {} chars]", large.chars().count());
         assert_eq!(composer.textarea.lines(), [placeholder.as_str()]);
-        assert!(composer.pending_paste.is_some());
+        assert_eq!(composer.pending_pastes.len(), 1);
+        assert_eq!(composer.pending_pastes[0].0, placeholder);
+        assert_eq!(composer.pending_pastes[0].1, large);
 
         let (result, _) =
             composer.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
@@ -851,7 +910,7 @@ mod tests {
             InputResult::Submitted(text) => assert_eq!(text, large),
             _ => panic!("expected Submitted"),
         }
-        assert!(composer.pending_paste.is_none());
+        assert!(composer.pending_pastes.is_empty());
     }
 
     #[test]
@@ -866,15 +925,18 @@ mod tests {
         let mut composer = ChatComposer::new(true, sender);
 
         composer.handle_paste(large);
-        assert!(composer.pending_paste.is_some());
+        assert_eq!(composer.pending_pastes.len(), 1);
 
         // Any edit that removes the placeholder should clear pending_paste
         composer.handle_key_event(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
-        assert!(composer.pending_paste.is_none());
+        assert!(composer.pending_pastes.is_empty());
     }
 
     #[test]
     fn ui_snapshots() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
         use insta::assert_snapshot;
         use ratatui::Terminal;
         use ratatui::backend::TestBackend;
@@ -891,6 +953,7 @@ mod tests {
             ("small", Some("short".to_string())),
             ("large", Some("z".repeat(LARGE_PASTE_CHAR_THRESHOLD + 5))),
             ("multiple_pastes", None),
+            ("backspace_after_pastes", None),
         ];
 
         for (name, input) in test_cases {
@@ -906,6 +969,14 @@ mod tests {
                 composer.handle_paste("y".repeat(LARGE_PASTE_CHAR_THRESHOLD + 7));
                 // Small paste
                 composer.handle_paste(" another short paste".to_string());
+            } else if name == "backspace_after_pastes" {
+                // Three large pastes
+                composer.handle_paste("a".repeat(LARGE_PASTE_CHAR_THRESHOLD + 2));
+                composer.handle_paste("b".repeat(LARGE_PASTE_CHAR_THRESHOLD + 4));
+                composer.handle_paste("c".repeat(LARGE_PASTE_CHAR_THRESHOLD + 6));
+                // Move cursor to end and press backspace
+                composer.textarea.move_cursor(tui_textarea::CursorMove::End);
+                composer.handle_key_event(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
             }
 
             terminal
@@ -914,5 +985,200 @@ mod tests {
 
             assert_snapshot!(name, terminal.backend());
         }
+    }
+
+    #[test]
+    fn test_multiple_pastes_submission() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let sender = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(true, sender);
+
+        // Define test cases: (paste content, is_large)
+        let test_cases = [
+            ("x".repeat(LARGE_PASTE_CHAR_THRESHOLD + 3), true),
+            (" and ".to_string(), false),
+            ("y".repeat(LARGE_PASTE_CHAR_THRESHOLD + 7), true),
+        ];
+
+        // Expected states after each paste
+        let mut expected_text = String::new();
+        let mut expected_pending_count = 0;
+
+        // Apply all pastes and build expected state
+        let states: Vec<_> = test_cases
+            .iter()
+            .map(|(content, is_large)| {
+                composer.handle_paste(content.clone());
+                if *is_large {
+                    let placeholder = format!("[Pasted Content {} chars]", content.chars().count());
+                    expected_text.push_str(&placeholder);
+                    expected_pending_count += 1;
+                } else {
+                    expected_text.push_str(content);
+                }
+                (expected_text.clone(), expected_pending_count)
+            })
+            .collect();
+
+        // Verify all intermediate states were correct
+        assert_eq!(
+            states,
+            vec![
+                (
+                    format!("[Pasted Content {} chars]", test_cases[0].0.chars().count()),
+                    1
+                ),
+                (
+                    format!(
+                        "[Pasted Content {} chars] and ",
+                        test_cases[0].0.chars().count()
+                    ),
+                    1
+                ),
+                (
+                    format!(
+                        "[Pasted Content {} chars] and [Pasted Content {} chars]",
+                        test_cases[0].0.chars().count(),
+                        test_cases[2].0.chars().count()
+                    ),
+                    2
+                ),
+            ]
+        );
+
+        // Submit and verify final expansion
+        let (result, _) =
+            composer.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        if let InputResult::Submitted(text) = result {
+            assert_eq!(text, format!("{} and {}", test_cases[0].0, test_cases[2].0));
+        } else {
+            panic!("expected Submitted");
+        }
+    }
+
+    #[test]
+    fn test_placeholder_deletion() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let sender = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(true, sender);
+
+        // Define test cases: (content, is_large)
+        let test_cases = [
+            ("a".repeat(LARGE_PASTE_CHAR_THRESHOLD + 5), true),
+            (" and ".to_string(), false),
+            ("b".repeat(LARGE_PASTE_CHAR_THRESHOLD + 6), true),
+        ];
+
+        // Apply all pastes
+        let mut current_pos = 0;
+        let states: Vec<_> = test_cases
+            .iter()
+            .map(|(content, is_large)| {
+                composer.handle_paste(content.clone());
+                if *is_large {
+                    let placeholder = format!("[Pasted Content {} chars]", content.chars().count());
+                    current_pos += placeholder.len();
+                } else {
+                    current_pos += content.len();
+                }
+                (
+                    composer.textarea.lines().join("\n"),
+                    composer.pending_pastes.len(),
+                    current_pos,
+                )
+            })
+            .collect();
+
+        // Delete placeholders one by one and collect states
+        let mut deletion_states = vec![];
+
+        // First deletion
+        composer
+            .textarea
+            .move_cursor(tui_textarea::CursorMove::Jump(0, states[0].2 as u16));
+        composer.handle_key_event(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
+        deletion_states.push((
+            composer.textarea.lines().join("\n"),
+            composer.pending_pastes.len(),
+        ));
+
+        // Second deletion
+        composer
+            .textarea
+            .move_cursor(tui_textarea::CursorMove::Jump(
+                0,
+                composer.textarea.lines().join("\n").len() as u16,
+            ));
+        composer.handle_key_event(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
+        deletion_states.push((
+            composer.textarea.lines().join("\n"),
+            composer.pending_pastes.len(),
+        ));
+
+        // Verify all states
+        assert_eq!(
+            deletion_states,
+            vec![
+                (" and [Pasted Content 1006 chars]".to_string(), 1),
+                (" and ".to_string(), 0),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_partial_placeholder_deletion() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        let (tx, _rx) = std::sync::mpsc::channel();
+        let sender = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(true, sender);
+
+        // Define test cases: (cursor_position_from_end, expected_pending_count)
+        let test_cases = [
+            5, // Delete from middle - should clear tracking
+            0, // Delete from end - should clear tracking
+        ];
+
+        let paste = "x".repeat(LARGE_PASTE_CHAR_THRESHOLD + 4);
+        let placeholder = format!("[Pasted Content {} chars]", paste.chars().count());
+
+        let states: Vec<_> = test_cases
+            .into_iter()
+            .map(|pos_from_end| {
+                composer.handle_paste(paste.clone());
+                composer
+                    .textarea
+                    .move_cursor(tui_textarea::CursorMove::Jump(
+                        0,
+                        (placeholder.len() - pos_from_end) as u16,
+                    ));
+                composer.handle_key_event(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
+                let result = (
+                    composer.textarea.lines().join("\n").contains(&placeholder),
+                    composer.pending_pastes.len(),
+                );
+                composer.textarea.select_all();
+                composer.textarea.cut();
+                result
+            })
+            .collect();
+
+        assert_eq!(
+            states,
+            vec![
+                (false, 0), // After deleting from middle
+                (false, 0), // After deleting from end
+            ]
+        );
     }
 }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -82,6 +82,15 @@ impl BottomPane<'_> {
         }
     }
 
+    pub fn handle_paste(&mut self, pasted: String) {
+        if self.active_view.is_none() {
+            let needs_redraw = self.composer.handle_paste(pasted);
+            if needs_redraw {
+                self.request_redraw();
+            }
+        }
+    }
+
     /// Update the status indicator text (only when the `StatusIndicatorView` is
     /// active).
     pub(crate) fn update_status_text(&mut self, text: String) {

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__backspace_after_pastes.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__backspace_after_pastes.snap
@@ -1,0 +1,14 @@
+---
+source: tui/src/bottom_pane/chat_composer.rs
+expression: terminal.backend()
+---
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮"
+"│[Pasted Content 1002 chars][Pasted Content 1004 chars]                                            │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"╰───────────────────────────────────────────────Enter to send | Ctrl+D to quit | Ctrl+J for newline╯"

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__empty.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__empty.snap
@@ -2,7 +2,13 @@
 source: tui/src/bottom_pane/chat_composer.rs
 expression: terminal.backend()
 ---
-"╭────────────────────────────╮"
-"│ send a message             │"
-"│                            │"
-"╰to quit | Ctrl+J for newline╯"
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮"
+"│ send a message                                                                                   │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"╰───────────────────────────────────────────────Enter to send | Ctrl+D to quit | Ctrl+J for newline╯"

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__empty.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__empty.snap
@@ -1,0 +1,8 @@
+---
+source: tui/src/bottom_pane/chat_composer.rs
+expression: terminal.backend()
+---
+"╭────────────────────────────╮"
+"│ send a message             │"
+"│                            │"
+"╰to quit | Ctrl+J for newline╯"

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__large.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__large.snap
@@ -1,0 +1,8 @@
+---
+source: tui/src/bottom_pane/chat_composer.rs
+expression: terminal.backend()
+---
+"╭────────────────────────────╮"
+"│t[Pasted Content 105 chars] │"
+"│                            │"
+"╰to quit | Ctrl+J for newline╯"

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__multiple_pastes.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__multiple_pastes.snap
@@ -3,7 +3,7 @@ source: tui/src/bottom_pane/chat_composer.rs
 expression: terminal.backend()
 ---
 "╭──────────────────────────────────────────────────────────────────────────────────────────────────╮"
-"│[Pasted Content 1005 chars]                                                                       │"
+"│[Pasted Content 1003 chars][Pasted Content 1007 chars] another short paste                        │"
 "│                                                                                                  │"
 "│                                                                                                  │"
 "│                                                                                                  │"

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
@@ -2,7 +2,13 @@
 source: tui/src/bottom_pane/chat_composer.rs
 expression: terminal.backend()
 ---
-"╭────────────────────────────╮"
-"│short                       │"
-"│                            │"
-"╰to quit | Ctrl+J for newline╯"
+"╭──────────────────────────────────────────────────────────────────────────────────────────────────╮"
+"│short                                                                                             │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"│                                                                                                  │"
+"╰───────────────────────────────────────────────Enter to send | Ctrl+D to quit | Ctrl+J for newline╯"

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
@@ -1,0 +1,8 @@
+---
+source: tui/src/bottom_pane/chat_composer.rs
+expression: terminal.backend()
+---
+"╭────────────────────────────╮"
+"│short                       │"
+"│                            │"
+"╰to quit | Ctrl+J for newline╯"

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -174,6 +174,12 @@ impl ChatWidget<'_> {
         }
     }
 
+    pub(crate) fn handle_paste(&mut self, text: String) {
+        if matches!(self.input_focus, InputFocus::BottomPane) {
+            self.bottom_pane.handle_paste(text);
+        }
+    }
+
     fn submit_user_message(&mut self, user_message: UserMessage) {
         let UserMessage { text, image_paths } = user_message;
         let mut items: Vec<InputItem> = Vec::new();


### PR DESCRIPTION
## Summary
- introduce `Paste` event to avoid per-character paste handling
- collapse large pasted blocks to `[Pasted Content X lines]`
- store the real text so submission still includes it
- wire paste handling through `App`, `ChatWidget`, `BottomPane`, and `ChatComposer`

## Testing
- `cargo test -p codex-tui`


------
https://chatgpt.com/codex/tasks/task_i_6871e24abf80832184d1f3ca0c61a5ee

https://github.com/user-attachments/assets/eda7412f-da30-4474-9f7c-96b49d48fbf8