### PR TITLE
Capture default prompt environment variables once

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1396,11 +1396,11 @@ fn parse_container_exec_arguments(
 
 fn maybe_run_with_user_profile(params: ExecParams, sess: &Session) -> ExecParams {
     if sess.shell_environment_policy.use_profile {
-        let command = sess
+        let wrapped_params = sess
             .user_shell
-            .format_default_shell_invocation(params.command.clone());
-        if let Some(command) = command {
-            return ExecParams { command, ..params };
+            .format_default_shell_invocation(params.clone());
+        if let Some(wrapped_params) = wrapped_params {
+            return wrapped_params;
         }
     }
     params

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -143,7 +143,6 @@ pub async fn default_user_shell() -> Shell {
 #[cfg(target_os = "macos")]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
     use std::process::Command;
 
     #[tokio::test]

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -173,21 +173,6 @@ mod tests {
         }
     }
 
-    #[tokio::test]
-    async fn test_run_with_profile_zshrc_not_exists() {
-        let shell = Shell::Zsh(ZshShell {
-            shell_path: "/bin/zsh".to_string(),
-            env: HashMap::new(),
-        });
-        let actual_cmd = shell.format_default_shell_invocation(ExecParams {
-            command: vec!["myecho".to_string()],
-            cwd: PathBuf::from("/"),
-            timeout_ms: None,
-            env: HashMap::new(),
-        });
-        assert!(actual_cmd.is_none());
-    }
-
     #[expect(clippy::unwrap_used)]
     #[tokio::test]
     async fn test_run_with_profile_escaping_and_execution() {

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -35,7 +35,6 @@ impl Shell {
 
                 Some(ExecParams {
                     command: result,
-                    // combine env fomr params and shell
                     env: {
                         let mut env = params.env.clone();
                         env.extend(zsh.env.clone());


### PR DESCRIPTION
Running the login shell every time causes warnings for sandbox environments and confuses the model. Instead capture the environment once and reuse it for future runs.