### PR TITLE
[core] Stop escalating timeouts

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1957,6 +1957,20 @@ async fn handle_sandbox_error(
         };
     }
 
+    // similarly, if the command timed out, we can simply return this failure to the model
+    if error == SandboxErr::Timeout {
+        return ResponseInputItem::FunctionCallOutput {
+            call_id,
+            output: FunctionCallOutputPayload {
+                content: format!(
+                    "command timed out after {} milliseconds",
+                    params.timeout_duration().as_millis()
+                ),
+                success: Some(false),
+            },
+        };
+    }
+
     // Note that when `error` is `SandboxErr::Denied`, it could be a false
     // positive. That is, it may have exited with a non-zero exit code, not
     // because the sandbox denied it, but because that is its expected behavior,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1958,7 +1958,7 @@ async fn handle_sandbox_error(
     }
 
     // similarly, if the command timed out, we can simply return this failure to the model
-    if error == SandboxErr::Timeout {
+    if matches!(error, SandboxErr::Timeout) {
         return ResponseInputItem::FunctionCallOutput {
             call_id,
             output: FunctionCallOutputPayload {

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -6,7 +6,7 @@ use tokio::task::JoinError;
 
 pub type Result<T> = std::result::Result<T, CodexErr>;
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum SandboxErr {
     /// Error from sandbox execution
     #[error("sandbox denied exec error, exit code: {0}, stdout: {1}, stderr: {2}")]

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -6,7 +6,7 @@ use tokio::task::JoinError;
 
 pub type Result<T> = std::result::Result<T, CodexErr>;
 
-#[derive(Error, Debug, PartialEq)]
+#[derive(Error, Debug)]
 pub enum SandboxErr {
     /// Error from sandbox execution
     #[error("sandbox denied exec error, exit code: {0}, stdout: {1}, stderr: {2}")]


### PR DESCRIPTION
## Summary
Escalating out of sandbox is (almost always) not going to fix long-running commands timing out - therefore we should just pass the failure back to the model instead of asking the user to re-run a command that took a long time anyway.

## Testing
- [x] Ran locally with a timeout and confirmed this worked as expected
```
{"type":"function_call","id":"...","name":"shell","arguments":"{\"command\":[\"bash\",\"-lc\",\"grep -Rin \\\"...\" -n evallib project lib | head -n 40\"]}","call_id":"...."}
{"type":"function_call_output","call_id":"...","output":"command timed out after 10000 milliseconds"}
{"record_type":"state"}
{"record_type":"state"}
{"type":"function_call","id":"fc_68924c6686a4819c8274131d396860b205ee7318f91d9151","name":"shell","arguments":"{\"command\":[\"bash\",\"-lc\",\"rg -n \\\"...:\\\" evallib project lib | head -n 60\"],\"timeout\": 120000}","call_id":"..."}
```

I'd like to start adding some tests here but `codex.rs` is a bit tangled right now - i can put up a unit test but it will be far more setup/config than actual testing. Would love to start pulling more of the exec logic out of there in subsequent PRs!