### PR TITLE
[client] Add item ids for deltas and messages

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -230,6 +230,7 @@ struct SseEvent {
     response: Option<Value>,
     item: Option<Value>,
     delta: Option<String>,
+    item_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -360,21 +361,22 @@ async fn process_sse<S>(
                 };
 
                 let event = ResponseEvent::OutputItemDone(item);
+                trace!(?event, "output_item.done");
                 if tx_event.send(Ok(event)).await.is_err() {
                     return;
                 }
             }
             "response.output_text.delta" => {
-                if let Some(delta) = event.delta {
-                    let event = ResponseEvent::OutputTextDelta(delta);
+                if let (Some(delta), Some(item_id)) = (event.delta, event.item_id) {
+                    let event = ResponseEvent::OutputTextDelta { delta, item_id };
                     if tx_event.send(Ok(event)).await.is_err() {
                         return;
                     }
                 }
             }
             "response.reasoning_summary_text.delta" => {
-                if let Some(delta) = event.delta {
-                    let event = ResponseEvent::ReasoningSummaryDelta(delta);
+                if let (Some(delta), Some(item_id)) = (event.delta, event.item_id) {
+                    let event = ResponseEvent::ReasoningSummaryDelta { delta, item_id };
                     if tx_event.send(Ok(event)).await.is_err() {
                         return;
                     }

--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -56,6 +56,8 @@ impl Prompt {
     }
 }
 
+/// Events emitted by the response stream.
+/// https://platform.openai.com/docs/api-reference/responses-streaming/response
 #[derive(Debug)]
 pub enum ResponseEvent {
     Created,
@@ -64,8 +66,14 @@ pub enum ResponseEvent {
         response_id: String,
         token_usage: Option<TokenUsage>,
     },
-    OutputTextDelta(String),
-    ReasoningSummaryDelta(String),
+    OutputTextDelta {
+        delta: String,
+        item_id: String,
+    },
+    ReasoningSummaryDelta {
+        delta: String,
+        item_id: String,
+    },
 }
 
 #[derive(Debug, Serialize)]

--- a/codex-rs/core/src/models.rs
+++ b/codex-rs/core/src/models.rs
@@ -37,6 +37,7 @@ pub enum ContentItem {
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum ResponseItem {
     Message {
+        id: Option<String>,
         role: String,
         content: Vec<ContentItem>,
     },
@@ -78,7 +79,11 @@ pub enum ResponseItem {
 impl From<ResponseInputItem> for ResponseItem {
     fn from(item: ResponseInputItem) -> Self {
         match item {
-            ResponseInputItem::Message { role, content } => Self::Message { role, content },
+            ResponseInputItem::Message { role, content } => Self::Message {
+                id: None,
+                role,
+                content,
+            },
             ResponseInputItem::FunctionCallOutput { call_id, output } => {
                 Self::FunctionCallOutput { call_id, output }
             }

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -351,22 +351,26 @@ pub struct TokenUsage {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentMessageEvent {
+    pub id: Option<String>,
     pub message: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentMessageDeltaEvent {
     pub delta: String,
+    pub item_id: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentReasoningEvent {
+    pub id: String,
     pub text: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct AgentReasoningDeltaEvent {
     pub delta: String,
+    pub item_id: String,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/codex-rs/core/tests/live_agent.rs
+++ b/codex-rs/core/tests/live_agent.rs
@@ -120,7 +120,7 @@ async fn live_streaming_and_prev_id_reset() {
             .expect("agent closed");
 
         match &ev.msg {
-            EventMsg::AgentMessage(AgentMessageEvent { message })
+            EventMsg::AgentMessage(AgentMessageEvent { id: _, message })
                 if message.contains("second turn succeeded") =>
             {
                 got_expected = true;

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -174,7 +174,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
             EventMsg::TokenCount(TokenUsage { total_tokens, .. }) => {
                 ts_println!(self, "tokens used: {total_tokens}");
             }
-            EventMsg::AgentMessageDelta(AgentMessageDeltaEvent { delta }) => {
+            EventMsg::AgentMessageDelta(AgentMessageDeltaEvent { delta, item_id: _ }) => {
                 if !self.answer_started {
                     ts_println!(self, "{}\n", "codex".style(self.italic).style(self.magenta));
                     self.answer_started = true;
@@ -183,7 +183,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                 #[allow(clippy::expect_used)]
                 std::io::stdout().flush().expect("could not flush stdout");
             }
-            EventMsg::AgentReasoningDelta(AgentReasoningDeltaEvent { delta }) => {
+            EventMsg::AgentReasoningDelta(AgentReasoningDeltaEvent { delta, item_id: _ }) => {
                 if !self.show_agent_reasoning {
                     return;
                 }
@@ -199,7 +199,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                 #[allow(clippy::expect_used)]
                 std::io::stdout().flush().expect("could not flush stdout");
             }
-            EventMsg::AgentMessage(AgentMessageEvent { message }) => {
+            EventMsg::AgentMessage(AgentMessageEvent { id: _, message }) => {
                 // if answer_started is false, this means we haven't received any
                 // delta. Thus, we need to print the message as a new answer.
                 if !self.answer_started {

--- a/codex-rs/mcp-server/src/outgoing_message.rs
+++ b/codex-rs/mcp-server/src/outgoing_message.rs
@@ -16,6 +16,7 @@ use serde::Serialize;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
+use tracing::trace;
 use tracing::warn;
 
 pub(crate) struct OutgoingMessageSender {
@@ -79,6 +80,7 @@ impl OutgoingMessageSender {
     }
 
     pub(crate) async fn send_event_as_notification(&self, event: &Event) {
+        trace!(?event, "sending event as notification");
         #[expect(clippy::expect_used)]
         let params = Some(serde_json::to_value(event).expect("Event must serialize"));
         let outgoing_message = OutgoingMessage::Notification(OutgoingNotification {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -246,7 +246,7 @@ impl ChatWidget<'_> {
 
                 self.request_redraw();
             }
-            EventMsg::AgentMessage(AgentMessageEvent { message }) => {
+            EventMsg::AgentMessage(AgentMessageEvent { id: _, message }) => {
                 // if the answer buffer is empty, this means we haven't received any
                 // delta. Thus, we need to print the message as a new answer.
                 if self.answer_buffer.is_empty() {
@@ -259,7 +259,7 @@ impl ChatWidget<'_> {
                 self.answer_buffer.clear();
                 self.request_redraw();
             }
-            EventMsg::AgentMessageDelta(AgentMessageDeltaEvent { delta }) => {
+            EventMsg::AgentMessageDelta(AgentMessageDeltaEvent { delta, .. }) => {
                 if self.answer_buffer.is_empty() {
                     self.conversation_history
                         .add_agent_message(&self.config, "".to_string());
@@ -269,7 +269,7 @@ impl ChatWidget<'_> {
                     .replace_prev_agent_message(&self.config, self.answer_buffer.clone());
                 self.request_redraw();
             }
-            EventMsg::AgentReasoningDelta(AgentReasoningDeltaEvent { delta }) => {
+            EventMsg::AgentReasoningDelta(AgentReasoningDeltaEvent { delta, .. }) => {
                 if self.reasoning_buffer.is_empty() {
                     self.conversation_history
                         .add_agent_reasoning(&self.config, "".to_string());
@@ -279,7 +279,7 @@ impl ChatWidget<'_> {
                     .replace_prev_agent_reasoning(&self.config, self.reasoning_buffer.clone());
                 self.request_redraw();
             }
-            EventMsg::AgentReasoning(AgentReasoningEvent { text }) => {
+            EventMsg::AgentReasoning(AgentReasoningEvent { id: _, text }) => {
                 // if the reasoning buffer is empty, this means we haven't received any
                 // delta. Thus, we need to print the message as a new reasoning.
                 if self.reasoning_buffer.is_empty() {


### PR DESCRIPTION
## Summary
Includes `id` in Message and Reasoning from `response.output_item.done` streaming events, and `item_id` in .delta events, so mcp clients can match deltas to their eventual final event.

Open Question: I think we re-use the same `ResponseItem::Message` struct for API input and output, which leads to some unnecessary `id: Option<String>` fields. Should we separate these? @bolinfest 

## Test Plan
- [x] Tested locally with mcp client