### PR TITLE
docs: update codex-rs/config.md to reflect that gpt-5 is the default model

### DIFF
--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -17,7 +17,7 @@ Both the `--config` flag and the `config.toml` file support the following option
 The model that Codex should use.
 
 ```toml
-model = "o3"  # overrides the default of "codex-mini-latest"
+model = "o3"  # overrides the default of "gpt-5"
 ```
 
 ## model_providers
@@ -213,7 +213,7 @@ Users can specify config values at multiple levels. Order of precedence is as fo
 1. custom command-line argument, e.g., `--model o3`
 2. as part of a profile, where the `--profile` is specified via a CLI (or in the config file itself)
 3. as an entry in `config.toml`, e.g., `model = "o3"`
-4. the default value that comes with Codex CLI (i.e., Codex CLI defaults to `codex-mini-latest`)
+4. the default value that comes with Codex CLI (i.e., Codex CLI defaults to `gpt-5`)
 
 ## model_reasoning_effort
 


### PR DESCRIPTION
`gpt-5` has replaced `codex-mini-latest` as the default.