### PR TITLE
tui: align diff display by always showing sign char and keeping fixed gutter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,18 @@
-# Codex – Snapshot Tests
+# Rust/codex-rs
+
+In the codex-rs folder where the rust code lives:
+
+- Crate names are prefixed with `codex-`. For examole, the `core` folder's crate is named `codex-core`
+- When using format! and you can inline variables into {}, always do that.
+- Never add or modify any code related to `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR` or `CODEX_SANDBOX_ENV_VAR`.
+  - You operate in a sandbox where `CODEX_SANDBOX_NETWORK_DISABLED=1` will be set whenever you use the `shell` tool. Any existing code that uses `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR` was authored with this fact in mind. It is often used to early exit out of tests that the author knew you would not be able to run given your sandbox limitations.
+  - Similarly, when you spawn a process using Seatbelt (`/usr/bin/sandbox-exec`), `CODEX_SANDBOX=seatbelt` will be set on the child process. Integration tests that want to run Seatbelt themselves cannot be run under Seatbelt, so checks for `CODEX_SANDBOX=seatbelt` are also often used to early exit out of tests, as appropriate.
+
+Before finalizing a change to `codex-rs`, run `just fmt` (in `codex-rs` directory) to format the code and `just fix` (in `codex-rs` directory) to fix any linter issues in the code. Additionally, run the tests:
+1. Run the test for the specific project that was changed. For example, if changes were made in `codex-rs/tui`, run `cargo test -p codex-tui`.
+2. Once those pass, if any changes were made in common, core, or protocol, run the complete test suite with `cargo test --all-features`.
+
+## Snapshot tests
 
 This repo uses snapshot tests (via `insta`), especially in `codex-rs/tui`, to validate rendered output. When UI or text output changes intentionally, update the snapshots as follows:
 
@@ -13,5 +27,3 @@ This repo uses snapshot tests (via `insta`), especially in `codex-rs/tui`, to va
 
 If you don’t have the tool:
 - `cargo install cargo-insta`
-
-After accepting, re-run the tests to ensure everything passes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,17 @@
-# Rust/codex-rs
+# Codex – Snapshot Tests
 
-In the codex-rs folder where the rust code lives:
+This repo uses snapshot tests (via `insta`), especially in `codex-rs/tui`, to validate rendered output. When UI or text output changes intentionally, update the snapshots as follows:
 
-- Crate names are prefixed with `codex-`. For examole, the `core` folder's crate is named `codex-core`
-- When using format! and you can inline variables into {}, always do that.
-- Never add or modify any code related to `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR` or `CODEX_SANDBOX_ENV_VAR`.
-  - You operate in a sandbox where `CODEX_SANDBOX_NETWORK_DISABLED=1` will be set whenever you use the `shell` tool. Any existing code that uses `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR` was authored with this fact in mind. It is often used to early exit out of tests that the author knew you would not be able to run given your sandbox limitations.
-  - Similarly, when you spawn a process using Seatbelt (`/usr/bin/sandbox-exec`), `CODEX_SANDBOX=seatbelt` will be set on the child process. Integration tests that want to run Seatbelt themselves cannot be run under Seatbelt, so checks for `CODEX_SANDBOX=seatbelt` are also often used to early exit out of tests, as appropriate.
+- Run tests to generate any updated snapshots:
+  - `cargo test -p codex-tui`
+- Check what’s pending:
+  - `cargo insta pending-snapshots -p codex-tui`
+- Review changes by reading the generated `*.snap.new` files directly in the repo, or preview a specific file:
+  - `cargo insta show -p codex-tui path/to/file.snap.new`
+- Only if you intend to accept all new snapshots in this crate, run:
+  - `cargo insta accept -p codex-tui`
 
-Before finalizing a change to `codex-rs`, run `just fmt` (in `codex-rs` directory) to format the code and `just fix` (in `codex-rs` directory) to fix any linter issues in the code. Additionally, run the tests:
-1. Run the test for the specific project that was changed. For example, if changes were made in `codex-rs/tui`, run `cargo test -p codex-tui`.
-2. Once those pass, if any changes were made in common, core, or protocol, run the complete test suite with `cargo test --all-features`.
+If you don’t have the tool:
+- `cargo install cargo-insta`
+
+After accepting, re-run the tests to ensure everything passes.

--- a/codex-rs/tui/src/snapshots/codex_tui__diff_render__tests__update_details_with_rename.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__diff_render__tests__update_details_with_rename.snap
@@ -1,13 +1,14 @@
 ---
 source: tui/src/diff_render.rs
+assertion_line: 380
 expression: terminal.backend()
 ---
 "proposed patch to 1 file (+1 -1)                                                "
 "  └ src/lib.rs → src/lib_new.rs (+1 -1)                                         "
-"    1     line one                                                              "
+"    1      line one                                                             "
 "    2     -line two                                                             "
 "    2     +line two changed                                                     "
-"    3     line three                                                            "
+"    3      line three                                                           "
 "                                                                                "
 "                                                                                "
 "                                                                                "

--- a/codex-rs/tui/src/snapshots/codex_tui__diff_render__tests__wrap_behavior_insert.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__diff_render__tests__wrap_behavior_insert.snap
@@ -1,9 +1,10 @@
 ---
 source: tui/src/diff_render.rs
+assertion_line: 380
 expression: terminal.backend()
 ---
 "    1     +this is a very long line that should wrap across multiple terminal col         "
-"          umns and continue                                                               "
+"           umns and continue                                                              "
 "                                                                                          "
 "                                                                                          "
 "                                                                                          "


### PR DESCRIPTION
diff lines without a sign char were misaligned.