### PR TITLE
Relative instruction file

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -481,9 +481,7 @@ impl Config {
                         // read or was invalid.
                         return Err(std::io::Error::new(
                             std::io::ErrorKind::InvalidInput,
-                            format!(
-                                "Failed to load experimental_instructions_file: {e}"
-                            ),
+                            format!("Failed to load experimental_instructions_file: {e}"),
                         ));
                     }
                 }

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -468,10 +468,27 @@ impl Config {
         // Load base instructions override from a file if specified. If the
         // path is relative, resolve it against the effective cwd so the
         // behaviour matches other path-like config values.
-        let base_instructions = base_instructions.or(Self::get_base_instructions(
-            cfg.experimental_instructions_file.as_ref(),
-            Some(&resolved_cwd),
-        ));
+        let base_instructions = match base_instructions {
+            Some(s) => Some(s),
+            None => {
+                match Self::get_base_instructions(
+                    cfg.experimental_instructions_file.as_ref(),
+                    Some(&resolved_cwd),
+                ) {
+                    Ok(v) => v,
+                    Err(e) => {
+                        // Surface a hard failure when an explicit path was provided but could not be
+                        // read or was invalid.
+                        return Err(std::io::Error::new(
+                            std::io::ErrorKind::InvalidInput,
+                            format!(
+                                "Failed to load experimental_instructions_file: {e}"
+                            ),
+                        ));
+                    }
+                }
+            }
+        };
 
         let config = Self {
             model,
@@ -543,25 +560,51 @@ impl Config {
         })
     }
 
-    fn get_base_instructions(path: Option<&PathBuf>, cwd: Option<&Path>) -> Option<String> {
-        let path = path.as_ref()?;
+    fn get_base_instructions(
+        path: Option<&PathBuf>,
+        cwd: Option<&Path>,
+    ) -> std::io::Result<Option<String>> {
+        let p = match path.as_ref() {
+            None => return Ok(None),
+            Some(p) => p,
+        };
 
         // Resolve relative paths against the provided cwd (if any) to make
         // CLI overrides consistent regardless of where the process was
         // launched from.
-        let path = if path.is_relative() {
+        let full_path = if p.is_relative() {
             match cwd {
-                Some(root) => root.join(path),
-                None => path.to_path_buf(),
+                Some(root) => root.join(p),
+                None => p.to_path_buf(),
             }
         } else {
-            path.to_path_buf()
+            p.to_path_buf()
         };
 
-        std::fs::read_to_string(path)
-            .ok()
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
+        match std::fs::read_to_string(&full_path) {
+            Ok(contents) => {
+                let s = contents.trim().to_string();
+                if s.is_empty() {
+                    let e = std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!(
+                            "experimental instructions file is empty: {}",
+                            full_path.display()
+                        ),
+                    );
+                    Err(e)
+                } else {
+                    Ok(Some(s))
+                }
+            }
+            Err(e) => Err(std::io::Error::new(
+                e.kind(),
+                format!(
+                    "failed to read experimental instructions file {}: {e}",
+                    full_path.display()
+                ),
+            )),
+        }
     }
 }
 


### PR DESCRIPTION
Passing in an instruction file with a bad path led to silent failures, also instruction relative paths were handled in an unintuitive fashion.