### PR TITLE
Release zip archived binaries

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -117,10 +117,11 @@ jobs:
           dest="dist/${{ matrix.target }}"
 
           # For compatibility with environments that lack the `zstd` tool we
-          # additionally create a `.tar.gz` alongside every single binary that
-          # we publish. The end result is:
+          # additionally create a `.tar.gz` and `.zip` alongside every single
+          # binary that we publish. The end result is:
           #   codex-<target>.zst          (existing)
           #   codex-<target>.tar.gz       (new)
+          #   codex-<target>.zip
 
           # 1. Produce a .tar.gz for every file in the directory *before* we
           #    run `zstd --rm`, because that flag deletes the original files.
@@ -128,12 +129,17 @@ jobs:
             base="$(basename "$f")"
             # Skip files that are already archives (shouldn't happen, but be
             # safe).
-            if [[ "$base" == *.tar.gz ]]; then
+            if [[ "$base" == *.tar.gz || "$base" == *.zip ]]; then
               continue
             fi
 
             # Create per-binary tar.gz
             tar -C "$dest" -czf "$dest/${base}.tar.gz" "$base"
+
+            # Create per-binary zip archive
+            # Must run from inside the dest dir so 7z won't
+            # embed the directory path inside the zip.
+            (cd "$dest" && 7z a "${base}.zip" "$base")
 
             # Also create .zst (existing behaviour) *and* remove the original
             # uncompressed binary to keep the directory small.

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -117,11 +117,11 @@ jobs:
           dest="dist/${{ matrix.target }}"
 
           # For compatibility with environments that lack the `zstd` tool we
-          # additionally create a `.tar.gz` and `.zip` alongside every single
-          # binary that we publish. The end result is:
+          # additionally create a `.tar.gz` for all platforms and `.zip` for
+          # Windows alongside every single binary that we publish. The end result is:
           #   codex-<target>.zst          (existing)
           #   codex-<target>.tar.gz       (new)
-          #   codex-<target>.zip
+          #   codex-<target>.zip          (only for Windows)
 
           # 1. Produce a .tar.gz for every file in the directory *before* we
           #    run `zstd --rm`, because that flag deletes the original files.
@@ -136,10 +136,12 @@ jobs:
             # Create per-binary tar.gz
             tar -C "$dest" -czf "$dest/${base}.tar.gz" "$base"
 
-            # Create per-binary zip archive
+            # Create zip archive for Windows binaries
             # Must run from inside the dest dir so 7z won't
             # embed the directory path inside the zip.
-            (cd "$dest" && 7z a "${base}.zip" "$base")
+            if [[ "${{ matrix.runner }}" == windows* ]]; then
+              (cd "$dest" && 7z a "${base}.zip" "$base")
+            fi
 
             # Also create .zst (existing behaviour) *and* remove the original
             # uncompressed binary to keep the directory small.


### PR DESCRIPTION
Adds zip archives to release workflow to improve compatibility (mainly older versions Windows which don't support `tar.gz` or `.zst` out of the box). 

Test release: https://github.com/UnownPlain/codex/releases/tag/rust-v0.0.0
Test run: https://github.com/UnownPlain/codex/actions/runs/16981943609