### PR TITLE
feat: `/reasoning` command

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -5,6 +5,7 @@ use ratatui::text::Line;
 
 use crate::app::ChatWidgetArgs;
 use crate::slash_command::SlashCommand;
+use codex_core::config_types::ReasoningEffort;
 
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum AppEvent {
@@ -35,6 +36,13 @@ pub(crate) enum AppEvent {
     /// layer so it can be handled centrally.
     DispatchCommand(SlashCommand),
 
+    /// Dispatch a slash command along with its raw argument string (first line after command).
+    /// Used for commands that accept parameters like `/reasoning high`.
+    DispatchCommandWithArgs {
+        cmd: SlashCommand,
+        args: String,
+    },
+
     /// Kick off an asynchronous file search for the given query (text after
     /// the `@`). Previous searches may be cancelled by the app layer so there
     /// is at most one in-flight search.
@@ -53,4 +61,7 @@ pub(crate) enum AppEvent {
     /// Onboarding: result of login_with_chatgpt.
     OnboardingAuthComplete(Result<(), String>),
     OnboardingComplete(ChatWidgetArgs),
+
+    /// Show a selector for setting the reasoning effort interactively.
+    ShowReasoningSelector(ReasoningEffort),
 }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -20,6 +20,7 @@ mod command_popup;
 mod file_search_popup;
 mod live_ring_widget;
 mod popup_consts;
+mod reasoning_selector_view;
 mod scroll_state;
 mod selection_popup_common;
 mod status_indicator_view;
@@ -36,6 +37,8 @@ pub(crate) use chat_composer::InputResult;
 
 use crate::status_indicator_widget::StatusIndicatorWidget;
 use approval_modal_view::ApprovalModalView;
+use codex_core::config_types::ReasoningEffort;
+use reasoning_selector_view::ReasoningSelectorView;
 use status_indicator_view::StatusIndicatorView;
 
 /// Pane displayed in the lower half of the chat UI.
@@ -296,6 +299,16 @@ impl BottomPane<'_> {
     ) {
         self.composer
             .set_token_usage(total_token_usage, last_token_usage, model_context_window);
+        self.request_redraw();
+    }
+
+    /// Show the selector for reasoning effort.
+    pub(crate) fn show_reasoning_selector(&mut self, current: ReasoningEffort) {
+        let view = ReasoningSelectorView::new(current, self.app_event_tx.clone());
+        self.active_view = Some(Box::new(view));
+        // Hide any overlay status while a modal view is visible.
+        self.live_status = None;
+        self.status_view_active = false;
         self.request_redraw();
     }
 

--- a/codex-rs/tui/src/bottom_pane/reasoning_selector_view.rs
+++ b/codex-rs/tui/src/bottom_pane/reasoning_selector_view.rs
@@ -1,0 +1,204 @@
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use crossterm::event::KeyModifiers;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Color;
+use ratatui::style::Modifier;
+use ratatui::style::Style;
+use ratatui::text::Line;
+use ratatui::text::Span;
+use ratatui::widgets::Block;
+use ratatui::widgets::BorderType;
+use ratatui::widgets::Borders;
+use ratatui::widgets::Paragraph;
+use ratatui::widgets::Wrap;
+
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+use crate::colors::LIGHT_BLUE;
+use crate::slash_command::SlashCommand;
+use codex_core::config_types::ReasoningEffort;
+
+use super::BottomPane;
+use super::CancellationEvent;
+use super::bottom_pane_view::BottomPaneView;
+use super::popup_consts::MAX_POPUP_ROWS;
+use super::scroll_state::ScrollState;
+use ratatui::prelude::Widget;
+
+/// Modal-style selector for choosing reasoning effort.
+pub(crate) struct ReasoningSelectorView {
+    state: ScrollState,
+    options: Vec<(String, ReasoningEffort)>,
+    current: ReasoningEffort,
+    app_event_tx: AppEventSender,
+    done: bool,
+}
+
+impl ReasoningSelectorView {
+    pub(crate) fn new(current: ReasoningEffort, app_event_tx: AppEventSender) -> Self {
+        let options = vec![
+            ("low".to_string(), ReasoningEffort::Low),
+            ("medium".to_string(), ReasoningEffort::Medium),
+            ("high".to_string(), ReasoningEffort::High),
+        ];
+
+        let mut state = ScrollState::new();
+        // Default selection to current effort when present among options; otherwise first.
+        let default_idx = options
+            .iter()
+            .position(|(_, eff)| *eff == current)
+            .unwrap_or(0);
+        state.selected_idx = Some(default_idx);
+        state.ensure_visible(options.len(), options.len().min(MAX_POPUP_ROWS));
+
+        Self {
+            state,
+            options,
+            current,
+            app_event_tx,
+            done: false,
+        }
+    }
+
+    fn confirm_selection(&mut self) {
+        if let Some(idx) = self.state.selected_idx {
+            if let Some((name, _eff)) = self.options.get(idx) {
+                // Dispatch `/reasoning <name>` to the app layer.
+                self.app_event_tx.send(AppEvent::DispatchCommandWithArgs {
+                    cmd: SlashCommand::Reasoning,
+                    args: name.clone(),
+                });
+                self.done = true;
+            }
+        }
+    }
+}
+
+impl<'a> BottomPaneView<'a> for ReasoningSelectorView {
+    fn handle_key_event(&mut self, _pane: &mut BottomPane<'a>, key_event: KeyEvent) {
+        match key_event {
+            KeyEvent {
+                code: KeyCode::Up, ..
+            } => {
+                let len = self.options.len();
+                self.state.move_up_wrap(len);
+                self.state.ensure_visible(len, len.min(MAX_POPUP_ROWS));
+            }
+            KeyEvent {
+                code: KeyCode::Down,
+                ..
+            } => {
+                let len = self.options.len();
+                self.state.move_down_wrap(len);
+                self.state.ensure_visible(len, len.min(MAX_POPUP_ROWS));
+            }
+            KeyEvent {
+                code: KeyCode::Enter,
+                modifiers: KeyModifiers::NONE,
+                ..
+            } => {
+                self.confirm_selection();
+            }
+            KeyEvent {
+                code: KeyCode::Esc, ..
+            } => {
+                self.done = true; // cancel
+            }
+            _ => {}
+        }
+    }
+
+    fn on_ctrl_c(&mut self, _pane: &mut BottomPane<'a>) -> CancellationEvent {
+        self.done = true;
+        CancellationEvent::Handled
+    }
+
+    fn is_complete(&self) -> bool {
+        self.done
+    }
+
+    fn desired_height(&self, _width: u16) -> u16 {
+        // Enough rows to show all options or cap by MAX_POPUP_ROWS.
+        self.options.len().clamp(1, MAX_POPUP_ROWS) as u16
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        // Draw a left border to match other popups, then render content in the inner area.
+        let border = Block::default()
+            .borders(Borders::LEFT)
+            .border_type(BorderType::QuadrantOutside)
+            .border_style(Style::default().fg(Color::DarkGray));
+        border.render(area, buf);
+
+        // Inner area avoids drawing over the left border when width permits.
+        let inner = if area.width > 1 {
+            Rect {
+                x: area.x + 1,
+                y: area.y,
+                width: area.width - 1,
+                height: area.height,
+            }
+        } else {
+            area
+        };
+
+        // Compute visible window from scroll state; height is capped by MAX_POPUP_ROWS via desired_height().
+        let total = self.options.len();
+        let max_rows_from_area = inner.height as usize;
+        let visible_rows = MAX_POPUP_ROWS.min(total).min(max_rows_from_area.max(1));
+        let mut start_idx = self.state.scroll_top.min(total.saturating_sub(1));
+        if let Some(sel) = self.state.selected_idx {
+            if sel < start_idx {
+                start_idx = sel;
+            } else if visible_rows > 0 {
+                let bottom = start_idx + visible_rows - 1;
+                if sel > bottom {
+                    start_idx = sel + 1 - visible_rows;
+                }
+            }
+        }
+
+        // Build lines with numbering and a caret for the highlighted selection.
+        let mut lines: Vec<Line> = Vec::new();
+        for (i, (name, eff)) in self
+            .options
+            .iter()
+            .enumerate()
+            .skip(start_idx)
+            .take(visible_rows)
+        {
+            let is_selected = Some(i) == self.state.selected_idx;
+            let is_current = *eff == self.current;
+
+            if is_selected {
+                // Selected row: use LIGHT_BLUE like the onboarding auth screen.
+                let mut spans: Vec<Span<'static>> = Vec::new();
+                spans.push(Span::styled(
+                    format!("> {}. ", i + 1),
+                    Style::default().fg(LIGHT_BLUE).add_modifier(Modifier::DIM),
+                ));
+                spans.push(Span::styled(name.clone(), Style::default().fg(LIGHT_BLUE)));
+                lines.push(Line::from(spans));
+            } else {
+                // Non-selected row: plain text with numbering; add a subtle current marker when applicable.
+                let mut spans: Vec<Span<'static>> = Vec::new();
+                spans.push(Span::from(format!("  {}. ", i + 1)));
+                spans.push(Span::from(name.clone()));
+                if is_current {
+                    spans.push(Span::from("  "));
+                    spans.push(Span::styled(
+                        "(current)",
+                        Style::default().add_modifier(Modifier::DIM),
+                    ));
+                }
+                lines.push(Line::from(spans));
+            }
+        }
+
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .render(inner, buf);
+    }
+}

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -566,9 +566,26 @@ impl ChatWidget<'_> {
         self.add_to_history(HistoryCell::new_prompts_output());
     }
 
