### PR TITLE
exploration: create Session as part of Codex::spawn()

### DIFF
--- a/codex-rs/core/src/conversation_manager.rs
+++ b/codex-rs/core/src/conversation_manager.rs
@@ -7,6 +7,7 @@ use uuid::Uuid;
 
 use crate::codex::Codex;
 use crate::codex::CodexSpawnOk;
+use crate::codex::INITIAL_SUBMIT_ID;
 use crate::codex_conversation::CodexConversation;
 use crate::config::Config;
 use crate::error::CodexErr;
@@ -52,7 +53,6 @@ impl ConversationManager {
     ) -> CodexResult<NewConversation> {
         let CodexSpawnOk {
             codex,
-            init_id,
             session_id: conversation_id,
         } = Codex::spawn(config, auth).await?;
 
@@ -64,7 +64,7 @@ impl ConversationManager {
             Event {
                 id,
                 msg: EventMsg::SessionConfigured(session_configured),
-            } if id == init_id => session_configured,
+            } if id == INITIAL_SUBMIT_ID => session_configured,
             _ => {
                 return Err(CodexErr::SessionConfiguredNotFirstEvent);
             }

--- a/codex-rs/core/src/protocol.rs
+++ b/codex-rs/core/src/protocol.rs
@@ -17,10 +17,7 @@ use serde_bytes::ByteBuf;
 use strum_macros::Display;
 use uuid::Uuid;
 
-use crate::config_types::ReasoningEffort as ReasoningEffortConfig;
-use crate::config_types::ReasoningSummary as ReasoningSummaryConfig;
 use crate::message_history::HistoryEntry;
-use crate::model_provider_info::ModelProviderInfo;
 use crate::parse_command::ParsedCommand;
 use crate::plan_tool::UpdatePlanArgs;
 
@@ -39,52 +36,6 @@ pub struct Submission {
 #[allow(clippy::large_enum_variant)]
 #[non_exhaustive]
 pub enum Op {
-    /// Configure the model session.
-    ConfigureSession {
-        /// Provider identifier ("openai", "openrouter", ...).
-        provider: ModelProviderInfo,
-
-        /// If not specified, server will use its default model.
-        model: String,
-
-        model_reasoning_effort: ReasoningEffortConfig,
-        model_reasoning_summary: ReasoningSummaryConfig,
-
-        /// Model instructions that are appended to the base instructions.
-        user_instructions: Option<String>,
-
-        /// Base instructions override.
-        base_instructions: Option<String>,
-
-        /// When to escalate for approval for execution
-        approval_policy: AskForApproval,
-        /// How to sandbox commands executed in the system
-        sandbox_policy: SandboxPolicy,
-        /// Disable server-side response storage (send full context each request)
-        #[serde(default)]
-        disable_response_storage: bool,
-
-        /// Optional external notifier command tokens. Present only when the
-        /// client wants the agent to spawn a program after each completed
-        /// turn.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        #[serde(default)]
-        notify: Option<Vec<String>>,
-
-        /// Working directory that should be treated as the *root* of the
-        /// session. All relative paths supplied by the model as well as the
-        /// execution sandbox are resolved against this directory **instead**
-        /// of the process-wide current working directory. CLI front-ends are
-        /// expected to expand this to an absolute path before sending the
-        /// `ConfigureSession` operation so that the business-logic layer can
-        /// operate deterministically.
-        cwd: std::path::PathBuf,
-
-        /// Path to a rollout file to resume from.
-        #[serde(skip_serializing_if = "Option::is_none")]
-        resume_path: Option<std::path::PathBuf>,
-    },
-
     /// Abort current task.
     /// This server sends no corresponding Event
     Interrupt,


### PR DESCRIPTION
Historically, `Codex::spawn()` would create the instance of `Codex` and enforce, by construction, that `Op::ConfigureSession` was the first `Op` submitted via `submit()`. Then over in `submission_loop()`, it would handle the case for taking the parameters of `Op::ConfigureSession` and turning it into a `Session`.

This approach has two challenges from a state management perspective:

https://github.com/openai/codex/blob/f968a1327ad39a7786759ea8f1d1c088fe41e91b/codex-rs/core/src/codex.rs#L718

- The local `sess` variable in `submission_loop()` has to be `mut` and `Option<Arc<Session>>` because it is not invariant that a `Session` is present for the lifetime of the loop, so there is a lot of logic to deal with the case where `sess` is `None` (e.g., the `send_no_session_event` function and all of its callsites).
- `submission_loop()` is written in such a way that `Op::ConfigureSession` could be observed multiple times, but in practice, it is only observed exactly once at the start of the loop.

In this PR, we try to simplify the state management by _removing_ the `Op::ConfigureSession` enum variant and constructing the `Session` as part of `Codex::spawn()` so that it can be passed to `submission_loop()` as `Arc<Session>`. The original logic from the `Op::ConfigureSession` has largely been moved to the new `Session::new()` constructor.

---

Incidentally, I also noticed that the handling of `Op::ConfigureSession` can result in events being dispatched in addition to `EventMsg::SessionConfigured`, as an `EventMsg::Error` is created for every MCP initialization error, so it is important to preserve that behavior:

https://github.com/openai/codex/blob/f968a1327ad39a7786759ea8f1d1c088fe41e91b/codex-rs/core/src/codex.rs#L901-L916

Though admittedly, I believe this does not play nice with #2264, as these error messages will likely be dispatched before the client has a chance to call `addConversationListener`, so we likely need to make it so `newConversation` automatically creates the subscription, but we must also guarantee that the "ack" from `newConversation` is returned before any other conversation-related notifications are sent so the client knows what `conversation_id` to match on.
