### PR TITLE
[sandbox] Filter out certain non-sandbox errors

### DIFF
--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -38,7 +38,7 @@ pub mod plan_tool;
 mod project_doc;
 pub mod protocol;
 mod rollout;
-mod safety;
+pub(crate) mod safety;
 pub mod seatbelt;
 pub mod shell;
 pub mod spawn;
@@ -47,3 +47,4 @@ pub mod util;
 
 pub use apply_patch::CODEX_APPLY_PATCH_ARG1;
 pub use client_common::model_supports_reasoning_summaries;
+pub use safety::get_platform_sandbox;

--- a/codex-rs/core/tests/exec.rs
+++ b/codex-rs/core/tests/exec.rs
@@ -1,64 +1,27 @@
 #![cfg(target_os = "macos")]
 #![expect(clippy::expect_used)]
-#![expect(clippy::unwrap_used)]
 
 use std::collections::HashMap;
 use std::sync::Arc;
 
-use codex_core::error::CodexErr;
-use codex_core::error::SandboxErr;
 use codex_core::exec::ExecParams;
-use codex_core::exec::ExecToolCallOutput;
+use codex_core::exec::SandboxType;
 use codex_core::exec::process_exec_tool_call;
 use codex_core::protocol::SandboxPolicy;
+use codex_core::spawn::CODEX_SANDBOX_ENV_VAR;
 use tempfile::TempDir;
 use tokio::sync::Notify;
 
 use codex_core::get_platform_sandbox;
 
