### PR TITLE
Tag InputItem

### DIFF
--- a/codex-rs/mcp-server/src/wire_format.rs
+++ b/codex-rs/mcp-server/src/wire_format.rs
@@ -144,7 +144,7 @@ pub struct RemoveConversationListenerParams {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
-#[serde(tag = "type", content = "data")] 
+#[serde(tag = "type", content = "data")]
 pub enum InputItem {
     Text {
         text: String,

--- a/codex-rs/mcp-server/src/wire_format.rs
+++ b/codex-rs/mcp-server/src/wire_format.rs
@@ -144,6 +144,7 @@ pub struct RemoveConversationListenerParams {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 #[serde(rename_all = "camelCase")]
+#[serde(tag = "type", content = "data")] 
 pub enum InputItem {
     Text {
         text: String,


### PR DESCRIPTION
Instead of:
```
{ Text: { text: string } }
```

It is now:
```
{ type: "text", data: { text: string } }
```
which makes for cleaner discriminated unions