### PR TITLE
feat: add /reasoning slash command to change reasoning effort mid-conversation

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -310,7 +310,7 @@ impl App<'_> {
                     AppState::Chat { widget } => widget.update_latest_log(line),
                     AppState::Onboarding { .. } => {}
                 },
-                AppEvent::DispatchCommand(command) => match command {
+                AppEvent::DispatchCommand(command, command_text) => match command {
                     SlashCommand::New => {
                         // User accepted – switch to chat view.
                         let new_widget = Box::new(ChatWidget::new(
@@ -371,6 +371,11 @@ impl App<'_> {
                             widget.add_status_output();
                         }
                     }
+                    SlashCommand::Reasoning => {
+                        if let AppState::Chat { widget } = &mut self.app_state {
+                            widget.handle_reasoning_command(command_text);
+                        }
+                    }
                     SlashCommand::Prompts => {
                         if let AppState::Chat { widget } = &mut self.app_state {
                             widget.add_prompts_output();
@@ -416,6 +421,11 @@ impl App<'_> {
                         }));
                     }
                 },
+                AppEvent::UpdateReasoningEffort(new_effort) => {
+                    if let AppState::Chat { widget } = &mut self.app_state {
+                        widget.set_reasoning_effort(new_effort);
+                    }
+                }
                 AppEvent::OnboardingAuthComplete(result) => {
                     if let AppState::Onboarding { screen } = &mut self.app_state {
                         screen.on_auth_complete(result);

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -1,3 +1,4 @@
+use codex_core::config_types::ReasoningEffort;
 use codex_core::protocol::Event;
 use codex_file_search::FileMatch;
 use crossterm::event::KeyEvent;
@@ -32,8 +33,11 @@ pub(crate) enum AppEvent {
     LatestLog(String),
 
     /// Dispatch a recognized slash command from the UI (composer) to the app
-    /// layer so it can be handled centrally.
-    DispatchCommand(SlashCommand),
+    /// layer so it can be handled centrally. Includes the full command text.
+    DispatchCommand(SlashCommand, String),
+    
+    /// Update the reasoning effort level
+    UpdateReasoningEffort(ReasoningEffort),
 
     /// Kick off an asynchronous file search for the given query (text after
     /// the `@`). Previous searches may be cancelled by the app layer so there

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -259,8 +259,11 @@ impl ChatComposer {
                 ..
             } => {
                 if let Some(cmd) = popup.selected_command() {
-                    // Send command to the app layer.
-                    self.app_event_tx.send(AppEvent::DispatchCommand(*cmd));
+                    // Get the full command text before clearing
+                    let command_text = self.textarea.text().to_string();
+                    
+                    // Send command to the app layer with full text.
+                    self.app_event_tx.send(AppEvent::DispatchCommand(*cmd, command_text));
 
                     // Clear textarea so no residual text remains.
                     self.textarea.set_text("");
@@ -1068,8 +1071,9 @@ mod tests {
 
         // Verify a DispatchCommand event for the "init" command was sent.
         match rx.try_recv() {
-            Ok(AppEvent::DispatchCommand(cmd)) => {
+            Ok(AppEvent::DispatchCommand(cmd, text)) => {
                 assert_eq!(cmd.command(), "init");
+                assert_eq!(text, "/init");
             }
             Ok(_other) => panic!("unexpected app event"),
             Err(TryRecvError::Empty) => panic!("expected a DispatchCommand event for '/init'"),

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -20,6 +20,7 @@ mod command_popup;
 mod file_search_popup;
 mod live_ring_widget;
 mod popup_consts;
+mod reasoning_selection_view;
 mod scroll_state;
 mod selection_popup_common;
 mod status_indicator_view;
@@ -36,7 +37,9 @@ pub(crate) use chat_composer::InputResult;
 
 use crate::status_indicator_widget::StatusIndicatorWidget;
 use approval_modal_view::ApprovalModalView;
+use reasoning_selection_view::ReasoningSelectionView;
 use status_indicator_view::StatusIndicatorView;
+use codex_core::config_types::ReasoningEffort;
 
 /// Pane displayed in the lower half of the chat UI.
 pub(crate) struct BottomPane<'a> {
@@ -317,6 +320,15 @@ impl BottomPane<'_> {
         let modal = ApprovalModalView::new(request, self.app_event_tx.clone());
         self.active_view = Some(Box::new(modal));
         // Hide any overlay status while a modal is visible.
+        self.live_status = None;
+        self.status_view_active = false;
+        self.request_redraw()
+    }
+    
+    /// Show the reasoning selection UI
+    pub fn show_reasoning_selection(&mut self, current_effort: ReasoningEffort) {
+        let view = ReasoningSelectionView::new(current_effort, self.app_event_tx.clone());
+        self.active_view = Some(Box::new(view));
         self.live_status = None;
         self.status_view_active = false;
         self.request_redraw()

--- a/codex-rs/tui/src/bottom_pane/reasoning_selection_view.rs
+++ b/codex-rs/tui/src/bottom_pane/reasoning_selection_view.rs
@@ -1,0 +1,182 @@
+use codex_core::config_types::ReasoningEffort;
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::buffer::Buffer;
+use ratatui::layout::{Alignment, Rect};
+use ratatui::style::{Color, Modifier, Style};
+use ratatui::text::{Line, Span};
+use ratatui::widgets::{Block, Borders, Clear, Paragraph, Widget};
+
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+
+use super::bottom_pane_view::BottomPaneView;
+use super::BottomPane;
+
+/// Interactive UI for selecting reasoning effort level
+pub(crate) struct ReasoningSelectionView {
+    current_effort: ReasoningEffort,
+    selected_effort: ReasoningEffort,
+    app_event_tx: AppEventSender,
+    is_complete: bool,
+}
+
+impl ReasoningSelectionView {
+    pub fn new(current_effort: ReasoningEffort, app_event_tx: AppEventSender) -> Self {
+        Self {
+            current_effort,
+            selected_effort: current_effort,
+            app_event_tx,
+            is_complete: false,
+        }
+    }
+
+    fn get_effort_options() -> Vec<(ReasoningEffort, &'static str, &'static str)> {
+        vec![
+            (ReasoningEffort::None, "None", "No reasoning (fastest)"),
+            (ReasoningEffort::Low, "Low", "Basic reasoning"),
+            (ReasoningEffort::Medium, "Medium", "Balanced reasoning (default)"),
+            (ReasoningEffort::High, "High", "Deep reasoning (slower)"),
+        ]
+    }
+
+    fn move_selection_up(&mut self) {
+        let options = Self::get_effort_options();
+        let current_idx = options
+            .iter()
+            .position(|(e, _, _)| *e == self.selected_effort)
+            .unwrap_or(0);
+        
+        let new_idx = if current_idx == 0 {
+            options.len() - 1
+        } else {
+            current_idx - 1
+        };
+        
+        self.selected_effort = options[new_idx].0;
+    }
+
+    fn move_selection_down(&mut self) {
+        let options = Self::get_effort_options();
+        let current_idx = options
+            .iter()
+            .position(|(e, _, _)| *e == self.selected_effort)
+            .unwrap_or(0);
+        
+        let new_idx = (current_idx + 1) % options.len();
+        self.selected_effort = options[new_idx].0;
+    }
+
+    fn confirm_selection(&self) {
+        // Send event to update reasoning effort
+        self.app_event_tx.send(AppEvent::UpdateReasoningEffort(self.selected_effort));
+    }
+}
+
+impl<'a> BottomPaneView<'a> for ReasoningSelectionView {
+    fn handle_key_event(&mut self, _pane: &mut BottomPane<'a>, key_event: KeyEvent) {
+        match key_event {
+            KeyEvent {
+                code: KeyCode::Up,
+                modifiers: KeyModifiers::NONE,
+                ..
+            } => {
+                self.move_selection_up();
+            }
+            KeyEvent {
+                code: KeyCode::Down,
+                modifiers: KeyModifiers::NONE,
+                ..
+            } => {
+                self.move_selection_down();
+            }
+            KeyEvent {
+                code: KeyCode::Enter,
+                modifiers: KeyModifiers::NONE,
+                ..
+            } => {
+                self.confirm_selection();
+                self.is_complete = true;
+            }
+            KeyEvent {
+                code: KeyCode::Esc,
+                modifiers: KeyModifiers::NONE,
+                ..
+            } => {
+                self.is_complete = true;
+            }
+            _ => {}
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        self.is_complete
+    }
+
+    fn desired_height(&self, _width: u16) -> u16 {
+        10 // Height for the selection box
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        // Clear the area first
+        Clear.render(area, buf);
+
+        // Create a centered box
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Blue))
+            .title(" Select Reasoning Effort ")
+            .title_alignment(Alignment::Center);
+
+        let inner_area = block.inner(area);
+        block.render(area, buf);
+
+        // Build the content
+        let mut lines = vec![
+            Line::from(vec![
+                Span::raw("Current: "),
+                Span::styled(
+                    format!("{}", self.current_effort),
+                    Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
+                ),
+            ]),
+            Line::from(""),
+        ];
+
+        // Add options
+        for (effort, name, description) in Self::get_effort_options() {
+            let is_selected = effort == self.selected_effort;
+            let is_current = effort == self.current_effort;
+            
+            let mut style = Style::default();
+            if is_selected {
+                style = style.bg(Color::DarkGray).add_modifier(Modifier::BOLD);
+            }
+            if is_current {
+                style = style.fg(Color::Yellow);
+            }
+
+            let prefix = if is_selected { "▶ " } else { "  " };
+            let line = Line::from(vec![
+                Span::raw(prefix),
+                Span::styled(format!("{:<8}", name), style),
+                Span::raw(" - "),
+                Span::styled(description, Style::default().fg(Color::Gray)),
+            ]);
+            lines.push(line);
+        }
+
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            Span::styled("↑↓", Style::default().fg(Color::Cyan)),
+            Span::raw(" Navigate  "),
+            Span::styled("Enter", Style::default().fg(Color::Green)),
+            Span::raw(" Select  "),
+            Span::styled("Esc", Style::default().fg(Color::Red)),
+            Span::raw(" Cancel"),
+        ]));
+
+        let paragraph = Paragraph::new(lines)
+            .alignment(Alignment::Left);
+        paragraph.render(inner_area, buf);
+    }
+}

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -8,6 +8,7 @@ use codex_ansi_escape::ansi_escape_line;
 use codex_common::create_config_summary_entries;
 use codex_common::elapsed::format_duration;
 use codex_core::config::Config;
+use codex_core::config_types::ReasoningEffort;
 use codex_core::plan_tool::PlanItemArg;
 use codex_core::plan_tool::StepStatus;
 use codex_core::plan_tool::UpdatePlanArgs;
@@ -107,6 +108,9 @@ pub(crate) enum HistoryCell {
 
     /// Output from the `/diff` command.
     GitDiffOutput { view: TextBlock },
+    
+    /// Output from the `/reasoning` command.
+    ReasoningOutput { view: TextBlock },
 
     /// Output from the `/status` command.
     StatusOutput { view: TextBlock },
@@ -166,6 +170,7 @@ impl HistoryCell {
             | HistoryCell::UserPrompt { view }
             | HistoryCell::BackgroundEvent { view }
             | HistoryCell::GitDiffOutput { view }
+            | HistoryCell::ReasoningOutput { view }
             | HistoryCell::StatusOutput { view }
             | HistoryCell::PromptsOutput { view }
             | HistoryCell::ErrorEvent { view }
@@ -500,6 +505,20 @@ impl HistoryCell {
 
         lines.push(Line::from(""));
         HistoryCell::GitDiffOutput {
+            view: TextBlock::new(lines),
+        }
+    }
+
+    pub(crate) fn new_reasoning_output(effort: ReasoningEffort) -> Self {
+        use ratatui::style::Stylize;
+        let mut lines: Vec<Line<'static>> = Vec::new();
+        lines.push(Line::from("/reasoning".magenta()));
+        lines.push(Line::from(vec![
+            "Reasoning effort changed to: ".into(),
+            format!("{}", effort).bold().into(),
+        ]));
+        lines.push(Line::from(""));
+        HistoryCell::ReasoningOutput {
             view: TextBlock::new(lines),
         }
     }

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -17,6 +17,7 @@ pub enum SlashCommand {
     Compact,
     Diff,
     Status,
+    Reasoning,
     Prompts,
     Logout,
     Quit,
@@ -34,6 +35,7 @@ impl SlashCommand {
             SlashCommand::Quit => "exit Codex",
             SlashCommand::Diff => "show git diff (including untracked files)",
             SlashCommand::Status => "show current session configuration and token usage",
+            SlashCommand::Reasoning => "change reasoning effort (low/medium/high/none)",
             SlashCommand::Prompts => "show example prompts",
             SlashCommand::Logout => "log out of Codex",
             #[cfg(debug_assertions)]


### PR DESCRIPTION
## Summary
- Adds a new `/reasoning` slash command to dynamically change reasoning effort levels during a conversation
- Implements both direct parameter setting and an interactive selection UI
- Fixes #2106

## Features

### 1. Direct Parameter Setting
Use `/reasoning <level>` to set a specific reasoning level:
- `/reasoning high` - Sets reasoning to high
- `/reasoning medium` or `/reasoning med` - Sets reasoning to medium  
- `/reasoning low` - Sets reasoning to low
- `/reasoning none` or `/reasoning off` - Disables reasoning

### 2. Interactive Selection UI
Use `/reasoning` without parameters to open an interactive selection:
- Shows current reasoning level highlighted in yellow
- Navigate with arrow keys (↑↓)
- Press Enter to select, Esc to cancel
- Each option displays a helpful description

### Implementation Details

#### Files Modified:
1. **slash_command.rs** - Added `Reasoning` command to enum
2. **app.rs** - Added handlers for command dispatch and UI events
3. **app_event.rs** - Added `UpdateReasoningEffort` event
4. **chatwidget.rs** - Implemented command handling and session updates
5. **history_cell.rs** - Added proper formatting for reasoning output
6. **bottom_pane/mod.rs** - Added UI management methods
7. **chat_composer.rs** - Modified to pass full command text

#### New File:
- **bottom_pane/reasoning_selection_view.rs** - Interactive selection UI component

### Improvements
- Uses actual bold formatting instead of markdown asterisks
- Prevents duplicate welcome message when changing reasoning level
- Proper error handling for invalid parameters
- Clean UI state management with completion tracking

## Test Plan
- [x] Test `/reasoning` without parameters - opens interactive UI
- [x] Test `/reasoning high/medium/low/none` - sets level directly  
- [x] Test invalid parameter - shows appropriate error
- [x] Test UI navigation with arrow keys
- [x] Test Enter to confirm, Esc to cancel
- [x] Verify no duplicate welcome message
- [x] Verify bold formatting works correctly
- [x] Test that UI properly closes after selection