### PR TITLE
feat: update launch screen

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1,4 +1,6 @@
+use crate::exec_command::relativize_to_home;
 use crate::exec_command::strip_bash_lc_and_escape;
+use crate::slash_command::SlashCommand;
 use crate::text_block::TextBlock;
 use crate::text_formatting::format_and_truncate_tool_result;
 use base64::Engine;
@@ -166,32 +168,35 @@ impl HistoryCell {
     ) -> Self {
         let SessionConfiguredEvent {
             model,
-            session_id,
+            session_id: _,
             history_log_id: _,
             history_entry_count: _,
         } = event;
         if is_first_event {
-            const VERSION: &str = env!("CARGO_PKG_VERSION");
+            let cwd_str = match relativize_to_home(&config.cwd) {
+                Some(rel) if !rel.as_os_str().is_empty() => format!("~/{}", rel.display()),
+                Some(_) => "~".to_string(),
+                None => config.cwd.display().to_string(),
+            };
 
-            let mut lines: Vec<Line<'static>> = vec![
+            let lines: Vec<Line<'static>> = vec![
                 Line::from(vec![
-                    "OpenAI ".into(),
-                    "Codex".bold(),
-                    format!(" v{VERSION}").into(),
-                    " (research preview)".dim(),
+                    Span::raw(">_ ").dim(),
+                    Span::styled(
+                        "You are using OpenAI Codex in",
+                        Style::default().add_modifier(Modifier::BOLD),
+                    ),
+                    Span::raw(format!(" {cwd_str}")).dim(),
                 ]),
-                Line::from(""),
-                Line::from(vec![
-                    "codex session".magenta().bold(),
-                    " ".into(),
-                    session_id.to_string().dim(),
-                ]),
+                Line::from("".dim()),
+                Line::from(" Try one of the following commands to get started:".dim()),
+                Line::from("".dim()),
+                Line::from(format!(" 1. /new - {}", SlashCommand::New.description()).dim()),
+                Line::from(format!(" 2. /status - {}", SlashCommand::Status.description()).dim()),
+                Line::from(format!(" 3. /diff - {}", SlashCommand::Diff.description()).dim()),
+                Line::from(format!(" 4. /compact - {}", SlashCommand::Compact.description()).dim()),
+                Line::from("".dim()),
             ];
-
-            for (key, value) in create_config_summary_entries(config) {
-                lines.push(Line::from(vec![format!("{key}: ").bold(), value.into()]));
-            }
-            lines.push(Line::from(""));
             HistoryCell::WelcomeMessage {
                 view: TextBlock::new(lines),
             }

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -191,10 +191,10 @@ impl HistoryCell {
                 Line::from("".dim()),
                 Line::from(" Try one of the following commands to get started:".dim()),
                 Line::from("".dim()),
-                Line::from(format!(" 1. /new - {}", SlashCommand::New.description()).dim()),
+                Line::from(format!(" 1. /init - {}", SlashCommand::Init.description()).dim()),
                 Line::from(format!(" 2. /status - {}", SlashCommand::Status.description()).dim()),
-                Line::from(format!(" 3. /diff - {}", SlashCommand::Diff.description()).dim()),
-                Line::from(format!(" 4. /compact - {}", SlashCommand::Compact.description()).dim()),
+                Line::from(format!(" 3. /compact - {}", SlashCommand::Compact.description()).dim()),
+                Line::from(format!(" 4. /new - {}", SlashCommand::New.description()).dim()),
                 Line::from("".dim()),
             ];
             HistoryCell::WelcomeMessage {

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -27,7 +27,7 @@ impl SlashCommand {
     pub fn description(self) -> &'static str {
         match self {
             SlashCommand::New => "Start a new chat",
-            SlashCommand::Init => "Create an AGENTS.md file with instructions for Codex.",
+            SlashCommand::Init => "Create an AGENTS.md file with instructions for Codex",
             SlashCommand::Compact => "Compact the chat history",
             SlashCommand::Quit => "Exit the application",
             SlashCommand::Diff => "Show git diff (including untracked files)",


### PR DESCRIPTION
- Updates the launch screen to:
  ```
  >_ You are using OpenAI Codex in ~/code/codex/codex-rs
  
   Try one of the following commands to get started:
  
   1. /init - Create an AGENTS.md file with instructions for Codex
   2. /status - Show current session configuration and token usage
   3. /compact - Compact the chat history
   4. /new - Start a new chat
   ```
- These aren't the perfect commands, but as more land soon we can update.
- We should also add logic later to make /init only show when there's no existing AGENTS.md.

<img width="905" height="769" alt="image" src="https://github.com/user-attachments/assets/5912939e-fb0e-4e76-94ff-785261e2d6ee" />



