### PR TITLE
[apply-patch] Support applypatch command string

### DIFF
--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -81,9 +81,10 @@ pub struct ApplyPatchArgs {
     pub hunks: Vec<Hunk>,
 }
 
+const APPLY_PATCH_COMMANDS: [&str; 2] = ["apply_patch", "applypatch"];
 pub fn maybe_parse_apply_patch(argv: &[String]) -> MaybeApplyPatch {
     match argv {
-        [cmd, body] if cmd == "apply_patch" => match parse_patch(body) {
+        [cmd, body] if APPLY_PATCH_COMMANDS.contains(&cmd.as_str()) => match parse_patch(body) {
             Ok(source) => MaybeApplyPatch::Body(source),
             Err(e) => MaybeApplyPatch::PatchParseError(e),
         },
@@ -701,6 +702,31 @@ mod tests {
     fn test_literal() {
         let args = strs_to_strings(&[
             "apply_patch",
+            r#"*** Begin Patch
+*** Add File: foo
++hi
+*** End Patch
+"#,
+        ]);
+
+        match maybe_parse_apply_patch(&args) {
+            MaybeApplyPatch::Body(ApplyPatchArgs { hunks, patch: _ }) => {
+                assert_eq!(
+                    hunks,
+                    vec![Hunk::AddFile {
+                        path: PathBuf::from("foo"),
+                        contents: "hi\n".to_string()
+                    }]
+                );
+            }
+            result => panic!("expected MaybeApplyPatch::Body got {result:?}"),
+        }
+    }
+
+    #[test]
+    fn test_literal_applypatch() {
+        let args = strs_to_strings(&[
+            "applypatch",
             r#"*** Begin Patch
 *** Add File: foo
 +hi

--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -81,8 +81,8 @@ pub struct ApplyPatchArgs {
     pub hunks: Vec<Hunk>,
 }
 
-const APPLY_PATCH_COMMANDS: [&str; 2] = ["apply_patch", "applypatch"];
 pub fn maybe_parse_apply_patch(argv: &[String]) -> MaybeApplyPatch {
+    const APPLY_PATCH_COMMANDS: [&str; 2] = ["apply_patch", "applypatch"];
     match argv {
         [cmd, body] if APPLY_PATCH_COMMANDS.contains(&cmd.as_str()) => match parse_patch(body) {
             Ok(source) => MaybeApplyPatch::Body(source),


### PR DESCRIPTION
## Summary
GPT-OSS and `gpt-5-mini` have training artifacts that cause the models to occasionally use `applypatch` instead of `apply_patch`. I think long-term we'll want to provide `apply_patch` as a first class tool, but for now let's silently handle this case to avoid hurting model performance

## Testing
- [x] Added unit test