### PR TITLE
TUI: message queue overlay, streaming spacing fix, and tests

### DIFF
--- a/codex-rs/tui/src/bottom_pane/approval_modal_view.rs
+++ b/codex-rs/tui/src/bottom_pane/approval_modal_view.rs
@@ -100,6 +100,7 @@ mod tests {
             app_event_tx: AppEventSender::new(tx_raw2),
             has_input_focus: true,
             enhanced_keys_supported: false,
+            allow_input_while_running: false,
         });
         assert_eq!(CancellationEvent::Handled, view.on_ctrl_c(&mut pane));
         assert!(view.queue.is_empty());

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -61,6 +61,8 @@ pub(crate) struct ChatComposer {
     pending_pastes: Vec<(String, String)>,
     token_usage_info: Option<TokenUsageInfo>,
     has_focus: bool,
+    /// True when Enter will queue instead of send (task running).
+    queue_mode: bool,
 }
 
 /// Popup state – at most one can be visible at any time.
@@ -91,6 +93,7 @@ impl ChatComposer {
             pending_pastes: Vec::new(),
             token_usage_info: None,
             has_focus: has_input_focus,
+            queue_mode: false,
         }
     }
 
@@ -649,6 +652,10 @@ impl ChatComposer {
     fn set_has_focus(&mut self, has_focus: bool) {
         self.has_focus = has_focus;
     }
+
+    pub(crate) fn set_queue_mode(&mut self, enabled: bool) {
+        self.queue_mode = enabled;
+    }
 }
 
 impl WidgetRef for &ChatComposer {
@@ -685,7 +692,11 @@ impl WidgetRef for &ChatComposer {
                     vec![
                         Span::from(" "),
                         "⏎".set_style(key_hint_style),
-                        Span::from(" send   "),
+                        Span::from(if self.queue_mode {
+                            " queue   "
+                        } else {
+                            " send   "
+                        }),
                         newline_hint_key.set_style(key_hint_style),
                         Span::from(" newline   "),
                         "Ctrl+C".set_style(key_hint_style),

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -743,6 +743,88 @@ mod tests {
     }
 
     #[test]
+    fn overlay_status_has_blank_above_when_live_ring_present() {
+        let (tx_raw, _rx) = channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let mut pane = BottomPane::new(BottomPaneParams {
+            app_event_tx: tx,
+            has_input_focus: true,
+            enhanced_keys_supported: false,
+            allow_input_while_running: true, // overlay mode
+        });
+
+        // Live status overlay (Working) is shown while running.
+        pane.set_task_running(true);
+        pane.update_status_text("waiting for model".to_string());
+
+        // Simulate a live ring with two streamed rows.
+        pane.set_live_ring_rows(2, vec![Line::from("stream1"), Line::from("stream2")]);
+
+        // Render enough height to include ring (2), spacer (1), status (1), and a couple more.
+        let area = Rect::new(0, 0, 40, 6);
+        let mut buf = Buffer::empty(area);
+        (&pane).render_ref(area, &mut buf);
+
+        // Row 0..1 are the live ring content.
+        let row0: String = (0..area.width)
+            .map(|x| buf[(x, 0)].symbol().chars().next().unwrap_or(' '))
+            .collect();
+        let row1: String = (0..area.width)
+            .map(|x| buf[(x, 1)].symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(row0.contains("stream1"));
+        assert!(row1.contains("stream2"));
+
+        // Row 2 should be a blank spacer between ring and Working.
+        let spacer: String = (0..area.width)
+            .map(|x| buf[(x, 2)].symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(
+            spacer.trim().is_empty(),
+            "expected blank spacer line above Working: {spacer:?}"
+        );
+
+        // Row 3 should contain the Working header.
+        let row3: String = (0..area.width)
+            .map(|x| buf[(x, 3)].symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(
+            row3.contains("Working"),
+            "expected Working header after spacer: {row3:?}"
+        );
+    }
+
+    #[test]
+    fn overlay_status_has_no_blank_above_when_no_live_ring() {
+        let (tx_raw, _rx) = channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let mut pane = BottomPane::new(BottomPaneParams {
+            app_event_tx: tx,
+            has_input_focus: true,
+            enhanced_keys_supported: false,
+            allow_input_while_running: true, // overlay mode
+        });
+
+        // Only the status overlay should be present.
+        pane.set_task_running(true);
+        pane.update_status_text("waiting for model".to_string());
+
+        // Render a small area; the first row should be Working (no blank above it).
+        let area = Rect::new(0, 0, 40, 3);
+        let mut buf = Buffer::empty(area);
+        (&pane).render_ref(area, &mut buf);
+
+        // Top row contains the Working header (no leading blank line).
+        let top: String = (0..area.width)
+            .map(|x| buf[(x, 0)].symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(
+            top.contains("Working"),
+            "expected Working header on top row: {top:?}"
+        );
+    }
+
+    #[test]
     fn overlay_not_shown_above_approval_modal() {
         let (tx_raw, _rx) = channel::<AppEvent>();
         let tx = AppEventSender::new(tx_raw);

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -20,6 +20,7 @@ mod command_popup;
 mod file_search_popup;
 mod live_ring_widget;
 mod popup_consts;
+mod queued_list_widget;
 mod scroll_state;
 mod selection_popup_common;
 mod status_indicator_view;
@@ -61,15 +62,24 @@ pub(crate) struct BottomPane<'a> {
     /// container used during development before we wire it to ChatWidget events.
     live_ring: Option<live_ring_widget::LiveRingWidget>,
 
+    /// Optional list of queued user messages displayed between the working
+    /// status and the composer while a task is running.
+    queued_list: Option<queued_list_widget::QueuedListWidget>,
+
     /// True if the active view is the StatusIndicatorView that replaces the
     /// composer during a running task.
     status_view_active: bool,
+
+    /// When true, keep the composer interactive while a task is running and
+    /// show status as an overlay instead of replacing the composer.
+    allow_input_while_running: bool,
 }
 
 pub(crate) struct BottomPaneParams {
     pub(crate) app_event_tx: AppEventSender,
     pub(crate) has_input_focus: bool,
     pub(crate) enhanced_keys_supported: bool,
+    pub(crate) allow_input_while_running: bool,
 }
 
 impl BottomPane<'_> {
@@ -89,7 +99,9 @@ impl BottomPane<'_> {
             ctrl_c_quit_hint: false,
             live_status: None,
             live_ring: None,
+            queued_list: None,
             status_view_active: false,
+            allow_input_while_running: params.allow_input_while_running,
         }
     }
 
@@ -99,6 +111,10 @@ impl BottomPane<'_> {
             .as_ref()
             .map(|s| s.desired_height(width))
             .unwrap_or(0);
+        // Optional spacer above the first overlay while streaming and the
+        // No extra spacer above overlay; separation is handled by the live ring
+        // placeholder injected when streaming begins.
+        let overlay_status_pad = 0;
         let ring_h = self
             .live_ring
             .as_ref()
@@ -117,8 +133,38 @@ impl BottomPane<'_> {
             self.composer.desired_height(width)
         };
 
+        let queued_h = self
+            .queued_list
+            .as_ref()
+            .map(|q| q.desired_height(width))
+            .unwrap_or(0);
+
+        // Spacer line below overlay (status + queued) before the composer when allowed
+        let overlay_status_pad_bottom = if self.allow_input_while_running
+            && self.active_view.is_none()
+            && (self.live_status.is_some() || self.queued_list.is_some())
+        {
+            1
+        } else {
+            0
+        };
+
         overlay_status_h
+            .saturating_add(overlay_status_pad)
             .saturating_add(ring_h)
+            // Spacer between ring and overlay status when both are visible
+            .saturating_add(
+                if self.live_ring.is_some()
+                    && self.live_status.is_some()
+                    && self.active_view.is_none()
+                {
+                    1
+                } else {
+                    0
+                },
+            )
+            .saturating_add(queued_h)
+            .saturating_add(overlay_status_pad_bottom)
             .saturating_add(view_height)
             .saturating_add(Self::BOTTOM_PAD_LINES)
     }
@@ -129,10 +175,76 @@ impl BottomPane<'_> {
         // In these states the textarea is not interactable, so we should not
         // show its caret.
         if self.active_view.is_some() {
-            None
-        } else {
-            self.composer.cursor_pos(area)
+            return None;
         }
+
+        // Mirror render_ref overlay layout to offset the cursor Y position by
+        // the height of any live overlays rendered above the composer.
+        let mut y_offset = 0u16;
+        // No top spacer to mirror.
+        if let Some(ring) = &self.live_ring {
+            let live_h = ring.desired_height(area.width).min(area.height);
+            if live_h > 0 {
+                y_offset = live_h;
+            }
+        }
+        if self.live_ring.is_some() && self.status_view_active && y_offset < area.height {
+            // Spacer line between live ring and status view
+            y_offset = y_offset.saturating_add(1);
+        }
+        // Spacer between live ring and overlay status (when no modal view)
+        if self.live_ring.is_some()
+            && self.live_status.is_some()
+            && self.active_view.is_none()
+            && y_offset < area.height
+        {
+            y_offset = y_offset.saturating_add(1);
+        }
+        if let Some(status) = &self.live_status {
+            // No additional spacer required.
+            let live_h = status
+                .desired_height(area.width)
+                .min(area.height.saturating_sub(y_offset));
+            if live_h > 0 {
+                y_offset = y_offset.saturating_add(live_h);
+            }
+        }
+
+        if let Some(q) = &self.queued_list {
+            let live_h = q
+                .desired_height(area.width)
+                .min(area.height.saturating_sub(y_offset));
+            if live_h > 0 {
+                y_offset = y_offset.saturating_add(live_h);
+            }
+        }
+
+        // Account for spacer between overlay and composer in cursor calculations.
+        if self.allow_input_while_running
+            && self.active_view.is_none()
+            && (self.live_status.is_some() || self.queued_list.is_some())
+        {
+            y_offset = y_offset.saturating_add(1);
+        }
+
+        // Compute composer rect after overlays, then translate the cursor pos.
+        let avail = area.height.saturating_sub(y_offset);
+        if avail == 0 {
+            return None;
+        }
+        let pad = BottomPane::BOTTOM_PAD_LINES.min(avail.saturating_sub(1));
+        let composer_rect = Rect {
+            x: area.x,
+            y: area.y + y_offset,
+            width: area.width,
+            height: avail - pad,
+        };
+
+        let (x, y) = match self.composer.cursor_pos(composer_rect) {
+            Some((x, y)) => (x, y),
+            None => return None,
+        };
+        Some((x, y))
     }
 
     /// Forward a key event to the active view or the composer.
@@ -200,36 +312,37 @@ impl BottomPane<'_> {
     /// the StatusIndicatorView so the input pane shows a single-line status
     /// like: `▌ Working waiting for model`.
     pub(crate) fn update_status_text(&mut self, text: String) {
-        let mut handled_by_view = false;
-        if let Some(view) = self.active_view.as_mut() {
-            if matches!(
-                view.update_status_text(text.clone()),
-                bottom_pane_view::ConditionalUpdate::NeedsRedraw
-            ) {
-                handled_by_view = true;
-            }
-        } else {
-            let mut v = StatusIndicatorView::new(self.app_event_tx.clone());
-            v.update_text(text.clone());
-            self.active_view = Some(Box::new(v));
-            self.status_view_active = true;
-            handled_by_view = true;
-        }
-
-        // Fallback: if the current active view did not consume status updates
-        // and no modal view is active, present an overlay above the composer.
-        // If a modal is active, do NOT render the overlay to avoid drawing
-        // over the dialog.
-        if !handled_by_view && self.active_view.is_none() {
+        // If we allow input while running and no modal view is active, prefer
+        // the overlay status above the composer. This keeps the composer
+        // interactive. Otherwise, fall back to the status view that replaces
+        // the composer.
+        if self.allow_input_while_running && self.active_view.is_none() {
             if self.live_status.is_none() {
                 self.live_status = Some(StatusIndicatorWidget::new(self.app_event_tx.clone()));
             }
             if let Some(status) = &mut self.live_status {
                 status.update_text(text);
             }
-        } else if !handled_by_view {
-            // Ensure any previous overlay is cleared when a modal becomes active.
-            self.live_status = None;
+        } else {
+            let mut handled_by_view = false;
+            if let Some(view) = self.active_view.as_mut() {
+                if matches!(
+                    view.update_status_text(text.clone()),
+                    bottom_pane_view::ConditionalUpdate::NeedsRedraw
+                ) {
+                    handled_by_view = true;
+                }
+            } else {
+                let mut v = StatusIndicatorView::new(self.app_event_tx.clone());
+                v.update_text(text.clone());
+                self.active_view = Some(Box::new(v));
+                self.status_view_active = true;
+                handled_by_view = true;
+            }
+            if !handled_by_view {
+                // Ensure any previous overlay is cleared when a modal becomes active.
+                self.live_status = None;
+            }
         }
         self.request_redraw();
     }
@@ -258,15 +371,25 @@ impl BottomPane<'_> {
         self.is_task_running = running;
 
         if running {
-            if self.active_view.is_none() {
-                self.active_view = Some(Box::new(StatusIndicatorView::new(
-                    self.app_event_tx.clone(),
-                )));
-                self.status_view_active = true;
+            if !self.allow_input_while_running {
+                if self.active_view.is_none() {
+                    self.active_view = Some(Box::new(StatusIndicatorView::new(
+                        self.app_event_tx.clone(),
+                    )));
+                    self.status_view_active = true;
+                }
+            } else {
+                // Ensure we use overlay status while running if allowed.
+                if self.live_status.is_none() {
+                    self.live_status = Some(StatusIndicatorWidget::new(self.app_event_tx.clone()));
+                }
+                // Composer remains visible; switch footer to queue mode.
+                self.composer.set_queue_mode(true);
             }
             self.request_redraw();
         } else {
             self.live_status = None;
+            self.composer.set_queue_mode(false);
             // Drop the status view when a task completes, but keep other
             // modal views (e.g. approval dialogs).
             if let Some(mut view) = self.active_view.take() {
@@ -366,11 +489,27 @@ impl BottomPane<'_> {
     }
 
     // Removed restart_live_status_with_text – no longer used by the current streaming UI.
+
+    /// Replace the queued messages list overlay with the provided rows.
+    pub(crate) fn set_queued_list_rows(&mut self, rows: Vec<Line<'static>>) {
+        let mut w = queued_list_widget::QueuedListWidget::new();
+        w.set_rows(rows);
+        self.queued_list = Some(w);
+        self.request_redraw();
+    }
+
+    pub(crate) fn clear_queued_list(&mut self) {
+        self.queued_list = None;
+        self.request_redraw();
+    }
+
+    // No dedicated top spacer; the live ring placeholder is used instead.
 }
 
 impl WidgetRef for &BottomPane<'_> {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
         let mut y_offset = 0u16;
+        // No top spacer; the live ring placeholder provides separation.
         if let Some(ring) = &self.live_ring {
             let live_h = ring.desired_height(area.width).min(area.height);
             if live_h > 0 {
@@ -389,6 +528,16 @@ impl WidgetRef for &BottomPane<'_> {
             // Leave one empty line
             y_offset = y_offset.saturating_add(1);
         }
+        // If both live ring and overlay status are visible (no modal view),
+        // insert a blank spacer line between them so "Working" is not tight
+        // against streamed text.
+        if self.live_ring.is_some()
+            && self.live_status.is_some()
+            && self.active_view.is_none()
+            && y_offset < area.height
+        {
+            y_offset = y_offset.saturating_add(1);
+        }
         if let Some(status) = &self.live_status {
             let live_h = status
                 .desired_height(area.width)
@@ -403,6 +552,32 @@ impl WidgetRef for &BottomPane<'_> {
                 status.render_ref(live_rect, buf);
                 y_offset = y_offset.saturating_add(live_h);
             }
+        }
+
+        // Render queued messages list below the working status overlay.
+        if let Some(q) = &self.queued_list {
+            let live_h = q
+                .desired_height(area.width)
+                .min(area.height.saturating_sub(y_offset));
+            if live_h > 0 {
+                let live_rect = Rect {
+                    x: area.x,
+                    y: area.y + y_offset,
+                    width: area.width,
+                    height: live_h,
+                };
+                q.render_ref(live_rect, buf);
+                y_offset = y_offset.saturating_add(live_h);
+            }
+        }
+
+        // Spacer line between overlay (status + queued) and composer when input is allowed.
+        if self.allow_input_while_running
+            && self.active_view.is_none()
+            && (self.live_status.is_some() || self.queued_list.is_some())
+            && y_offset < area.height
+        {
+            y_offset = y_offset.saturating_add(1);
         }
 
         if let Some(view) = &self.active_view {
@@ -459,6 +634,7 @@ mod tests {
             app_event_tx: tx,
             has_input_focus: true,
             enhanced_keys_supported: false,
+            allow_input_while_running: false,
         });
         pane.push_approval_request(exec_request());
         assert_eq!(CancellationEvent::Handled, pane.on_ctrl_c());
@@ -474,6 +650,7 @@ mod tests {
             app_event_tx: tx,
             has_input_focus: true,
             enhanced_keys_supported: false,
+            allow_input_while_running: false,
         });
 
         // Provide 4 rows with max_rows=3; only the last 3 should be visible.
@@ -511,6 +688,7 @@ mod tests {
             app_event_tx: tx,
             has_input_focus: true,
             enhanced_keys_supported: false,
+            allow_input_while_running: false,
         });
 
         // Simulate task running which replaces composer with the status indicator.
@@ -572,6 +750,7 @@ mod tests {
             app_event_tx: tx,
             has_input_focus: true,
             enhanced_keys_supported: false,
+            allow_input_while_running: false,
         });
 
         // Create an approval modal (active view).
@@ -602,6 +781,7 @@ mod tests {
             app_event_tx: tx.clone(),
             has_input_focus: true,
             enhanced_keys_supported: false,
+            allow_input_while_running: false,
         });
 
         // Start a running task so the status indicator replaces the composer.
