### PR TITLE
Bridge command generation to powershell when on Windows

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -737,6 +737,7 @@ dependencies = [
  "tree-sitter-bash",
  "uuid",
  "walkdir",
+ "which",
  "whoami",
  "wildmatch",
  "wiremock",
@@ -5600,6 +5601,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a751b3277700db47d3e574514de2eced5e54dc8a5436a3bf7a0b248b2cee16f3"
 
 [[package]]
+name = "which"
+version = "6.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
+dependencies = [
+ "either",
+ "home",
+ "rustix 0.38.44",
+ "winsafe",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6010,6 +6023,12 @@ checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "winsafe"
+version = "0.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d135d17ab770252ad95e9a872d365cf3090e3be864a34ab46f48555993efc904"
 
 [[package]]
 name = "wiremock"

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -71,6 +71,9 @@ openssl-sys = { version = "*", features = ["vendored"] }
 [target.aarch64-unknown-linux-musl.dependencies]
 openssl-sys = { version = "*", features = ["vendored"] }
 
+[target.'cfg(target_os = "windows")'.dependencies]
+which = "6"
+
 [dev-dependencies]
 assert_cmd = "2"
 core_test_support = { path = "tests/common" }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2052,7 +2052,7 @@ pub struct ExecInvokeArgs<'a> {
     pub stdout_stream: Option<StdoutStream>,
 }
 
-fn maybe_run_with_user_profile(
+fn maybe_translate_shell_command(
     params: ExecParams,
     sess: &Session,
     turn_context: &TurnContext,
@@ -2231,7 +2231,7 @@ async fn handle_container_exec_with_params(
         ),
     };
 
-    let params = maybe_run_with_user_profile(params, sess, turn_context);
+    let params = maybe_translate_shell_command(params, sess, turn_context);
     let output_result = sess
         .run_exec_with_events(
             turn_diff_tracker,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -511,7 +511,7 @@ impl Session {
             turn_context.cwd.to_path_buf(),
             turn_context.approval_policy,
             turn_context.sandbox_policy.clone(),
-            default_shell.clone(),
+            sess.user_shell.clone(),
         )));
         sess.record_conversation_items(&conversation_items).await;
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2061,13 +2061,12 @@ fn maybe_translate_shell_command(
     let should_translate = matches!(sess.user_shell, crate::shell::Shell::PowerShell(_))
         || turn_context.shell_environment_policy.use_profile;
 
-    if should_translate {
-        if let Some(command) = sess
+    if should_translate
+        && let Some(command) = sess
             .user_shell
             .format_default_shell_invocation(params.command.clone())
-        {
-            return ExecParams { command, ..params };
-        }
+    {
+        return ExecParams { command, ..params };
     }
     params
 }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2057,8 +2057,7 @@ fn maybe_run_with_user_profile(
     sess: &Session,
     turn_context: &TurnContext,
 ) -> ExecParams {
-    let should_translate =
-        matches!(sess.user_shell, crate::shell::Shell::PowerShell(_))
+    let should_translate = matches!(sess.user_shell, crate::shell::Shell::PowerShell(_))
         || turn_context.shell_environment_policy.use_profile;
 
     if should_translate {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -511,6 +511,7 @@ impl Session {
             turn_context.cwd.to_path_buf(),
             turn_context.approval_policy,
             turn_context.sandbox_policy.clone(),
+            default_shell.clone(),
         )));
         sess.record_conversation_items(&conversation_items).await;
 
@@ -2056,11 +2057,15 @@ fn maybe_run_with_user_profile(
     sess: &Session,
     turn_context: &TurnContext,
 ) -> ExecParams {
-    if turn_context.shell_environment_policy.use_profile {
-        let command = sess
+    let should_translate =
+        matches!(sess.user_shell, crate::shell::Shell::PowerShell(_))
+        || turn_context.shell_environment_policy.use_profile;
+
+    if should_translate {
+        if let Some(command) = sess
             .user_shell
-            .format_default_shell_invocation(params.command.clone());
-        if let Some(command) = command {
+            .format_default_shell_invocation(params.command.clone())
+        {
             return ExecParams { command, ..params };
         }
     }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1071,6 +1071,7 @@ async fn submission_loop(
                         new_cwd,
                         new_approval_policy,
                         new_sandbox_policy,
+                        sess.user_shell.clone(),
                     ))])
                     .await;
                 }

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -6,6 +6,7 @@ use crate::models::ContentItem;
 use crate::models::ResponseItem;
 use crate::protocol::AskForApproval;
 use crate::protocol::SandboxPolicy;
+use crate::shell::Shell;
 use codex_protocol::config_types::SandboxMode;
 use std::fmt::Display;
 use std::path::PathBuf;
@@ -28,7 +29,7 @@ pub(crate) struct EnvironmentContext {
     pub approval_policy: AskForApproval,
     pub sandbox_mode: SandboxMode,
     pub network_access: NetworkAccess,
-    pub shell_name: Option<String>,
+    pub shell: Shell,
 }
 
 impl EnvironmentContext {
@@ -36,7 +37,7 @@ impl EnvironmentContext {
         cwd: PathBuf,
         approval_policy: AskForApproval,
         sandbox_policy: SandboxPolicy,
-        shell_name: Option<String>,
+        shell: Shell,
     ) -> Self {
         Self {
             cwd,
@@ -57,7 +58,7 @@ impl EnvironmentContext {
                     }
                 }
             },
-            shell_name,
+            shell,
         }
     }
 }
