### PR TITLE
Store rollouts in /sessions

### DIFF
--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -36,7 +36,7 @@ sha1 = "0.10.6"
 shlex = "1.3.0"
 strum_macros = "0.27.2"
 thiserror = "2.0.12"
-time = { version = "0.3", features = ["formatting", "local-offset", "macros"] }
+time = { version = "0.3", features = ["formatting", "local-offset", "macros", "parsing"] }
 tokio = { version = "1", features = [
     "io-std",
     "macros",

--- a/codex-rs/core/tests/cli_stream.rs
+++ b/codex-rs/core/tests/cli_stream.rs
@@ -330,30 +330,9 @@ async fn integration_creates_and_checks_session_file() {
         .collect();
     assert_eq!(
         comps.len(),
-        4,
-        "Expected sessions/YYYY/MM/DD/<file>, got {rel:?}"
+        1,
+        "Expected sessions/<file>, got nested path {rel:?}"
     );
-    let year = &comps[0];
-    let month = &comps[1];
-    let day = &comps[2];
-    assert!(
-        year.len() == 4 && year.chars().all(|c| c.is_ascii_digit()),
-        "Year dir not 4-digit numeric: {year}"
-    );
-    assert!(
-        month.len() == 2 && month.chars().all(|c| c.is_ascii_digit()),
-        "Month dir not zero-padded 2-digit numeric: {month}"
-    );
-    assert!(
-        day.len() == 2 && day.chars().all(|c| c.is_ascii_digit()),
-        "Day dir not zero-padded 2-digit numeric: {day}"
-    );
-    if let Ok(m) = month.parse::<u8>() {
-        assert!((1..=12).contains(&m), "Month out of range: {m}");
-    }
-    if let Ok(d) = day.parse::<u8>() {
-        assert!((1..=31).contains(&d), "Day out of range: {d}");
-    }
 
     let content =
         std::fs::read_to_string(&path).unwrap_or_else(|_| panic!("Failed to read session file"));


### PR DESCRIPTION
- Checks for and creates /sessions directory
- Adds rollouts in json and jsonl format
- Uses local timezone for rollout dates