### PR TITLE
ctrl-t opens a 'transcript' in less

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -924,6 +924,7 @@ dependencies = [
  "strum 0.27.2",
  "strum_macros 0.27.2",
  "supports-color",
+ "tempfile",
  "textwrap 0.16.2",
  "tokio",
  "tracing",

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -66,6 +66,7 @@ tokio = { version = "1", features = [
     "rt-multi-thread",
     "signal",
 ] }
+tempfile = "3"
 tracing = { version = "0.1.41", features = ["log"] }
 tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -5,6 +5,7 @@ use ratatui::text::Line;
 use std::time::Duration;
 
 use crate::app::ChatWidgetArgs;
+use crate::history_cell::HistoryCell;
 use crate::slash_command::SlashCommand;
 
 #[allow(clippy::large_enum_variant)]
@@ -51,7 +52,8 @@ pub(crate) enum AppEvent {
         matches: Vec<FileMatch>,
     },
 
-    InsertHistory(Vec<Line<'static>>),
+    InsertHistoryLines(Vec<Line<'static>>),
+    InsertHistoryCell(Box<dyn HistoryCell>),
 
     StartCommitAnimation,
     StopCommitAnimation,

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -917,22 +917,6 @@ fn format_mcp_invocation<'a>(invocation: McpInvocation) -> Line<'a> {
     Line::from(invocation_spans)
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parsed_command_with_newlines_starts_each_line_at_origin() {
-        let parsed = vec![ParsedCommand::Unknown {
-            cmd: "printf 'foo\nbar'".to_string(),
-        }];
-        let lines = exec_command_lines(&[], &parsed, None, None);
-        assert!(lines.len() >= 3);
-        assert_eq!(lines[1].spans[0].content, "  └ ");
-        assert_eq!(lines[2].spans[0].content, "    ");
-    }
-}
-
 pub(crate) fn new_exec_approval_decision(
     approval_request: &ApprovalRequest,
     decision: codex_core::protocol::ReviewDecision,
@@ -1019,4 +1003,20 @@ pub(crate) fn new_reasoning_block(
     append_markdown(&full_reasoning_buffer, &mut lines, config);
     lines.push(Line::from(""));
     TranscriptOnlyHistoryCell { lines }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parsed_command_with_newlines_starts_each_line_at_origin() {
+        let parsed = vec![ParsedCommand::Unknown {
+            cmd: "printf 'foo\nbar'".to_string(),
+        }];
+        let lines = exec_command_lines(&[], &parsed, None, None);
+        assert!(lines.len() >= 3);
+        assert_eq!(lines[1].spans[0].content, "  └ ");
+        assert_eq!(lines[2].spans[0].content, "    ");
+    }
 }

--- a/codex-rs/tui/src/insert_history.rs
+++ b/codex-rs/tui/src/insert_history.rs
@@ -109,6 +109,13 @@ pub fn insert_history_lines_to_writer<B, W>(
     }
 }
 
+pub fn write_lines(writer: &mut impl Write, lines: Vec<Line>) {
+    for line in lines {
+        queue!(writer, Print("\r\n")).ok();
+        write_spans(writer, line.iter()).ok();
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SetScrollRegion(pub std::ops::Range<u16>);
 

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -288,7 +288,7 @@ fn run_ratatui_app(
     reason = "TUI should no longer be displayed, so we can write to stderr."
 )]
 fn restore() {
-    if let Err(err) = tui::restore() {
+    if let Err(err) = tui::restore_modes() {
         eprintln!(
             "failed to restore terminal. Run `reset` or restart your terminal to recover: {err}"
         );

--- a/codex-rs/tui/src/session_log.rs
+++ b/codex-rs/tui/src/session_log.rs
@@ -160,12 +160,12 @@ pub(crate) fn log_inbound_app_event(event: &AppEvent) {
             LOGGER.write_json_line(value);
         }
         // Internal UI events; still log for fidelity, but avoid heavy payloads.
-        AppEvent::InsertHistory(lines) => {
+        AppEvent::InsertHistoryCell(cell) => {
             let value = json!({
                 "ts": now_ts(),
                 "dir": "to_tui",
                 "kind": "insert_history",
-                "lines": lines.len(),
+                "lines": cell.transcript_lines().len(),
             });
             LOGGER.write_json_line(value);
         }

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -17,7 +17,7 @@ pub(crate) struct AppEventHistorySink(pub(crate) crate::app_event_sender::AppEve
 impl HistorySink for AppEventHistorySink {
     fn insert_history(&self, lines: Vec<Line<'static>>) {
         self.0
-            .send(crate::app_event::AppEvent::InsertHistory(lines))
+            .send(crate::app_event::AppEvent::InsertHistoryLines(lines))
     }
     fn start_commit_animation(&self) {
         self.0


### PR DESCRIPTION
#2316 hides the CoT summaries by default, only showing the headers. But it's still useful to be able to see the full CoT summaries sometimes. This adds the concept of a "transcript mode", triggered by <kbd>Ctrl+T</kbd>, which shows a complete "expanded" transcript of the session. Currently, the only thing that's expanded is CoT summaries, but in future this should also include:

* complete commands (instead of / in addition to the "pretty" summarized commands that we show in the main history)
* full command output
* anything else that's occasionally useful, but too large or noisy to fit in the main history.