### PR TITLE
Added mcp-server name validation

### DIFF
--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -40,9 +40,9 @@ fn fully_qualified_tool_name(server: &str, tool: &str) -> String {
 }
 // Validate MCPserver name
 fn is_valid_server_name(s: &str) -> bool {
-    !s.is_empty() && s.chars().all(|c| {
-        c.is_ascii_alphanumeric() || c == '_' || c == '-'
-    })
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }
 pub(crate) fn try_parse_fully_qualified_tool_name(fq_name: &str) -> Option<(String, String)> {
     let (server, tool) = fq_name.split_once(MCP_TOOL_NAME_DELIMITER)?;
@@ -89,11 +89,14 @@ impl McpConnectionManager {
         for (server_name, cfg) in mcp_servers {
             // Validate server name before spawning
             if !is_valid_server_name(&server_name) {
-                let error = anyhow::anyhow!("invalid server name '{}': must match pattern ^[a-zA-Z0-9_-]+$", server_name);
+                let error = anyhow::anyhow!(
+                    "invalid server name '{}': must match pattern ^[a-zA-Z0-9_-]+$",
+                    server_name
+                );
                 errors.insert(server_name, error);
                 continue;
             }
-            
+
             join_set.spawn(async move {
                 let McpServerConfig { command, args, env } = cfg;
                 let client_res = McpClient::new_stdio_client(command, args, env).await;

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -38,12 +38,7 @@ pub type ClientStartErrors = HashMap<String, anyhow::Error>;
 fn fully_qualified_tool_name(server: &str, tool: &str) -> String {
     format!("{server}{MCP_TOOL_NAME_DELIMITER}{tool}")
 }
-// Validate MCPserver name
-fn is_valid_server_name(s: &str) -> bool {
-    !s.is_empty()
-        && s.chars()
-            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
-}
+
 pub(crate) fn try_parse_fully_qualified_tool_name(fq_name: &str) -> Option<(String, String)> {
     let (server, tool) = fq_name.split_once(MCP_TOOL_NAME_DELIMITER)?;
     if server.is_empty() || tool.is_empty() {
@@ -221,4 +216,10 @@ pub async fn list_all_tools(
     );
 
     Ok(aggregated)
+}
+
+fn is_valid_server_name(s: &server_name) -> bool {
+    !server_name.is_empty()
+        && server_name.chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -220,6 +220,7 @@ pub async fn list_all_tools(
 
 fn is_valid_server_name(s: &server_name) -> bool {
     !server_name.is_empty()
-        && server_name.chars()
+        && server_name
+            .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
 }

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -83,7 +83,7 @@ impl McpConnectionManager {
 
         for (server_name, cfg) in mcp_servers {
             // Validate server name before spawning
-            if !is_valid_server_name(&server_name) {
+            if !is_valid_mcp_server_name(&server_name) {
                 let error = anyhow::anyhow!(
                     "invalid server name '{}': must match pattern ^[a-zA-Z0-9_-]+$",
                     server_name
@@ -218,7 +218,7 @@ pub async fn list_all_tools(
     Ok(aggregated)
 }
 
-fn is_valid_server_name(s: &server_name) -> bool {
+fn is_valid_mcp_server_name(server_name: &str) -> bool {
     !server_name.is_empty()
         && server_name
             .chars()

--- a/codex-rs/core/src/util.rs
+++ b/codex-rs/core/src/util.rs
@@ -64,9 +64,3 @@ pub fn is_inside_git_repo(config: &Config) -> bool {
 
     false
 }
-
-pub fn is_valid_server_name(server_name: &str) -> bool {
-    !server_name.is_empty() && server_name.chars().all(|c| {
-        c.is_ascii_alphanumeric() || c == '_' || c == '-'
-    })
-}

--- a/codex-rs/core/src/util.rs
+++ b/codex-rs/core/src/util.rs
@@ -64,3 +64,9 @@ pub fn is_inside_git_repo(config: &Config) -> bool {
 
     false
 }
+
+pub fn is_valid_server_name(server_name: &str) -> bool {
+    !server_name.is_empty() && server_name.chars().all(|c| {
+        c.is_ascii_alphanumeric() || c == '_' || c == '-'
+    })
+}


### PR DESCRIPTION
This PR implements server name validation for MCP (Model Context Protocol) servers to ensure they conform to the required pattern ^[a-zA-Z0-9_-]+$. This addresses the TODO comment in mcp_connection_manager.rs:82.

+ Added validation before spawning MCP client tasks
+ Invalid server names are added to errors map with descriptive messages

I have read the CLA Document and I hereby sign the CLA

