### PR TITLE
fix: ensure PatchApplyBeginEvent and PatchApplyEndEvent are dispatched reliably

### DIFF
--- a/codex-rs/core/src/apply_patch.rs
+++ b/codex-rs/core/src/apply_patch.rs
@@ -1,19 +1,12 @@
 use crate::codex::Session;
 use crate::models::FunctionCallOutputPayload;
 use crate::models::ResponseInputItem;
-use crate::protocol::Event;
-use crate::protocol::EventMsg;
 use crate::protocol::FileChange;
-use crate::protocol::PatchApplyBeginEvent;
-use crate::protocol::PatchApplyEndEvent;
 use crate::protocol::ReviewDecision;
 use crate::safety::SafetyCheck;
 use crate::safety::assess_patch_safety;
-use anyhow::Context;
-use codex_apply_patch::AffectedPaths;
 use codex_apply_patch::ApplyPatchAction;
 use codex_apply_patch::ApplyPatchFileChange;
-use codex_apply_patch::print_summary;
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
@@ -26,12 +19,18 @@ pub(crate) enum InternalApplyPatchInvocation {
     /// result to use with the `shell` function call that contained `apply_patch`.
     Output(ResponseInputItem),
 
-    /// The `apply_patch` call was auto-approved, which means that, on the
-    /// surface, it appears to be safe, but it should be run in a sandbox if the
-    /// user has configured one because a path being written could be a hard
-    /// link to a file outside the writable folders, so only the sandbox can
-    /// faithfully prevent the write in that case.
-    DelegateToExec(ApplyPatchAction),
+    /// The `apply_patch` call was approved, either automatically because it
+    /// appears that it should be allowed based on the user's sandbox policy
+    /// *or* because the user explicitly approved it. In either case, we use
+    /// exec with [`CODEX_APPLY_PATCH_ARG1`] to realize the `apply_patch` call,
+    /// but [`ApplyPatchExec::auto_approved`] is used to determine the sandbox
+    /// used with the `exec()`.
+    DelegateToExec(ApplyPatchExec),
+}
+
+pub(crate) struct ApplyPatchExec {
+    pub(crate) action: ApplyPatchAction,
+    pub(crate) user_explicitly_approved_this_action: bool,
 }
 
 impl From<ResponseInputItem> for InternalApplyPatchInvocation {
@@ -52,254 +51,57 @@ pub(crate) async fn apply_patch(
         guard.clone()
     };
 
-    let auto_approved = match assess_patch_safety(
+    match assess_patch_safety(
         &action,
         sess.approval_policy,
         &writable_roots_snapshot,
         &sess.cwd,
     ) {
         SafetyCheck::AutoApprove { .. } => {
-            return InternalApplyPatchInvocation::DelegateToExec(action);
+            InternalApplyPatchInvocation::DelegateToExec(ApplyPatchExec {
+                action,
+                user_explicitly_approved_this_action: false,
+            })
         }
         SafetyCheck::AskUser => {
             // Compute a readable summary of path changes to include in the
             // approval request so the user can make an informed decision.
+            //
+            // Note that it might be worth expanding this approval request to
+            // give the user the option to expand the set of writable roots so
+            // that similar patches can be auto-approved in the future during
+            // this session.
             let rx_approve = sess
                 .request_patch_approval(sub_id.to_owned(), call_id.to_owned(), &action, None, None)
                 .await;
             match rx_approve.await.unwrap_or_default() {
-                ReviewDecision::Approved | ReviewDecision::ApprovedForSession => false,
+                ReviewDecision::Approved | ReviewDecision::ApprovedForSession => {
+                    InternalApplyPatchInvocation::DelegateToExec(ApplyPatchExec {
+                        action,
+                        user_explicitly_approved_this_action: true,
+                    })
+                }
                 ReviewDecision::Denied | ReviewDecision::Abort => {
-                    return ResponseInputItem::FunctionCallOutput {
+                    ResponseInputItem::FunctionCallOutput {
                         call_id: call_id.to_owned(),
                         output: FunctionCallOutputPayload {
                             content: "patch rejected by user".to_string(),
                             success: Some(false),
                         },
                     }
-                    .into();
+                    .into()
                 }
             }
         }
-        SafetyCheck::Reject { reason } => {
-            return ResponseInputItem::FunctionCallOutput {
-                call_id: call_id.to_owned(),
-                output: FunctionCallOutputPayload {
-                    content: format!("patch rejected: {reason}"),
-                    success: Some(false),
-                },
-            }
-            .into();
-        }
-    };
-
-    // Verify write permissions before touching the filesystem.
-    let writable_snapshot = {
-        #[allow(clippy::unwrap_used)]
-        sess.writable_roots.lock().unwrap().clone()
-    };
-
-    if let Some(offending) = first_offending_path(&action, &writable_snapshot, &sess.cwd) {
-        let root = offending.parent().unwrap_or(&offending).to_path_buf();
-
-        let reason = Some(format!(
-            "grant write access to {} for this session",
-            root.display()
-        ));
-
-        let rx = sess
-            .request_patch_approval(
-                sub_id.to_owned(),
-                call_id.to_owned(),
-                &action,
-                reason.clone(),
-                Some(root.clone()),
-            )
-            .await;
-
-        if !matches!(
-            rx.await.unwrap_or_default(),
-            ReviewDecision::Approved | ReviewDecision::ApprovedForSession
-        ) {
-            return ResponseInputItem::FunctionCallOutput {
-                call_id: call_id.to_owned(),
-                output: FunctionCallOutputPayload {
-                    content: "patch rejected by user".to_string(),
-                    success: Some(false),
-                },
-            }
-            .into();
-        }
-
-        // user approved, extend writable roots for this session
-        #[allow(clippy::unwrap_used)]
-        sess.writable_roots.lock().unwrap().push(root);
-    }
-
-    let _ = sess
-        .tx_event
-        .send(Event {
-            id: sub_id.to_owned(),
-            msg: EventMsg::PatchApplyBegin(PatchApplyBeginEvent {
-                call_id: call_id.to_owned(),
-                auto_approved,
-                changes: convert_apply_patch_to_protocol(&action),
-            }),
-        })
-        .await;
-
-    let mut stdout = Vec::new();
-    let mut stderr = Vec::new();
-    // Enforce writable roots. If a write is blocked, collect offending root
-    // and prompt the user to extend permissions.
-    let mut result = apply_changes_from_apply_patch_and_report(&action, &mut stdout, &mut stderr);
-
-    if let Err(err) = &result {
-        if err.kind() == std::io::ErrorKind::PermissionDenied {
-            // Determine first offending path.
-            let offending_opt = action
-                .changes()
-                .iter()
-                .flat_map(|(path, change)| match change {
-                    ApplyPatchFileChange::Add { .. } => vec![path.as_ref()],
-                    ApplyPatchFileChange::Delete => vec![path.as_ref()],
-                    ApplyPatchFileChange::Update {
-                        move_path: Some(move_path),
-                        ..
-                    } => {
-                        vec![path.as_ref(), move_path.as_ref()]
-                    }
-                    ApplyPatchFileChange::Update {
-                        move_path: None, ..
-                    } => vec![path.as_ref()],
-                })
-                .find_map(|path: &Path| {
-                    // ApplyPatchAction promises to guarantee absolute paths.
-                    if !path.is_absolute() {
-                        panic!("apply_patch invariant failed: path is not absolute: {path:?}");
-                    }
-
-                    let writable = {
-                        #[allow(clippy::unwrap_used)]
-                        let roots = sess.writable_roots.lock().unwrap();
-                        roots.iter().any(|root| path.starts_with(root))
-                    };
-                    if writable {
-                        None
-                    } else {
-                        Some(path.to_path_buf())
-                    }
-                });
-
-            if let Some(offending) = offending_opt {
-                let root = offending.parent().unwrap_or(&offending).to_path_buf();
-
-                let reason = Some(format!(
-                    "grant write access to {} for this session",
-                    root.display()
-                ));
-                let rx = sess
-                    .request_patch_approval(
-                        sub_id.to_owned(),
-                        call_id.to_owned(),
-                        &action,
-                        reason.clone(),
-                        Some(root.clone()),
-                    )
-                    .await;
-                if matches!(
-                    rx.await.unwrap_or_default(),
-                    ReviewDecision::Approved | ReviewDecision::ApprovedForSession
-                ) {
-                    // Extend writable roots.
-                    #[allow(clippy::unwrap_used)]
-                    sess.writable_roots.lock().unwrap().push(root);
-                    stdout.clear();
-                    stderr.clear();
-                    result = apply_changes_from_apply_patch_and_report(
-                        &action,
-                        &mut stdout,
-                        &mut stderr,
-                    );
-                }
-            }
-        }
-    }
-
-    // Emit PatchApplyEnd event.
-    let success_flag = result.is_ok();
-    let _ = sess
-        .tx_event
-        .send(Event {
-            id: sub_id.to_owned(),
-            msg: EventMsg::PatchApplyEnd(PatchApplyEndEvent {
-                call_id: call_id.to_owned(),
-                stdout: String::from_utf8_lossy(&stdout).to_string(),
-                stderr: String::from_utf8_lossy(&stderr).to_string(),
-                success: success_flag,
-            }),
-        })
-        .await;
-
-    let item = match result {
-        Ok(_) => ResponseInputItem::FunctionCallOutput {
+        SafetyCheck::Reject { reason } => ResponseInputItem::FunctionCallOutput {
             call_id: call_id.to_owned(),
             output: FunctionCallOutputPayload {
-                content: String::from_utf8_lossy(&stdout).to_string(),
-                success: None,
-            },
-        },
-        Err(e) => ResponseInputItem::FunctionCallOutput {
-            call_id: call_id.to_owned(),
-            output: FunctionCallOutputPayload {
-                content: format!("error: {e:#}, stderr: {}", String::from_utf8_lossy(&stderr)),
+                content: format!("patch rejected: {reason}"),
                 success: Some(false),
             },
-        },
-    };
-    InternalApplyPatchInvocation::Output(item)
-}
-
-/// Return the first path in `hunks` that is NOT under any of the
-/// `writable_roots` (after normalising). If all paths are acceptable,
-/// returns None.
-fn first_offending_path(
-    action: &ApplyPatchAction,
-    writable_roots: &[PathBuf],
-    cwd: &Path,
-) -> Option<PathBuf> {
-    let changes = action.changes();
-    for (path, change) in changes {
-        let candidate = match change {
-            ApplyPatchFileChange::Add { .. } => path,
-            ApplyPatchFileChange::Delete => path,
-            ApplyPatchFileChange::Update { move_path, .. } => move_path.as_ref().unwrap_or(path),
-        };
-
-        let abs = if candidate.is_absolute() {
-            candidate.clone()
-        } else {
-            cwd.join(candidate)
-        };
-
-        let mut allowed = false;
-        for root in writable_roots {
-            let root_abs = if root.is_absolute() {
-                root.clone()
-            } else {
-                cwd.join(root)
-            };
-            if abs.starts_with(&root_abs) {
-                allowed = true;
-                break;
-            }
         }
-
-        if !allowed {
-            return Some(candidate.clone());
-        }
+        .into(),
     }
-    None
 }
 
 pub(crate) fn convert_apply_patch_to_protocol(
@@ -325,85 +127,6 @@ pub(crate) fn convert_apply_patch_to_protocol(
         result.insert(path.clone(), protocol_change);
     }
     result
-}
-
-fn apply_changes_from_apply_patch_and_report(
-    action: &ApplyPatchAction,
-    stdout: &mut impl std::io::Write,
-    stderr: &mut impl std::io::Write,
-) -> std::io::Result<()> {
-    match apply_changes_from_apply_patch(action) {
-        Ok(affected_paths) => {
-            print_summary(&affected_paths, stdout)?;
-        }
-        Err(err) => {
-            writeln!(stderr, "{err:?}")?;
-        }
-    }
-
-    Ok(())
-}
-
-fn apply_changes_from_apply_patch(action: &ApplyPatchAction) -> anyhow::Result<AffectedPaths> {
-    let mut added: Vec<PathBuf> = Vec::new();
-    let mut modified: Vec<PathBuf> = Vec::new();
-    let mut deleted: Vec<PathBuf> = Vec::new();
-
-    let changes = action.changes();
-    for (path, change) in changes {
-        match change {
-            ApplyPatchFileChange::Add { content } => {
-                if let Some(parent) = path.parent() {
-                    if !parent.as_os_str().is_empty() {
-                        std::fs::create_dir_all(parent).with_context(|| {
-                            format!("Failed to create parent directories for {}", path.display())
-                        })?;
-                    }
-                }
-                std::fs::write(path, content)
-                    .with_context(|| format!("Failed to write file {}", path.display()))?;
-                added.push(path.clone());
-            }
-            ApplyPatchFileChange::Delete => {
-                std::fs::remove_file(path)
-                    .with_context(|| format!("Failed to delete file {}", path.display()))?;
-                deleted.push(path.clone());
-            }
-            ApplyPatchFileChange::Update {
-                unified_diff: _unified_diff,
-                move_path,
-                new_content,
-            } => {
-                if let Some(move_path) = move_path {
-                    if let Some(parent) = move_path.parent() {
-                        if !parent.as_os_str().is_empty() {
-                            std::fs::create_dir_all(parent).with_context(|| {
-                                format!(
-                                    "Failed to create parent directories for {}",
-                                    move_path.display()
-                                )
-                            })?;
-                        }
-                    }
-
-                    std::fs::rename(path, move_path)
-                        .with_context(|| format!("Failed to rename file {}", path.display()))?;
-                    std::fs::write(move_path, new_content)?;
-                    modified.push(move_path.clone());
-                    deleted.push(path.clone());
-                } else {
-                    std::fs::write(path, new_content)?;
-                    modified.push(path.clone());
-                }
-            }
-        }
-    }
-
-    Ok(AffectedPaths {
-        added,
-        modified,
-        deleted,
-    })
 }
 
 pub(crate) fn get_writable_roots(cwd: &Path) -> Vec<PathBuf> {

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -41,11 +41,13 @@ pub fn assess_patch_safety(
         }
     }
 
-    if is_write_patch_constrained_to_writable_paths(action, writable_roots, cwd) {
-        SafetyCheck::AutoApprove {
-            sandbox_type: SandboxType::None,
-        }
-    } else if policy == AskForApproval::OnFailure {
+    // Even though the patch *appears* to be constrained to writable paths, it
+    // is possible that paths in the patch are hard links to files outside the
+    // writable roots, so we should still run `apply_patch` in a sandbox in that
+    // case.
+    if is_write_patch_constrained_to_writable_paths(action, writable_roots, cwd)
+        || policy == AskForApproval::OnFailure
+    {
         // Only auto‑approve when we can actually enforce a sandbox. Otherwise
         // fall back to asking the user because the patch may touch arbitrary
         // paths outside the project.


### PR DESCRIPTION
This is a follow-up to https://github.com/openai/codex/pull/1705, as that PR inadvertently lost the logic where `PatchApplyBeginEvent` and `PatchApplyEndEvent` events were sent when patches were auto-approved.

Though as part of this fix, I believe this also makes an important safety fix to `assess_patch_safety()`, as there was a case that returned `SandboxType::None`, which arguably is the thing we were trying to avoid in #1705.

On a high level, we want there to be only one codepath where `apply_patch` happens, which should be unified with the patch to run `exec`, in general, so that sandboxing is applied consistently for both cases.

Prior to this change, `apply_patch()` in `core` would either:

* exit early, delegating to `exec()` to shell out to `apply_patch` using the appropriate sandbox
* proceed to run the logic for `apply_patch` in memory

https://github.com/openai/codex/blob/549846b29ad52f6cb4f8560365a731966054a9b3/codex-rs/core/src/apply_patch.rs#L61-L63

In this implementation, only the latter would dispatch `PatchApplyBeginEvent` and `PatchApplyEndEvent`, though the former would dispatch `ExecCommandBeginEvent` and `ExecCommandEndEvent` for the `apply_patch` call (or, more specifically, the `codex --codex-run-as-apply-patch PATCH` call).

To unify things in this PR, we:

* Eliminate the back half of the `apply_patch()` function, and instead have it also return with `DelegateToExec`, though we add an extra field to the return value, `user_explicitly_approved_this_action`.
* In `codex.rs` where we process `DelegateToExec`, we use `SandboxType::None` when `user_explicitly_approved_this_action` is `true`. This means **we no longer run the apply_patch logic in memory**, as we always `exec()`. (Note this is what allowed us to delete so much code in `apply_patch.rs`.)
* In `codex.rs`, we further update `notify_exec_command_begin()` and `notify_exec_command_end()` to take additional fields to determine what type of notification to send: `ExecCommand` or `PatchApply`.

Admittedly, this PR also drops some of the functionality about giving the user the opportunity to expand the set of writable roots as part of approving the `apply_patch` command. I'm not sure how much that was used, and we should probably rethink how that works as we are currently tidying up the protocol to the TUI, in general.