### PR TITLE
fix: remove shutdown_flag param to run_login_server()

### DIFF
--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -14,7 +14,7 @@ use std::path::PathBuf;
 
 pub async fn login_with_chatgpt(codex_home: PathBuf) -> std::io::Result<()> {
     let opts = ServerOptions::new(codex_home, CLIENT_ID.to_string());
-    let server = run_login_server(opts, None)?;
+    let server = run_login_server(opts)?;
 
     eprintln!(
         "Starting local login server on http://localhost:{}.\nIf your browser did not open, navigate to this URL to authenticate:\n\n{}",

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -77,10 +77,7 @@ impl ShutdownHandle {
     }
 }
 
-pub fn run_login_server(
-    opts: ServerOptions,
-    shutdown_flag: Option<Arc<tokio::sync::Notify>>,
-) -> io::Result<LoginServer> {
+pub fn run_login_server(opts: ServerOptions) -> io::Result<LoginServer> {
     let pkce = generate_pkce();
     let state = opts.force_state.clone().unwrap_or_else(generate_state);
 
@@ -118,7 +115,7 @@ pub fn run_login_server(
         })
     };
 
-    let shutdown_notify = shutdown_flag.unwrap_or_else(|| Arc::new(tokio::sync::Notify::new()));
+    let shutdown_notify = Arc::new(tokio::sync::Notify::new());
     let server_handle = {
         let shutdown_notify = shutdown_notify.clone();
         let server = server.clone();

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -3,11 +3,7 @@ use std::io::{self};
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::atomic::AtomicBool;
-use std::sync::atomic::Ordering;
-use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
 
 use crate::AuthDotJson;
 use crate::get_auth_file;
@@ -32,7 +28,6 @@ pub struct ServerOptions {
     pub port: u16,
     pub open_browser: bool,
     pub force_state: Option<String>,
-    pub login_timeout: Option<Duration>,
 }
 
 impl ServerOptions {
@@ -44,7 +39,6 @@ impl ServerOptions {
             port: DEFAULT_PORT,
             open_browser: true,
             force_state: None,
-            login_timeout: None,
         }
     }
 }
@@ -126,24 +120,8 @@ pub fn run_login_server(
     if opts.open_browser {
         let _ = webbrowser::open(&auth_url);
     }
-    let shutdown_notify: Arc<tokio::sync::Notify> =
-        shutdown_flag.unwrap_or_else(|| Arc::new(tokio::sync::Notify::new()));
-    let shutdown_notify_clone = shutdown_notify.clone();
-    let timeout_flag = Arc::new(AtomicBool::new(false));
 
-    // Channel used to signal completion to timeout watcher.
-    let (done_tx, done_rx) = mpsc::channel::<()>();
-
-    if let Some(timeout) = opts.login_timeout {
-        spawn_timeout_watcher(
-            done_rx,
-            timeout,
-            shutdown_notify.clone(),
-            timeout_flag.clone(),
-            server.clone(),
-        );
-    }
-
+    // Map blocking reads from server.recv() to an async channel.
     let (tx, mut rx) = tokio::sync::mpsc::channel::<Request>(16);
     let _server_handle = {
         let server = server.clone();
@@ -158,59 +136,52 @@ pub fn run_login_server(
         })
     };
 
-    let server_for_task = server.clone();
-    let server_handle = tokio::spawn(async move {
-        loop {
-            tokio::select! {
-                _ = shutdown_notify.notified() => {
-                    let _ = done_tx.send(());
-                    if timeout_flag.load(Ordering::SeqCst) {
-                        return Err(io::Error::other("Login timed out"));
-                    } else {
+    let shutdown_notify = shutdown_flag.unwrap_or_else(|| Arc::new(tokio::sync::Notify::new()));
+    let server_handle = {
+        let shutdown_notify = shutdown_notify.clone();
+        let server = server.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = shutdown_notify.notified() => {
                         return Err(io::Error::other("Login was not completed"));
                     }
-                }
-                maybe_req = rx.recv() => {
-                    let Some(req) = maybe_req else {
-                        let _ = done_tx.send(());
-                        if timeout_flag.load(Ordering::SeqCst) {
-                            return Err(io::Error::other("Login timed out"));
-                        } else {
+                    maybe_req = rx.recv() => {
+                        let Some(req) = maybe_req else {
                             return Err(io::Error::other("Login was not completed"));
-                        }
-                    };
+                        };
 
-                    let url_raw = req.url().to_string();
-                    let response =
-                        process_request(&url_raw, &opts, &redirect_uri, &pkce, actual_port, &state).await;
+                        let url_raw = req.url().to_string();
+                        let response =
+                            process_request(&url_raw, &opts, &redirect_uri, &pkce, actual_port, &state).await;
 
-                    let is_login_complete = matches!(response, HandledRequest::ResponseAndExit(_));
-                    match response {
-                        HandledRequest::Response(r) | HandledRequest::ResponseAndExit(r) => {
-                            let _ = tokio::task::spawn_blocking(move || req.respond(r)).await;
+                        let is_login_complete = matches!(response, HandledRequest::ResponseAndExit(_));
+                        match response {
+                            HandledRequest::Response(r) | HandledRequest::ResponseAndExit(r) => {
+                                let _ = tokio::task::spawn_blocking(move || req.respond(r)).await;
+                            }
+                            HandledRequest::RedirectWithHeader(header) => {
+                                let redirect = Response::empty(302).with_header(header);
+                                let _ = tokio::task::spawn_blocking(move || req.respond(redirect)).await;
+                            }
                         }
-                        HandledRequest::RedirectWithHeader(header) => {
-                            let redirect = Response::empty(302).with_header(header);
-                            let _ = tokio::task::spawn_blocking(move || req.respond(redirect)).await;
-                        }
-                    }
 
-                    if is_login_complete {
-                        shutdown_notify.notify_waiters();
-                        let _ = done_tx.send(());
-                        server_for_task.unblock();
-                        return Ok(());
+                        if is_login_complete {
+                            shutdown_notify.notify_waiters();
+                            server.unblock();
+                            return Ok(());
+                        }
                     }
                 }
             }
-        }
-    });
+        })
+    };
 
     Ok(LoginServer {
-        auth_url: auth_url.clone(),
+        auth_url,
         actual_port,
         server_handle,
-        shutdown_flag: shutdown_notify_clone,
+        shutdown_flag: shutdown_notify,
         server,
     })
 }
@@ -317,26 +288,6 @@ async fn process_request(
         }
         _ => HandledRequest::Response(Response::from_string("Not Found").with_status_code(404)),
     }
