### PR TITLE
Fix #2391 Add Ctrl+H as backspace keyboard shortcut

### DIFF
--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -230,6 +230,11 @@ impl TextArea {
                 code: KeyCode::Backspace,
                 modifiers: KeyModifiers::NONE,
                 ..
+            }
+            | KeyEvent {
+                code: KeyCode::Char('h'),
+                modifiers: KeyModifiers::CONTROL,
+                ..
             } => self.delete_backward(1),
             KeyEvent {
                 code: KeyCode::Delete,


### PR DESCRIPTION
This pull request resolves #2391. ctrl + h is not assigned to any other operations at this moment, and this feature request sounds valid to me. If we don't prefer having this, please feel free to close this.