### PR TITLE
[Codex] Improve messages emitted for exec failures

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -143,6 +143,10 @@ pub struct Config {
 
     /// Experimental rollout resume path (absolute path to .jsonl; undocumented).
     pub experimental_resume: Option<PathBuf>,
+
+    /// When true, force any sandboxed command execution attempt to fail prior to execution.
+    /// This is useful for testing sandbox escalation and fallback handling paths.
+    pub always_fail_sandbox: bool,
 }
 
 impl Config {
@@ -333,6 +337,10 @@ pub struct ConfigToml {
 
     /// Experimental path to a file whose contents replace the built-in BASE_INSTRUCTIONS.
     pub experimental_instructions_file: Option<PathBuf>,
+
+    /// When true, force any sandboxed command execution attempt to fail prior to execution.
+    /// This is useful for testing sandbox escalation and fallback handling paths.
+    pub always_fail_sandbox: Option<bool>,
 }
 
 impl ConfigToml {
@@ -518,6 +526,7 @@ impl Config {
                 .unwrap_or("https://chatgpt.com/backend-api/".to_string()),
 
             experimental_resume,
+            always_fail_sandbox: cfg.always_fail_sandbox.unwrap_or(false),
         };
         Ok(config)
     }
@@ -841,6 +850,7 @@ disable_response_storage = true
                 chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
                 experimental_resume: None,
                 base_instructions: None,
+                always_fail_sandbox: false,
             },
             o3_profile_config
         );
@@ -889,6 +899,7 @@ disable_response_storage = true
             chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
             experimental_resume: None,
             base_instructions: None,
+            always_fail_sandbox: false,
         };
 
         assert_eq!(expected_gpt3_profile_config, gpt3_profile_config);
@@ -952,6 +963,7 @@ disable_response_storage = true
             chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
             experimental_resume: None,
             base_instructions: None,
+            always_fail_sandbox: false,
         };
 
         assert_eq!(expected_zdr_profile_config, zdr_profile_config);

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -422,6 +422,8 @@ pub struct ExecCommandEndEvent {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct ExecApprovalRequestEvent {
+    /// Identifier for the associated exec call, if available.
+    pub call_id: String,
     /// The command to be executed.
     pub command: Vec<String>,
     /// The command's working directory.

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -156,6 +156,7 @@ async fn run_codex_tool_session_inner(
                     EventMsg::ExecApprovalRequest(ExecApprovalRequestEvent {
                         command,
                         cwd,
+                        call_id: _,
                         reason: _,
                     }) => {
                         handle_exec_approval_request(

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -314,6 +314,7 @@ impl ChatWidget<'_> {
                 self.bottom_pane.set_task_running(false);
             }
             EventMsg::ExecApprovalRequest(ExecApprovalRequestEvent {
+                call_id: _,
                 command,
                 cwd,
                 reason,
@@ -362,7 +363,7 @@ impl ChatWidget<'_> {
                 cwd: _,
             }) => {
                 self.conversation_history
-                    .add_active_exec_command(call_id, command);
+                    .reset_or_add_active_exec_command(call_id, command);
                 self.request_redraw();
             }
             EventMsg::PatchApplyBegin(PatchApplyBeginEvent {

--- a/codex-rs/tui/src/conversation_history_widget.rs
+++ b/codex-rs/tui/src/conversation_history_widget.rs
@@ -235,6 +235,33 @@ impl ConversationHistoryWidget {
         self.add_to_history(HistoryCell::new_active_exec_command(call_id, command));
     }
 
+    /// If an ActiveExecCommand with the same call_id already exists, replace
+    /// it with a fresh one (resetting start time and view). Otherwise, add a new entry.
+    pub fn reset_or_add_active_exec_command(&mut self, call_id: String, command: Vec<String>) {
+        // Find the most recent matching ActiveExecCommand.
+        let maybe_idx = self
+            .entries
+            .iter()
+            .rposition(|entry| {
+                if let HistoryCell::ActiveExecCommand { call_id: id, .. } = &entry.cell {
+                    id == &call_id
+                } else {
+                    false
+                }
+            });
+
+        if let Some(idx) = maybe_idx {
+            let width = self.cached_width.get();
+            self.entries[idx].cell = HistoryCell::new_active_exec_command(call_id.clone(), command);
+            if width > 0 {
+                let height = self.entries[idx].cell.height(width);
+                self.entries[idx].line_count.set(height);
+            }
+        } else {
+            self.add_active_exec_command(call_id, command);
+        }
+    }
+
     pub fn add_active_mcp_tool_call(
         &mut self,
         call_id: String,

--- a/codex-rs/tui/src/conversation_history_widget.rs
+++ b/codex-rs/tui/src/conversation_history_widget.rs
@@ -239,16 +239,13 @@ impl ConversationHistoryWidget {
     /// it with a fresh one (resetting start time and view). Otherwise, add a new entry.
     pub fn reset_or_add_active_exec_command(&mut self, call_id: String, command: Vec<String>) {
         // Find the most recent matching ActiveExecCommand.
-        let maybe_idx = self
-            .entries
-            .iter()
-            .rposition(|entry| {
-                if let HistoryCell::ActiveExecCommand { call_id: id, .. } = &entry.cell {
-                    id == &call_id
-                } else {
-                    false
-                }
-            });
+        let maybe_idx = self.entries.iter().rposition(|entry| {
+            if let HistoryCell::ActiveExecCommand { call_id: id, .. } = &entry.cell {
+                id == &call_id
+            } else {
+                false
+            }
+        });
 
         if let Some(idx) = maybe_idx {
             let width = self.cached_width.get();

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -174,6 +174,9 @@ impl HistoryCell {
             for (key, value) in entries {
                 lines.push(Line::from(vec![format!("{key}: ").bold(), value.into()]));
             }
+            if config.always_fail_sandbox {
+                lines.push(Line::from("Always fail in sandbox is on".red().bold()));
+            }
             lines.push(Line::from(""));
             HistoryCell::WelcomeMessage {
                 view: TextBlock::new(lines),


### PR DESCRIPTION
1. Allow you to set a config to auto-fail all commands in the sandbox
2. Emit call_id to exec approval elicitations for mcp client convenience
3. Remove the `-retry` from the call id for the same reason as above but upstream the reset behavior to the mcp client