### PR TITLE
feat(config): Allow setting sandbox_mode within profiles

### DIFF
--- a/codex-rs/core/src/config_profile.rs
+++ b/codex-rs/core/src/config_profile.rs
@@ -3,6 +3,8 @@ use std::path::PathBuf;
 
 use crate::config_types::ReasoningEffort;
 use crate::config_types::ReasoningSummary;
+use crate::config_types::SandboxMode;
+use crate::config_types::SandboxWorkspaceWrite;
 use crate::protocol::AskForApproval;
 
 /// Collection of common configuration options that a user can define as a unit
@@ -14,6 +16,8 @@ pub struct ConfigProfile {
     /// [`ModelProviderInfo`] to use.
     pub model_provider: Option<String>,
     pub approval_policy: Option<AskForApproval>,
+    pub sandbox_mode: Option<SandboxMode>,
+    pub sandbox_workspace_write: Option<SandboxWorkspaceWrite>,
     pub disable_response_storage: Option<bool>,
     pub model_reasoning_effort: Option<ReasoningEffort>,
     pub model_reasoning_summary: Option<ReasoningSummary>,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -330,9 +330,8 @@ fn determine_repo_trust_state(
         // if the user has overridden either approval policy or sandbox mode,
         // skip the trust flow
         Ok(false)
-    } else if config_profile.approval_policy.is_some() {
+    } else if config_profile.approval_policy.is_some() || config_profile.sandbox_mode.is_some() {
         // if the user has specified settings in a config profile, skip the trust flow
-        // todo: profile sandbox mode?
         Ok(false)
     } else if config_toml.approval_policy.is_some() || config_toml.sandbox_mode.is_some() {
         // if the user has specified either approval policy or sandbox mode in config.toml


### PR DESCRIPTION
Allow defining `sandbox_mode` and its
related `sandbox_workspace_write` settings directly within a profile.

Changes:
- Extending the `ConfigProfile` struct to include `sandbox_mode` and
  `sandbox_workspace_write` fields.
- Modifying the `derive_sandbox_policy` function to apply settings with the
  following precedence: CLI > Profile > Top-level.
- Including the necessary unit tests.
- Updating the trust flow logic to also skip the prompt if a
  profile defines a sandbox mode.

Example:

```
[profiles.dev-project]
sandbox_mode = "workspace-write"
[profiles.dev-project.sandbox_workspace_write]
writable_roots = ["~/dev/project-a"]
```

Fixes #2384