### PR TITLE
use modifier dim instead of gray and .dim

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -731,15 +731,15 @@ impl WidgetRef for &ChatComposer {
                     .render_ref(bottom_line_rect, buf);
             }
         }
+        let border_style = if self.has_focus {
+            Style::default().fg(Color::Cyan)
+        } else {
+            Style::default().add_modifier(Modifier::DIM)
+        };
         Block::default()
-            .border_style(Style::default().dim())
             .borders(Borders::LEFT)
             .border_type(BorderType::QuadrantOutside)
-            .border_style(Style::default().fg(if self.has_focus {
-                Color::Cyan
-            } else {
-                Color::Gray
-            }))
+            .border_style(border_style)
             .render_ref(
                 Rect::new(textarea_rect.x, textarea_rect.y, 1, textarea_rect.height),
                 buf,

--- a/codex-rs/tui/src/bottom_pane/selection_popup_common.rs
+++ b/codex-rs/tui/src/bottom_pane/selection_popup_common.rs
@@ -93,9 +93,7 @@ pub(crate) fn render_rows(
                 spans.push(Span::raw("  "));
                 spans.push(Span::styled(
                     desc.clone(),
-                    Style::default()
-                        .fg(Color::DarkGray)
-                        .add_modifier(Modifier::DIM),
+                    Style::default().add_modifier(Modifier::DIM),
                 ));
             }
 
@@ -118,7 +116,7 @@ pub(crate) fn render_rows(
             Block::default()
                 .borders(Borders::LEFT)
                 .border_type(BorderType::QuadrantOutside)
-                .border_style(Style::default().fg(Color::DarkGray)),
+                .border_style(Style::default().add_modifier(Modifier::DIM)),
         )
         .widths([Constraint::Percentage(100)]);
 

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -479,7 +479,7 @@ impl HistoryCell {
             } else {
                 status_str.red()
             },
-            format!(", duration: {duration}").gray(),
+            format!(", duration: {duration}").dim(),
         ]);
 
         let mut lines: Vec<Line<'static>> = Vec::new();
@@ -522,7 +522,10 @@ impl HistoryCell {
                                 format!("link: {uri}")
                             }
                         };
-                        lines.push(Line::styled(line_text, Style::default().fg(Color::Gray)));
+                        lines.push(Line::styled(
+                            line_text,
+                            Style::default().add_modifier(Modifier::DIM),
+                        ));
                     }
                 }
 
@@ -751,7 +754,7 @@ impl HistoryCell {
         if empty > 0 {
             header.push(Span::styled(
                 "░".repeat(empty),
-                Style::default().fg(Color::Gray),
+                Style::default().add_modifier(Modifier::DIM),
             ));
         }
         header.push(Span::raw("] "));
@@ -763,15 +766,15 @@ impl HistoryCell {
             let t = s.trim().to_string();
             if t.is_empty() { None } else { Some(t) }
         }) {
-            lines.push(Line::from("note".gray().italic()));
+            lines.push(Line::from("note".dim().italic()));
             for l in expl.lines() {
-                lines.push(Line::from(l.to_string()).gray());
+                lines.push(Line::from(l.to_string()).dim());
             }
         }
 
         // Steps styled as checkbox items
         if plan.is_empty() {
-            lines.push(Line::from("(no steps provided)".gray().italic()));
+            lines.push(Line::from("(no steps provided)".dim().italic()));
         } else {
             for (idx, PlanItemArg { step, status }) in plan.into_iter().enumerate() {
                 let (box_span, text_span) = match status {
@@ -780,7 +783,6 @@ impl HistoryCell {
                         Span::styled(
                             step,
                             Style::default()
-                                .fg(Color::Gray)
                                 .add_modifier(Modifier::CROSSED_OUT | Modifier::DIM),
                         ),
                     ),
@@ -797,7 +799,7 @@ impl HistoryCell {
                         Span::raw("□"),
                         Span::styled(
                             step,
-                            Style::default().fg(Color::Gray).add_modifier(Modifier::DIM),
+                            Style::default().add_modifier(Modifier::DIM),
                         ),
                     ),
                 };
@@ -993,7 +995,7 @@ fn format_mcp_invocation<'a>(invocation: McpInvocation) -> Line<'a> {
         Span::raw("."),
         Span::styled(invocation.tool.clone(), Style::default().fg(Color::Blue)),
         Span::raw("("),
-        Span::styled(args_str, Style::default().fg(Color::Gray)),
+        Span::styled(args_str, Style::default().add_modifier(Modifier::DIM)),
         Span::raw(")"),
     ];
     Line::from(invocation_spans)

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -782,8 +782,7 @@ impl HistoryCell {
                         Span::styled("✔", Style::default().fg(Color::Green)),
                         Span::styled(
                             step,
-                            Style::default()
-                                .add_modifier(Modifier::CROSSED_OUT | Modifier::DIM),
+                            Style::default().add_modifier(Modifier::CROSSED_OUT | Modifier::DIM),
                         ),
                     ),
                     StepStatus::InProgress => (
@@ -797,10 +796,7 @@ impl HistoryCell {
                     ),
                     StepStatus::Pending => (
                         Span::raw("□"),
-                        Span::styled(
-                            step,
-                            Style::default().add_modifier(Modifier::DIM),
-                        ),
+                        Span::styled(step, Style::default().add_modifier(Modifier::DIM)),
                     ),
                 };
                 let prefix = if idx == 0 {

--- a/codex-rs/tui/src/shimmer.rs
+++ b/codex-rs/tui/src/shimmer.rs
@@ -66,18 +66,19 @@ pub(crate) fn shimmer_spans(text: &str, frame_idx: usize) -> Vec<Span<'static>> 
                 .fg(Color::Rgb(level, level, level))
                 .add_modifier(Modifier::BOLD)
         } else {
-            // Fallback without gray colors: DIM for low levels, normal for mid, BOLD for high
-            if level < 144 {
-                Style::default().add_modifier(Modifier::DIM)
-            } else if level < 208 {
-                Style::default()
-            } else {
-                Style::default().add_modifier(Modifier::BOLD)
-            }
+            color_for_level(level)
         };
         spans.push(Span::styled(ch.to_string(), style));
     }
     spans
 }
 
