### PR TITLE
fix: try building the npm package in CI

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -154,6 +154,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           path: dist
@@ -168,6 +171,44 @@ jobs:
           # "rust-v0.1.0".
           version="${GITHUB_REF_NAME#rust-v}"
           echo "name=${version}" >> $GITHUB_OUTPUT
+
+      # Setup Node + pnpm similar to ci.yml so we can build the npm package
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.8.1
+          run_install: false
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: |
+          echo "store_path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.store_path }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Stage npm package
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TMP_DIR="${RUNNER_TEMP}/npm-stage"
+          python3 codex-cli/scripts/stage_rust_release.py \
+            --release-version "${{ steps.release_name.outputs.name }}" \
+            --tmp "${TMP_DIR}"
+          mkdir -p dist/npm
+          (cd "$TMP_DIR" && zip -r "${GITHUB_WORKSPACE}/dist/npm/codex-npm-${{ steps.release_name.outputs.name }}.zip" .)
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2

--- a/codex-cli/scripts/stage_rust_release.py
+++ b/codex-cli/scripts/stage_rust_release.py
@@ -13,10 +13,17 @@ def main() -> int:
 
 Run this after the GitHub Release has been created and use
 `--release-version` to specify the version to release.
+
+Optionally pass `--tmp` to control the temporary staging directory that will be
+forwarded to stage_release.sh.
 """
     )
     parser.add_argument(
         "--release-version", required=True, help="Version to release, e.g., 0.3.0"
+    )
+    parser.add_argument(
+        "--tmp",
+        help="Optional path to stage the npm package; forwarded to stage_release.sh",
     )
     args = parser.parse_args()
     version = args.release_version
@@ -43,15 +50,17 @@ Run this after the GitHub Release has been created and use
     print(f"should `git checkout {sha}`")
 
     current_dir = Path(__file__).parent.resolve()
-    stage_release = subprocess.run(
-        [
-            current_dir / "stage_release.sh",
-            "--version",
-            version,
-            "--workflow-url",
-            workflow["url"],
-        ]
-    )
+    cmd = [
+        str(current_dir / "stage_release.sh"),
+        "--version",
+        version,
+        "--workflow-url",
+        workflow["url"],
+    ]
+    if args.tmp:
+        cmd.extend(["--tmp", args.tmp])
+
+    stage_release = subprocess.run(cmd)
     stage_release.check_returncode()
 
     return 0


### PR DESCRIPTION
Historically, the release process for the npm module has been:

- I run `codex-rs/scripts/create_github_release.sh` to kick off a release for the native artifacts.
- I wait until it is done.
- I run `codex-cli/scripts/stage_rust_release.py` to build the npm release locally
- I run `npm publish` from my laptop

It has been a longstanding issue to move the npm build to CI. I may still have to do the `npm publish` manually because it requires 2fac with `npm`, though I assume we can work that out later.

Note I asked Codex to make these updates, and while they look pretty good to me, I'm not 100% certain, but let's just merge this and I'll kick off another alpha build and we'll see what happens?