### PR TITLE
Optimize deleteWordLeft loop iteration

### DIFF
--- a/codex-cli/src/text-buffer.ts
+++ b/codex-cli/src/text-buffer.ts
@@ -457,7 +457,7 @@ export default class TextBuffer {
     // then, on the next call, the previous word. We should never delete the entire line.
     let start = this.cursorCol;
     let onlySpaces = true;
-    for (let i = 0; i < start; i++) {
+    for (let i = start - 1; i >= 0; i--) {
       if (isWordChar(arr[i])) {
         onlySpaces = false;
         break;


### PR DESCRIPTION
This PR optimizes the loop in `deleteWordLeft` that checks for word characters. Instead of iterating forward through all characters from 0 to cursor position, it now iterates backward from the cursor. This is more efficient since we can exit early when finding a word character.

The functionality remains unchanged - just the iteration direction.