-// No longer using gray shades for fallback; gradient is handled via DIM/BOLD modifiers above.
+fn color_for_level(level: u8) -> Style {
+    if level < 144 {
+        Style::default().add_modifier(Modifier::DIM)
+    } else if level < 208 {
+        Style::default()
+    } else {
+        Style::default().add_modifier(Modifier::BOLD)
+    }
+}

--- a/codex-rs/tui/src/shimmer.rs
+++ b/codex-rs/tui/src/shimmer.rs
@@ -66,19 +66,18 @@ pub(crate) fn shimmer_spans(text: &str, frame_idx: usize) -> Vec<Span<'static>> 
                 .fg(Color::Rgb(level, level, level))
                 .add_modifier(Modifier::BOLD)
         } else {
-            Style::default().fg(color_for_level(level))
+            // Fallback without gray colors: DIM for low levels, normal for mid, BOLD for high
+            if level < 144 {
+                Style::default().add_modifier(Modifier::DIM)
+            } else if level < 208 {
+                Style::default()
+            } else {
+                Style::default().add_modifier(Modifier::BOLD)
+            }
         };
         spans.push(Span::styled(ch.to_string(), style));
     }
     spans
 }
 
-fn color_for_level(level: u8) -> Color {
-    if level < 128 {
-        Color::DarkGray
-    } else if level < 192 {
-        Color::Gray
-    } else {
-        Color::White
-    }
-}
+// No longer using gray shades for fallback; gradient is handled via DIM/BOLD modifiers above.

--- a/codex-rs/tui/src/status_indicator_widget.rs
+++ b/codex-rs/tui/src/status_indicator_widget.rs
@@ -205,14 +205,7 @@ impl WidgetRef for StatusIndicatorWidget {
                     .fg(Color::Rgb(level, level, level))
                     .add_modifier(Modifier::BOLD)
             } else {
-                // Fallback without gray colors: use DIM for low levels, normal for mid, bold for high
-                if level < 144 {
-                    Style::default().add_modifier(Modifier::DIM)
-                } else if level < 208 {
-                    Style::default()
-                } else {
-                    Style::default().add_modifier(Modifier::BOLD)
-                }
+                color_for_level(level)
             };
 
             animated_spans.push(Span::styled(ch.to_string(), style));
@@ -286,7 +279,15 @@ impl WidgetRef for StatusIndicatorWidget {
     }
 }
 
