### PR TITLE
fix: add stricter checks and better error messages to create_github_release.sh

### DIFF
--- a/codex-rs/scripts/create_github_release.sh
+++ b/codex-rs/scripts/create_github_release.sh
@@ -19,7 +19,33 @@ if ! git diff --quiet || ! git diff --cached --quiet || [ -n "$(git ls-files --o
 fi
 
 # Fail if in a detached HEAD state.
-CURRENT_BRANCH=$(git symbolic-ref --short -q HEAD)
+CURRENT_BRANCH=$(git symbolic-ref --short -q HEAD 2>/dev/null || true)
+if [ -z "${CURRENT_BRANCH:-}" ]; then
+  echo "ERROR: Could not determine the current branch (detached HEAD?)." >&2
+  echo "       Please run this script from a checked-out branch." >&2
+  exit 1
+fi
+
+# Ensure we are on the 'main' branch before proceeding.
+if [ "${CURRENT_BRANCH}" != "main" ]; then
+  echo "ERROR: Releases must be created from the 'main' branch (current: '${CURRENT_BRANCH}')." >&2
+  echo "       Please switch to 'main' and try again." >&2
+  exit 1
+fi
+
+# Ensure the current local commit on 'main' is present on 'origin/main'.
+# This guarantees we only create releases from commits that are already on
+# the canonical repository (https://github.com/openai/codex).
+if ! git fetch --quiet origin main; then
+  echo "ERROR: Failed to fetch 'origin/main'. Ensure the 'origin' remote is configured and reachable." >&2
+  exit 1
+fi
+
+if ! git merge-base --is-ancestor HEAD origin/main; then
+  echo "ERROR: Your local 'main' HEAD commit is not present on 'origin/main'." >&2
+  echo "       Please push your commits first (git push origin main) or check out a commit on 'origin/main'." >&2
+  exit 1
+fi
 
 # Create a new branch for the release and make a commit with the new version.
 if [ $# -ge 1 ]; then


### PR DESCRIPTION
This script attempts to verify that:

- You have no local, uncommitted changes.
- You are on `main`
- The commit you are on exists on `main` also exists on the origin `https://github.com/openai/codex`, i.e., it is not just a commit you have pushed to your local version of `main`

As part of this, try to print better error message if/when these conditions are violated.