### PR TITLE
Serializing the `eventmsg` type to snake_case

### DIFF
--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -280,7 +280,7 @@ pub struct Event {
 /// Response event from the agent
 #[derive(Debug, Clone, Deserialize, Serialize, Display)]
 #[serde(tag = "type", rename_all = "snake_case")]
-#[strum(serialize_all = "lowercase")]
+#[strum(serialize_all = "snake_case")]
 pub enum EventMsg {
     /// Error while executing a submission
     Error(ErrorEvent),

--- a/codex-rs/mcp-server/tests/common/mcp_process.rs
+++ b/codex-rs/mcp-server/tests/common/mcp_process.rs
@@ -294,7 +294,7 @@ impl McpProcess {
                             }
                         }
                         // New schema: method is the Display of EventMsg::SessionConfigured => "SessionConfigured"
-                        if notification.method == "sessionconfigured" {
+                        if notification.method == "session_configured" {
                             if let Some(msg) = params.get("msg") {
                                 if let Some(session_id) =
                                     msg.get("session_id").and_then(|v| v.as_str())


### PR DESCRIPTION
This was an abrupt change on our clients. We need to serialize as snake_case.