@@ -652,6 +832,7 @@ mod tests {
             app_event_tx: tx,
             has_input_focus: true,
             enhanced_keys_supported: false,
+            allow_input_while_running: false,
         });
 
         // Begin a task: show initial status.
@@ -688,6 +869,7 @@ mod tests {
             app_event_tx: tx,
             has_input_focus: true,
             enhanced_keys_supported: false,
+            allow_input_while_running: false,
         });
 
         // Activate spinner (status view replaces composer) with no live ring.
@@ -740,6 +922,7 @@ mod tests {
             app_event_tx: tx,
             has_input_focus: true,
             enhanced_keys_supported: false,
+            allow_input_while_running: false,
         });
 
         pane.set_task_running(true);

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -825,6 +825,62 @@ mod tests {
     }
 
     #[test]
+    fn cursor_pos_accounts_for_live_ring_and_status_spacer() {
+        let (tx_raw, _rx) = channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let mut pane = BottomPane::new(BottomPaneParams {
+            app_event_tx: tx,
+            has_input_focus: true,
+            enhanced_keys_supported: false,
+            allow_input_while_running: true, // overlay mode keeps composer visible
+        });
+
+        // Begin running: show overlay status.
+        pane.set_task_running(true);
+        pane.update_status_text("waiting for model".to_string());
+        // Provide a live ring with two rows (e.g., streaming content preview).
+        pane.set_live_ring_rows(3, vec![Line::from("one"), Line::from("two")]);
+
+        let area = Rect::new(0, 0, 60, 12);
+        // Offsets: ring_h (2) + spacer (1) + status (1) + overlay→composer spacer (1) = 5
+        let expected_offset_y = 5u16;
+        let (_x, y) = pane
+            .cursor_pos(area)
+            .expect("cursor position should be available in overlay mode");
+        assert_eq!(
+            y, expected_offset_y,
+            "cursor y should be offset by overlays"
+        );
+    }
+
+    #[test]
+    fn cursor_pos_accounts_for_status_only_no_ring() {
+        let (tx_raw, _rx) = channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let mut pane = BottomPane::new(BottomPaneParams {
+            app_event_tx: tx,
+            has_input_focus: true,
+            enhanced_keys_supported: false,
+            allow_input_while_running: true,
+        });
+
+        // Running with status overlay only (no live ring).
+        pane.set_task_running(true);
+        pane.update_status_text("waiting for model".to_string());
+
+        let area = Rect::new(0, 0, 60, 10);
+        // Offsets: status height (1) + overlay→composer spacer (1) = 2
+        let expected_offset_y = 2u16;
+        let (_x, y) = pane
+            .cursor_pos(area)
+            .expect("cursor position should be available in overlay mode");
+        assert_eq!(
+            y, expected_offset_y,
+            "cursor y should include status + spacer"
+        );
+    }
+
+    #[test]
     fn overlay_not_shown_above_approval_modal() {
         let (tx_raw, _rx) = channel::<AppEvent>();
         let tx = AppEventSender::new(tx_raw);

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -111,9 +111,8 @@ impl BottomPane<'_> {
             .as_ref()
             .map(|s| s.desired_height(width))
             .unwrap_or(0);
-        // Optional spacer above the first overlay while streaming and the
-        // No extra spacer above overlay; separation is handled by the live ring
-        // placeholder injected when streaming begins.
+        // No extra spacer is added above the first overlay; separation is
+        // handled by the live ring placeholder that is injected when streaming begins.
         let overlay_status_pad = 0;
         let ring_h = self
             .live_ring
@@ -742,13 +741,7 @@ mod tests {
         );
     }
 
