### PR TITLE
chore: prefer returning Err to expect()

### DIFF
--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -59,10 +59,9 @@ pub struct LoginServer {
 
 impl LoginServer {
     pub fn block_until_done(self) -> io::Result<()> {
-        #[expect(clippy::expect_used)]
         self.server_handle
             .join()
-            .expect("can't join on the server thread")
+            .map_err(|err| io::Error::other(format!("login server thread panicked: {err:?}")))?
     }
 
     pub fn cancel(&self) {


### PR DESCRIPTION
Letting the caller deal with `Err` seems preferable to using `expect()` (which would `panic!()`), particularly given that the function already returns `Result`.









---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/2389).
* #2399
* #2398
* #2396
* #2395
* #2394
* #2393
* __->__ #2389