### PR TITLE
Fix double-scrolling in approval model

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -96,9 +96,6 @@ impl App<'_> {
                         if let Ok(event) = crossterm::event::read() {
                             match event {
                                 crossterm::event::Event::Key(key_event) => {
-                                    // Filter out key release events to avoid handling a single
-                                    // key press twice (press + release). Keep presses and
-                                    // auto‑repeats so holding a key continues to work.
                                     if key_event.kind != crossterm::event::KeyEventKind::Release {
                                         app_event_tx.send(AppEvent::KeyEvent(key_event));
                                     }

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -96,7 +96,7 @@ impl App<'_> {
                         if let Ok(event) = crossterm::event::read() {
                             match event {
                                 crossterm::event::Event::Key(key_event) => {
-                                    if key_event.kind != crossterm::event::KeyEventKind::Release {
+                                    if key_event.kind == crossterm::event::KeyEventKind::Press {
                                         app_event_tx.send(AppEvent::KeyEvent(key_event));
                                     }
                                 }

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -96,7 +96,12 @@ impl App<'_> {
                         if let Ok(event) = crossterm::event::read() {
                             match event {
                                 crossterm::event::Event::Key(key_event) => {
-                                    app_event_tx.send(AppEvent::KeyEvent(key_event));
+                                    // Filter out key release events to avoid handling a single
+                                    // key press twice (press + release). Keep presses and
+                                    // auto‑repeats so holding a key continues to work.
+                                    if key_event.kind != crossterm::event::KeyEventKind::Release {
+                                        app_event_tx.send(AppEvent::KeyEvent(key_event));
+                                    }
                                 }
                                 crossterm::event::Event::Resize(_, _) => {
                                     app_event_tx.send(AppEvent::RequestRedraw);


### PR DESCRIPTION
Previously, pressing up or down arrow in the new approval modal would be the equivalent of two up or down presses.