### PR TITLE
custom textarea

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -864,13 +864,13 @@ dependencies = [
  "shlex",
  "strum 0.27.2",
  "strum_macros 0.27.2",
+ "textwrap 0.16.2",
  "tokio",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
  "tui-input",
  "tui-markdown",
- "tui-textarea",
  "unicode-segmentation",
  "unicode-width 0.1.14",
  "uuid",
@@ -4161,6 +4161,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
+name = "smawk"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+
+[[package]]
 name = "socket2"
 version = "0.5.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4222,7 +4228,7 @@ dependencies = [
  "starlark_syntax",
  "static_assertions",
  "strsim 0.10.0",
- "textwrap",
+ "textwrap 0.11.0",
  "thiserror 1.0.69",
 ]
 
@@ -4509,6 +4515,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width 0.1.14",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c13547615a44dc9c452a8a534638acdf07120d4b6847c8178705da06306a3057"
+dependencies = [
+ "smawk",
+ "unicode-linebreak",
+ "unicode-width 0.2.0",
 ]
 
 [[package]]
@@ -4976,17 +4993,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tui-textarea"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5318dd619ed73c52a9417ad19046724effc1287fb75cdcc4eca1d6ac1acbae"
-dependencies = [
- "crossterm",
- "ratatui",
- "unicode-width 0.2.0",
-]
-
-[[package]]
 name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5003,6 +5009,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-segmentation"

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -842,6 +842,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
+ "chrono",
  "clap",
  "codex-ansi-escape",
  "codex-arg0",
@@ -857,6 +858,7 @@ dependencies = [
  "mcp-types",
  "path-clean",
  "pretty_assertions",
+ "rand 0.8.5",
  "ratatui",
  "ratatui-image",
  "regex-lite",

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -67,3 +67,5 @@ uuid = "1"
 [dev-dependencies]
 insta = "1.43.1"
 pretty_assertions = "1"
+rand = "0.8"
+chrono = { version = "0.4", features = ["serde"] }

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -45,6 +45,7 @@ serde_json = { version = "1", features = ["preserve_order"] }
 shlex = "1.3.0"
 strum = "0.27.2"
 strum_macros = "0.27.2"
+textwrap = "0.16.2"
 tokio = { version = "1", features = [
     "io-std",
     "macros",
@@ -57,7 +58,6 @@ tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
 tui-input = "0.14.0"
 tui-markdown = "0.3.3"
-tui-textarea = "0.7.0"
 unicode-segmentation = "1.12.0"
 unicode-width = "0.1"
 uuid = "1"

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -438,14 +438,15 @@ impl App<'_> {
             );
             self.pending_history_lines.clear();
         }
-        match &mut self.app_state {
+        terminal.draw(|frame| match &mut self.app_state {
             AppState::Chat { widget } => {
-                terminal.draw(|frame| frame.render_widget_ref(&**widget, frame.area()))?;
+                if let Some((x, y)) = widget.cursor_pos(frame.area()) {
+                    frame.set_cursor_position((x, y));
+                }
+                frame.render_widget_ref(&**widget, frame.area())
             }
-            AppState::GitWarning { screen } => {
-                terminal.draw(|frame| frame.render_widget_ref(&*screen, frame.area()))?;
-            }
-        }
+            AppState::GitWarning { screen } => frame.render_widget_ref(&*screen, frame.area()),
+        })?;
         Ok(())
     }
 

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -17,7 +17,6 @@ use ratatui::widgets::Block;
 use ratatui::widgets::BorderType;
 use ratatui::widgets::Borders;
 use ratatui::widgets::StatefulWidgetRef;
