### PR TITLE
feat: interrupt running task on ctrl-z

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -239,6 +239,16 @@ impl App<'_> {
                             }
                         }
                         KeyEvent {
+                            code: KeyCode::Char('z'),
+                            modifiers: crossterm::event::KeyModifiers::CONTROL,
+                            kind: KeyEventKind::Press,
+                            ..
+                        } => {
+                            if let AppState::Chat { widget } = &mut self.app_state {
+                                widget.on_ctrl_z();
+                            }
+                        }
+                        KeyEvent {
                             code: KeyCode::Char('d'),
                             modifiers: crossterm::event::KeyModifiers::CONTROL,
                             kind: KeyEventKind::Press,


### PR DESCRIPTION
- Arguably a bugfix as previously CTRL-Z didn't do anything.
- Only in TUI mode for now. This may make sense in other modes... to be researched.
- The TUI runs the terminal in raw mode and the signals arrive as key events, so we handle CTRL-Z as a key event just like CTRL-C.
- Not adding UI for it as a composer redesign is coming, and we can just add it then.
- We should follow with CTRL-Z a second time doing the native terminal action.