### PR TITLE
Include output truncation message in tool call results

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -51,6 +51,7 @@ use crate::exec::ExecParams;
 use crate::exec::ExecToolCallOutput;
 use crate::exec::SandboxType;
 use crate::exec::StdoutStream;
+use crate::exec::StreamOutput;
 use crate::exec::process_exec_tool_call;
 use crate::exec_env::create_env;
 use crate::mcp_connection_manager::McpConnectionManager;
@@ -429,8 +430,8 @@ impl Session {
         // Because stdout and stderr could each be up to 100 KiB, we send
         // truncated versions.
         const MAX_STREAM_OUTPUT: usize = 5 * 1024; // 5KiB
-        let stdout = stdout.chars().take(MAX_STREAM_OUTPUT).collect();
-        let stderr = stderr.chars().take(MAX_STREAM_OUTPUT).collect();
+        let stdout = stdout.text.chars().take(MAX_STREAM_OUTPUT).collect();
+        let stderr = stderr.text.chars().take(MAX_STREAM_OUTPUT).collect();
 
         let msg = if is_apply_patch {
             EventMsg::PatchApplyEnd(PatchApplyEndEvent {
@@ -502,8 +503,8 @@ impl Session {
             Err(e) => {
                 output_stderr = ExecToolCallOutput {
                     exit_code: -1,
-                    stdout: String::new(),
-                    stderr: get_error_message_ui(e),
+                    stdout: StreamOutput::new(String::new()),
+                    stderr: StreamOutput::new(get_error_message_ui(e)),
                     duration: Duration::default(),
                 };
                 &output_stderr
@@ -1975,19 +1976,10 @@ async fn handle_container_exec_with_params(
 
     match output_result {
         Ok(output) => {
-            let ExecToolCallOutput {
-                exit_code,
-                stdout,
-                stderr,
-                duration,
-            } = &output;
+            let ExecToolCallOutput { exit_code, .. } = &output;
 
             let is_success = *exit_code == 0;
-            let content = format_exec_output(
-                if is_success { stdout } else { stderr },
-                *exit_code,
-                *duration,
-            );
+            let content = format_exec_output(&output);
             ResponseInputItem::FunctionCallOutput {
                 call_id: call_id.clone(),
                 output: FunctionCallOutputPayload {
@@ -2116,19 +2108,10 @@ async fn handle_sandbox_error(
 
             match retry_output_result {
                 Ok(retry_output) => {
-                    let ExecToolCallOutput {
-                        exit_code,
-                        stdout,
-                        stderr,
-                        duration,
-                    } = &retry_output;
+                    let ExecToolCallOutput { exit_code, .. } = &retry_output;
 
                     let is_success = *exit_code == 0;
-                    let content = format_exec_output(
-                        if is_success { stdout } else { stderr },
-                        *exit_code,
-                        *duration,
-                    );
+                    let content = format_exec_output(&retry_output);
 
                     ResponseInputItem::FunctionCallOutput {
                         call_id: call_id.clone(),
@@ -2161,7 +2144,14 @@ async fn handle_sandbox_error(
 }
 
 /// Exec output is a pre-serialized JSON payload
-fn format_exec_output(output: &str, exit_code: i32, duration: Duration) -> String {
+fn format_exec_output(exec_output: &ExecToolCallOutput) -> String {
+    let ExecToolCallOutput {
+        exit_code,
+        stdout,
+        stderr,
+        duration,
+    } = exec_output;
+
     #[derive(Serialize)]
     struct ExecMetadata {
         exit_code: i32,
@@ -2177,10 +2167,20 @@ fn format_exec_output(output: &str, exit_code: i32, duration: Duration) -> Strin
     // round to 1 decimal place
     let duration_seconds = ((duration.as_secs_f32()) * 10.0).round() / 10.0;
 
+    let is_success = *exit_code == 0;
+    let output = if is_success { stdout } else { stderr };
+
+    let mut formatted_output = output.text.clone();
+    if let Some(truncated_after_lines) = output.truncated_after_lines {
+        formatted_output.push_str(&format!(
+            "Output truncated after {truncated_after_lines} lines",
+        ));
+    }
+
     let payload = ExecOutput {
-        output,
+        output: &formatted_output,
         metadata: ExecMetadata {
-            exit_code,
+            exit_code: *exit_code,
             duration_seconds,
         },
     };

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2173,7 +2173,7 @@ fn format_exec_output(exec_output: &ExecToolCallOutput) -> String {
     let mut formatted_output = output.text.clone();
     if let Some(truncated_after_lines) = output.truncated_after_lines {
         formatted_output.push_str(&format!(
-            "Output truncated after {truncated_after_lines} lines",
+            "\n\n[Output truncated after {truncated_after_lines} lines: too many lines or bytes.]",
         ));
     }
 

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -230,7 +230,7 @@ mod tests {
             assert_eq!(output.exit_code, 0, "input: {input:?} output: {output:?}");
             if let Some(expected) = expected_output {
                 assert_eq!(
-                    output.stdout, expected,
+                    output.stdout.text, expected,
                     "input: {input:?} output: {output:?}"
                 );
             }

--- a/codex-rs/core/tests/exec.rs
+++ b/codex-rs/core/tests/exec.rs
@@ -13,18 +13,20 @@ use codex_core::spawn::CODEX_SANDBOX_ENV_VAR;
 use tempfile::TempDir;
 use tokio::sync::Notify;
 
+use codex_core::error::Result;
+
 use codex_core::get_platform_sandbox;
 
-async fn run_test_cmd(
-    tmp: TempDir,
-    cmd: Vec<&str>,
-    should_be_ok: bool,
-) -> Option<ExecToolCallOutput> {
+fn skip_test() -> bool {
     if std::env::var(CODEX_SANDBOX_ENV_VAR) == Ok("seatbelt".to_string()) {
         eprintln!("{CODEX_SANDBOX_ENV_VAR} is set to 'seatbelt', skipping test.");
-        return None;
+        return true;
     }
 
+    false
+}
+
+async fn run_test_cmd(tmp: TempDir, cmd: Vec<&str>) -> Result<ExecToolCallOutput> {
     let sandbox_type = get_platform_sandbox().expect("should be able to get sandbox type");
     assert_eq!(sandbox_type, SandboxType::MacosSeatbelt);
 
@@ -40,20 +42,20 @@ async fn run_test_cmd(
     let ctrl_c = Arc::new(Notify::new());
     let policy = SandboxPolicy::new_read_only_policy();
 
-    let result = process_exec_tool_call(params, sandbox_type, ctrl_c, &policy, &None, None).await;
-
-    assert!(result.is_ok() == should_be_ok);
-    result.ok()
+    process_exec_tool_call(params, sandbox_type, ctrl_c, &policy, &None, None).await
 }
 
 /// Command succeeds with exit code 0 normally
 #[tokio::test]
 async fn exit_code_0_succeeds() {
+    if skip_test() {
+        return;
+    }
+
     let tmp = TempDir::new().expect("should be able to create temp dir");
     let cmd = vec!["echo", "hello"];
 
-    #[expect(clippy::unwrap_used)]
-    let output = run_test_cmd(tmp, cmd, true).await.unwrap();
+    let output = run_test_cmd(tmp, cmd).await.unwrap();
     assert_eq!(output.stdout.text, "hello\n");
     assert_eq!(output.stderr.text, "");
     assert_eq!(output.stdout.truncated_after_lines, None);
@@ -62,11 +64,15 @@ async fn exit_code_0_succeeds() {
 /// Command succeeds with exit code 0 normally
 #[tokio::test]
 async fn truncates_output_lines() {
+    if skip_test() {
+        return;
+    }
+
     let tmp = TempDir::new().expect("should be able to create temp dir");
     let cmd = vec!["seq", "300"];
 
     #[expect(clippy::unwrap_used)]
-    let output = run_test_cmd(tmp, cmd, true).await.unwrap();
+    let output = run_test_cmd(tmp, cmd).await.unwrap();
 
     let expected_output = (1..=256)
         .map(|i| format!("{i}\n"))
@@ -79,12 +85,15 @@ async fn truncates_output_lines() {
 /// Command succeeds with exit code 0 normally
 #[tokio::test]
 async fn truncates_output_bytes() {
+    if skip_test() {
+        return;
+    }
+
     let tmp = TempDir::new().expect("should be able to create temp dir");
     // each line is 1000 bytes
     let cmd = vec!["bash", "-lc", "seq 15 | awk '{printf \"%-1000s\\n\", $0}'"];
 
-    #[expect(clippy::unwrap_used)]
-    let output = run_test_cmd(tmp, cmd, true).await.unwrap();
+    let output = run_test_cmd(tmp, cmd).await.unwrap();
 
     assert_eq!(output.stdout.text.len(), 10240);
     assert_eq!(output.stdout.truncated_after_lines, Some(10));
@@ -93,14 +102,22 @@ async fn truncates_output_bytes() {
 /// Command not found returns exit code 127, this is not considered a sandbox error
 #[tokio::test]
 async fn exit_command_not_found_is_ok() {
+    if skip_test() {
+        return;
+    }
+
     let tmp = TempDir::new().expect("should be able to create temp dir");
     let cmd = vec!["/bin/bash", "-c", "nonexistent_command_12345"];
-    run_test_cmd(tmp, cmd, true).await;
+    run_test_cmd(tmp, cmd).await.unwrap();
 }
 
 /// Writing a file fails and should be considered a sandbox error
 #[tokio::test]
 async fn write_file_fails_as_sandbox_error() {
+    if skip_test() {
+        return;
+    }
+
     let tmp = TempDir::new().expect("should be able to create temp dir");
     let path = tmp.path().join("test.txt");
     let cmd = vec![
@@ -108,5 +125,5 @@ async fn write_file_fails_as_sandbox_error() {
         path.to_str().expect("should be able to get path"),
     ];
 
-    run_test_cmd(tmp, cmd, false).await;
+    assert!(run_test_cmd(tmp, cmd).await.is_err());
 }

--- a/codex-rs/core/tests/exec.rs
+++ b/codex-rs/core/tests/exec.rs
@@ -1,5 +1,5 @@
 #![cfg(target_os = "macos")]
-#![expect(clippy::expect_used)]
+#![expect(clippy::unwrap_used, clippy::expect_used)]
 
 use std::collections::HashMap;
 use std::sync::Arc;

--- a/codex-rs/core/tests/exec_stream_events.rs
+++ b/codex-rs/core/tests/exec_stream_events.rs
@@ -76,7 +76,7 @@ async fn test_exec_stdout_stream_events_echo() {
     };
 
     assert_eq!(result.exit_code, 0);
-    assert_eq!(result.stdout, "hello-world\n");
+    assert_eq!(result.stdout.text, "hello-world\n");
 
     let streamed = collect_stdout_events(rx);
     // We should have received at least the same contents (possibly in one chunk)

--- a/codex-rs/core/tests/exec_stream_events.rs
+++ b/codex-rs/core/tests/exec_stream_events.rs
@@ -128,8 +128,8 @@ async fn test_exec_stderr_stream_events_echo() {
     };
 
     assert_eq!(result.exit_code, 0);
-    assert_eq!(result.stdout, "");
-    assert_eq!(result.stderr, "oops\n");
+    assert_eq!(result.stdout.text, "");
+    assert_eq!(result.stderr.text, "oops\n");
 
     // Collect only stderr delta events
     let mut err = Vec::new();

--- a/codex-rs/linux-sandbox/tests/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/landlock.rs
@@ -72,8 +72,8 @@ async fn run_cmd(cmd: &[&str], writable_roots: &[PathBuf], timeout_ms: u64) {
     .unwrap();
 
     if res.exit_code != 0 {
-        println!("stdout:\n{}", res.stdout);
-        println!("stderr:\n{}", res.stderr);
+        println!("stdout:\n{}", res.stdout.text);
+        println!("stderr:\n{}", res.stderr.text);
         panic!("exit code: {}", res.exit_code);
     }
 }

--- a/codex-rs/linux-sandbox/tests/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/landlock.rs
@@ -164,7 +164,7 @@ async fn assert_network_blocked(cmd: &[&str]) {
     .await;
 
     let (exit_code, stdout, stderr) = match result {
-        Ok(output) => (output.exit_code, output.stdout, output.stderr),
+        Ok(output) => (output.exit_code, output.stdout.text, output.stderr.text),
         Err(CodexErr::Sandbox(SandboxErr::Denied(exit_code, stdout, stderr))) => {
             (exit_code, stdout, stderr)
         }


### PR DESCRIPTION
To avoid model being confused about incomplete output.