### PR TITLE
Pass call_id to ExecApprovalRequestEvent

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -246,6 +246,7 @@ impl Session {
     pub async fn request_command_approval(
         &self,
         sub_id: String,
+        call_id: String,
         command: Vec<String>,
         cwd: PathBuf,
         reason: Option<String>,
@@ -257,6 +258,7 @@ impl Session {
                 command,
                 cwd,
                 reason,
+                call_id,
             }),
         };
         let _ = self.tx_event.send(event).await;
@@ -1391,6 +1393,7 @@ async fn handle_container_exec_with_params(
             let rx_approve = sess
                 .request_command_approval(
                     sub_id.clone(),
+                    call_id.clone(),
                     params.command.clone(),
                     params.cwd.clone(),
                     None,
@@ -1518,6 +1521,7 @@ async fn handle_sandbox_error(
     let rx_approve = sess
         .request_command_approval(
             sub_id.clone(),
+            call_id.clone(),
             params.command.clone(),
             params.cwd.clone(),
             Some("command failed; retry without sandbox?".to_string()),

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -414,6 +414,8 @@ pub struct ExecCommandEndEvent {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ExecApprovalRequestEvent {
+    /// Identifier to tie the tool call events together
+    pub call_id: String,
     /// The command to be executed.
     pub command: Vec<String>,
     /// The command's working directory.

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -316,6 +316,7 @@ impl ChatWidget<'_> {
                 command,
                 cwd,
                 reason,
+                call_id: _,
             }) => {
                 let request = ApprovalRequest::Exec {
                     id,


### PR DESCRIPTION
Its useful to be able to correlate which approval request
corresponds to which tool call.
