### PR TITLE
feat(tui): stream agent message deltas

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -48,4 +48,10 @@ pub(crate) enum AppEvent {
     },
 
     InsertHistory(Vec<Line<'static>>),
+
+    /// Update the currently streaming history cell.
+    SetLiveHistory(Vec<Line<'static>>),
+
+    /// Clear any currently streaming history cell.
+    ClearLiveHistory,
 }

--- a/codex-rs/tui/src/insert_history.rs
+++ b/codex-rs/tui/src/insert_history.rs
@@ -79,7 +79,7 @@ pub(crate) fn insert_history_lines(terminal: &mut tui::Tui, lines: Vec<Line>) {
     }
 }
 
-fn wrapped_line_count(lines: &[Line], width: u16) -> u16 {
+pub(crate) fn wrapped_line_count(lines: &[Line], width: u16) -> u16 {
     let mut count = 0;
     for line in lines {
         count += line_height(line, width);
@@ -87,7 +87,7 @@ fn wrapped_line_count(lines: &[Line], width: u16) -> u16 {
     count
 }
 
-fn line_height(line: &Line, width: u16) -> u16 {
+pub(crate) fn line_height(line: &Line, width: u16) -> u16 {
     use unicode_width::UnicodeWidthStr;
     // get the total display width of the line, accounting for double-width chars
     let total_width = line


### PR DESCRIPTION
## Summary
- stream agent reasoning and message deltas into a live history cell
- track committed and live history to update the TUI viewport
- expose wrapped line utilities for layout calculations

## Testing
- `just fmt`
- `just fix`
- `cargo test --all-features` *(fails: test `landlock` in `codex-linux-sandbox`)*

------
https://chatgpt.com/codex/tasks/task_i_688d59c8542883219cb0b031020ab845