### PR TITLE
Show "Update plan" in TUI plan updates

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -682,10 +682,10 @@ impl HistoryCell {
         let mut header: Vec<Span> = Vec::new();
         header.push(Span::raw("📋"));
         header.push(Span::styled(
-            " Updated",
+            " Update plan",
             Style::default().add_modifier(Modifier::BOLD).magenta(),
         ));
-        header.push(Span::raw(" to do list ["));
+        header.push(Span::raw(" ["));
         if filled > 0 {
             header.push(Span::styled(
                 "█".repeat(filled),


### PR DESCRIPTION
## Summary
- Display "Update plan" instead of "Update to do" when the plan is updated in the TUI

## Testing
- `just fmt`
- `just fix` *(fails: E0658 `let` expressions in this position are unstable)*
- `cargo test --all-features` *(fails: E0658 `let` expressions in this position are unstable)*

------
https://chatgpt.com/codex/tasks/task_i_6897f78fc5908322be488f02db42a5b9