### PR TITLE
fix: async-ify login flow

### DIFF
--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -21,7 +21,7 @@ pub async fn login_with_chatgpt(codex_home: PathBuf) -> std::io::Result<()> {
         server.actual_port, server.auth_url,
     );
 
-    server.block_until_done()
+    server.block_until_done().await
 }
 
 pub async fn run_login_with_chatgpt(cli_config_overrides: CliConfigOverrides) -> ! {

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -59,10 +59,9 @@ pub struct LoginServer {
 
 impl LoginServer {
     pub fn block_until_done(self) -> io::Result<()> {
-        #[expect(clippy::expect_used)]
         self.server_handle
             .join()
-            .expect("can't join on the server thread")
+            .map_err(|err| io::Error::other(format!("login server thread panicked: {err:?}")))?
     }
 
     pub fn cancel(&self) {

--- a/codex-rs/login/tests/login_server_e2e.rs
+++ b/codex-rs/login/tests/login_server_e2e.rs
@@ -73,8 +73,8 @@ fn start_mock_issuer() -> (SocketAddr, thread::JoinHandle<()>) {
     (addr, handle)
 }
 
-#[test]
-fn end_to_end_login_flow_persists_auth_json() {
+#[tokio::test]
+async fn end_to_end_login_flow_persists_auth_json() {
     if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() {
         println!(
             "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
@@ -106,16 +106,16 @@ fn end_to_end_login_flow_persists_auth_json() {
     let login_port = server.actual_port;
 
     // Simulate browser callback, and follow redirect to /success
-    let client = reqwest::blocking::Client::builder()
+    let client = reqwest::Client::builder()
         .redirect(reqwest::redirect::Policy::limited(5))
         .build()
         .unwrap();
     let url = format!("http://127.0.0.1:{login_port}/auth/callback?code=abc&state=test_state_123");
-    let resp = client.get(&url).send().unwrap();
+    let resp = client.get(&url).send().await.unwrap();
     assert!(resp.status().is_success());
 
     // Wait for server shutdown
-    server.block_until_done().unwrap();
+    server.block_until_done().await.unwrap();
 
     // Validate auth.json
     let auth_path = codex_home.join("auth.json");
@@ -133,8 +133,8 @@ fn end_to_end_login_flow_persists_auth_json() {
     drop(issuer_handle);
 }
 
-#[test]
-fn creates_missing_codex_home_dir() {
+#[tokio::test]
+async fn creates_missing_codex_home_dir() {
     if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() {
         println!(
             "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
@@ -164,12 +164,12 @@ fn creates_missing_codex_home_dir() {
     let server = run_login_server(opts, None).unwrap();
     let login_port = server.actual_port;
 
-    let client = reqwest::blocking::Client::new();
+    let client = reqwest::Client::new();
     let url = format!("http://127.0.0.1:{login_port}/auth/callback?code=abc&state=state2");
-    let resp = client.get(&url).send().unwrap();
+    let resp = client.get(&url).send().await.unwrap();
     assert!(resp.status().is_success());
 
-    server.block_until_done().unwrap();
+    server.block_until_done().await.unwrap();
 
     let auth_path = codex_home.join("auth.json");
     assert!(

--- a/codex-rs/mcp-server/src/codex_message_processor.rs
+++ b/codex-rs/mcp-server/src/codex_message_processor.rs
@@ -180,15 +180,9 @@ impl CodexMessageProcessor {
                 let outgoing_clone = self.outgoing.clone();
                 let active_login = self.active_login.clone();
                 tokio::spawn(async move {
-                    let result =
-                        tokio::task::spawn_blocking(move || server.block_until_done()).await;
-                    let (success, error_msg) = match result {
-                        Ok(Ok(())) => (true, None),
-                        Ok(Err(err)) => (false, Some(format!("Login server error: {err}"))),
-                        Err(join_err) => (
-                            false,
-                            Some(format!("failed to join login server thread: {join_err}")),
-                        ),
+                    let (success, error_msg) = match server.block_until_done().await {
+                        Ok(()) => (true, None),
+                        Err(err) => (false, Some(format!("Login server error: {err}"))),
                     };
                     let notification = LoginChatGptCompleteNotification {
                         login_id,


### PR DESCRIPTION
This replaces blocking I/O with async/non-blocking I/O in a number of cases. This facilitates the use of `tokio::sync::Notify` and `tokio::select!` in #2394.









---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/2393).
* #2399
* #2398
* #2396
* #2395
* #2394
* __->__ #2393
* #2389