### PR TITLE
remove logs from composer by default

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -621,7 +621,7 @@ impl ChatWidget<'_> {
             | EventMsg::AgentReasoningDelta(_)
             | EventMsg::ExecCommandOutputDelta(_) => {}
             _ => {
-                tracing::info!("handle_codex_event: {:?}", msg);
+                tracing::trace!("handle_codex_event: {:?}", msg);
             }
         }
 


### PR DESCRIPTION
Currently the composer shows `handle_codex_event:<event name>` by default which feels confusing. Let's make it appear in trace.