### PR TITLE
change the default debounce rate to 10ms

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -26,7 +26,7 @@ use std::thread;
 use std::time::Duration;
 
 /// Time window for debouncing redraw requests.
-const REDRAW_DEBOUNCE: Duration = Duration::from_millis(100);
+const REDRAW_DEBOUNCE: Duration = Duration::from_millis(10);
 
 /// Top-level application state: which full-screen view is currently active.
 #[allow(clippy::large_enum_variant)]


### PR DESCRIPTION
changed the default debounce rate to 10ms because typing was laggy.

Before:

https://github.com/user-attachments/assets/e5d15fcb-6a2b-4837-b2b4-c3dcb4cc3409

After


https://github.com/user-attachments/assets/6f0005eb-fd49-4130-ba68-635ee0f2831f

