### PR TITLE
feat: change shell_environment_policy to default to inherit="all"

### DIFF
--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -339,12 +339,11 @@ disable_response_storage = true
 
 ## shell_environment_policy
 
-Codex spawns subprocesses (e.g. when executing a `local_shell` tool-call suggested by the assistant). By default it passes **only a minimal core subset** of your environment to those subprocesses to avoid leaking credentials. You can tune this behavior via the **`shell_environment_policy`** block in
-`config.toml`:
+Codex spawns subprocesses (e.g. when executing a `local_shell` tool-call suggested by the assistant). By default it now passes **your full environment** to those subprocesses. You can tune this behavior via the **`shell_environment_policy`** block in `config.toml`:
 
 ```toml
 [shell_environment_policy]
-# inherit can be "core" (default), "all", or "none"
+# inherit can be "all" (default), "core", or "none"
 inherit = "core"
 # set to true to *skip* the filter for `"*KEY*"` and `"*TOKEN*"`
 ignore_default_excludes = false
@@ -358,7 +357,7 @@ include_only = ["PATH", "HOME"]
 
 | Field                     | Type                       | Default | Description                                                                                                                                     |
 | ------------------------- | -------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
-| `inherit`                 | string                     | `core`  | Starting template for the environment:<br>`core` (`HOME`, `PATH`, `USER`, …), `all` (clone full parent env), or `none` (start empty).           |
+| `inherit`                 | string                     | `all`   | Starting template for the environment:<br>`all` (clone full parent env), `core` (`HOME`, `PATH`, `USER`, …), or `none` (start empty).           |
 | `ignore_default_excludes` | boolean                    | `false` | When `false`, Codex removes any var whose **name** contains `KEY`, `SECRET`, or `TOKEN` (case-insensitive) before other rules run.              |
 | `exclude`                 | array&lt;string&gt;        | `[]`    | Case-insensitive glob patterns to drop after the default filter.<br>Examples: `"AWS_*"`, `"AZURE_*"`.                                           |
 | `set`                     | table&lt;string,string&gt; | `{}`    | Explicit key/value overrides or additions – always win over inherited values.                                                                   |

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -109,10 +109,10 @@ pub struct SandboxWorkspaceWrite {
 pub enum ShellEnvironmentPolicyInherit {
     /// "Core" environment variables for the platform. On UNIX, this would
     /// include HOME, LOGNAME, PATH, SHELL, and USER, among others.
-    #[default]
     Core,
 
     /// Inherits the full environment from the parent process.
+    #[default]
     All,
 
     /// Do not inherit any environment variables from the parent process.
@@ -171,7 +171,8 @@ pub struct ShellEnvironmentPolicy {
 
 impl From<ShellEnvironmentPolicyToml> for ShellEnvironmentPolicy {
     fn from(toml: ShellEnvironmentPolicyToml) -> Self {
-        let inherit = toml.inherit.unwrap_or(ShellEnvironmentPolicyInherit::Core);
+        // Default to inheriting the full environment when not specified.
+        let inherit = toml.inherit.unwrap_or(ShellEnvironmentPolicyInherit::All);
         let ignore_default_excludes = toml.ignore_default_excludes.unwrap_or(false);
         let exclude = toml
             .exclude


### PR DESCRIPTION
Trying to use `core` as the default has been "too clever." Users can always take responsibility for controlling the env without this setting at all by specifying the `env` they use when calling `codex` in the first place.

See https://github.com/openai/codex/issues/1249.