### PR TITLE
fix: public load_auth() fn always called with include_env_var=true

### DIFF
--- a/codex-rs/chatgpt/src/chatgpt_token.rs
+++ b/codex-rs/chatgpt/src/chatgpt_token.rs
@@ -18,7 +18,7 @@ pub fn set_chatgpt_token_data(value: TokenData) {
 
 /// Initialize the ChatGPT token from auth.json file
 pub async fn init_chatgpt_token_from_auth(codex_home: &Path) -> std::io::Result<()> {
-    let auth = codex_login::load_auth(codex_home, true)?;
+    let auth = codex_login::load_auth(codex_home)?;
     if let Some(auth) = auth {
         let token_data = auth.get_token_data().await?;
         set_chatgpt_token_data(token_data);

--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -47,7 +47,7 @@ pub async fn run_login_with_api_key(
 pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {
     let config = load_config_or_exit(cli_config_overrides);
 
-    match load_auth(&config.codex_home, true) {
+    match load_auth(&config.codex_home) {
         Ok(Some(auth)) => match auth.mode {
             AuthMode::ApiKey => {
                 if let Some(api_key) = auth.api_key.as_deref() {

--- a/codex-rs/cli/src/proto.rs
+++ b/codex-rs/cli/src/proto.rs
@@ -36,7 +36,7 @@ pub async fn run_main(opts: ProtoCli) -> anyhow::Result<()> {
         .map_err(anyhow::Error::msg)?;
 
     let config = Config::load_with_cli_overrides(overrides_vec, ConfigOverrides::default())?;
-    let auth = load_auth(&config.codex_home, true)?;
+    let auth = load_auth(&config.codex_home)?;
     let ctrl_c = notify_on_sigint();
     let CodexSpawnOk { codex, .. } = Codex::spawn(config, auth, ctrl_c.clone()).await?;
     let codex = Arc::new(codex);

--- a/codex-rs/core/src/codex_wrapper.rs
+++ b/codex-rs/core/src/codex_wrapper.rs
@@ -26,7 +26,7 @@ pub struct CodexConversation {
 /// that callers can surface the information to the UI.
 pub async fn init_codex(config: Config) -> anyhow::Result<CodexConversation> {
     let ctrl_c = notify_on_sigint();
-    let auth = load_auth(&config.codex_home, true)?;
+    let auth = load_auth(&config.codex_home)?;
     let CodexSpawnOk {
         codex,
         init_id,

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -145,7 +145,11 @@ impl CodexAuth {
 }
 
 // Loads the available auth information from the auth.json or OPENAI_API_KEY environment variable.
-pub fn load_auth(codex_home: &Path, include_env_var: bool) -> std::io::Result<Option<CodexAuth>> {
+pub fn load_auth(codex_home: &Path) -> std::io::Result<Option<CodexAuth>> {
+    _load_auth(codex_home, true)
+}
+
+fn _load_auth(codex_home: &Path, include_env_var: bool) -> std::io::Result<Option<CodexAuth>> {
     let auth_file = get_auth_file(codex_home);
 
     let auth_dot_json = try_read_auth_json(&auth_file).ok();
@@ -421,7 +425,7 @@ mod tests {
     fn writes_api_key_and_loads_auth() {
         let dir = tempdir().unwrap();
         login_with_api_key(dir.path(), "sk-test-key").unwrap();
-        let auth = load_auth(dir.path(), false).unwrap().unwrap();
+        let auth = _load_auth(dir.path(), false).unwrap().unwrap();
         assert_eq!(auth.mode, AuthMode::ApiKey);
         assert_eq!(auth.api_key.as_deref(), Some("sk-test-key"));
     }
@@ -434,7 +438,7 @@ mod tests {
         let env_var = std::env::var(OPENAI_API_KEY_ENV_VAR);
 
         if let Ok(env_var) = env_var {
-            let auth = load_auth(dir.path(), true).unwrap().unwrap();
+            let auth = _load_auth(dir.path(), true).unwrap().unwrap();
             assert_eq!(auth.mode, AuthMode::ApiKey);
             assert_eq!(auth.api_key, Some(env_var));
         }
@@ -493,7 +497,7 @@ mod tests {
             mode,
             auth_dot_json,
             auth_file,
-        } = load_auth(dir.path(), false).unwrap().unwrap();
+        } = _load_auth(dir.path(), false).unwrap().unwrap();
         assert_eq!(None, api_key);
         assert_eq!(AuthMode::ChatGPT, mode);
         assert_eq!(dir.path().join("auth.json"), auth_file);
@@ -558,7 +562,7 @@ mod tests {
         )
         .unwrap();
 
-        let auth = load_auth(dir.path(), false).unwrap().unwrap();
+        let auth = _load_auth(dir.path(), false).unwrap().unwrap();
         assert_eq!(auth.mode, AuthMode::ApiKey);
         assert_eq!(auth.api_key, Some("sk-test-key".to_string()));
 

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -304,7 +304,7 @@ fn should_show_login_screen(config: &Config) -> bool {
         // Reading the OpenAI API key is an async operation because it may need
         // to refresh the token. Block on it.
         let codex_home = config.codex_home.clone();
-        match load_auth(&codex_home, true) {
+        match load_auth(&codex_home) {
             Ok(Some(_)) => false,
             Ok(None) => true,
             Err(err) => {


### PR DESCRIPTION
Apparently `include_env_var=false` was only used for testing, so clean up the API a little to make that clear.


---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/1961).
* #1962
* __->__ #1961