### PR TITLE
Get rid of unnecessary ERROR messages

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -628,7 +628,7 @@ impl AgentTask {
             let event = Event {
                 id: self.sub_id,
                 msg: EventMsg::BackgroundEvent(BackgroundEventEvent {
-                    message: "Turn interrupted — returning to the prompt.".to_string(),
+                    message: "Response interrupted.".to_string(),
                 }),
             };
             let tx_event = self.sess.tx_event.clone();

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -601,8 +601,8 @@ impl AgentTask {
             self.handle.abort();
             let event = Event {
                 id: self.sub_id,
-                msg: EventMsg::Error(ErrorEvent {
-                    message: "Turn interrupted".to_string(),
+                msg: EventMsg::BackgroundEvent(BackgroundEventEvent {
+                    message: "Turn interrupted — returning to the prompt.".to_string(),
                 }),
             };
             let tx_event = self.sess.tx_event.clone();

--- a/codex-rs/exec/src/event_processor.rs
+++ b/codex-rs/exec/src/event_processor.rs
@@ -57,7 +57,7 @@ pub(crate) fn handle_last_message(
                 path.display()
             );
         }
-        (None, _) => eprintln!("Warning: no file to write last message to."),
+        (None, _) => {}
     }
 }
 

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -173,6 +173,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                     last_agent_message.as_deref(),
                     self.last_message_path.as_deref(),
                 );
+                ts_println!(self, "{}", "Task complete.".style(self.green));
                 return CodexStatus::InitiateShutdown;
             }
             EventMsg::TokenCount(TokenUsage { total_tokens, .. }) => {

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -181,20 +181,22 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
                             )
                             .await;
 
-                        // Exit the inner loop and return to the main input prompt.  The codex
-                        // will emit a `TurnInterrupted` (Error) event which is drained later.
                         break;
                     }
                     res = codex.next_event() => match res {
                         Ok(event) => {
+                            let is_shutdown = matches!(event.msg, EventMsg::ShutdownComplete);
                             debug!("Received event: {event:?}");
                             if let Err(e) = tx.send(event) {
                                 error!("Error sending event: {e:?}");
                                 break;
                             }
+                            if is_shutdown {
+                                break;
+                            }
                         },
                         Err(e) => {
-                            error!("Error receiving event: {e:?}");
+                            debug!("Event stream ended: {e:?}");
                             break;
                         }
                     }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -10,6 +10,7 @@ use codex_core::protocol::AgentMessageEvent;
 use codex_core::protocol::AgentReasoningDeltaEvent;
 use codex_core::protocol::AgentReasoningEvent;
 use codex_core::protocol::ApplyPatchApprovalRequestEvent;
+use codex_core::protocol::BackgroundEventEvent;
 use codex_core::protocol::ErrorEvent;
 use codex_core::protocol::Event;
 use codex_core::protocol::EventMsg;
@@ -220,6 +221,13 @@ impl ChatWidget<'_> {
     pub(crate) fn handle_codex_event(&mut self, event: Event) {
         let Event { id, msg } = event;
         match msg {
+            EventMsg::BackgroundEvent(BackgroundEventEvent { message }) => {
+                self.add_to_history(HistoryCell::new_background_event(message.clone()));
+                if message.contains("Turn interrupted") {
+                    self.bottom_pane.set_task_running(false);
+                }
+                self.request_redraw();
+            }
             EventMsg::SessionConfigured(event) => {
                 self.bottom_pane
                     .set_history_metadata(event.history_log_id, event.history_entry_count);


### PR DESCRIPTION
When interrupting a model turn with ctr-c or at end of exec, we print an ERROR message, which is jank. Let's not do that.