### PR TITLE
Pretty-print config.toml when saving

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -258,7 +258,9 @@ pub fn set_project_trusted(codex_home: &Path, project_path: &Path) -> anyhow::Re
 
     // create a tmp_file
     let tmp_file = NamedTempFile::new_in(codex_home)?;
-    std::fs::write(tmp_file.path(), doc.to_string())?;
+    let val: TomlValue = doc.to_string().parse::<TomlValue>()?;
+    let pretty = toml::to_string_pretty(&val)?;
+    std::fs::write(tmp_file.path(), pretty)?;
 
     // atomically move the tmp file into config.toml
     tmp_file.persist(config_path)?;


### PR DESCRIPTION
## Summary
- Save patched config.toml using toml::to_string_pretty for readable indentation

## Testing
- `just fmt`
- `just fix` *(fails: `let` expressions in this position are unstable)*
- `cargo test --all-features` *(fails: `let` expressions in this position are unstable)*

------
https://chatgpt.com/codex/tasks/task_i_689b66284b38832d9d77f3b9e6fdeb80