+    /// Update the in-memory config's reasoning effort so status output reflects runtime changes.
+    pub(crate) fn set_model_reasoning_effort(
+        &mut self,
+        effort: codex_core::config_types::ReasoningEffort,
+    ) {
+        self.config.model_reasoning_effort = effort;
+    }
+
     /// Forward file-search results to the bottom pane.
     pub(crate) fn apply_file_search_result(&mut self, query: String, matches: Vec<FileMatch>) {
         self.bottom_pane.on_file_search_result(query, matches);
+    }
+
+    /// Show the interactive selector for reasoning effort.
+    pub(crate) fn show_reasoning_selector(
+        &mut self,
+        current: codex_core::config_types::ReasoningEffort,
+    ) {
+        self.bottom_pane.show_reasoning_selector(current);
+        self.request_redraw();
     }
 
     /// Handle Ctrl-C key press.

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -227,6 +227,9 @@ impl HistoryCell {
                 Line::from(format!(" /init - {}", SlashCommand::Init.description()).dim()),
                 Line::from(format!(" /status - {}", SlashCommand::Status.description()).dim()),
                 Line::from(format!(" /diff - {}", SlashCommand::Diff.description()).dim()),
+                Line::from(
+                    format!(" /reasoning - {}", SlashCommand::Reasoning.description()).dim(),
+                ),
                 Line::from(format!(" /prompts - {}", SlashCommand::Prompts.description()).dim()),
                 Line::from("".dim()),
             ];

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -17,6 +17,7 @@ pub enum SlashCommand {
     Compact,
     Diff,
     Status,
+    Reasoning,
     Prompts,
     Logout,
     Quit,
@@ -34,6 +35,7 @@ impl SlashCommand {
             SlashCommand::Quit => "exit Codex",
             SlashCommand::Diff => "show git diff (including untracked files)",
             SlashCommand::Status => "show current session configuration and token usage",
+            SlashCommand::Reasoning => "set reasoning effort (low|medium|high)",
             SlashCommand::Prompts => "show example prompts",
             SlashCommand::Logout => "log out of Codex",
             #[cfg(debug_assertions)]


### PR DESCRIPTION
## What
- Add `/reasoning` command with interactive selector to set reasoning effort at
runtime.

## Why
- Fast, in-session control of reasoning effort without editing config files.
- Fits product intent to expose reasoning controls while maintaining clarity.

## How
- UI:
  - New `tui/src/bottom_pane/reasoning_selector_view.rs`: modal-style selector (
Up/Down, Enter, Esc).
  - `CommandPopup` shows `/reasoning` with description.
  - Welcome and status outputs surface reasoning entries.
- Events:
  - Add `AppEvent::ShowReasoningSelector` and `AppEvent::DispatchCommandWithArgs
`.
  - `ChatComposer` can dispatch a command plus its first-line args.
- App handling:
  - `tui/src/app.rs`: handle `/reasoning` via args or interactive selector; upda
te `config.model_reasoning_effort`; send `Op::ConfigureSession` so backend appli
es immediately.
- Core compatibility:

## Tests
- TUI unit tests pass (`codex-tui`): composer, popup filtering/selection, textar
ea, layout, vt100 docs.
- Workspace tests pass with `--all-features`.
- Manual checks:
  - Type `/reasoning` → selector opens; choose an option → session reconfigures;
 `/status` shows updated effort.
  - Type `/reasoning high` → applies immediately; `/reasoning none` is rejected
(falls back to showing status hint).

## Docs
- Slash popup description guides usage: “set reasoning effort (low|medium|high)”.
- Welcome message lists `/reasoning`.
- No separate docs changed; `config.toml` support for `"none"` remains (out of s
cope for this PR).

## Risk/Impact
- Low: UI-only change to command parsing and new selector view; backend reconfig
 is already supported.
- Behavior change: cannot disable reasoning via `/reasoning none` in the UI; use
rs can still set `"none"` in `config.toml` if needed.
- No changes to sandboxing, networking, or non-TUI flows.

## Screenshots

<img width="800" height="170" alt="reasoning-command" src="https://github.com/user-attachments/assets/4ff86241-1fb4-4de0-bf43-dca570d5eafc" />
<img width="800" height="170" alt="reasoning-interactive-mode" src="https://github.com/user-attachments/assets/790d2213-34fe-48da-b9c9-5c328a0c47cd" />
<img width="800" height="170" alt="reasoning-interactive-mode-showcase" src="https://github.com/user-attachments/assets/d726e172-3c4d-4f3a-b4f2-9e6907ce1287" />