### PR TITLE
fix: add call_id to ApprovalParams in mcp-server/src/wire_format.rs

### DIFF
--- a/codex-rs/mcp-server/src/codex_message_processor.rs
+++ b/codex-rs/mcp-server/src/codex_message_processor.rs
@@ -306,13 +306,14 @@ async fn apply_bespoke_event_handling(
     let Event { id: event_id, msg } = event;
     match msg {
         EventMsg::ApplyPatchApprovalRequest(ApplyPatchApprovalRequestEvent {
-            call_id: _,
+            call_id,
             changes,
             reason,
             grant_root,
         }) => {
             let params = ApplyPatchApprovalParams {
                 conversation_id,
+                call_id,
                 file_changes: changes,
                 reason,
                 grant_root,
@@ -327,13 +328,14 @@ async fn apply_bespoke_event_handling(
             });
         }
         EventMsg::ExecApprovalRequest(ExecApprovalRequestEvent {
-            call_id: _,
+            call_id,
             command,
             cwd,
             reason,
         }) => {
             let params = ExecCommandApprovalParams {
                 conversation_id,
+                call_id,
                 command,
                 cwd,
                 reason,

--- a/codex-rs/mcp-server/src/wire_format.rs
+++ b/codex-rs/mcp-server/src/wire_format.rs
@@ -187,6 +187,9 @@ pub enum ServerRequest {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ApplyPatchApprovalParams {
     pub conversation_id: ConversationId,
+    /// Use to correlate this with [codex_core::protocol::PatchApplyBeginEvent]
+    /// and [codex_core::protocol::PatchApplyEndEvent].
+    pub call_id: String,
     pub file_changes: HashMap<PathBuf, FileChange>,
     /// Optional explanatory reason (e.g. request for extra write access).
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -200,6 +203,9 @@ pub struct ApplyPatchApprovalParams {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct ExecCommandApprovalParams {
     pub conversation_id: ConversationId,
+    /// Use to correlate this with [codex_core::protocol::ExecCommandBeginEvent]
+    /// and [codex_core::protocol::ExecCommandEndEvent].
+    pub call_id: String,
     pub command: Vec<String>,
     pub cwd: PathBuf,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Clients still need this field.