### PR TITLE
Animate TUI welcome prompt

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -300,7 +300,12 @@ impl ChatWidget<'_> {
                 self.bottom_pane
                     .set_history_metadata(event.history_log_id, event.history_entry_count);
                 // Record session information at the top of the conversation.
-                self.add_to_history(HistoryCell::new_session_info(&self.config, event, true));
+                self.add_to_history(HistoryCell::new_session_info(
+                    &self.config,
+                    event,
+                    true,
+                    self.app_event_tx.clone(),
+                ));
 
                 if let Some(user_message) = self.initial_user_message.take() {
                     // If the user provided an initial message, add it to the


### PR DESCRIPTION
## Summary
- add an animated start indicator to the initial welcome line in the TUI
- update event handling so the welcome message can trigger redraws while the animation plays

## Testing
- `just fmt`
- `just fix` *(fails: could not compile `codex-core` due to E0658 `let` expressions)*
- `cargo test --all-features` *(fails: could not compile `codex-core` due to E0658 `let` expressions)*

------
https://chatgpt.com/codex/tasks/task_i_6893ef50d69c8322989c3d3483efeb6d