### PR TITLE
fix: disable reorderArrays in tamasfe.even-better-toml

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -11,6 +11,8 @@
         "editor.defaultFormatter": "tamasfe.even-better-toml",
         "editor.formatOnSave": true,
     },
-    "evenBetterToml.formatter.reorderArrays": true,
+    // Array order for options in ~/.codex/config.toml such as `notify` and the
+    // `args` for an MCP server is significant, so we disable reordering.
+    "evenBetterToml.formatter.reorderArrays": false,
     "evenBetterToml.formatter.reorderKeys": true,
 }


### PR DESCRIPTION
The existing setting kept destroying my `~/.codex/config.toml` for the reasons mentioned in the comment.