### PR TITLE
handle PatchApplyEnd

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -21,6 +21,7 @@ use codex_core::protocol::McpToolCallBeginEvent;
 use codex_core::protocol::McpToolCallEndEvent;
 use codex_core::protocol::Op;
 use codex_core::protocol::PatchApplyBeginEvent;
+use codex_core::protocol::PatchApplyEndEvent;
 use codex_core::protocol::TaskCompleteEvent;
 use codex_core::protocol::TokenUsage;
 use crossterm::event::KeyEvent;
@@ -385,6 +386,16 @@ impl ChatWidget<'_> {
                     PatchEventType::ApplyBegin { auto_approved },
                     changes,
                 ));
+            }
+            EventMsg::PatchApplyEnd(PatchApplyEndEvent {
+                call_id: _,
+                stdout,
+                stderr,
+                success,
+            }) => {
+                if !success {
+                    self.add_to_history(HistoryCell::new_patch_failed_event(stdout, stderr));
+                }
             }
             EventMsg::ExecCommandEnd(ExecCommandEndEvent {
                 call_id,

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -113,6 +113,9 @@ pub(crate) enum HistoryCell {
     /// model wants to apply before being prompted to approve or deny it.
     PendingPatch { view: TextBlock },
 
+    /// A patch failed to apply.
+    PatchFailed { view: TextBlock },
+
     /// A human‑friendly rendering of the model's current plan and step
     /// statuses provided via the `update_plan` tool.
     PlanUpdate { view: TextBlock },
@@ -137,6 +140,7 @@ impl HistoryCell {
             | HistoryCell::CompletedExecCommand { view }
             | HistoryCell::CompletedMcpToolCall { view }
             | HistoryCell::PendingPatch { view }
+            | HistoryCell::PatchFailed { view }
             | HistoryCell::PlanUpdate { view }
             | HistoryCell::ActiveExecCommand { view, .. }
             | HistoryCell::ActiveMcpToolCall { view, .. } => {
@@ -148,6 +152,7 @@ impl HistoryCell {
             ],
         }
     }
+
     pub(crate) fn new_session_info(
         config: &Config,
         event: SessionConfiguredEvent,
@@ -626,6 +631,18 @@ impl HistoryCell {
         lines.push(Line::from(""));
 
         HistoryCell::PendingPatch {
+            view: TextBlock::new(lines),
+        }
+    }
+
+    pub fn new_patch_failed_event(stdout: String, stderr: String) -> Self {
+        let lines: Vec<Line<'static>> = vec![
+            Line::from("patch failed".red().bold()),
+            Line::from(stdout),
+            Line::from(stderr),
+            Line::from(""),
+        ];
+        HistoryCell::PatchFailed {
             view: TextBlock::new(lines),
         }
     }


### PR DESCRIPTION
This is more to drop the ugly unhandled `PatchApplyEnd` messages than it is about showing patch failures cleanly (I haven't been able to get a patch failure to occur so it's hard for me to test the failure message).