### PR TITLE
Fix multiline exec command rendering

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -276,7 +276,7 @@ impl HistoryCell {
             lines.push(Line::from(vec!["▌ ".cyan(), "Running command".magenta()]));
         }
         for cont in iter {
-            lines.push(Line::from(vec!["".into(), cont.to_string().into()]));
+            lines.push(Line::from(cont.to_string()));
         }
         lines.push(Line::from(""));
 
@@ -304,7 +304,7 @@ impl HistoryCell {
             lines.push(Line::from("⚡ Ran command".magenta()));
         }
         for cont in cmd_lines {
-            lines.push(Line::from(vec!["".into(), cont.to_string().into()]));
+            lines.push(Line::from(cont.to_string()));
         }
 
         let src = if exit_code == 0 { stdout } else { stderr };

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -264,14 +264,21 @@ impl HistoryCell {
     pub(crate) fn new_active_exec_command(command: Vec<String>) -> Self {
         let command_escaped = strip_bash_lc_and_escape(&command);
 
-        let lines: Vec<Line<'static>> = vec![
-            Line::from(vec![
+        let mut lines: Vec<Line<'static>> = Vec::new();
+        let mut iter = command_escaped.lines();
+        if let Some(first) = iter.next() {
+            lines.push(Line::from(vec![
                 "▌ ".cyan(),
                 "Running command ".magenta(),
-                command_escaped.into(),
-            ]),
-            Line::from(""),
-        ];
+                first.to_string().into(),
+            ]));
+        } else {
+            lines.push(Line::from(vec!["▌ ".cyan(), "Running command".magenta()]));
+        }
+        for cont in iter {
+            lines.push(Line::from(vec!["".into(), cont.to_string().into()]));
+        }
+        lines.push(Line::from(""));
 
         HistoryCell::ActiveExecCommand {
             view: TextBlock::new(lines),
@@ -287,10 +294,18 @@ impl HistoryCell {
 
         let mut lines: Vec<Line<'static>> = Vec::new();
         let command_escaped = strip_bash_lc_and_escape(&command);
-        lines.push(Line::from(vec![
-            "⚡ Ran command ".magenta(),
-            command_escaped.into(),
-        ]));
+        let mut cmd_lines = command_escaped.lines();
+        if let Some(first) = cmd_lines.next() {
+            lines.push(Line::from(vec![
+                "⚡ Ran command ".magenta(),
+                first.to_string().into(),
+            ]));
+        } else {
+            lines.push(Line::from("⚡ Ran command".magenta()));
+        }
+        for cont in cmd_lines {
+            lines.push(Line::from(vec!["".into(), cont.to_string().into()]));
+        }
 
         let src = if exit_code == 0 { stdout } else { stderr };
 


### PR DESCRIPTION
With Ratatui, if a single line contains newlines, it increments y but not x so each subsequent line continued from the same x position as the previous line ended on.

Before
<img width="2010" height="376" alt="CleanShot 2025-08-08 at 09 13 13" src="https://github.com/user-attachments/assets/09feefbd-c5ee-4631-8967-93ab108c352a" />
After
<img width="1002" height="364" alt="CleanShot 2025-08-08 at 09 11 54" src="https://github.com/user-attachments/assets/a58b47cf-777f-436a-93d9-ab277046a577" />
