### PR TITLE
[1/3] Parse exec commands and format them more nicely in the UI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,7 @@
 In the codex-rs folder where the rust code lives:
 
 - Crate names are prefixed with `codex-`. For examole, the `core` folder's crate is named `codex-core`
+- When using format! and you can inline variables into {}, always do that.
 - Never add or modify any code related to `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR` or `CODEX_SANDBOX_ENV_VAR`.
   - You operate in a sandbox where `CODEX_SANDBOX_NETWORK_DISABLED=1` will be set whenever you use the `shell` tool. Any existing code that uses `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR` was authored with this fact in mind. It is often used to early exit out of tests that the author knew you would not be able to run given your sandbox limitations.
   - Similarly, when you spawn a process using Seatbelt (`/usr/bin/sandbox-exec`), `CODEX_SANDBOX=seatbelt` will be set on the child process. Integration tests that want to run Seatbelt themselves cannot be run under Seatbelt, so checks for `CODEX_SANDBOX=seatbelt` are also often used to early exit out of tests, as appropriate.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,7 @@
 
 In the codex-rs folder where the rust code lives:
 
+- Crate names are prefixed with `codex-`. For examole, the `core` folder's crate is named `codex-core`
 - Never add or modify any code related to `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR` or `CODEX_SANDBOX_ENV_VAR`.
   - You operate in a sandbox where `CODEX_SANDBOX_NETWORK_DISABLED=1` will be set whenever you use the `shell` tool. Any existing code that uses `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR` was authored with this fact in mind. It is often used to early exit out of tests that the author knew you would not be able to run given your sandbox limitations.
   - Similarly, when you spawn a process using Seatbelt (`/usr/bin/sandbox-exec`), `CODEX_SANDBOX=seatbelt` will be set on the child process. Integration tests that want to run Seatbelt themselves cannot be run under Seatbelt, so checks for `CODEX_SANDBOX=seatbelt` are also often used to early exit out of tests, as appropriate.

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -65,6 +65,7 @@ use crate::models::ResponseItem;
 use crate::models::ShellToolCallParams;
 use crate::openai_tools::ToolsConfig;
 use crate::openai_tools::get_openai_tools;
+use crate::parse_command::parse_command;
 use crate::plan_tool::handle_update_plan;
 use crate::project_doc::get_user_instructions;
 use crate::protocol::AgentMessageDeltaEvent;
@@ -373,7 +374,7 @@ impl Session {
         }
     }
 
-    async fn on_exec_command_begin(
+    pub async fn on_exec_command_begin(
         &self,
         turn_diff_tracker: &mut TurnDiffTracker,
         exec_command_context: ExecCommandContext,
@@ -402,6 +403,7 @@ impl Session {
                 call_id,
                 command: command_for_display.clone(),
                 cwd,
+                parsed_cmd: parse_command(&command_for_display),
             }),
         };
         let event = Event {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -374,7 +374,7 @@ impl Session {
         }
     }
 
-    pub async fn on_exec_command_begin(
+    async fn on_exec_command_begin(
         &self,
         turn_diff_tracker: &mut TurnDiffTracker,
         exec_command_context: ExecCommandContext,

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -28,6 +28,7 @@ mod mcp_connection_manager;
 mod mcp_tool_call;
 mod message_history;
 mod model_provider_info;
+pub mod parse_command;
 pub use model_provider_info::BUILT_IN_OSS_MODEL_PROVIDER_ID;
 pub use model_provider_info::ModelProviderInfo;
 pub use model_provider_info::WireApi;

--- a/codex-rs/core/src/parse_command.rs
+++ b/codex-rs/core/src/parse_command.rs
@@ -18,7 +18,6 @@ pub enum ParsedCommand {
         cmd: Vec<String>,
         query: Option<String>,
         path: Option<String>,
-        files_only: bool,
     },
     Format {
         cmd: Vec<String>,
@@ -95,13 +94,11 @@ mod tests {
                     cmd: vec_str(&["rg", "--files"]),
                     query: None,
                     path: None,
-                    files_only: true,
                 },
                 ParsedCommand::Search {
                     cmd: vec_str(&["rg", "--files"]),
                     query: None,
                     path: None,
-                    files_only: true,
                 },
                 ParsedCommand::Unknown {
                     cmd: vec_str(&["pnpm", "-v"]),
@@ -113,7 +110,6 @@ mod tests {
                     cmd: vec_str(&["rg", "--version"]),
                     query: None,
                     path: None,
-                    files_only: false,
                 },
             ],
         );
@@ -128,7 +124,6 @@ mod tests {
                 cmd: shlex_split_safe(inner),
                 query: Some("navigate-to-route".to_string()),
                 path: None,
-                files_only: false,
             }],
         );
         Ok(())
@@ -147,7 +142,6 @@ mod tests {
                     cmd: vec_str(&["rg", "-n", "BUG|FIXME|TODO|XXX|HACK", "-S"]),
                     query: Some("BUG|FIXME|TODO|XXX|HACK".to_string()),
                     path: None,
-                    files_only: false,
                 },
             ],
         );
@@ -162,7 +156,6 @@ mod tests {
                 cmd: vec_str(&["rg", "--files", "webview/src"]),
                 query: None,
                 path: Some("webview".to_string()),
-                files_only: true,
             }],
         );
     }
@@ -180,7 +173,6 @@ mod tests {
                     cmd: vec_str(&["rg", "--files"]),
                     query: None,
                     path: None,
-                    files_only: true,
                 },
             ],
         );
@@ -307,7 +299,6 @@ mod tests {
                 cmd: vec_str(&["grep", "-R", "CODEX_SANDBOX_ENV_VAR", "-n", "."]),
                 query: Some("CODEX_SANDBOX_ENV_VAR".to_string()),
                 path: Some(".".to_string()),
-                files_only: false,
             }],
         );
     }
@@ -332,7 +323,6 @@ mod tests {
                 ]),
                 query: Some("CODEX_SANDBOX_ENV_VAR".to_string()),
                 path: Some("spawn.rs".to_string()),
-                files_only: false,
             }],
         );
     }
@@ -347,7 +337,6 @@ mod tests {
                 cmd: vec_str(&["grep", "-R", "src/main.rs", "-n", "."]),
                 query: Some("src/main.rs".to_string()),
                 path: Some(".".to_string()),
-                files_only: false,
             }],
         );
     }
@@ -360,7 +349,6 @@ mod tests {
                 cmd: vec_str(&["grep", "-R", "COD`EX_SANDBOX", "-n"]),
                 query: Some("COD`EX_SANDBOX".to_string()),
                 path: None,
-                files_only: false,
             }],
         );
     }
@@ -377,7 +365,6 @@ mod tests {
                     cmd: vec_str(&["rg", "--files"]),
                     query: None,
                     path: None,
-                    files_only: true,
                 },
             ],
         );
@@ -680,7 +667,6 @@ mod tests {
                 cmd: vec_str(&["rg", "--files"]),
                 query: None,
                 path: None,
-                files_only: true,
             }],
         );
     }
@@ -710,7 +696,6 @@ mod tests {
                 cmd: shlex_split_safe("rg -n 'foo bar' -S"),
                 query: Some("foo bar".to_string()),
                 path: None,
-                files_only: false,
             }],
         );
     }
@@ -735,7 +720,6 @@ mod tests {
                     cmd: shlex_split_safe("rg foo"),
                     query: Some("foo".to_string()),
                     path: None,
-                    files_only: false,
                 },
                 ParsedCommand::Unknown {
                     cmd: shlex_split_safe("echo done"),
@@ -754,7 +738,6 @@ mod tests {
                     cmd: shlex_split_safe("rg foo"),
                     query: Some("foo".to_string()),
                     path: None,
-                    files_only: false,
                 },
                 ParsedCommand::Unknown {
                     cmd: shlex_split_safe("echo done"),
@@ -796,7 +779,6 @@ mod tests {
                     cmd: shlex_split_safe("rg --files"),
                     query: None,
                     path: None,
-                    files_only: true,
                 },
                 ParsedCommand::Unknown {
                     cmd: shlex_split_safe("head -n 1"),
@@ -981,7 +963,6 @@ mod tests {
                 cmd: shlex_split_safe("grep -R TODO src"),
                 query: Some("TODO".to_string()),
                 path: Some("src".to_string()),
-                files_only: false,
             }],
         );
     }
@@ -994,7 +975,6 @@ mod tests {
                 cmd: shlex_split_safe("rg --colors=never -n foo src"),
                 query: Some("foo".to_string()),
                 path: Some("src".to_string()),
-                files_only: false,
             }],
         );
     }
@@ -1029,7 +1009,6 @@ mod tests {
                 cmd: shlex_split_safe("rg --files"),
                 query: None,
                 path: None,
-                files_only: true,
             }],
         );
     }
@@ -1072,14 +1051,12 @@ mod tests {
 
     #[test]
     fn fd_file_finder_variants() {
-        // fd with only a path should set files_only and capture the path
         assert_parsed(
             &shlex_split_safe("fd -t f src/"),
             vec![ParsedCommand::Search {
                 cmd: shlex_split_safe("fd -t f src/"),
                 query: None,
                 path: Some("src".to_string()),
-                files_only: true,
             }],
         );
 
@@ -1090,7 +1067,6 @@ mod tests {
                 cmd: shlex_split_safe("fd main src"),
                 query: Some("main".to_string()),
                 path: Some("src".to_string()),
-                files_only: true,
             }],
         );
     }
@@ -1103,7 +1079,6 @@ mod tests {
                 cmd: shlex_split_safe("find . -name '*.rs'"),
                 query: Some("*.rs".to_string()),
                 path: Some(".".to_string()),
-                files_only: true,
             }],
         );
     }
@@ -1116,7 +1091,6 @@ mod tests {
                 cmd: shlex_split_safe("find src -type f"),
                 query: None,
                 path: Some("src".to_string()),
-                files_only: true,
             }],
         );
     }
@@ -1561,25 +1535,14 @@ fn parse_bash_lc_commands(
                                     }
                                 }
                             }
