### PR TITLE
Added launch profile for attaching to a running codex CLI process

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,18 +1,22 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Cargo launch",
-            "cargo": {
-                "cwd": "${workspaceFolder}/codex-rs",
-                "args": [
-                    "build",
-                    "--bin=codex-tui"
-                ]
-            },
-            "args": []
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Cargo launch",
+      "cargo": {
+        "cwd": "${workspaceFolder}/codex-rs",
+        "args": ["build", "--bin=codex-tui"]
+      },
+      "args": []
+    },
+    {
+      "type": "lldb",
+      "request": "attach",
+      "name": "Attach to running codex CLI",
+      "pid": "${command:pickProcess}",
+      "sourceLanguages": ["rust"]
+    }
+  ]
 }


### PR DESCRIPTION
This launch profile make it easy to attach the rust debugger to a CLI process that has already been launched.