### PR TITLE
fix: display canonical command name in help

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -27,7 +27,11 @@ use crate::proto::ProtoCli;
     author,
     version,
     // If a sub‑command is given, ignore requirements of the default args.
-    subcommand_negates_reqs = true
+    subcommand_negates_reqs = true,
+    // The executable is sometimes invoked via a platform‑specific name like
+    // `codex-x86_64-unknown-linux-musl`, but the help output should always use
+    // the generic `codex` command name that users run.
+    bin_name = "codex"
 )]
 struct MultitoolCli {
     #[clap(flatten)]


### PR DESCRIPTION
## Summary
- ensure CLI help uses `codex` as program name regardless of binary filename

## Testing
- `just fmt`
- `just fix` *(fails: `let` expressions in this position are unstable)*
- `cargo test --all-features` *(fails: `let` expressions in this position are unstable)*

------
https://chatgpt.com/codex/tasks/task_i_689bd5a731188320814dcbbc546ce22a