### PR TITLE
do not dispatch key releases

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -249,13 +249,13 @@ impl App<'_> {
                             }
                         }
                         KeyEvent {
-                            kind: KeyEventKind::Press,
+                            kind: KeyEventKind::Press | KeyEventKind::Repeat,
                             ..
                         } => {
                             self.dispatch_key_event(key_event);
                         }
                         _ => {
-                            // Ignore non-Press key events for now.
+                            // Ignore Release key events for now.
                         }
                     };
                 }

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -15,6 +15,7 @@ use color_eyre::eyre::Result;
 use crossterm::SynchronizedUpdate;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
+use crossterm::event::KeyEventKind;
 use ratatui::layout::Offset;
 use ratatui::prelude::Backend;
 use std::path::PathBuf;
@@ -213,6 +214,7 @@ impl App<'_> {
                         KeyEvent {
                             code: KeyCode::Char('c'),
                             modifiers: crossterm::event::KeyModifiers::CONTROL,
+                            kind: KeyEventKind::Press,
                             ..
                         } => {
                             match &mut self.app_state {
@@ -227,6 +229,7 @@ impl App<'_> {
                         KeyEvent {
                             code: KeyCode::Char('d'),
                             modifiers: crossterm::event::KeyModifiers::CONTROL,
+                            kind: KeyEventKind::Press,
                             ..
                         } => {
                             match &mut self.app_state {
@@ -245,8 +248,14 @@ impl App<'_> {
                                 }
                             }
                         }
-                        _ => {
+                        KeyEvent {
+                            kind: KeyEventKind::Press,
+                            ..
+                        } => {
                             self.dispatch_key_event(key_event);
+                        }
+                        _ => {
+                            // Ignore non-Press key events for now.
                         }
                     };
                 }


### PR DESCRIPTION
when we enabled KKP in https://github.com/openai/codex/pull/1743, we started receiving keyup events, but didn't expect them anywhere in our code. for now, just don't dispatch them at all.