### PR TITLE
feat: stream agent message deltas

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -48,4 +48,6 @@ pub(crate) enum AppEvent {
     },
 
     InsertHistory(Vec<Line<'static>>),
+    /// Overwrite the last line in the scrollback with the provided content.
+    OverwriteHistoryLine(Line<'static>),
 }

--- a/codex-rs/tui/src/insert_history.rs
+++ b/codex-rs/tui/src/insert_history.rs
@@ -5,6 +5,7 @@ use std::io::Write;
 use crate::tui;
 use crossterm::Command;
 use crossterm::cursor::MoveTo;
+use crossterm::cursor::MoveToColumn;
 use crossterm::queue;
 use crossterm::style::Color as CColor;
 use crossterm::style::Colors;
@@ -13,6 +14,8 @@ use crossterm::style::SetAttribute;
 use crossterm::style::SetBackgroundColor;
 use crossterm::style::SetColors;
 use crossterm::style::SetForegroundColor;
+use crossterm::terminal::Clear;
+use crossterm::terminal::ClearType;
 use ratatui::layout::Size;
 use ratatui::prelude::Backend;
 use ratatui::style::Color;
@@ -77,6 +80,17 @@ pub(crate) fn insert_history_lines(terminal: &mut tui::Tui, lines: Vec<Line>) {
     if let Some(cursor_pos) = cursor_pos {
         queue!(std::io::stdout(), MoveTo(cursor_pos.x, cursor_pos.y)).ok();
     }
+}
+
+/// Overwrite the current line in the history area with new content.
+pub(crate) fn overwrite_last_history_line(line: Line) {
+    queue!(
+        std::io::stdout(),
+        MoveToColumn(0),
+        Clear(ClearType::CurrentLine)
+    )
+    .ok();
+    write_spans(&mut std::io::stdout(), line.iter()).ok();
 }
 
 fn wrapped_line_count(lines: &[Line], width: u16) -> u16 {


### PR DESCRIPTION
## Summary
- allow overwriting history lines during rendering
- stream agent and reasoning message deltas without extra blank lines

## Testing
- `just fmt` *(fails: failed to load manifest for workspace member `/workspace/codex/codex-rs/ansi-escape` caused by unstable `edition2024` feature)*
- `just fix` *(fails: failed to load manifest for workspace member `/workspace/codex/codex-rs/ansi-escape` caused by unstable `edition2024` feature)*
- `cargo test --all-features` *(fails: failed to load manifest for workspace member `/workspace/codex/codex-rs/ansi-escape` caused by unstable `edition2024` feature)*

------
https://chatgpt.com/codex/tasks/task_i_688c396c61748321b125666c5599559a