### PR TITLE
fix: only tag as prerelease when the version has an -alpha or -beta suffix

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -181,9 +181,9 @@ jobs:
           name: ${{ steps.release_name.outputs.name }}
           tag_name: ${{ github.ref_name }}
           files: dist/**
-          # For now, tag releases as "prerelease" because we are not claiming
-          # the Rust CLI is stable yet.
-          prerelease: true
+          # Mark as prerelease only when the version has a suffix after x.y.z
+          # (e.g. -alpha, -beta). Otherwise publish a normal release.
+          prerelease: ${{ contains(steps.release_name.outputs.name, '-') }}
 
       - uses: facebook/dotslash-publish-release@v2
         env:


### PR DESCRIPTION
Hardcoding to `prerelease: true` is a holdover from before we had migrated to the Rust CLI for releases and decided on how we were doing version numbers.

To date, I have had to change the release status from "prerelease" to "actual release" manually through the GitHub Releases web page. This is a semi-serious problem because I've discovered that it messes up Homebrew's automation if the version number _looks_ like a real release but turns out to be a prerelease. The release potentially gets skipped from being published on Homebrew, so it's important to set the value correctly from the start.

I verified that `steps.release_name.outputs.name` does not include the `rust-v` prefix from the tag name.