-// No longer using gray shades for fallback; gradient is handled via DIM/BOLD modifiers above.
+fn color_for_level(level: u8) -> Style {
+    if level < 144 {
+        Style::default().add_modifier(Modifier::DIM)
+    } else if level < 208 {
+        Style::default()
+    } else {
+        Style::default().add_modifier(Modifier::BOLD)
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/codex-rs/tui/src/status_indicator_widget.rs
+++ b/codex-rs/tui/src/status_indicator_widget.rs
@@ -205,7 +205,14 @@ impl WidgetRef for StatusIndicatorWidget {
                     .fg(Color::Rgb(level, level, level))
                     .add_modifier(Modifier::BOLD)
             } else {
-                Style::default().fg(color_for_level(level))
+                // Fallback without gray colors: use DIM for low levels, normal for mid, bold for high
+                if level < 144 {
+                    Style::default().add_modifier(Modifier::DIM)
+                } else if level < 208 {
+                    Style::default()
+                } else {
+                    Style::default().add_modifier(Modifier::BOLD)
+                }
             };
 
             animated_spans.push(Span::styled(ch.to_string(), style));
@@ -223,7 +230,7 @@ impl WidgetRef for StatusIndicatorWidget {
         let spinner_ch = spinner_frames[(idx / SPINNER_SLOWDOWN) % spinner_frames.len()];
         spans.push(Span::styled(
             spinner_ch.to_string(),
-            Style::default().fg(Color::DarkGray),
+            Style::default().add_modifier(Modifier::DIM),
         ));
         spans.push(Span::raw(" "));
 
@@ -236,27 +243,25 @@ impl WidgetRef for StatusIndicatorWidget {
         let bracket_prefix = format!("({elapsed}s • ");
         spans.push(Span::styled(
             bracket_prefix,
-            Style::default().fg(Color::Gray).add_modifier(Modifier::DIM),
+            Style::default().add_modifier(Modifier::DIM),
         ));
         spans.push(Span::styled(
             "Esc",
-            Style::default()
-                .fg(Color::Gray)
-                .add_modifier(Modifier::DIM | Modifier::BOLD),
+            Style::default().add_modifier(Modifier::DIM | Modifier::BOLD),
         ));
         spans.push(Span::styled(
             " to interrupt)",
-            Style::default().fg(Color::Gray).add_modifier(Modifier::DIM),
+            Style::default().add_modifier(Modifier::DIM),
         ));
         // Add a space and then the log text (not animated by the gradient)
         if !status_prefix.is_empty() {
             spans.push(Span::styled(
                 " ",
-                Style::default().fg(Color::Gray).add_modifier(Modifier::DIM),
+                Style::default().add_modifier(Modifier::DIM),
             ));
             spans.push(Span::styled(
                 status_prefix,
-                Style::default().fg(Color::Gray).add_modifier(Modifier::DIM),
+                Style::default().add_modifier(Modifier::DIM),
             ));
         }
 
@@ -281,15 +286,7 @@ impl WidgetRef for StatusIndicatorWidget {
     }
 }
 
-fn color_for_level(level: u8) -> Color {
-    if level < 128 {
-        Color::DarkGray
-    } else if level < 192 {
-        Color::Gray
-    } else {
-        Color::White
-    }
-}
+// No longer using gray shades for fallback; gradient is handled via DIM/BOLD modifiers above.
 
 #[cfg(test)]
 mod tests {

--- a/codex-rs/tui/src/user_approval_widget.rs
+++ b/codex-rs/tui/src/user_approval_widget.rs
@@ -340,7 +340,7 @@ impl WidgetRef for &UserApprovalWidget<'_> {
                 let style = if idx == self.selected_option {
                     Style::new().bg(Color::Cyan).fg(Color::Black)
                 } else {
-                    Style::new().bg(Color::DarkGray)
+                    Style::new().add_modifier(Modifier::DIM)
                 };
                 opt.label.clone().alignment(Alignment::Center).style(style)
             })
@@ -372,7 +372,7 @@ impl WidgetRef for &UserApprovalWidget<'_> {
         }
 
         Line::from(self.select_options[self.selected_option].description)
-            .style(Style::new().italic().fg(Color::DarkGray))
+            .style(Style::new().italic().add_modifier(Modifier::DIM))
             .render(description_area.inner(Margin::new(1, 0)), buf);
 
         Block::bordered()


### PR DESCRIPTION
gray color doesn't work very well with white terminals. `.dim` doesn't have an effect for some reason.

after:
<img width="1080" height="149" alt="image" src="https://github.com/user-attachments/assets/26c0f8bb-550d-4d71-bd06-11b3189bc1d7" />

Before
<img width="1077" height="186" alt="image" src="https://github.com/user-attachments/assets/b1fba0c7-bc4d-4da1-9754-6c0a105e8cd1" />


