### PR TITLE
feat(tui): show current model in composer footer

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -45,6 +45,7 @@ struct TokenUsageInfo {
     total_token_usage: TokenUsage,
     last_token_usage: TokenUsage,
     model_context_window: Option<u64>,
+    model: String,
 }
 
 pub(crate) struct ChatComposer {
@@ -133,11 +134,13 @@ impl ChatComposer {
         total_token_usage: TokenUsage,
         last_token_usage: TokenUsage,
         model_context_window: Option<u64>,
+        model: String,
     ) {
         self.token_usage_info = Some(TokenUsageInfo {
             total_token_usage,
             last_token_usage,
             model_context_window,
+            model,
         });
     }
 
@@ -665,11 +668,10 @@ impl WidgetRef for &ChatComposer {
                 // Append token/context usage info to the footer hints when available.
                 if let Some(token_usage_info) = &self.token_usage_info {
                     let token_usage = &token_usage_info.total_token_usage;
-                    hint.push(Span::from("   "));
-                    hint.push(
-                        Span::from(format!("{} tokens used", token_usage.blended_total()))
-                            .style(Style::default().add_modifier(Modifier::DIM)),
-                    );
+                    hint.push("   ".into());
+                    hint.push(token_usage_info.model.clone().dim());
+                    hint.push("   ".into());
+                    hint.push(format!("{} tokens used", token_usage.blended_total()).dim());
                     let last_token_usage = &token_usage_info.last_token_usage;
                     if let Some(context_window) = token_usage_info.model_context_window {
                         let percent_remaining: u8 = if context_window > 0 {

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -669,7 +669,7 @@ impl WidgetRef for &ChatComposer {
                 if let Some(token_usage_info) = &self.token_usage_info {
                     let token_usage = &token_usage_info.total_token_usage;
                     hint.push("   ".into());
-                    hint.push(token_usage_info.model.clone().dim());
+                    hint.push(format!("model: {}", token_usage_info.model.clone()).dim());
                     hint.push("   ".into());
                     hint.push(format!("{} tokens used", token_usage.blended_total()).dim());
                     let last_token_usage = &token_usage_info.last_token_usage;

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -240,9 +240,14 @@ impl BottomPane<'_> {
         total_token_usage: TokenUsage,
         last_token_usage: TokenUsage,
         model_context_window: Option<u64>,
+        model: String,
     ) {
-        self.composer
-            .set_token_usage(total_token_usage, last_token_usage, model_context_window);
+        self.composer.set_token_usage(
+            total_token_usage,
+            last_token_usage,
+            model_context_window,
+            model,
+        );
         self.request_redraw();
     }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -196,6 +196,7 @@ impl ChatWidget<'_> {
             self.total_token_usage.clone(),
             self.last_token_usage.clone(),
             self.config.model_context_window,
+            self.config.model.clone(),
         );
     }
 
@@ -746,6 +747,7 @@ impl ChatWidget<'_> {
             self.total_token_usage.clone(),
             self.last_token_usage.clone(),
             self.config.model_context_window,
+            self.config.model.clone(),
         );
     }
 


### PR DESCRIPTION
## Summary
- show the current model beside token usage in the chat composer footer
- plumb the model through token usage updates

## Testing
- `cargo test -p codex-tui` *(fails: snapshot differences)*

------
https://chatgpt.com/codex/tasks/task_i_68a385a08af48322b67e156fb9397c37