### PR TITLE
feat(tui): add ctrl-b and ctrl-f shortcuts

### DIFF
--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -295,6 +295,20 @@ impl TextArea {
             } => {
                 self.move_cursor_right();
             }
+            KeyEvent {
+                code: KeyCode::Char('b'),
+                modifiers: KeyModifiers::CONTROL,
+                ..
+            } => {
+                self.move_cursor_left();
+            }
+            KeyEvent {
+                code: KeyCode::Char('f'),
+                modifiers: KeyModifiers::CONTROL,
+                ..
+            } => {
+                self.move_cursor_right();
+            }
             // Some terminals send Alt+Arrow for word-wise movement:
             // Option/Left -> Alt+Left (previous word start)
             // Option/Right -> Alt+Right (next word end)
@@ -906,6 +920,22 @@ mod tests {
         t.move_cursor_right();
         t.move_cursor_right();
         assert_eq!(t.cursor(), t.text().len());
+    }
+
+    #[test]
+    fn control_b_and_f_move_cursor() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        let mut t = ta_with("abcd");
+        t.set_cursor(1);
+
+        t.input(KeyEvent::new(KeyCode::Char('f'), KeyModifiers::CONTROL));
+        assert_eq!(t.cursor(), 2);
+
+        t.input(KeyEvent::new(KeyCode::Char('b'), KeyModifiers::CONTROL));
+        assert_eq!(t.cursor(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- support Ctrl-b and Ctrl-f to move the cursor left and right in the chat composer text area
- test Ctrl-b/Ctrl-f cursor movements

## Testing
- `just fmt`
- `just fix` *(fails: `let` expressions in this position are unstable)*
- `cargo test --all-features` *(fails: `let` expressions in this position are unstable)*

------
https://chatgpt.com/codex/tasks/task_i_689cbd1d7968832e876fff169891e486