### PR TITLE
fix: add true,false,nl to the list of trusted commands

### DIFF
--- a/codex-rs/core/src/is_safe_command.rs
+++ b/codex-rs/core/src/is_safe_command.rs
@@ -23,9 +23,23 @@ fn is_safe_to_call_with_exec(command: &[String]) -> bool {
     let cmd0 = command.first().map(String::as_str);
 
     match cmd0 {
-        Some("cat" | "cd" | "echo" | "grep" | "head" | "ls" | "pwd" | "tail" | "wc" | "which") => {
+        #[rustfmt::skip]
+        Some(
+            "cat" |
+            "cd" |
+            "echo" |
+            "false" |
+            "grep" |
+            "head" |
+            "ls" |
+            "nl" |
+            "pwd" |
+            "tail" |
+            "true" |
+            "wc" |
+            "which") => {
             true
-        }
+        },
 
         Some("find") => {
             // Certain options to `find` can delete files, write to files, or
@@ -231,6 +245,11 @@ mod tests {
         assert!(is_safe_to_call_with_exec(&vec_str(&["git", "status"])));
         assert!(is_safe_to_call_with_exec(&vec_str(&[
             "sed", "-n", "1,5p", "file.txt"
+        ])));
+        assert!(is_safe_to_call_with_exec(&vec_str(&[
+            "nl",
+            "-nrz",
+            "Cargo.toml"
         ])));
 
         // Safe `find` command (no unsafe options).


### PR DESCRIPTION
`nl` is a line-numbering tool that should be on the _trusted _ list, as there is nothing concerning on https://gtfobins.github.io/gtfobins/nl/ that would merit exclusion.

`true` and `false` are also safe, though not particularly useful given how `is_known_safe_command()` works today, but that will change with https://github.com/openai/codex/pull/1668.