### PR TITLE
show messages if there is no delta. i.e. /Compact command feedback

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -312,9 +312,7 @@ impl ChatWidget<'_> {
                 self.request_redraw();
             }
             EventMsg::AgentMessage(AgentMessageEvent { message }) => {
-                // Final assistant answer.
-                // If no deltas were streamed (no active Answer stream), still render
-                // the provided final message text so events like compact completion are visible.
+                // AgentMessage: if no deltas were streamed, render the final text.
                 if self.current_stream != Some(StreamKind::Answer) && !message.is_empty() {
                     self.begin_stream(StreamKind::Answer);
                     self.stream_push_and_maybe_commit(&message);
@@ -336,8 +334,12 @@ impl ChatWidget<'_> {
                 self.stream_push_and_maybe_commit(&delta);
                 self.request_redraw();
             }
-            EventMsg::AgentReasoning(AgentReasoningEvent { text: _ }) => {
-                // Final reasoning: commit remaining rows and close with a blank.
+            EventMsg::AgentReasoning(AgentReasoningEvent { text }) => {
+                // Final reasoning: if no deltas were streamed, render the final text.
+                if self.current_stream != Some(StreamKind::Reasoning) && !text.is_empty() {
+                    self.begin_stream(StreamKind::Reasoning);
+                    self.stream_push_and_maybe_commit(&text);
+                }
                 self.finalize_stream(StreamKind::Reasoning);
                 self.request_redraw();
             }
@@ -350,8 +352,12 @@ impl ChatWidget<'_> {
                 self.stream_push_and_maybe_commit(&delta);
                 self.request_redraw();
             }
-            EventMsg::AgentReasoningRawContent(AgentReasoningRawContentEvent { text: _ }) => {
-                // Finalize the raw reasoning stream just like the summarized reasoning event.
+            EventMsg::AgentReasoningRawContent(AgentReasoningRawContentEvent { text }) => {
+                // Final raw reasoning content: if no deltas were streamed, render the final text.
+                if self.current_stream != Some(StreamKind::Reasoning) && !text.is_empty() {
+                    self.begin_stream(StreamKind::Reasoning);
+                    self.stream_push_and_maybe_commit(&text);
+                }
                 self.finalize_stream(StreamKind::Reasoning);
                 self.request_redraw();
             }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -311,10 +311,14 @@ impl ChatWidget<'_> {
 
                 self.request_redraw();
             }
-            EventMsg::AgentMessage(AgentMessageEvent { message: _ }) => {
-                // Final assistant answer: commit all remaining rows and close with
-                // a blank line. Use the final text if provided, otherwise rely on
-                // streamed deltas already in the builder.
+            EventMsg::AgentMessage(AgentMessageEvent { message }) => {
+                // Final assistant answer.
+                // If no deltas were streamed (no active Answer stream), still render
+                // the provided final message text so events like compact completion are visible.
+                if self.current_stream != Some(StreamKind::Answer) && !message.is_empty() {
+                    self.begin_stream(StreamKind::Answer);
+                    self.stream_push_and_maybe_commit(&message);
+                }
                 self.finalize_stream(StreamKind::Answer);
                 self.request_redraw();
             }


### PR DESCRIPTION
This PR updates ChatWidget to ensure that when AgentMessage, AgentReasoning, or AgentReasoningRawContent events arrive without any streamed deltas, the final text from the event is rendered before the stream is finalized. Previously, these handlers ignored the event text in such cases, relying solely on prior deltas.

<img width="603" height="189" alt="image" src="https://github.com/user-attachments/assets/868516f2-7963-4603-9af4-adb1b1eda61e" />
