### PR TITLE
chore: for release build, build specific targets instead of --all-targets

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -93,7 +93,7 @@ jobs:
           sudo apt install -y musl-tools pkg-config
 
       - name: Cargo build
-        run: cargo build --target ${{ matrix.target }} --release --all-targets --all-features
+        run: cargo build --target ${{ matrix.target }} --release --bin codex --bin codex-exec --bin codex-linux-sandbox
 
       - name: Stage artifacts
         shell: bash


### PR DESCRIPTION
I noticed that releases have taken longer and longer to build. Originally, I think I did `--all-targets` to be confident that everything builds cleanly, but that's really the job of CI that runs on `main`, so we're spending a lot of time in `rust-release.yml` for not that much additional signal.