### PR TITLE
fix: remove unused import in release mode

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -11,7 +11,6 @@ use crate::slash_command::SlashCommand;
 use crate::tui;
 use codex_core::config::Config;
 use codex_core::protocol::Event;
-use codex_core::protocol::EventMsg;
 use codex_core::protocol::Op;
 use color_eyre::eyre::Result;
 use crossterm::SynchronizedUpdate;
@@ -383,6 +382,7 @@ impl App<'_> {
                     }
                     #[cfg(debug_assertions)]
                     SlashCommand::TestApproval => {
+                        use codex_core::protocol::EventMsg;
                         use std::collections::HashMap;
 
                         use codex_core::protocol::ApplyPatchApprovalRequestEvent;


### PR DESCRIPTION
Moves `use codex_core::protocol::EventMsg` inside the block annotated with `#[cfg(debug_assertions)]` since that was the only place in the file that was using it.

This eliminates the `warning: unused import:` when building with `cargo build --release` in `cargo-rs/tui`.

Note this was not breaking CI because we do not build release builds on CI since we're impatient :P