### PR TITLE
feat: add optional session_id parameter to MCP codex tool

### DIFF
--- a/codex-rs/cli/src/proto.rs
+++ b/codex-rs/cli/src/proto.rs
@@ -41,7 +41,7 @@ pub async fn run_main(opts: ProtoCli) -> anyhow::Result<()> {
         conversation_id: _,
         conversation,
         session_configured,
-    } = conversation_manager.new_conversation(config).await?;
+    } = conversation_manager.new_conversation(config, None).await?;
 
     // Simulate streaming the session_configured event.
     let synthetic_event = Event {

--- a/codex-rs/core/src/conversation_manager.rs
+++ b/codex-rs/core/src/conversation_manager.rs
@@ -39,9 +39,14 @@ impl Default for ConversationManager {
 }
 
 impl ConversationManager {
-    pub async fn new_conversation(&self, config: Config) -> CodexResult<NewConversation> {
+    pub async fn new_conversation(
+        &self,
+        config: Config,
+        session_id: Option<Uuid>,
+    ) -> CodexResult<NewConversation> {
         let auth = CodexAuth::from_codex_home(&config.codex_home)?;
-        self.new_conversation_with_auth(config, auth).await
+        self.new_conversation_with_auth(config, auth, session_id)
+            .await
     }
 
     /// Used for integration tests: should not be used by ordinary business
@@ -50,11 +55,12 @@ impl ConversationManager {
         &self,
         config: Config,
         auth: Option<CodexAuth>,
+        session_id: Option<Uuid>,
     ) -> CodexResult<NewConversation> {
         let CodexSpawnOk {
             codex,
             session_id: conversation_id,
-        } = Codex::spawn(config, auth).await?;
+        } = Codex::spawn(config, auth, session_id).await?;
 
         // The first event must be `SessionInitialized`. Validate and forward it
         // to the caller so that they can display it in the conversation

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -190,7 +190,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         conversation_id: _,
         conversation,
         session_configured,
-    } = conversation_manager.new_conversation(config).await?;
+    } = conversation_manager.new_conversation(config, None).await?;
     info!("Codex initialized with event: {session_configured:?}");
 
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();

--- a/codex-rs/mcp-server/src/codex_message_processor.rs
+++ b/codex-rs/mcp-server/src/codex_message_processor.rs
@@ -109,7 +109,11 @@ impl CodexMessageProcessor {
             }
         };
 
-        match self.conversation_manager.new_conversation(config).await {
+        match self
+            .conversation_manager
+            .new_conversation(config, None)
+            .await
+        {
             Ok(conversation_id) => {
                 let NewConversation {
                     conversation_id,

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -20,6 +20,10 @@ pub struct CodexToolCallParam {
     /// The *initial user prompt* to start the Codex conversation.
     pub prompt: String,
 
+    /// Optional client-provided session identifier. If omitted, a new UUID is generated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<String>,
+
     /// Optional override for the model name (e.g. "o3", "o4-mini").
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
@@ -136,9 +140,10 @@ impl CodexToolCallParam {
     pub fn into_config(
         self,
         codex_linux_sandbox_exe: Option<PathBuf>,
-    ) -> std::io::Result<(String, codex_core::config::Config)> {
+    ) -> std::io::Result<(String, codex_core::config::Config, Option<String>)> {
         let Self {
             prompt,
+            session_id,
             model,
             profile,
             cwd,
@@ -173,7 +178,7 @@ impl CodexToolCallParam {
 
         let cfg = codex_core::config::Config::load_with_cli_overrides(cli_overrides, overrides)?;
 
-        Ok((prompt, cfg))
+        Ok((prompt, cfg, session_id))
     }
 }
 
@@ -291,6 +296,10 @@ mod tests {
               },
               "base-instructions": {
                 "description": "The set of instructions to use instead of the default ones.",
+                "type": "string"
+              },
+              "session-id": {
+                "description": "Optional client-provided session ID (some clients must provide a valid UUIDv4 to be able to continue the conversation). If omitted, a new UUID is generated.",
                 "type": "string"
               },
             },

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -44,12 +44,16 @@ pub async fn run_codex_tool_session(
     outgoing: Arc<OutgoingMessageSender>,
     conversation_manager: Arc<ConversationManager>,
     running_requests_id_to_codex_uuid: Arc<Mutex<HashMap<RequestId, Uuid>>>,
+    session_id: Option<Uuid>,
 ) {
     let NewConversation {
         conversation_id,
         conversation,
         session_configured,
-    } = match conversation_manager.new_conversation(config).await {
+    } = match conversation_manager
+        .new_conversation(config, session_id)
+        .await
+    {
         Ok(res) => res,
         Err(e) => {
             let result = CallToolResult {

--- a/codex-rs/mcp-server/src/tool_handlers/create_conversation.rs
+++ b/codex-rs/mcp-server/src/tool_handlers/create_conversation.rs
@@ -82,7 +82,7 @@ pub(crate) async fn handle_create_conversation(
         session_configured,
     } = match message_processor
         .get_conversation_manager()
-        .new_conversation(cfg)
+        .new_conversation(cfg, None)
         .await
     {
         Ok(conv) => conv,

--- a/codex-rs/mcp-server/tests/interrupt.rs
+++ b/codex-rs/mcp-server/tests/interrupt.rs
@@ -75,6 +75,7 @@ async fn shell_command_interruption() -> anyhow::Result<()> {
         .send_codex_tool_call(CodexToolCallParam {
             cwd: None,
             prompt: "First Run: run `sleep 60`".to_string(),
+            session_id: None,
             model: None,
             profile: None,
             approval_policy: None,

--- a/codex-rs/tui/src/chatwidget/agent.rs
+++ b/codex-rs/tui/src/chatwidget/agent.rs
@@ -25,7 +25,7 @@ pub(crate) fn spawn_agent(
             conversation_id: _,
             conversation,
             session_configured,
-        } = match server.new_conversation(config).await {
+        } = match server.new_conversation(config, None).await {
             Ok(v) => v,
             Err(e) => {
                 // TODO: surface this error to the user.


### PR DESCRIPTION
Allow MCP clients to provide a custom session_id UUID when initiating a new Codex session via MCP.

This allows MCP clients such as Claude (who cannot access the session_id) to have multiturn conversations with the Codex MCP server.

I have read the CLA Document and I hereby sign the CLA
