### PR TITLE
feat: parse info from auth.json and show in /status

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -792,6 +792,7 @@ dependencies = [
 name = "codex-login"
 version = "0.0.0"
 dependencies = [
+ "base64 0.22.1",
  "chrono",
  "reqwest",
  "serde",

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -794,6 +794,7 @@ version = "0.0.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
+ "pretty_assertions",
  "reqwest",
  "serde",
  "serde_json",

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -798,6 +798,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thiserror 2.0.12",
  "tokio",
 ]
 

--- a/codex-rs/core/tests/client.rs
+++ b/codex-rs/core/tests/client.rs
@@ -561,7 +561,7 @@ async fn env_var_overrides_loaded_auth() {
     wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
 }
 
-fn auth_from_token(id_token: String) -> CodexAuth {
+fn auth_from_token(_id_token: String) -> CodexAuth {
     CodexAuth::new(
         None,
         AuthMode::ChatGPT,
@@ -569,7 +569,7 @@ fn auth_from_token(id_token: String) -> CodexAuth {
         Some(AuthDotJson {
             openai_api_key: None,
             tokens: Some(TokenData {
-                id_token,
+                id_token: Default::default(),
                 access_token: "Access Token".to_string(),
                 refresh_token: "test".to_string(),
                 account_id: Some("account_id".to_string()),

--- a/codex-rs/core/tests/client.rs
+++ b/codex-rs/core/tests/client.rs
@@ -290,13 +290,10 @@ async fn chatgpt_auth_sends_correct_request() {
     let mut config = load_default_config_for_test(&codex_home);
     config.model_provider = model_provider;
     let ctrl_c = std::sync::Arc::new(tokio::sync::Notify::new());
-    let CodexSpawnOk { codex, .. } = Codex::spawn(
-        config,
-        Some(auth_from_token("Access Token".to_string())),
-        ctrl_c.clone(),
-    )
-    .await
-    .unwrap();
+    let CodexSpawnOk { codex, .. } =
+        Codex::spawn(config, Some(create_dummy_codex_auth()), ctrl_c.clone())
+            .await
+            .unwrap();
 
     codex
         .submit(Op::UserInput {
@@ -541,13 +538,10 @@ async fn env_var_overrides_loaded_auth() {
     config.model_provider = provider;
 
     let ctrl_c = std::sync::Arc::new(tokio::sync::Notify::new());
-    let CodexSpawnOk { codex, .. } = Codex::spawn(
-        config,
-        Some(auth_from_token("Default Access Token".to_string())),
-        ctrl_c.clone(),
-    )
-    .await
-    .unwrap();
+    let CodexSpawnOk { codex, .. } =
+        Codex::spawn(config, Some(create_dummy_codex_auth()), ctrl_c.clone())
+            .await
+            .unwrap();
 
     codex
         .submit(Op::UserInput {
@@ -561,7 +555,7 @@ async fn env_var_overrides_loaded_auth() {
     wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
 }
 
-fn auth_from_token(_id_token: String) -> CodexAuth {
+fn create_dummy_codex_auth() -> CodexAuth {
     CodexAuth::new(
         None,
         AuthMode::ChatGPT,

--- a/codex-rs/login/Cargo.toml
+++ b/codex-rs/login/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
+base64 = "0.22"
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/codex-rs/login/Cargo.toml
+++ b/codex-rs/login/Cargo.toml
@@ -12,6 +12,7 @@ base64 = "0.22"
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+thiserror = "2.0.12"
 tokio = { version = "1", features = [
     "io-std",
     "macros",

--- a/codex-rs/login/Cargo.toml
+++ b/codex-rs/login/Cargo.toml
@@ -7,8 +7,8 @@ version = { workspace = true }
 workspace = true
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
 base64 = "0.22"
+chrono = { version = "0.4", features = ["serde"] }
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -22,4 +22,5 @@ tokio = { version = "1", features = [
 ] }
 
 [dev-dependencies]
+pretty_assertions = "1.4.1"
 tempfile = "3"

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -186,7 +186,7 @@ pub fn load_auth(codex_home: &Path, include_env_var: bool) -> std::io::Result<Op
     }))
 }
 
-fn get_auth_file(codex_home: &Path) -> PathBuf {
+pub fn get_auth_file(codex_home: &Path) -> PathBuf {
     codex_home.join("auth.json")
 }
 

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -1,7 +1,6 @@
 use chrono::DateTime;
 
 use base64::Engine;
-use thiserror::Error;
 use chrono::Utc;
 use serde::Deserialize;
 use serde::Serialize;
@@ -19,6 +18,7 @@ use std::process::Stdio;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::time::Duration;
+use thiserror::Error;
 use tokio::process::Command;
 
 const SOURCE_FOR_PYTHON_SERVER: &str = include_str!("./login_with_chatgpt.py");
@@ -439,8 +439,7 @@ impl TokenData {
             _ => return Err(IdTokenInfoError::InvalidFormat),
         };
 
-        let payload_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
-            .decode(payload_b64)?;
+        let payload_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload_b64)?;
 
         #[derive(Deserialize)]
         struct AuthClaims {

--- a/codex-rs/login/src/token_data.rs
+++ b/codex-rs/login/src/token_data.rs
@@ -1,0 +1,117 @@
+use base64::Engine;
+use serde::Deserialize;
+use serde::Serialize;
+use thiserror::Error;
+
+#[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Default)]
+pub struct TokenData {
+    /// Flat info parsed from the JWT in auth.json.
+    #[serde(deserialize_with = "deserialize_id_token")]
+    pub id_token: IdTokenInfo,
+
+    /// This is a JWT.
+    pub access_token: String,
+
+    pub refresh_token: String,
+
+    pub account_id: Option<String>,
+}
+
+/// Flat subset of useful claims in id_token from auth.json.
+#[derive(Debug, Clone, PartialEq, Eq, Default, Serialize)]
+pub struct IdTokenInfo {
+    pub email: Option<String>,
+    /// The ChatGPT subscription plan type
+    /// (e.g., "free", "plus", "pro", "business", "enterprise", "edu").
+    /// (Note: ae has not verified that those are the exact values.)
+    pub chatgpt_plan_type: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct IdClaims {
+    #[serde(default)]
+    email: Option<String>,
+    #[serde(rename = "https://api.openai.com/auth", default)]
+    auth: Option<AuthClaims>,
+}
+
+#[derive(Deserialize)]
+struct AuthClaims {
+    #[serde(default)]
+    chatgpt_plan_type: Option<String>,
+}
+
+#[derive(Debug, Error)]
+pub enum IdTokenInfoError {
+    #[error("invalid ID token format")]
+    InvalidFormat,
+    #[error(transparent)]
+    Base64(#[from] base64::DecodeError),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+}
+
+pub(crate) fn parse_id_token(id_token: &str) -> Result<IdTokenInfo, IdTokenInfoError> {
+    // JWT format: header.payload.signature
+    let mut parts = id_token.split('.');
+    let (_header_b64, payload_b64, _sig_b64) = match (parts.next(), parts.next(), parts.next()) {
+        (Some(h), Some(p), Some(s)) if !h.is_empty() && !p.is_empty() && !s.is_empty() => (h, p, s),
+        _ => return Err(IdTokenInfoError::InvalidFormat),
+    };
+
+    let payload_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload_b64)?;
+    let claims: IdClaims = serde_json::from_slice(&payload_bytes)?;
+
+    Ok(IdTokenInfo {
+        email: claims.email,
+        chatgpt_plan_type: claims.auth.and_then(|a| a.chatgpt_plan_type),
+    })
+}
+
+fn deserialize_id_token<'de, D>(deserializer: D) -> Result<IdTokenInfo, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let s = String::deserialize(deserializer)?;
+    parse_id_token(&s).map_err(serde::de::Error::custom)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde::Serialize;
+
+    #[test]
+    #[expect(clippy::expect_used, clippy::unwrap_used)]
+    fn id_token_info_parses_email_and_plan() {
+        // Build a fake JWT with a URL-safe base64 payload containing email and plan.
+        #[derive(Serialize)]
+        struct Header {
+            alg: &'static str,
+            typ: &'static str,
+        }
+        let header = Header {
+            alg: "none",
+            typ: "JWT",
+        };
+        let payload = serde_json::json!({
+            "email": "user@example.com",
+            "https://api.openai.com/auth": {
+                "chatgpt_plan_type": "pro"
+            }
+        });
+
+        fn b64url_no_pad(bytes: &[u8]) -> String {
+            base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+        }
+
+        let header_b64 = b64url_no_pad(&serde_json::to_vec(&header).unwrap());
+        let payload_b64 = b64url_no_pad(&serde_json::to_vec(&payload).unwrap());
+        let signature_b64 = b64url_no_pad(b"sig");
+        let fake_jwt = format!("{header_b64}.{payload_b64}.{signature_b64}");
+
+        let info = parse_id_token(&fake_jwt).expect("should parse");
+        assert_eq!(info.email.as_deref(), Some("user@example.com"));
+        assert_eq!(info.chatgpt_plan_type.as_deref(), Some("pro"));
+    }
+}

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -15,7 +15,6 @@ use codex_core::protocol::FileChange;
 use codex_core::protocol::McpInvocation;
 use codex_core::protocol::SessionConfiguredEvent;
 use codex_core::protocol::TokenUsage;
-use codex_login::TokenData;
 use codex_login::try_read_auth_json;
 use image::DynamicImage;
 use image::ImageReader;
@@ -473,25 +472,19 @@ impl HistoryCell {
                 lines.push(Line::from("signed in with chatgpt".bold()));
 
                 if let Some(tokens) = auth.tokens.as_ref() {
-                    let td = TokenData {
-                        id_token: tokens.id_token.clone(),
-                        ..Default::default()
-                    };
-                    if let Ok(info) = td.id_token_info() {
-                        if let Some(email) = info.email {
-                            lines.push(Line::from(vec!["  login: ".bold(), email.into()]));
-                        }
+                    let info = tokens.id_token.clone();
+                    if let Some(email) = info.email {
+                        lines.push(Line::from(vec!["  login: ".bold(), email.into()]));
+                    }
 
-                        match auth.openai_api_key.as_deref() {
-                            Some(key) if !key.is_empty() => {
-                                lines.push(Line::from("  using api key"));
-                            }
-                            _ => {
-                                let plan_text = info
-                                    .chatgpt_plan_type
-                                    .unwrap_or_else(|| "Unknown".to_string());
-                                lines.push(Line::from(vec!["  plan: ".bold(), plan_text.into()]));
-                            }
+                    match auth.openai_api_key.as_deref() {
+                        Some(key) if !key.is_empty() => {
+                            lines.push(Line::from("  using api key"));
+                        }
+                        _ => {
+                            let plan_text =
+                                info.chatgpt_plan_type.unwrap_or_else(|| "Unknown".to_string());
+                            lines.push(Line::from(vec!["  plan: ".bold(), plan_text.into()]));
                         }
                     }
                 }

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -125,8 +125,6 @@ pub(crate) enum HistoryCell {
 
 const TOOL_CALL_MAX_LINES: usize = 3;
 
-// title_case helper removed to keep plan output unchanged from source
-
 impl HistoryCell {
     /// Return a cloned, plain representation of the cell's lines suitable for
     /// one‑shot insertion into the terminal scrollback. Image cells are
@@ -469,6 +467,7 @@ impl HistoryCell {
 
         lines.push(Line::from(""));
 
+        // Auth
         if let Ok(auth) = try_read_auth_json(&config.codex_home.join("auth.json"))
             && auth.tokens.is_some()
         {
@@ -501,7 +500,7 @@ impl HistoryCell {
             lines.push(Line::from(""));
         }
 
-        // token usage
+        // Token usage
         lines.push(Line::from("token usage".bold()));
         lines.push(Line::from(vec![
             "  input: ".bold(),

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -468,16 +468,12 @@ impl HistoryCell {
         lines.push(Line::from(""));
 
         // Auth
-        if let Ok(auth) = try_read_auth_json(&config.codex_home.join("auth.json"))
-            && auth.tokens.is_some()
-        {
+        if let Ok(auth) = try_read_auth_json(&config.codex_home.join("auth.json")) {
+            if auth.tokens.as_ref().is_some() {
             lines.push(Line::from("signed in with chatgpt".bold()));
 
-            if let Some(TokenData { id_token, .. }) = auth.tokens.clone() {
-                let td = TokenData {
-                    id_token,
-                    ..Default::default()
-                };
+            if let Some(tokens) = auth.tokens.as_ref() {
+                let td = TokenData { id_token: tokens.id_token.clone(), ..Default::default() };
                 if let Ok(info) = td.id_token_info() {
                     if let Some(email) = info.email {
                         lines.push(Line::from(vec!["  login: ".bold(), email.into()]));
@@ -498,6 +494,7 @@ impl HistoryCell {
             }
 
             lines.push(Line::from(""));
+            }
         }
 
         // Token usage

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -15,6 +15,7 @@ use codex_core::protocol::FileChange;
 use codex_core::protocol::McpInvocation;
 use codex_core::protocol::SessionConfiguredEvent;
 use codex_core::protocol::TokenUsage;
+use codex_login::get_auth_file;
 use codex_login::try_read_auth_json;
 use image::DynamicImage;
 use image::ImageReader;
@@ -467,7 +468,8 @@ impl HistoryCell {
         lines.push(Line::from(""));
 
         // Auth
-        if let Ok(auth) = try_read_auth_json(&config.codex_home.join("auth.json")) {
+        let auth_file = get_auth_file(&config.codex_home);
+        if let Ok(auth) = try_read_auth_json(&auth_file) {
             if auth.tokens.as_ref().is_some() {
                 lines.push(Line::from("signed in with chatgpt".bold()));
 
@@ -482,8 +484,9 @@ impl HistoryCell {
                             lines.push(Line::from("  using api key"));
                         }
                         _ => {
-                            let plan_text =
-                                info.chatgpt_plan_type.unwrap_or_else(|| "Unknown".to_string());
+                            let plan_text = info
+                                .chatgpt_plan_type
+                                .unwrap_or_else(|| "Unknown".to_string());
                             lines.push(Line::from(vec!["  plan: ".bold(), plan_text.into()]));
                         }
                     }

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -470,30 +470,33 @@ impl HistoryCell {
         // Auth
         if let Ok(auth) = try_read_auth_json(&config.codex_home.join("auth.json")) {
             if auth.tokens.as_ref().is_some() {
-            lines.push(Line::from("signed in with chatgpt".bold()));
+                lines.push(Line::from("signed in with chatgpt".bold()));
 
-            if let Some(tokens) = auth.tokens.as_ref() {
-                let td = TokenData { id_token: tokens.id_token.clone(), ..Default::default() };
-                if let Ok(info) = td.id_token_info() {
-                    if let Some(email) = info.email {
-                        lines.push(Line::from(vec!["  login: ".bold(), email.into()]));
-                    }
-
-                    match auth.openai_api_key.as_deref() {
-                        Some(key) if !key.is_empty() => {
-                            lines.push(Line::from("  using api key"));
+                if let Some(tokens) = auth.tokens.as_ref() {
+                    let td = TokenData {
+                        id_token: tokens.id_token.clone(),
+                        ..Default::default()
+                    };
+                    if let Ok(info) = td.id_token_info() {
+                        if let Some(email) = info.email {
+                            lines.push(Line::from(vec!["  login: ".bold(), email.into()]));
                         }
-                        _ => {
-                            let plan_text = info
-                                .chatgpt_plan_type
-                                .unwrap_or_else(|| "Unknown".to_string());
-                            lines.push(Line::from(vec!["  plan: ".bold(), plan_text.into()]));
+
+                        match auth.openai_api_key.as_deref() {
+                            Some(key) if !key.is_empty() => {
+                                lines.push(Line::from("  using api key"));
+                            }
+                            _ => {
+                                let plan_text = info
+                                    .chatgpt_plan_type
+                                    .unwrap_or_else(|| "Unknown".to_string());
+                                lines.push(Line::from(vec!["  plan: ".bold(), plan_text.into()]));
+                            }
                         }
                     }
                 }
-            }
 
-            lines.push(Line::from(""));
+                lines.push(Line::from(""));
             }
         }
 


### PR DESCRIPTION
- `/status` renders
    ```
    signed in with chatgpt
      login: example@example.com
      plan: plus
    ```
- Setup for using this info in a few more places.