-                            ParsedCommand::Search {
-                                cmd,
-                                query,
-                                path,
-                                files_only,
-                            } => {
+                            ParsedCommand::Search { cmd, query, path } => {
                                 if had_connectors {
-                                    ParsedCommand::Search {
-                                        cmd,
-                                        query,
-                                        path,
-                                        files_only,
-                                    }
+                                    ParsedCommand::Search { cmd, query, path }
                                 } else {
                                     ParsedCommand::Search {
                                         cmd: script_tokens.clone(),
                                         query,
                                         path,
-                                        files_only,
                                     }
                                 }
                             }
@@ -1823,34 +1786,24 @@ fn summarize_main_tokens(main_cmd: &[String]) -> ParsedCommand {
         }
         Some((head, tail)) if head == "rg" => {
             let args_no_connector = trim_at_connector(tail);
-            let files_only = args_no_connector.iter().any(|a| a == "--files");
             let non_flags: Vec<&String> = args_no_connector
                 .iter()
                 .filter(|p| !p.starts_with('-'))
                 .collect();
-            let (query, path) = if files_only {
-                let p = non_flags.first().map(|s| short_display_path(s));
-                (None, p)
-            } else {
-                let q = non_flags.first().cloned().map(|s| s.to_string());
-                let p = non_flags.get(1).map(|s| short_display_path(s));
-                (q, p)
-            };
+            let query = non_flags.first().cloned().map(|s| s.to_string());
+            let path = non_flags.get(1).map(|s| short_display_path(s));
             ParsedCommand::Search {
                 cmd: main_cmd.to_vec(),
                 query,
                 path,
-                files_only,
             }
         }
         Some((head, tail)) if head == "fd" => {
-            // fd is a file finder; treat results as files_only
             let (query, path) = parse_fd_query_and_path(tail);
             ParsedCommand::Search {
                 cmd: main_cmd.to_vec(),
                 query,
                 path,
-                files_only: true,
             }
         }
         Some((head, tail)) if head == "find" => {
@@ -1860,7 +1813,6 @@ fn summarize_main_tokens(main_cmd: &[String]) -> ParsedCommand {
                 cmd: main_cmd.to_vec(),
                 query,
                 path,
-                files_only: true,
             }
         }
         Some((head, tail)) if head == "grep" => {
@@ -1877,7 +1829,6 @@ fn summarize_main_tokens(main_cmd: &[String]) -> ParsedCommand {
                 cmd: main_cmd.to_vec(),
                 query,
                 path,
-                files_only: false,
             }
         }
         Some((head, tail)) if head == "cat" => {

--- a/codex-rs/core/src/parse_command.rs
+++ b/codex-rs/core/src/parse_command.rs
@@ -1,0 +1,1468 @@
+use crate::bash::try_parse_bash;
+use crate::bash::try_parse_word_only_commands_sequence;
+use serde::Deserialize;
+use serde::Serialize;
+use shlex::split as shlex_split;
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+pub enum ParsedCommand {
+    Read {
+        cmd: Vec<String>,
+        name: String,
+    },
+    Ls {
+        cmd: Vec<String>,
+        path: Option<String>,
+    },
+    Search {
+        cmd: Vec<String>,
+        query: Option<String>,
+        path: Option<String>,
+        files_only: bool,
+    },
+    Format {
+        cmd: Vec<String>,
+        tool: Option<String>,
+        targets: Option<Vec<String>>,
+    },
+    Test {
+        cmd: Vec<String>,
+        runner: Option<String>,
+        test_filter: Option<Vec<String>>,
+    },
+    Lint {
+        cmd: Vec<String>,
+        tool: Option<String>,
+        targets: Option<Vec<String>>,
+    },
+    Unknown {
+        cmd: Vec<String>,
+    },
+}
+
+pub fn parse_command(command: &[String]) -> Vec<ParsedCommand> {
+    let normalized = normalize_tokens(command);
+
+    if let Some(commands) = parse_bash_lc_commands(command, &normalized) {
+        return commands;
+    }
+
+    let parts = if contains_connectors(&normalized) {
+        split_on_connectors(&normalized)
+    } else {
+        vec![normalized.clone()]
+    };
+
+    // Map each pipeline segment to its parsed summary.
+    let mut parsed: Vec<ParsedCommand> = parts
+        .iter()
+        .map(|tokens| summarize_main_tokens(tokens))
+        .collect();
+
+    // If a pipeline ends with `nl` using only flags (e.g., `| nl -ba`), drop it so the
+    // main action (e.g., a sed range over a file) is surfaced cleanly.
+    if parsed.len() >= 2 {
+        parsed.retain(|pc| {
+            match pc {
+                ParsedCommand::Unknown { cmd } => {
+                    if let Some(first) = cmd.first() {
+                        if first == "nl" {
+                            // Treat `nl` without an explicit file operand as formatting-only.
+                            return cmd.iter().skip(1).any(|a| !a.starts_with('-'));
+                        }
+                    }
+                    true
+                }
+                _ => true,
+            }
+        });
+    }
+
+    parsed
+}
+
+/// Validates that this is a `sed -n 123,123p` command.
+fn is_valid_sed_n_arg(arg: Option<&str>) -> bool {
+    let s = match arg {
+        Some(s) => s,
+        None => return false,
+    };
+    let core = match s.strip_suffix('p') {
+        Some(rest) => rest,
+        None => return false,
+    };
+    let parts: Vec<&str> = core.split(',').collect();
+    match parts.as_slice() {
+        [num] => !num.is_empty() && num.chars().all(|c| c.is_ascii_digit()),
+        [a, b] => {
+            !a.is_empty()
+                && !b.is_empty()
+                && a.chars().all(|c| c.is_ascii_digit())
+                && b.chars().all(|c| c.is_ascii_digit())
+        }
+        _ => false,
+    }
+}
+
+/// Normalize a command by:
+/// - Removing `yes`/`no`/`bash -c`/`bash -lc` prefixes.
+/// - Splitting on `|` and `&&`/`||`/`;
+fn normalize_tokens(cmd: &[String]) -> Vec<String> {
+    match cmd {
+        [first, pipe, rest @ ..] if (first == "yes" || first == "y") && pipe == "|" => {
+            let s = rest.join(" ");
+            shlex_split(&s).unwrap_or_else(|| rest.to_vec())
+        }
+        [first, pipe, rest @ ..] if (first == "no" || first == "n") && pipe == "|" => {
+            let s = rest.join(" ");
+            shlex_split(&s).unwrap_or_else(|| rest.to_vec())
+        }
+        [bash, flag, script] if bash == "bash" && (flag == "-c" || flag == "-lc") => {
+            shlex_split(script)
+                .unwrap_or_else(|| vec!["bash".to_string(), flag.clone(), script.clone()])
+        }
+        _ => cmd.to_vec(),
+    }
+}
+
+fn contains_connectors(tokens: &[String]) -> bool {
+    tokens
+        .iter()
+        .any(|t| t == "&&" || t == "||" || t == "|" || t == ";")
+}
+
+fn split_on_connectors(tokens: &[String]) -> Vec<Vec<String>> {
+    let mut out: Vec<Vec<String>> = Vec::new();
+    let mut cur: Vec<String> = Vec::new();
+    for t in tokens {
+        if t == "&&" || t == "||" || t == "|" || t == ";" {
+            if !cur.is_empty() {
+                out.push(std::mem::take(&mut cur));
+            }
+        } else {
+            cur.push(t.clone());
+        }
+    }
+    if !cur.is_empty() {
+        out.push(cur);
+    }
+    out
+}
+
+fn trim_at_connector(tokens: &[String]) -> Vec<String> {
+    let idx = tokens
+        .iter()
+        .position(|t| t == "|" || t == "&&" || t == "||")
+        .unwrap_or(tokens.len());
+    tokens[..idx].to_vec()
+}
+
+/// Shorten a path to the last component, excluding `build`/`dist`/`node_modules`/`src`.
+/// It also pulls out a useful path from a directory such as:
+/// - webview/src -> webview
+/// - foo/src/ -> foo
+/// - packages/app/node_modules/ -> app
+fn short_display_path(path: &str) -> String {
+    let mut parts = path.split('/').rev().filter(|p| {
+        !p.is_empty() && *p != "build" && *p != "dist" && *p != "node_modules" && *p != "src"
+    });
+    parts
+        .next()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| path.to_string())
+}
+
+fn collect_non_flag_targets(args: &[String]) -> Option<Vec<String>> {
+    let mut targets = Vec::new();
+    let mut skip_next = false;
+    for (i, a) in args.iter().enumerate() {
+        if a == "--" {
+            break;
+        }
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if a == "-p"
+            || a == "--package"
+            || a == "--features"
+            || a == "-C"
+            || a == "--config"
+            || a == "--config-path"
+            || a == "--out-dir"
+            || a == "-o"
+            || a == "--run"
+            || a == "--max-warnings"
+            || a == "--format"
+        {
+            if i + 1 < args.len() {
+                skip_next = true;
+            }
+            continue;
+        }
+        if a.starts_with('-') {
+            continue;
+        }
+        targets.push(a.clone());
+    }
+    if targets.is_empty() {
+        None
+    } else {
+        Some(targets)
+    }
+}
+
+fn parse_cargo_test_filter(args: &[String]) -> Option<Vec<String>> {
+    let mut out: Vec<String> = Vec::new();
+    let mut skip_next = false;
+    for (i, a) in args.iter().enumerate() {
+        if a == "--" {
+            break;
+        }
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if a == "-p" || a == "--package" {
+            if let Some(val) = args.get(i + 1) {
+                out.push(val.clone());
+            }
+            if i + 1 < args.len() {
+                skip_next = true;
+            }
+            continue;
+        }
+        if let Some(rest) = a.strip_prefix("--package=") {
+            if !rest.is_empty() {
+                out.push(rest.to_string());
+            }
+            continue;
+        }
+        if a == "--features" {
+            if i + 1 < args.len() {
+                skip_next = true;
+            }
+            continue;
+        }
+        if a.starts_with('-') {
+            continue;
+        }
+        out.push(a.clone());
+    }
+    if out.is_empty() { None } else { Some(out) }
+}
+
+fn parse_pytest_filters(args: &[String]) -> Option<Vec<String>> {
+    let mut out: Vec<String> = Vec::new();
+    let mut next_is_k = false;
+    for a in args {
+        if next_is_k {
+            out.push(a.clone());
+            next_is_k = false;
+            continue;
+        }
+        if a == "-k" || a == "--keyword" {
+            next_is_k = true;
+            continue;
+        }
+        if !a.starts_with('-') && (a.ends_with(".py") || a.contains("::")) {
+            out.push(a.clone());
+        }
+    }
+    if out.is_empty() { None } else { Some(out) }
+}
+
+fn parse_jest_vitest_filters(args: &[String]) -> Option<Vec<String>> {
+    let mut out: Vec<String> = Vec::new();
+    let mut next_is_t = false;
+    for a in args {
+        if next_is_t {
+            out.push(a.clone());
+            next_is_t = false;
+            continue;
+        }
+        if a == "-t" || a == "--testNamePattern" {
+            next_is_t = true;
+            continue;
+        }
+        if !a.starts_with('-')
+            && (a.ends_with(".ts")
+                || a.ends_with(".tsx")
+                || a.ends_with(".js")
+                || a.ends_with(".jsx"))
+        {
+            out.push(a.clone());
+        }
+    }
+    if out.is_empty() { None } else { Some(out) }
+}
+
+fn parse_go_test_filters(args: &[String]) -> Option<Vec<String>> {
+    let mut out: Vec<String> = Vec::new();
+    let mut next_is_run = false;
+    for a in args {
+        if next_is_run {
+            out.push(a.clone());
+            next_is_run = false;
+            continue;
+        }
+        if a == "-run" {
+            next_is_run = true;
+            continue;
+        }
+    }
+    if out.is_empty() { None } else { Some(out) }
+}
+
+fn classify_npm_like(tool: &str, tail: &[String], full_cmd: &[String]) -> Option<ParsedCommand> {
+    let mut r = tail;
+    if tool == "pnpm" && r.first().map(|s| s.as_str()) == Some("-r") {
+        r = &r[1..];
+    }
+    let mut script_name: Option<String> = None;
+    if r.first().map(|s| s.as_str()) == Some("run") {
+        script_name = r.get(1).cloned();
+    } else {
+        let is_test_cmd = (tool == "npm" && r.first().map(|s| s.as_str()) == Some("t"))
+            || ((tool == "npm" || tool == "pnpm" || tool == "yarn")
+                && r.first().map(|s| s.as_str()) == Some("test"));
+        if is_test_cmd {
+            script_name = Some("test".to_string());
+        }
+    }
+    if let Some(name) = script_name {
+        let lname = name.to_lowercase();
+        if lname == "test" || lname == "unit" || lname == "jest" || lname == "vitest" {
+            return Some(ParsedCommand::Test {
+                cmd: full_cmd.to_vec(),
+                runner: Some(format!("{tool}-script")),
+                test_filter: None,
+            });
+        }
+        if lname == "lint" || lname == "eslint" {
+            return Some(ParsedCommand::Lint {
+                cmd: full_cmd.to_vec(),
+                tool: Some(format!("{tool}-script:{name}")),
+                targets: None,
+            });
+        }
+        if lname == "format" || lname == "fmt" || lname == "prettier" {
+            return Some(ParsedCommand::Format {
+                cmd: full_cmd.to_vec(),
+                tool: Some(format!("{tool}-script:{name}")),
+                targets: None,
+            });
+        }
+    }
+    None
+}
+
+fn parse_bash_lc_commands(
+    original: &[String],
+    normalized: &[String],
+) -> Option<Vec<ParsedCommand>> {
+    let [bash, flag, script] = original else {
+        return None;
+    };
+    if bash != "bash" || flag != "-lc" {
+        return None;
+    }
+    if let Some(tree) = try_parse_bash(script) {
+        if let Some(all_commands) = try_parse_word_only_commands_sequence(&tree, script) {
+            if !all_commands.is_empty() {
+                let script_tokens = shlex_split(script)
+                    .unwrap_or_else(|| vec!["bash".to_string(), flag.clone(), script.clone()]);
+                // Strip small formatting helpers (e.g., head/tail/awk/wc/etc) so we
+                // bias toward the primary command when pipelines are present.
+                // First, drop obvious small formatting helpers (e.g., wc/awk/etc).
+                let filtered_commands = drop_small_formatting_commands(all_commands);
+                if filtered_commands.is_empty() {
+                    return Some(vec![ParsedCommand::Unknown {
+                        cmd: normalized.to_vec(),
+                    }]);
+                }
+                let mut commands: Vec<ParsedCommand> = filtered_commands
+                    .into_iter()
+                    .map(|tokens| match summarize_main_tokens(&tokens) {
+                        ParsedCommand::Ls { path, .. } => ParsedCommand::Ls {
+                            cmd: script_tokens.clone(),
+                            path,
+                        },
+                        other => other,
+                    })
+                    .collect();
+                commands = maybe_collapse_cat_sed(commands, &script_tokens);
+                if commands.len() == 1 {
+                    // If we reduced to a single command, attribute the full original script
+                    // for clearer UX in file-reading and listing scenarios, or when there were
+                    // no connectors in the original script. For search commands that came from
+                    // a pipeline (e.g. `rg --files | sed -n`), keep only the primary command.
+                    let had_connectors = script_tokens
+                        .iter()
+                        .any(|t| t == "|" || t == "&&" || t == "||" || t == ";");
+                    commands = commands
+                        .into_iter()
+                        .map(|pc| match pc {
+                            ParsedCommand::Read { name, .. } => ParsedCommand::Read {
+                                cmd: script_tokens.clone(),
+                                name,
+                            },
+                            ParsedCommand::Ls { path, .. } => ParsedCommand::Ls {
+                                cmd: script_tokens.clone(),
+                                path,
+                            },
+                            ParsedCommand::Search {
+                                cmd,
+                                query,
+                                path,
+                                files_only,
+                            } => {
+                                if had_connectors {
+                                    ParsedCommand::Search {
+                                        cmd,
+                                        query,
+                                        path,
+                                        files_only,
+                                    }
+                                } else {
+                                    ParsedCommand::Search {
+                                        cmd: script_tokens.clone(),
+                                        query,
+                                        path,
+                                        files_only,
+                                    }
+                                }
+                            }
+                            ParsedCommand::Format { tool, targets, .. } => ParsedCommand::Format {
+                                cmd: script_tokens.clone(),
+                                tool,
+                                targets,
+                            },
+                            ParsedCommand::Test {
+                                runner,
+                                test_filter,
+                                ..
+                            } => ParsedCommand::Test {
+                                cmd: script_tokens.clone(),
+                                runner,
+                                test_filter,
+                            },
+                            ParsedCommand::Lint { tool, targets, .. } => ParsedCommand::Lint {
+                                cmd: script_tokens.clone(),
+                                tool,
+                                targets,
+                            },
+                            ParsedCommand::Unknown { .. } => ParsedCommand::Unknown {
+                                cmd: script_tokens.clone(),
+                            },
+                        })
+                        .collect();
+                }
+                return Some(commands);
+            }
+        }
+    }
+    Some(vec![ParsedCommand::Unknown {
+        cmd: normalized.to_vec(),
+    }])
+}
+
+/// Return true if this looks like a small formatting helper in a pipeline.
+/// Examples: `head -n 40`, `tail -n +10`, `wc -l`, `awk ...`, `cut ...`, `tr ...`.
+/// We try to keep variants that clearly include a file path (e.g. `tail -n 30 file`).
+fn is_small_formatting_command(tokens: &[String]) -> bool {
+    if tokens.is_empty() {
+        return false;
+    }
+    let cmd = tokens[0].as_str();
+    match cmd {
+        // Always formatting; typically used in pipes.
+        // `nl` is special-cased below to allow `nl <file>` to be treated as a read command.
+        "wc" | "tr" | "cut" | "sort" | "uniq" | "xargs" | "tee" | "column" | "awk" | "yes"
+        | "printf" => true,
+        "head" => {
+            // Treat as formatting when no explicit file operand is present.
+            // Common forms: `head -n 40`, `head -c 100`.
+            // Keep cases like `head -n 40 file`.
+            tokens.len() < 3
+        }
+        "tail" => {
+            // Treat as formatting when no explicit file operand is present.
+            // Common forms: `tail -n +10`, `tail -n 30`.
+            // Keep cases like `tail -n 30 file`.
+            tokens.len() < 3
+        }
+        "sed" => {
+            // Keep `sed -n <range> file` (treated as a file read elsewhere);
+            // otherwise consider it a formatting helper in a pipeline.
+            tokens.len() < 4
+                || !(tokens[1] == "-n" && is_valid_sed_n_arg(tokens.get(2).map(|s| s.as_str())))
+        }
+        _ => false,
+    }
+}
+
+fn drop_small_formatting_commands(mut commands: Vec<Vec<String>>) -> Vec<Vec<String>> {
+    commands.retain(|tokens| !is_small_formatting_command(tokens));
+    commands
+}
+
+fn maybe_collapse_cat_sed(
+    commands: Vec<ParsedCommand>,
+    script_tokens: &[String],
+) -> Vec<ParsedCommand> {
+    if commands.len() < 2 {
+        return commands;
+    }
+    let drop_leading_sed = match (&commands[0], &commands[1]) {
+        (ParsedCommand::Unknown { cmd: sed_cmd }, ParsedCommand::Read { cmd: cat_cmd, .. }) => {
+            let is_sed_n = sed_cmd.first().map(|s| s.as_str()) == Some("sed")
+                && sed_cmd.get(1).map(|s| s.as_str()) == Some("-n")
+                && is_valid_sed_n_arg(sed_cmd.get(2).map(|s| s.as_str()))
+                && sed_cmd.len() == 3;
+            let is_cat_file =
+                cat_cmd.first().map(|s| s.as_str()) == Some("cat") && cat_cmd.len() == 2;
+            is_sed_n && is_cat_file
+        }
+        _ => false,
+    };
+    if drop_leading_sed {
+        if let ParsedCommand::Read { name, .. } = &commands[1] {
+            return vec![ParsedCommand::Read {
+                cmd: script_tokens.to_vec(),
+                name: name.clone(),
+            }];
+        }
+    }
+    commands
+}
+
+fn summarize_main_tokens(main_cmd: &[String]) -> ParsedCommand {
+    match main_cmd.split_first() {
+        // sed -n '<range>' <file> | ...  -> treat as a search targeting <file>.
+        // This is commonly used with `nl -ba` in a pipeline for line numbering.
+        Some((head, tail)) if head == "sed" => {
+            if tail.get(0).map(|s| s.as_str()) == Some("-n")
+                && is_valid_sed_n_arg(tail.get(1).map(|s| s.as_str()))
+                && tail.len() >= 3
+            {
+                // Use the last non-flag argument as the file operand.
+                let file = tail.iter().rev().find(|s| !s.starts_with('-')).cloned();
+                if let Some(p) = file {
+                    return ParsedCommand::Search {
+                        cmd: main_cmd.to_vec(),
+                        query: None,
+                        path: Some(short_display_path(&p)),
+                        files_only: false,
+                    };
+                }
+            }
+            ParsedCommand::Unknown {
+                cmd: main_cmd.to_vec(),
+            }
+        }
+        Some((head, tail)) if head == "nl" => {
+            let path = tail.iter().find(|p| !p.starts_with('-'));
+            if let Some(p) = path {
+                let name = short_display_path(p);
+                ParsedCommand::Read {
+                    cmd: main_cmd.to_vec(),
+                    name,
+                }
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: main_cmd.to_vec(),
+                }
+            }
+        }
+        Some((head, tail))
+            if head == "cargo" && tail.first().map(|s| s.as_str()) == Some("fmt") =>
+        {
+            ParsedCommand::Format {
+                cmd: main_cmd.to_vec(),
+                tool: Some("cargo fmt".to_string()),
+                targets: collect_non_flag_targets(&tail[1..]),
+            }
+        }
+        Some((head, tail))
+            if head == "cargo" && tail.first().map(|s| s.as_str()) == Some("clippy") =>
+        {
+            ParsedCommand::Lint {
+                cmd: main_cmd.to_vec(),
+                tool: Some("cargo clippy".to_string()),
+                targets: collect_non_flag_targets(&tail[1..]),
+            }
+        }
+        Some((head, tail))
+            if head == "cargo" && tail.first().map(|s| s.as_str()) == Some("test") =>
+        {
+            ParsedCommand::Test {
+                cmd: main_cmd.to_vec(),
+                runner: Some("cargo".to_string()),
+                test_filter: parse_cargo_test_filter(&tail[1..]),
+            }
+        }
+        Some((head, tail)) if head == "rustfmt" => ParsedCommand::Format {
+            cmd: main_cmd.to_vec(),
+            tool: Some("rustfmt".to_string()),
+            targets: collect_non_flag_targets(tail),
+        },
+        Some((head, tail)) if head == "go" && tail.first().map(|s| s.as_str()) == Some("fmt") => {
+            ParsedCommand::Format {
+                cmd: main_cmd.to_vec(),
+                tool: Some("go fmt".to_string()),
+                targets: collect_non_flag_targets(&tail[1..]),
+            }
+        }
+        Some((head, tail)) if head == "go" && tail.first().map(|s| s.as_str()) == Some("test") => {
+            ParsedCommand::Test {
+                cmd: main_cmd.to_vec(),
+                runner: Some("go".to_string()),
+                test_filter: parse_go_test_filters(&tail[1..]),
+            }
+        }
+        Some((head, tail)) if head == "pytest" => ParsedCommand::Test {
+            cmd: main_cmd.to_vec(),
+            runner: Some("pytest".to_string()),
+            test_filter: parse_pytest_filters(tail),
+        },
+        Some((head, tail)) if head == "eslint" => ParsedCommand::Lint {
+            cmd: main_cmd.to_vec(),
+            tool: Some("eslint".to_string()),
+            targets: collect_non_flag_targets(tail),
+        },
+        Some((head, tail)) if head == "prettier" => ParsedCommand::Format {
+            cmd: main_cmd.to_vec(),
+            tool: Some("prettier".to_string()),
+            targets: collect_non_flag_targets(tail),
+        },
+        Some((head, tail)) if head == "black" => ParsedCommand::Format {
+            cmd: main_cmd.to_vec(),
+            tool: Some("black".to_string()),
+            targets: collect_non_flag_targets(tail),
+        },
+        Some((head, tail))
+            if head == "ruff" && tail.first().map(|s| s.as_str()) == Some("check") =>
+        {
+            ParsedCommand::Lint {
+                cmd: main_cmd.to_vec(),
+                tool: Some("ruff".to_string()),
+                targets: collect_non_flag_targets(&tail[1..]),
+            }
+        }
+        Some((head, tail))
+            if head == "ruff" && tail.first().map(|s| s.as_str()) == Some("format") =>
+        {
+            ParsedCommand::Format {
+                cmd: main_cmd.to_vec(),
+                tool: Some("ruff".to_string()),
+                targets: collect_non_flag_targets(&tail[1..]),
+            }
+        }
+        Some((head, tail)) if (head == "jest" || head == "vitest") => ParsedCommand::Test {
+            cmd: main_cmd.to_vec(),
+            runner: Some(head.clone()),
+            test_filter: parse_jest_vitest_filters(tail),
+        },
+        Some((head, tail))
+            if head == "npx" && tail.first().map(|s| s.as_str()) == Some("eslint") =>
+        {
+            ParsedCommand::Lint {
+                cmd: main_cmd.to_vec(),
+                tool: Some("eslint".to_string()),
+                targets: collect_non_flag_targets(&tail[1..]),
+            }
+        }
+        Some((head, tail))
+            if head == "npx" && tail.first().map(|s| s.as_str()) == Some("prettier") =>
+        {
+            ParsedCommand::Format {
+                cmd: main_cmd.to_vec(),
+                tool: Some("prettier".to_string()),
+                targets: collect_non_flag_targets(&tail[1..]),
+            }
+        }
+        // NPM-like scripts including yarn
+        Some((tool, tail)) if (tool == "pnpm" || tool == "npm" || tool == "yarn") => {
+            if let Some(cmd) = classify_npm_like(tool, tail, main_cmd) {
+                cmd
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: main_cmd.to_vec(),
+                }
+            }
+        }
+        Some((head, tail)) if head == "ls" => {
+            let path = tail
+                .iter()
+                .find(|p| !p.starts_with('-'))
+                .map(|p| short_display_path(p));
+            ParsedCommand::Ls {
+                cmd: main_cmd.to_vec(),
+                path,
+            }
+        }
+        Some((head, tail)) if head == "rg" => {
+            let args_no_connector = trim_at_connector(tail);
+            let files_only = args_no_connector.iter().any(|a| a == "--files");
+            let non_flags: Vec<&String> = args_no_connector
+                .iter()
+                .filter(|p| !p.starts_with('-'))
+                .collect();
+            let (query, path) = if files_only {
+                let p = non_flags.first().map(|s| short_display_path(s));
+                (None, p)
+            } else {
+                let q = non_flags.first().map(|s| short_display_path(s));
+                let p = non_flags.get(1).map(|s| short_display_path(s));
+                (q, p)
+            };
+            ParsedCommand::Search {
+                cmd: main_cmd.to_vec(),
+                query,
+                path,
+                files_only,
+            }
+        }
+        Some((head, tail)) if head == "grep" => {
+            let args_no_connector = trim_at_connector(tail);
+            let non_flags: Vec<&String> = args_no_connector
+                .iter()
+                .filter(|p| !p.starts_with('-'))
+                .collect();
+            let query = non_flags.first().map(|s| short_display_path(s));
+            let path = non_flags.get(1).map(|s| short_display_path(s));
+            ParsedCommand::Search {
+                cmd: main_cmd.to_vec(),
+                query,
+                path,
+                files_only: false,
+            }
+        }
+        Some((head, tail)) if head == "cat" => {
+            // Support both `cat <file>` and `cat -- <file>` forms.
+            let effective_tail: &[String] = if tail.first().map(|s| s.as_str()) == Some("--") {
+                &tail[1..]
+            } else {
+                tail
+            };
+            if effective_tail.len() == 1 {
+                let name = short_display_path(&effective_tail[0]);
+                ParsedCommand::Read {
+                    cmd: main_cmd.to_vec(),
+                    name,
+                }
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: main_cmd.to_vec(),
+                }
+            }
+        }
+        Some((head, tail))
+            if head == "head"
+                && tail.len() >= 3
+                && tail[0] == "-n"
+                && tail[1].chars().all(|c| c.is_ascii_digit()) =>
+        {
+            let name = short_display_path(&tail[2]);
+            ParsedCommand::Read {
+                cmd: main_cmd.to_vec(),
+                name,
+            }
+        }
+        Some((head, tail))
+            if head == "tail" && tail.len() >= 3 && tail[0] == "-n" && {
+                let n = &tail[1];
+                let s = n.strip_prefix('+').unwrap_or(n);
+                !s.is_empty() && s.chars().all(|c| c.is_ascii_digit())
+            } =>
+        {
+            let name = short_display_path(&tail[2]);
+            ParsedCommand::Read {
+                cmd: main_cmd.to_vec(),
+                name,
+            }
+        }
+        Some((head, tail))
+            if head == "sed"
+                && tail.len() >= 3
+                && tail[0] == "-n"
+                && is_valid_sed_n_arg(tail.get(1).map(|s| s.as_str())) =>
+        {
+            if let Some(path) = tail.get(2) {
+                let name = short_display_path(path);
+                ParsedCommand::Read {
+                    cmd: main_cmd.to_vec(),
+                    name,
+                }
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: main_cmd.to_vec(),
+                }
+            }
+        }
+        // Other commands
+        _ => ParsedCommand::Unknown {
+            cmd: main_cmd.to_vec(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #![allow(clippy::unwrap_used)]
+    use super::*;
+
+    fn vec_str(args: &[&str]) -> Vec<String> {
+        args.iter().map(|s| s.to_string()).collect()
+    }
+
+    fn assert_parsed(args: &[String], expected: Vec<ParsedCommand>) {
+        let out = parse_command(args);
+        assert_eq!(out, expected);
+    }
+
+    #[test]
+    fn git_status_is_unknown() {
+        assert_parsed(
+            &vec_str(&["git", "status"]),
+            vec![ParsedCommand::Unknown {
+                cmd: vec_str(&["git", "status"]),
+            }],
+        );
+    }
+
+    #[test]
+    fn handles_complex_bash_command_head() {
+        let inner =
+            "rg --version && node -v && pnpm -v && rg --files | wc -l && rg --files | head -n 40";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![
+                ParsedCommand::Unknown {
+                    cmd: vec_str(&["head", "-n", "40"]),
+                },
+                ParsedCommand::Search {
+                    cmd: vec_str(&["rg", "--files"]),
+                    query: None,
+                    path: None,
+                    files_only: true,
+                },
+                ParsedCommand::Search {
+                    cmd: vec_str(&["rg", "--files"]),
+                    query: None,
+                    path: None,
+                    files_only: true,
+                },
+                ParsedCommand::Unknown {
+                    cmd: vec_str(&["pnpm", "-v"]),
+                },
+                ParsedCommand::Unknown {
+                    cmd: vec_str(&["node", "-v"]),
+                },
+                ParsedCommand::Search {
+                    cmd: vec_str(&["rg", "--version"]),
+                    query: None,
+                    path: None,
+                    files_only: false,
+                },
+            ],
+        );
+    }
+
+    #[test]
+    fn supports_searching_for_navigate_to_route() {
+        let inner = "rg -n \"navigate-to-route\" -S";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Search {
+                cmd: shlex_split(inner).unwrap(),
+                query: Some("navigate-to-route".to_string()),
+                path: None,
+                files_only: false,
+            }],
+        );
+    }
+
+    #[test]
+    fn handles_complex_bash_command() {
+        let inner = "rg -n \"BUG|FIXME|TODO|XXX|HACK\" -S | head -n 200";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![
+                ParsedCommand::Unknown {
+                    cmd: vec_str(&["head", "-n", "200"]),
+                },
+                ParsedCommand::Search {
+                    cmd: vec_str(&["rg", "-n", "BUG|FIXME|TODO|XXX|HACK", "-S"]),
+                    query: Some("BUG|FIXME|TODO|XXX|HACK".to_string()),
+                    path: None,
+                    files_only: false,
+                },
+            ],
+        );
+    }
+
+    #[test]
+    fn supports_rg_files_with_path_and_pipe() {
+        let inner = "rg --files webview/src | sed -n";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Search {
+                cmd: vec_str(&["rg", "--files", "webview/src"]),
+                query: None,
+                path: Some("webview".to_string()),
+                files_only: true,
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_rg_files_then_head() {
+        let inner = "rg --files | head -n 50";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![
+                ParsedCommand::Unknown {
+                    cmd: vec_str(&["head", "-n", "50"]),
+                },
+                ParsedCommand::Search {
+                    cmd: vec_str(&["rg", "--files"]),
+                    query: None,
+                    path: None,
+                    files_only: true,
+                },
+            ],
+        );
+    }
+
+    #[test]
+    fn supports_cat() {
+        let inner = "cat webview/README.md";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: shlex_split(inner).unwrap(),
+                name: "README.md".to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_ls_with_pipe() {
+        let inner = "ls -la | sed -n '1,120p'";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Ls {
+                cmd: shlex_split(inner).unwrap(),
+                path: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_head_n() {
+        let inner = "head -n 50 Cargo.toml";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: shlex_split(inner).unwrap(),
+                name: "Cargo.toml".to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_cat_sed_n() {
+        let inner = "cat tui/Cargo.toml | sed -n '1,200p'";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: shlex_split(inner).unwrap(),
+                name: "Cargo.toml".to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_tail_n_plus() {
+        let inner = "tail -n +522 README.md";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: shlex_split(inner).unwrap(),
+                name: "README.md".to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_tail_n_last_lines() {
+        let inner = "tail -n 30 README.md";
+        let out = parse_command(&vec_str(&["bash", "-lc", inner]));
+        assert_eq!(
+            out,
+            vec![ParsedCommand::Read {
+                cmd: shlex_split(inner).unwrap(),
+                name: "README.md".to_string(),
+            }]
+        );
+    }
+
+    #[test]
+    fn supports_npm_run_build_is_unknown() {
+        assert_parsed(
+            &vec_str(&["npm", "run", "build"]),
+            vec![ParsedCommand::Unknown {
+                cmd: vec_str(&["npm", "run", "build"]),
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_npm_run_with_forwarded_args() {
+        assert_parsed(
+            &vec_str(&[
+                "npm",
+                "run",
+                "lint",
+                "--",
+                "--max-warnings",
+                "0",
+                "--format",
+                "json",
+            ]),
+            vec![ParsedCommand::Lint {
+                cmd: vec_str(&[
+                    "npm",
+                    "run",
+                    "lint",
+                    "--",
+                    "--max-warnings",
+                    "0",
+                    "--format",
+                    "json",
+                ]),
+                tool: Some("npm-script:lint".to_string()),
+                targets: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_grep_recursive_current_dir() {
+        assert_parsed(
+            &vec_str(&["grep", "-R", "CODEX_SANDBOX_ENV_VAR", "-n", "."]),
+            vec![ParsedCommand::Search {
+                cmd: vec_str(&["grep", "-R", "CODEX_SANDBOX_ENV_VAR", "-n", "."]),
+                query: Some("CODEX_SANDBOX_ENV_VAR".to_string()),
+                path: Some(".".to_string()),
+                files_only: false,
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_grep_recursive_specific_file() {
+        assert_parsed(
+            &vec_str(&[
+                "grep",
+                "-R",
+                "CODEX_SANDBOX_ENV_VAR",
+                "-n",
+                "core/src/spawn.rs",
+            ]),
+            vec![ParsedCommand::Search {
+                cmd: vec_str(&[
+                    "grep",
+                    "-R",
+                    "CODEX_SANDBOX_ENV_VAR",
+                    "-n",
+                    "core/src/spawn.rs",
+                ]),
+                query: Some("CODEX_SANDBOX_ENV_VAR".to_string()),
+                path: Some("spawn.rs".to_string()),
+                files_only: false,
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_grep_weird_backtick_in_query() {
+        assert_parsed(
+            &vec_str(&["grep", "-R", "COD`EX_SANDBOX", "-n"]),
+            vec![ParsedCommand::Search {
+                cmd: vec_str(&["grep", "-R", "COD`EX_SANDBOX", "-n"]),
+                query: Some("COD`EX_SANDBOX".to_string()),
+                path: None,
+                files_only: false,
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_cd_and_rg_files() {
+        assert_parsed(
+            &vec_str(&["cd", "codex-rs", "&&", "rg", "--files"]),
+            vec![
+                ParsedCommand::Unknown {
+                    cmd: vec_str(&["cd", "codex-rs"]),
+                },
+                ParsedCommand::Search {
+                    cmd: vec_str(&["rg", "--files"]),
+                    query: None,
+                    path: None,
+                    files_only: true,
+                },
+            ],
+        );
+    }
+
+    #[test]
+    fn supports_cargo_fmt_and_test_with_config() {
+        assert_parsed(
+            &vec_str(&[
+                "cargo",
+                "fmt",
+                "--",
+                "--config",
+                "imports_granularity=Item",
+                "&&",
+                "cargo",
+                "test",
+                "-p",
+                "core",
+                "--all-features",
+            ]),
+            vec![
+                ParsedCommand::Format {
+                    cmd: vec_str(&["cargo", "fmt", "--", "--config", "imports_granularity=Item"]),
+                    tool: Some("cargo fmt".to_string()),
+                    targets: None,
+                },
+                ParsedCommand::Test {
+                    cmd: vec_str(&["cargo", "test", "-p", "core", "--all-features"]),
+                    runner: Some("cargo".to_string()),
+                    test_filter: Some(vec!["core".to_string()]),
+                },
+            ],
+        );
+    }
+
+    #[test]
+    fn recognizes_rustfmt_and_clippy() {
+        assert_parsed(
+            &vec_str(&["rustfmt", "src/main.rs"]),
+            vec![ParsedCommand::Format {
+                cmd: vec_str(&["rustfmt", "src/main.rs"]),
+                tool: Some("rustfmt".to_string()),
+                targets: Some(vec!["src/main.rs".to_string()]),
+            }],
+        );
+
+        assert_parsed(
+            &vec_str(&[
+                "cargo",
+                "clippy",
+                "-p",
+                "core",
+                "--all-features",
+                "--",
+                "-D",
+                "warnings",
+            ]),
+            vec![ParsedCommand::Lint {
+                cmd: vec_str(&[
+                    "cargo",
+                    "clippy",
+                    "-p",
+                    "core",
+                    "--all-features",
+                    "--",
+                    "-D",
+                    "warnings",
+                ]),
+                tool: Some("cargo clippy".to_string()),
+                targets: None,
+            }],
+        );
+    }
+
+    #[test]
+    fn recognizes_pytest_go_and_tools() {
+        assert_parsed(
+            &vec_str(&[
+                "pytest",
+                "-k",
+                "Login and not slow",
+                "tests/test_login.py::TestLogin::test_ok",
+            ]),
+            vec![ParsedCommand::Test {
+                cmd: vec_str(&[
+                    "pytest",
+                    "-k",
+                    "Login and not slow",
+                    "tests/test_login.py::TestLogin::test_ok",
+                ]),
+                runner: Some("pytest".to_string()),
+                test_filter: Some(vec![
+                    "Login and not slow".to_string(),
+                    "tests/test_login.py::TestLogin::test_ok".to_string(),
+                ]),
+            }],
+        );
+
+        assert_parsed(
+            &vec_str(&["go", "fmt", "./..."]),
+            vec![ParsedCommand::Format {
+                cmd: vec_str(&["go", "fmt", "./..."]),
+                tool: Some("go fmt".to_string()),
+                targets: Some(vec!["./...".to_string()]),
+            }],
+        );
+
+        assert_parsed(
+            &vec_str(&["go", "test", "./pkg", "-run", "TestThing"]),
+            vec![ParsedCommand::Test {
+                cmd: vec_str(&["go", "test", "./pkg", "-run", "TestThing"]),
+                runner: Some("go".to_string()),
+                test_filter: Some(vec!["TestThing".to_string()]),
+            }],
+        );
+
+        assert_parsed(
+            &vec_str(&["eslint", ".", "--max-warnings", "0"]),
+            vec![ParsedCommand::Lint {
+                cmd: vec_str(&["eslint", ".", "--max-warnings", "0"]),
+                tool: Some("eslint".to_string()),
+                targets: Some(vec![".".to_string()]),
+            }],
+        );
+
+        assert_parsed(
+            &vec_str(&["prettier", "-w", "."]),
+            vec![ParsedCommand::Format {
+                cmd: vec_str(&["prettier", "-w", "."]),
+                tool: Some("prettier".to_string()),
+                targets: Some(vec![".".to_string()]),
+            }],
+        );
+    }
+
+    #[test]
+    fn recognizes_jest_and_vitest_filters() {
+        assert_parsed(
+            &vec_str(&["jest", "-t", "should work", "src/foo.test.ts"]),
+            vec![ParsedCommand::Test {
+                cmd: vec_str(&["jest", "-t", "should work", "src/foo.test.ts"]),
+                runner: Some("jest".to_string()),
+                test_filter: Some(vec![
+                    "should work".to_string(),
+                    "src/foo.test.ts".to_string(),
+                ]),
+            }],
+        );
+
+        assert_parsed(
+            &vec_str(&["vitest", "-t", "runs", "src/foo.test.tsx"]),
+            vec![ParsedCommand::Test {
+                cmd: vec_str(&["vitest", "-t", "runs", "src/foo.test.tsx"]),
+                runner: Some("vitest".to_string()),
+                test_filter: Some(vec!["runs".to_string(), "src/foo.test.tsx".to_string()]),
+            }],
+        );
+    }
+
+    #[test]
+    fn recognizes_npx_and_scripts() {
+        assert_parsed(
+            &vec_str(&["npx", "eslint", "src"]),
+            vec![ParsedCommand::Lint {
+                cmd: vec_str(&["npx", "eslint", "src"]),
+                tool: Some("eslint".to_string()),
+                targets: Some(vec!["src".to_string()]),
+            }],
+        );
+
+        assert_parsed(
+            &vec_str(&["npx", "prettier", "-c", "."]),
+            vec![ParsedCommand::Format {
+                cmd: vec_str(&["npx", "prettier", "-c", "."]),
+                tool: Some("prettier".to_string()),
+                targets: Some(vec![".".to_string()]),
+            }],
+        );
+
+        assert_parsed(
+            &vec_str(&["pnpm", "run", "lint", "--", "--max-warnings", "0"]),
+            vec![ParsedCommand::Lint {
+                cmd: vec_str(&["pnpm", "run", "lint", "--", "--max-warnings", "0"]),
+                tool: Some("pnpm-script:lint".to_string()),
+                targets: None,
+            }],
+        );
+
+        assert_parsed(
+            &vec_str(&["npm", "test"]),
+            vec![ParsedCommand::Test {
+                cmd: vec_str(&["npm", "test"]),
+                runner: Some("npm-script".to_string()),
+                test_filter: None,
+            }],
+        );
+
+        assert_parsed(
+            &vec_str(&["yarn", "test"]),
+            vec![ParsedCommand::Test {
+                cmd: vec_str(&["yarn", "test"]),
+                runner: Some("yarn-script".to_string()),
+                test_filter: None,
+            }],
+        );
+    }
+
+    // ---- is_small_formatting_command unit tests ----
+    #[test]
+    fn small_formatting_always_true_commands() {
+        for cmd in [
+            "wc", "tr", "cut", "sort", "uniq", "xargs", "tee", "column", "awk",
+        ] {
+            assert!(is_small_formatting_command(&vec_str(&[cmd])));
+            assert!(is_small_formatting_command(&vec_str(&[cmd, "-x"])));
+        }
+    }
+
+    #[test]
+    fn head_behavior() {
+        // No args -> small formatting
+        assert!(is_small_formatting_command(&vec_str(&["head"])));
+        // Numeric count only -> not considered small formatting by implementation
+        assert!(!is_small_formatting_command(&vec_str(&[
+            "head", "-n", "40"
+        ])));
+        // With explicit file -> not small formatting
+        assert!(!is_small_formatting_command(&vec_str(&[
+            "head", "-n", "40", "file.txt"
+        ])));
+        // File only (no count) -> treated as small formatting by implementation
+        assert!(is_small_formatting_command(&vec_str(&["head", "file.txt"])));
+    }
+
+    #[test]
+    fn tail_behavior() {
+        // No args -> small formatting
+        assert!(is_small_formatting_command(&vec_str(&["tail"])));
+        // Numeric with plus offset -> not small formatting
+        assert!(!is_small_formatting_command(&vec_str(&[
+            "tail", "-n", "+10"
+        ])));
+        assert!(!is_small_formatting_command(&vec_str(&[
+            "tail", "-n", "+10", "file.txt"
+        ])));
+        // Numeric count
+        assert!(!is_small_formatting_command(&vec_str(&[
+            "tail", "-n", "30"
+        ])));
+        assert!(!is_small_formatting_command(&vec_str(&[
+            "tail", "-n", "30", "file.txt"
+        ])));
+        // File only -> small formatting by implementation
+        assert!(is_small_formatting_command(&vec_str(&["tail", "file.txt"])));
+    }
+
+    #[test]
+    fn sed_behavior() {
+        // Plain sed -> small formatting
+        assert!(is_small_formatting_command(&vec_str(&["sed"])));
+        // sed -n <range> (no file) -> still small formatting
+        assert!(is_small_formatting_command(&vec_str(&["sed", "-n", "10p"])));
+        // Valid range with file -> not small formatting
+        assert!(!is_small_formatting_command(&vec_str(&[
+            "sed", "-n", "10p", "file.txt"
+        ])));
+        assert!(!is_small_formatting_command(&vec_str(&[
+            "sed", "-n", "1,200p", "file.txt"
+        ])));
+        // Invalid ranges with file -> small formatting
+        assert!(is_small_formatting_command(&vec_str(&[
+            "sed", "-n", "p", "file.txt"
+        ])));
+        assert!(is_small_formatting_command(&vec_str(&[
+            "sed", "-n", "+10p", "file.txt"
+        ])));
+    }
+
+    #[test]
+    fn empty_tokens_is_not_small() {
+        let empty: Vec<String> = Vec::new();
+        assert!(!is_small_formatting_command(&empty));
+    }
+
+    #[test]
+    fn supports_nl_then_sed_reading() {
+        let inner = "nl -ba core/src/parse_command.rs | sed -n '1200,1720p'";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: shlex_split(inner).unwrap(),
+                name: "parse_command.rs".to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn filters_out_printf() {
+        let inner =
+            r#"printf "\n===== ansi-escape/Cargo.toml =====\n"; cat -- ansi-escape/Cargo.toml"#;
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Read {
+                cmd: shlex_split(inner).unwrap(),
+                name: "Cargo.toml".to_string(),
+            }],
+        );
+    }
+
+    #[test]
+    fn drops_yes_in_pipelines() {
+        // Inside bash -lc, `yes | rg --files` should focus on the primary command.
+        let inner = "yes | rg --files";
+        assert_parsed(
+            &vec_str(&["bash", "-lc", inner]),
+            vec![ParsedCommand::Search {
+                cmd: vec_str(&["rg", "--files"]),
+                query: None,
+                path: None,
+                files_only: true,
+            }],
+        );
+    }
+
+    #[test]
+    fn supports_sed_n_then_nl_as_search() {
+        // Ensure `sed -n '<range>' <file> | nl -ba` is summarized as a search for that file.
+        let args = vec_str(&[
+            "sed",
+            "-n",
+            "260,640p",
+            "exec/src/event_processor_with_human_output.rs",
+            "|",
+            "nl",
+            "-ba",
+        ]);
+        assert_parsed(
+            &args,
+            vec![ParsedCommand::Search {
+                cmd: vec_str(&[
+                    "sed",
+                    "-n",
+                    "260,640p",
+                    "exec/src/event_processor_with_human_output.rs",
+                ]),
+                query: None,
+                path: Some("event_processor_with_human_output.rs".to_string()),
+                files_only: false,
+            }],
+        );
+    }
+}

--- a/codex-rs/core/src/parse_command.rs
+++ b/codex-rs/core/src/parse_command.rs
@@ -38,914 +38,24 @@ pub enum ParsedCommand {
     },
 }
 
+/// DO NOT REVIEW THIS CODE BY HAND
+/// This parsing code is quite complex and not easy to hand-modify.
+/// The easiest way to iterate is to add unit tests and have Codex fix the implementation.
+/// To encourage this, the tests have been put directly below this function rather than at the bottom of the
+///
 /// Parses metadata out of an arbitrary command.
 /// These commands are model driven and could include just about anything.
 /// The parsing is slightly lossy due to the ~infinite expressiveness of an arbitrary command.
 /// The goal of the parsed metadata is to be able to provide the user with a human readable gis
 /// of what it is doing.
-///
-/// This parsing code is quite complex and not easy to hand-modify.
-/// The easiest way to iterate is to add unit tests and have Codex fix the implementation.
 pub fn parse_command(command: &[String]) -> Vec<ParsedCommand> {
-    let normalized = normalize_tokens(command);
-
-    if let Some(commands) = parse_bash_lc_commands(command, &normalized) {
-        return commands;
-    }
-
-    let mut parts = if contains_connectors(&normalized) {
-        split_on_connectors(&normalized)
-    } else {
-        vec![normalized.clone()]
-    };
-
-    // When normalized from `bash -c`, prefer showing pipeline segments from right-to-left
-    // to better surface the formatting step first, matching expectations in tests.
-    if let [bash, flag, _script] = command {
-        if bash == "bash" && flag == "-c" && normalized.iter().any(|t| t == "|") {
-            parts.reverse();
-        }
-    }
-
-    // Map each pipeline segment to its parsed summary.
-    let mut parsed: Vec<ParsedCommand> = parts
-        .iter()
-        .map(|tokens| summarize_main_tokens(tokens))
-        .collect();
-
-    // If a pipeline ends with `nl` using only flags (e.g., `| nl -ba`), drop it so the
-    // main action (e.g., a sed range over a file) is surfaced cleanly.
-    if parsed.len() >= 2 {
-        let has_and_and = normalized.iter().any(|t| t == "&&");
-        let contains_test = parsed
-            .iter()
-            .any(|pc| matches!(pc, ParsedCommand::Test { .. }));
-        parsed.retain(|pc| match pc {
-            ParsedCommand::Unknown { cmd } => {
-                if let Some(first) = cmd.first() {
-                    // Drop cosmetic echo segments in chained commands
-                    if has_and_and && first == "echo" {
-                        return false;
-                    }
-                    // In non-bash chained commands, ignore directory changes like `cd foo`
-                    // when the sequence includes a recognized test command. Preserve `cd`
-                    // for other sequences (e.g., followed by a search command).
-                    if has_and_and && contains_test && first == "cd" {
-                        return false;
-                    }
-                    if first == "nl" {
-                        // Treat `nl` without an explicit file operand as formatting-only.
-                        return cmd.iter().skip(1).any(|a| !a.starts_with('-'));
-                    }
-                }
-                true
-            }
-            _ => true,
-        });
-    }
-
-    parsed
-}
-
-/// Validates that this is a `sed -n 123,123p` command.
-fn is_valid_sed_n_arg(arg: Option<&str>) -> bool {
-    let s = match arg {
-        Some(s) => s,
-        None => return false,
-    };
-    let core = match s.strip_suffix('p') {
-        Some(rest) => rest,
-        None => return false,
-    };
-    let parts: Vec<&str> = core.split(',').collect();
-    match parts.as_slice() {
-        [num] => !num.is_empty() && num.chars().all(|c| c.is_ascii_digit()),
-        [a, b] => {
-            !a.is_empty()
-                && !b.is_empty()
-                && a.chars().all(|c| c.is_ascii_digit())
-                && b.chars().all(|c| c.is_ascii_digit())
-        }
-        _ => false,
-    }
-}
-
-/// Normalize a command by:
-/// - Removing `yes`/`no`/`bash -c`/`bash -lc` prefixes.
-/// - Splitting on `|` and `&&`/`||`/`;
-fn normalize_tokens(cmd: &[String]) -> Vec<String> {
-    match cmd {
-        [first, pipe, rest @ ..] if (first == "yes" || first == "y") && pipe == "|" => {
-            // Do not re-shlex already-tokenized input; just drop the prefix.
-            rest.to_vec()
-        }
-        [first, pipe, rest @ ..] if (first == "no" || first == "n") && pipe == "|" => {
-            // Do not re-shlex already-tokenized input; just drop the prefix.
-            rest.to_vec()
-        }
-        [bash, flag, script] if bash == "bash" && (flag == "-c" || flag == "-lc") => {
-            shlex_split(script)
-                .unwrap_or_else(|| vec!["bash".to_string(), flag.clone(), script.clone()])
-        }
-        _ => cmd.to_vec(),
-    }
-}
-
-fn contains_connectors(tokens: &[String]) -> bool {
-    tokens
-        .iter()
-        .any(|t| t == "&&" || t == "||" || t == "|" || t == ";")
-}
-
-fn split_on_connectors(tokens: &[String]) -> Vec<Vec<String>> {
-    let mut out: Vec<Vec<String>> = Vec::new();
-    let mut cur: Vec<String> = Vec::new();
-    for t in tokens {
-        if t == "&&" || t == "||" || t == "|" || t == ";" {
-            if !cur.is_empty() {
-                out.push(std::mem::take(&mut cur));
-            }
-        } else {
-            cur.push(t.clone());
-        }
-    }
-    if !cur.is_empty() {
-        out.push(cur);
-    }
-    out
-}
-
-fn trim_at_connector(tokens: &[String]) -> Vec<String> {
-    let idx = tokens
-        .iter()
-        .position(|t| t == "|" || t == "&&" || t == "||" || t == ";")
-        .unwrap_or(tokens.len());
-    tokens[..idx].to_vec()
-}
-
-/// Shorten a path to the last component, excluding `build`/`dist`/`node_modules`/`src`.
-/// It also pulls out a useful path from a directory such as:
-/// - webview/src -> webview
-/// - foo/src/ -> foo
-/// - packages/app/node_modules/ -> app
-fn short_display_path(path: &str) -> String {
-    // Normalize separators and drop any trailing slash for display.
-    let normalized = path.replace('\\', "/");
-    let trimmed = normalized.trim_end_matches('/');
-    let mut parts = trimmed.split('/').rev().filter(|p| {
-        !p.is_empty() && *p != "build" && *p != "dist" && *p != "node_modules" && *p != "src"
-    });
-    parts
-        .next()
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| trimmed.to_string())
-}
-
-// Skip values consumed by specific flags and ignore --flag=value style arguments.
-fn skip_flag_values<'a>(args: &'a [String], flags_with_vals: &[&str]) -> Vec<&'a String> {
-    let mut out: Vec<&'a String> = Vec::new();
-    let mut skip_next = false;
-    for (i, a) in args.iter().enumerate() {
-        if skip_next {
-            skip_next = false;
-            continue;
-        }
-        if a == "--" {
-            // From here on, everything is positional operands; push the rest and break.
-            for rest in &args[i + 1..] {
-                out.push(rest);
-            }
-            break;
-        }
-        if a.starts_with("--") && a.contains('=') {
-            // --flag=value form: treat as a flag taking a value; skip entirely.
-            continue;
-        }
-        if flags_with_vals.contains(&a.as_str()) {
-            // This flag consumes the next argument as its value.
-            if i + 1 < args.len() {
-                skip_next = true;
-            }
-            continue;
-        }
-        out.push(a);
-    }
-    out
-}
-
-/// Common flags for ESLint that take a following value and should not be
-/// considered positional targets.
-const ESLINT_FLAGS_WITH_VALUES: &[&str] = &[
-    "-c",
-    "--config",
-    "--parser",
-    "--parser-options",
-    "--rulesdir",
-    "--plugin",
-    "--max-warnings",
-    "--format",
-];
-
-fn collect_non_flag_targets(args: &[String]) -> Option<Vec<String>> {
-    let mut targets = Vec::new();
-    let mut skip_next = false;
-    for (i, a) in args.iter().enumerate() {
-        if a == "--" {
-            break;
-        }
-        if skip_next {
-            skip_next = false;
-            continue;
-        }
-        if a == "-p"
-            || a == "--package"
-            || a == "--features"
-            || a == "-C"
-            || a == "--config"
-            || a == "--config-path"
-            || a == "--out-dir"
-            || a == "-o"
-            || a == "--run"
-            || a == "--max-warnings"
-            || a == "--format"
-        {
-            if i + 1 < args.len() {
-                skip_next = true;
-            }
-            continue;
-        }
-        if a.starts_with('-') {
-            continue;
-        }
-        targets.push(a.clone());
-    }
-    if targets.is_empty() {
-        None
-    } else {
-        Some(targets)
-    }
-}
-
-fn collect_non_flag_targets_with_flags(
-    args: &[String],
-    flags_with_vals: &[&str],
-) -> Option<Vec<String>> {
-    let targets: Vec<String> = skip_flag_values(args, flags_with_vals)
-        .into_iter()
-        .filter(|a| !a.starts_with('-'))
-        .cloned()
-        .collect();
-    if targets.is_empty() {
-        None
-    } else {
-        Some(targets)
-    }
-}
-
-fn is_pathish(s: &str) -> bool {
-    s == "."
-        || s == ".."
-        || s.starts_with("./")
-        || s.starts_with("../")
-        || s.contains('/')
-        || s.contains('\\')
-}
-
-fn parse_fd_query_and_path(tail: &[String]) -> (Option<String>, Option<String>) {
-    let args_no_connector = trim_at_connector(tail);
-    // fd has several flags that take values (e.g., -t/--type, -e/--extension).
-    // Skip those values when extracting positional operands.
-    let candidates = skip_flag_values(
-        &args_no_connector,
-        &[
-            "-t",
-            "--type",
-            "-e",
-            "--extension",
-            "-E",
-            "--exclude",
-            "--search-path",
-        ],
-    );
-    let non_flags: Vec<&String> = candidates
-        .into_iter()
-        .filter(|p| !p.starts_with('-'))
-        .collect();
-    match non_flags.as_slice() {
-        [one] => {
-            if is_pathish(one) {
-                (None, Some(short_display_path(one)))
-            } else {
-                (Some((*one).clone()), None)
-            }
-        }
-        [q, p, ..] => (Some((*q).clone()), Some(short_display_path(p))),
-        _ => (None, None),
-    }
-}
-
-fn parse_find_query_and_path(tail: &[String]) -> (Option<String>, Option<String>) {
-    let args_no_connector = trim_at_connector(tail);
-    // First positional argument (excluding common unary operators) is the root path
-    let mut path: Option<String> = None;
-    for a in &args_no_connector {
-        if !a.starts_with('-') && *a != "!" && *a != "(" && *a != ")" {
-            path = Some(short_display_path(a));
-            break;
-        }
-    }
-    // Extract a common name/path/regex pattern if present
-    let mut query: Option<String> = None;
-    let mut i = 0;
-    while i < args_no_connector.len() {
-        let a = &args_no_connector[i];
-        if a == "-name" || a == "-iname" || a == "-path" || a == "-regex" {
-            if i + 1 < args_no_connector.len() {
-                query = Some(args_no_connector[i + 1].clone());
-            }
-            break;
-        }
-        i += 1;
-    }
-    (query, path)
-}
-
-fn classify_npm_like(tool: &str, tail: &[String], full_cmd: &[String]) -> Option<ParsedCommand> {
-    let mut r = tail;
-    if tool == "pnpm" && r.first().map(|s| s.as_str()) == Some("-r") {
-        r = &r[1..];
-    }
-    let mut script_name: Option<String> = None;
-    if r.first().map(|s| s.as_str()) == Some("run") {
-        script_name = r.get(1).cloned();
-    } else {
-        let is_test_cmd = (tool == "npm" && r.first().map(|s| s.as_str()) == Some("t"))
-            || ((tool == "npm" || tool == "pnpm" || tool == "yarn")
-                && r.first().map(|s| s.as_str()) == Some("test"));
-        if is_test_cmd {
-            script_name = Some("test".to_string());
-        }
-    }
-    if let Some(name) = script_name {
-        let lname = name.to_lowercase();
-        if lname == "test" || lname == "unit" || lname == "jest" || lname == "vitest" {
-            return Some(ParsedCommand::Test {
-                cmd: full_cmd.to_vec(),
-            });
-        }
-        if lname == "lint" || lname == "eslint" {
-            return Some(ParsedCommand::Lint {
-                cmd: full_cmd.to_vec(),
-                tool: Some(format!("{tool}-script:{name}")),
-                targets: None,
-            });
-        }
-        if lname == "format" || lname == "fmt" || lname == "prettier" {
-            return Some(ParsedCommand::Format {
-                cmd: full_cmd.to_vec(),
-                tool: Some(format!("{tool}-script:{name}")),
-                targets: None,
-            });
-        }
-    }
-    None
-}
-
-fn parse_bash_lc_commands(
-    original: &[String],
-    normalized: &[String],
-) -> Option<Vec<ParsedCommand>> {
-    let [bash, flag, script] = original else {
-        return None;
-    };
-    if bash != "bash" || flag != "-lc" {
-        return None;
-    }
-    if let Some(tree) = try_parse_bash(script) {
-        if let Some(all_commands) = try_parse_word_only_commands_sequence(&tree, script) {
-            if !all_commands.is_empty() {
-                let script_tokens = shlex_split(script)
-                    .unwrap_or_else(|| vec!["bash".to_string(), flag.clone(), script.clone()]);
-                // Strip small formatting helpers (e.g., head/tail/awk/wc/etc) so we
-                // bias toward the primary command when pipelines are present.
-                // First, drop obvious small formatting helpers (e.g., wc/awk/etc).
-                let had_multiple_commands = all_commands.len() > 1;
-                let filtered_commands = drop_small_formatting_commands(all_commands);
-                if filtered_commands.is_empty() {
-                    return Some(vec![ParsedCommand::Unknown {
-                        cmd: normalized.to_vec(),
-                    }]);
-                }
-                let mut commands: Vec<ParsedCommand> = filtered_commands
-                    .into_iter()
-                    .map(|tokens| summarize_main_tokens(&tokens))
-                    .collect();
-                commands = maybe_collapse_cat_sed(commands, &script_tokens);
-                if commands.len() == 1 {
-                    // If we reduced to a single command, attribute the full original script
-                    // for clearer UX in file-reading and listing scenarios, or when there were
-                    // no connectors in the original script. For search commands that came from
-                    // a pipeline (e.g. `rg --files | sed -n`), keep only the primary command.
-                    let had_connectors = had_multiple_commands
-                        || script_tokens
-                            .iter()
-                            .any(|t| t == "|" || t == "&&" || t == "||" || t == ";");
-                    commands = commands
-                        .into_iter()
-                        .map(|pc| match pc {
-                            ParsedCommand::Read { name, cmd } => {
-                                if had_connectors {
-                                    let has_pipe = script_tokens.iter().any(|t| t == "|");
-                                    let has_sed_n = script_tokens.windows(2).any(|w| {
-                                        w.first().map(|s| s.as_str()) == Some("sed")
-                                            && w.get(1).map(|s| s.as_str()) == Some("-n")
-                                    });
-                                    if has_pipe && has_sed_n {
-                                        ParsedCommand::Read {
-                                            cmd: script_tokens.clone(),
-                                            name,
-                                        }
-                                    } else {
-                                        ParsedCommand::Read { cmd, name }
-                                    }
-                                } else {
-                                    ParsedCommand::Read {
-                                        cmd: script_tokens.clone(),
-                                        name,
-                                    }
-                                }
-                            }
-                            ParsedCommand::Ls { path, cmd } => {
-                                if had_connectors {
-                                    ParsedCommand::Ls { cmd, path }
-                                } else {
-                                    ParsedCommand::Ls {
-                                        cmd: script_tokens.clone(),
-                                        path,
-                                    }
-                                }
-                            }
-                            ParsedCommand::Search {
-                                cmd,
-                                query,
-                                path,
-                                files_only,
-                            } => {
-                                if had_connectors {
-                                    ParsedCommand::Search {
-                                        cmd,
-                                        query,
-                                        path,
-                                        files_only,
-                                    }
-                                } else {
-                                    ParsedCommand::Search {
-                                        cmd: script_tokens.clone(),
-                                        query,
-                                        path,
-                                        files_only,
-                                    }
-                                }
-                            }
-                            ParsedCommand::Format { tool, targets, .. } => ParsedCommand::Format {
-                                cmd: script_tokens.clone(),
-                                tool,
-                                targets,
-                            },
-                            ParsedCommand::Test { .. } => ParsedCommand::Test {
-                                cmd: script_tokens.clone(),
-                            },
-                            ParsedCommand::Lint { tool, targets, .. } => ParsedCommand::Lint {
-                                cmd: script_tokens.clone(),
-                                tool,
-                                targets,
-                            },
-                            ParsedCommand::Unknown { .. } => ParsedCommand::Unknown {
-                                cmd: script_tokens.clone(),
-                            },
-                        })
-                        .collect();
-                }
-                return Some(commands);
-            }
-        }
-    }
-    Some(vec![ParsedCommand::Unknown {
-        cmd: normalized.to_vec(),
-    }])
-}
-
-/// Return true if this looks like a small formatting helper in a pipeline.
-/// Examples: `head -n 40`, `tail -n +10`, `wc -l`, `awk ...`, `cut ...`, `tr ...`.
-/// We try to keep variants that clearly include a file path (e.g. `tail -n 30 file`).
-fn is_small_formatting_command(tokens: &[String]) -> bool {
-    if tokens.is_empty() {
-        return false;
-    }
-    let cmd = tokens[0].as_str();
-    match cmd {
-        // Always formatting; typically used in pipes.
-        // `nl` is special-cased below to allow `nl <file>` to be treated as a read command.
-        "wc" | "tr" | "cut" | "sort" | "uniq" | "xargs" | "tee" | "column" | "awk" | "yes"
-        | "printf" => true,
-        "head" => {
-            // Treat as formatting when no explicit file operand is present.
-            // Common forms: `head -n 40`, `head -c 100`.
-            // Keep cases like `head -n 40 file`.
-            tokens.len() < 3
-        }
-        "tail" => {
-            // Treat as formatting when no explicit file operand is present.
-            // Common forms: `tail -n +10`, `tail -n 30`.
-            // Keep cases like `tail -n 30 file`.
-            tokens.len() < 3
-        }
-        "sed" => {
-            // Keep `sed -n <range> file` (treated as a file read elsewhere);
-            // otherwise consider it a formatting helper in a pipeline.
-            tokens.len() < 4
-                || !(tokens[1] == "-n" && is_valid_sed_n_arg(tokens.get(2).map(|s| s.as_str())))
-        }
-        _ => false,
-    }
-}
-
-fn drop_small_formatting_commands(mut commands: Vec<Vec<String>>) -> Vec<Vec<String>> {
-    commands.retain(|tokens| !is_small_formatting_command(tokens));
-    commands
-}
-
-fn maybe_collapse_cat_sed(
-    commands: Vec<ParsedCommand>,
-    script_tokens: &[String],
-) -> Vec<ParsedCommand> {
-    if commands.len() < 2 {
-        return commands;
-    }
-    let drop_leading_sed = match (&commands[0], &commands[1]) {
-        (ParsedCommand::Unknown { cmd: sed_cmd }, ParsedCommand::Read { cmd: cat_cmd, .. }) => {
-            let is_sed_n = sed_cmd.first().map(|s| s.as_str()) == Some("sed")
-                && sed_cmd.get(1).map(|s| s.as_str()) == Some("-n")
-                && is_valid_sed_n_arg(sed_cmd.get(2).map(|s| s.as_str()))
-                && sed_cmd.len() == 3;
-            let is_cat_file =
-                cat_cmd.first().map(|s| s.as_str()) == Some("cat") && cat_cmd.len() == 2;
-            is_sed_n && is_cat_file
-        }
-        _ => false,
-    };
-    if drop_leading_sed {
-        if let ParsedCommand::Read { name, .. } = &commands[1] {
-            return vec![ParsedCommand::Read {
-                cmd: script_tokens.to_vec(),
-                name: name.clone(),
-            }];
-        }
-    }
-    commands
-}
-
-fn summarize_main_tokens(main_cmd: &[String]) -> ParsedCommand {
-    match main_cmd.split_first() {
-        // (sed-specific logic handled below in dedicated arm returning Read)
-        Some((head, tail))
-            if head == "cargo" && tail.first().map(|s| s.as_str()) == Some("fmt") =>
-        {
-            ParsedCommand::Format {
-                cmd: main_cmd.to_vec(),
-                tool: Some("cargo fmt".to_string()),
-                targets: collect_non_flag_targets(&tail[1..]),
-            }
-        }
-        Some((head, tail))
-            if head == "cargo" && tail.first().map(|s| s.as_str()) == Some("clippy") =>
-        {
-            ParsedCommand::Lint {
-                cmd: main_cmd.to_vec(),
-                tool: Some("cargo clippy".to_string()),
-                targets: collect_non_flag_targets(&tail[1..]),
-            }
-        }
-        Some((head, tail))
-            if head == "cargo" && tail.first().map(|s| s.as_str()) == Some("test") =>
-        {
-            ParsedCommand::Test {
-                cmd: main_cmd.to_vec(),
-            }
-        }
-        Some((head, tail)) if head == "rustfmt" => ParsedCommand::Format {
-            cmd: main_cmd.to_vec(),
-            tool: Some("rustfmt".to_string()),
-            targets: collect_non_flag_targets(tail),
-        },
-        Some((head, tail)) if head == "go" && tail.first().map(|s| s.as_str()) == Some("fmt") => {
-            ParsedCommand::Format {
-                cmd: main_cmd.to_vec(),
-                tool: Some("go fmt".to_string()),
-                targets: collect_non_flag_targets(&tail[1..]),
-            }
-        }
-        Some((head, tail)) if head == "go" && tail.first().map(|s| s.as_str()) == Some("test") => {
-            ParsedCommand::Test {
-                cmd: main_cmd.to_vec(),
-            }
-        }
-        Some((head, _)) if head == "pytest" => ParsedCommand::Test {
-            cmd: main_cmd.to_vec(),
-        },
-        Some((head, tail)) if head == "eslint" => {
-            // Treat configuration flags with values (e.g. `-c .eslintrc`) as non-targets.
-            let targets = collect_non_flag_targets_with_flags(tail, ESLINT_FLAGS_WITH_VALUES);
-            ParsedCommand::Lint {
-                cmd: main_cmd.to_vec(),
-                tool: Some("eslint".to_string()),
-                targets,
-            }
-        }
-        Some((head, tail)) if head == "prettier" => ParsedCommand::Format {
-            cmd: main_cmd.to_vec(),
-            tool: Some("prettier".to_string()),
-            targets: collect_non_flag_targets(tail),
-        },
-        Some((head, tail)) if head == "black" => ParsedCommand::Format {
-            cmd: main_cmd.to_vec(),
-            tool: Some("black".to_string()),
-            targets: collect_non_flag_targets(tail),
-        },
-        Some((head, tail))
-            if head == "ruff" && tail.first().map(|s| s.as_str()) == Some("check") =>
-        {
-            ParsedCommand::Lint {
-                cmd: main_cmd.to_vec(),
-                tool: Some("ruff".to_string()),
-                targets: collect_non_flag_targets(&tail[1..]),
-            }
-        }
-        Some((head, tail))
-            if head == "ruff" && tail.first().map(|s| s.as_str()) == Some("format") =>
-        {
-            ParsedCommand::Format {
-                cmd: main_cmd.to_vec(),
-                tool: Some("ruff".to_string()),
-                targets: collect_non_flag_targets(&tail[1..]),
-            }
-        }
-        Some((head, _)) if (head == "jest" || head == "vitest") => ParsedCommand::Test {
-            cmd: main_cmd.to_vec(),
-        },
-        Some((head, tail))
-            if head == "npx" && tail.first().map(|s| s.as_str()) == Some("eslint") =>
-        {
-            let targets = collect_non_flag_targets_with_flags(&tail[1..], ESLINT_FLAGS_WITH_VALUES);
-            ParsedCommand::Lint {
-                cmd: main_cmd.to_vec(),
-                tool: Some("eslint".to_string()),
-                targets,
-            }
-        }
-        Some((head, tail))
-            if head == "npx" && tail.first().map(|s| s.as_str()) == Some("prettier") =>
-        {
-            ParsedCommand::Format {
-                cmd: main_cmd.to_vec(),
-                tool: Some("prettier".to_string()),
-                targets: collect_non_flag_targets(&tail[1..]),
-            }
-        }
-        // NPM-like scripts including yarn
-        Some((tool, tail)) if (tool == "pnpm" || tool == "npm" || tool == "yarn") => {
-            if let Some(cmd) = classify_npm_like(tool, tail, main_cmd) {
-                cmd
-            } else {
-                ParsedCommand::Unknown {
-                    cmd: main_cmd.to_vec(),
-                }
-            }
-        }
-        Some((head, tail)) if head == "ls" => {
-            // Avoid treating option values as paths (e.g., ls -I "*.test.js").
-            let candidates = skip_flag_values(
-                tail,
-                &[
-                    "-I",
-                    "-w",
-                    "--block-size",
-                    "--format",
-                    "--time-style",
-                    "--color",
-                    "--quoting-style",
-                ],
-            );
-            let path = candidates
-                .into_iter()
-                .find(|p| !p.starts_with('-'))
-                .map(|p| short_display_path(p));
-            ParsedCommand::Ls {
-                cmd: main_cmd.to_vec(),
-                path,
-            }
-        }
-        Some((head, tail)) if head == "rg" => {
-            let args_no_connector = trim_at_connector(tail);
-            let files_only = args_no_connector.iter().any(|a| a == "--files");
-            let non_flags: Vec<&String> = args_no_connector
-                .iter()
-                .filter(|p| !p.starts_with('-'))
-                .collect();
-            let (query, path) = if files_only {
-                let p = non_flags.first().map(|s| short_display_path(s));
-                (None, p)
-            } else {
-                let q = non_flags.first().cloned().map(|s| s.to_string());
-                let p = non_flags.get(1).map(|s| short_display_path(s));
-                (q, p)
-            };
-            ParsedCommand::Search {
-                cmd: main_cmd.to_vec(),
-                query,
-                path,
-                files_only,
-            }
-        }
-        Some((head, tail)) if head == "fd" => {
-            // fd is a file finder; treat results as files_only
-            let (query, path) = parse_fd_query_and_path(tail);
-            ParsedCommand::Search {
-                cmd: main_cmd.to_vec(),
-                query,
-                path,
-                files_only: true,
-            }
-        }
-        Some((head, tail)) if head == "find" => {
-            // Basic find support: capture path and common name filter
-            let (query, path) = parse_find_query_and_path(tail);
-            ParsedCommand::Search {
-                cmd: main_cmd.to_vec(),
-                query,
-                path,
-                files_only: true,
-            }
-        }
-        Some((head, tail)) if head == "grep" => {
-            let args_no_connector = trim_at_connector(tail);
-            let non_flags: Vec<&String> = args_no_connector
-                .iter()
-                .filter(|p| !p.starts_with('-'))
-                .collect();
-            // Do not shorten the query: grep patterns may legitimately contain slashes
-            // and should be preserved verbatim. Only paths should be shortened.
-            let query = non_flags.first().cloned().map(|s| s.to_string());
-            let path = non_flags.get(1).map(|s| short_display_path(s));
-            ParsedCommand::Search {
-                cmd: main_cmd.to_vec(),
-                query,
-                path,
-                files_only: false,
-            }
-        }
-        Some((head, tail)) if head == "cat" => {
-            // Support both `cat <file>` and `cat -- <file>` forms.
-            let effective_tail: &[String] = if tail.first().map(|s| s.as_str()) == Some("--") {
-                &tail[1..]
-            } else {
-                tail
-            };
-            if effective_tail.len() == 1 {
-                let name = short_display_path(&effective_tail[0]);
-                ParsedCommand::Read {
-                    cmd: main_cmd.to_vec(),
-                    name,
-                }
-            } else {
-                ParsedCommand::Unknown {
-                    cmd: main_cmd.to_vec(),
-                }
-            }
-        }
-        Some((head, tail)) if head == "head" => {
-            // Support `head -n 50 file` and `head -n50 file` forms.
-            let has_valid_n = match tail.split_first() {
-                Some((first, rest)) if first == "-n" => rest
-                    .first()
-                    .is_some_and(|n| n.chars().all(|c| c.is_ascii_digit())),
-                Some((first, _)) if first.starts_with("-n") => {
-                    first[2..].chars().all(|c| c.is_ascii_digit())
-                }
-                _ => false,
-            };
-            if has_valid_n {
-                // Build candidates skipping the numeric value consumed by `-n` when separated.
-                let mut candidates: Vec<&String> = Vec::new();
-                let mut i = 0;
-                while i < tail.len() {
-                    if i == 0 && tail[i] == "-n" && i + 1 < tail.len() {
-                        let n = &tail[i + 1];
-                        if n.chars().all(|c| c.is_ascii_digit()) {
-                            i += 2;
-                            continue;
-                        }
-                    }
-                    candidates.push(&tail[i]);
-                    i += 1;
-                }
-                if let Some(p) = candidates.into_iter().find(|p| !p.starts_with('-')) {
-                    let name = short_display_path(p);
-                    return ParsedCommand::Read {
-                        cmd: main_cmd.to_vec(),
-                        name,
-                    };
-                }
-            }
-            ParsedCommand::Unknown {
-                cmd: main_cmd.to_vec(),
-            }
-        }
-        Some((head, tail)) if head == "tail" => {
-            // Support `tail -n +10 file` and `tail -n+10 file` forms.
-            let has_valid_n = match tail.split_first() {
-                Some((first, rest)) if first == "-n" => rest.first().is_some_and(|n| {
-                    let s = n.strip_prefix('+').unwrap_or(n);
-                    !s.is_empty() && s.chars().all(|c| c.is_ascii_digit())
-                }),
-                Some((first, _)) if first.starts_with("-n") => {
-                    let v = &first[2..];
-                    let s = v.strip_prefix('+').unwrap_or(v);
-                    !s.is_empty() && s.chars().all(|c| c.is_ascii_digit())
-                }
-                _ => false,
-            };
-            if has_valid_n {
-                // Build candidates skipping the numeric value consumed by `-n` when separated.
-                let mut candidates: Vec<&String> = Vec::new();
-                let mut i = 0;
-                while i < tail.len() {
-                    if i == 0 && tail[i] == "-n" && i + 1 < tail.len() {
-                        let n = &tail[i + 1];
-                        let s = n.strip_prefix('+').unwrap_or(n);
-                        if !s.is_empty() && s.chars().all(|c| c.is_ascii_digit()) {
-                            i += 2;
-                            continue;
-                        }
-                    }
-                    candidates.push(&tail[i]);
-                    i += 1;
-                }
-                if let Some(p) = candidates.into_iter().find(|p| !p.starts_with('-')) {
-                    let name = short_display_path(p);
-                    return ParsedCommand::Read {
-                        cmd: main_cmd.to_vec(),
-                        name,
-                    };
-                }
-            }
-            ParsedCommand::Unknown {
-                cmd: main_cmd.to_vec(),
-            }
-        }
-        Some((head, tail)) if head == "nl" => {
-            // Avoid treating option values as paths (e.g., nl -s "  ").
-            let candidates = skip_flag_values(tail, &["-s", "-w", "-v", "-i", "-b"]);
-            if let Some(p) = candidates.into_iter().find(|p| !p.starts_with('-')) {
-                let name = short_display_path(p);
-                ParsedCommand::Read {
-                    cmd: main_cmd.to_vec(),
-                    name,
-                }
-            } else {
-                ParsedCommand::Unknown {
-                    cmd: main_cmd.to_vec(),
-                }
-            }
-        }
-        Some((head, tail))
-            if head == "sed"
-                && tail.len() >= 3
-                && tail[0] == "-n"
-                && is_valid_sed_n_arg(tail.get(1).map(|s| s.as_str())) =>
-        {
-            if let Some(path) = tail.get(2) {
-                let name = short_display_path(path);
-                ParsedCommand::Read {
-                    cmd: main_cmd.to_vec(),
-                    name,
-                }
-            } else {
-                ParsedCommand::Unknown {
-                    cmd: main_cmd.to_vec(),
-                }
-            }
-        }
-        // Other commands
-        _ => ParsedCommand::Unknown {
-            cmd: main_cmd.to_vec(),
-        },
-    }
+    parse_command_impl(command)
 }
 
 #[cfg(test)]
+#[allow(clippy::items_after_test_module)]
+/// Tests are at the top to encourage using TDD + Codex to fix the implementation.
 mod tests {
-    #![allow(clippy::unwrap_used)]
     use super::*;
 
     fn vec_str(args: &[&str]) -> Vec<String> {
@@ -1011,7 +121,7 @@ mod tests {
         assert_parsed(
             &vec_str(&["bash", "-lc", inner]),
             vec![ParsedCommand::Search {
-                cmd: shlex_split(inner).unwrap(),
+                cmd: shlex_split(inner).expect("failed to split"),
                 query: Some("navigate-to-route".to_string()),
                 path: None,
                 files_only: false,
@@ -2084,5 +1194,902 @@ mod tests {
                 files_only: true,
             }],
         );
+    }
+}
+
+pub fn parse_command_impl(command: &[String]) -> Vec<ParsedCommand> {
+    let normalized = normalize_tokens(command);
+
+    if let Some(commands) = parse_bash_lc_commands(command, &normalized) {
+        return commands;
+    }
+
+    let mut parts = if contains_connectors(&normalized) {
+        split_on_connectors(&normalized)
+    } else {
+        vec![normalized.clone()]
+    };
+
+    // When normalized from `bash -c`, prefer showing pipeline segments from right-to-left
+    // to better surface the formatting step first, matching expectations in tests.
+    if let [bash, flag, _script] = command {
+        if bash == "bash" && flag == "-c" && normalized.iter().any(|t| t == "|") {
+            parts.reverse();
+        }
+    }
+
+    // Map each pipeline segment to its parsed summary.
+    let mut parsed: Vec<ParsedCommand> = parts
+        .iter()
+        .map(|tokens| summarize_main_tokens(tokens))
+        .collect();
+
+    // If a pipeline ends with `nl` using only flags (e.g., `| nl -ba`), drop it so the
+    // main action (e.g., a sed range over a file) is surfaced cleanly.
+    if parsed.len() >= 2 {
+        let has_and_and = normalized.iter().any(|t| t == "&&");
+        let contains_test = parsed
+            .iter()
+            .any(|pc| matches!(pc, ParsedCommand::Test { .. }));
+        parsed.retain(|pc| match pc {
+            ParsedCommand::Unknown { cmd } => {
+                if let Some(first) = cmd.first() {
+                    // Drop cosmetic echo segments in chained commands
+                    if has_and_and && first == "echo" {
+                        return false;
+                    }
+                    // In non-bash chained commands, ignore directory changes like `cd foo`
+                    // when the sequence includes a recognized test command. Preserve `cd`
+                    // for other sequences (e.g., followed by a search command).
+                    if has_and_and && contains_test && first == "cd" {
+                        return false;
+                    }
+                    if first == "nl" {
+                        // Treat `nl` without an explicit file operand as formatting-only.
+                        return cmd.iter().skip(1).any(|a| !a.starts_with('-'));
+                    }
+                }
+                true
+            }
+            _ => true,
+        });
+    }
+
+    parsed
+}
+
+/// Validates that this is a `sed -n 123,123p` command.
+fn is_valid_sed_n_arg(arg: Option<&str>) -> bool {
+    let s = match arg {
+        Some(s) => s,
+        None => return false,
+    };
+    let core = match s.strip_suffix('p') {
+        Some(rest) => rest,
+        None => return false,
+    };
+    let parts: Vec<&str> = core.split(',').collect();
+    match parts.as_slice() {
+        [num] => !num.is_empty() && num.chars().all(|c| c.is_ascii_digit()),
+        [a, b] => {
+            !a.is_empty()
+                && !b.is_empty()
+                && a.chars().all(|c| c.is_ascii_digit())
+                && b.chars().all(|c| c.is_ascii_digit())
+        }
+        _ => false,
+    }
+}
+
+/// Normalize a command by:
+/// - Removing `yes`/`no`/`bash -c`/`bash -lc` prefixes.
+/// - Splitting on `|` and `&&`/`||`/`;
+fn normalize_tokens(cmd: &[String]) -> Vec<String> {
+    match cmd {
+        [first, pipe, rest @ ..] if (first == "yes" || first == "y") && pipe == "|" => {
+            // Do not re-shlex already-tokenized input; just drop the prefix.
+            rest.to_vec()
+        }
+        [first, pipe, rest @ ..] if (first == "no" || first == "n") && pipe == "|" => {
+            // Do not re-shlex already-tokenized input; just drop the prefix.
+            rest.to_vec()
+        }
+        [bash, flag, script] if bash == "bash" && (flag == "-c" || flag == "-lc") => {
+            shlex_split(script)
+                .unwrap_or_else(|| vec!["bash".to_string(), flag.clone(), script.clone()])
+        }
+        _ => cmd.to_vec(),
+    }
+}
+
+fn contains_connectors(tokens: &[String]) -> bool {
+    tokens
+        .iter()
+        .any(|t| t == "&&" || t == "||" || t == "|" || t == ";")
+}
+
+fn split_on_connectors(tokens: &[String]) -> Vec<Vec<String>> {
+    let mut out: Vec<Vec<String>> = Vec::new();
+    let mut cur: Vec<String> = Vec::new();
+    for t in tokens {
+        if t == "&&" || t == "||" || t == "|" || t == ";" {
+            if !cur.is_empty() {
+                out.push(std::mem::take(&mut cur));
+            }
+        } else {
+            cur.push(t.clone());
+        }
+    }
+    if !cur.is_empty() {
+        out.push(cur);
+    }
+    out
+}
+
+fn trim_at_connector(tokens: &[String]) -> Vec<String> {
+    let idx = tokens
+        .iter()
+        .position(|t| t == "|" || t == "&&" || t == "||" || t == ";")
+        .unwrap_or(tokens.len());
+    tokens[..idx].to_vec()
+}
+
+/// Shorten a path to the last component, excluding `build`/`dist`/`node_modules`/`src`.
+/// It also pulls out a useful path from a directory such as:
+/// - webview/src -> webview
+/// - foo/src/ -> foo
+/// - packages/app/node_modules/ -> app
+fn short_display_path(path: &str) -> String {
+    // Normalize separators and drop any trailing slash for display.
+    let normalized = path.replace('\\', "/");
+    let trimmed = normalized.trim_end_matches('/');
+    let mut parts = trimmed.split('/').rev().filter(|p| {
+        !p.is_empty() && *p != "build" && *p != "dist" && *p != "node_modules" && *p != "src"
+    });
+    parts
+        .next()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| trimmed.to_string())
+}
+
+// Skip values consumed by specific flags and ignore --flag=value style arguments.
+fn skip_flag_values<'a>(args: &'a [String], flags_with_vals: &[&str]) -> Vec<&'a String> {
+    let mut out: Vec<&'a String> = Vec::new();
+    let mut skip_next = false;
+    for (i, a) in args.iter().enumerate() {
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if a == "--" {
+            // From here on, everything is positional operands; push the rest and break.
+            for rest in &args[i + 1..] {
+                out.push(rest);
+            }
+            break;
+        }
+        if a.starts_with("--") && a.contains('=') {
+            // --flag=value form: treat as a flag taking a value; skip entirely.
+            continue;
+        }
+        if flags_with_vals.contains(&a.as_str()) {
+            // This flag consumes the next argument as its value.
+            if i + 1 < args.len() {
+                skip_next = true;
+            }
+            continue;
+        }
+        out.push(a);
+    }
+    out
+}
+
+/// Common flags for ESLint that take a following value and should not be
+/// considered positional targets.
+const ESLINT_FLAGS_WITH_VALUES: &[&str] = &[
+    "-c",
+    "--config",
+    "--parser",
+    "--parser-options",
+    "--rulesdir",
+    "--plugin",
+    "--max-warnings",
+    "--format",
+];
+
+fn collect_non_flag_targets(args: &[String]) -> Option<Vec<String>> {
+    let mut targets = Vec::new();
+    let mut skip_next = false;
+    for (i, a) in args.iter().enumerate() {
+        if a == "--" {
+            break;
+        }
+        if skip_next {
+            skip_next = false;
+            continue;
+        }
+        if a == "-p"
+            || a == "--package"
+            || a == "--features"
+            || a == "-C"
+            || a == "--config"
+            || a == "--config-path"
+            || a == "--out-dir"
+            || a == "-o"
+            || a == "--run"
+            || a == "--max-warnings"
+            || a == "--format"
+        {
+            if i + 1 < args.len() {
+                skip_next = true;
+            }
+            continue;
+        }
+        if a.starts_with('-') {
+            continue;
+        }
+        targets.push(a.clone());
+    }
+    if targets.is_empty() {
+        None
+    } else {
+        Some(targets)
+    }
+}
+
+fn collect_non_flag_targets_with_flags(
+    args: &[String],
+    flags_with_vals: &[&str],
+) -> Option<Vec<String>> {
+    let targets: Vec<String> = skip_flag_values(args, flags_with_vals)
+        .into_iter()
+        .filter(|a| !a.starts_with('-'))
+        .cloned()
+        .collect();
+    if targets.is_empty() {
+        None
+    } else {
+        Some(targets)
+    }
+}
+
+fn is_pathish(s: &str) -> bool {
+    s == "."
+        || s == ".."
+        || s.starts_with("./")
+        || s.starts_with("../")
+        || s.contains('/')
+        || s.contains('\\')
+}
+
+fn parse_fd_query_and_path(tail: &[String]) -> (Option<String>, Option<String>) {
+    let args_no_connector = trim_at_connector(tail);
+    // fd has several flags that take values (e.g., -t/--type, -e/--extension).
+    // Skip those values when extracting positional operands.
+    let candidates = skip_flag_values(
+        &args_no_connector,
+        &[
+            "-t",
+            "--type",
+            "-e",
+            "--extension",
+            "-E",
+            "--exclude",
+            "--search-path",
+        ],
+    );
+    let non_flags: Vec<&String> = candidates
+        .into_iter()
+        .filter(|p| !p.starts_with('-'))
+        .collect();
+    match non_flags.as_slice() {
+        [one] => {
+            if is_pathish(one) {
+                (None, Some(short_display_path(one)))
+            } else {
+                (Some((*one).clone()), None)
+            }
+        }
+        [q, p, ..] => (Some((*q).clone()), Some(short_display_path(p))),
+        _ => (None, None),
+    }
+}
+
+fn parse_find_query_and_path(tail: &[String]) -> (Option<String>, Option<String>) {
+    let args_no_connector = trim_at_connector(tail);
+    // First positional argument (excluding common unary operators) is the root path
+    let mut path: Option<String> = None;
+    for a in &args_no_connector {
+        if !a.starts_with('-') && *a != "!" && *a != "(" && *a != ")" {
+            path = Some(short_display_path(a));
+            break;
+        }
+    }
+    // Extract a common name/path/regex pattern if present
+    let mut query: Option<String> = None;
+    let mut i = 0;
+    while i < args_no_connector.len() {
+        let a = &args_no_connector[i];
+        if a == "-name" || a == "-iname" || a == "-path" || a == "-regex" {
+            if i + 1 < args_no_connector.len() {
+                query = Some(args_no_connector[i + 1].clone());
+            }
+            break;
+        }
+        i += 1;
+    }
+    (query, path)
+}
+
+fn classify_npm_like(tool: &str, tail: &[String], full_cmd: &[String]) -> Option<ParsedCommand> {
+    let mut r = tail;
+    if tool == "pnpm" && r.first().map(|s| s.as_str()) == Some("-r") {
+        r = &r[1..];
+    }
+    let mut script_name: Option<String> = None;
+    if r.first().map(|s| s.as_str()) == Some("run") {
+        script_name = r.get(1).cloned();
+    } else {
+        let is_test_cmd = (tool == "npm" && r.first().map(|s| s.as_str()) == Some("t"))
+            || ((tool == "npm" || tool == "pnpm" || tool == "yarn")
+                && r.first().map(|s| s.as_str()) == Some("test"));
+        if is_test_cmd {
+            script_name = Some("test".to_string());
+        }
+    }
+    if let Some(name) = script_name {
+        let lname = name.to_lowercase();
+        if lname == "test" || lname == "unit" || lname == "jest" || lname == "vitest" {
+            return Some(ParsedCommand::Test {
+                cmd: full_cmd.to_vec(),
+            });
+        }
+        if lname == "lint" || lname == "eslint" {
+            return Some(ParsedCommand::Lint {
+                cmd: full_cmd.to_vec(),
+                tool: Some(format!("{tool}-script:{name}")),
+                targets: None,
+            });
+        }
+        if lname == "format" || lname == "fmt" || lname == "prettier" {
+            return Some(ParsedCommand::Format {
+                cmd: full_cmd.to_vec(),
+                tool: Some(format!("{tool}-script:{name}")),
+                targets: None,
+            });
+        }
+    }
+    None
+}
+
+fn parse_bash_lc_commands(
+    original: &[String],
+    normalized: &[String],
+) -> Option<Vec<ParsedCommand>> {
+    let [bash, flag, script] = original else {
+        return None;
+    };
+    if bash != "bash" || flag != "-lc" {
+        return None;
+    }
+    if let Some(tree) = try_parse_bash(script) {
+        if let Some(all_commands) = try_parse_word_only_commands_sequence(&tree, script) {
+            if !all_commands.is_empty() {
+                let script_tokens = shlex_split(script)
+                    .unwrap_or_else(|| vec!["bash".to_string(), flag.clone(), script.clone()]);
+                // Strip small formatting helpers (e.g., head/tail/awk/wc/etc) so we
+                // bias toward the primary command when pipelines are present.
+                // First, drop obvious small formatting helpers (e.g., wc/awk/etc).
+                let had_multiple_commands = all_commands.len() > 1;
+                let filtered_commands = drop_small_formatting_commands(all_commands);
+                if filtered_commands.is_empty() {
+                    return Some(vec![ParsedCommand::Unknown {
+                        cmd: normalized.to_vec(),
+                    }]);
+                }
+                let mut commands: Vec<ParsedCommand> = filtered_commands
+                    .into_iter()
+                    .map(|tokens| summarize_main_tokens(&tokens))
+                    .collect();
+                commands = maybe_collapse_cat_sed(commands, &script_tokens);
+                if commands.len() == 1 {
+                    // If we reduced to a single command, attribute the full original script
+                    // for clearer UX in file-reading and listing scenarios, or when there were
+                    // no connectors in the original script. For search commands that came from
+                    // a pipeline (e.g. `rg --files | sed -n`), keep only the primary command.
+                    let had_connectors = had_multiple_commands
+                        || script_tokens
+                            .iter()
+                            .any(|t| t == "|" || t == "&&" || t == "||" || t == ";");
+                    commands = commands
+                        .into_iter()
+                        .map(|pc| match pc {
+                            ParsedCommand::Read { name, cmd } => {
+                                if had_connectors {
+                                    let has_pipe = script_tokens.iter().any(|t| t == "|");
+                                    let has_sed_n = script_tokens.windows(2).any(|w| {
+                                        w.first().map(|s| s.as_str()) == Some("sed")
+                                            && w.get(1).map(|s| s.as_str()) == Some("-n")
+                                    });
+                                    if has_pipe && has_sed_n {
+                                        ParsedCommand::Read {
+                                            cmd: script_tokens.clone(),
+                                            name,
+                                        }
+                                    } else {
+                                        ParsedCommand::Read { cmd, name }
+                                    }
+                                } else {
+                                    ParsedCommand::Read {
+                                        cmd: script_tokens.clone(),
+                                        name,
+                                    }
+                                }
+                            }
+                            ParsedCommand::Ls { path, cmd } => {
+                                if had_connectors {
+                                    ParsedCommand::Ls { cmd, path }
+                                } else {
+                                    ParsedCommand::Ls {
+                                        cmd: script_tokens.clone(),
+                                        path,
+                                    }
+                                }
+                            }
+                            ParsedCommand::Search {
+                                cmd,
+                                query,
+                                path,
+                                files_only,
+                            } => {
+                                if had_connectors {
+                                    ParsedCommand::Search {
+                                        cmd,
+                                        query,
+                                        path,
+                                        files_only,
+                                    }
+                                } else {
+                                    ParsedCommand::Search {
+                                        cmd: script_tokens.clone(),
+                                        query,
+                                        path,
+                                        files_only,
+                                    }
+                                }
+                            }
+                            ParsedCommand::Format { tool, targets, .. } => ParsedCommand::Format {
+                                cmd: script_tokens.clone(),
+                                tool,
+                                targets,
+                            },
+                            ParsedCommand::Test { .. } => ParsedCommand::Test {
+                                cmd: script_tokens.clone(),
+                            },
+                            ParsedCommand::Lint { tool, targets, .. } => ParsedCommand::Lint {
+                                cmd: script_tokens.clone(),
+                                tool,
+                                targets,
+                            },
+                            ParsedCommand::Unknown { .. } => ParsedCommand::Unknown {
+                                cmd: script_tokens.clone(),
+                            },
+                        })
+                        .collect();
+                }
+                return Some(commands);
+            }
+        }
+    }
+    Some(vec![ParsedCommand::Unknown {
+        cmd: normalized.to_vec(),
+    }])
+}
+
+/// Return true if this looks like a small formatting helper in a pipeline.
+/// Examples: `head -n 40`, `tail -n +10`, `wc -l`, `awk ...`, `cut ...`, `tr ...`.
+/// We try to keep variants that clearly include a file path (e.g. `tail -n 30 file`).
+fn is_small_formatting_command(tokens: &[String]) -> bool {
+    if tokens.is_empty() {
+        return false;
+    }
+    let cmd = tokens[0].as_str();
+    match cmd {
+        // Always formatting; typically used in pipes.
+        // `nl` is special-cased below to allow `nl <file>` to be treated as a read command.
+        "wc" | "tr" | "cut" | "sort" | "uniq" | "xargs" | "tee" | "column" | "awk" | "yes"
+        | "printf" => true,
+        "head" => {
+            // Treat as formatting when no explicit file operand is present.
+            // Common forms: `head -n 40`, `head -c 100`.
+            // Keep cases like `head -n 40 file`.
+            tokens.len() < 3
+        }
+        "tail" => {
+            // Treat as formatting when no explicit file operand is present.
+            // Common forms: `tail -n +10`, `tail -n 30`.
+            // Keep cases like `tail -n 30 file`.
+            tokens.len() < 3
+        }
+        "sed" => {
+            // Keep `sed -n <range> file` (treated as a file read elsewhere);
+            // otherwise consider it a formatting helper in a pipeline.
+            tokens.len() < 4
+                || !(tokens[1] == "-n" && is_valid_sed_n_arg(tokens.get(2).map(|s| s.as_str())))
+        }
+        _ => false,
+    }
+}
+
+fn drop_small_formatting_commands(mut commands: Vec<Vec<String>>) -> Vec<Vec<String>> {
+    commands.retain(|tokens| !is_small_formatting_command(tokens));
+    commands
+}
+
+fn maybe_collapse_cat_sed(
+    commands: Vec<ParsedCommand>,
+    script_tokens: &[String],
+) -> Vec<ParsedCommand> {
+    if commands.len() < 2 {
+        return commands;
+    }
+    let drop_leading_sed = match (&commands[0], &commands[1]) {
+        (ParsedCommand::Unknown { cmd: sed_cmd }, ParsedCommand::Read { cmd: cat_cmd, .. }) => {
+            let is_sed_n = sed_cmd.first().map(|s| s.as_str()) == Some("sed")
+                && sed_cmd.get(1).map(|s| s.as_str()) == Some("-n")
+                && is_valid_sed_n_arg(sed_cmd.get(2).map(|s| s.as_str()))
+                && sed_cmd.len() == 3;
+            let is_cat_file =
+                cat_cmd.first().map(|s| s.as_str()) == Some("cat") && cat_cmd.len() == 2;
+            is_sed_n && is_cat_file
+        }
+        _ => false,
+    };
+    if drop_leading_sed {
+        if let ParsedCommand::Read { name, .. } = &commands[1] {
+            return vec![ParsedCommand::Read {
+                cmd: script_tokens.to_vec(),
+                name: name.clone(),
+            }];
+        }
+    }
+    commands
+}
+
+fn summarize_main_tokens(main_cmd: &[String]) -> ParsedCommand {
+    match main_cmd.split_first() {
+        // (sed-specific logic handled below in dedicated arm returning Read)
+        Some((head, tail))
+            if head == "cargo" && tail.first().map(|s| s.as_str()) == Some("fmt") =>
+        {
+            ParsedCommand::Format {
+                cmd: main_cmd.to_vec(),
+                tool: Some("cargo fmt".to_string()),
+                targets: collect_non_flag_targets(&tail[1..]),
+            }
+        }
+        Some((head, tail))
+            if head == "cargo" && tail.first().map(|s| s.as_str()) == Some("clippy") =>
+        {
+            ParsedCommand::Lint {
+                cmd: main_cmd.to_vec(),
+                tool: Some("cargo clippy".to_string()),
+                targets: collect_non_flag_targets(&tail[1..]),
+            }
+        }
+        Some((head, tail))
+            if head == "cargo" && tail.first().map(|s| s.as_str()) == Some("test") =>
+        {
+            ParsedCommand::Test {
+                cmd: main_cmd.to_vec(),
+            }
+        }
+        Some((head, tail)) if head == "rustfmt" => ParsedCommand::Format {
+            cmd: main_cmd.to_vec(),
+            tool: Some("rustfmt".to_string()),
+            targets: collect_non_flag_targets(tail),
+        },
+        Some((head, tail)) if head == "go" && tail.first().map(|s| s.as_str()) == Some("fmt") => {
+            ParsedCommand::Format {
+                cmd: main_cmd.to_vec(),
+                tool: Some("go fmt".to_string()),
+                targets: collect_non_flag_targets(&tail[1..]),
+            }
+        }
+        Some((head, tail)) if head == "go" && tail.first().map(|s| s.as_str()) == Some("test") => {
+            ParsedCommand::Test {
+                cmd: main_cmd.to_vec(),
+            }
+        }
+        Some((head, _)) if head == "pytest" => ParsedCommand::Test {
+            cmd: main_cmd.to_vec(),
+        },
+        Some((head, tail)) if head == "eslint" => {
+            // Treat configuration flags with values (e.g. `-c .eslintrc`) as non-targets.
+            let targets = collect_non_flag_targets_with_flags(tail, ESLINT_FLAGS_WITH_VALUES);
+            ParsedCommand::Lint {
+                cmd: main_cmd.to_vec(),
+                tool: Some("eslint".to_string()),
+                targets,
+            }
+        }
+        Some((head, tail)) if head == "prettier" => ParsedCommand::Format {
+            cmd: main_cmd.to_vec(),
+            tool: Some("prettier".to_string()),
+            targets: collect_non_flag_targets(tail),
+        },
+        Some((head, tail)) if head == "black" => ParsedCommand::Format {
+            cmd: main_cmd.to_vec(),
+            tool: Some("black".to_string()),
+            targets: collect_non_flag_targets(tail),
+        },
+        Some((head, tail))
+            if head == "ruff" && tail.first().map(|s| s.as_str()) == Some("check") =>
+        {
+            ParsedCommand::Lint {
+                cmd: main_cmd.to_vec(),
+                tool: Some("ruff".to_string()),
+                targets: collect_non_flag_targets(&tail[1..]),
+            }
+        }
+        Some((head, tail))
+            if head == "ruff" && tail.first().map(|s| s.as_str()) == Some("format") =>
+        {
+            ParsedCommand::Format {
+                cmd: main_cmd.to_vec(),
+                tool: Some("ruff".to_string()),
+                targets: collect_non_flag_targets(&tail[1..]),
+            }
+        }
+        Some((head, _)) if (head == "jest" || head == "vitest") => ParsedCommand::Test {
+            cmd: main_cmd.to_vec(),
+        },
+        Some((head, tail))
+            if head == "npx" && tail.first().map(|s| s.as_str()) == Some("eslint") =>
+        {
+            let targets = collect_non_flag_targets_with_flags(&tail[1..], ESLINT_FLAGS_WITH_VALUES);
+            ParsedCommand::Lint {
+                cmd: main_cmd.to_vec(),
+                tool: Some("eslint".to_string()),
+                targets,
+            }
+        }
+        Some((head, tail))
+            if head == "npx" && tail.first().map(|s| s.as_str()) == Some("prettier") =>
+        {
+            ParsedCommand::Format {
+                cmd: main_cmd.to_vec(),
+                tool: Some("prettier".to_string()),
+                targets: collect_non_flag_targets(&tail[1..]),
+            }
+        }
+        // NPM-like scripts including yarn
+        Some((tool, tail)) if (tool == "pnpm" || tool == "npm" || tool == "yarn") => {
+            if let Some(cmd) = classify_npm_like(tool, tail, main_cmd) {
+                cmd
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: main_cmd.to_vec(),
+                }
+            }
+        }
+        Some((head, tail)) if head == "ls" => {
+            // Avoid treating option values as paths (e.g., ls -I "*.test.js").
+            let candidates = skip_flag_values(
+                tail,
+                &[
+                    "-I",
+                    "-w",
+                    "--block-size",
+                    "--format",
+                    "--time-style",
+                    "--color",
+                    "--quoting-style",
+                ],
+            );
+            let path = candidates
+                .into_iter()
+                .find(|p| !p.starts_with('-'))
+                .map(|p| short_display_path(p));
+            ParsedCommand::Ls {
+                cmd: main_cmd.to_vec(),
+                path,
+            }
+        }
+        Some((head, tail)) if head == "rg" => {
+            let args_no_connector = trim_at_connector(tail);
+            let files_only = args_no_connector.iter().any(|a| a == "--files");
+            let non_flags: Vec<&String> = args_no_connector
+                .iter()
+                .filter(|p| !p.starts_with('-'))
+                .collect();
+            let (query, path) = if files_only {
+                let p = non_flags.first().map(|s| short_display_path(s));
+                (None, p)
+            } else {
+                let q = non_flags.first().cloned().map(|s| s.to_string());
+                let p = non_flags.get(1).map(|s| short_display_path(s));
+                (q, p)
+            };
+            ParsedCommand::Search {
+                cmd: main_cmd.to_vec(),
+                query,
+                path,
+                files_only,
+            }
+        }
+        Some((head, tail)) if head == "fd" => {
+            // fd is a file finder; treat results as files_only
+            let (query, path) = parse_fd_query_and_path(tail);
+            ParsedCommand::Search {
+                cmd: main_cmd.to_vec(),
+                query,
+                path,
+                files_only: true,
+            }
+        }
+        Some((head, tail)) if head == "find" => {
+            // Basic find support: capture path and common name filter
+            let (query, path) = parse_find_query_and_path(tail);
+            ParsedCommand::Search {
+                cmd: main_cmd.to_vec(),
+                query,
+                path,
+                files_only: true,
+            }
+        }
+        Some((head, tail)) if head == "grep" => {
+            let args_no_connector = trim_at_connector(tail);
+            let non_flags: Vec<&String> = args_no_connector
+                .iter()
+                .filter(|p| !p.starts_with('-'))
+                .collect();
+            // Do not shorten the query: grep patterns may legitimately contain slashes
+            // and should be preserved verbatim. Only paths should be shortened.
+            let query = non_flags.first().cloned().map(|s| s.to_string());
+            let path = non_flags.get(1).map(|s| short_display_path(s));
+            ParsedCommand::Search {
+                cmd: main_cmd.to_vec(),
+                query,
+                path,
+                files_only: false,
+            }
+        }
+        Some((head, tail)) if head == "cat" => {
+            // Support both `cat <file>` and `cat -- <file>` forms.
+            let effective_tail: &[String] = if tail.first().map(|s| s.as_str()) == Some("--") {
+                &tail[1..]
+            } else {
+                tail
+            };
+            if effective_tail.len() == 1 {
+                let name = short_display_path(&effective_tail[0]);
+                ParsedCommand::Read {
+                    cmd: main_cmd.to_vec(),
+                    name,
+                }
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: main_cmd.to_vec(),
+                }
+            }
+        }
+        Some((head, tail)) if head == "head" => {
+            // Support `head -n 50 file` and `head -n50 file` forms.
+            let has_valid_n = match tail.split_first() {
+                Some((first, rest)) if first == "-n" => rest
+                    .first()
+                    .is_some_and(|n| n.chars().all(|c| c.is_ascii_digit())),
+                Some((first, _)) if first.starts_with("-n") => {
+                    first[2..].chars().all(|c| c.is_ascii_digit())
+                }
+                _ => false,
+            };
+            if has_valid_n {
+                // Build candidates skipping the numeric value consumed by `-n` when separated.
+                let mut candidates: Vec<&String> = Vec::new();
+                let mut i = 0;
+                while i < tail.len() {
+                    if i == 0 && tail[i] == "-n" && i + 1 < tail.len() {
+                        let n = &tail[i + 1];
+                        if n.chars().all(|c| c.is_ascii_digit()) {
+                            i += 2;
+                            continue;
+                        }
+                    }
+                    candidates.push(&tail[i]);
+                    i += 1;
+                }
+                if let Some(p) = candidates.into_iter().find(|p| !p.starts_with('-')) {
+                    let name = short_display_path(p);
+                    return ParsedCommand::Read {
+                        cmd: main_cmd.to_vec(),
+                        name,
+                    };
+                }
+            }
+            ParsedCommand::Unknown {
+                cmd: main_cmd.to_vec(),
+            }
+        }
+        Some((head, tail)) if head == "tail" => {
+            // Support `tail -n +10 file` and `tail -n+10 file` forms.
+            let has_valid_n = match tail.split_first() {
+                Some((first, rest)) if first == "-n" => rest.first().is_some_and(|n| {
+                    let s = n.strip_prefix('+').unwrap_or(n);
+                    !s.is_empty() && s.chars().all(|c| c.is_ascii_digit())
+                }),
+                Some((first, _)) if first.starts_with("-n") => {
+                    let v = &first[2..];
+                    let s = v.strip_prefix('+').unwrap_or(v);
+                    !s.is_empty() && s.chars().all(|c| c.is_ascii_digit())
+                }
+                _ => false,
+            };
+            if has_valid_n {
+                // Build candidates skipping the numeric value consumed by `-n` when separated.
+                let mut candidates: Vec<&String> = Vec::new();
+                let mut i = 0;
+                while i < tail.len() {
+                    if i == 0 && tail[i] == "-n" && i + 1 < tail.len() {
+                        let n = &tail[i + 1];
+                        let s = n.strip_prefix('+').unwrap_or(n);
+                        if !s.is_empty() && s.chars().all(|c| c.is_ascii_digit()) {
+                            i += 2;
+                            continue;
+                        }
+                    }
+                    candidates.push(&tail[i]);
+                    i += 1;
+                }
+                if let Some(p) = candidates.into_iter().find(|p| !p.starts_with('-')) {
+                    let name = short_display_path(p);
+                    return ParsedCommand::Read {
+                        cmd: main_cmd.to_vec(),
+                        name,
+                    };
+                }
+            }
+            ParsedCommand::Unknown {
+                cmd: main_cmd.to_vec(),
+            }
+        }
+        Some((head, tail)) if head == "nl" => {
+            // Avoid treating option values as paths (e.g., nl -s "  ").
+            let candidates = skip_flag_values(tail, &["-s", "-w", "-v", "-i", "-b"]);
+            if let Some(p) = candidates.into_iter().find(|p| !p.starts_with('-')) {
+                let name = short_display_path(p);
+                ParsedCommand::Read {
+                    cmd: main_cmd.to_vec(),
+                    name,
+                }
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: main_cmd.to_vec(),
+                }
+            }
+        }
+        Some((head, tail))
+            if head == "sed"
+                && tail.len() >= 3
+                && tail[0] == "-n"
+                && is_valid_sed_n_arg(tail.get(1).map(|s| s.as_str())) =>
+        {
+            if let Some(path) = tail.get(2) {
+                let name = short_display_path(path);
+                ParsedCommand::Read {
+                    cmd: main_cmd.to_vec(),
+                    name,
+                }
+            } else {
+                ParsedCommand::Unknown {
+                    cmd: main_cmd.to_vec(),
+                }
+            }
+        }
+        // Other commands
+        _ => ParsedCommand::Unknown {
+            cmd: main_cmd.to_vec(),
+        },
     }
 }

--- a/codex-rs/core/src/parse_command.rs
+++ b/codex-rs/core/src/parse_command.rs
@@ -48,7 +48,16 @@ pub enum ParsedCommand {
 /// The goal of the parsed metadata is to be able to provide the user with a human readable gis
 /// of what it is doing.
 pub fn parse_command(command: &[String]) -> Vec<ParsedCommand> {
-    parse_command_impl(command)
+    // Parse and then collapse consecutive duplicate commands to avoid redundant summaries.
+    let parsed = parse_command_impl(command);
+    let mut deduped: Vec<ParsedCommand> = Vec::with_capacity(parsed.len());
+    for cmd in parsed.into_iter() {
+        if deduped.last().is_some_and(|prev| prev == &cmd) {
+            continue;
+        }
+        deduped.push(cmd);
+    }
+    deduped
 }
 
 #[cfg(test)]
@@ -98,11 +107,6 @@ mod tests {
                 },
                 ParsedCommand::Unknown {
                     cmd: vec_str(&["pnpm", "-v"]),
-                },
-                ParsedCommand::Search {
-                    cmd: vec_str(&["rg", "--files"]),
-                    query: None,
-                    path: None,
                 },
                 ParsedCommand::Search {
                     cmd: vec_str(&["rg", "--files"]),

--- a/codex-rs/core/src/parse_command.rs
+++ b/codex-rs/core/src/parse_command.rs
@@ -10,7 +10,7 @@ pub enum ParsedCommand {
         cmd: Vec<String>,
         name: String,
     },
-    Ls {
+    ListFiles {
         cmd: Vec<String>,
         path: Option<String>,
     },
@@ -200,7 +200,7 @@ mod tests {
         let inner = "ls -la | sed -n '1,120p'";
         assert_parsed(
             &vec_str(&["bash", "-lc", inner]),
-            vec![ParsedCommand::Ls {
+            vec![ParsedCommand::ListFiles {
                 cmd: vec_str(&["ls", "-la"]),
                 path: None,
             }],
@@ -709,7 +709,7 @@ mod tests {
     fn ls_with_glob() {
         assert_parsed(
             &shlex_split_safe("ls -I '*.test.js'"),
-            vec![ParsedCommand::Ls {
+            vec![ParsedCommand::ListFiles {
                 cmd: shlex_split_safe("ls -I '*.test.js'"),
                 path: None,
             }],
@@ -1067,7 +1067,7 @@ mod tests {
     fn ls_with_time_style_and_path() {
         assert_parsed(
             &shlex_split_safe("ls --time-style=long-iso ./dist"),
-            vec![ParsedCommand::Ls {
+            vec![ParsedCommand::ListFiles {
                 cmd: shlex_split_safe("ls --time-style=long-iso ./dist"),
                 // short_display_path drops "dist" and shows "." as the last useful segment
                 path: Some(".".to_string()),
@@ -1592,11 +1592,11 @@ fn parse_bash_lc_commands(
                                     }
                                 }
                             }
-                            ParsedCommand::Ls { path, cmd } => {
+                            ParsedCommand::ListFiles { path, cmd } => {
                                 if had_connectors {
-                                    ParsedCommand::Ls { cmd, path }
+                                    ParsedCommand::ListFiles { cmd, path }
                                 } else {
-                                    ParsedCommand::Ls {
+                                    ParsedCommand::ListFiles {
                                         cmd: script_tokens.clone(),
                                         path,
                                     }
@@ -1846,7 +1846,7 @@ fn summarize_main_tokens(main_cmd: &[String]) -> ParsedCommand {
                 .into_iter()
                 .find(|p| !p.starts_with('-'))
                 .map(|p| short_display_path(p));
-            ParsedCommand::Ls {
+            ParsedCommand::ListFiles {
                 cmd: main_cmd.to_vec(),
                 path,
             }

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -21,6 +21,7 @@ use crate::config_types::ReasoningEffort as ReasoningEffortConfig;
 use crate::config_types::ReasoningSummary as ReasoningSummaryConfig;
 use crate::message_history::HistoryEntry;
 use crate::model_provider_info::ModelProviderInfo;
+use crate::parse_command::ParsedCommand;
 use crate::plan_tool::UpdatePlanArgs;
 
 /// Submission Queue Entry - requests from user
@@ -579,6 +580,7 @@ pub struct ExecCommandBeginEvent {
     pub command: Vec<String>,
     /// The command's working directory if not the default cwd for the agent.
     pub cwd: PathBuf,
+    pub parsed_cmd: Vec<ParsedCommand>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -255,6 +255,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                 call_id,
                 command,
                 cwd,
+                parsed_cmd: _,
             }) => {
                 self.call_id_to_command.insert(
                     call_id.clone(),

--- a/codex-rs/mcp-server/src/mcp_protocol.rs
+++ b/codex-rs/mcp-server/src/mcp_protocol.rs
@@ -936,6 +936,7 @@ mod tests {
                 call_id: "c1".into(),
                 command: vec!["bash".into(), "-lc".into(), "echo hi".into()],
                 cwd: std::path::PathBuf::from("/work"),
+                parsed_cmd: vec![],
             }),
         };
 
@@ -947,7 +948,8 @@ mod tests {
                     "type": "exec_command_begin",
                     "call_id": "c1",
                     "command": ["bash", "-lc", "echo hi"],
-                    "cwd": "/work"
+                    "cwd": "/work",
+                    "parsed_cmd": []
                 }
             }
         });

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -261,6 +261,16 @@ impl App<'_> {
                             }
                         }
                         KeyEvent {
+                            code: KeyCode::Char('r'),
+                            modifiers: crossterm::event::KeyModifiers::CONTROL,
+                            kind: KeyEventKind::Press,
+                            ..
+                        } => {
+                            if let AppState::Chat { widget } = &mut self.app_state {
+                                widget.on_ctrl_r();
+                            }
+                        }
+                        KeyEvent {
                             code: KeyCode::Char('d'),
                             modifiers: crossterm::event::KeyModifiers::CONTROL,
                             kind: KeyEventKind::Press,

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -261,16 +261,6 @@ impl App<'_> {
                             }
                         }
                         KeyEvent {
-                            code: KeyCode::Char('r'),
-                            modifiers: crossterm::event::KeyModifiers::CONTROL,
-                            kind: KeyEventKind::Press,
-                            ..
-                        } => {
-                            if let AppState::Chat { widget } = &mut self.app_state {
-                                widget.on_ctrl_r();
-                            }
-                        }
-                        KeyEvent {
                             code: KeyCode::Char('d'),
                             modifiers: crossterm::event::KeyModifiers::CONTROL,
                             kind: KeyEventKind::Press,

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -489,17 +489,19 @@ impl ChatWidget<'_> {
                 // Compute summary before moving stdout into the history cell.
                 let cmd = self.running_commands.remove(&call_id);
                 self.active_history_cell = None;
-                if let Some(cmd) = cmd {
-                    self.add_to_history(HistoryCell::new_completed_exec_command(
-                        cmd.command,
-                        parsed_cmd,
-                        CommandOutput {
-                            exit_code,
-                            stdout,
-                            stderr,
-                        },
-                    ));
-                }
+                let (command, parsed_cmd) = match cmd {
+                    Some(cmd) => (cmd.command, cmd.parsed_cmd),
+                    None => (vec![call_id], vec![]),
+                };
+                self.add_to_history(HistoryCell::new_completed_exec_command(
+                    command,
+                    parsed_cmd,
+                    CommandOutput {
+                        exit_code,
+                        stdout,
+                        stderr,
+                    },
+                ))
             }
             EventMsg::McpToolCallBegin(McpToolCallBeginEvent {
                 call_id: _,

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -349,22 +349,31 @@ impl HistoryCell {
         list_commands: &[ParsedCommand],
         output: Option<&CommandOutput>,
     ) -> Vec<Line<'static>> {
-        let paths: HashSet<&String> = list_commands
+        let paths: HashSet<String> = list_commands
             .iter()
             .flat_map(|c| match c {
-                ParsedCommand::Ls { path, .. } => path.as_ref(),
+                ParsedCommand::Ls { path, cmd } => match path {
+                    Some(p) => Some(p.clone()),
+                    None => Some(cmd.join(" ")),
+                },
                 _ => None,
             })
             .collect();
 
         let mut lines: Vec<Line> = vec![Line::from("📂 Listing")];
 
-        for name in paths {
-            lines.push(Line::from(vec![
-                Span::styled("  L ", Style::default().fg(Color::Gray)),
-                Span::styled(name.clone(), Style::default().fg(LIGHT_BLUE)),
-            ]));
+        match paths.len() {
+            0 => {}
+            _ => {
+                for name in paths {
+                    lines.push(Line::from(vec![
+                        Span::styled("  L ", Style::default().fg(Color::Gray)),
+                        Span::styled(name, Style::default().fg(LIGHT_BLUE)),
+                    ]));
+                }
+            }
         }
+
         lines.extend(output_lines(output, true, false));
         lines.push(Line::from(""));
 

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -513,46 +513,24 @@ impl HistoryCell {
         output: Option<&CommandOutput>,
     ) -> Vec<Line<'static>> {
         use std::collections::BTreeSet;
-        let mut runners: BTreeSet<String> = BTreeSet::new();
-        let mut filters: BTreeSet<String> = BTreeSet::new();
+        let mut cmds: BTreeSet<String> = BTreeSet::new();
         for c in test_commands {
-            if let ParsedCommand::Test {
-                runner,
-                test_filter,
-                ..
-            } = c
-            {
-                if let Some(runner) = runner {
-                    runners.insert(runner.clone());
-                }
-                if let Some(f) = test_filter {
-                    for it in f {
-                        filters.insert(it.clone());
-                    }
-                }
+            if let ParsedCommand::Test { cmd, .. } = c {
+                cmds.insert(cmd.join(" "));
             }
         }
 
-        if filters.is_empty() {
+        if cmds.is_empty() {
             for c in test_commands {
                 if let ParsedCommand::Test { cmd, .. } = c {
-                    filters.insert(cmd.join(" "));
+                    cmds.insert(cmd.join(" "));
                 }
             }
         }
-
-        let mut runners_vec: Vec<String> = runners.into_iter().collect();
-        runners_vec.sort();
-        let mut lines: Vec<Line> = vec![match runners_vec.len() {
-            0 => Line::from("🧪 Testing"),
-            _ => Line::from(format!(
-                "🧪 Testing with {}",
-                formatted_list_str(runners_vec)
-            )),
-        }];
+        let mut lines: Vec<Line> = vec![Line::from("🧪 Testing")];
 
         let mut first = true;
-        for f in filters.into_iter().take(10) {
+        for f in cmds.into_iter().take(10) {
             if first {
                 lines.push(Line::from(vec![
                     "  ⎿ ".into(),

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -381,7 +381,6 @@ impl HistoryCell {
         search_commands: &[ParsedCommand],
         output: Option<&CommandOutput>,
     ) -> Vec<Line<'static>> {
-        tracing::error!("[GABE] new_search_command {:?}", search_commands);
         let file_names: HashSet<&String> = search_commands
             .iter()
             .flat_map(|c| match c {

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1280,16 +1280,3 @@ fn format_mcp_invocation<'a>(invocation: McpInvocation) -> Line<'a> {
     ];
     Line::from(invocation_spans)
 }
-
-fn formatted_list_str(items: Vec<String>) -> String {
-    match items.len() {
-        0 => "".to_string(),
-        1 => items[0].clone(),
-        2 => format!("{} and {}", items[0], items[1]),
-        _ => {
-            let mut items = items.clone();
-            let last = items.pop().unwrap_or_default();
-            format!("{}, and {}", items.join(", "), last)
-        }
-    }
-}

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -291,38 +291,32 @@ impl HistoryCell {
         parsed: &[ParsedCommand],
         output: Option<&CommandOutput>,
     ) -> Vec<Line<'static>> {
-        let is_read_command = parsed
-            .iter()
-            .all(|c| matches!(c, ParsedCommand::Read { .. }));
+        let all = |pred: fn(&ParsedCommand) -> bool| -> bool {
+            !parsed.is_empty() && parsed.iter().all(&pred)
+        };
 
-        let is_list_command = parsed.iter().all(|c| matches!(c, ParsedCommand::Ls { .. }));
-        let is_search_command = parsed
-            .iter()
-            .all(|c| matches!(c, ParsedCommand::Search { .. }));
-        let is_format_command = parsed
-            .iter()
-            .all(|c| matches!(c, ParsedCommand::Format { .. }));
-        let is_lint_command = parsed
-            .iter()
-            .all(|c| matches!(c, ParsedCommand::Lint { .. }));
-        let is_test_command = parsed
-            .iter()
-            .all(|c| matches!(c, ParsedCommand::Test { .. }));
-
-        if is_read_command {
-            return HistoryCell::new_read_command(parsed, output);
-        } else if is_list_command {
-            return HistoryCell::new_list_command(parsed, output);
-        } else if is_search_command {
-            return HistoryCell::new_search_command(parsed, output);
-        } else if is_format_command {
-            return HistoryCell::new_format_command(parsed, output);
-        } else if is_lint_command {
-            return HistoryCell::new_lint_command(parsed, output);
-        } else if is_test_command {
-            return HistoryCell::new_test_command(parsed, output);
+        // Only render a typed cell if all of the parsed commands are of the same type.
+        match () {
+            _ if all(|c| matches!(c, ParsedCommand::Read { .. })) => {
+                HistoryCell::new_read_command(parsed, output)
+            }
+            _ if all(|c| matches!(c, ParsedCommand::Ls { .. })) => {
+                HistoryCell::new_list_command(parsed, output)
+            }
+            _ if all(|c| matches!(c, ParsedCommand::Search { .. })) => {
+                HistoryCell::new_search_command(parsed, output)
+            }
+            _ if all(|c| matches!(c, ParsedCommand::Format { .. })) => {
+                HistoryCell::new_format_command(parsed, output)
+            }
+            _ if all(|c| matches!(c, ParsedCommand::Lint { .. })) => {
+                HistoryCell::new_lint_command(parsed, output)
+            }
+            _ if all(|c| matches!(c, ParsedCommand::Test { .. })) => {
+                HistoryCell::new_test_command(parsed, output)
+            }
+            _ => HistoryCell::new_exec_command_generic(command, output),
         }
-        HistoryCell::new_exec_command_generic(command, output)
     }
 
     fn new_read_command(

--- a/codex-rs/tui/src/user_approval_widget.rs
+++ b/codex-rs/tui/src/user_approval_widget.rs
@@ -247,7 +247,7 @@ impl UserApprovalWidget<'_> {
                 match decision {
                     ReviewDecision::Approved => {
                         lines.push(Line::from(vec![
-                            "✓ ".fg(Color::Green),
+                            "✔ ".fg(Color::Green),
                             "You ".into(),
                             "approved".bold(),
                             " codex to run ".into(),
@@ -258,7 +258,7 @@ impl UserApprovalWidget<'_> {
                     }
                     ReviewDecision::ApprovedForSession => {
                         lines.push(Line::from(vec![
-                            "✓ ".fg(Color::Green),
+                            "✔ ".fg(Color::Green),
                             "You ".into(),
                             "approved".bold(),
                             " codex to run ".into(),


### PR DESCRIPTION
# Note for reviewers
The bulk of this PR is in in the new file, `parse_command.rs`. This file is designed to be written TDD and implemented with Codex. Do not worry about reviewing the code, just review the unit tests (if you want). If any cases are missing, we'll add more tests and have Codex fix them.

I think the best approach will be to land and iterate. I have some follow-ups I want to do after this lands. The next PR after this will let us merge (and dedupe) multiple sequential cells of the same such as multiple read commands. The deduping will also be important because the model often reads the same file multiple times in a row in chunks

===

This PR formats common commands like reading, formatting, testing, etc more nicely:

It tries to extract things like file names, tests and falls back to the cmd if it doesn't. It also only shows stdout/err if the command failed.

<img width="770" height="238" alt="CleanShot 2025-08-09 at 16 05 15" src="https://github.com/user-attachments/assets/0ead179a-8910-486b-aa3d-7d26264d751e" />
<img width="348" height="158" alt="CleanShot 2025-08-09 at 16 05 32" src="https://github.com/user-attachments/assets/4302681b-5e87-4ff3-85b4-0252c6c485a9" />
<img width="834" height="324" alt="CleanShot 2025-08-09 at 16 05 56 2" src="https://github.com/user-attachments/assets/09fb3517-7bd6-40f6-a126-4172106b700f" />

Part 2: https://github.com/openai/codex/pull/2097
Part 3: https://github.com/openai/codex/pull/2110


