### PR TITLE
feat(tui): stream agent output

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -48,4 +48,7 @@ pub(crate) enum AppEvent {
     },
 
     InsertHistory(Vec<Line<'static>>),
+    /// Replace the most recently inserted history line without adding a new
+    /// newline. Used for streaming updates of the agent's response.
+    UpdateHistoryLastLine(Line<'static>),
 }


### PR DESCRIPTION
## Summary
- stream agent and reasoning messages directly into the TUI
- support in-place history line updates without inserting newlines
- wire up app event handling for streaming updates

## Testing
- `just fmt` *(fails: command not found)*
- `just fix` *(fails: command not found)*
- `cargo test --all-features` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_i_688c396c61748321b125666c5599559a