### PR TITLE
chore: rename CodexAuth::new() to create_dummy_codex_auth_for_testing() because it is not for general consumption

### DIFF
--- a/codex-rs/core/tests/client.rs
+++ b/codex-rs/core/tests/client.rs
@@ -1,8 +1,5 @@
-#![allow(clippy::expect_used)]
-#![allow(clippy::unwrap_used)]
-use std::path::PathBuf;
+#![allow(clippy::expect_used, clippy::unwrap_used)]
 
-use chrono::Utc;
 use codex_core::Codex;
 use codex_core::CodexSpawnOk;
 use codex_core::ModelProviderInfo;
@@ -13,10 +10,7 @@ use codex_core::protocol::InputItem;
 use codex_core::protocol::Op;
 use codex_core::protocol::SessionConfiguredEvent;
 use codex_core::spawn::CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR;
-use codex_login::AuthDotJson;
-use codex_login::AuthMode;
 use codex_login::CodexAuth;
-use codex_login::TokenData;
 use core_test_support::load_default_config_for_test;
 use core_test_support::load_sse_fixture_with_id;
 use core_test_support::wait_for_event;
@@ -556,19 +550,5 @@ async fn env_var_overrides_loaded_auth() {
 }
 
 fn create_dummy_codex_auth() -> CodexAuth {
-    CodexAuth::new(
-        None,
-        AuthMode::ChatGPT,
-        PathBuf::new(),
-        Some(AuthDotJson {
-            openai_api_key: None,
-            tokens: Some(TokenData {
-                id_token: Default::default(),
-                access_token: "Access Token".to_string(),
-                refresh_token: "test".to_string(),
-                account_id: Some("account_id".to_string()),
-            }),
-            last_refresh: Some(Utc::now()),
-        }),
-    )
+    CodexAuth::create_dummy_chatgpt_auth_for_testing()
 }

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -51,21 +51,6 @@ impl PartialEq for CodexAuth {
 }
 
 impl CodexAuth {
-    pub fn new(
-        api_key: Option<String>,
-        mode: AuthMode,
-        auth_file: PathBuf,
-        auth_dot_json: Option<AuthDotJson>,
-    ) -> Self {
-        let auth_dot_json = Arc::new(Mutex::new(auth_dot_json));
-        Self {
-            api_key,
-            mode,
-            auth_file,
-            auth_dot_json,
-        }
-    }
-
     pub fn from_api_key(api_key: String) -> Self {
         Self {
             api_key: Some(api_key),
@@ -140,6 +125,28 @@ impl CodexAuth {
 
                 token_data.account_id.clone()
             }
+        }
+    }
+
+    /// Consider this private to integration tests.
+    pub fn create_dummy_chatgpt_auth_for_testing() -> Self {
+        let auth_dot_json = AuthDotJson {
+            openai_api_key: None,
+            tokens: Some(TokenData {
+                id_token: Default::default(),
+                access_token: "Access Token".to_string(),
+                refresh_token: "test".to_string(),
+                account_id: Some("account_id".to_string()),
+            }),
+            last_refresh: Some(Utc::now()),
+        };
+
+        let auth_dot_json = Arc::new(Mutex::new(Some(auth_dot_json)));
+        Self {
+            api_key: None,
+            mode: AuthMode::ChatGPT,
+            auth_file: PathBuf::new(),
+            auth_dot_json,
         }
     }
 }


### PR DESCRIPTION
`CodexAuth::new()` was the first method listed in `CodexAuth`, but it is only meant to be used by tests. Rename it to `create_dummy_chatgpt_auth_for_testing()` and move it to the end of the implementation.







---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/1962).
* #1971
* #1970
* #1966
* #1965
* __->__ #1962