### PR TITLE
chore: introduce ModelFamily abstraction

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -82,7 +82,7 @@ impl ModelClient {
                 // Create the raw streaming connection first.
                 let response_stream = stream_chat_completions(
                     prompt,
-                    &self.config.model,
+                    &self.config.model_family,
                     self.config.include_plan_tool,
                     &self.client,
                     &self.provider,
@@ -127,13 +127,17 @@ impl ModelClient {
 
         let store = prompt.store && auth_mode != Some(AuthMode::ChatGPT);
 
-        let full_instructions = prompt.get_full_instructions(&self.config.model);
+        let full_instructions = prompt.get_full_instructions(&self.config.model_family);
         let tools_json = create_tools_json_for_responses_api(
             prompt,
-            &self.config.model,
+            &self.config.model_family,
             self.config.include_plan_tool,
         )?;
-        let reasoning = create_reasoning_param_for_request(&self.config, self.effort, self.summary);
+        let reasoning = create_reasoning_param_for_request(
+            &self.config.model_family,
+            self.effort,
+            self.summary,
+        );
 
         // Request encrypted COT if we are not storing responses,
         // otherwise reasoning items will be referenced by ID

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -31,6 +31,7 @@ mod model_provider_info;
 pub use model_provider_info::ModelProviderInfo;
 pub use model_provider_info::WireApi;
 pub use model_provider_info::built_in_model_providers;
+pub mod model_family;
 mod models;
 mod openai_model_info;
 mod openai_tools;
@@ -47,5 +48,4 @@ mod user_notification;
 pub mod util;
 
 pub use apply_patch::CODEX_APPLY_PATCH_ARG1;
-pub use client_common::model_supports_reasoning_summaries;
 pub use safety::get_platform_sandbox;

--- a/codex-rs/core/src/model_family.rs
+++ b/codex-rs/core/src/model_family.rs
@@ -1,0 +1,93 @@
+/// A model family is a group of models that share certain characteristics.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ModelFamily {
+    /// The full model slug used to derive this model family, e.g.
+    /// "gpt-4.1-2025-04-14".
+    pub slug: String,
+
+    /// The model family name, e.g. "gpt-4.1". Note this should able to be used
+    /// with [`crate::openai_model_info::get_model_info`].
+    pub family: String,
+
+    /// True if the model needs additional instructions on how to use the
+    /// "virtual" `apply_patch` CLI.
+    pub needs_special_apply_patch_instructions: bool,
+
+    // Whether the `reasoning` field can be set when making a request to this
+    // model family. Note it has `effort` and `summary` subfields (though
+    // `summary` is optional).
+    pub supports_reasoning_summaries: bool,
+
+    // This should be set to true when the model expects a tool named
+    // "local_shell" to be provided. Its contract must be understood natively by
+    // the model such that its description can be omitted.
+    // See https://platform.openai.com/docs/guides/tools-local-shell
+    pub uses_local_shell_tool: bool,
+}
+
+macro_rules! model_family {
+    (
+        $slug:expr, $family:expr $(, $key:ident : $value:expr )* $(,)?
+    ) => {{
+        // defaults
+        let mut mf = ModelFamily {
+            slug: $slug.to_string(),
+            family: $family.to_string(),
+            needs_special_apply_patch_instructions: false,
+            supports_reasoning_summaries: false,
+            uses_local_shell_tool: false,
+        };
+        // apply overrides
+        $(
+            mf.$key = $value;
+        )*
+        Some(mf)
+    }};
+}
+
+macro_rules! simple_model_family {
+    (
+        $slug:expr, $family:expr
+    ) => {{
+        Some(ModelFamily {
+            slug: $slug.to_string(),
+            family: $family.to_string(),
+            needs_special_apply_patch_instructions: false,
+            supports_reasoning_summaries: false,
+            uses_local_shell_tool: false,
+        })
+    }};
+}
+
+/// Returns a `ModelFamily` for the given model slug, or `None` if the slug
+/// does not match any known model family.
+pub fn find_family_for_model(slug: &str) -> Option<ModelFamily> {
+    if slug.starts_with("o3") {
+        model_family!(
+            slug, "o3",
+            supports_reasoning_summaries: true,
+        )
+    } else if slug.starts_with("o4-mini") {
+        model_family!(
+            slug, "o4-mini",
+            supports_reasoning_summaries: true,
+        )
+    } else if slug.starts_with("codex-mini-latest") {
+        model_family!(
+            slug, "codex-mini-latest",
+            supports_reasoning_summaries: true,
+            uses_local_shell_tool: true,
+        )
+    } else if slug.starts_with("gpt-4.1") {
+        model_family!(
+            slug, "gpt-4.1",
+            needs_special_apply_patch_instructions: true,
+        )
+    } else if slug.starts_with("gpt-4o") {
+        simple_model_family!(slug, "gpt-4o")
+    } else if slug.starts_with("gpt-3.5") {
+        simple_model_family!(slug, "gpt-3.5")
+    } else {
+        None
+    }
+}

--- a/codex-rs/core/src/openai_model_info.rs
+++ b/codex-rs/core/src/openai_model_info.rs
@@ -1,3 +1,5 @@
+use crate::model_family::ModelFamily;
+
 /// Metadata about a model, particularly OpenAI models.
 /// We may want to consider including details like the pricing for
 /// input tokens, output tokens, etc., though users will need to be able to
@@ -14,8 +16,8 @@ pub(crate) struct ModelInfo {
 
 /// Note details such as what a model like gpt-4o is aliased to may be out of
 /// date.
-pub(crate) fn get_model_info(name: &str) -> Option<ModelInfo> {
-    match name {
+pub(crate) fn get_model_info(model_family: &ModelFamily) -> Option<ModelInfo> {
+    match model_family.slug.as_str() {
         // https://platform.openai.com/docs/models/o3
         "o3" => Some(ModelInfo {
             context_window: 200_000,

--- a/codex-rs/exec/src/event_processor.rs
+++ b/codex-rs/exec/src/event_processor.rs
@@ -3,7 +3,6 @@ use std::path::Path;
 use codex_common::summarize_sandbox_policy;
 use codex_core::WireApi;
 use codex_core::config::Config;
-use codex_core::model_supports_reasoning_summaries;
 use codex_core::protocol::Event;
 
 pub(crate) enum CodexStatus {
@@ -29,7 +28,7 @@ pub(crate) fn create_config_summary_entries(config: &Config) -> Vec<(&'static st
         ("sandbox", summarize_sandbox_policy(&config.sandbox_policy)),
     ];
     if config.model_provider.wire_api == WireApi::Responses
-        && model_supports_reasoning_summaries(config)
+        && config.model_family.supports_reasoning_summaries
     {
         entries.push((
             "reasoning effort",

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -7,7 +7,6 @@ use codex_common::elapsed::format_duration;
 use codex_common::summarize_sandbox_policy;
 use codex_core::WireApi;
 use codex_core::config::Config;
-use codex_core::model_supports_reasoning_summaries;
 use codex_core::plan_tool::PlanItemArg;
 use codex_core::plan_tool::StepStatus;
 use codex_core::plan_tool::UpdatePlanArgs;
@@ -177,7 +176,7 @@ impl HistoryCell {
                 ("sandbox", summarize_sandbox_policy(&config.sandbox_policy)),
             ];
             if config.model_provider.wire_api == WireApi::Responses
-                && model_supports_reasoning_summaries(config)
+                && config.model_family.supports_reasoning_summaries
             {
                 entries.push((
                     "reasoning effort",


### PR DESCRIPTION
To date, we have a number of hardcoded OpenAI model slug checks spread throughout the codebase, which makes it hard to audit the various special cases for each model. To mitigate this issue, this PR introduces the idea of a `ModelFamily` that has fields to represent the existing special cases, such as `supports_reasoning_summaries` and `uses_local_shell_tool`.

There is a `find_family_for_model()` function that maps the raw model slug to a `ModelFamily`. This function hardcodes all the knowledge about the special attributes for each model. This PR then replaces the hardcoded model name checks with checks against a `ModelFamily`.

Note `ModelFamily` is now available as `Config::model_family`. We should ultimately remove `Config::model` in favor of `Config::model_family::slug`. 