-}
-
-/// Spawns a detached thread that waits for either a completion signal on `done_rx`
-/// or the specified `timeout` to elapse. If the timeout elapses first it marks
-/// the `shutdown_flag`, records `timeout_flag`, and unblocks the HTTP server so
-/// that the main server loop can exit promptly.
-fn spawn_timeout_watcher(
-    done_rx: mpsc::Receiver<()>,
-    timeout: Duration,
-    shutdown_notify: Arc<tokio::sync::Notify>,
-    timeout_flag: Arc<AtomicBool>,
-    server: Arc<Server>,
-) {
-    thread::spawn(move || {
-        if done_rx.recv_timeout(timeout).is_err() {
-            timeout_flag.store(true, Ordering::SeqCst);
-            shutdown_notify.notify_waiters();
-            server.unblock();
-        }
-    });
 }
 
 fn build_authorize_url(

--- a/codex-rs/login/tests/login_server_e2e.rs
+++ b/codex-rs/login/tests/login_server_e2e.rs
@@ -101,7 +101,7 @@ async fn end_to_end_login_flow_persists_auth_json() {
         open_browser: false,
         force_state: Some(state),
     };
-    let server = run_login_server(opts, None).unwrap();
+    let server = run_login_server(opts).unwrap();
     let login_port = server.actual_port;
 
     // Simulate browser callback, and follow redirect to /success
@@ -159,7 +159,7 @@ async fn creates_missing_codex_home_dir() {
         open_browser: false,
         force_state: Some(state),
     };
-    let server = run_login_server(opts, None).unwrap();
+    let server = run_login_server(opts).unwrap();
     let login_port = server.actual_port;
 
     let client = reqwest::Client::new();

--- a/codex-rs/login/tests/login_server_e2e.rs
+++ b/codex-rs/login/tests/login_server_e2e.rs
@@ -100,7 +100,6 @@ async fn end_to_end_login_flow_persists_auth_json() {
         port: 0,
         open_browser: false,
         force_state: Some(state),
-        login_timeout: None,
     };
     let server = run_login_server(opts, None).unwrap();
     let login_port = server.actual_port;
@@ -159,7 +158,6 @@ async fn creates_missing_codex_home_dir() {
         port: 0,
         open_browser: false,
         force_state: Some(state),
-        login_timeout: None,
     };
     let server = run_login_server(opts, None).unwrap();
     let login_port = server.actual_port;

--- a/codex-rs/mcp-server/src/codex_message_processor.rs
+++ b/codex-rs/mcp-server/src/codex_message_processor.rs
@@ -154,7 +154,7 @@ impl CodexMessageProcessor {
             Error(JSONRPCErrorError),
         }
 
-        let reply = match run_login_server(opts, None) {
+        let reply = match run_login_server(opts) {
             Ok(server) => {
                 let login_id = Uuid::new_v4();
                 let shutdown_handle = server.cancel_handle();

--- a/codex-rs/mcp-server/src/codex_message_processor.rs
+++ b/codex-rs/mcp-server/src/codex_message_processor.rs
@@ -66,7 +66,7 @@ struct ActiveLogin {
 
 impl ActiveLogin {
     fn drop(&self) {
-        self.shutdown_handle.cancel();
+        self.shutdown_handle.shutdown();
     }
 }
 
@@ -190,7 +190,7 @@ impl CodexMessageProcessor {
                         Ok(Err(err)) => (false, Some(format!("Login server error: {err}"))),
                         Err(_elapsed) => {
                             // Timeout: cancel server and report
-                            shutdown_handle.cancel();
+                            shutdown_handle.shutdown();
                             (false, Some("Login timed out".to_string()))
                         }
                     };

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -281,7 +281,7 @@ impl AuthModeWidget {
     fn start_chatgpt_login(&mut self) {
         self.error = None;
         let opts = ServerOptions::new(self.codex_home.clone(), CLIENT_ID.to_string());
-        let server = run_login_server(opts, None);
+        let server = run_login_server(opts);
         match server {
             Ok(child) => {
                 let auth_url = child.auth_url.clone();

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -50,7 +50,7 @@ pub(crate) struct ContinueInBrowserState {
 impl Drop for ContinueInBrowserState {
     fn drop(&mut self) {
         if let Some(flag) = &self.shutdown_handle {
-            flag.cancel();
+            flag.shutdown();
         }
     }
 }


### PR DESCRIPTION
In practice, this was always passed in as `None`, so eliminated the param and updated all the call sites.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/2399).
* __->__ #2399
* #2398
* #2396
* #2395
* #2394
* #2393
* #2389