### PR TITLE
fix(tui): Initialize the logger before ollama checks

### DIFF
--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -205,13 +205,13 @@ pub async fn run_main(
         .with_target(false)
         .with_filter(env_filter());
 
+    let _ = tracing_subscriber::registry().with(file_layer).try_init();
+
     if cli.oss {
         codex_ollama::ensure_oss_ready(&config)
             .await
             .map_err(|e| std::io::Error::other(format!("OSS setup failed: {e}")))?;
     }
-
-    let _ = tracing_subscriber::registry().with(file_layer).try_init();
 
     #[allow(clippy::print_stderr)]
     #[cfg(not(debug_assertions))]


### PR DESCRIPTION
The logger was initializing after executing the ensure_oss_ready function, causing errors to be lost if an error occurred there.

Closes #2248 