### PR TITLE
Fix approval workflow

### DIFF
--- a/codex-rs/tui/src/bottom_pane/approval_modal_view.rs
+++ b/codex-rs/tui/src/bottom_pane/approval_modal_view.rs
@@ -17,6 +17,50 @@ pub(crate) struct ApprovalModalView<'a> {
     app_event_tx: AppEventSender,
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_event::AppEvent;
+    use std::path::PathBuf;
+    use std::sync::mpsc::channel;
+
+    fn make_sender() -> AppEventSender {
+        let (tx, _rx) = channel::<AppEvent>();
+        AppEventSender::new(tx)
+    }
+
+    fn make_exec_request() -> ApprovalRequest {
+        ApprovalRequest::Exec {
+            id: "test".to_string(),
+            command: vec!["echo".to_string(), "hi".to_string()],
+            cwd: PathBuf::from("/tmp"),
+            reason: None,
+        }
+    }
+
+    #[test]
+    fn ctrl_c_aborts_and_clears_queue() {
+        let tx = make_sender();
+        let first = make_exec_request();
+        let mut view = ApprovalModalView::new(first, tx);
+        // enqueue a second request so we can verify it gets dropped
+        view.enqueue_request(make_exec_request());
+
+        // Simulate Ctrl-C
+        // We don't have a BottomPane in this unit test; pass a Null pointer through Option
+        view.on_ctrl_c(&mut BottomPane::new(super::super::BottomPaneParams {
+            app_event_tx: make_sender(),
+            has_input_focus: true,
+        }));
+
+        // Queue should be empty and the current request should be complete.
+        assert!(view.queue.is_empty());
+        assert!(view.current.is_complete());
+        // The modal reports completion as well
+        assert!(view.is_complete());
+    }
+}
+
 impl ApprovalModalView<'_> {
     pub fn new(request: ApprovalRequest, app_event_tx: AppEventSender) -> Self {
         Self {
@@ -44,6 +88,14 @@ impl<'a> BottomPaneView<'a> for ApprovalModalView<'a> {
     fn handle_key_event(&mut self, _pane: &mut BottomPane<'a>, key_event: KeyEvent) {
         self.current.handle_key_event(key_event);
         self.maybe_advance();
+    }
+
+    fn on_ctrl_c(&mut self, _pane: &mut BottomPane<'a>) -> bool {
+        // Abort the current request and drop any queued approvals.
+        self.current.on_ctrl_c();
+        self.queue.clear();
+        // Do not advance to next request; the modal should be closed.
+        true
     }
 
     fn is_complete(&self) -> bool {

--- a/codex-rs/tui/src/bottom_pane/bottom_pane_view.rs
+++ b/codex-rs/tui/src/bottom_pane/bottom_pane_view.rs
@@ -4,6 +4,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 
 use super::BottomPane;
+use super::CancellationEvent;
 
 /// Type to use for a method that may require a redraw of the UI.
 pub(crate) enum ConditionalUpdate {
@@ -22,11 +23,9 @@ pub(crate) trait BottomPaneView<'a> {
         false
     }
 
-    /// Handle Ctrl-C while this view is active. Return true if the view
-    /// consumed the event (e.g. to cancel itself), false to let the caller
-    /// handle it.
-    fn on_ctrl_c(&mut self, _pane: &mut BottomPane<'a>) -> bool {
-        false
+    /// Handle Ctrl-C while this view is active.
+    fn on_ctrl_c(&mut self, _pane: &mut BottomPane<'a>) -> CancellationEvent {
+        CancellationEvent::Ignored
     }
 
     /// Render the view: this will be displayed in place of the composer.

--- a/codex-rs/tui/src/bottom_pane/bottom_pane_view.rs
+++ b/codex-rs/tui/src/bottom_pane/bottom_pane_view.rs
@@ -22,6 +22,13 @@ pub(crate) trait BottomPaneView<'a> {
         false
     }
 
+    /// Handle Ctrl-C while this view is active. Return true if the view
+    /// consumed the event (e.g. to cancel itself), false to let the caller
+    /// handle it.
+    fn on_ctrl_c(&mut self, _pane: &mut BottomPane<'a>) -> bool {
+        false
+    }
+
     /// Render the view: this will be displayed in place of the composer.
     fn render(&self, area: Rect, buf: &mut Buffer);
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -466,9 +466,11 @@ impl ChatWidget<'_> {
     }
 
     /// Handle Ctrl-C key press.
-    pub(crate) fn on_ctrl_c(&mut self) -> bool {
+    /// Returns CancellationEvent::Handled if the event was consumed by the UI, or
+    /// CancellationEvent::Ignored if the caller should handle it (e.g. exit).
+    pub(crate) fn on_ctrl_c(&mut self) -> CancellationEvent {
         match self.bottom_pane.on_ctrl_c() {
-            CancellationEvent::Handled => return true,
+            CancellationEvent::Handled => return CancellationEvent::Handled,
             CancellationEvent::Ignored => {}
         }
         if self.bottom_pane.is_task_running() {
@@ -476,13 +478,13 @@ impl ChatWidget<'_> {
             self.submit_op(Op::Interrupt);
             self.answer_buffer.clear();
             self.reasoning_buffer.clear();
-            false
+            CancellationEvent::Ignored
         } else if self.bottom_pane.ctrl_c_quit_hint_visible() {
             self.submit_op(Op::Shutdown);
-            true
+            CancellationEvent::Handled
         } else {
             self.bottom_pane.show_ctrl_c_quit_hint();
-            false
+            CancellationEvent::Ignored
         }
     }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -469,6 +469,10 @@ impl ChatWidget<'_> {
     /// Returns true if the key press was handled, false if it was not.
     /// If the key press was not handled, the caller should handle it (likely by exiting the process).
     pub(crate) fn on_ctrl_c(&mut self) -> bool {
+        // Give active modal views (e.g. approval modal) a chance to consume Ctrl-C.
+        if self.bottom_pane.on_ctrl_c() {
+            return true;
+        }
         if self.bottom_pane.is_task_running() {
             self.bottom_pane.clear_ctrl_c_quit_hint();
             self.submit_op(Op::Interrupt);

--- a/codex-rs/tui/src/user_approval_widget.rs
+++ b/codex-rs/tui/src/user_approval_widget.rs
@@ -272,7 +272,6 @@ impl UserApprovalWidget<'_> {
     }
 
     fn send_decision_with_feedback(&mut self, decision: ReviewDecision, feedback: String) {
-        // Emit a short summary into the history so the transcript captures the user's decision.
         let mut lines: Vec<Line<'static>> = Vec::new();
         match &self.approval_request {
             ApprovalRequest::Exec { command, .. } => {
@@ -280,25 +279,18 @@ impl UserApprovalWidget<'_> {
                 lines.push(Line::from("approval decision"));
                 lines.push(Line::from(format!("$ {cmd}")));
                 lines.push(Line::from(format!("decision: {decision:?}")));
-                if !feedback.trim().is_empty() {
-                    lines.push(Line::from("feedback:"));
-                    for l in feedback.lines() {
-                        lines.push(Line::from(l.to_string()));
-                    }
-                }
-                lines.push(Line::from(""));
             }
             ApprovalRequest::ApplyPatch { .. } => {
                 lines.push(Line::from(format!("patch approval decision: {decision:?}")));
-                if !feedback.trim().is_empty() {
-                    lines.push(Line::from("feedback:"));
-                    for l in feedback.lines() {
-                        lines.push(Line::from(l.to_string()));
-                    }
-                }
-                lines.push(Line::from(""));
             }
         }
+        if !feedback.trim().is_empty() {
+            lines.push(Line::from("feedback:"));
+            for l in feedback.lines() {
+                lines.push(Line::from(l.to_string()));
+            }
+        }
+        lines.push(Line::from(""));
         self.app_event_tx.send(AppEvent::InsertHistory(lines));
 
         let op = match &self.approval_request {

--- a/codex-rs/tui/src/user_approval_widget.rs
+++ b/codex-rs/tui/src/user_approval_widget.rs
@@ -203,6 +203,12 @@ impl UserApprovalWidget<'_> {
         }
     }
 
+    /// Handle Ctrl-C pressed by the user while the modal is visible.
+    /// Behaves like pressing Escape: abort the request and close the modal.
+    pub(crate) fn on_ctrl_c(&mut self) {
+        self.send_decision(ReviewDecision::Abort);
+    }
+
     fn handle_select_key(&mut self, key_event: KeyEvent) {
         match key_event.code {
             KeyCode::Up => {


### PR DESCRIPTION
(Hopefully) temporary solution to the invisible approvals problem - prints commands to history when they need approval and then also prints the result of the approval. In the near future we should be able to do some fancy stuff with updating commands before writing them to permanent history.

Also, ctr-c while in the approval modal now acts as esc (aborts command) and puts the TUI in the state where one additional ctr-c will exit.