### PR TITLE
tui: support Ghostty Ctrl-b/Ctrl-f fallback

### DIFF
--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -208,14 +208,10 @@ impl TextArea {
             // C0 control characters without reporting the CONTROL modifier.
             // Handle common fallbacks for Ctrl-B/Ctrl-F here so they don't get
             // inserted as literal control bytes.
-            KeyEvent { code: KeyCode::Char(c), modifiers: KeyModifiers::NONE, .. }
-                if c == '\u{0002}' /* ^B */ =>
-            {
+            KeyEvent { code: KeyCode::Char('\u{0002}'), modifiers: KeyModifiers::NONE, .. } /* ^B */ => {
                 self.move_cursor_left();
             }
-            KeyEvent { code: KeyCode::Char(c), modifiers: KeyModifiers::NONE, .. }
-                if c == '\u{0006}' /* ^F */ =>
-            {
+            KeyEvent { code: KeyCode::Char('\u{0006}'), modifiers: KeyModifiers::NONE, .. } /* ^F */ => {
                 self.move_cursor_right();
             }
             KeyEvent {


### PR DESCRIPTION
Ensure Emacs-style Ctrl-b/Ctrl-f work when terminals send bare control chars.

- Map ^B (U+0002) to move left when no CONTROL modifier is reported.
- Map ^F (U+0006) to move right when no CONTROL modifier is reported.
- Preserve existing Ctrl-b/Ctrl-f and Alt-b/Alt-f behavior.
- Add unit test covering the fallback path.

Background: Ghostty (and some tmux/terminal configs) can emit bare control characters for Ctrl-b/Ctrl-f. Previously these could be treated as literal input; with this change both styles behave identically.