### PR TITLE
[codex] stop printing error message when --output-last-message is not specified

### DIFF
--- a/codex-rs/exec/src/event_processor.rs
+++ b/codex-rs/exec/src/event_processor.rs
@@ -44,20 +44,14 @@ pub(crate) fn create_config_summary_entries(config: &Config) -> Vec<(&'static st
     entries
 }
 
-pub(crate) fn handle_last_message(
-    last_agent_message: Option<&str>,
-    last_message_path: Option<&Path>,
-) {
-    match (last_message_path, last_agent_message) {
-        (Some(path), Some(msg)) => write_last_message_file(msg, Some(path)),
-        (Some(path), None) => {
-            write_last_message_file("", Some(path));
-            eprintln!(
-                "Warning: no last agent message; wrote empty content to {}",
-                path.display()
-            );
-        }
-        (None, _) => eprintln!("Warning: no file to write last message to."),
+pub(crate) fn handle_last_message(last_agent_message: Option<&str>, output_file: &Path) {
+    let message = last_agent_message.unwrap_or_default();
+    write_last_message_file(message, Some(output_file));
+    if last_agent_message.is_none() {
+        eprintln!(
+            "Warning: no last agent message; wrote empty content to {}",
+            output_file.display()
+        );
     }
 }
 

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -170,10 +170,9 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                 // Ignore.
             }
             EventMsg::TaskComplete(TaskCompleteEvent { last_agent_message }) => {
-                handle_last_message(
-                    last_agent_message.as_deref(),
-                    self.last_message_path.as_deref(),
-                );
+                if let Some(output_file) = self.last_message_path.as_deref() {
+                    handle_last_message(last_agent_message.as_deref(), output_file);
+                }
                 return CodexStatus::InitiateShutdown;
             }
             EventMsg::TokenCount(TokenUsage { total_tokens, .. }) => {

--- a/codex-rs/exec/src/event_processor_with_json_output.rs
+++ b/codex-rs/exec/src/event_processor_with_json_output.rs
@@ -46,10 +46,9 @@ impl EventProcessor for EventProcessorWithJsonOutput {
                 CodexStatus::Running
             }
             EventMsg::TaskComplete(TaskCompleteEvent { last_agent_message }) => {
-                handle_last_message(
-                    last_agent_message.as_deref(),
-                    self.last_message_path.as_deref(),
-                );
+                if let Some(output_file) = self.last_message_path.as_deref() {
+                    handle_last_message(last_agent_message.as_deref(), output_file);
+                }
                 CodexStatus::InitiateShutdown
             }
             EventMsg::ShutdownComplete => CodexStatus::Shutdown,


### PR DESCRIPTION
Previously, `codex exec` was printing `Warning: no file to write last message to` as a warning to stderr even though `--output-last-message` was not specified, which is wrong. This fixes the code and changes `handle_last_message()` so that it is only called when `last_message_path` is `Some`.