-use ratatui::widgets::Widget;
 use ratatui::widgets::WidgetRef;
 
 use super::chat_composer_history::ChatComposerHistory;

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -324,8 +324,6 @@ impl ChatComposer {
     ///   one additional character, that token (without `@`) is returned.
     fn current_at_token(textarea: &TextArea) -> Option<String> {
         let cursor_offset = textarea.cursor();
-        tracing::info!("textarea: {:?}", textarea);
-        tracing::info!("cursor_offset: {}", cursor_offset);
         let text = textarea.text();
 
         // Split the line at the cursor position so we can search for word

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -847,13 +847,13 @@ mod tests {
             // Full-width space boundaries
             (
                 "test　@İstanbul",
-                6,
+                8,
                 Some("İstanbul".to_string()),
                 "@ token after full-width space",
             ),
             (
                 "@ЙЦУ　@诶",
-                6,
+                10,
                 Some("诶".to_string()),
                 "Full-width space between Unicode tokens",
             ),

--- a/codex-rs/tui/src/bottom_pane/chat_composer_history.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer_history.rs
@@ -199,7 +199,7 @@ mod tests {
 
         // First Up should request offset 2 (latest) and await async data.
         assert!(history.should_handle_navigation("", 0));
-        assert!(history.navigate_up(&tx).is_some());
+        assert!(history.navigate_up(&tx).is_none()); // don't replace the text yet
 
         // Verify that an AppEvent::CodexOp with the correct GetHistoryEntryRequest was sent.
         let event = rx.try_recv().expect("expected AppEvent to be sent");
@@ -221,7 +221,7 @@ mod tests {
         );
 
         // Next Up should move to offset 1.
-        assert!(history.navigate_up(&tx).is_some());
+        assert!(history.navigate_up(&tx).is_none()); // don't replace the text yet
 
         // Verify second CodexOp event for offset 1.
         let event2 = rx.try_recv().expect("expected second event");

--- a/codex-rs/tui/src/bottom_pane/chat_composer_history.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer_history.rs
@@ -1,8 +1,5 @@
 use std::collections::HashMap;
 
-use tui_textarea::CursorMove;
-use tui_textarea::TextArea;
-
 use crate::app_event::AppEvent;
 use crate::app_event_sender::AppEventSender;
 use codex_core::protocol::Op;
@@ -67,59 +64,52 @@ impl ChatComposerHistory {
 
     /// Should Up/Down key presses be interpreted as history navigation given
     /// the current content and cursor position of `textarea`?
-    pub fn should_handle_navigation(&self, textarea: &TextArea) -> bool {
+    pub fn should_handle_navigation(&self, text: &str, cursor: usize) -> bool {
         if self.history_entry_count == 0 && self.local_history.is_empty() {
             return false;
         }
 
-        if textarea.is_empty() {
+        if text.is_empty() {
             return true;
         }
 
         // Textarea is not empty – only navigate when cursor is at start and
         // text matches last recalled history entry so regular editing is not
         // hijacked.
-        let (row, col) = textarea.cursor();
-        if row != 0 || col != 0 {
+        if cursor != 0 {
             return false;
         }
 
-        let lines = textarea.lines();
-        matches!(&self.last_history_text, Some(prev) if prev == &lines.join("\n"))
+        matches!(&self.last_history_text, Some(prev) if prev == text)
     }
 
     /// Handle <Up>. Returns true when the key was consumed and the caller
     /// should request a redraw.
-    pub fn navigate_up(&mut self, textarea: &mut TextArea, app_event_tx: &AppEventSender) -> bool {
+    pub fn navigate_up(&mut self, app_event_tx: &AppEventSender) -> Option<String> {
         let total_entries = self.history_entry_count + self.local_history.len();
         if total_entries == 0 {
-            return false;
+            return None;
         }
 
         let next_idx = match self.history_cursor {
             None => (total_entries as isize) - 1,
-            Some(0) => return true, // already at oldest
+            Some(0) => return None, // already at oldest
             Some(idx) => idx - 1,
         };
 
         self.history_cursor = Some(next_idx);
-        self.populate_history_at_index(next_idx as usize, textarea, app_event_tx);
-        true
+        self.populate_history_at_index(next_idx as usize, app_event_tx)
     }
 
     /// Handle <Down>.
-    pub fn navigate_down(
-        &mut self,
-        textarea: &mut TextArea,
-        app_event_tx: &AppEventSender,
-    ) -> bool {
+    pub fn navigate_down(&mut self, app_event_tx: &AppEventSender) -> Option<String> {
         let total_entries = self.history_entry_count + self.local_history.len();
         if total_entries == 0 {
-            return false;
+            return None;
         }
 
         let next_idx_opt = match self.history_cursor {
-            None => return false, // not browsing
+            None => return None, // not browsing
             Some(idx) if (idx as usize) + 1 >= total_entries => None,
             Some(idx) => Some(idx + 1),
         };
@@ -127,16 +117,15 @@ impl ChatComposerHistory {
         match next_idx_opt {
             Some(idx) => {
                 self.history_cursor = Some(idx);
-                self.populate_history_at_index(idx as usize, textarea, app_event_tx);
+                self.populate_history_at_index(idx as usize, app_event_tx)
             }
             None => {
                 // Past newest – clear and exit browsing mode.
                 self.history_cursor = None;
                 self.last_history_text = None;
-                self.replace_textarea_content(textarea, "");
+                Some(String::new())
             }
         }
-        true
     }
 
     /// Integrate a GetHistoryEntryResponse event.
@@ -145,19 +134,18 @@ impl ChatComposerHistory {
         log_id: u64,
         offset: usize,
         entry: Option<String>,
-        textarea: &mut TextArea,
-    ) -> bool {
+    ) -> Option<String> {
         if self.history_log_id != Some(log_id) {
-            return false;
+            return None;
         }
-        let Some(text) = entry else { return false };
+        let text = entry?;
         self.fetched_history.insert(offset, text.clone());
 
         if self.history_cursor == Some(offset as isize) {
-            self.replace_textarea_content(textarea, &text);
-            return true;
+            self.last_history_text = Some(text.clone());
+            return Some(text);
         }
-        false
+        None
     }
 
     // ---------------------------------------------------------------------
@@ -167,21 +155,20 @@ impl ChatComposerHistory {
     fn populate_history_at_index(
         &mut self,
         global_idx: usize,
-        textarea: &mut TextArea,
         app_event_tx: &AppEventSender,
-    ) {
+    ) -> Option<String> {
         if global_idx >= self.history_entry_count {
             // Local entry.
             if let Some(text) = self
                 .local_history
                 .get(global_idx - self.history_entry_count)
             {
-                let t = text.clone();
-                self.replace_textarea_content(textarea, &t);
+                self.last_history_text = Some(text.clone());
+                return Some(text.clone());
             }
         } else if let Some(text) = self.fetched_history.get(&global_idx) {
-            let t = text.clone();
-            self.replace_textarea_content(textarea, &t);
+            self.last_history_text = Some(text.clone());
+            return Some(text.clone());
         } else if let Some(log_id) = self.history_log_id {
             let op = Op::GetHistoryEntryRequest {
                 offset: global_idx,
@@ -189,14 +176,7 @@ impl ChatComposerHistory {
             };
             app_event_tx.send(AppEvent::CodexOp(op));
         }
-    }
-
-    fn replace_textarea_content(&mut self, textarea: &mut TextArea, text: &str) {
-        textarea.select_all();
-        textarea.cut();
-        let _ = textarea.insert_str(text);
-        textarea.move_cursor(CursorMove::Jump(0, 0));
-        self.last_history_text = Some(text.to_string());
+        None
     }
 }
 
@@ -217,11 +197,9 @@ mod tests {
         // Pretend there are 3 persistent entries.
         history.set_metadata(1, 3);
 
-        let mut textarea = TextArea::default();
-
         // First Up should request offset 2 (latest) and await async data.
-        assert!(history.should_handle_navigation(&textarea));
-        assert!(history.navigate_up(&mut textarea, &tx));
+        assert!(history.should_handle_navigation("", 0));
+        assert!(history.navigate_up(&tx).is_some());
 
         // Verify that an AppEvent::CodexOp with the correct GetHistoryEntryRequest was sent.
         let event = rx.try_recv().expect("expected AppEvent to be sent");
@@ -235,14 +213,15 @@ mod tests {
             },
             history_request1
         );
-        assert_eq!(textarea.lines().join("\n"), ""); // still empty
 
         // Inject the async response.
-        assert!(history.on_entry_response(1, 2, Some("latest".into()), &mut textarea));
-        assert_eq!(textarea.lines().join("\n"), "latest");
+        assert_eq!(
+            Some("latest".into()),
+            history.on_entry_response(1, 2, Some("latest".into()))
+        );
 
         // Next Up should move to offset 1.
-        assert!(history.navigate_up(&mut textarea, &tx));
+        assert!(history.navigate_up(&tx).is_some());
 
         // Verify second CodexOp event for offset 1.
         let event2 = rx.try_recv().expect("expected second event");
@@ -257,7 +236,9 @@ mod tests {
             history_request_2
         );
 
-        history.on_entry_response(1, 1, Some("older".into()), &mut textarea);
-        assert_eq!(textarea.lines().join("\n"), "older");
+        assert_eq!(
+            Some("older".into()),
+            history.on_entry_response(1, 1, Some("older".into()))
+        );
     }
 }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -79,7 +79,15 @@ impl BottomPane<'_> {
     }
 
     pub fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
-        self.composer.cursor_pos(area)
+        // Hide the cursor whenever an overlay view is active (e.g. the
+        // status indicator shown while a task is running, or approval modal).
+        // In these states the textarea is not interactable, so we should not
+        // show its caret.
+        if self.active_view.is_some() {
+            None
+        } else {
+            self.composer.cursor_pos(area)
+        }
     }
 
     /// Forward a key event to the active view or the composer.

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -19,6 +19,7 @@ mod chat_composer_history;
 mod command_popup;
 mod file_search_popup;
 mod status_indicator_view;
+mod textarea;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CancellationEvent {
@@ -36,7 +37,7 @@ use status_indicator_view::StatusIndicatorView;
 pub(crate) struct BottomPane<'a> {
     /// Composer is retained even when a BottomPaneView is displayed so the
     /// input state is retained when the view is closed.
-    composer: ChatComposer<'a>,
+    composer: ChatComposer,
 
     /// If present, this is displayed instead of the `composer`.
     active_view: Option<Box<dyn BottomPaneView<'a> + 'a>>,
@@ -74,7 +75,11 @@ impl BottomPane<'_> {
         self.active_view
             .as_ref()
             .map(|v| v.desired_height(width))
-            .unwrap_or(self.composer.desired_height())
+            .unwrap_or(self.composer.desired_height(width))
+    }
+
+    pub fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
+        self.composer.cursor_pos(area)
     }
 
     /// Forward a key event to the active view or the composer.

--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -987,7 +987,6 @@ mod tests {
     fn cursor_pos_with_state_basic_and_scroll_behaviors() {
         // Case 1: No wrapping needed, height fits — scroll ignored, y maps directly.
         let mut t = ta_with("hello world");
-        // Place cursor after "hel"
         t.set_cursor(3);
         let area = Rect::new(2, 5, 20, 3);
         // Even if an absurd scroll is provided, when content fits the area the

--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -111,11 +111,7 @@ impl TextArea {
 
     #[allow(dead_code)]
     pub fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
-        let lines = self.wrapped_lines(area.width);
-        let i = Self::wrapped_line_index_by_start(&lines, self.cursor_pos)?;
-        let ls = &lines[i];
-        let col = self.text[ls.start..self.cursor_pos].width() as u16;
-        Some((area.x + col, area.y + i as u16))
+        self.cursor_pos_with_state(area, &TextAreaState::default())
     }
 
     /// Compute the on-screen cursor position taking scrolling into account.

--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -5,6 +5,10 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Style;
 use ratatui::widgets::WidgetRef;
+use std::cell::Ref;
+use std::cell::RefCell;
+use std::ops::Range;
+use textwrap::Options;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
@@ -12,19 +16,31 @@ use unicode_width::UnicodeWidthStr;
 pub(crate) struct TextArea {
     text: String,
     cursor_pos: usize,
+    wrap_cache: RefCell<Option<WrapCache>>,
 }
+
+#[derive(Debug, Clone)]
+struct WrapCache {
+    width: u16,
+    lines: Vec<Range<usize>>,
+}
+
+// TODO:
+// - [ ] scrolling
 
 impl TextArea {
     pub fn new() -> Self {
         Self {
             text: String::new(),
             cursor_pos: 0,
+            wrap_cache: RefCell::new(None),
         }
     }
 
     pub fn set_text(&mut self, text: &str) {
         self.text = text.to_string();
         self.cursor_pos = self.cursor_pos.clamp(0, self.text.len());
+        self.wrap_cache.replace(None);
     }
 
     pub fn text(&self) -> &str {
@@ -37,13 +53,13 @@ impl TextArea {
 
     pub fn insert_str_at(&mut self, pos: usize, text: &str) {
         self.text.insert_str(pos, text);
+        self.wrap_cache.replace(None);
         if pos <= self.cursor_pos {
             self.cursor_pos += text.len();
         }
     }
 
     pub fn replace_range(&mut self, range: std::ops::Range<usize>, text: &str) {
-        // Capture the information we need **before** mutating `self.text`.
         assert!(range.start <= range.end);
         let start = range.start.clamp(0, self.text.len());
         let end = range.end.clamp(0, self.text.len());
@@ -51,8 +67,8 @@ impl TextArea {
         let inserted_len = text.len();
         let diff = inserted_len as isize - removed_len as isize;
 
-        // Perform the actual replacement.
         self.text.replace_range(range, text);
+        self.wrap_cache.replace(None);
 
         // Update the cursor position to account for the edit.
         self.cursor_pos = if self.cursor_pos < start {
@@ -65,7 +81,7 @@ impl TextArea {
             // Cursor was after the replaced range – shift by the length diff.
             ((self.cursor_pos as isize) + diff) as usize
         }
-        .min(self.text.len()); // Clamp just in case
+        .min(self.text.len());
     }
 
     pub fn cursor(&self) -> usize {
@@ -77,33 +93,18 @@ impl TextArea {
     }
 
     pub fn desired_height(&self, width: u16) -> u16 {
-        textwrap::wrap(&self.text, width as usize).len() as u16
+        self.wrapped_lines(width).len() as u16
     }
 
     pub fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
-        let lines = textwrap::wrap(&self.text, area.width as usize);
-        for (i, line) in lines.iter().enumerate() {
-            match line {
-                std::borrow::Cow::Borrowed(line) => {
-                    let line_start =
-                        unsafe { line.as_ptr().offset_from(self.text.as_ptr()) as usize };
-                    let line_end = line_start
-                        + line.len()
-                        + self.text[line_start + line.len()..]
-                            .chars()
-                            .take_while(|c| *c == ' ')
-                            .count();
-                    if (line_start <= self.cursor_pos && self.cursor_pos < line_end)
-                        || (line_end == self.text.len() && self.cursor_pos == line_end)
-                    {
-                        let col = self.text[line_start..self.cursor_pos].width() as u16;
-                        return Some((area.x + col, area.y + i as u16));
-                    }
-                }
-                std::borrow::Cow::Owned(_) => unreachable!(),
+        let lines = self.wrapped_lines(area.width);
+        for (i, ls) in lines.iter().enumerate() {
+            if ls.contains(&self.cursor_pos) {
+                let col = self.text[ls.start..self.cursor_pos].width() as u16;
+                return Some((area.x + col, area.y + i as u16));
             }
         }
-        unreachable!()
+        unreachable!("No line contains the cursor");
     }
 
     pub fn is_empty(&self) -> bool {
@@ -349,20 +350,56 @@ impl TextArea {
                 self.cursor_pos = self.end_of_next_word();
             }
             o => {
-                tracing::info!("Other: {:?}", o);
+                tracing::info!("Unhandled key event in TextArea: {:?}", o);
             }
         }
         self.cursor_pos = self.cursor_pos.clamp(0, self.text.len());
+    }
+
+    #[allow(clippy::unwrap_used)]
+    fn wrapped_lines(&self, width: u16) -> Ref<'_, Vec<Range<usize>>> {
+        // Ensure cache is ready (potentially mutably borrow, then drop)
+        {
+            let mut cache = self.wrap_cache.borrow_mut();
+            let needs_recalc = match cache.as_ref() {
+                Some(c) => c.width != width,
+                None => true,
+            };
+            if needs_recalc {
+                let mut lines: Vec<Range<usize>> = Vec::new();
+                for line in textwrap::wrap(
+                    &self.text,
+                    Options::new(width as usize).wrap_algorithm(textwrap::WrapAlgorithm::FirstFit),
+                )
+                .iter()
+                {
+                    match line {
+                        std::borrow::Cow::Borrowed(slice) => {
+                            let start =
+                                unsafe { slice.as_ptr().offset_from(self.text.as_ptr()) as usize };
+                            let end = start + slice.len();
+                            let trailing_spaces =
+                                self.text[end..].chars().take_while(|c| *c == ' ').count();
+                            lines.push(start..end + trailing_spaces + 1);
+                        }
+                        std::borrow::Cow::Owned(_) => unreachable!(),
+                    }
+                }
+                *cache = Some(WrapCache { width, lines });
+            }
+        }
+
+        let cache = self.wrap_cache.borrow();
+        Ref::map(cache, |c| &c.as_ref().unwrap().lines)
     }
 }
 
 impl WidgetRef for &TextArea {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
-        for (i, line) in textwrap::wrap(&self.text, area.width as usize)
-            .iter()
-            .enumerate()
-        {
-            buf.set_string(area.x, area.y + i as u16, line, Style::default());
+        let lines = self.wrapped_lines(area.width);
+        for (i, ls) in lines.iter().enumerate() {
+            let s = &self.text[ls.start..ls.end - 1];
+            buf.set_string(area.x, area.y + i as u16, s, Style::default());
         }
     }
 }

--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -1,0 +1,357 @@
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use crossterm::event::KeyModifiers;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Style;
+use ratatui::widgets::WidgetRef;
+use unicode_segmentation::UnicodeSegmentation;
+use unicode_width::UnicodeWidthStr;
+
+#[derive(Debug)]
+pub(crate) struct TextArea {
+    text: String,
+    cursor_pos: usize,
+}
+
+impl TextArea {
+    pub fn new() -> Self {
+        Self {
+            text: String::new(),
+            cursor_pos: 0,
+        }
+    }
+
+    pub fn set_text(&mut self, text: &str) {
+        self.text = text.to_string();
+        self.cursor_pos = self.cursor_pos.clamp(0, self.text.len());
+    }
+
+    pub fn text(&self) -> &str {
+        &self.text
+    }
+
+    pub fn insert_str(&mut self, text: &str) {
+        self.insert_str_at(self.cursor_pos, text);
+    }
+
+    pub fn insert_str_at(&mut self, pos: usize, text: &str) {
+        self.text.insert_str(pos, text);
+        if pos <= self.cursor_pos {
+            self.cursor_pos += text.len();
+        }
+    }
+
+    pub fn replace_range(&mut self, range: std::ops::Range<usize>, text: &str) {
+        // Capture the information we need **before** mutating `self.text`.
+        assert!(range.start <= range.end);
+        let start = range.start.clamp(0, self.text.len());
+        let end = range.end.clamp(0, self.text.len());
+        let removed_len = end - start;
+        let inserted_len = text.len();
+        let diff = inserted_len as isize - removed_len as isize;
+
+        // Perform the actual replacement.
+        self.text.replace_range(range, text);
+
+        // Update the cursor position to account for the edit.
+        self.cursor_pos = if self.cursor_pos < start {
+            // Cursor was before the edited range – no shift.
+            self.cursor_pos
+        } else if self.cursor_pos <= end {
+            // Cursor was inside the replaced range – move to end of the new text.
+            start + inserted_len
+        } else {
+            // Cursor was after the replaced range – shift by the length diff.
+            ((self.cursor_pos as isize) + diff) as usize
+        }
+        .min(self.text.len()); // Clamp just in case
+    }
+
+    pub fn cursor(&self) -> usize {
+        self.cursor_pos
+    }
+
+    pub fn set_cursor(&mut self, pos: usize) {
+        self.cursor_pos = pos.clamp(0, self.text.len());
+    }
+
+    pub fn desired_height(&self, width: u16) -> u16 {
+        textwrap::wrap(&self.text, width as usize).len() as u16
+    }
+
+    #[allow(clippy::unwrap_used)]
+    pub fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
+        let lines = textwrap::wrap(&self.text[..self.cursor_pos], area.width as usize);
+        // textwrap trims trailing whitespace, so we need to add it back.
+        let last_line = lines.last().unwrap();
+        let whitespace_before_cursor = self.text[..self.cursor_pos]
+            .chars()
+            .rev()
+            .take_while(|&c| c == ' ')
+            .count();
+        let row = lines.len() as u16;
+        let col = last_line.width() as u16 + whitespace_before_cursor as u16;
+        Some((area.x + col, area.y + row - 1))
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.text.is_empty()
+    }
+
+    fn beginning_of_current_line(&self) -> usize {
+        self.text[..self.cursor_pos]
+            .rfind('\n')
+            .map(|i| i + 1)
+            .unwrap_or(0)
+    }
+
+    fn end_of_current_line(&self) -> usize {
+        self.text[self.cursor_pos..]
+            .find('\n')
+            .map(|i| i + self.cursor_pos)
+            .unwrap_or(self.text.len())
+    }
+
+    fn beginning_of_previous_word(&self) -> usize {
+        if let Some(first_non_ws) = self.text[..self.cursor_pos].rfind(|c: char| !c.is_whitespace())
+        {
+            self.text[..first_non_ws]
+                .rfind(|c: char| c.is_whitespace())
+                .map(|i| i + 1)
+                .unwrap_or(0)
+        } else {
+            0
+        }
+    }
+
+    fn end_of_next_word(&self) -> usize {
+        let Some(first_non_ws) = self.text[self.cursor_pos..].find(|c: char| !c.is_whitespace())
+        else {
+            return self.text.len();
+        };
+        let word_start = self.cursor_pos + first_non_ws;
+        match self.text[word_start..].find(|c: char| c.is_whitespace()) {
+            Some(rel_idx) => word_start + rel_idx,
+            None => self.text.len(),
+        }
+    }
+
+    pub fn input(&mut self, event: KeyEvent) {
+        match event {
+            KeyEvent {
+                code: KeyCode::Char(c),
+                modifiers: KeyModifiers::NONE | KeyModifiers::SHIFT | KeyModifiers::ALT,
+                ..
+            } => self.insert_str(&c.to_string()),
+            KeyEvent {
+                code: KeyCode::Char('j'),
+                modifiers: KeyModifiers::CONTROL,
+                ..
+            }
+            | KeyEvent {
+                code: KeyCode::Enter,
+                ..
+            } => self.insert_str("\n"),
+            KeyEvent {
+                code: KeyCode::Backspace,
+                ..
+            } => self.replace_range(self.cursor_pos.saturating_sub(1)..self.cursor_pos, ""),
+            KeyEvent {
+                code: KeyCode::Delete,
+                ..
+            } => self.replace_range(self.cursor_pos..self.cursor_pos + 1, ""),
+
+            KeyEvent {
+                code: KeyCode::Char('w'),
+                modifiers: KeyModifiers::CONTROL,
+                ..
+            } => {
+                self.replace_range(self.beginning_of_previous_word()..self.cursor_pos, "");
+            }
+            KeyEvent {
+                code: KeyCode::Char('u'),
+                modifiers: KeyModifiers::CONTROL,
+                ..
+            } => {
+                if self.cursor_pos > 0 {
+                    let bol = self.beginning_of_current_line();
+                    if self.cursor_pos == bol {
+                        self.replace_range(bol - 1..bol, "");
+                    } else {
+                        self.replace_range(bol..self.cursor_pos, "");
+                    }
+                }
+            }
+            KeyEvent {
+                code: KeyCode::Char('k'),
+                modifiers: KeyModifiers::CONTROL,
+                ..
+            } => {
+                if self.cursor_pos < self.text.len() {
+                    let eol = self.text[self.cursor_pos..]
+                        .find('\n')
+                        .map(|i| i + self.cursor_pos)
+                        .unwrap_or(self.text.len());
+                    if self.cursor_pos == eol {
+                        self.replace_range(self.cursor_pos..eol + 1, "");
+                    } else {
+                        self.replace_range(self.cursor_pos..eol, "");
+                    }
+                }
+            }
+
+            // Cursor movement
+            KeyEvent {
+                code: KeyCode::Left,
+                modifiers: KeyModifiers::NONE,
+                ..
+            } => {
+                // Move the cursor left by a single grapheme cluster
+                // rather than a single byte.
+                let mut gc = unicode_segmentation::GraphemeCursor::new(
+                    self.cursor_pos,
+                    self.text.len(),
+                    false,
+                );
+                match gc.prev_boundary(&self.text, 0) {
+                    Ok(Some(boundary)) => self.cursor_pos = boundary,
+                    Ok(None) => self.cursor_pos = 0, // Already at start.
+                    Err(_) => self.cursor_pos = self.cursor_pos.saturating_sub(1),
+                }
+            }
+            KeyEvent {
+                code: KeyCode::Right,
+                modifiers: KeyModifiers::NONE,
+                ..
+            } => {
+                let mut gc = unicode_segmentation::GraphemeCursor::new(
+                    self.cursor_pos,
+                    self.text.len(),
+                    false,
+                );
+                match gc.next_boundary(&self.text, 0) {
+                    Ok(Some(boundary)) => self.cursor_pos = boundary,
+                    Ok(None) => self.cursor_pos = self.text.len(), // Already at end.
+                    Err(_) => self.cursor_pos = self.cursor_pos.saturating_add(1),
+                }
+            }
+            KeyEvent {
+                code: KeyCode::Up, ..
+            } => {
+                if let Some(prev_nl) = self.text[..self.cursor_pos].rfind('\n') {
+                    let cursor_column = self.text[prev_nl..self.cursor_pos].width();
+                    let prev_line_start = self.text[..prev_nl].rfind('\n').unwrap_or(0);
+                    let mut width_so_far = 0;
+                    for (i, w) in self.text[prev_line_start..prev_nl].grapheme_indices(true) {
+                        width_so_far += w.width();
+                        if width_so_far > cursor_column {
+                            self.cursor_pos = prev_line_start + i;
+                            return;
+                        }
+                    }
+                    self.cursor_pos = prev_nl;
+                } else {
+                    self.cursor_pos = 0;
+                }
+            }
+            KeyEvent {
+                code: KeyCode::Down,
+                ..
+            } => {
+                let prev_nl = self.text[..self.cursor_pos]
+                    .rfind('\n')
+                    .map(|i| i + 1)
+                    .unwrap_or(0);
+                let cursor_column = self.text[prev_nl..self.cursor_pos].width();
+                if let Some(next_nl) = self.text[self.cursor_pos..]
+                    .find('\n')
+                    .map(|i| i + self.cursor_pos)
+                {
+                    let next_line_end = self.text[next_nl + 1..]
+                        .find('\n')
+                        .map(|i| i + next_nl + 1)
+                        .unwrap_or(self.text.len());
+                    let mut width_so_far = 0;
+                    for (i, w) in self.text[next_nl + 1..next_line_end].grapheme_indices(true) {
+                        width_so_far += w.width();
+                        if width_so_far > cursor_column {
+                            self.cursor_pos = next_nl + 1 + i;
+                            return;
+                        }
+                    }
+                    self.cursor_pos = next_line_end;
+                } else {
+                    self.cursor_pos = self.text.len();
+                }
+            }
+            KeyEvent {
+                code: KeyCode::Home,
+                ..
+            } => {
+                self.cursor_pos = self.beginning_of_current_line();
+            }
+            KeyEvent {
+                code: KeyCode::Char('a'),
+                modifiers: KeyModifiers::CONTROL,
+                ..
+            } => {
+                let bol = self.beginning_of_current_line();
+                if self.cursor_pos == bol {
+                    self.cursor_pos = self.cursor_pos.saturating_sub(1);
+                    self.cursor_pos = self.beginning_of_current_line();
+                } else {
+                    self.cursor_pos = bol;
+                }
+            }
+
+            KeyEvent {
+                code: KeyCode::End, ..
+            } => {
+                self.cursor_pos = self.end_of_current_line();
+            }
+            KeyEvent {
+                code: KeyCode::Char('e'),
+                modifiers: KeyModifiers::CONTROL,
+                ..
+            } => {
+                let eol = self.end_of_current_line();
+                if self.cursor_pos == eol {
+                    self.cursor_pos = (self.cursor_pos + 1).min(self.text.len());
+                    self.cursor_pos = self.end_of_current_line();
+                } else {
+                    self.cursor_pos = eol;
+                }
+            }
+            KeyEvent {
+                code: KeyCode::Left,
+                modifiers: KeyModifiers::CONTROL,
+                ..
+            } => {
+                self.cursor_pos = self.beginning_of_previous_word();
+            }
+            KeyEvent {
+                code: KeyCode::Right,
+                modifiers: KeyModifiers::CONTROL,
+                ..
+            } => {
+                self.cursor_pos = self.end_of_next_word();
+            }
+            o => {
+                tracing::info!("Other: {:?}", o);
+            }
+        }
+        self.cursor_pos = self.cursor_pos.clamp(0, self.text.len());
+    }
+}
+
+impl WidgetRef for &TextArea {
+    fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        for (i, line) in textwrap::wrap(&self.text, area.width as usize)
+            .iter()
+            .enumerate()
+        {
+            buf.set_string(area.x, area.y + i as u16, line, Style::default());
+        }
+    }
+}

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -508,6 +508,10 @@ impl ChatWidget<'_> {
         self.bottom_pane
             .set_token_usage(self.token_usage.clone(), self.config.model_context_window);
     }
+
+    pub fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
+        self.bottom_pane.cursor_pos(area)
+    }
 }
 
 impl WidgetRef for &ChatWidget<'_> {


### PR DESCRIPTION
This replaces tui-textarea with a custom textarea component.

Key differences:
1. wrapped lines
2. better unicode handling
3. uses the native terminal cursor

This should perhaps be spun out into its own separate crate at some point, but for now it's convenient to have it in-tree.