### PR TITLE
chore: remove unnecessary default_ prefix

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -385,8 +385,8 @@ pub struct ConfigOverrides {
     pub codex_linux_sandbox_exe: Option<PathBuf>,
     pub base_instructions: Option<String>,
     pub include_plan_tool: Option<bool>,
-    pub default_disable_response_storage: Option<bool>,
-    pub default_show_raw_agent_reasoning: Option<bool>,
+    pub disable_response_storage: Option<bool>,
+    pub show_raw_agent_reasoning: Option<bool>,
 }
 
 impl Config {
@@ -410,8 +410,8 @@ impl Config {
             codex_linux_sandbox_exe,
             base_instructions,
             include_plan_tool,
-            default_disable_response_storage,
-            default_show_raw_agent_reasoning,
+            disable_response_storage,
+            show_raw_agent_reasoning,
         } = overrides;
 
         let config_profile = match config_profile_key.as_ref().or(cfg.profile.as_ref()) {
@@ -529,7 +529,7 @@ impl Config {
             disable_response_storage: config_profile
                 .disable_response_storage
                 .or(cfg.disable_response_storage)
-                .or(default_disable_response_storage)
+                .or(disable_response_storage)
                 .unwrap_or(false),
             notify: cfg.notify,
             user_instructions,
@@ -546,7 +546,7 @@ impl Config {
             hide_agent_reasoning: cfg.hide_agent_reasoning.unwrap_or(false),
             show_raw_agent_reasoning: cfg
                 .show_raw_agent_reasoning
-                .or(default_show_raw_agent_reasoning)
+                .or(show_raw_agent_reasoning)
                 .unwrap_or(false),
             model_reasoning_effort: config_profile
                 .model_reasoning_effort

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -147,8 +147,8 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         codex_linux_sandbox_exe,
         base_instructions: None,
         include_plan_tool: None,
-        default_disable_response_storage: oss.then_some(true),
-        default_show_raw_agent_reasoning: oss.then_some(true),
+        disable_response_storage: oss.then_some(true),
+        show_raw_agent_reasoning: oss.then_some(true),
     };
     // Parse `-c` overrides.
     let cli_kv_overrides = match config_overrides.parse_overrides() {

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -158,8 +158,8 @@ impl CodexToolCallParam {
             codex_linux_sandbox_exe,
             base_instructions,
             include_plan_tool,
-            default_disable_response_storage: None,
-            default_show_raw_agent_reasoning: None,
+            disable_response_storage: None,
+            show_raw_agent_reasoning: None,
         };
 
         let cli_overrides = cli_overrides

--- a/codex-rs/mcp-server/src/tool_handlers/create_conversation.rs
+++ b/codex-rs/mcp-server/src/tool_handlers/create_conversation.rs
@@ -59,8 +59,8 @@ pub(crate) async fn handle_create_conversation(
         codex_linux_sandbox_exe: None,
         base_instructions,
         include_plan_tool: None,
-        default_disable_response_storage: None,
-        default_show_raw_agent_reasoning: None,
+        disable_response_storage: None,
+        show_raw_agent_reasoning: None,
     };
 
     let cfg: CodexConfig = match CodexConfig::load_with_cli_overrides(cli_overrides, overrides) {

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -101,8 +101,8 @@ pub async fn run_main(
             codex_linux_sandbox_exe,
             base_instructions: None,
             include_plan_tool: Some(true),
-            default_disable_response_storage: cli.oss.then_some(true),
-            default_show_raw_agent_reasoning: cli.oss.then_some(true),
+            disable_response_storage: cli.oss.then_some(true),
+            show_raw_agent_reasoning: cli.oss.then_some(true),
         };
         // Parse `-c` overrides from the CLI.
         let cli_kv_overrides = match cli.config_overrides.parse_overrides() {


### PR DESCRIPTION
This prefix is not inline with the other fields on the `ConfigOverrides` struct.