### PR TITLE
[exec] Fix exec sandbox arg

### DIFF
--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -19,7 +19,7 @@ pub struct Cli {
 
     /// Select the sandbox policy to use when executing model-generated shell
     /// commands.
-    #[arg(long = "sandbox", short = 's')]
+    #[arg(long = "sandbox", short = 's', value_enum)]
     pub sandbox_mode: Option<codex_common::SandboxModeCliArg>,
 
     /// Configuration profile from config.toml to specify default options.


### PR DESCRIPTION
From codex-cli 😁 

## Summary
`-s/--sandbox` now correctly affects sandbox mode.

What changed
- In `codex-rs/exec/src/cli.rs`:
  - Added `value_enum` to the `--sandbox` flag so Clap parses enum values into `
SandboxModeCliArg`.
  - This ensures values like `-s read-only`, `-s workspace-write`, and `-s dange
r-full-access` are recognized and propagated.

Why this fixes it
- The enum already derives `ValueEnum`, but without `#[arg(value_enum)]` Clap ma
y not map the string into the enum, leaving the option ineffective at runtime. W
ith `value_enum`, `sandbox_mode` is parsed and then converted to `SandboxMode` i
n `run_main`, which feeds into `ConfigOverrides` and ultimately into the effecti
ve `sandbox_policy`.