-    // moved to tests/overlay_spacing.rs
-
-    // moved to tests/overlay_spacing.rs
-
-    // moved to tests/queued_overlay.rs
-    // moved to tests/queued_overlay.rs
-    // moved to tests/cursor_pos.rs
+    // heavy UI tests have been moved to dedicated modules below
 
     #[test]
     fn cursor_pos_accounts_for_live_ring_and_status_spacer() {

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -825,6 +825,133 @@ mod tests {
     }
 
     #[test]
+    fn queued_list_renders_below_working_above_composer() {
+        let (tx_raw, _rx) = channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let mut pane = BottomPane::new(BottomPaneParams {
+            app_event_tx: tx,
+            has_input_focus: true,
+            enhanced_keys_supported: false,
+            allow_input_while_running: true, // overlay mode
+        });
+
+        // Status overlay only (no live ring), then a queued list with two items.
+        pane.set_task_running(true);
+        pane.update_status_text("waiting for model".to_string());
+        pane.set_queued_list_rows(vec![
+            Line::from("  ⎿ ⏳ queued1"),
+            Line::from("    ⏳ queued2"),
+        ]);
+
+        // Render: expect status at row0, queued rows at row1-2, spacer at row3, then composer.
+        let area = Rect::new(0, 0, 50, 6);
+        let mut buf = Buffer::empty(area);
+        (&pane).render_ref(area, &mut buf);
+
+        let row0: String = (0..area.width)
+            .map(|x| buf[(x, 0)].symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(row0.contains("Working"), "row0 should be Working: {row0:?}");
+
+        let row1: String = (0..area.width)
+            .map(|x| buf[(x, 1)].symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(
+            row1.contains("⏳"),
+            "row1 should show first queued item: {row1:?}"
+        );
+
+        let row2: String = (0..area.width)
+            .map(|x| buf[(x, 2)].symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(
+            row2.contains("queued2"),
+            "row2 should show second queued item: {row2:?}"
+        );
+
+        let row3: String = (0..area.width)
+            .map(|x| buf[(x, 3)].symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(
+            row3.trim().is_empty(),
+            "row3 should be spacer above composer: {row3:?}"
+        );
+
+        // Composer content should appear on the next row (not Working and not queued).
+        let row4: String = (0..area.width)
+            .map(|x| buf[(x, 4)].symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(
+            !row4.contains("Working") && !row4.contains("⏳"),
+            "row4 should be composer (not Working/queued): {row4:?}"
+        );
+    }
+
+    #[test]
+    fn queued_list_clear_hides_overlay() {
+        let (tx_raw, _rx) = channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let mut pane = BottomPane::new(BottomPaneParams {
+            app_event_tx: tx,
+            has_input_focus: true,
+            enhanced_keys_supported: false,
+            allow_input_while_running: true,
+        });
+
+        pane.set_task_running(true);
+        pane.update_status_text("waiting for model".to_string());
+        pane.set_queued_list_rows(vec![Line::from("  ⎿ ⏳ queued1")]);
+
+        // Now clear the queued overlay and ensure the line after Working is not a queued item.
+        pane.clear_queued_list();
+
+        let area = Rect::new(0, 0, 50, 5);
+        let mut buf = Buffer::empty(area);
+        (&pane).render_ref(area, &mut buf);
+
+        let row0: String = (0..area.width)
+            .map(|x| buf[(x, 0)].symbol().chars().next().unwrap_or(' '))
+            .collect();
+        assert!(row0.contains("Working"));
+        let row1: String = (0..area.width)
+            .map(|x| buf[(x, 1)].symbol().chars().next().unwrap_or(' '))
+            .collect();
+        // Depending on height, row1 may be spacer or start of composer; in either
+        // case it must not contain queued content.
+        assert!(
+            !row1.contains("⏳") && !row1.contains("queued1"),
+            "queued overlay should be cleared: {row1:?}"
+        );
+    }
+
+    #[test]
+    fn cursor_pos_accounts_for_queued_list() {
+        let (tx_raw, _rx) = channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let mut pane = BottomPane::new(BottomPaneParams {
+            app_event_tx: tx,
+            has_input_focus: true,
+            enhanced_keys_supported: false,
+            allow_input_while_running: true,
+        });
+
+        pane.set_task_running(true);
+        pane.update_status_text("waiting for model".to_string());
+        pane.set_queued_list_rows(vec![Line::from("  ⎿ ⏳ q1"), Line::from("    ⏳ q2")]);
+
+        let area = Rect::new(0, 0, 60, 12);
+        // Offsets: status (1) + queued (2) + overlay→composer spacer (1) = 4
+        let expected_offset_y = 4u16;
+        let (_x, y) = pane
+            .cursor_pos(area)
+            .expect("cursor position should be available");
+        assert_eq!(
+            y, expected_offset_y,
+            "cursor y should include queued overlay"
+        );
+    }
+
+    #[test]
     fn cursor_pos_accounts_for_live_ring_and_status_spacer() {
         let (tx_raw, _rx) = channel::<AppEvent>();
         let tx = AppEventSender::new(tx_raw);

--- a/codex-rs/tui/src/bottom_pane/queued_list_widget.rs
+++ b/codex-rs/tui/src/bottom_pane/queued_list_widget.rs
@@ -1,0 +1,38 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::text::Line;
+use ratatui::widgets::{Paragraph, WidgetRef};
+
+pub(crate) struct QueuedListWidget {
+    rows: Vec<Line<'static>>,
+}
+
+impl QueuedListWidget {
+    pub(crate) fn new() -> Self {
+        Self { rows: Vec::new() }
+    }
+
+    pub(crate) fn set_rows(&mut self, rows: Vec<Line<'static>>) {
+        self.rows = rows;
+    }
+
+    pub(crate) fn desired_height(&self, _width: u16) -> u16 {
+        self.rows.len() as u16
+    }
+}
+
+impl WidgetRef for QueuedListWidget {
+    fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        if area.height == 0 || self.rows.is_empty() {
+            return;
+        }
+        let max_rows = area.height as usize;
+        let start = if self.rows.len() > max_rows {
+            self.rows.len() - max_rows
+        } else {
+            0
+        };
+        let visible = self.rows[start..].to_vec();
+        Paragraph::new(visible).render_ref(area, buf);
+    }
+}

--- a/codex-rs/tui/src/bottom_pane/tests/cursor_pos.rs
+++ b/codex-rs/tui/src/bottom_pane/tests/cursor_pos.rs
@@ -1,9 +1,3 @@
-use crate::app_event::AppEvent;
-use crate::app_event_sender::AppEventSender;
-use crate::bottom_pane::{BottomPane, BottomPaneParams};
-use ratatui::layout::Rect;
-use ratatui::text::Line;
-use std::sync::mpsc::channel;
 
 #[test]
 fn cursor_pos_accounts_for_live_ring_and_status_spacer() {

--- a/codex-rs/tui/src/bottom_pane/tests/cursor_pos.rs
+++ b/codex-rs/tui/src/bottom_pane/tests/cursor_pos.rs
@@ -1,0 +1,89 @@
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+use crate::bottom_pane::{BottomPane, BottomPaneParams};
+use ratatui::layout::Rect;
+use ratatui::text::Line;
+use std::sync::mpsc::channel;
+
+#[test]
+fn cursor_pos_accounts_for_live_ring_and_status_spacer() {
+    let (tx_raw, _rx) = channel::<AppEvent>();
+    let tx = AppEventSender::new(tx_raw);
+    let mut pane = BottomPane::new(BottomPaneParams {
+        app_event_tx: tx,
+        has_input_focus: true,
+        enhanced_keys_supported: false,
+        allow_input_while_running: true, // overlay mode keeps composer visible
+    });
+
+    // Begin running: show overlay status.
+    pane.set_task_running(true);
+    pane.update_status_text("waiting for model".to_string());
+    // Provide a live ring with two rows (e.g., streaming content preview).
+    pane.set_live_ring_rows(3, vec![Line::from("one"), Line::from("two")]);
+
+    let area = Rect::new(0, 0, 60, 12);
+    // Offsets: ring_h (2) + spacer (1) + status (1) + overlay→composer spacer (1) = 5
+    let expected_offset_y = 5u16;
+    let (_x, y) = pane
+        .cursor_pos(area)
+        .expect("cursor position should be available in overlay mode");
+    assert_eq!(
+        y, expected_offset_y,
+        "cursor y should be offset by overlays"
+    );
+}
+
+#[test]
+fn cursor_pos_accounts_for_status_only_no_ring() {
+    let (tx_raw, _rx) = channel::<AppEvent>();
+    let tx = AppEventSender::new(tx_raw);
+    let mut pane = BottomPane::new(BottomPaneParams {
+        app_event_tx: tx,
+        has_input_focus: true,
+        enhanced_keys_supported: false,
+        allow_input_while_running: true,
+    });
+
+    // Running with status overlay only (no live ring).
+    pane.set_task_running(true);
+    pane.update_status_text("waiting for model".to_string());
+
+    let area = Rect::new(0, 0, 60, 10);
+    // Offsets: status height (1) + overlay→composer spacer (1) = 2
+    let expected_offset_y = 2u16;
+    let (_x, y) = pane
+        .cursor_pos(area)
+        .expect("cursor position should be available in overlay mode");
+    assert_eq!(
+        y, expected_offset_y,
+        "cursor y should include status + spacer"
+    );
+}
+
+#[test]
+fn cursor_pos_accounts_for_queued_list() {
+    let (tx_raw, _rx) = channel::<AppEvent>();
+    let tx = AppEventSender::new(tx_raw);
+    let mut pane = BottomPane::new(BottomPaneParams {
+        app_event_tx: tx,
+        has_input_focus: true,
+        enhanced_keys_supported: false,
+        allow_input_while_running: true,
+    });
+
+    pane.set_task_running(true);
+    pane.update_status_text("waiting for model".to_string());
+    pane.set_queued_list_rows(vec![Line::from("  ⎿ ⏳ q1"), Line::from("    ⏳ q2")]);
+
+    let area = Rect::new(0, 0, 60, 12);
+    // Offsets: status (1) + queued (2) + overlay→composer spacer (1) = 4
+    let expected_offset_y = 4u16;
+    let (_x, y) = pane
+        .cursor_pos(area)
+        .expect("cursor position should be available");
+    assert_eq!(
+        y, expected_offset_y,
+        "cursor y should include queued overlay"
+    );
+}

--- a/codex-rs/tui/src/bottom_pane/tests/overlay_spacing.rs
+++ b/codex-rs/tui/src/bottom_pane/tests/overlay_spacing.rs
@@ -1,11 +1,3 @@
-use crate::app_event::AppEvent;
-use crate::app_event_sender::AppEventSender;
-use crate::bottom_pane::{BottomPane, BottomPaneParams};
-use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
-use ratatui::text::Line;
-use ratatui::widgets::WidgetRef;
-use std::sync::mpsc::channel;
 
 #[test]
 fn overlay_status_has_blank_above_when_live_ring_present() {

--- a/codex-rs/tui/src/bottom_pane/tests/overlay_spacing.rs
+++ b/codex-rs/tui/src/bottom_pane/tests/overlay_spacing.rs
@@ -1,0 +1,89 @@
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+use crate::bottom_pane::{BottomPane, BottomPaneParams};
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::text::Line;
+use std::sync::mpsc::channel;
+
+#[test]
+fn overlay_status_has_blank_above_when_live_ring_present() {
+    let (tx_raw, _rx) = channel::<AppEvent>();
+    let tx = AppEventSender::new(tx_raw);
+    let mut pane = BottomPane::new(BottomPaneParams {
+        app_event_tx: tx,
+        has_input_focus: true,
+        enhanced_keys_supported: false,
+        allow_input_while_running: true, // overlay mode
+    });
+
+    // Live status overlay (Working) is shown while running.
+    pane.set_task_running(true);
+    pane.update_status_text("waiting for model".to_string());
+
+    // Simulate a live ring with two streamed rows.
+    pane.set_live_ring_rows(2, vec![Line::from("stream1"), Line::from("stream2")]);
+
+    // Render enough height to include ring (2), spacer (1), status (1), and a couple more.
+    let area = Rect::new(0, 0, 40, 6);
+    let mut buf = Buffer::empty(area);
+    (&pane).render_ref(area, &mut buf);
+
+    // Row 0..1 are the live ring content.
+    let row0: String = (0..area.width)
+        .map(|x| buf[(x, 0)].symbol().chars().next().unwrap_or(' '))
+        .collect();
+    let row1: String = (0..area.width)
+        .map(|x| buf[(x, 1)].symbol().chars().next().unwrap_or(' '))
+        .collect();
+    assert!(row0.contains("stream1"));
+    assert!(row1.contains("stream2"));
+
+    // Row 2 should be a blank spacer between ring and Working.
+    let spacer: String = (0..area.width)
+        .map(|x| buf[(x, 2)].symbol().chars().next().unwrap_or(' '))
+        .collect();
+    assert!(
+        spacer.trim().is_empty(),
+        "expected blank spacer line above Working: {spacer:?}"
+    );
+
+    // Row 3 should contain the Working header.
+    let row3: String = (0..area.width)
+        .map(|x| buf[(x, 3)].symbol().chars().next().unwrap_or(' '))
+        .collect();
+    assert!(
+        row3.contains("Working"),
+        "expected Working header after spacer: {row3:?}"
+    );
+}
+
+#[test]
+fn overlay_status_has_no_blank_above_when_no_live_ring() {
+    let (tx_raw, _rx) = channel::<AppEvent>();
+    let tx = AppEventSender::new(tx_raw);
+    let mut pane = BottomPane::new(BottomPaneParams {
+        app_event_tx: tx,
+        has_input_focus: true,
+        enhanced_keys_supported: false,
+        allow_input_while_running: true, // overlay mode
+    });
+
+    // Only the status overlay should be present.
+    pane.set_task_running(true);
+    pane.update_status_text("waiting for model".to_string());
+
+    // Render a small area; the first row should be Working (no blank above it).
+    let area = Rect::new(0, 0, 40, 3);
+    let mut buf = Buffer::empty(area);
+    (&pane).render_ref(area, &mut buf);
+
+    // Top row contains the Working header (no leading blank line).
+    let top: String = (0..area.width)
+        .map(|x| buf[(x, 0)].symbol().chars().next().unwrap_or(' '))
+        .collect();
+    assert!(
+        top.contains("Working"),
+        "expected Working header on top row: {top:?}"
+    );
+}

--- a/codex-rs/tui/src/bottom_pane/tests/overlay_spacing.rs
+++ b/codex-rs/tui/src/bottom_pane/tests/overlay_spacing.rs
@@ -4,6 +4,7 @@ use crate::bottom_pane::{BottomPane, BottomPaneParams};
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::text::Line;
+use ratatui::widgets::WidgetRef;
 use std::sync::mpsc::channel;
 
 #[test]

--- a/codex-rs/tui/src/bottom_pane/tests/queued_overlay.rs
+++ b/codex-rs/tui/src/bottom_pane/tests/queued_overlay.rs
@@ -1,11 +1,3 @@
-use crate::app_event::AppEvent;
-use crate::app_event_sender::AppEventSender;
-use crate::bottom_pane::{BottomPane, BottomPaneParams};
-use ratatui::buffer::Buffer;
-use ratatui::layout::Rect;
-use ratatui::text::Line;
-use ratatui::widgets::WidgetRef;
-use std::sync::mpsc::channel;
 
 #[test]
 fn queued_list_renders_below_working_above_composer() {

--- a/codex-rs/tui/src/bottom_pane/tests/queued_overlay.rs
+++ b/codex-rs/tui/src/bottom_pane/tests/queued_overlay.rs
@@ -1,0 +1,107 @@
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+use crate::bottom_pane::{BottomPane, BottomPaneParams};
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::text::Line;
+use std::sync::mpsc::channel;
+
+#[test]
+fn queued_list_renders_below_working_above_composer() {
+    let (tx_raw, _rx) = channel::<AppEvent>();
+    let tx = AppEventSender::new(tx_raw);
+    let mut pane = BottomPane::new(BottomPaneParams {
+        app_event_tx: tx,
+        has_input_focus: true,
+        enhanced_keys_supported: false,
+        allow_input_while_running: true, // overlay mode
+    });
+
+    // Status overlay only (no live ring), then a queued list with two items.
+    pane.set_task_running(true);
+    pane.update_status_text("waiting for model".to_string());
+    pane.set_queued_list_rows(vec![
+        Line::from("  ⎿ ⏳ queued1"),
+        Line::from("    ⏳ queued2"),
+    ]);
+
+    // Render: expect status at row0, queued rows at row1-2, spacer at row3, then composer.
+    let area = Rect::new(0, 0, 50, 6);
+    let mut buf = Buffer::empty(area);
+    (&pane).render_ref(area, &mut buf);
+
+    let row0: String = (0..area.width)
+        .map(|x| buf[(x, 0)].symbol().chars().next().unwrap_or(' '))
+        .collect();
+    assert!(row0.contains("Working"), "row0 should be Working: {row0:?}");
+
+    let row1: String = (0..area.width)
+        .map(|x| buf[(x, 1)].symbol().chars().next().unwrap_or(' '))
+        .collect();
+    assert!(
+        row1.contains("⏳"),
+        "row1 should show first queued item: {row1:?}"
+    );
+
+    let row2: String = (0..area.width)
+        .map(|x| buf[(x, 2)].symbol().chars().next().unwrap_or(' '))
+        .collect();
+    assert!(
+        row2.contains("queued2"),
+        "row2 should show second queued item: {row2:?}"
+    );
+
+    let row3: String = (0..area.width)
+        .map(|x| buf[(x, 3)].symbol().chars().next().unwrap_or(' '))
+        .collect();
+    assert!(
+        row3.trim().is_empty(),
+        "row3 should be spacer above composer: {row3:?}"
+    );
+
+    // Composer content should appear on the next row (not Working and not queued).
+    let row4: String = (0..area.width)
+        .map(|x| buf[(x, 4)].symbol().chars().next().unwrap_or(' '))
+        .collect();
+    assert!(
+        !row4.contains("Working") && !row4.contains("⏳"),
+        "row4 should be composer (not Working/queued): {row4:?}"
+    );
+}
+
+#[test]
+fn queued_list_clear_hides_overlay() {
+    let (tx_raw, _rx) = channel::<AppEvent>();
+    let tx = AppEventSender::new(tx_raw);
+    let mut pane = BottomPane::new(BottomPaneParams {
+        app_event_tx: tx,
+        has_input_focus: true,
+        enhanced_keys_supported: false,
+        allow_input_while_running: true,
+    });
+
+    pane.set_task_running(true);
+    pane.update_status_text("waiting for model".to_string());
+    pane.set_queued_list_rows(vec![Line::from("  ⎿ ⏳ queued1")]);
+
+    // Now clear the queued overlay and ensure the line after Working is not a queued item.
+    pane.clear_queued_list();
+
+    let area = Rect::new(0, 0, 50, 5);
+    let mut buf = Buffer::empty(area);
+    (&pane).render_ref(area, &mut buf);
+
+    let row0: String = (0..area.width)
+        .map(|x| buf[(x, 0)].symbol().chars().next().unwrap_or(' '))
+        .collect();
+    assert!(row0.contains("Working"));
+    let row1: String = (0..area.width)
+        .map(|x| buf[(x, 1)].symbol().chars().next().unwrap_or(' '))
+        .collect();
+    // Depending on height, row1 may be spacer or start of composer; in either
+    // case it must not contain queued content.
+    assert!(
+        !row1.contains("⏳") && !row1.contains("queued1"),
+        "queued overlay should be cleared: {row1:?}"
+    );
+}

--- a/codex-rs/tui/src/bottom_pane/tests/queued_overlay.rs
+++ b/codex-rs/tui/src/bottom_pane/tests/queued_overlay.rs
@@ -4,6 +4,7 @@ use crate::bottom_pane::{BottomPane, BottomPaneParams};
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::text::Line;
+use ratatui::widgets::WidgetRef;
 use std::sync::mpsc::channel;
 
 #[test]


### PR DESCRIPTION
TUI: message queue overlay, streaming spacing fix, and tests

Summary: Improve TUI streaming and queuing UX.
- Overlay mode keeps the composer visible while running (allow_input_while_running).
- Guarantees a single blank line between streamed text (live ring) and the "Working" label.
- Adds a queued messages overlay under "Working" (with ⏳ prefix), placed above the composer, and clears correctly.
- Fixes caret/cursor Y offset to account for overlays and spacers.
- Splits new layout tests into test-only modules to keep code lean.

Changes:
- Add spacer between live ring and "Working" when both render (no spacer when ring absent).
- Maintain overlay→composer spacer for readability.
- Do not inject extra history newlines; avoid blank under "codex".
- Message queue overlay: render list below "Working", clear on empty, and mirror offsets in cursor_pos.
- Test refactor: move new UI layout tests into:
  - tui/src/bottom_pane/tests/overlay_spacing.rs
  - tui/src/bottom_pane/tests/queued_overlay.rs
  - tui/src/bottom_pane/tests/cursor_pos.rs

Tests:
- overlay_spacing: one blank above "Working" when ring present; none when absent.
- queued_overlay: list renders below "Working" and above composer; clearing hides overlay.
- cursor_pos: offsets for ring+spacer+status+spacer; status+spacer; status+queued+spacer.
- TUI crate: all tests pass (84).

Notes:
- All feature commits squashed on feat/tui-message-queue after merge-base with main.


Resolves #2011