### PR TITLE
feat-rust-cli-local-ollama-support

### DIFF
--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -443,9 +443,6 @@ async fn process_chat_sse<S>(
                                 let _ = tx_event.send(Ok(ResponseEvent::OutputItemDone(item))).await;
                             }
                         }
-                            };
-                            let _ = tx_event.send(Ok(ResponseEvent::OutputItemDone(item))).await;
-                        }
                     }
                     _ => {}
                 }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1760,14 +1760,18 @@ fn parse_container_exec_arguments(
     call_id: &str,
 ) -> Result<ExecParams, Box<ResponseInputItem>> {
     // parse command
+    debug!("Parsing shell arguments: {}", arguments);
     match serde_json::from_str::<ShellToolCallParams>(&arguments) {
-        Ok(shell_tool_call_params) => Ok(to_exec_params(shell_tool_call_params, sess)),
+        Ok(shell_tool_call_params) => {
+            debug!("Parsed shell params: {:?}", shell_tool_call_params);
+            Ok(to_exec_params(shell_tool_call_params, sess))
+        }
         Err(e) => {
             // allow model to re-sample
             let output = ResponseInputItem::FunctionCallOutput {
                 call_id: call_id.to_string(),
                 output: FunctionCallOutputPayload {
-                    content: format!("failed to parse function arguments: {e}"),
+                    content: format!("failed to parse function arguments: {e}\nArguments were: {arguments}"),
                     success: None,
                 },
             };

--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -265,19 +265,21 @@ pub(crate) fn create_tools_json_for_chat_completions_api(
             if tool.get("type") != Some(&serde_json::Value::String("function".to_string())) {
                 return None;
             }
-
-            if let Some(map) = tool.as_object_mut() {
-                // Remove "type" field as it is not needed in chat completions.
-                map.remove("type");
+            
+            // Convert from Responses API format to Chat Completions format
+            if let Some(map) = tool.as_object() {
+                let mut function_map = map.clone();
+                function_map.remove("type");
                 Some(json!({
                     "type": "function",
-                    "function": map,
+                    "function": function_map,
                 }))
             } else {
                 None
             }
         })
-        .collect::<Vec<serde_json::Value>>();
+        .collect();
+
     Ok(tools_json)
 }
 

--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -261,7 +261,7 @@ pub(crate) fn create_tools_json_for_chat_completions_api(
     let responses_api_tools_json = create_tools_json_for_responses_api(tools)?;
     let tools_json = responses_api_tools_json
         .into_iter()
-        .filter_map(|mut tool| {
+        .filter_map(|tool| {
             if tool.get("type") != Some(&serde_json::Value::String("function".to_string())) {
                 return None;
             }

--- a/example_config.toml
+++ b/example_config.toml
@@ -1,0 +1,35 @@
+# Example configuration showing how to use alternate providers
+# This demonstrates the fixes for API key requirement and tool calling issues
+
+# Use Ollama as the default provider
+model_provider = "ollama"
+model = "qwen2.5:7b"  # Tools will work correctly with any model name
+approval_policy = "never"  # Required for tools to execute automatically
+
+# Define providers - note that Ollama doesn't require an API key
+[model_providers.ollama]
+name = "Ollama"
+base_url = "http://localhost:11434/v1"
+# No env_key needed for local providers
+
+[model_providers.mistral]
+name = "Mistral AI"
+base_url = "https://api.mistral.ai/v1"
+env_key = "MISTRAL_API_KEY"  # Optional - will work even if not set
+
+# OpenAI still requires API key (unchanged behavior)
+[model_providers.openai]
+name = "OpenAI"
+base_url = "https://api.openai.com/v1"
+env_key = "OPENAI_API_KEY"  # Required for OpenAI
+
+# Example profiles for easy switching
+[profiles.local]
+model_provider = "ollama"
+model = "qwen2.5:7b"
+approval_policy = "never"
+
+[profiles.cloud]
+model_provider = "mistral"
+model = "mistral-large-latest"
+approval_policy = "on-failure"


### PR DESCRIPTION
This is a set of fixes (and tests) tracking down the same issues as #1424 (where the JSON messages are not correctly processed and tools are not correctly called, even in `full-auto` mode) and a correction to address the need to specify environment variables for unneeded APIs in #1558.

I've tested this locally and it appears to work without issue. My configurations are listed on #1558 for any other testing.