### PR TITLE
feat: allow esc to interrupt session

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -242,9 +242,7 @@ impl App<'_> {
                             ..
                         } => match &mut self.app_state {
                             AppState::Chat { widget } => {
-                                if widget.is_task_running() {
-                                    widget.on_ctrl_c();
-                                } else {
+                                if !widget.on_esc() {
                                     self.dispatch_key_event(key_event);
                                 }
                             }

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -237,6 +237,22 @@ impl App<'_> {
                             }
                         },
                         KeyEvent {
+                            code: KeyCode::Esc,
+                            kind: KeyEventKind::Press,
+                            ..
+                        } => match &mut self.app_state {
+                            AppState::Chat { widget } => {
+                                if widget.is_task_running() {
+                                    widget.on_ctrl_c();
+                                } else {
+                                    self.dispatch_key_event(key_event);
+                                }
+                            }
+                            AppState::Onboarding { .. } => {
+                                self.dispatch_key_event(key_event);
+                            }
+                        },
+                        KeyEvent {
                             code: KeyCode::Char('z'),
                             modifiers: crossterm::event::KeyModifiers::CONTROL,
                             kind: KeyEventKind::Press,

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -571,6 +571,14 @@ impl ChatWidget<'_> {
         self.bottom_pane.on_file_search_result(query, matches);
     }
 
+    pub(crate) fn on_esc(&mut self) -> bool {
+        if self.bottom_pane.is_task_running() {
+            self.interrupt_running_task();
+            return true;
+        }
+        false
+    }
+
     /// Handle Ctrl-C key press.
     /// Returns CancellationEvent::Handled if the event was consumed by the UI, or
     /// CancellationEvent::Ignored if the caller should handle it (e.g. exit).

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -607,10 +607,6 @@ impl ChatWidget<'_> {
         self.bottom_pane.composer_is_empty()
     }
 
-    pub(crate) fn is_task_running(&self) -> bool {
-        self.bottom_pane.is_task_running()
-    }
-
     /// Forward an `Op` directly to codex.
     pub(crate) fn submit_op(&self, op: Op) {
         if let Err(e) = self.codex_op_tx.send(op) {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -599,6 +599,10 @@ impl ChatWidget<'_> {
         self.bottom_pane.composer_is_empty()
     }
 
+    pub(crate) fn is_task_running(&self) -> bool {
+        self.bottom_pane.is_task_running()
+    }
+
     /// Forward an `Op` directly to codex.
     pub(crate) fn submit_op(&self, op: Op) {
         if let Err(e) = self.codex_op_tx.send(op) {

--- a/codex-rs/tui/src/status_indicator_widget.rs
+++ b/codex-rs/tui/src/status_indicator_widget.rs
@@ -231,10 +231,20 @@ impl WidgetRef for StatusIndicatorWidget {
         spans.extend(animated_spans);
         // Space between header and bracket block
         spans.push(Span::raw(" "));
-        // Non-animated, dim bracket content, with only "Ctrl c" bold
+        // Non-animated, dim bracket content, with keys bold
         let bracket_prefix = format!("({elapsed}s • ");
         spans.push(Span::styled(
             bracket_prefix,
+            Style::default().fg(Color::Gray).add_modifier(Modifier::DIM),
+        ));
+        spans.push(Span::styled(
+            "Esc",
+            Style::default()
+                .fg(Color::Gray)
+                .add_modifier(Modifier::DIM | Modifier::BOLD),
+        ));
+        spans.push(Span::styled(
+            " or ",
             Style::default().fg(Color::Gray).add_modifier(Modifier::DIM),
         ));
         spans.push(Span::styled(

--- a/codex-rs/tui/src/status_indicator_widget.rs
+++ b/codex-rs/tui/src/status_indicator_widget.rs
@@ -244,16 +244,6 @@ impl WidgetRef for StatusIndicatorWidget {
                 .add_modifier(Modifier::DIM | Modifier::BOLD),
         ));
         spans.push(Span::styled(
-            " or ",
-            Style::default().fg(Color::Gray).add_modifier(Modifier::DIM),
-        ));
-        spans.push(Span::styled(
-            "Ctrl C",
-            Style::default()
-                .fg(Color::Gray)
-                .add_modifier(Modifier::DIM | Modifier::BOLD),
-        ));
-        spans.push(Span::styled(
             " to interrupt)",
             Style::default().fg(Color::Gray).add_modifier(Modifier::DIM),
         ));


### PR DESCRIPTION
## Summary
- allow Esc to interrupt the current session when a task is running
- document Esc as an interrupt key in status indicator

## Testing
- `just fmt`
- `just fix` *(fails: E0658 `let` expressions in this position are unstable)*
- `cargo test --all-features` *(fails: E0658 `let` expressions in this position are unstable)*

------
https://chatgpt.com/codex/tasks/task_i_689698cf605883208f57b0317ff6a303