### PR TITLE
fix: make all fields of Session private

### DIFF
--- a/codex-rs/core/src/apply_patch.rs
+++ b/codex-rs/core/src/apply_patch.rs
@@ -45,17 +45,13 @@ pub(crate) async fn apply_patch(
     call_id: &str,
     action: ApplyPatchAction,
 ) -> InternalApplyPatchInvocation {
-    let writable_roots_snapshot = {
-        #[allow(clippy::unwrap_used)]
-        let guard = sess.writable_roots.lock().unwrap();
-        guard.clone()
-    };
+    let writable_roots_snapshot = sess.get_writable_roots().to_vec();
 
     match assess_patch_safety(
         &action,
-        sess.approval_policy,
+        sess.get_approval_policy(),
         &writable_roots_snapshot,
-        &sess.cwd,
+        sess.get_cwd(),
     ) {
         SafetyCheck::AutoApprove { .. } => {
             InternalApplyPatchInvocation::DelegateToExec(ApplyPatchExec {

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -723,7 +723,7 @@ pub enum ReviewDecision {
     Abort,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq)]
 #[serde(rename_all = "snake_case")]
 pub enum FileChange {
     Add {


### PR DESCRIPTION
As `Session` needs a bit of work, it will make things easier to move around if we can start by reducing the extent of its public API. This makes all the fields private, though adds three `pub(crate)` getters.



---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/2285).
* #2287
* #2286
* __->__ #2285