### PR TITLE
tui: standardize tree prefix glyphs to └

### DIFF
--- a/codex-rs/tui/src/diff_render.rs
+++ b/codex-rs/tui/src/diff_render.rs
@@ -143,7 +143,7 @@ pub(crate) fn create_diff_summary(
         spans.push(RtSpan::raw(")"));
 
         let mut line = RtLine::from(spans);
-        let prefix = if idx == 0 { "  ⎿ " } else { "    " };
+        let prefix = if idx == 0 { "  └ " } else { "    " };
         line.spans.insert(0, prefix.into());
         line.spans
             .iter_mut()

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -367,7 +367,7 @@ impl HistoryCell {
                 ParsedCommand::Unknown { cmd } => format!("⌨️ {}", shlex_join_safe(cmd)),
             };
 
-            let first_prefix = if i == 0 { "  L " } else { "    " };
+            let first_prefix = if i == 0 { "  └ " } else { "    " };
             for (j, line_text) in text.lines().enumerate() {
                 let prefix = if j == 0 { first_prefix } else { "    " };
                 lines.push(Line::from(vec![
@@ -806,7 +806,7 @@ impl HistoryCell {
                     ),
                 };
                 let prefix = if idx == 0 {
-                    Span::raw("  ⎿ ")
+                    Span::raw("  └ ")
                 } else {
                     Span::raw("    ")
                 };
@@ -894,7 +894,7 @@ impl HistoryCell {
         if !stdout.trim().is_empty() {
             let mut iter = stdout.lines();
             for (i, raw) in iter.by_ref().take(TOOL_CALL_MAX_LINES).enumerate() {
-                let prefix = if i == 0 { "  ⎿ " } else { "    " };
+                let prefix = if i == 0 { "  └ " } else { "    " };
                 let s = format!("{prefix}{raw}");
                 lines.push(ansi_escape_line(&s).dim());
             }
@@ -947,7 +947,7 @@ fn output_lines(
     for (i, raw) in lines[..head_end].iter().enumerate() {
         let mut line = ansi_escape_line(raw);
         let prefix = if i == 0 && include_angle_pipe {
-            "  ⎿ "
+            "  └ "
         } else {
             "    "
         };
@@ -1021,7 +1021,7 @@ mod tests {
         }];
         let lines = HistoryCell::exec_command_lines(&[], &parsed, None);
         assert!(lines.len() >= 3);
-        assert_eq!(lines[1].spans[0].content, "  L ");
+        assert_eq!(lines[1].spans[0].content, "  └ ");
         assert_eq!(lines[2].spans[0].content, "    ");
     }
 }

--- a/codex-rs/tui/src/snapshots/codex_tui__diff_render__tests__add_details.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__diff_render__tests__add_details.snap
@@ -3,7 +3,7 @@ source: tui/src/diff_render.rs
 expression: terminal.backend()
 ---
 "proposed patch to 1 file (+2 -0)                                                "
-"  ⎿ README.md (+2 -0)                                                           "
+"  └ README.md (+2 -0)                                                           "
 "    1     +first line                                                           "
 "    2     +second line                                                          "
 "                                                                                "

--- a/codex-rs/tui/src/snapshots/codex_tui__diff_render__tests__update_details_with_rename.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__diff_render__tests__update_details_with_rename.snap
@@ -3,7 +3,7 @@ source: tui/src/diff_render.rs
 expression: terminal.backend()
 ---
 "proposed patch to 1 file (+1 -1)                                                "
-"  ⎿ src/lib.rs → src/lib_new.rs (+1 -1)                                         "
+"  └ src/lib.rs → src/lib_new.rs (+1 -1)                                         "
 "    1     line one                                                              "
 "    2     -line two                                                             "
 "    2     +line two changed                                                     "

--- a/codex-rs/tui/tests/fixtures/ideal-binary-response.txt
+++ b/codex-rs/tui/tests/fixtures/ideal-binary-response.txt
@@ -13,7 +13,7 @@ I’m going to scan the workspace and Cargo manifests to see build profiles and
 dependencies that impact binary size. Then I’ll summarize the main causes.
 
 ⚡  Running ls -la
-  ⎿ total 6696
+  └ total 6696
     drwxr-xr-x@ 39 easong  staff     1248 Aug  9 08:49 .
     drwxr-xr-x@ 29 easong  staff      928 Aug  9 08:50 ..
     -rw-r--r--@  1 easong  staff    10244 Aug  8 21:13 .DS_Store
@@ -25,7 +25,7 @@ dependencies that impact binary size. Then I’ll summarize the main causes.
     -rw-r--r--@  1 easong  staff     8639 Aug  6 23:30 typewriter.md
     -rw-r--r--@  1 easong  staff     7673 Aug  6 21:58 wrap-plan.md
 ⚡  Running sed -n '1,200p' Cargo.toml
-  ⎿ [workspace]
+  └ [workspace]
     members = [
         "ansi-escape",
         "apply-patch",
@@ -50,7 +50,7 @@ tui, login, ollama, and mcp.
 ⚡  Running for d in ansi-escape apply-patch arg0 cli common core exec execpolicy
 file-search linux-sandbox login mcp-client mcp-server mcp-types ollama tui; do
 echo "--- $d/Cargo.toml"; sed -n '1,200p' $d/Cargo.toml; echo; done
-  ⎿ --- ansi-escape/Cargo.toml
+  └ --- ansi-escape/Cargo.toml
     [package]
     edition = "2024"
     name = "codex-ansi-escape"
@@ -62,7 +62,7 @@ echo "--- $d/Cargo.toml"; sed -n '1,200p' $d/Cargo.toml; echo; done
     ] }
     tracing = { version
 ⚡  Running sed -n '1,200p' execpolicy/Cargo.toml
-  ⎿ [package]
+  └ [package]
     name = "codex-execpolicy"
     version = { workspace = true }
     edition = "2024"
@@ -74,7 +74,7 @@ echo "--- $d/Cargo.toml"; sed -n '1,200p' $d/Cargo.toml; echo; done
     [dev-dependencies]
     tempfile = "3.13.0"
 ⚡  Running sed -n '1,200p' file-search/Cargo.toml
-  ⎿ [package]
+  └ [package]
     edition = "2024"
     name = "codex-file-search"
     version = { workspace = true }
@@ -86,7 +86,7 @@ echo "--- $d/Cargo.toml"; sed -n '1,200p' $d/Cargo.toml; echo; done
     serde_json = "1.0.142"
     tokio = { version = "1", features = ["full"] }
 ⚡  Running sed -n '1,200p' linux-sandbox/Cargo.toml
-  ⎿ [package]
+  └ [package]
     edition = "2024"
     name = "codex-linux-sandbox"
     version = { workspace = true }
@@ -98,7 +98,7 @@ echo "--- $d/Cargo.toml"; sed -n '1,200p' $d/Cargo.toml; echo; done
         "signal",
     ] }
 ⚡  Running sed -n '1,200p' login/Cargo.toml
-  ⎿ [package]
+  └ [package]
     edition = "2024"
     name = "codex-login"
     version = { workspace = true }
@@ -110,7 +110,7 @@ echo "--- $d/Cargo.toml"; sed -n '1,200p' $d/Cargo.toml; echo; done
     pretty_assertions = "1.4.1"
     tempfile = "3"
 ⚡  Running sed -n '1,200p' mcp-client/Cargo.toml
-  ⎿ [package]
+  └ [package]
     name = "codex-mcp-client"
     version = { workspace = true }
     edition = "2024"
@@ -122,7 +122,7 @@ echo "--- $d/Cargo.toml"; sed -n '1,200p' $d/Cargo.toml; echo; done
         "time",
     ] }
 ⚡  Running sed -n '1,200p' mcp-server/Cargo.toml
-  ⎿ [package]
+  └ [package]
     edition = "2024"
     name = "codex-mcp-server"
     version = { workspace = true }
@@ -134,7 +134,7 @@ echo "--- $d/Cargo.toml"; sed -n '1,200p' $d/Cargo.toml; echo; done
     tokio-test = "0.4"
     wiremock = "0.6"
 ⚡  Running sed -n '1,200p' mcp-types/Cargo.toml
-  ⎿ [package]
+  └ [package]
     edition = "2024"
     name = "mcp-types"
     version = { workspace = true }
@@ -146,7 +146,7 @@ echo "--- $d/Cargo.toml"; sed -n '1,200p' $d/Cargo.toml; echo; done
     serde = { version = "1", features = ["derive"] }
     serde_json = "1"
 ⚡  Running sed -n '1,200p' ollama/Cargo.toml
-  ⎿ [package]
+  └ [package]
     edition = "2024"
     name = "codex-ollama"
     version = { workspace = true }
@@ -158,7 +158,7 @@ echo "--- $d/Cargo.toml"; sed -n '1,200p' $d/Cargo.toml; echo; done
     [dev-dependencies]
     tempfile = "3"
 ⚡  Running sed -n '1,200p' tui/Cargo.toml
-  ⎿ [package]
+  └ [package]
     edition = "2024"
     name = "codex-tui"
     version = { workspace = true }
@@ -170,7 +170,7 @@ echo "--- $d/Cargo.toml"; sed -n '1,200p' $d/Cargo.toml; echo; done
     rand = "0.8"
     vt100 = "0.16.2"
 ⚡  Running sed -n '1,200p' chatgpt/Cargo.toml
-  ⎿ [package]
+  └ [package]
     edition = "2024"
     name = "codex-chatgpt"
     version = { workspace = true }


### PR DESCRIPTION
Replace mixed `⎿` and `L` prefixes with `└` in TUI rendering.

<img width="454" height="659" alt="Screenshot 2025-08-13 at 4 02 03 PM" src="https://github.com/user-attachments/assets/61c9c7da-830b-4040-bb79-a91be90870ca" />
