### PR TITLE
Use enhancement tag for feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/4-feature-request.yml
@@ -1,7 +1,7 @@
 name: 🎁 Feature Request
 description: Propose a new feature for Codex
 labels:
-  - feature
+  - enhancement
   - needs triage
 body:
   - type: markdown


### PR DESCRIPTION
We don't have `feature` tag, and we've been using the standard `enhancement` for feature requests. Can you change the preset tag for issues?