### PR TITLE
Add --experimental-instructions

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -860,6 +860,7 @@ dependencies = [
  "shlex",
  "strum 0.27.2",
  "strum_macros 0.27.2",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-appender",

--- a/codex-rs/core/src/util.rs
+++ b/codex-rs/core/src/util.rs
@@ -64,3 +64,21 @@ pub fn is_inside_git_repo(config: &Config) -> bool {
 
     false
 }
+
+/// If `val` is a path to a readable file, return its trimmed contents.
+///
+/// - When `val` points to a file, this reads the file, trims leading/trailing
+///   whitespace and returns `Ok(Some(contents))` unless the trimmed contents are
+///   empty in which case it returns `Ok(None)`.
+/// - When `val` is not a file path, return `Ok(Some(val.to_string()))` so
+///   callers can treat the value as a literal string.
+pub fn maybe_read_file(val: &str) -> std::io::Result<Option<String>> {
+    let p = std::path::Path::new(val);
+    if p.is_file() {
+        let s = std::fs::read_to_string(p)?;
+        let s = s.trim().to_string();
+        if s.is_empty() { Ok(None) } else { Ok(Some(s)) }
+    } else {
+        Ok(Some(val.to_string()))
+    }
+}

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -63,6 +63,40 @@ pub struct Cli {
     /// if `-` is used), instructions are read from stdin.
     #[arg(value_name = "PROMPT")]
     pub prompt: Option<String>,
+
+    /// Override the built-in system prompt (base instructions).
+    ///
+    /// If the value looks like a path to an existing file, the contents of the
+    /// file are used. Otherwise, the value itself is used verbatim as the
+    /// instructions string.
+    #[arg(long = "experimental-instructions")]
+    pub experimental_instructions: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+    use clap::CommandFactory;
+
+    #[test]
+    fn help_includes_file_behavior_for_experimental_instructions() {
+        let mut cmd = Cli::command();
+        let mut buf: Vec<u8> = Vec::new();
+        assert!(cmd.write_long_help(&mut buf).is_ok(), "help should render");
+        let help = match String::from_utf8(buf) {
+            Ok(s) => s,
+            Err(e) => panic!("invalid utf8: {e}"),
+        };
+        assert!(help.contains("Override the built-in system prompt (base instructions)."));
+        assert!(help.contains(
+            "If the value looks like a path to an existing file, the contents of the file are used."
+        ));
+        assert!(
+            help.contains(
+                "Otherwise, the value itself is used verbatim as the instructions string."
+            )
+        );
+    }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]

--- a/codex-rs/exec/src/event_processor.rs
+++ b/codex-rs/exec/src/event_processor.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::path::PathBuf;
 
 use codex_common::summarize_sandbox_policy;
 use codex_core::WireApi;
@@ -20,7 +21,16 @@ pub(crate) trait EventProcessor {
     fn process_event(&mut self, event: Event) -> CodexStatus;
 }
 
-pub(crate) fn create_config_summary_entries(config: &Config) -> Vec<(&'static str, String)> {
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum ExperimentalInstructionsOrigin {
+    File(PathBuf),
+    Literal,
+}
+
+pub(crate) fn create_config_summary_entries(
+    config: &Config,
+    experimental_origin: Option<&ExperimentalInstructionsOrigin>,
+) -> Vec<(&'static str, String)> {
     let mut entries = vec![
         ("workdir", config.cwd.display().to_string()),
         ("model", config.model.clone()),
@@ -28,6 +38,16 @@ pub(crate) fn create_config_summary_entries(config: &Config) -> Vec<(&'static st
         ("approval", config.approval_policy.to_string()),
         ("sandbox", summarize_sandbox_policy(&config.sandbox_policy)),
     ];
+    if let Some(origin) = experimental_origin {
+        let prompt_val = match origin {
+            ExperimentalInstructionsOrigin::Literal => "experimental".to_string(),
+            ExperimentalInstructionsOrigin::File(path) => path
+                .file_name()
+                .map(|s| s.to_string_lossy().to_string())
+                .unwrap_or_else(|| path.display().to_string()),
+        };
+        entries.push(("prompt", prompt_val));
+    }
     if config.model_provider.wire_api == WireApi::Responses
         && model_supports_reasoning_summaries(config)
     {
@@ -66,5 +86,67 @@ fn write_last_message_file(contents: &str, last_message_path: Option<&Path>) {
         if let Err(e) = std::fs::write(path, contents) {
             eprintln!("Failed to write last message file {path:?}: {e}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_core::config::Config;
+    use codex_core::config::ConfigOverrides;
+    use codex_core::config::ConfigToml;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    fn minimal_config() -> Config {
+        let cwd = match TempDir::new() {
+            Ok(t) => t,
+            Err(e) => panic!("tempdir error: {e}"),
+        };
+        let codex_home = match TempDir::new() {
+            Ok(t) => t,
+            Err(e) => panic!("tempdir error: {e}"),
+        };
+        let cfg = ConfigToml {
+            ..Default::default()
+        };
+        let overrides = ConfigOverrides {
+            cwd: Some(cwd.path().to_path_buf()),
+            ..Default::default()
+        };
+        match Config::load_from_base_config_with_overrides(
+            cfg,
+            overrides,
+            codex_home.path().to_path_buf(),
+        ) {
+            Ok(c) => c,
+            Err(e) => panic!("config error: {e}"),
+        }
+    }
+
+    #[test]
+    fn entries_include_prompt_experimental_for_literal_origin() {
+        let mut cfg = minimal_config();
+        cfg.base_instructions = Some("hello".to_string());
+        let entries =
+            create_config_summary_entries(&cfg, Some(&ExperimentalInstructionsOrigin::Literal));
+        let map: HashMap<_, _> = entries.into_iter().collect();
+        assert_eq!(map.get("prompt").cloned(), Some("experimental".to_string()));
+    }
+
+    #[test]
+    fn entries_include_prompt_filename_for_file_origin() {
+        let mut cfg = minimal_config();
+        cfg.base_instructions = Some("hello".to_string());
+        let path = PathBuf::from("/tmp/custom_instructions.txt");
+        let entries = create_config_summary_entries(
+            &cfg,
+            Some(&ExperimentalInstructionsOrigin::File(path.clone())),
+        );
+        let map: HashMap<_, _> = entries.into_iter().collect();
+        assert_eq!(
+            map.get("prompt").cloned(),
+            Some("custom_instructions.txt".to_string())
+        );
     }
 }

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -27,6 +27,7 @@ use std::time::Instant;
 
 use crate::event_processor::CodexStatus;
 use crate::event_processor::EventProcessor;
+use crate::event_processor::ExperimentalInstructionsOrigin;
 use crate::event_processor::create_config_summary_entries;
 use crate::event_processor::handle_last_message;
 
@@ -59,6 +60,7 @@ pub(crate) struct EventProcessorWithHumanOutput {
     answer_started: bool,
     reasoning_started: bool,
     last_message_path: Option<PathBuf>,
+    experimental_origin: Option<ExperimentalInstructionsOrigin>,
 }
 
 impl EventProcessorWithHumanOutput {
@@ -66,6 +68,7 @@ impl EventProcessorWithHumanOutput {
         with_ansi: bool,
         config: &Config,
         last_message_path: Option<PathBuf>,
+        experimental_origin: Option<ExperimentalInstructionsOrigin>,
     ) -> Self {
         let call_id_to_command = HashMap::new();
         let call_id_to_patch = HashMap::new();
@@ -87,6 +90,7 @@ impl EventProcessorWithHumanOutput {
                 answer_started: false,
                 reasoning_started: false,
                 last_message_path,
+                experimental_origin,
             }
         } else {
             Self {
@@ -104,6 +108,7 @@ impl EventProcessorWithHumanOutput {
                 answer_started: false,
                 reasoning_started: false,
                 last_message_path,
+                experimental_origin,
             }
         }
     }
@@ -150,7 +155,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
             VERSION
         );
 
-        let entries = create_config_summary_entries(config);
+        let entries = create_config_summary_entries(config, self.experimental_origin.as_ref());
 
         for (key, value) in entries {
             println!("{} {}", format!("{key}:").style(self.bold), value);

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -27,7 +27,7 @@ use std::time::Instant;
 
 use crate::event_processor::CodexStatus;
 use crate::event_processor::EventProcessor;
-use crate::event_processor::ExperimentalInstructionsOrigin;
+use crate::event_processor::PromptOrigin;
 use crate::event_processor::create_config_summary_entries;
 use crate::event_processor::handle_last_message;
 
@@ -60,7 +60,7 @@ pub(crate) struct EventProcessorWithHumanOutput {
     answer_started: bool,
     reasoning_started: bool,
     last_message_path: Option<PathBuf>,
-    experimental_origin: Option<ExperimentalInstructionsOrigin>,
+    prompt_origin: Option<PromptOrigin>,
 }
 
 impl EventProcessorWithHumanOutput {
@@ -68,7 +68,7 @@ impl EventProcessorWithHumanOutput {
         with_ansi: bool,
         config: &Config,
         last_message_path: Option<PathBuf>,
-        experimental_origin: Option<ExperimentalInstructionsOrigin>,
+        prompt_origin: Option<PromptOrigin>,
     ) -> Self {
         let call_id_to_command = HashMap::new();
         let call_id_to_patch = HashMap::new();
@@ -90,7 +90,7 @@ impl EventProcessorWithHumanOutput {
                 answer_started: false,
                 reasoning_started: false,
                 last_message_path,
-                experimental_origin,
+                prompt_origin,
             }
         } else {
             Self {
@@ -108,7 +108,7 @@ impl EventProcessorWithHumanOutput {
                 answer_started: false,
                 reasoning_started: false,
                 last_message_path,
-                experimental_origin,
+                prompt_origin,
             }
         }
     }
@@ -155,7 +155,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
             VERSION
         );
 
-        let entries = create_config_summary_entries(config, self.experimental_origin.as_ref());
+        let entries = create_config_summary_entries(config, self.prompt_origin.as_ref());
 
         for (key, value) in entries {
             println!("{} {}", format!("{key}:").style(self.bold), value);

--- a/codex-rs/exec/src/event_processor_with_json_output.rs
+++ b/codex-rs/exec/src/event_processor_with_json_output.rs
@@ -9,30 +9,27 @@ use serde_json::json;
 
 use crate::event_processor::CodexStatus;
 use crate::event_processor::EventProcessor;
-use crate::event_processor::ExperimentalInstructionsOrigin;
+use crate::event_processor::PromptOrigin;
 use crate::event_processor::create_config_summary_entries;
 use crate::event_processor::handle_last_message;
 
 pub(crate) struct EventProcessorWithJsonOutput {
     last_message_path: Option<PathBuf>,
-    experimental_origin: Option<ExperimentalInstructionsOrigin>,
+    prompt_origin: Option<PromptOrigin>,
 }
 
 impl EventProcessorWithJsonOutput {
-    pub fn new(
-        last_message_path: Option<PathBuf>,
-        experimental_origin: Option<ExperimentalInstructionsOrigin>,
-    ) -> Self {
+    pub fn new(last_message_path: Option<PathBuf>, prompt_origin: Option<PromptOrigin>) -> Self {
         Self {
             last_message_path,
-            experimental_origin,
+            prompt_origin,
         }
     }
 }
 
 impl EventProcessor for EventProcessorWithJsonOutput {
     fn print_config_summary(&mut self, config: &Config, prompt: &str) {
-        let entries = create_config_summary_entries(config, self.experimental_origin.as_ref())
+        let entries = create_config_summary_entries(config, self.prompt_origin.as_ref())
             .into_iter()
             .map(|(key, value)| (key.to_string(), value))
             .collect::<HashMap<String, String>>();

--- a/codex-rs/exec/src/event_processor_with_json_output.rs
+++ b/codex-rs/exec/src/event_processor_with_json_output.rs
@@ -9,22 +9,30 @@ use serde_json::json;
 
 use crate::event_processor::CodexStatus;
 use crate::event_processor::EventProcessor;
+use crate::event_processor::ExperimentalInstructionsOrigin;
 use crate::event_processor::create_config_summary_entries;
 use crate::event_processor::handle_last_message;
 
 pub(crate) struct EventProcessorWithJsonOutput {
     last_message_path: Option<PathBuf>,
+    experimental_origin: Option<ExperimentalInstructionsOrigin>,
 }
 
 impl EventProcessorWithJsonOutput {
-    pub fn new(last_message_path: Option<PathBuf>) -> Self {
-        Self { last_message_path }
+    pub fn new(
+        last_message_path: Option<PathBuf>,
+        experimental_origin: Option<ExperimentalInstructionsOrigin>,
+    ) -> Self {
+        Self {
+            last_message_path,
+            experimental_origin,
+        }
     }
 }
 
 impl EventProcessor for EventProcessorWithJsonOutput {
     fn print_config_summary(&mut self, config: &Config, prompt: &str) {
-        let entries = create_config_summary_entries(config)
+        let entries = create_config_summary_entries(config, self.experimental_origin.as_ref())
             .into_iter()
             .map(|(key, value)| (key.to_string(), value))
             .collect::<HashMap<String, String>>();

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -65,3 +65,4 @@ uuid = "1"
 [dev-dependencies]
 insta = "1.43.1"
 pretty_assertions = "1"
+tempfile = "3.13.0"

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -68,6 +68,7 @@ struct ChatWidgetArgs {
     config: Config,
     initial_prompt: Option<String>,
     initial_images: Vec<PathBuf>,
+    prompt_label: Option<String>,
 }
 
 impl App<'_> {
@@ -77,6 +78,7 @@ impl App<'_> {
         show_login_screen: bool,
         show_git_warning: bool,
         initial_images: Vec<std::path::PathBuf>,
+        prompt_label: Option<String>,
     ) -> Self {
         let (app_event_tx, app_event_rx) = channel();
         let app_event_tx = AppEventSender::new(app_event_tx);
@@ -147,6 +149,7 @@ impl App<'_> {
                     config: config.clone(),
                     initial_prompt,
                     initial_images,
+                    prompt_label: prompt_label.clone(),
                 }),
             )
         } else if show_git_warning {
@@ -158,6 +161,7 @@ impl App<'_> {
                     config: config.clone(),
                     initial_prompt,
                     initial_images,
+                    prompt_label: prompt_label.clone(),
                 }),
             )
         } else {
@@ -166,6 +170,7 @@ impl App<'_> {
                 app_event_tx.clone(),
                 initial_prompt,
                 initial_images,
+                prompt_label.clone(),
             );
             (
                 AppState::Chat {
@@ -301,6 +306,7 @@ impl App<'_> {
                             self.app_event_tx.clone(),
                             None,
                             Vec::new(),
+                            None,
                         ));
                         self.app_state = AppState::Chat { widget: new_widget };
                         self.app_event_tx.send(AppEvent::RequestRedraw);
@@ -392,6 +398,7 @@ impl App<'_> {
                         self.app_event_tx.clone(),
                         args.initial_prompt,
                         args.initial_images,
+                        args.prompt_label,
                     ));
                     self.app_state = AppState::Chat { widget };
                     self.app_event_tx.send(AppEvent::RequestRedraw);

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -55,6 +55,7 @@ pub(crate) struct ChatWidget<'a> {
     // We wait for the final AgentMessage event and then emit the full text
     // at once into scrollback so the history contains a single message.
     answer_buffer: String,
+    prompt_label: Option<String>,
 }
 
 struct UserMessage {
@@ -85,6 +86,7 @@ impl ChatWidget<'_> {
         app_event_tx: AppEventSender,
         initial_prompt: Option<String>,
         initial_images: Vec<PathBuf>,
+        prompt_label: Option<String>,
     ) -> Self {
         let (codex_op_tx, mut codex_op_rx) = unbounded_channel::<Op>();
 
@@ -140,6 +142,7 @@ impl ChatWidget<'_> {
             token_usage: TokenUsage::default(),
             reasoning_buffer: String::new(),
             answer_buffer: String::new(),
+            prompt_label,
         }
     }
 
@@ -209,8 +212,11 @@ impl ChatWidget<'_> {
         match msg {
             EventMsg::SessionConfigured(event) => {
                 // Record session information at the top of the conversation.
-                self.conversation_history
-                    .add_session_info(&self.config, event.clone());
+                self.conversation_history.add_session_info(
+                    &self.config,
+                    event.clone(),
+                    self.prompt_label.as_deref(),
+                );
                 // Immediately surface the session banner / settings summary in
                 // scrollback so the user can review configuration (model,
                 // sandbox, approvals, etc.) before interacting.

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -53,4 +53,38 @@ pub struct Cli {
 
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,
+
+    /// Override the built-in system prompt (base instructions).
+    ///
+    /// If the value looks like a path to an existing file, the contents of the
+    /// file are used. Otherwise, the value itself is used verbatim as the
+    /// instructions string.
+    #[arg(long = "experimental-instructions")]
+    pub experimental_instructions: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+    use clap::CommandFactory;
+
+    #[test]
+    fn help_includes_file_behavior_for_experimental_instructions() {
+        let mut cmd = Cli::command();
+        let mut buf: Vec<u8> = Vec::new();
+        assert!(cmd.write_long_help(&mut buf).is_ok(), "help should render");
+        let help = match String::from_utf8(buf) {
+            Ok(s) => s,
+            Err(e) => panic!("invalid utf8: {e}"),
+        };
+        assert!(help.contains("Override the built-in system prompt (base instructions)."));
+        assert!(help.contains(
+            "If the value looks like a path to an existing file, the contents of the file are used."
+        ));
+        assert!(
+            help.contains(
+                "Otherwise, the value itself is used verbatim as the instructions string."
+            )
+        );
+    }
 }

--- a/codex-rs/tui/src/conversation_history_widget.rs
+++ b/codex-rs/tui/src/conversation_history_widget.rs
@@ -99,7 +99,12 @@ impl ConversationHistoryWidget {
 
     /// Note `model` could differ from `config.model` if the agent decided to
     /// use a different model than the one requested by the user.
-    pub fn add_session_info(&mut self, config: &Config, event: SessionConfiguredEvent) {
+    pub fn add_session_info(
+        &mut self,
+        config: &Config,
+        event: SessionConfiguredEvent,
+        prompt_label: Option<&str>,
+    ) {
         // In practice, SessionConfiguredEvent should always be the first entry
         // in the history, but it is possible that an error could be sent
         // before the session info.
@@ -111,6 +116,7 @@ impl ConversationHistoryWidget {
             config,
             event,
             !has_welcome_message,
+            prompt_label,
         ));
     }
 

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -33,8 +33,6 @@ use std::path::PathBuf;
 use std::time::Duration;
 use std::time::Instant;
 use tracing::error;
-#[cfg(test)]
-use uuid::Uuid;
 
 pub(crate) struct CommandOutput {
     pub(crate) exit_code: i32,
@@ -593,6 +591,7 @@ mod tests {
     use codex_core::config::Config;
     use codex_core::config::ConfigOverrides;
     use codex_core::config::ConfigToml;
+    use uuid::Uuid;
 
     use tempfile::TempDir;
 


### PR DESCRIPTION
Add the ability for users to override the built in prompt by either passing in a string or a filename.