### PR TITLE
tui: add space after ✏️ in ‘Applying patch’ label for readability

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -842,63 +842,7 @@ impl WidgetRef for &HistoryCell {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use codex_core::protocol::FileChange;
-    use std::collections::HashMap;
-    use std::path::PathBuf;
-
-    #[test]
-    fn applying_patch_title_spacing_auto_approved() {
-        let mut changes = HashMap::new();
-        changes.insert(
-            PathBuf::from("foo.txt"),
-            FileChange::Add {
-                content: "line1\nline2\n".into(),
-            },
-        );
-
-        let cell = HistoryCell::new_patch_event(
-            PatchEventType::ApplyBegin { auto_approved: true },
-            changes,
-        );
-
-        let lines = cell.plain_lines();
-        assert!(!lines.is_empty());
-        let first_line = &lines[0];
-        assert!(
-            !first_line.spans.is_empty(),
-            "header line should have at least one span"
-        );
-        let title = first_line.spans[0].content.clone().into_owned();
-        assert_eq!(title, "✏️  Applying patch");
-    }
-
-    #[test]
-    fn applying_patch_title_spacing_manual() {
-        let mut changes = HashMap::new();
-        changes.insert(
-            PathBuf::from("bar.txt"),
-            FileChange::Add {
-                content: "hello\n".into(),
-            },
-        );
-
-        let cell = HistoryCell::new_patch_event(
-            PatchEventType::ApplyBegin { auto_approved: false },
-            changes,
-        );
-
-        let lines = cell.plain_lines();
-        assert!(
-            !lines.is_empty(),
-            "manual path should include a title line"
-        );
-        let title = lines[0].spans[0].content.clone().into_owned();
-        assert_eq!(title, "✏️  Applying patch");
-    }
-}
+ 
 
 fn create_diff_summary(title: &str, changes: HashMap<PathBuf, FileChange>) -> Vec<RtLine<'static>> {
     let mut files: Vec<FileSummary> = Vec::new();
@@ -1053,4 +997,62 @@ fn format_mcp_invocation<'a>(invocation: McpInvocation) -> Line<'a> {
         Span::raw(")"),
     ];
     Line::from(invocation_spans)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_core::protocol::FileChange;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    #[test]
+    fn applying_patch_title_spacing_auto_approved() {
+        let mut changes = HashMap::new();
+        changes.insert(
+            PathBuf::from("foo.txt"),
+            FileChange::Add {
+                content: "line1\nline2\n".into(),
+            },
+        );
+
+        let cell = HistoryCell::new_patch_event(
+            PatchEventType::ApplyBegin { auto_approved: true },
+            changes,
+        );
+
+        let lines = cell.plain_lines();
+        assert!(!lines.is_empty());
+        let first_line = &lines[0];
+        assert!(
+            !first_line.spans.is_empty(),
+            "header line should have at least one span"
+        );
+        let title = first_line.spans[0].content.clone().into_owned();
+        assert_eq!(title, "✏️  Applying patch");
+    }
+
+    #[test]
+    fn applying_patch_title_spacing_manual() {
+        let mut changes = HashMap::new();
+        changes.insert(
+            PathBuf::from("bar.txt"),
+            FileChange::Add {
+                content: "hello\n".into(),
+            },
+        );
+
+        let cell = HistoryCell::new_patch_event(
+            PatchEventType::ApplyBegin { auto_approved: false },
+            changes,
+        );
+
+        let lines = cell.plain_lines();
+        assert!(
+            !lines.is_empty(),
+            "manual path should include a title line"
+        );
+        let title = lines[0].spans[0].content.clone().into_owned();
+        assert_eq!(title, "✏️  Applying patch");
+    }
 }

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -777,12 +777,12 @@ impl HistoryCell {
             PatchEventType::ApprovalRequest => "proposed patch",
             PatchEventType::ApplyBegin {
                 auto_approved: true,
-            } => "✏️ Applying patch",
+            } => "✏️  Applying patch",
             PatchEventType::ApplyBegin {
                 auto_approved: false,
             } => {
                 let lines: Vec<Line<'static>> = vec![
-                    Line::from("✏️ Applying patch".magenta().bold()),
+                    Line::from("✏️  Applying patch".magenta().bold()),
                     Line::from(""),
                 ];
                 return Self::PendingPatch {


### PR DESCRIPTION
Fixes missing whitespace after the ✏️ emoji in the TUI “Applying patch” label for better readability.

- Updated both auto-approved and manual paths in `codex-rs/tui/src/history_cell.rs` to use two spaces after the emoji for consistent visual separation across terminals.
- Ran `cargo fmt`, `clippy --fix`, and the full test suite.