### PR TITLE
feat: map ^U to kill-line-to-head

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -477,6 +477,17 @@ impl ChatComposer<'_> {
             }
         }
 
+        if let Input {
+            key: Key::Char('u'),
+            ctrl: true,
+            alt: false,
+            ..
+        } = input
+        {
+            self.textarea.delete_line_by_head();
+            return (InputResult::None, true);
+        }
+
         // Normal input handling
         self.textarea.input(input);
         let text_after = self.textarea.lines().join("\n");


### PR DESCRIPTION
see [discussion](https://github.com/rhysd/tui-textarea/issues/51#issuecomment-3021191712), it's surprising that ^U behaves this way. IMO the undo/redo functionality in tui-textarea isn't good enough to be worth preserving, but if we do bring it back it should probably be on C-z / C-S-z / C-y.