### PR TITLE
Check both python and python3 binaries for compatible version

### DIFF
--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -427,7 +427,7 @@ fn python_version_ok(exe: &str) -> std::io::Result<bool> {
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
-        .and_then(|mut child| child.wait_with_output())?;
+        .and_then(|child| child.wait_with_output())?;
 
     if !out.status.success() {
         return Err(std::io::Error::other(format!(

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -343,7 +343,7 @@ pub fn spawn_login_with_chatgpt(codex_home: &Path) -> std::io::Result<SpawnedLog
     })
 }
 
-/// Run the Python login helper with the CODEX_HOME
+/// Run `python3 -c {{SOURCE_FOR_PYTHON_SERVER}}` or `python -c {{SOURCE_FOR_PYTHON_SERVER}}` with the CODEX_HOME
 /// environment variable set to the provided `codex_home` path. If the
 /// subprocess exits 0, read the OPENAI_API_KEY property out of
 /// CODEX_HOME/auth.json and return Ok(OPENAI_API_KEY). Otherwise, return Err


### PR DESCRIPTION
This fixes issues raised from #2000, and #2206, by trying python3 and python, and checking the version required on each.

If no python executable is found, returns an error message. 