### PR TITLE
[prompt] deduplicate user instructions

### DIFF
--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -147,7 +147,9 @@ fn is_user_instruction_item(item: &ResponseItem) -> bool {
     match item {
         ResponseItem::Message { content, .. } => content.iter().any(|c| match c {
             ContentItem::InputText { text } | ContentItem::OutputText { text } => {
-                text.starts_with(USER_INSTRUCTIONS_START) && text.ends_with(USER_INSTRUCTIONS_END)
+                let trimmed = text.trim();
+                trimmed.starts_with(USER_INSTRUCTIONS_START)
+                    && trimmed.ends_with(USER_INSTRUCTIONS_END)
             }
             _ => false,
         }),

--- a/codex-rs/core/tests/client.rs
+++ b/codex-rs/core/tests/client.rs
@@ -400,11 +400,11 @@ async fn includes_user_instructions_message_in_request() {
             .contains("be nice")
     );
     assert_message_role(&request_body["input"][0], "user");
-    assert_message_starts_with(&request_body["input"][0], "<environment_context>\n\n");
-    assert_message_ends_with(&request_body["input"][0], "</environment_context>");
+    assert_message_starts_with(&request_body["input"][0], "<user_instructions>\n\n");
+    assert_message_ends_with(&request_body["input"][0], "</user_instructions>");
     assert_message_role(&request_body["input"][1], "user");
-    assert_message_starts_with(&request_body["input"][1], "<user_instructions>\n\n");
-    assert_message_ends_with(&request_body["input"][1], "</user_instructions>");
+    assert_message_starts_with(&request_body["input"][1], "<environment_context>\n\n");
+    assert_message_ends_with(&request_body["input"][1], "</environment_context>");
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]


### PR DESCRIPTION
## Summary
Back when we moved these out of the user instruction, #1737, we started appending it to every turn. I think this makes sense for environment context, which might start to change over the course of a conversation, but AGENTS.md might be longer and is more stable.

## Testing
- [x] Added unit tests