### PR TITLE
[tools] Let the model request approval for shell commands

### DIFF
--- a/codex-rs/common/src/approval_mode_cli_arg.rs
+++ b/codex-rs/common/src/approval_mode_cli_arg.rs
@@ -18,6 +18,9 @@ pub enum ApprovalModeCliArg {
     /// will escalate to the user to ask for un-sandboxed execution.
     OnFailure,
 
+    /// Only ask for approval if the model requests it.
+    OnRequest,
+
     /// Never ask for user approval
     /// Execution failures are immediately returned to the model.
     Never,
@@ -28,6 +31,7 @@ impl From<ApprovalModeCliArg> for AskForApproval {
         match value {
             ApprovalModeCliArg::Untrusted => AskForApproval::UnlessTrusted,
             ApprovalModeCliArg::OnFailure => AskForApproval::OnFailure,
+            ApprovalModeCliArg::OnRequest => AskForApproval::OnRequest,
             ApprovalModeCliArg::Never => AskForApproval::Never,
         }
     }

--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -24,6 +24,7 @@ use crate::error::Result;
 use crate::models::ContentItem;
 use crate::models::ResponseItem;
 use crate::openai_tools::create_tools_json_for_chat_completions_api;
+use crate::protocol::SandboxPolicy;
 use crate::util::backoff;
 
 /// Implementation for the classic Chat Completions API.
@@ -33,6 +34,7 @@ pub(crate) async fn stream_chat_completions(
     include_plan_tool: bool,
     client: &reqwest::Client,
     provider: &ModelProviderInfo,
+    sandbox_policy: Option<SandboxPolicy>,
 ) -> Result<ResponseStream> {
     // Build messages array
     let mut messages = Vec::<serde_json::Value>::new();
@@ -110,7 +112,12 @@ pub(crate) async fn stream_chat_completions(
         }
     }
 
-    let tools_json = create_tools_json_for_chat_completions_api(prompt, model, include_plan_tool)?;
+    let tools_json = create_tools_json_for_chat_completions_api(
+        prompt,
+        model,
+        include_plan_tool,
+        sandbox_policy,
+    )?;
     let payload = json!({
         "model": model,
         "messages": messages,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1483,7 +1483,7 @@ async fn handle_response_item(
                 command: action.command,
                 workdir: action.working_directory,
                 timeout_ms: action.timeout_ms,
-                with_escalated_privileges: None,
+                with_escalated_permissions: None,
                 justification: None,
             };
             let effective_call_id = match (call_id, id) {
@@ -1570,7 +1570,7 @@ fn to_exec_params(params: ShellToolCallParams, sess: &Session) -> ExecParams {
         cwd: sess.resolve_path(params.workdir.clone()),
         timeout_ms: params.timeout_ms,
         env: create_env(&sess.shell_environment_policy),
-        with_escalated_privileges: params.with_escalated_privileges,
+        with_escalated_permissions: params.with_escalated_permissions,
         justification: params.justification,
     }
 }
@@ -1671,7 +1671,7 @@ async fn handle_container_exec_with_params(
                 cwd: cwd.clone(),
                 timeout_ms: params.timeout_ms,
                 env: HashMap::new(),
-                with_escalated_privileges: None,
+                with_escalated_permissions: None,
                 justification: None,
             };
             let safety = if *user_explicitly_approved_this_action {
@@ -1682,7 +1682,7 @@ async fn handle_container_exec_with_params(
                 assess_safety_for_untrusted_command(
                     sess.approval_policy,
                     &sess.sandbox_policy,
-                    params.with_escalated_privileges.unwrap_or(false),
+                    params.with_escalated_permissions.unwrap_or(false),
                 )
             };
             (
@@ -1699,7 +1699,7 @@ async fn handle_container_exec_with_params(
                     sess.approval_policy,
                     &sess.sandbox_policy,
                     &state.approved_commands,
-                    params.with_escalated_privileges.unwrap_or(false),
+                    params.with_escalated_permissions.unwrap_or(false),
                 )
             };
             let command_for_display = params.command.clone();

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2011,7 +2011,7 @@ fn get_last_assistant_message_from_turn(responses: &[ResponseItem]) -> Option<St
 }
 
 async fn drain_to_completed(sess: &Session, prompt: &Prompt) -> CodexResult<()> {
-    let mut stream = sess.client.clone().stream(prompt).await?;
+    let mut stream = sess.client.clone().stream(prompt, None).await?;
     loop {
         let maybe_event = stream.next().await;
         let Some(event) = maybe_event else {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1841,8 +1841,11 @@ async fn handle_sandbox_error(
     let cwd = exec_command_context.cwd.clone();
     let is_apply_patch = exec_command_context.apply_patch.is_some();
 
-    // Early out if the user never wants to be asked for approval; just return to the model immediately
-    if sess.approval_policy == AskForApproval::Never {
+    // Early out if either the user never wants to be asked for approval, or
+    // we're letting the model manage escalation requests.
+    if sess.approval_policy == AskForApproval::Never
+        || sess.approval_policy == AskForApproval::OnRequest
+    {
         return ResponseInputItem::FunctionCallOutput {
             call_id,
             output: FunctionCallOutputPayload {

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -43,6 +43,8 @@ pub struct ExecParams {
     pub cwd: PathBuf,
     pub timeout_ms: Option<u64>,
     pub env: HashMap<String, String>,
+    pub with_escalated_privileges: Option<bool>,
+    pub justification: Option<String>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq)]
@@ -74,6 +76,8 @@ pub async fn process_exec_tool_call(
                 cwd,
                 timeout_ms,
                 env,
+                with_escalated_privileges: _,
+                justification: _,
             } = params;
             let child = spawn_command_under_seatbelt(
                 command,
@@ -91,6 +95,8 @@ pub async fn process_exec_tool_call(
                 cwd,
                 timeout_ms,
                 env,
+                with_escalated_privileges: _,
+                justification: _,
             } = params;
 
             let codex_linux_sandbox_exe = codex_linux_sandbox_exe
@@ -230,6 +236,8 @@ async fn exec(
         cwd,
         timeout_ms,
         env,
+        with_escalated_privileges: _,
+        justification: _,
     }: ExecParams,
     sandbox_policy: &SandboxPolicy,
     ctrl_c: Arc<Notify>,

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -43,7 +43,7 @@ pub struct ExecParams {
     pub cwd: PathBuf,
     pub timeout_ms: Option<u64>,
     pub env: HashMap<String, String>,
-    pub with_escalated_privileges: Option<bool>,
+    pub with_escalated_permissions: Option<bool>,
     pub justification: Option<String>,
 }
 
@@ -76,7 +76,7 @@ pub async fn process_exec_tool_call(
                 cwd,
                 timeout_ms,
                 env,
-                with_escalated_privileges: _,
+                with_escalated_permissions: _,
                 justification: _,
             } = params;
             let child = spawn_command_under_seatbelt(
@@ -95,7 +95,7 @@ pub async fn process_exec_tool_call(
                 cwd,
                 timeout_ms,
                 env,
-                with_escalated_privileges: _,
+                with_escalated_permissions: _,
                 justification: _,
             } = params;
 
@@ -236,7 +236,7 @@ async fn exec(
         cwd,
         timeout_ms,
         env,
-        with_escalated_privileges: _,
+        with_escalated_permissions: _,
         justification: _,
     }: ExecParams,
     sandbox_policy: &SandboxPolicy,

--- a/codex-rs/core/src/models.rs
+++ b/codex-rs/core/src/models.rs
@@ -183,6 +183,8 @@ pub struct ShellToolCallParams {
     // The wire format uses `timeout`, which has ambiguous units, so we use
     // `timeout_ms` as the field name so it is clear in code.
     pub timeout_ms: Option<u64>,
+    pub with_escalated_privileges: Option<bool>,
+    pub justification: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -295,6 +297,30 @@ mod tests {
                 command: vec!["ls".to_string(), "-l".to_string()],
                 workdir: Some("/tmp".to_string()),
                 timeout_ms: Some(1000),
+                with_escalated_privileges: None,
+                justification: None,
+            },
+            params
+        );
+    }
+    #[test]
+    fn deserialize_shell_tool_call_params_with_escalated_privileges() {
+        let json = r#"{
+            "command": ["ls", "-l"],
+            "workdir": "/tmp",
+            "timeout": 1000,
+            "with_escalated_privileges": true,
+            "justification": "I need internet access to run npm install"
+        }"#;
+
+        let params: ShellToolCallParams = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            ShellToolCallParams {
+                command: vec!["ls".to_string(), "-l".to_string()],
+                workdir: Some("/tmp".to_string()),
+                timeout_ms: Some(1000),
+                with_escalated_privileges: Some(true),
+                justification: Some("I need internet access to run npm install".to_string()),
             },
             params
         );

--- a/codex-rs/core/src/models.rs
+++ b/codex-rs/core/src/models.rs
@@ -183,7 +183,7 @@ pub struct ShellToolCallParams {
     // The wire format uses `timeout`, which has ambiguous units, so we use
     // `timeout_ms` as the field name so it is clear in code.
     pub timeout_ms: Option<u64>,
-    pub with_escalated_privileges: Option<bool>,
+    pub with_escalated_permissions: Option<bool>,
     pub justification: Option<String>,
 }
 
@@ -297,19 +297,19 @@ mod tests {
                 command: vec!["ls".to_string(), "-l".to_string()],
                 workdir: Some("/tmp".to_string()),
                 timeout_ms: Some(1000),
-                with_escalated_privileges: None,
+                with_escalated_permissions: None,
                 justification: None,
             },
             params
         );
     }
     #[test]
-    fn deserialize_shell_tool_call_params_with_escalated_privileges() {
+    fn deserialize_shell_tool_call_params_with_escalated_permissions() {
         let json = r#"{
             "command": ["ls", "-l"],
             "workdir": "/tmp",
             "timeout": 1000,
-            "with_escalated_privileges": true,
+            "with_escalated_permissions": true,
             "justification": "I need internet access to run npm install"
         }"#;
 
@@ -319,7 +319,7 @@ mod tests {
                 command: vec!["ls".to_string(), "-l".to_string()],
                 workdir: Some("/tmp".to_string()),
                 timeout_ms: Some(1000),
-                with_escalated_privileges: Some(true),
+                with_escalated_permissions: Some(true),
                 justification: Some("I need internet access to run npm install".to_string()),
             },
             params

--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -169,9 +169,9 @@ fn create_shell_tool_for_sandbox(sandbox_policy: SandboxPolicy) -> OpenAiTool {
         } => {
             format!(
                 r#"
-The exec_command tool is used to execute shell commands.
+The shell tool is used to execute shell commands.
 
-- When invoking the exec_command tool, your call will be running in a landlock sandbox, and some shell commands will require escalated privileges:
+- When invoking the shell tool, your call will be running in a landlock sandbox, and some shell commands will require escalated privileges:
   - Types of actions that require escalated privileges:
     - Reading files outside the current directory
     - Writing files outside the current directory, and protected folders like .git or .env{}
@@ -195,7 +195,7 @@ The exec_command tool is used to execute shell commands.
     };
 
     OpenAiTool::Function(ResponsesApiTool {
-        name: "exec_command",
+        name: "shell",
         description,
         strict: false,
         parameters: JsonSchema::Object {

--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -149,15 +149,15 @@ fn create_shell_tool_for_sandbox(sandbox_policy: SandboxPolicy) -> OpenAiTool {
 
     if sandbox_policy != SandboxPolicy::DangerFullAccess {
         properties.insert(
-        "with_escalated_privileges".to_string(),
+        "with_escalated_permissions".to_string(),
         JsonSchema::Boolean {
-            description: Some("Whether to request escalated privileges. Set to true if command needs to be run without sandbox restrictions".to_string()),
+            description: Some("Whether to request escalated permissions. Set to true if command needs to be run without sandbox restrictions".to_string()),
         },
     );
         properties.insert(
         "justification".to_string(),
         JsonSchema::String {
-            description: Some("Only set if with_escalated_privileges is true. 1-sentence explanation of why we want to run this command.".to_string()),
+            description: Some("Only set if ask_for_escalated_permissions is true. 1-sentence explanation of why we want to run this command.".to_string()),
         },
     );
     }
@@ -181,8 +181,8 @@ The shell tool is used to execute shell commands.
     - cargo build
     - cargo test
 - When invoking a command that will require escalated privileges:
-  - Provide the with_escalated_privileges parameter with the boolean value true
-  - Include a short, 1 sentence explanation for why we need to run with_escalated_privileges."#,
+  - Provide the with_escalated_permissions parameter with the boolean value true
+  - Include a short, 1 sentence explanation for why we need to run with_escalated_permissions in the justification parameter."#,
                 if !network_access {
                     "\n  - Commands that require network access\n"
                 } else {
@@ -196,9 +196,9 @@ The shell tool is used to execute shell commands.
         SandboxPolicy::ReadOnly => {
             r#"
 The shell tool is used to execute shell commands.
-IMPORTANT: If you are running the apply_patch command, you will need to provide the with_escalated_privileges parameter with the boolean value true.
+IMPORTANT: If you are running the apply_patch command, you will need to provide the with_escalated_permissions parameter with the boolean value true.
 
-- When invoking the shell tool, your call will be running in a landlock sandbox, and some shell commands (including apply_patch) will require escalated privileges:
+- When invoking the shell tool, your call will be running in a landlock sandbox, and some shell commands (including apply_patch) will require escalated permissions:
   - Types of actions that require escalated privileges:
     - Reading files outside the current directory
     - Writing files
@@ -210,8 +210,8 @@ IMPORTANT: If you are running the apply_patch command, you will need to provide 
     - cargo build
     - cargo test
 - When invoking a command that will require escalated privileges:
-  - Provide the with_escalated_privileges parameter with the boolean value true
-  - Include a short, 1 sentence explanation for why we need to run with_escalated_privileges."#.to_string()
+  - Provide the with_escalated_permissions parameter with the boolean value true
+  - Include a short, 1 sentence explanation for why we need to run with_escalated_permissions in the justification parameter"#.to_string()
         }
     };
 
@@ -312,7 +312,7 @@ mod tests {
         let properties = tools_json[0]["parameters"]["properties"]
             .as_object()
             .unwrap();
-        assert!(!properties.contains_key("with_escalated_privileges"));
+        assert!(!properties.contains_key("with_escalated_permissions"));
         assert!(!properties.contains_key("justification"));
     }
 
@@ -332,7 +332,7 @@ mod tests {
         let properties = tools_json[0]["parameters"]["properties"]
             .as_object()
             .unwrap();
-        assert!(properties.contains_key("with_escalated_privileges"));
+        assert!(properties.contains_key("with_escalated_permissions"));
         assert!(properties.contains_key("justification"));
     }
 }

--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -196,12 +196,15 @@ The shell tool is used to execute shell commands.
         SandboxPolicy::ReadOnly => {
             r#"
 The shell tool is used to execute shell commands.
+IMPORTANT: If you are running the apply_patch command, you will need to provide the with_escalated_privileges parameter with the boolean value true.
 
-- When invoking the shell tool, your call will be running in a landlock sandbox, and some shell commands will require escalated privileges:
+- When invoking the shell tool, your call will be running in a landlock sandbox, and some shell commands (including apply_patch) will require escalated privileges:
   - Types of actions that require escalated privileges:
     - Reading files outside the current directory
     - Writing files
+    - Applying patches
   - Examples of commands that require escalated privileges:
+    - apply_patch
     - git commit
     - npm install or pnpm install
     - cargo build

--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -268,3 +268,50 @@ fn mcp_tool_to_openai_tool(
         "type": "function",
     })
 }
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+
+    use super::*;
+
+    #[test]
+    fn test_create_tools_json_for_responses_api() {
+        let prompt = Prompt {
+            ..Default::default()
+        };
+        let model = "gpt-4o-mini";
+        let include_plan_tool = true;
+        let sandbox_policy = None;
+
+        let tools_json =
+            create_tools_json_for_responses_api(&prompt, model, include_plan_tool, sandbox_policy)
+                .unwrap();
+        assert_eq!(tools_json[0]["name"], "shell");
+        let properties = tools_json[0]["parameters"]["properties"]
+            .as_object()
+            .unwrap();
+        assert!(!properties.contains_key("with_escalated_privileges"));
+        assert!(!properties.contains_key("justification"));
+    }
+
+    #[test]
+    fn test_create_tools_json_for_responses_api_with_sandbox() {
+        let prompt = Prompt {
+            ..Default::default()
+        };
+        let model = "codex-mini-latest";
+        let include_plan_tool = true;
+        let sandbox_policy = Some(SandboxPolicy::ReadOnly);
+
+        let tools_json =
+            create_tools_json_for_responses_api(&prompt, model, include_plan_tool, sandbox_policy)
+                .unwrap();
+        assert_eq!(tools_json[0]["name"], "shell");
+        let properties = tools_json[0]["parameters"]["properties"]
+            .as_object()
+            .unwrap();
+        assert!(properties.contains_key("with_escalated_privileges"));
+        assert!(properties.contains_key("justification"));
+    }
+}

--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -218,7 +218,7 @@ The shell tool is used to execute shell commands.
         strict: false,
         parameters: JsonSchema::Object {
             properties,
-            required: &["cmd"],
+            required: &["command"],
             additional_properties: false,
         },
     })

--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -190,8 +190,26 @@ The shell tool is used to execute shell commands.
                 }
             )
         }
-        SandboxPolicy::DangerFullAccess => "Runs a shell command, and returns its output.".to_string(),
-        SandboxPolicy::ReadOnly => "Run a shell command, and return its output. This command will be run in a read-only sandbox, and will not have access to the network or the ability to write to the file system.".to_string(),
+        SandboxPolicy::DangerFullAccess => {
+            "Runs a shell command, and returns its output.".to_string()
+        }
+        SandboxPolicy::ReadOnly => {
+            r#"
+The shell tool is used to execute shell commands.
+
+- When invoking the shell tool, your call will be running in a landlock sandbox, and some shell commands will require escalated privileges:
+  - Types of actions that require escalated privileges:
+    - Reading files outside the current directory
+    - Writing files
+  - Examples of commands that require escalated privileges:
+    - git commit
+    - npm install or pnpm install
+    - cargo build
+    - cargo test
+- When invoking a command that will require escalated privileges:
+  - Provide the with_escalated_privileges parameter with the boolean value true
+  - Include a short, 1 sentence explanation for why we need to run with_escalated_privileges."#.to_string()
+        }
     };
 
     OpenAiTool::Function(ResponsesApiTool {

--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -5,11 +5,12 @@ use std::sync::LazyLock;
 
 use crate::client_common::Prompt;
 use crate::plan_tool::PLAN_TOOL;
+use crate::protocol::SandboxPolicy;
 
 #[derive(Debug, Clone, Serialize)]
 pub(crate) struct ResponsesApiTool {
     pub(crate) name: &'static str,
-    pub(crate) description: &'static str,
+    pub(crate) description: String,
     pub(crate) strict: bool,
     pub(crate) parameters: JsonSchema,
 }
@@ -29,8 +30,18 @@ pub(crate) enum OpenAiTool {
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "lowercase")]
 pub(crate) enum JsonSchema {
-    String,
-    Number,
+    Boolean {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+    },
+    String {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+    },
+    Number {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        description: Option<String>,
+    },
     Array {
         items: Box<JsonSchema>,
     },
@@ -48,15 +59,21 @@ static DEFAULT_TOOLS: LazyLock<Vec<OpenAiTool>> = LazyLock::new(|| {
     properties.insert(
         "command".to_string(),
         JsonSchema::Array {
-            items: Box::new(JsonSchema::String),
+            items: Box::new(JsonSchema::String { description: None }),
         },
     );
-    properties.insert("workdir".to_string(), JsonSchema::String);
-    properties.insert("timeout".to_string(), JsonSchema::Number);
+    properties.insert(
+        "workdir".to_string(),
+        JsonSchema::String { description: None },
+    );
+    properties.insert(
+        "timeout".to_string(),
+        JsonSchema::Number { description: None },
+    );
 
     vec![OpenAiTool::Function(ResponsesApiTool {
         name: "shell",
-        description: "Runs a shell command, and returns its output.",
+        description: "Runs a shell command, and returns its output.".to_string(),
         strict: false,
         parameters: JsonSchema::Object {
             properties,
@@ -72,13 +89,18 @@ static DEFAULT_CODEX_MODEL_TOOLS: LazyLock<Vec<OpenAiTool>> =
 /// Returns JSON values that are compatible with Function Calling in the
 /// Responses API:
 /// https://platform.openai.com/docs/guides/function-calling?api-mode=responses
+/// TODO: we're starting to get more complex with our tool config, let's
 pub(crate) fn create_tools_json_for_responses_api(
     prompt: &Prompt,
     model: &str,
     include_plan_tool: bool,
+    sandbox_policy: Option<SandboxPolicy>,
 ) -> crate::error::Result<Vec<serde_json::Value>> {
     // Assemble tool list: built-in tools + any extra tools from the prompt.
-    let default_tools = if model.starts_with("codex") {
+    let default_tools = if let Some(sandbox_policy) = sandbox_policy {
+        // if sandbox_policy is provided, create the shell tool
+        &vec![create_shell_tool_for_sandbox(sandbox_policy)]
+    } else if model.contains("codex") {
         &DEFAULT_CODEX_MODEL_TOOLS
     } else {
         &DEFAULT_TOOLS
@@ -102,6 +124,88 @@ pub(crate) fn create_tools_json_for_responses_api(
     Ok(tools_json)
 }
 
+fn create_shell_tool_for_sandbox(sandbox_policy: SandboxPolicy) -> OpenAiTool {
+    let mut properties = BTreeMap::new();
+    properties.insert(
+        "command".to_string(),
+        JsonSchema::Array {
+            items: Box::new(JsonSchema::String {
+                description: Some("The command to execute".to_string()),
+            }),
+        },
+    );
+    properties.insert(
+        "workdir".to_string(),
+        JsonSchema::String {
+            description: Some("The working directory to execute the command in".to_string()),
+        },
+    );
+    properties.insert(
+        "timeout".to_string(),
+        JsonSchema::Number {
+            description: Some("The timeout for the command in milliseconds".to_string()),
+        },
+    );
+
+    if sandbox_policy != SandboxPolicy::DangerFullAccess {
+        properties.insert(
+        "with_escalated_privileges".to_string(),
+        JsonSchema::Boolean {
+            description: Some("Whether to request escalated privileges. Set to true if command needs to be run without sandbox restrictions".to_string()),
+        },
+    );
+        properties.insert(
+        "justification".to_string(),
+        JsonSchema::String {
+            description: Some("Only set if with_escalated_privileges is true. 1-sentence explanation of why we want to run this command.".to_string()),
+        },
+    );
+    }
+
+    let description = match sandbox_policy {
+        SandboxPolicy::WorkspaceWrite {
+            writable_roots: _,
+            network_access,
+        } => {
+            format!(
+                r#"
+The exec_command tool is used to execute shell commands.
+
+- When invoking the exec_command tool, your call will be running in a landlock sandbox, and some shell commands will require escalated privileges:
+  - Types of actions that require escalated privileges:
+    - Reading files outside the current directory
+    - Writing files outside the current directory, and protected folders like .git or .env{}
+  - Examples of commands that require escalated privileges:
+    - git commit
+    - npm install or pnpm install
+    - cargo build
+    - cargo test
+- When invoking a command that will require escalated privileges:
+  - Provide the with_escalated_privileges parameter with the boolean value true
+  - Include a short, 1 sentence explanation for why we need to run with_escalated_privileges."#,
+                if !network_access {
+                    "\n  - Commands that require network access\n"
+                } else {
+                    ""
+                }
+            )
+        }
+        SandboxPolicy::DangerFullAccess => "Runs a shell command, and returns its output.".to_string(),
+        SandboxPolicy::ReadOnly => "Run a shell command, and return its output. This command will be run in a read-only sandbox, and will not have access to the network or the ability to write to the file system.".to_string(),
+    };
+
+    OpenAiTool::Function(ResponsesApiTool {
+        name: "exec_command",
+        description,
+        strict: false,
+        parameters: JsonSchema::Object {
+            properties,
+            required: &["cmd"],
+            additional_properties: false,
+        },
+    })
+}
+
 /// Returns JSON values that are compatible with Function Calling in the
 /// Chat Completions API:
 /// https://platform.openai.com/docs/guides/function-calling?api-mode=chat
@@ -109,11 +213,12 @@ pub(crate) fn create_tools_json_for_chat_completions_api(
     prompt: &Prompt,
     model: &str,
     include_plan_tool: bool,
+    sandbox_policy: Option<SandboxPolicy>,
 ) -> crate::error::Result<Vec<serde_json::Value>> {
     // We start with the JSON for the Responses API and than rewrite it to match
     // the chat completions tool call format.
     let responses_api_tools_json =
-        create_tools_json_for_responses_api(prompt, model, include_plan_tool)?;
+        create_tools_json_for_responses_api(prompt, model, include_plan_tool, sandbox_policy)?;
     let tools_json = responses_api_tools_json
         .into_iter()
         .filter_map(|mut tool| {

--- a/codex-rs/core/src/plan_tool.rs
+++ b/codex-rs/core/src/plan_tool.rs
@@ -39,8 +39,11 @@ pub struct UpdatePlanArgs {
 
 pub(crate) static PLAN_TOOL: LazyLock<OpenAiTool> = LazyLock::new(|| {
     let mut plan_item_props = BTreeMap::new();
-    plan_item_props.insert("step".to_string(), JsonSchema::String);
-    plan_item_props.insert("status".to_string(), JsonSchema::String);
+    plan_item_props.insert("step".to_string(), JsonSchema::String { description: None });
+    plan_item_props.insert(
+        "status".to_string(),
+        JsonSchema::String { description: None },
+    );
 
     let plan_items_schema = JsonSchema::Array {
         items: Box::new(JsonSchema::Object {
@@ -51,7 +54,10 @@ pub(crate) static PLAN_TOOL: LazyLock<OpenAiTool> = LazyLock::new(|| {
     };
 
     let mut properties = BTreeMap::new();
-    properties.insert("explanation".to_string(), JsonSchema::String);
+    properties.insert(
+        "explanation".to_string(),
+        JsonSchema::String { description: None },
+    );
     properties.insert("plan".to_string(), plan_items_schema);
 
     OpenAiTool::Function(ResponsesApiTool {
@@ -66,7 +72,7 @@ Until all the steps are finished, there should always be exactly one in_progress
 Call the update_plan tool whenever you finish a step, marking the completed step as `completed` and marking the next step as `in_progress`.
 Before running a command, consider whether or not you have completed the previous step, and make sure to mark it as completed before moving on to the next step.
 Sometimes, you may need to change plans in the middle of a task: call `update_plan` with the updated plan and make sure to provide an `explanation` of the rationale when doing so.
-When all steps are completed, call update_plan one last time with all steps marked as `completed`."#,
+When all steps are completed, call update_plan one last time with all steps marked as `completed`."#.to_string(),
         strict: false,
         parameters: JsonSchema::Object {
             properties,

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -149,7 +149,9 @@ pub enum AskForApproval {
     /// the user to approve execution without a sandbox.
     OnFailure,
 
-    // Experimental: only request approval for commands when the model requests it.
+    // Experimental: Commands are run inside a sandbox, and the model can
+    // proactively request escalation of privileges. Failures are handled by
+    // the model.
     OnRequest,
 
     /// Never ask the user to approve commands. Failures are immediately returned

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -149,6 +149,9 @@ pub enum AskForApproval {
     /// the user to approve execution without a sandbox.
     OnFailure,
 
+    // Experimental: only request approval for commands when the model requests it.
+    OnRequest,
+
     /// Never ask the user to approve commands. Failures are immediately returned
     /// to the model, and never escalated to the user for approval.
     Never,

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -107,7 +107,7 @@ pub fn assess_command_safety(
 pub(crate) fn assess_safety_for_untrusted_command(
     approval_policy: AskForApproval,
     sandbox_policy: &SandboxPolicy,
-    with_escalated_privileges: bool,
+    with_escalated_permissions: bool,
 ) -> SafetyCheck {
     use AskForApproval::*;
     use SandboxPolicy::*;
@@ -125,7 +125,7 @@ pub(crate) fn assess_safety_for_untrusted_command(
             sandbox_type: SandboxType::None,
         },
         (OnRequest, ReadOnly) | (OnRequest, WorkspaceWrite { .. }) => {
-            if with_escalated_privileges {
+            if with_escalated_permissions {
                 SafetyCheck::AskUser
             } else {
                 match get_platform_sandbox() {

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -128,8 +128,11 @@ pub(crate) fn assess_safety_for_untrusted_command(
             if with_escalated_privileges {
                 SafetyCheck::AskUser
             } else {
-                SafetyCheck::AutoApprove {
-                    sandbox_type: get_platform_sandbox().unwrap_or(SandboxType::None),
+                match get_platform_sandbox() {
+                    Some(sandbox_type) => SafetyCheck::AutoApprove { sandbox_type },
+                    // Fall back to asking since the command is untrusted and
+                    // we do not have a sandbox available
+                    None => SafetyCheck::AskUser,
                 }
             }
         }

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -215,7 +215,7 @@ mod tests {
                         "HOME".to_string(),
                         temp_home.path().to_str().unwrap().to_string(),
                     )]),
-                    with_escalated_privileges: None,
+                    with_escalated_permissions: None,
                     justification: None,
                 },
                 SandboxType::None,

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -215,6 +215,8 @@ mod tests {
                         "HOME".to_string(),
                         temp_home.path().to_str().unwrap().to_string(),
                     )]),
+                    with_escalated_privileges: None,
+                    justification: None,
                 },
                 SandboxType::None,
                 Arc::new(Notify::new()),

--- a/codex-rs/linux-sandbox/tests/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/landlock.rs
@@ -44,6 +44,8 @@ async fn run_cmd(cmd: &[&str], writable_roots: &[PathBuf], timeout_ms: u64) {
         cwd: std::env::current_dir().expect("cwd should exist"),
         timeout_ms: Some(timeout_ms),
         env: create_env_from_core_vars(),
+        with_escalated_privileges: None,
+        justification: None,
     };
 
     let sandbox_policy = SandboxPolicy::WorkspaceWrite {
@@ -137,6 +139,8 @@ async fn assert_network_blocked(cmd: &[&str]) {
         // do not stall the suite.
         timeout_ms: Some(NETWORK_TIMEOUT_MS),
         env: create_env_from_core_vars(),
+        with_escalated_privileges: None,
+        justification: None,
     };
 
     let sandbox_policy = SandboxPolicy::new_read_only_policy();

--- a/codex-rs/linux-sandbox/tests/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/landlock.rs
@@ -44,7 +44,7 @@ async fn run_cmd(cmd: &[&str], writable_roots: &[PathBuf], timeout_ms: u64) {
         cwd: std::env::current_dir().expect("cwd should exist"),
         timeout_ms: Some(timeout_ms),
         env: create_env_from_core_vars(),
-        with_escalated_privileges: None,
+        with_escalated_permissions: None,
         justification: None,
     };
 
@@ -139,7 +139,7 @@ async fn assert_network_blocked(cmd: &[&str]) {
         // do not stall the suite.
         timeout_ms: Some(NETWORK_TIMEOUT_MS),
         env: create_env_from_core_vars(),
-        with_escalated_privileges: None,
+        with_escalated_permissions: None,
         justification: None,
     };
 

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -10,7 +10,6 @@ use crate::tui;
 use codex_core::config::Config;
 use codex_core::protocol::Event;
 use codex_core::protocol::EventMsg;
-use codex_core::protocol::ExecApprovalRequestEvent;
 use codex_core::protocol::Op;
 use color_eyre::eyre::Result;
 use crossterm::SynchronizedUpdate;


### PR DESCRIPTION
## Summary
Let's try something new: tell the model about the sandbox, and let it decide when it will need to break the sandbox. Some local testing suggests that it works pretty well with zero iteration on the prompt!

**Example of this PR in action, on this PR:** 
<img width="749" height="833" alt="Screenshot 2025-07-31 at 12 17 24 PM" src="https://github.com/user-attachments/assets/b56cff95-bf16-4283-9e97-08dc12bd1b07" />
It wasn't totally correct - I'll try to steer the prompt a bit more.

**Things I'm considering out of scope for this change, but that I think we should do:**
- simplify/consolidate our tool config logic, so we don't have to pass an infinite list of params to `create_tools_json_for_responses_api`
- Continue iterating on our tool prompt and system prompt to make this call more accurate

## Testing
- [x] Added unit tests
- [x] Played around with it locally and it feels really good