### PR TITLE
Fix usage limit banner grammar

### DIFF
--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -132,7 +132,7 @@ impl std::fmt::Display for UsageLimitReachedError {
         } else {
             write!(
                 f,
-                "You've hit usage your usage limit. Limits reset every 5h and every week."
+                "You've hit your usage limit. Limits reset every 5h and every week."
             )?;
         }
         Ok(())
@@ -195,7 +195,7 @@ mod tests {
         let err = UsageLimitReachedError { plan_type: None };
         assert_eq!(
             err.to_string(),
-            "You've hit usage your usage limit. Limits reset every 5h and every week."
+            "You've hit your usage limit. Limits reset every 5h and every week."
         );
     }
 
@@ -206,7 +206,7 @@ mod tests {
         };
         assert_eq!(
             err.to_string(),
-            "You've hit usage your usage limit. Limits reset every 5h and every week."
+            "You've hit your usage limit. Limits reset every 5h and every week."
         );
     }
 }


### PR DESCRIPTION
## Summary
- fix typo in usage limit banner text
- update error message tests

## Testing
- `just fmt`
- `RUSTC_BOOTSTRAP=1 just fix` *(fails: `let` expressions in this position are unstable)*
- `RUSTC_BOOTSTRAP=1 cargo test --all-features` *(fails: `let` expressions in this position are unstable)*

------
https://chatgpt.com/codex/tasks/task_i_689610fc1fe4832081bdd1118779b60b