@@ -72,7 +73,7 @@ impl Display for EnvironmentContext {
         writeln!(f, "Approval policy: {}", self.approval_policy)?;
         writeln!(f, "Sandbox mode: {}", self.sandbox_mode)?;
         writeln!(f, "Network access: {}", self.network_access)?;
-        if let Some(shell_name) = &self.shell_name {
+        if let Some(shell_name) = self.shell.name() {
             writeln!(f, "Shell: {shell_name}")?;
         }
         Ok(())

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -28,6 +28,7 @@ pub(crate) struct EnvironmentContext {
     pub approval_policy: AskForApproval,
     pub sandbox_mode: SandboxMode,
     pub network_access: NetworkAccess,
+    pub shell_name: Option<String>,
 }
 
 impl EnvironmentContext {
@@ -35,6 +36,7 @@ impl EnvironmentContext {
         cwd: PathBuf,
         approval_policy: AskForApproval,
         sandbox_policy: SandboxPolicy,
+        shell_name: Option<String>,
     ) -> Self {
         Self {
             cwd,
@@ -55,6 +57,7 @@ impl EnvironmentContext {
                     }
                 }
             },
+            shell_name,
         }
     }
 }
@@ -69,6 +72,9 @@ impl Display for EnvironmentContext {
         writeln!(f, "Approval policy: {}", self.approval_policy)?;
         writeln!(f, "Sandbox mode: {}", self.sandbox_mode)?;
         writeln!(f, "Network access: {}", self.network_access)?;
+        if let Some(shell_name) = &self.shell_name {
+            writeln!(f, "Shell: {shell_name}")?;
+        }
         Ok(())
     }
 }

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -62,7 +62,7 @@ impl Shell {
 
                 // Not a bash command. If model did not generate a PowerShell command,
                 // turn it into a PowerShell command.
-                let first = command.get(0).map(String::as_str);
+                let first = command.first().map(String::as_str);
                 if first != Some(ps.exe.as_str()) {
                     if let Ok(joined) = shlex::try_join(command.iter().map(|s| s.as_str())) {
                         return Some(vec![

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -289,3 +289,27 @@ mod tests {
         }
     }
 }
+
+#[cfg(test)]
+#[cfg(target_os = "windows")]
+mod tests_windows {
+    use super::*;
+
+    #[test]
+    fn test_powershell_strips_bash_lc() {
+        let shell = Shell::PowerShell(PowerShellShell {
+            exe: "pwsh.exe".to_string(),
+        });
+
+        let input = vec!["bash".to_string(), "-lc".to_string(), "echo hello".to_string()];
+
+        let out = shell
+            .format_default_shell_invocation(input)
+            .expect("expected wrapped command");
+
+        assert_eq!(
+            out,
+            vec!["pwsh.exe".to_string(), "-NoProfile".to_string(), "-Command".to_string(), "echo hello".to_string()]
+        );
+    }
+}

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -301,15 +301,22 @@ mod tests_windows {
             exe: "pwsh.exe".to_string(),
         });
 
-        let input = vec!["bash".to_string(), "-lc".to_string(), "echo hello".to_string()];
+        let input = vec![
+            "bash".to_string(),
+            "-lc".to_string(),
+            "echo hello".to_string(),
+        ];
 
-        let out = shell
-            .format_default_shell_invocation(input)
-            .expect("expected wrapped command");
+        let out = shell.format_default_shell_invocation(input);
 
         assert_eq!(
             out,
-            vec!["pwsh.exe".to_string(), "-NoProfile".to_string(), "-Command".to_string(), "echo hello".to_string()]
+            Some(vec![
+                "pwsh.exe".to_string(),
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                "echo hello".to_string()
+            ])
         );
     }
 }

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -1,7 +1,7 @@
 use serde::Deserialize;
 use serde::Serialize;
