### PR TITLE
clamp render area to terminal size

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -362,7 +362,7 @@ impl App<'_> {
             AppState::GitWarning { .. } => 10,
         };
         let mut area = terminal.viewport_area;
-        area.height = desired_height;
+        area.height = desired_height.min(size.height);
         area.width = size.width;
         if area.bottom() > size.height {
             terminal

--- a/codex-rs/tui/src/insert_history.rs
+++ b/codex-rs/tui/src/insert_history.rs
@@ -36,12 +36,12 @@ pub(crate) fn insert_history_lines(terminal: &mut tui::Tui, lines: Vec<Line>) {
             .backend_mut()
             .scroll_region_down(area.top()..screen_size.height, scroll_amount)
             .ok();
-        let cursor_top = area.top() - 1;
+        let cursor_top = area.top().saturating_sub(1);
         area.y += scroll_amount;
         terminal.set_viewport_area(area);
         cursor_top
     } else {
-        area.top() - 1
+        area.top().saturating_sub(1)
     };
 
     // Limit the scroll region to the lines from the top of the screen to the


### PR DESCRIPTION
this fixes a couple of panics that would happen when trying to render something larger than the terminal, or insert history lines when the top of the viewport is at y=0.