### PR TITLE
ctrl+l support

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -585,13 +585,10 @@ mod tests {
     use ratatui::layout::Rect;
 
     #[test]
-    fn ctrl_l_clear_reanchors_viewport_and_moves_cursor() {
+    fn ctrl_l_clear_reanchors_viewport_and_moves_cursor() -> std::io::Result<()> {
         // Build a test terminal with a small screen and a viewport offset.
         let backend = TestBackend::new(20, 6);
-        let mut term = match crate::custom_terminal::Terminal::with_options(backend) {
-            Ok(t) => t,
-            Err(e) => panic!("failed to construct terminal: {e}"),
-        };
+        let mut term = crate::custom_terminal::Terminal::with_options(backend)?;
 
         // Simulate a viewport not at the top (e.g., after history insertions).
         term.set_viewport_area(Rect::new(0, 3, 20, 2));
@@ -602,10 +599,9 @@ mod tests {
 
         // Viewport should be re-anchored at the top and cursor at (0,0).
         assert_eq!(term.viewport_area.y, 0);
-        let pos = term
-            .get_cursor_position()
-            .expect("backend should provide cursor position");
+        let pos = term.get_cursor_position()?;
         assert_eq!(pos.x, 0);
         assert_eq!(pos.y, 0);
+        Ok(())
     }
 }

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -237,6 +237,27 @@ impl App<'_> {
                             }
                         },
                         KeyEvent {
+                            code: KeyCode::Char('l'),
+                            modifiers: crossterm::event::KeyModifiers::CONTROL,
+                            kind: KeyEventKind::Press,
+                            ..
+                        } => {
+                            // Clear terminal, move cursor to (0,0) then clear all to wipe anything above.
+                            // Keep composer area visible including the prompt and cursor position.
+                            let mut area = terminal.viewport_area;
+                            area.y = 0;
+                            terminal.set_viewport_area(area);
+
+                            let _ = terminal.set_cursor_position((0, 0));
+                            let _ = terminal
+                                .backend_mut()
+                                .clear_region(ratatui::backend::ClearType::All);
+
+                            let _ = terminal.clear();
+
+                            self.app_event_tx.send(AppEvent::RequestRedraw);
+                        }
+                        KeyEvent {
                             code: KeyCode::Esc,
                             kind: KeyEventKind::Press,
                             ..


### PR DESCRIPTION
Adding clear screen shortcut (ctrl+l).

Behavior:

<img width="737" height="763" alt="Pasted Graphic 1" src="https://github.com/user-attachments/assets/ebce3758-583d-4743-b393-7ffd1b3bede4" />

ctrl+l

<img width="737" height="763" alt="I in typind" src="https://github.com/user-attachments/assets/64c7fa0f-fabf-4bf6-993f-5e1544dadd4a" />

---

ctrl+l can also be pressed during chain of thought or tool calling (I don't see any reason to restrict it) – but it does cut messages in-between (which I assume should be the expected behaviour), the screenshot below, I pressed ctrl+l during CoT and scrolled back at the end to see how it "broke" the streaming into two.

<img width="738" height="764" alt="a casual" src="https://github.com/user-attachments/assets/50687d19-daf3-4b2a-837c-c8373dd9aaec" />