### PR TITLE
fix: change the model used with the GitHub action from o3 to gpt-5

### DIFF
--- a/.github/codex/home/config.toml
+++ b/.github/codex/home/config.toml
@@ -1,3 +1,3 @@
-model = "o3"
+model = "gpt-5"
 
 # Consider setting [mcp_servers] here!


### PR DESCRIPTION
`gpt-5` has been a valid slug since https://github.com/openai/codex/pull/1942.