### PR TITLE
Add Error variant to ConversationCreateResult [Stack 1/2]

### DIFF
--- a/codex-rs/mcp-server/src/mcp_protocol.rs
+++ b/codex-rs/mcp-server/src/mcp_protocol.rs
@@ -172,7 +172,6 @@ pub enum ToolCallResponseResult {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-#[serde(tag = "status", rename_all = "camelCase")]
 pub enum ConversationCreateResult {
     Ok {
         conversation_id: ConversationId,
@@ -507,7 +506,7 @@ mod tests {
         let observed = to_val(&CallToolResult::from(env));
         let expected = json!({
             "content": [
-                { "type": "text", "text": "{\"status\":\"ok\",\"conversation_id\":\"d0f6ecbe-84a2-41c1-b23d-b20473b25eab\",\"model\":\"o3\"}" }
+                { "type": "text", "text": "{\"conversation_id\":\"d0f6ecbe-84a2-41c1-b23d-b20473b25eab\",\"model\":\"o3\"}" }
             ],
             "structuredContent": {
                 "status": "ok",
@@ -537,7 +536,7 @@ mod tests {
         let observed = to_val(&CallToolResult::from(env));
         let expected = json!({
             "content": [
-                { "type": "text", "text": "{\"status\":\"error\",\"message\":\"Failed to initialize session\"}" }
+                { "type": "text", "text": "{\"message\":\"Failed to initialize session\"}" }
             ],
             "isError": true,
             "structuredContent": {

--- a/codex-rs/mcp-server/src/mcp_protocol.rs
+++ b/codex-rs/mcp-server/src/mcp_protocol.rs
@@ -172,6 +172,7 @@ pub enum ToolCallResponseResult {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[serde(untagged)]
 pub enum ConversationCreateResult {
     Ok {
         conversation_id: ConversationId,
@@ -507,13 +508,11 @@ mod tests {
         let observed = to_val(&CallToolResult::from(env));
         let expected = json!({
             "content": [
-                { "type": "text", "text": "{\"Ok\":{\"conversation_id\":\"d0f6ecbe-84a2-41c1-b23d-b20473b25eab\",\"model\":\"o3\"}}" }
+                { "type": "text", "text": "{\"conversation_id\":\"d0f6ecbe-84a2-41c1-b23d-b20473b25eab\",\"model\":\"o3\"}" }
             ],
             "structuredContent": {
-                "Ok": {
-                    "conversation_id": "d0f6ecbe-84a2-41c1-b23d-b20473b25eab",
-                    "model": "o3"
-                }
+                "conversation_id": "d0f6ecbe-84a2-41c1-b23d-b20473b25eab",
+                "model": "o3"
             }
         });
         assert_eq!(
@@ -538,13 +537,11 @@ mod tests {
         let observed = to_val(&CallToolResult::from(env));
         let expected = json!({
             "content": [
-                { "type": "text", "text": "{\"Error\":{\"message\":\"Failed to initialize session\"}}" }
+                { "type": "text", "text": "{\"message\":\"Failed to initialize session\"}" }
             ],
             "isError": true,
             "structuredContent": {
-                "Error": {
-                    "message": "Failed to initialize session"
-                }
+                "message": "Failed to initialize session"
             }
         });
         assert_eq!(

--- a/codex-rs/mcp-server/src/mcp_protocol.rs
+++ b/codex-rs/mcp-server/src/mcp_protocol.rs
@@ -172,9 +172,15 @@ pub enum ToolCallResponseResult {
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct ConversationCreateResult {
-    pub conversation_id: ConversationId,
-    pub model: String,
+#[serde(tag = "status", rename_all = "camelCase")]
+pub enum ConversationCreateResult {
+    Ok {
+        conversation_id: ConversationId,
+        model: String,
+    },
+    Error {
+        message: String,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
@@ -491,7 +497,7 @@ mod tests {
             request_id: RequestId::Integer(1),
             is_error: None,
             result: Some(ToolCallResponseResult::ConversationCreate(
-                ConversationCreateResult {
+                ConversationCreateResult::Ok {
                     conversation_id: ConversationId(uuid!("d0f6ecbe-84a2-41c1-b23d-b20473b25eab")),
                     model: "o3".into(),
                 },
@@ -501,9 +507,10 @@ mod tests {
         let observed = to_val(&CallToolResult::from(env));
         let expected = json!({
             "content": [
-                { "type": "text", "text": "{\"conversation_id\":\"d0f6ecbe-84a2-41c1-b23d-b20473b25eab\",\"model\":\"o3\"}" }
+                { "type": "text", "text": "{\"status\":\"ok\",\"conversation_id\":\"d0f6ecbe-84a2-41c1-b23d-b20473b25eab\",\"model\":\"o3\"}" }
             ],
             "structuredContent": {
+                "status": "ok",
                 "conversation_id": "d0f6ecbe-84a2-41c1-b23d-b20473b25eab",
                 "model": "o3"
             }
@@ -513,6 +520,36 @@ mod tests {
             "response (ConversationCreate) must match"
         );
         assert_eq!(req_id, RequestId::Integer(1));
+    }
+
+    #[test]
+    fn response_error_conversation_create_full_schema() {
+        let env = ToolCallResponse {
+            request_id: RequestId::Integer(2),
+            is_error: Some(true),
+            result: Some(ToolCallResponseResult::ConversationCreate(
+                ConversationCreateResult::Error {
+                    message: "Failed to initialize session".into(),
+                },
+            )),
+        };
+        let req_id = env.request_id.clone();
+        let observed = to_val(&CallToolResult::from(env));
+        let expected = json!({
+            "content": [
+                { "type": "text", "text": "{\"status\":\"error\",\"message\":\"Failed to initialize session\"}" }
+            ],
+            "isError": true,
+            "structuredContent": {
+                "status": "error",
+                "message": "Failed to initialize session"
+            }
+        });
+        assert_eq!(
+            observed, expected,
+            "error response (ConversationCreate) must match"
+        );
+        assert_eq!(req_id, RequestId::Integer(2));
     }
 
     #[test]

--- a/codex-rs/mcp-server/src/mcp_protocol.rs
+++ b/codex-rs/mcp-server/src/mcp_protocol.rs
@@ -186,6 +186,7 @@ pub enum ConversationCreateResult {
 pub struct ConversationStreamResult {}
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+// we need to remove t
 #[serde(tag = "status", rename_all = "camelCase")]
 pub enum ConversationSendMessageResult {
     Ok,
@@ -506,12 +507,13 @@ mod tests {
         let observed = to_val(&CallToolResult::from(env));
         let expected = json!({
             "content": [
-                { "type": "text", "text": "{\"conversation_id\":\"d0f6ecbe-84a2-41c1-b23d-b20473b25eab\",\"model\":\"o3\"}" }
+                { "type": "text", "text": "{\"Ok\":{\"conversation_id\":\"d0f6ecbe-84a2-41c1-b23d-b20473b25eab\",\"model\":\"o3\"}}" }
             ],
             "structuredContent": {
-                "status": "ok",
-                "conversation_id": "d0f6ecbe-84a2-41c1-b23d-b20473b25eab",
-                "model": "o3"
+                "Ok": {
+                    "conversation_id": "d0f6ecbe-84a2-41c1-b23d-b20473b25eab",
+                    "model": "o3"
+                }
             }
         });
         assert_eq!(
@@ -536,12 +538,13 @@ mod tests {
         let observed = to_val(&CallToolResult::from(env));
         let expected = json!({
             "content": [
-                { "type": "text", "text": "{\"message\":\"Failed to initialize session\"}" }
+                { "type": "text", "text": "{\"Error\":{\"message\":\"Failed to initialize session\"}}" }
             ],
             "isError": true,
             "structuredContent": {
-                "status": "error",
-                "message": "Failed to initialize session"
+                "Error": {
+                    "message": "Failed to initialize session"
+                }
             }
         });
         assert_eq!(

--- a/codex-rs/mcp-server/src/mcp_protocol.rs
+++ b/codex-rs/mcp-server/src/mcp_protocol.rs
@@ -186,7 +186,7 @@ pub enum ConversationCreateResult {
 pub struct ConversationStreamResult {}
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-// we need to remove t
+// TODO: remove this status because we have is_error field in the response.
 #[serde(tag = "status", rename_all = "camelCase")]
 pub enum ConversationSendMessageResult {
     Ok,


### PR DESCRIPTION
Switch ConversationCreateResult from a struct to a tagged enum (Ok | Error)

Stack:
Top: #1783 
Bottom: #1784