### PR TITLE
[tui] Support /mcp command

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1212,7 +1212,7 @@ async fn submission_loop(
                     ),
                 };
                 if let Err(e) = tx_event.send(event).await {
-                    warn!("failed to send ListMcpToolsResponse event: {e}");
+                    warn!("failed to send McpListToolsResponse event: {e}");
                 }
             }
             Op::Compact => {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1207,8 +1207,8 @@ async fn submission_loop(
                 let tools = sess.mcp_connection_manager.list_all_tools();
                 let event = Event {
                     id: sub_id,
-                    msg: EventMsg::ListMcpToolsResponse(
-                        crate::protocol::ListMcpToolsResponseEvent { tools },
+                    msg: EventMsg::McpListToolsResponse(
+                        crate::protocol::McpListToolsResponseEvent { tools },
                     ),
                 };
                 if let Err(e) = tx_event.send(event).await {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1199,6 +1199,22 @@ async fn submission_loop(
                     }
                 });
             }
+            Op::ListMcpTools => {
+                let tx_event = sess.tx_event.clone();
+                let sub_id = sub.id.clone();
+
+                // This is a cheap lookup from the connection manager's cache.
+                let tools = sess.mcp_connection_manager.list_all_tools();
+                let event = Event {
+                    id: sub_id,
+                    msg: EventMsg::ListMcpToolsResponse(
+                        crate::protocol::ListMcpToolsResponseEvent { tools },
+                    ),
+                };
+                if let Err(e) = tx_event.send(event).await {
+                    warn!("failed to send ListMcpToolsResponse event: {e}");
+                }
+            }
             Op::Compact => {
                 // Create a summarization request as user input
                 const SUMMARIZATION_PROMPT: &str = include_str!("prompt_for_compact_command.md");

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -523,7 +523,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
             EventMsg::GetHistoryEntryResponse(_) => {
                 // Currently ignored in exec output.
             }
-            EventMsg::ListMcpToolsResponse(_) => {
+            EventMsg::McpListToolsResponse(_) => {
                 // Currently ignored in exec output.
             }
             EventMsg::TurnAborted(abort_reason) => match abort_reason.reason {

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -523,6 +523,9 @@ impl EventProcessor for EventProcessorWithHumanOutput {
             EventMsg::GetHistoryEntryResponse(_) => {
                 // Currently ignored in exec output.
             }
+            EventMsg::ListMcpToolsResponse(_) => {
+                // Currently ignored in exec output.
+            }
             EventMsg::TurnAborted(abort_reason) => match abort_reason.reason {
                 TurnAbortReason::Interrupted => {
                     ts_println!(self, "task interrupted");

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -263,6 +263,7 @@ async fn run_codex_tool_session_inner(
                     | EventMsg::AgentReasoningSectionBreak(_)
                     | EventMsg::McpToolCallBegin(_)
                     | EventMsg::McpToolCallEnd(_)
+                    | EventMsg::ListMcpToolsResponse(_)
                     | EventMsg::ExecCommandBegin(_)
                     | EventMsg::ExecCommandOutputDelta(_)
                     | EventMsg::ExecCommandEnd(_)

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -263,7 +263,7 @@ async fn run_codex_tool_session_inner(
                     | EventMsg::AgentReasoningSectionBreak(_)
                     | EventMsg::McpToolCallBegin(_)
                     | EventMsg::McpToolCallEnd(_)
-                    | EventMsg::ListMcpToolsResponse(_)
+                    | EventMsg::McpListToolsResponse(_)
                     | EventMsg::ExecCommandBegin(_)
                     | EventMsg::ExecCommandOutputDelta(_)
                     | EventMsg::ExecCommandEnd(_)

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -11,6 +11,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use mcp_types::CallToolResult;
+use mcp_types::Tool as McpTool;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_bytes::ByteBuf;
@@ -134,6 +135,10 @@ pub enum Op {
 
     /// Request a single history entry identified by `log_id` + `offset`.
     GetHistoryEntryRequest { offset: usize, log_id: u64 },
+
+    /// Request the list of MCP tools available across all configured servers.
+    /// Reply is delivered via `EventMsg::ListMcpToolsResponse`.
+    ListMcpTools,
 
     /// Request the agent to summarize the current conversation context.
     /// The agent will use its existing context (either conversation history or previous response id)
@@ -452,6 +457,9 @@ pub enum EventMsg {
     /// Response to GetHistoryEntryRequest.
     GetHistoryEntryResponse(GetHistoryEntryResponseEvent),
 
+    /// List of MCP tools available to the agent.
+    ListMcpToolsResponse(ListMcpToolsResponseEvent),
+
     PlanUpdate(UpdatePlanArgs),
 
     TurnAborted(TurnAbortedEvent),
@@ -719,6 +727,13 @@ pub struct GetHistoryEntryResponseEvent {
     /// The entry at the requested offset, if available and parseable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub entry: Option<HistoryEntry>,
+}
+
+/// Response payload for `Op::ListMcpTools`.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct ListMcpToolsResponseEvent {
+    /// Fully qualified tool name -> tool definition.
+    pub tools: std::collections::HashMap<String, McpTool>,
 }
 
 #[derive(Debug, Default, Clone, Deserialize, Serialize)]

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -458,7 +458,7 @@ pub enum EventMsg {
     GetHistoryEntryResponse(GetHistoryEntryResponseEvent),
 
     /// List of MCP tools available to the agent.
-    ListMcpToolsResponse(ListMcpToolsResponseEvent),
+    McpListToolsResponse(McpListToolsResponseEvent),
 
     PlanUpdate(UpdatePlanArgs),
 
@@ -731,7 +731,7 @@ pub struct GetHistoryEntryResponseEvent {
 
 /// Response payload for `Op::ListMcpTools`.
 #[derive(Debug, Clone, Deserialize, Serialize)]
-pub struct ListMcpToolsResponseEvent {
+pub struct McpListToolsResponseEvent {
     /// Fully qualified tool name -> tool definition.
     pub tools: std::collections::HashMap<String, McpTool>,
 }

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -137,7 +137,7 @@ pub enum Op {
     GetHistoryEntryRequest { offset: usize, log_id: u64 },
 
     /// Request the list of MCP tools available across all configured servers.
-    /// Reply is delivered via `EventMsg::ListMcpToolsResponse`.
+    /// Reply is delivered via `EventMsg::McpListToolsResponse`.
     ListMcpTools,
 
     /// Request the agent to summarize the current conversation context.

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -416,6 +416,11 @@ impl App<'_> {
                             widget.add_status_output();
                         }
                     }
+                    SlashCommand::Mcp => {
+                        if let AppState::Chat { widget } = &mut self.app_state {
+                            widget.add_mcp_output();
+                        }
+                    }
                     #[cfg(debug_assertions)]
                     SlashCommand::TestApproval => {
                         use codex_core::protocol::EventMsg;

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -685,6 +685,10 @@ impl ChatWidget<'_> {
         ));
     }
 
+    pub(crate) fn add_mcp_output(&mut self) {
+        self.add_to_history(&history_cell::new_mcp_output(&self.config));
+    }
+
     /// Forward file-search results to the bottom pane.
     pub(crate) fn apply_file_search_result(&mut self, query: String, matches: Vec<FileMatch>) {
         self.bottom_pane.on_file_search_result(query, matches);

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -18,7 +18,7 @@ use codex_core::protocol::ExecApprovalRequestEvent;
 use codex_core::protocol::ExecCommandBeginEvent;
 use codex_core::protocol::ExecCommandEndEvent;
 use codex_core::protocol::InputItem;
-use codex_core::protocol::ListMcpToolsResponseEvent;
+use codex_core::protocol::McpListToolsResponseEvent;
 use codex_core::protocol::McpToolCallBeginEvent;
 use codex_core::protocol::McpToolCallEndEvent;
 use codex_core::protocol::Op;
@@ -648,7 +648,7 @@ impl ChatWidget<'_> {
             EventMsg::McpToolCallBegin(ev) => self.on_mcp_tool_call_begin(ev),
             EventMsg::McpToolCallEnd(ev) => self.on_mcp_tool_call_end(ev),
             EventMsg::GetHistoryEntryResponse(ev) => self.on_get_history_entry_response(ev),
-            EventMsg::ListMcpToolsResponse(ev) => self.on_list_mcp_tools(ev),
+            EventMsg::McpListToolsResponse(ev) => self.on_list_mcp_tools(ev),
             EventMsg::ShutdownComplete => self.on_shutdown_complete(),
             EventMsg::TurnDiff(TurnDiffEvent { unified_diff }) => self.on_turn_diff(unified_diff),
             EventMsg::BackgroundEvent(BackgroundEventEvent { message }) => {
@@ -736,7 +736,7 @@ impl ChatWidget<'_> {
         }
     }
 
-    fn on_list_mcp_tools(&mut self, ev: ListMcpToolsResponseEvent) {
+    fn on_list_mcp_tools(&mut self, ev: McpListToolsResponseEvent) {
         self.add_to_history(&history_cell::new_mcp_tools_output(&self.config, ev.tools));
     }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -18,6 +18,7 @@ use codex_core::protocol::ExecApprovalRequestEvent;
 use codex_core::protocol::ExecCommandBeginEvent;
 use codex_core::protocol::ExecCommandEndEvent;
 use codex_core::protocol::InputItem;
+use codex_core::protocol::ListMcpToolsResponseEvent;
 use codex_core::protocol::McpToolCallBeginEvent;
 use codex_core::protocol::McpToolCallEndEvent;
 use codex_core::protocol::Op;
@@ -647,6 +648,7 @@ impl ChatWidget<'_> {
             EventMsg::McpToolCallBegin(ev) => self.on_mcp_tool_call_begin(ev),
             EventMsg::McpToolCallEnd(ev) => self.on_mcp_tool_call_end(ev),
             EventMsg::GetHistoryEntryResponse(ev) => self.on_get_history_entry_response(ev),
+            EventMsg::ListMcpToolsResponse(ev) => self.on_list_mcp_tools(ev),
             EventMsg::ShutdownComplete => self.on_shutdown_complete(),
             EventMsg::TurnDiff(TurnDiffEvent { unified_diff }) => self.on_turn_diff(unified_diff),
             EventMsg::BackgroundEvent(BackgroundEventEvent { message }) => {
@@ -686,7 +688,11 @@ impl ChatWidget<'_> {
     }
 
     pub(crate) fn add_mcp_output(&mut self) {
-        self.add_to_history(&history_cell::new_mcp_output(&self.config));
+        if self.config.mcp_servers.is_empty() {
+            self.add_to_history(&history_cell::empty_mcp_output());
+        } else {
+            self.submit_op(Op::ListMcpTools);
+        }
     }
 
     /// Forward file-search results to the bottom pane.
@@ -728,6 +734,10 @@ impl ChatWidget<'_> {
         if let Err(e) = self.codex_op_tx.send(op) {
             tracing::error!("failed to submit op: {e}");
         }
+    }
+
+    fn on_list_mcp_tools(&mut self, ev: ListMcpToolsResponseEvent) {
+        self.add_to_history(&history_cell::new_mcp_tools_output(&self.config, ev.tools));
     }
 
     /// Programmatically submit a user text message as if typed in the

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -656,7 +656,7 @@ pub(crate) fn new_mcp_tools_output(
     let mut lines: Vec<Line<'static>> = vec![
         Line::from("/mcp".magenta()),
         Line::from(""),
-        Line::from(vec!["🔌 ".into(), "MCP Tools".bold()]),
+        Line::from(vec!["🔌  ".into(), "MCP Tools".bold()]),
         Line::from(""),
     ];
 
@@ -692,6 +692,18 @@ pub(crate) fn new_mcp_tools_output(
             ]));
         }
 
+        if let Some(env) = cfg.env.as_ref() {
+            if !env.is_empty() {
+                let mut env_pairs: Vec<String> =
+                    env.iter().map(|(k, v)| format!("{k}={v}")).collect();
+                env_pairs.sort();
+                lines.push(Line::from(vec![
+                    "    • Env: ".into(),
+                    env_pairs.join(" ").into(),
+                ]));
+            }
+        }
+
         if names.is_empty() {
             lines.push(Line::from("    • Tools: (none)"));
         } else {
@@ -702,43 +714,6 @@ pub(crate) fn new_mcp_tools_output(
         }
         lines.push(Line::from(""));
     }
-
-    // Deterministic ordering for testability
-    //    let mut keys: Vec<String> = config.mcp_servers.keys().cloned().collect();
-    //    keys.sort();
-    //
-    //    for key in keys {
-    //        if let Some(cfg) = config.mcp_servers.get(&key) {
-    //            // Name
-    //            lines.push(Line::from(vec!["  • Name: ".into(), key.clone().into()]));
-    //            // Command + args
-    //            let mut cmd_display = cfg.command.clone();
-    //            if !cfg.args.is_empty() {
-    //                let joined_args = cfg.args.join(" ");
-    //                cmd_display = format!("{cmd_display} {joined_args}");
-    //            }
-    //            lines.push(Line::from(vec![
-    //                "    • Command: ".into(),
-    //                cmd_display.into(),
-    //            ]));
-    //
-    //            // Env (if any) — show as k=v pairs
-    //            if let Some(env) = cfg.env.as_ref() {
-    //                if !env.is_empty() {
-    //                    let mut env_pairs: Vec<String> =
-    //                        env.iter().map(|(k, v)| format!("{k}={v}")).collect();
-    //                    env_pairs.sort();
-    //                    lines.push(Line::from(vec![
-    //                        "    • Env: ".into(),
-    //                        env_pairs.join(" ").into(),
-    //                    ]));
-    //                }
-    //            }
-    //
-    //            lines.push(Line::from(""));
-    //        }
-    //    }
-    //
 
     PlainHistoryCell { lines }
 }

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -634,6 +634,75 @@ pub(crate) fn new_status_output(
     PlainHistoryCell { lines }
 }
 
+pub(crate) fn new_prompts_output() -> PlainHistoryCell {
+    let lines: Vec<Line<'static>> = vec![
+        Line::from("/prompts".magenta()),
+        Line::from(""),
+        Line::from(" 1. Explain this codebase"),
+        Line::from(" 2. Summarize recent commits"),
+        Line::from(" 3. Implement {feature}"),
+        Line::from(" 4. Find and fix a bug in @filename"),
+        Line::from(" 5. Write tests for @filename"),
+        Line::from(" 6. Improve documentation in @filename"),
+        Line::from(""),
+    ];
+    PlainHistoryCell { lines }
+}
+
+/// Render a summary of configured MCP servers from the current `Config`.
+pub(crate) fn new_mcp_output(config: &Config) -> PlainHistoryCell {
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    lines.push(Line::from("/mcp".magenta()));
+    lines.push(Line::from(""));
+
+    // Header
+    lines.push(Line::from(vec!["🔌 ".into(), "MCP Connections".bold()]));
+
+    if config.mcp_servers.is_empty() {
+        lines.push(Line::from("  • No MCP servers configured.".italic()));
+        lines.push(Line::from(""));
+        return PlainHistoryCell { lines };
+    }
+
+    // Deterministic ordering for testability
+    let mut keys: Vec<String> = config.mcp_servers.keys().cloned().collect();
+    keys.sort();
+
+    for key in keys {
+        if let Some(cfg) = config.mcp_servers.get(&key) {
+            // Name
+            lines.push(Line::from(vec!["  • Name: ".into(), key.clone().into()]));
+            // Command + args
+            let mut cmd_display = cfg.command.clone();
+            if !cfg.args.is_empty() {
+                let joined_args = cfg.args.join(" ");
+                cmd_display = format!("{cmd_display} {joined_args}");
+            }
+            lines.push(Line::from(vec![
+                "    • Command: ".into(),
+                cmd_display.into(),
+            ]));
+
+            // Env (if any) — show as k=v pairs
+            if let Some(env) = cfg.env.as_ref() {
+                if !env.is_empty() {
+                    let mut env_pairs: Vec<String> =
+                        env.iter().map(|(k, v)| format!("{k}={v}")).collect();
+                    env_pairs.sort();
+                    lines.push(Line::from(vec![
+                        "    • Env: ".into(),
+                        env_pairs.join(" ").into(),
+                    ]));
+                }
+            }
+
+            lines.push(Line::from(""));
+        }
+    }
+
+    PlainHistoryCell { lines }
+}
+
 pub(crate) fn new_error_event(message: String) -> PlainHistoryCell {
     let lines: Vec<Line<'static>> = vec![vec!["🖐 ".red().bold(), message.into()].into(), "".into()];
     PlainHistoryCell { lines }

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -634,21 +634,6 @@ pub(crate) fn new_status_output(
     PlainHistoryCell { lines }
 }
 
-pub(crate) fn new_prompts_output() -> PlainHistoryCell {
-    let lines: Vec<Line<'static>> = vec![
-        Line::from("/prompts".magenta()),
-        Line::from(""),
-        Line::from(" 1. Explain this codebase"),
-        Line::from(" 2. Summarize recent commits"),
-        Line::from(" 3. Implement {feature}"),
-        Line::from(" 4. Find and fix a bug in @filename"),
-        Line::from(" 5. Write tests for @filename"),
-        Line::from(" 6. Improve documentation in @filename"),
-        Line::from(""),
-    ];
-    PlainHistoryCell { lines }
-}
-
 /// Render a summary of configured MCP servers from the current `Config`.
 pub(crate) fn empty_mcp_output() -> PlainHistoryCell {
     let lines: Vec<Line<'static>> = vec![

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -666,9 +666,6 @@ pub(crate) fn new_mcp_tools_output(
         return PlainHistoryCell { lines };
     }
 
-    let mut servers: Vec<String> = config.mcp_servers.keys().cloned().collect();
-    servers.sort();
-
     for (server, cfg) in config.mcp_servers.iter() {
         let prefix = format!("{server}__");
         let mut names: Vec<String> = tools

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -18,6 +18,7 @@ pub enum SlashCommand {
     Diff,
     Mention,
     Status,
+    Mcp,
     Logout,
     Quit,
     #[cfg(debug_assertions)]
@@ -35,6 +36,7 @@ impl SlashCommand {
             SlashCommand::Diff => "show git diff (including untracked files)",
             SlashCommand::Mention => "mention a file",
             SlashCommand::Status => "show current session configuration and token usage",
+            SlashCommand::Mcp => "list configured MCP tools",
             SlashCommand::Logout => "log out of Codex",
             #[cfg(debug_assertions)]
             SlashCommand::TestApproval => "test approval request",


### PR DESCRIPTION
## Summary
Adds a `/mcp` command to list active tools. We can extend this command to allow configuration of MCP tools, but for now a simple list command will help debug if your config.toml and your tools are working as expected.

## Testing
- [x] Ran locally
<img width="1182" height="508" alt="Screenshot 2025-08-18 at 11 38 04 AM" src="https://github.com/user-attachments/assets/6099e22d-f2e8-4efe-96e5-439471f26eb6" />
