### PR TITLE
Allow deadcode in test_support

### DIFF
--- a/codex-rs/core/tests/test_support.rs
+++ b/codex-rs/core/tests/test_support.rs
@@ -30,6 +30,7 @@ pub fn load_default_config_for_test(codex_home: &TempDir) -> Config {
 /// with only a `type` field results in an event with no `data:` section. This
 /// makes it trivial to extend the fixtures as OpenAI adds new event kinds or
 /// fields.
+#[allow(dead_code)]
 pub fn load_sse_fixture(path: impl AsRef<std::path::Path>) -> String {
     let events: Vec<serde_json::Value> =
         serde_json::from_reader(std::fs::File::open(path).expect("read fixture"))
@@ -54,6 +55,7 @@ pub fn load_sse_fixture(path: impl AsRef<std::path::Path>) -> String {
 /// fixture template with the supplied identifier before parsing. This lets a
 /// single JSON template be reused by multiple tests that each need a unique
 /// `response_id`.
+#[allow(dead_code)]
 pub fn load_sse_fixture_with_id(path: impl AsRef<std::path::Path>, id: &str) -> String {
     let raw = std::fs::read_to_string(path).expect("read fixture template");
     let replaced = raw.replace("__ID__", id);


### PR DESCRIPTION
#1546 Was pushed while not passing the clippy integration tests. This is fixing it.