### PR TITLE
tui: refresh context-left after /compact

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -629,7 +629,10 @@ impl ChatWidget<'_> {
     }
 
     pub(crate) fn clear_token_usage(&mut self) {
+        // Reset both the aggregated and last-turn usage so the UI
+        // reflects the refreshed context after operations like `/compact`.
         self.total_token_usage = TokenUsage::default();
+        self.last_token_usage = TokenUsage::default();
         self.bottom_pane.set_token_usage(
             self.total_token_usage.clone(),
             self.last_token_usage.clone(),


### PR DESCRIPTION
Fixes: context-left footer not refreshing after /compact.

Changes:
- Reset both total and last token usage in ChatWidget::clear_token_usage so the footer percent reflects a fresh context after /compact.
- Add UI test to verify footer updates (60%→100%) after reset.

Validation:
- Ran cargo fmt in codex-rs.
- Ran cargo test -p codex-tui --all-features (78 passing).
- Full workspace tests show one unrelated core shell-detection failure under sandbox; TUI crate is clean.

Related issues:
- Related to #2077 (/compact issues in general). This PR improves UI feedback post-compact but does not change backend compact behavior.
- Follow-up to #395 (Context Left Percentage does not reset after /clear) — this applies the analogous fix for /compact.
- Touches UI added per #1242 (Show how much context window is left).
