### PR TITLE
docs: clarify the build process for the npm release

### DIFF
--- a/codex-cli/scripts/README.md
+++ b/codex-cli/scripts/README.md
@@ -1,0 +1,9 @@
+# npm releases
+
+Run the following:
+
+To build the 0.2.x or later version of the npm module, which runs the Rust version of the CLI, build it as follows:
+
+```bash
+./codex-cli/scripts/stage_rust_release.py --release-version 0.6.0
+```

--- a/codex-cli/scripts/stage_release.sh
+++ b/codex-cli/scripts/stage_release.sh
@@ -4,10 +4,7 @@
 # -----------------------------------------------------------------------------
 # Stages an npm release for @openai/codex.
 #
-# The script used to accept a single optional positional argument that indicated
-# the temporary directory in which to stage the package.  We now support a
-# flag-based interface so that we can extend the command with further options
-# without breaking the call-site contract.
+# Usage:
 #
 #   --tmp <dir>  : Use <dir> instead of a freshly created temp directory.
 #   --native     : Bundle the pre-built Rust CLI binaries for Linux alongside
@@ -141,7 +138,8 @@ popd >/dev/null
 echo "Staged version $VERSION for release in $TMPDIR"
 
 if [[ "$INCLUDE_NATIVE" -eq 1 ]]; then
-  echo "Test Rust:"
+  echo "Verify the CLI:"
+  echo "    node ${TMPDIR}/bin/codex.js --version"
   echo "    node ${TMPDIR}/bin/codex.js --help"
 else
   echo "Test Node:"


### PR DESCRIPTION
It appears that `0.5.0` was built with `stage_release.sh` instead of `stage_rust_release.py`, so add docs to clarify this and recommend running `--version` on the release candidate to verify the right thing was built.