### PR TITLE
chore: move top-level load_auth() to CodexAuth::from_codex_home()

### DIFF
--- a/codex-rs/chatgpt/src/chatgpt_token.rs
+++ b/codex-rs/chatgpt/src/chatgpt_token.rs
@@ -1,3 +1,4 @@
+use codex_login::CodexAuth;
 use std::path::Path;
 use std::sync::LazyLock;
 use std::sync::RwLock;
@@ -18,7 +19,7 @@ pub fn set_chatgpt_token_data(value: TokenData) {
 
 /// Initialize the ChatGPT token from auth.json file
 pub async fn init_chatgpt_token_from_auth(codex_home: &Path) -> std::io::Result<()> {
-    let auth = codex_login::load_auth(codex_home)?;
+    let auth = CodexAuth::from_codex_home(codex_home)?;
     if let Some(auth) = auth {
         let token_data = auth.get_token_data().await?;
         set_chatgpt_token_data(token_data);

--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -49,9 +49,9 @@ pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {
 
     match load_auth(&config.codex_home) {
         Ok(Some(auth)) => match auth.mode {
-            AuthMode::ApiKey => {
-                if let Some(api_key) = auth.api_key.as_deref() {
-                    eprintln!("Logged in using an API key - {}", safe_format_key(api_key));
+            AuthMode::ApiKey => match auth.get_token().await {
+                Ok(api_key) => {
+                    eprintln!("Logged in using an API key - {}", safe_format_key(&api_key));
 
                     if let Ok(env_api_key) = env::var(OPENAI_API_KEY_ENV_VAR) {
                         if env_api_key == api_key {
@@ -60,11 +60,13 @@ pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {
                             );
                         }
                     }
-                } else {
-                    eprintln!("Logged in using an API key");
+                    std::process::exit(0);
                 }
-                std::process::exit(0);
-            }
+                Err(e) => {
+                    eprintln!("Unexpected error retrieving API key: {e}");
+                    std::process::exit(1);
+                }
+            },
             AuthMode::ChatGPT => {
                 eprintln!("Logged in using ChatGPT");
                 std::process::exit(0);

--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -4,8 +4,8 @@ use codex_common::CliConfigOverrides;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
 use codex_login::AuthMode;
+use codex_login::CodexAuth;
 use codex_login::OPENAI_API_KEY_ENV_VAR;
-use codex_login::load_auth;
 use codex_login::login_with_api_key;
 use codex_login::login_with_chatgpt;
 use codex_login::logout;
@@ -47,7 +47,7 @@ pub async fn run_login_with_api_key(
 pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {
     let config = load_config_or_exit(cli_config_overrides);
 
-    match load_auth(&config.codex_home) {
+    match CodexAuth::from_codex_home(&config.codex_home) {
         Ok(Some(auth)) => match auth.mode {
             AuthMode::ApiKey => match auth.get_token().await {
                 Ok(api_key) => {

--- a/codex-rs/cli/src/proto.rs
+++ b/codex-rs/cli/src/proto.rs
@@ -9,7 +9,7 @@ use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
 use codex_core::protocol::Submission;
 use codex_core::util::notify_on_sigint;
-use codex_login::load_auth;
+use codex_login::CodexAuth;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::BufReader;
 use tracing::error;
@@ -36,7 +36,7 @@ pub async fn run_main(opts: ProtoCli) -> anyhow::Result<()> {
         .map_err(anyhow::Error::msg)?;
 
     let config = Config::load_with_cli_overrides(overrides_vec, ConfigOverrides::default())?;
-    let auth = load_auth(&config.codex_home)?;
+    let auth = CodexAuth::from_codex_home(&config.codex_home)?;
     let ctrl_c = notify_on_sigint();
     let CodexSpawnOk { codex, .. } = Codex::spawn(config, auth, ctrl_c.clone()).await?;
     let codex = Arc::new(codex);

--- a/codex-rs/core/src/codex_wrapper.rs
+++ b/codex-rs/core/src/codex_wrapper.rs
@@ -6,7 +6,7 @@ use crate::config::Config;
 use crate::protocol::Event;
 use crate::protocol::EventMsg;
 use crate::util::notify_on_sigint;
-use codex_login::load_auth;
+use codex_login::CodexAuth;
 use tokio::sync::Notify;
 use uuid::Uuid;
 
@@ -26,7 +26,7 @@ pub struct CodexConversation {
 /// that callers can surface the information to the UI.
 pub async fn init_codex(config: Config) -> anyhow::Result<CodexConversation> {
     let ctrl_c = notify_on_sigint();
-    let auth = load_auth(&config.codex_home)?;
+    let auth = CodexAuth::from_codex_home(&config.codex_home)?;
     let CodexSpawnOk {
         codex,
         init_id,

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -38,8 +38,9 @@ pub enum AuthMode {
 
 #[derive(Debug, Clone)]
 pub struct CodexAuth {
-    pub api_key: Option<String>,
     pub mode: AuthMode,
+
+    api_key: Option<String>,
     auth_dot_json: Arc<Mutex<Option<AuthDotJson>>>,
     auth_file: PathBuf,
 }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -12,7 +12,7 @@ use codex_core::config::load_config_as_toml_with_cli_overrides;
 use codex_core::config_types::SandboxMode;
 use codex_core::protocol::AskForApproval;
 use codex_core::protocol::SandboxPolicy;
-use codex_login::load_auth;
+use codex_login::CodexAuth;
 use codex_ollama::DEFAULT_OSS_MODEL;
 use log_layer::TuiLogLayer;
 use std::fs::OpenOptions;
@@ -304,7 +304,7 @@ fn should_show_login_screen(config: &Config) -> bool {
         // Reading the OpenAI API key is an async operation because it may need
         // to refresh the token. Block on it.
         let codex_home = config.codex_home.clone();
-        match load_auth(&codex_home) {
+        match CodexAuth::from_codex_home(&codex_home) {
             Ok(Some(_)) => false,
             Ok(None) => true,
             Err(err) => {


### PR DESCRIPTION
There are two valid ways to create an instance of `CodexAuth`: `from_api_key()` and `from_codex_home()`. Now both are static methods of `CodexAuth` and are listed first in the implementation.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/1966).
* #1971
* #1970
* __->__ #1966
* #1965
* #1962