### PR TITLE
fix: stop building codex-exec and codex-linux-sandbox binaries

### DIFF
--- a/.github/actions/codex/action.yml
+++ b/.github/actions/codex/action.yml
@@ -82,20 +82,18 @@ runs:
 
         # Note that if we start baking version numbers into the artifact name,
         # we will need to update this action.yml file to match.
-        artifact="codex-exec-${triple}.tar.gz"
+        artifact="codex-${triple}.tar.gz"
 
         TAG_ARG="${{ inputs.codex_release_tag }}"
         # The usage is `gh release download [<tag>] [flags]`, so if TAG_ARG
         # is empty, we do not pass it so we can default to the latest release.
         gh release download ${TAG_ARG:+$TAG_ARG} --repo openai/codex \
           --pattern "$artifact" --output - \
-        | tar xzO > /usr/local/bin/codex-exec
-        chmod +x /usr/local/bin/codex-exec
+        | tar xzO > /usr/local/bin/codex
+        chmod +x /usr/local/bin/codex
 
-        # Display Codex version to confirm binary integrity; ensure we point it
-        # at the checked-out repository via --cd so that any subsequent commands
-        # use the correct working directory.
-        codex-exec --cd "$GITHUB_WORKSPACE" --version
+        # Display Codex version to confirm binary integrity.
+        codex --version
 
     - name: Install Bun
       uses: oven-sh/setup-bun@v2

--- a/.github/actions/codex/src/run-codex.ts
+++ b/.github/actions/codex/src/run-codex.ts
@@ -18,7 +18,9 @@ export async function runCodex(
   const tempDirPath = await mkdtemp(join(tmpdir(), "codex-"));
   const lastMessageOutput = join(tempDirPath, "codex-prompt.md");
 
-  const args = ["/usr/local/bin/codex-exec"];
+  // Use the unified CLI and its `exec` subcommand instead of the old
+  // standalone `codex-exec` binary.
+  const args = ["/usr/local/bin/codex", "exec"];
 
   const inputCodexArgs = ctx.tryGet("INPUT_CODEX_ARGS")?.trim();
   if (inputCodexArgs) {

--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -1,27 +1,23 @@
 {
   "outputs": {
-    "codex-exec": {
-      "platforms": {
-        "macos-aarch64":  { "regex": "^codex-exec-aarch64-apple-darwin\\.zst$",          "path": "codex-exec" },
-        "macos-x86_64":   { "regex": "^codex-exec-x86_64-apple-darwin\\.zst$",           "path": "codex-exec" },
-        "linux-x86_64":   { "regex": "^codex-exec-x86_64-unknown-linux-musl\\.zst$",     "path": "codex-exec" },
-        "linux-aarch64":  { "regex": "^codex-exec-aarch64-unknown-linux-musl\\.zst$",     "path": "codex-exec" }
-      }
-    },
-
     "codex": {
       "platforms": {
-        "macos-aarch64":  { "regex": "^codex-aarch64-apple-darwin\\.zst$",          "path": "codex" },
-        "macos-x86_64":   { "regex": "^codex-x86_64-apple-darwin\\.zst$",           "path": "codex" },
-        "linux-x86_64":   { "regex": "^codex-x86_64-unknown-linux-musl\\.zst$",     "path": "codex" },
-        "linux-aarch64":  { "regex": "^codex-aarch64-unknown-linux-musl\\.zst$",     "path": "codex" }
-      }
-    },
-
-    "codex-linux-sandbox": {
-      "platforms": {
-        "linux-x86_64":   { "regex": "^codex-linux-sandbox-x86_64-unknown-linux-musl\\.zst$",     "path": "codex-linux-sandbox" },
-        "linux-aarch64":  { "regex": "^codex-linux-sandbox-aarch64-unknown-linux-musl\\.zst$",     "path": "codex-linux-sandbox" }
+        "macos-aarch64": {
+          "regex": "^codex-aarch64-apple-darwin\\.zst$",
+          "path": "codex"
+        },
+        "macos-x86_64": {
+          "regex": "^codex-x86_64-apple-darwin\\.zst$",
+          "path": "codex"
+        },
+        "linux-x86_64": {
+          "regex": "^codex-x86_64-unknown-linux-musl\\.zst$",
+          "path": "codex"
+        },
+        "linux-aarch64": {
+          "regex": "^codex-aarch64-unknown-linux-musl\\.zst$",
+          "path": "codex"
+        }
       }
     }
   }

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -95,7 +95,7 @@ jobs:
           sudo apt install -y musl-tools pkg-config
 
       - name: Cargo build
-        run: cargo build --target ${{ matrix.target }} --release --bin codex --bin codex-exec --bin codex-linux-sandbox
+        run: cargo build --target ${{ matrix.target }} --release --bin codex
 
       - name: Stage artifacts
         shell: bash
@@ -104,22 +104,10 @@ jobs:
           mkdir -p "$dest"
 
           if [[ "${{ matrix.runner }}" == windows* ]]; then
-            cp target/${{ matrix.target }}/release/codex-exec.exe "$dest/codex-exec-${{ matrix.target }}.exe"
             cp target/${{ matrix.target }}/release/codex.exe "$dest/codex-${{ matrix.target }}.exe"
           else
-            cp target/${{ matrix.target }}/release/codex-exec "$dest/codex-exec-${{ matrix.target }}"
             cp target/${{ matrix.target }}/release/codex "$dest/codex-${{ matrix.target }}"
           fi
-
-        # After https://github.com/openai/codex/pull/1228 is merged and a new
-        # release is cut with an artifacts built after that PR, the `-gnu`
-        # variants can go away as we will only use the `-musl` variants.
-      - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-musl' }}
-        name: Stage Linux-only artifacts
-        shell: bash
-        run: |
-          dest="dist/${{ matrix.target }}"
-          cp target/${{ matrix.target }}/release/codex-linux-sandbox "$dest/codex-linux-sandbox-${{ matrix.target }}"
 
       - name: Compress artifacts
         shell: bash
@@ -133,7 +121,6 @@ jobs:
           # we publish. The end result is:
           #   codex-<target>.zst          (existing)
           #   codex-<target>.tar.gz       (new)
-          #   ...same naming for codex-exec-* and codex-linux-sandbox-*
 
           # 1. Produce a .tar.gz for every file in the directory *before* we
           #    run `zstd --rm`, because that flag deletes the original files.


### PR DESCRIPTION
Release builds are taking awhile and part of the reason that we are building binaries that we are not really using. Adding Windows binaries into releases (https://github.com/openai/codex/pull/2035) slows things down, so we need to get some time back.

- `codex-exec` is basically a standalone `codex exec` that we were offering because it's a bit smaller as it does not include all the bits to power the TUI. We were using it in our experimental GitHub Action, so this PR updates the Action to use `codex exec` instead.
- `codex-linux-sandbox` was a helper binary for the TypeScript version of the CLI, but I am about to axe that, so we don't need this either.

If we decide to bring `codex-exec` back at some point, we should use a separate instances so we can build it in parallel with `codex`. (I think if we had beefier build machines, this wouldn't be so bad, but that's not the case with the default runners from GitHub.)