### PR TITLE
[mcp-server] Populate notifications._meta with requestId

### DIFF
--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -19,7 +19,6 @@ use codex_core::protocol::Submission;
 use codex_core::protocol::TaskCompleteEvent;
 use mcp_types::CallToolResult;
 use mcp_types::ContentBlock;
-use mcp_types::ProgressToken;
 use mcp_types::RequestId;
 use mcp_types::TextContent;
 use serde_json::json;
@@ -82,7 +81,7 @@ pub async fn run_codex_tool_session(
         .send_event_as_notification(
             &session_configured,
             Some(OutgoingNotificationMeta {
-                progress_token: Some(ProgressToken::String(request_id_str)),
+                request_id: Some(RequestId::String(request_id_str)),
             }),
         )
         .await;
@@ -173,8 +172,7 @@ async fn run_codex_tool_session_inner(
                     .send_event_as_notification(
                         &event,
                         Some(OutgoingNotificationMeta {
-                            // TODO: use request.params.progressToken
-                            progress_token: Some(ProgressToken::String(request_id_str.clone())),
+                            request_id: Some(RequestId::String(request_id_str.clone())),
                         }),
                     )
                     .await;

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -72,17 +72,10 @@ pub async fn run_codex_tool_session(
     session_map.lock().await.insert(session_id, codex.clone());
     drop(session_map);
 
-    // Send initial SessionConfigured event, and include the request id
-    let request_id_str = match &id {
-        RequestId::String(s) => s.clone(),
-        RequestId::Integer(n) => n.to_string(),
-    };
     outgoing
         .send_event_as_notification(
             &session_configured,
-            Some(OutgoingNotificationMeta {
-                request_id: Some(RequestId::String(request_id_str)),
-            }),
+            Some(OutgoingNotificationMeta::new(Some(id.clone()))),
         )
         .await;
 
@@ -171,9 +164,7 @@ async fn run_codex_tool_session_inner(
                 outgoing
                     .send_event_as_notification(
                         &event,
-                        Some(OutgoingNotificationMeta {
-                            request_id: Some(RequestId::String(request_id_str.clone())),
-                        }),
+                        Some(OutgoingNotificationMeta::new(Some(request_id.clone()))),
                     )
                     .await;
 

--- a/codex-rs/mcp-server/src/outgoing_message.rs
+++ b/codex-rs/mcp-server/src/outgoing_message.rs
@@ -202,6 +202,12 @@ pub(crate) struct OutgoingNotificationMeta {
     pub request_id: Option<RequestId>,
 }
 
+impl OutgoingNotificationMeta {
+    pub(crate) fn new(request_id: Option<RequestId>) -> Self {
+        Self { request_id }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub(crate) struct OutgoingResponse {
     pub id: RequestId,


### PR DESCRIPTION
## Summary
Per the [latest MCP spec](https://modelcontextprotocol.io/specification/2025-06-18/basic#meta), the `_meta` field is reserved for metadata. In the [Typescript Schema](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/0695a497eb50a804fc0e88c18a93a21a675d6b3e/schema/2025-06-18/schema.ts#L37-L40), `progressToken` is defined as a value to be attached to subsequent notifications for that request. 

The [CallToolRequestParams](https://github.com/modelcontextprotocol/modelcontextprotocol/blob/0695a497eb50a804fc0e88c18a93a21a675d6b3e/schema/2025-06-18/schema.ts#L806-L817) extends this definition but overwrites the params field.  This ambiguity makes our generated type definitions tricky, so I'm going to skip `progressToken` field for now and just send back the `requestId` instead.
 
In a future PR, we can clarify, update our `generate_mcp_types.py` script, and update our progressToken logic accordingly.

## Testing
- [x] Added unit tests
- [x] Manually tested with mcp client