-use std::path::PathBuf;
 use shlex;
+use std::path::PathBuf;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct ZshShell {
@@ -47,7 +47,11 @@ impl Shell {
                 // If model generated a bash command, prefer a detected bash fallback
                 if let Some(script) = strip_bash_lc(&command) {
                     return match &ps.bash_exe_fallback {
-                        Some(bash) => Some(vec![bash.to_string_lossy().to_string(), "-lc".to_string(), script]),
+                        Some(bash) => Some(vec![
+                            bash.to_string_lossy().to_string(),
+                            "-lc".to_string(),
+                            script,
+                        ]),
 
                         // No bash fallback → run the script under PowerShell.
                         // It will likely fail (except for some simple commands), but the error
@@ -71,12 +75,14 @@ impl Shell {
                     }
 
                     let joined = shlex::try_join(command.iter().map(|s| s.as_str())).ok();
-                    return joined.map(|arg| vec![
-                        ps.exe.clone(),
-                        "-NoProfile".to_string(),
-                        "-Command".to_string(),
-                        arg,
-                    ]);
+                    return joined.map(|arg| {
+                        vec![
+                            ps.exe.clone(),
+                            "-NoProfile".to_string(),
+                            "-Command".to_string(),
+                            arg,
+                        ]
+                    });
                 }
 
                 // Model generated a PowerShell command. Run it.

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -1,4 +1,5 @@
-use serde::{Deserialize, Serialize};
+use serde::Deserialize;
+use serde::Serialize;
 use shlex;
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -64,7 +64,7 @@ impl Shell {
                 // turn it into a PowerShell command.
                 let first = command.first().map(String::as_str);
                 if first != Some(ps.exe.as_str()) {
-                    // TODO: Handle escaping newlines.
+                    // TODO (CODEX_2900): Handle escaping newlines.
                     if command.iter().any(|a| a.contains('\n') || a.contains('\r')) {
                         return Some(command);
                     }
@@ -398,7 +398,7 @@ mod tests_windows {
                 vec!["pwsh.exe", "-NoProfile", "-Command", "echo hello"],
             ),
             (
-                // TODO: Handle escaping newlines for powershell invocation.
+                // TODO (CODEX_2900): Handle escaping newlines for powershell invocation.
                 Shell::PowerShell(PowerShellShell {
                     exe: "powershell.exe".to_string(),
                     bash_exe_fallback: Some("bash.exe".to_string()),

--- a/codex-rs/core/tests/prompt_caching.rs
+++ b/codex-rs/core/tests/prompt_caching.rs
@@ -8,6 +8,7 @@ use codex_core::protocol::Op;
 use codex_core::protocol::SandboxPolicy;
 use codex_core::protocol_config_types::ReasoningEffort;
 use codex_core::protocol_config_types::ReasoningSummary;
+use codex_core::shell::default_user_shell;
 use codex_login::CodexAuth;
 use core_test_support::load_default_config_for_test;
 use core_test_support::load_sse_fixture_with_id;
@@ -85,10 +86,15 @@ async fn prefixes_context_and_instructions_once_and_consistently_across_requests
     let requests = server.received_requests().await.unwrap();
     assert_eq!(requests.len(), 2, "expected two POST requests");
 
-    let expected_env_text = format!(
-        "<environment_context>\nCurrent working directory: {}\nApproval policy: on-request\nSandbox mode: read-only\nNetwork access: restricted\n</environment_context>",
+    let expected_env_text_base = format!(
+        "<environment_context>\nCurrent working directory: {}\nApproval policy: on-request\nSandbox mode: read-only\nNetwork access: restricted\n",
         cwd.path().to_string_lossy()
     );
+    let shell = default_user_shell().await;
+    let expected_env_text = match shell.name() {
+        Some(name) => format!("{expected_env_text_base}Shell: {name}\n</environment_context>"),
+        None => format!("{expected_env_text_base}</environment_context>"),
+    };
     let expected_ui_text =
         "<user_instructions>\n\nbe consistent and helpful\n\n</user_instructions>";
 


### PR DESCRIPTION
## What? Why? How?
- When running on Windows, codex often tries to invoke bash commands, which commonly fail (unless WSL is installed)
- Fix: Detect if powershell is available and, if so, route commands to it
  - Also add a shell_name property to environmental context for codex to default to powershell commands when running in that environment

## Testing
- Tested within WSL and powershell (e.g. get top 5 largest files within a folder and validated that commands generated were powershell commands)
- Tested within Zsh
- Updated unit tests
