### PR TITLE
fix: include an entry for windows-x86_64 in the generated DotSlash file

### DIFF
--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -17,6 +17,10 @@
         "linux-aarch64": {
           "regex": "^codex-aarch64-unknown-linux-musl\\.zst$",
           "path": "codex"
+        },
+        "windows-x86_64": {
+          "regex": "^codex-x86_64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex.exe"
         }
       }
     }


### PR DESCRIPTION
Now that we are improving our Windows support, we should be including an entry for it in the DotSlash file.

Though anyone using the DotSlash file with Windows should use the new Windows shim introduced in https://github.com/facebook/dotslash/pull/46. For more info, see https://dotslash-cli.com/docs/windows/.