### PR TITLE
fix cursor file name insert

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -453,6 +453,8 @@ impl ChatComposer {
         new_text.push_str(&text[end_idx..]);
 
         self.textarea.set_text(&new_text);
+        let new_cursor = start_idx.saturating_add(path.len()).saturating_add(1);
+        self.textarea.set_cursor(new_cursor);
     }
 
     /// Handle key event when no popup is visible.


### PR DESCRIPTION
Cursor wasn't moving when inserting a file, resulting in being not at the end of the filename when inserting the file.
This fixes it by moving the cursor to the end of the file + one trailing space.


Example screenshot after selecting a file when typing `@`
<img width="823" height="268" alt="image" src="https://github.com/user-attachments/assets/ec6e3741-e1ba-4752-89d2-11f14a2bd69f" />