-/// Command succeeds with exit code 0 normally
-#[tokio::test]
-async fn exit_code_0_succeeds() {
-    let tmp = TempDir::new().expect("should be able to create temp dir");
-    let cmd = vec!["echo", "hello"];
-    let output = run_test_cmd(tmp, cmd)
-        .await
-        .expect("command should return successfully");
+async fn run_test_cmd(tmp: TempDir, cmd: Vec<&str>, should_be_ok: bool) {
+    if std::env::var(CODEX_SANDBOX_ENV_VAR) == Ok("seatbelt".to_string()) {
+        eprintln!("{CODEX_SANDBOX_ENV_VAR} is set to 'seatbelt', skipping test.");
+        return;
+    }
 
-    assert_eq!(output.exit_code, 0);
-}
-
-/// Command not found returns exit code 127, this is not considered a sandbox error
-#[tokio::test]
-async fn exit_command_not_found_is_propagated() {
-    let tmp = TempDir::new().expect("should be able to create temp dir");
-    let cmd = vec!["/bin/bash", "-c", "nonexistent_command_12345"];
-    let output = run_test_cmd(tmp, cmd)
-        .await
-        .expect("command should return successfully");
-
-    assert_eq!(output.exit_code, 127);
-}
-
-/// Writing a file fails and should be considered a sandbox error
-#[tokio::test]
-async fn write_file_fails_as_sandbox_error() {
-    let tmp = TempDir::new().expect("should be able to create temp dir");
-    let cmd = vec!["/bin/bash", "-c", "touch", "/tmp/test.txt"];
-    let result = run_test_cmd(tmp, cmd).await;
-
-    assert!(result.is_err());
-    assert!(matches!(
-        result.err().unwrap(),
-        CodexErr::Sandbox(SandboxErr::Denied(_, _, _))
-    ));
-}
-
-async fn run_test_cmd(
-    tmp: TempDir,
-    cmd: Vec<&'static str>,
-) -> Result<ExecToolCallOutput, CodexErr> {
     let sandbox_type = get_platform_sandbox().expect("should be able to get sandbox type");
+    assert_eq!(sandbox_type, SandboxType::MacosSeatbelt);
 
     let params = ExecParams {
         command: cmd.iter().map(|s| s.to_string()).collect(),
@@ -70,5 +33,37 @@ async fn run_test_cmd(
     let ctrl_c = Arc::new(Notify::new());
     let policy = SandboxPolicy::new_read_only_policy();
 
-    process_exec_tool_call(params, sandbox_type, ctrl_c, &policy, &None, None).await
+    let result = process_exec_tool_call(params, sandbox_type, ctrl_c, &policy, &None, None).await;
+
+    assert!(result.is_ok() == should_be_ok);
+}
+
+/// Command succeeds with exit code 0 normally
+#[tokio::test]
+async fn exit_code_0_succeeds() {
+    let tmp = TempDir::new().expect("should be able to create temp dir");
+    let cmd = vec!["echo", "hello"];
+
+    run_test_cmd(tmp, cmd, true).await
+}
+
+/// Command not found returns exit code 127, this is not considered a sandbox error
+#[tokio::test]
+async fn exit_command_not_found_is_ok() {
+    let tmp = TempDir::new().expect("should be able to create temp dir");
+    let cmd = vec!["/bin/bash", "-c", "nonexistent_command_12345"];
+    run_test_cmd(tmp, cmd, true).await
+}
+
+/// Writing a file fails and should be considered a sandbox error
+#[tokio::test]
+async fn write_file_fails_as_sandbox_error() {
+    let tmp = TempDir::new().expect("should be able to create temp dir");
+    let path = tmp.path().join("test.txt");
+    let cmd = vec![
+        "/user/bin/touch",
+        path.to_str().expect("should be able to get path"),
+    ];
+
+    run_test_cmd(tmp, cmd, false).await;
 }

--- a/codex-rs/core/tests/exec.rs
+++ b/codex-rs/core/tests/exec.rs
@@ -26,7 +26,7 @@ async fn run_test_cmd(tmp: TempDir, cmd: Vec<&str>, should_be_ok: bool) {
     let params = ExecParams {
         command: cmd.iter().map(|s| s.to_string()).collect(),
         cwd: tmp.path().to_path_buf(),
-        timeout_ms: Some(100),
+        timeout_ms: Some(1000),
         env: HashMap::new(),
     };
 

--- a/codex-rs/core/tests/exec.rs
+++ b/codex-rs/core/tests/exec.rs
@@ -1,0 +1,74 @@
+#![cfg(target_os = "macos")]
+#![expect(clippy::expect_used)]
+#![expect(clippy::unwrap_used)]
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use codex_core::error::CodexErr;
+use codex_core::error::SandboxErr;
+use codex_core::exec::ExecParams;
+use codex_core::exec::ExecToolCallOutput;
+use codex_core::exec::process_exec_tool_call;
+use codex_core::protocol::SandboxPolicy;
+use tempfile::TempDir;
+use tokio::sync::Notify;
+
+use codex_core::get_platform_sandbox;
+
+/// Command succeeds with exit code 0 normally
+#[tokio::test]
+async fn exit_code_0_succeeds() {
+    let tmp = TempDir::new().expect("should be able to create temp dir");
+    let cmd = vec!["echo", "hello"];
+    let output = run_test_cmd(tmp, cmd)
+        .await
+        .expect("command should return successfully");
+
+    assert_eq!(output.exit_code, 0);
+}
+
+/// Command not found returns exit code 127, this is not considered a sandbox error
+#[tokio::test]
+async fn exit_command_not_found_is_propagated() {
+    let tmp = TempDir::new().expect("should be able to create temp dir");
+    let cmd = vec!["/bin/bash", "-c", "nonexistent_command_12345"];
+    let output = run_test_cmd(tmp, cmd)
+        .await
+        .expect("command should return successfully");
+
+    assert_eq!(output.exit_code, 127);
+}
+
+/// Writing a file fails and should be considered a sandbox error
+#[tokio::test]
+async fn write_file_fails_as_sandbox_error() {
+    let tmp = TempDir::new().expect("should be able to create temp dir");
+    let cmd = vec!["/bin/bash", "-c", "touch", "/tmp/test.txt"];
+    let result = run_test_cmd(tmp, cmd).await;
+
+    assert!(result.is_err());
+    assert!(matches!(
+        result.err().unwrap(),
+        CodexErr::Sandbox(SandboxErr::Denied(_, _, _))
+    ));
+}
+
+async fn run_test_cmd(
+    tmp: TempDir,
+    cmd: Vec<&'static str>,
+) -> Result<ExecToolCallOutput, CodexErr> {
+    let sandbox_type = get_platform_sandbox().expect("should be able to get sandbox type");
+
+    let params = ExecParams {
+        command: cmd.iter().map(|s| s.to_string()).collect(),
+        cwd: tmp.path().to_path_buf(),
+        timeout_ms: Some(100),
+        env: HashMap::new(),
+    };
+
+    let ctrl_c = Arc::new(Notify::new());
+    let policy = SandboxPolicy::new_read_only_policy();
+
+    process_exec_tool_call(params, sandbox_type, ctrl_c, &policy, &None, None).await
+}


### PR DESCRIPTION
## Summary
Users frequently complain about re-approving commands that have failed for non-sandbox reasons. We can't diagnose with complete accuracy which errors happened because of a sandbox failure, but we can start to eliminate some common simple cases.

This PR captures the most common case I've seen, which is a `command not found` error.

## Testing
- [x] Added unit tests
- [x] Ran a few cases locally