### PR TITLE
[prompts] Add <environment_context>

### DIFF
--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -41,11 +41,9 @@ pub(crate) async fn stream_chat_completions(
     let full_instructions = prompt.get_full_instructions(model_family);
     messages.push(json!({"role": "system", "content": full_instructions}));
 
-    if let Some(instr) = &prompt.get_formatted_user_instructions() {
-        messages.push(json!({"role": "user", "content": instr}));
-    }
+    let input = prompt.get_formatted_input();
 
-    for item in &prompt.input {
+    for item in &input {
         match item {
             ResponseItem::Message { role, content, .. } => {
                 let mut text = String::new();

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -34,7 +34,6 @@ use crate::error::Result;
 use crate::flags::CODEX_RS_SSE_FIXTURE;
 use crate::model_provider_info::ModelProviderInfo;
 use crate::model_provider_info::WireApi;
-use crate::models::ContentItem;
 use crate::models::ResponseItem;
 use crate::openai_tools::create_tools_json_for_responses_api;
 use crate::protocol::TokenUsage;
@@ -146,22 +145,7 @@ impl ModelClient {
             vec![]
         };
 
-        let mut input_with_instructions = Vec::with_capacity(prompt.input.len() + 2);
-        if let Some(ec) = prompt.get_formatted_environment_context() {
-            input_with_instructions.push(ResponseItem::Message {
-                id: None,
-                role: "developer".to_string(),
-                content: vec![ContentItem::InputText { text: ec }],
-            });
-        }
-        if let Some(ui) = prompt.get_formatted_user_instructions() {
-            input_with_instructions.push(ResponseItem::Message {
-                id: None,
-                role: "user".to_string(),
-                content: vec![ContentItem::InputText { text: ui }],
-            });
-        }
-        input_with_instructions.extend(prompt.input.clone());
+        let input_with_instructions = prompt.get_formatted_input();
 
         let payload = ResponsesApiRequest {
             model: &self.config.model,

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -146,7 +146,14 @@ impl ModelClient {
             vec![]
         };
 
-        let mut input_with_instructions = Vec::with_capacity(prompt.input.len() + 1);
+        let mut input_with_instructions = Vec::with_capacity(prompt.input.len() + 2);
+        if let Some(ec) = prompt.get_formatted_environment_context() {
+            input_with_instructions.push(ResponseItem::Message {
+                id: None,
+                role: "developer".to_string(),
+                content: vec![ContentItem::InputText { text: ec }],
+            });
+        }
         if let Some(ui) = prompt.get_formatted_user_instructions() {
             input_with_instructions.push(ResponseItem::Message {
                 id: None,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -52,7 +52,6 @@ use crate::exec::SandboxType;
 use crate::exec::StdoutStream;
 use crate::exec::process_exec_tool_call;
 use crate::exec_env::create_env;
-use crate::git_info::GitInfo;
 use crate::git_info::collect_git_info;
 use crate::mcp_connection_manager::McpConnectionManager;
 use crate::mcp_tool_call::handle_mcp_tool_call;
@@ -221,7 +220,6 @@ pub(crate) struct Session {
     shell_environment_policy: ShellEnvironmentPolicy,
     pub(crate) writable_roots: Mutex<Vec<PathBuf>>,
     disable_response_storage: bool,
-    git_info: Option<GitInfo>,
     tools_config: ToolsConfig,
 
     /// Manager for external MCP servers/tools.
@@ -748,7 +746,6 @@ async fn submission_loop(
                         None
                     };
 
-                let git_info = collect_git_info(&cwd).await;
                 let rollout_recorder = match rollout_recorder {
                     Some(rec) => Some(rec),
                     None => {
@@ -832,7 +829,6 @@ async fn submission_loop(
                     sandbox_policy,
                     shell_environment_policy: config.shell_environment_policy.clone(),
                     cwd,
-                    git_info,
                     writable_roots,
                     mcp_connection_manager,
                     notify,
@@ -1232,7 +1228,7 @@ async fn run_turn(
         base_instructions_override: sess.base_instructions.clone(),
         environment_context: Some(EnvironmentContext {
             cwd: sess.cwd.clone(),
-            is_git_repo: sess.git_info.is_some(),
+            git_info: collect_git_info(&sess.cwd).await,
             approval_policy: sess.approval_policy,
             sandbox_policy: sess.sandbox_policy.clone(),
         }),

--- a/codex-rs/core/src/git_info.rs
+++ b/codex-rs/core/src/git_info.rs
@@ -9,7 +9,7 @@ use tokio::time::timeout;
 /// Timeout for git commands to prevent freezing on large repositories
 const GIT_COMMAND_TIMEOUT: TokioDuration = TokioDuration::from_secs(5);
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct GitInfo {
     /// Current commit hash (SHA)
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -159,7 +159,8 @@ pub enum AskForApproval {
 }
 
 /// Determines execution restrictions for model shell commands.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Display)]
+#[strum(serialize_all = "kebab-case")]
 #[serde(tag = "mode", rename_all = "kebab-case")]
 pub enum SandboxPolicy {
     /// No restrictions whatsoever. Use with caution.

--- a/codex-rs/mcp-server/tests/send_message.rs
+++ b/codex-rs/mcp-server/tests/send_message.rs
@@ -99,7 +99,7 @@ async fn test_send_message_success() {
         response
     );
     // wait for the server to hear the user message
-    sleep(Duration::from_secs(1));
+    sleep(Duration::from_secs(5));
 
     // Ensure the server and tempdir live until end of test
     drop(server);

--- a/codex-rs/mcp-server/tests/send_message.rs
+++ b/codex-rs/mcp-server/tests/send_message.rs
@@ -99,7 +99,7 @@ async fn test_send_message_success() {
         response
     );
     // wait for the server to hear the user message
-    sleep(Duration::from_secs(5));
+    sleep(Duration::from_secs(10));
 
     // Ensure the server and tempdir live until end of test
     drop(server);


### PR DESCRIPTION
## Summary
Includes a new user message in the api payload which provides useful environment context for the model, so it knows about things like the current working directory and the sandbox.

## Testing
Examined payload from message:
```
[{"type":"message","id":null,"role":"developer","content":[{"type":"input_text","text":"<environment_context>\n\nCurrent working directo
ry: .../codex-rs\nIs directory a git repo: true\napproval_policy: on-request\nsandbox_policy: read-only\n\n</environment_context>"}]}
```

Notice no failure - it requests right away!
<img width="1275" height="603" alt="Screenshot 2025-08-05 at 9 14 16 PM" src="https://github.com/user-attachments/assets/69247fd3-79b3-465e-8886-06a7b897ee37" />
