### PR TITLE
feat: add /tmp by default

### DIFF
--- a/codex-rs/common/src/sandbox_summary.rs
+++ b/codex-rs/common/src/sandbox_summary.rs
@@ -7,22 +7,26 @@ pub fn summarize_sandbox_policy(sandbox_policy: &SandboxPolicy) -> String {
         SandboxPolicy::WorkspaceWrite {
             writable_roots,
             network_access,
-            include_default_writable_roots,
+            exclude_tmpdir_env_var,
+            exclude_slash_tmp,
         } => {
             let mut summary = "workspace-write".to_string();
-            if !writable_roots.is_empty() {
-                summary.push_str(&format!(
-                    " [{}]",
-                    writable_roots
-                        .iter()
-                        .map(|p| p.to_string_lossy())
-                        .collect::<Vec<_>>()
-                        .join(", ")
-                ));
+
+            let mut writable_entries = Vec::<String>::new();
+            writable_entries.push("workdir".to_string());
+            if !*exclude_slash_tmp {
+                writable_entries.push("/tmp".to_string());
             }
-            if !*include_default_writable_roots {
-                summary.push_str(" (exact writable roots)");
+            if !*exclude_tmpdir_env_var {
+                writable_entries.push("$TMPDIR".to_string());
             }
+            writable_entries.extend(
+                writable_roots
+                    .iter()
+                    .map(|p| p.to_string_lossy().to_string()),
+            );
+
+            summary.push_str(&format!(" [{}]", writable_entries.join(", ")));
             if *network_access {
                 summary.push_str(" (network access enabled)");
             }

--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -275,9 +275,12 @@ sandbox_mode = "workspace-write"
 
 # Extra settings that only apply when `sandbox = "workspace-write"`.
 [sandbox_workspace_write]
-# By default, only the cwd for the Codex session will be writable (and $TMPDIR
-# on macOS), but you can specify additional writable folders in this array.
-writable_roots = ["/tmp"]
+# By default, the cwd for the Codex session will be writable as well as $TMPDIR
+# if set) and /tmp (if it exists). Setting the respective options to `true`
+# will override those defaults.
+exclude_tmpdir_env_var = false
+exclude_slash_tmp = false
+
 # Allow the command being run inside the sandbox to make outbound network
 # requests. Disabled by default.
 network_access = false

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -98,6 +98,10 @@ pub struct SandboxWorkplaceWrite {
     pub writable_roots: Vec<PathBuf>,
     #[serde(default)]
     pub network_access: bool,
+    #[serde(default)]
+    pub exclude_tmpdir_env_var: bool,
+    #[serde(default)]
+    pub exclude_slash_tmp: bool,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -185,11 +185,16 @@ pub enum SandboxPolicy {
         #[serde(default)]
         network_access: bool,
 
-        /// When set to `true`, will include defaults like the current working
-        /// directory and TMPDIR (on macOS). When `false`, only `writable_roots`
-        /// are used. (Mainly used for testing.)
-        #[serde(default = "default_true")]
-        include_default_writable_roots: bool,
+        /// When set to `true`, will NOT include the per-user `TMPDIR`
+        /// environment variable among the default writable roots. Defaults to
+        /// `false`.
+        #[serde(default)]
+        exclude_tmpdir_env_var: bool,
+
+        /// When set to `true`, will NOT include the `/tmp` among the default
+        /// writable roots on UNIX. Defaults to `false`.
+        #[serde(default)]
+        exclude_slash_tmp: bool,
     },
 }
 
@@ -201,10 +206,6 @@ pub enum SandboxPolicy {
 pub struct WritableRoot {
     pub root: PathBuf,
     pub read_only_subpaths: Vec<PathBuf>,
-}
-
-fn default_true() -> bool {
-    true
 }
 
 impl FromStr for SandboxPolicy {
@@ -228,7 +229,8 @@ impl SandboxPolicy {
         SandboxPolicy::WorkspaceWrite {
             writable_roots: vec![],
             network_access: false,
-            include_default_writable_roots: true,
+            exclude_tmpdir_env_var: false,
+            exclude_slash_tmp: false,
         }
     }
 
@@ -263,25 +265,38 @@ impl SandboxPolicy {
             SandboxPolicy::ReadOnly => Vec::new(),
             SandboxPolicy::WorkspaceWrite {
                 writable_roots,
-                include_default_writable_roots,
-                ..
+                exclude_tmpdir_env_var,
+                exclude_slash_tmp,
+                network_access: _,
             } => {
                 // Start from explicitly configured writable roots.
                 let mut roots: Vec<PathBuf> = writable_roots.clone();
 
-                // Optionally include defaults (cwd and TMPDIR on macOS).
-                if *include_default_writable_roots {
-                    roots.push(cwd.to_path_buf());
+                // Always include defaults: cwd, /tmp (if present on Unix), and
+                // on macOS, the per-user TMPDIR unless explicitly excluded.
+                roots.push(cwd.to_path_buf());
 
-                    // Also include the per-user tmp dir on macOS.
-                    // Note this is added dynamically rather than storing it in
-                    // `writable_roots` because `writable_roots` contains only static
-                    // values deserialized from the config file.
-                    if cfg!(target_os = "macos") {
-                        if let Some(tmpdir) = std::env::var_os("TMPDIR") {
-                            roots.push(PathBuf::from(tmpdir));
-                        }
+                // Include /tmp on Unix unless explicitly excluded.
+                if cfg!(unix) && !exclude_slash_tmp {
+                    let slash_tmp = PathBuf::from("/tmp");
+                    if slash_tmp.is_dir() {
+                        roots.push(slash_tmp);
                     }
+                }
+
+                // Include $TMPDIR unless explicitly excluded. On macOS, TMPDIR
+                // is per-user, so writes to TMPDIR should not be readable by
+                // other users on the system.
+                //
+                // By comparison, TMPDIR is not guaranteed to be defined on
+                // Linux or Windows, but supporting it here gives users a way to
+                // provide the model with their own temporary directory without
+                // having to hardcode it in the config.
+                if !exclude_tmpdir_env_var
+                    && let Some(tmpdir) = std::env::var_os("TMPDIR")
+                    && !tmpdir.is_empty()
+                {
+                    roots.push(PathBuf::from(tmpdir));
                 }
 
                 // For each root, compute subpaths that should remain read-only.

--- a/codex-rs/core/tests/sandbox.rs
+++ b/codex-rs/core/tests/sandbox.rs
@@ -76,7 +76,8 @@ async fn if_parent_of_repo_is_writable_then_dot_git_folder_is_writable() {
     let policy = SandboxPolicy::WorkspaceWrite {
         writable_roots: vec![test_scenario.repo_parent.clone()],
         network_access: false,
-        include_default_writable_roots: false,
+        exclude_tmpdir_env_var: true,
+        exclude_slash_tmp: true,
     };
 
     test_scenario
@@ -101,7 +102,8 @@ async fn if_git_repo_is_writable_root_then_dot_git_folder_is_read_only() {
     let policy = SandboxPolicy::WorkspaceWrite {
         writable_roots: vec![test_scenario.repo_root.clone()],
         network_access: false,
-        include_default_writable_roots: false,
+        exclude_tmpdir_env_var: true,
+        exclude_slash_tmp: true,
     };
 
     test_scenario

--- a/codex-rs/linux-sandbox/tests/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/landlock.rs
@@ -51,7 +51,11 @@ async fn run_cmd(cmd: &[&str], writable_roots: &[PathBuf], timeout_ms: u64) {
     let sandbox_policy = SandboxPolicy::WorkspaceWrite {
         writable_roots: writable_roots.to_vec(),
         network_access: false,
-        include_default_writable_roots: true,
+        // Exclude tmp-related folders from writable roots because we need a
+        // folder that is writable by tests but that we intentionally disallow
+        // writing to in the sandbox.
+        exclude_tmpdir_env_var: true,
+        exclude_slash_tmp: true,
     };
     let sandbox_program = env!("CARGO_BIN_EXE_codex-linux-sandbox");
     let codex_linux_sandbox_exe = Some(PathBuf::from(sandbox_program));


### PR DESCRIPTION
Replaces the `include_default_writable_roots` option on `sandbox_workspace_write` (that defaulted to `true`, which was slightly weird/annoying) with `exclude_tmpdir_env_var`, which defaults to `false`.

Though perhaps more importantly `/tmp` is now enabled by default as part of `sandbox_mode = "workspace-write"`, though `exclude_slash_tmp = false` can be used to disable this.