### PR TITLE
feat: render messages in markdown

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -250,10 +250,12 @@ impl HistoryCell {
         }
     }
 
-    pub(crate) fn new_user_prompt(message: String) -> Self {
+    pub(crate) fn new_user_prompt(config: &Config, message: String) -> Self {
         let mut lines: Vec<Line<'static>> = Vec::new();
         lines.push(Line::from("user".cyan().bold()));
-        lines.extend(message.lines().map(|l| Line::from(l.to_string())));
+        // Render the user's message using markdown so it matches assistant output
+        // and supports links, emphasis, code blocks, etc.
+        crate::markdown::append_markdown(&message, &mut lines, config);
         lines.push(Line::from(""));
 
         HistoryCell::UserPrompt {


### PR DESCRIPTION
## What

This change updates the TUI conversation history to render both user and assistant messages as Markdown and changes the streaming behavior to stop committing partial rows into history; partial content now remains only in the live overlay, and the complete message is inserted into history once finalized.

## Why

I found Codex was outputting plain Markdown text in the TUI history, which was hard on my eyes during longer sessions and made messages harder to scan. So I implemented a Markdown rendering for both user and assistant messages and adjusted streaming so the history shows a single, fully formatted block once the response is complete.

## How

- Removed incremental history inserts during streaming from `stream_push_and_maybe_commit`, keeping partial content only in the live overlay for a low‑churn preview.
- Rendered the final accumulated content in finalize_stream as Markdown via `crate::markdown::append_markdown`, added a role header (“codex” or “thinking”), appended a trailing blank line for readability, and inserted it into history as a single formatted block.
- Updated `HistoryCell::new_user_prompt` to accept `&Config` and to render the user’s message using the same Markdown path, and adjusted the call site in the chat widget accordingly.
- Reset the live builder and cleared internal buffers/state after finalization to ensure the next stream starts cleanly.

## Tests

- No new tests added
- Local results:
    - Ran `cargo fmt -- --config imports_granularity=Item`
    - Ran `cargo clippy --fix --all-features --tests --allow-dirty`
    - Ran `cargo test --all-features (workspace) → all passing`
- Rationale: existing TUI and workspace tests pass; rendering change validated via manual runs of codex tui.

## Docs

- No user-facing docs changed. This is a rendering improvement within the TUI.
- Inline help and CLI usage remain the same.

## Risks/Impact

- Markdown rendering on very large messages could have a performance cost; mitigated by rendering once on finalize.
- Streaming feel changes: history is now updated once per message instead of incrementally; the live overlay still shows progress.