### PR TITLE
fix: correct spelling error that sneaked through

### DIFF
--- a/codex-rs/ollama/src/client.rs
+++ b/codex-rs/ollama/src/client.rs
@@ -192,7 +192,7 @@ impl OllamaClient {
                     return Ok(());
                 }
                 PullEvent::Error(err) => {
-                    // Emperically, ollama returns a 200 OK response even when
+                    // Empirically, ollama returns a 200 OK response even when
                     // the output stream includes an error message. Verify with:
                     //
                     // `curl -i http://localhost:11434/api/pull -d '{ "model": "foobarbaz" }'`


### PR DESCRIPTION
I ended up force-pushing https://github.com/openai/codex/pull/1848 because CI jobs were not being triggered after updating the PR on GitHub, so this spelling error sneaked through.