### PR TITLE
fix: scope EventMsg import to debug builds

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -11,7 +11,6 @@ use crate::slash_command::SlashCommand;
 use crate::tui;
 use codex_core::config::Config;
 use codex_core::protocol::Event;
-use codex_core::protocol::EventMsg;
 use codex_core::protocol::Op;
 use color_eyre::eyre::Result;
 use crossterm::SynchronizedUpdate;
@@ -381,6 +380,7 @@ impl App<'_> {
                         use std::collections::HashMap;
 
                         use codex_core::protocol::ApplyPatchApprovalRequestEvent;
+                        use codex_core::protocol::EventMsg;
                         use codex_core::protocol::FileChange;
 
                         self.app_event_tx.send(AppEvent::CodexEvent(Event {


### PR DESCRIPTION
What: Moves the `EventMsg` import inside the `#[cfg(debug_assertions)]` block where it is used.

Why: The import is unused in release builds, triggering a compiler warning.

How: Moves the `EventMsg` import inside the `#[cfg(debug_assertions)]` block where it is used.

Fixes #2063 