### PR TITLE
feat: Auto compact

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -74,6 +74,7 @@ pub(crate) struct ChatWidgetArgs {
     initial_prompt: Option<String>,
     initial_images: Vec<PathBuf>,
     enhanced_keys_supported: bool,
+    auto_compact: bool,
 }
 
 impl App<'_> {
@@ -82,6 +83,7 @@ impl App<'_> {
         initial_prompt: Option<String>,
         initial_images: Vec<std::path::PathBuf>,
         show_trust_screen: bool,
+        auto_compact: bool,
     ) -> Self {
         let (app_event_tx, app_event_rx) = channel();
         let app_event_tx = AppEventSender::new(app_event_tx);
@@ -139,6 +141,7 @@ impl App<'_> {
                 initial_prompt,
                 initial_images,
                 enhanced_keys_supported,
+                auto_compact,
             };
             AppState::Onboarding {
                 screen: OnboardingScreen::new(OnboardingScreenArgs {
@@ -157,6 +160,7 @@ impl App<'_> {
                 initial_prompt,
                 initial_images,
                 enhanced_keys_supported,
+                auto_compact,
             );
             AppState::Chat {
                 widget: Box::new(chat_widget),
@@ -319,6 +323,7 @@ impl App<'_> {
                             None,
                             Vec::new(),
                             self.enhanced_keys_supported,
+                            false,
                         ));
                         self.app_state = AppState::Chat { widget: new_widget };
                         self.app_event_tx.send(AppEvent::RequestRedraw);
@@ -431,6 +436,7 @@ impl App<'_> {
                     enhanced_keys_supported,
                     initial_images,
                     initial_prompt,
+                    auto_compact,
                 }) => {
                     self.app_state = AppState::Chat {
                         widget: Box::new(ChatWidget::new(
@@ -439,6 +445,7 @@ impl App<'_> {
                             initial_prompt,
                             initial_images,
                             enhanced_keys_supported,
+                            auto_compact,
                         )),
                     }
                 }

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -1354,8 +1354,7 @@ mod tests {
         let idx = match row.find(needle) {
             Some(i) => i,
             None => {
-                assert!(false, "expected hint substring present");
-                0
+                panic!("expected hint substring present");
             }
         };
         let start = idx as u16;
@@ -1397,8 +1396,7 @@ mod tests {
         let idx = match row.find(needle) {
             Some(i) => i,
             None => {
-                assert!(false, "expected hint substring present");
-                0
+                panic!("expected hint substring present");
             }
         };
         let start = idx as u16;

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -61,6 +61,7 @@ pub(crate) struct ChatComposer {
     pending_pastes: Vec<(String, String)>,
     token_usage_info: Option<TokenUsageInfo>,
     has_focus: bool,
+    auto_compact_enabled: bool,
 }
 
 /// Popup state – at most one can be visible at any time.
@@ -91,6 +92,7 @@ impl ChatComposer {
             pending_pastes: Vec::new(),
             token_usage_info: None,
             has_focus: has_input_focus,
+            auto_compact_enabled: false,
         }
     }
 
@@ -196,6 +198,10 @@ impl ChatComposer {
     pub fn set_ctrl_c_quit_hint(&mut self, show: bool, has_focus: bool) {
         self.ctrl_c_quit_hint = show;
         self.set_has_focus(has_focus);
+    }
+
+    pub(crate) fn set_auto_compact_enabled(&mut self, enabled: bool) {
+        self.auto_compact_enabled = enabled;
     }
 
     pub(crate) fn insert_str(&mut self, text: &str) {
@@ -719,9 +725,13 @@ impl WidgetRef for &ChatComposer {
                             100
                         };
                         hint.push(Span::from("   "));
+                        let style = if self.auto_compact_enabled && percent_remaining <= 20 {
+                            Style::default().fg(Color::Red)
+                        } else {
+                            Style::default().add_modifier(Modifier::DIM)
+                        };
                         hint.push(
-                            Span::from(format!("{percent_remaining}% context left"))
-                                .style(Style::default().add_modifier(Modifier::DIM)),
+                            Span::from(format!("{percent_remaining}% context left")).style(style),
                         );
                     }
                 }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -259,6 +259,10 @@ impl BottomPane<'_> {
         self.ctrl_c_quit_hint
     }
 
+    pub(crate) fn set_auto_compact_enabled(&mut self, enabled: bool) {
+        self.composer.set_auto_compact_enabled(enabled);
+    }
+
     pub fn set_task_running(&mut self, running: bool) {
         self.is_task_running = running;
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -275,9 +275,7 @@ impl ChatWidget<'_> {
     }
 
     fn percent_remaining(&self) -> Option<u8> {
-        let Some(context_window) = self.config.model_context_window else {
-            return None;
-        };
+        let context_window = self.config.model_context_window?;
         if context_window == 0 {
             return Some(100);
         }

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -40,6 +40,10 @@ pub struct Cli {
     #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
 
+    /// Automatically run /compact when the remaining model context is 0%.
+    #[arg(long = "auto-compact", default_value_t = false)]
+    pub auto_compact: bool,
+
     /// Skip all confirmation prompts and execute commands without sandboxing.
     /// EXTREMELY DANGEROUS. Intended solely for running in environments that are externally sandboxed.
     #[arg(

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -266,8 +266,19 @@ fn run_ratatui_app(
     let mut terminal = tui::init(&config)?;
     terminal.clear()?;
 
-    let Cli { prompt, images, .. } = cli;
-    let mut app = App::new(config.clone(), prompt, images, should_show_trust_screen);
+    let Cli {
+        prompt,
+        images,
+        auto_compact,
+        ..
+    } = cli;
+    let mut app = App::new(
+        config.clone(),
+        prompt,
+        images,
+        should_show_trust_screen,
+        auto_compact,
+    );
 
     // Bridge log receiver into the AppEvent channel so latest log lines update the UI.
     {


### PR DESCRIPTION
Added auto-compact mode, triggered by the --auto-compact flag. Makes 2 changes:
- When the user sends a message with 0% context remaining, triggers the /compact command and queues the message.
- When there is <= 20% context remaining, the "% context remaining" message turns red. 
- Plumbed flag CLI → App → ChatWidget; propagated to Composer.
- Wrote/passed tests