### PR TITLE
Check ripgrep availability before suggesting it

### DIFF
--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -25,6 +25,7 @@ futures = "0.3"
 libc = "0.2.174"
 mcp-types = { path = "../mcp-types" }
 mime_guess = "2.0"
+once_cell = "1"
 rand = "0.9"
 reqwest = { version = "0.12", features = ["json", "stream"] }
 serde = { version = "1", features = ["derive"] }


### PR DESCRIPTION
## Summary
- avoid recommending rg when it is not installed
- detect rg once and adjust base instructions

## Testing
- `just fmt` *(fails: cargo not found)*
- `just fix` *(fails: cargo not found)*
- `cargo test --all-features` *(fails: cargo not found)*

------
https://chatgpt.com/codex/tasks/task_i_6883ac0090c4832cb8434edc024685b7