### PR TITLE
Add custom slash commands

### DIFF
--- a/codex-rs/tui/src/any_command.rs
+++ b/codex-rs/tui/src/any_command.rs
@@ -1,0 +1,66 @@
+use crate::custom_command::CustomCommand;
+use crate::slash_command::SlashCommand;
+
+/// Unified representation of all available commands (built-in and custom)
+#[derive(Debug, Clone)]
+pub enum AnyCommand {
+    BuiltIn(SlashCommand),
+    Custom {
+        name: String,
+        command: CustomCommand,
+    },
+}
+
+impl AnyCommand {
+    /// Get the command name (without the slash)
+    pub fn name(&self) -> String {
+        match self {
+            AnyCommand::BuiltIn(cmd) => cmd.command().to_string(),
+            AnyCommand::Custom { name, .. } => name.clone(),
+        }
+    }
+
+    /// Get the description for this command
+    pub fn description(&self) -> String {
+        match self {
+            AnyCommand::BuiltIn(cmd) => cmd.description().to_string(),
+            AnyCommand::Custom { command, .. } => command.description(),
+        }
+    }
+
+    /// Get the display name with source context
+    pub fn display_name(&self) -> String {
+        match self {
+            AnyCommand::BuiltIn(cmd) => cmd.command().to_string(),
+            AnyCommand::Custom { command, .. } => command.display_name(),
+        }
+    }
+
+    /// Check if this command supports arguments
+    pub fn supports_arguments(&self) -> bool {
+        match self {
+            AnyCommand::BuiltIn(_) => false,
+            AnyCommand::Custom { command, .. } => command.supports_arguments,
+        }
+    }
+}
+
+/// Create a combined list of all available commands
+pub fn all_available_commands(custom_commands: &std::collections::HashMap<String, CustomCommand>) -> Vec<AnyCommand> {
+    let mut commands = Vec::new();
+    
+    // Add built-in commands
+    for (_, built_in) in crate::slash_command::built_in_slash_commands() {
+        commands.push(AnyCommand::BuiltIn(built_in));
+    }
+    
+    // Add custom commands
+    for (name, custom_cmd) in custom_commands {
+        commands.push(AnyCommand::Custom {
+            name: name.clone(),
+            command: custom_cmd.clone(),
+        });
+    }
+    
+    commands
+}

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -369,7 +369,7 @@ impl App<'_> {
                         widget.add_diff_output(text);
                     }
                 }
-                AppEvent::DispatchCommand(command) => match command {
+                AppEvent::DispatchCommand(command, arguments) => match command {
                     SlashCommand::BuiltIn(builtin_cmd) => match builtin_cmd {
                         crate::slash_command::BuiltInSlashCommand::New => {
                             // User accepted – switch to chat view.
@@ -493,9 +493,7 @@ impl App<'_> {
                     SlashCommand::Custom(custom_cmd) => {
                         // Handle custom commands by extracting arguments and submitting the prompt
                         if let AppState::Chat { widget } = &mut self.app_state {
-                            // For now, we don't have access to the original command line with arguments
-                            // In a full implementation, we'd need to pass the raw command text
-                            let prompt = custom_cmd.get_prompt("");
+                            let prompt = custom_cmd.get_prompt(&arguments);
                             widget.submit_text_message(prompt);
                         }
                     }

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -175,11 +175,15 @@ impl App<'_> {
                 initial_images,
                 enhanced_keys_supported,
             );
-            
+
             // Load and apply custom commands
-            let custom_commands: Vec<_> = custom_command_manager.get_commands().into_iter().cloned().collect();
+            let custom_commands: Vec<_> = custom_command_manager
+                .get_commands()
+                .into_iter()
+                .cloned()
+                .collect();
             chat_widget.update_custom_commands(custom_commands);
-            
+
             AppState::Chat {
                 widget: Box::new(chat_widget),
             }
@@ -377,18 +381,26 @@ impl App<'_> {
                                 Vec::new(),
                                 self.enhanced_keys_supported,
                             );
-                            
+
                             // Load and apply custom commands
-                            let custom_commands: Vec<_> = self.custom_command_manager.get_commands().into_iter().cloned().collect();
+                            let custom_commands: Vec<_> = self
+                                .custom_command_manager
+                                .get_commands()
+                                .into_iter()
+                                .cloned()
+                                .collect();
                             new_widget.update_custom_commands(custom_commands);
-                            
-                            self.app_state = AppState::Chat { widget: Box::new(new_widget) };
+
+                            self.app_state = AppState::Chat {
+                                widget: Box::new(new_widget),
+                            };
                             self.app_event_tx.send(AppEvent::RequestRedraw);
                         }
                         crate::slash_command::BuiltInSlashCommand::Init => {
                             // Guard: do not run if a task is active.
                             if let AppState::Chat { widget } = &mut self.app_state {
-                                const INIT_PROMPT: &str = include_str!("../prompt_for_init_command.md");
+                                const INIT_PROMPT: &str =
+                                    include_str!("../prompt_for_init_command.md");
                                 widget.submit_text_message(INIT_PROMPT.to_string());
                             }
                         }
@@ -447,37 +459,37 @@ impl App<'_> {
 
                             self.app_event_tx.send(AppEvent::CodexEvent(Event {
                                 id: "1".to_string(),
-                            // msg: EventMsg::ExecApprovalRequest(ExecApprovalRequestEvent {
-                            //     call_id: "1".to_string(),
-                            //     command: vec!["git".into(), "apply".into()],
-                            //     cwd: self.config.cwd.clone(),
-                            //     reason: Some("test".to_string()),
-                            // }),
-                            msg: EventMsg::ApplyPatchApprovalRequest(
-                                ApplyPatchApprovalRequestEvent {
-                                    call_id: "1".to_string(),
-                                    changes: HashMap::from([
-                                        (
-                                            PathBuf::from("/tmp/test.txt"),
-                                            FileChange::Add {
-                                                content: "test".to_string(),
-                                            },
-                                        ),
-                                        (
-                                            PathBuf::from("/tmp/test2.txt"),
-                                            FileChange::Update {
-                                                unified_diff: "+test\n-test2".to_string(),
-                                                move_path: None,
-                                            },
-                                        ),
-                                    ]),
-                                    reason: None,
-                                    grant_root: Some(PathBuf::from("/tmp")),
-                                },
-                            ),
-                        }));
+                                // msg: EventMsg::ExecApprovalRequest(ExecApprovalRequestEvent {
+                                //     call_id: "1".to_string(),
+                                //     command: vec!["git".into(), "apply".into()],
+                                //     cwd: self.config.cwd.clone(),
+                                //     reason: Some("test".to_string()),
+                                // }),
+                                msg: EventMsg::ApplyPatchApprovalRequest(
+                                    ApplyPatchApprovalRequestEvent {
+                                        call_id: "1".to_string(),
+                                        changes: HashMap::from([
+                                            (
+                                                PathBuf::from("/tmp/test.txt"),
+                                                FileChange::Add {
+                                                    content: "test".to_string(),
+                                                },
+                                            ),
+                                            (
+                                                PathBuf::from("/tmp/test2.txt"),
+                                                FileChange::Update {
+                                                    unified_diff: "+test\n-test2".to_string(),
+                                                    move_path: None,
+                                                },
+                                            ),
+                                        ]),
+                                        reason: None,
+                                        grant_root: Some(PathBuf::from("/tmp")),
+                                    },
+                                ),
+                            }));
                         }
-                    }
+                    },
                     SlashCommand::Custom(custom_cmd) => {
                         // Handle custom commands by extracting arguments and submitting the prompt
                         if let AppState::Chat { widget } = &mut self.app_state {
@@ -487,7 +499,7 @@ impl App<'_> {
                             widget.submit_text_message(prompt);
                         }
                     }
-                }
+                },
                 AppEvent::OnboardingAuthComplete(result) => {
                     if let AppState::Onboarding { screen } = &mut self.app_state {
                         screen.on_auth_complete(result);
@@ -507,11 +519,16 @@ impl App<'_> {
                         initial_images,
                         enhanced_keys_supported,
                     );
-                    
+
                     // Load and apply custom commands
-                    let custom_commands: Vec<_> = self.custom_command_manager.get_commands().into_iter().cloned().collect();
+                    let custom_commands: Vec<_> = self
+                        .custom_command_manager
+                        .get_commands()
+                        .into_iter()
+                        .cloned()
+                        .collect();
                     chat_widget.update_custom_commands(custom_commands);
-                    
+
                     self.app_state = AppState::Chat {
                         widget: Box::new(chat_widget),
                     }

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -36,7 +36,7 @@ pub(crate) enum AppEvent {
 
     /// Dispatch a recognized slash command from the UI (composer) to the app
     /// layer so it can be handled centrally.
-    DispatchCommand(SlashCommand),
+    DispatchCommand(SlashCommand, String),
 
     /// Kick off an asynchronous file search for the given query (text after
     /// the `@`). Previous searches may be cancelled by the app layer so there

--- a/codex-rs/tui/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/command_popup.rs
@@ -6,9 +6,9 @@ use super::popup_consts::MAX_POPUP_ROWS;
 use super::scroll_state::ScrollState;
 use super::selection_popup_common::GenericDisplayRow;
 use super::selection_popup_common::render_rows;
+use crate::custom_commands::CustomSlashCommand;
 use crate::slash_command::SlashCommand;
 use crate::slash_command::built_in_slash_commands;
-use crate::custom_commands::CustomSlashCommand;
 use codex_common::fuzzy_match::fuzzy_match;
 
 pub(crate) struct CommandPopup {
@@ -87,7 +87,10 @@ impl CommandPopup {
                 }
             }
         }
-        out.sort_by(|a, b| a.2.cmp(&b.2).then_with(|| a.0.command().cmp(&b.0.command())));
+        out.sort_by(|a, b| {
+            a.2.cmp(&b.2)
+                .then_with(|| a.0.command().cmp(&b.0.command()))
+        });
         out
     }
 

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -190,7 +190,10 @@ impl BottomPane<'_> {
     }
 
     /// Update available custom commands
-    pub(crate) fn update_custom_commands(&mut self, custom_commands: Vec<crate::custom_commands::CustomSlashCommand>) {
+    pub(crate) fn update_custom_commands(
+        &mut self,
+        custom_commands: Vec<crate::custom_commands::CustomSlashCommand>,
+    ) {
         self.composer.update_custom_commands(custom_commands);
     }
 

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -189,6 +189,11 @@ impl BottomPane<'_> {
         self.ctrl_c_quit_hint
     }
 
+    /// Update available custom commands
+    pub(crate) fn update_custom_commands(&mut self, custom_commands: Vec<crate::custom_commands::CustomSlashCommand>) {
+        self.composer.update_custom_commands(custom_commands);
+    }
+
     pub fn set_task_running(&mut self, running: bool) {
         self.is_task_running = running;
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -548,8 +548,10 @@ impl ChatWidget<'_> {
         }
     }
 
-    /// Update available custom commands
-    pub(crate) fn update_custom_commands(&mut self, custom_commands: Vec<crate::custom_commands::CustomSlashCommand>) {
+    pub(crate) fn update_custom_commands(
+        &mut self,
+        custom_commands: Vec<crate::custom_commands::CustomSlashCommand>,
+    ) {
         self.bottom_pane.update_custom_commands(custom_commands);
     }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -548,6 +548,11 @@ impl ChatWidget<'_> {
         }
     }
 
+    /// Update available custom commands
+    pub(crate) fn update_custom_commands(&mut self, custom_commands: Vec<crate::custom_commands::CustomSlashCommand>) {
+        self.bottom_pane.update_custom_commands(custom_commands);
+    }
+
     pub(crate) fn handle_paste(&mut self, text: String) {
         self.bottom_pane.handle_paste(text);
     }

--- a/codex-rs/tui/src/custom_command.rs
+++ b/codex-rs/tui/src/custom_command.rs
@@ -1,0 +1,301 @@
+use anyhow::Context;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+/// Represents a custom slash command loaded from a markdown file
+#[derive(Debug, Clone)]
+pub struct CustomCommand {
+    /// The command name (derived from filename)
+    pub name: String,
+    /// The full prompt content from the markdown file
+    pub content: String,
+    /// Whether this command supports $ARGUMENTS placeholder
+    pub supports_arguments: bool,
+    /// The source of this command (user/project/subdirectory)
+    pub source: CommandSource,
+    /// Optional subdirectory for organization (e.g., "frontend" from frontend/component.md)
+    pub subdirectory: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum CommandSource {
+    /// Personal command from ~/.codex/commands/
+    User,
+    /// Project-specific command from .codex/commands/
+    Project,
+}
+
+impl CustomCommand {
+    /// Create a new custom command
+    pub fn new(
+        name: String,
+        content: String,
+        source: CommandSource,
+        subdirectory: Option<String>,
+    ) -> Self {
+        let supports_arguments = content.contains("$ARGUMENTS");
+        Self {
+            name,
+            content,
+            supports_arguments,
+            source,
+            subdirectory,
+        }
+    }
+
+    /// Get the display name for the command including subdirectory context
+    pub fn display_name(&self) -> String {
+        match &self.subdirectory {
+            Some(subdir) => format!("{} ({}:{})", self.name, self.source_label(), subdir),
+            None => format!("{} ({})", self.name, self.source_label()),
+        }
+    }
+
+    /// Get the source label for display
+    pub fn source_label(&self) -> &'static str {
+        match self.source {
+            CommandSource::User => "user",
+            CommandSource::Project => "project",
+        }
+    }
+
+    /// Generate the final prompt by replacing $ARGUMENTS placeholder
+    pub fn generate_prompt(&self, arguments: Option<&str>) -> String {
+        if self.supports_arguments {
+            if let Some(args) = arguments {
+                self.content.replace("$ARGUMENTS", args)
+            } else {
+                self.content.replace("$ARGUMENTS", "")
+            }
+        } else {
+            self.content.clone()
+        }
+    }
+
+    /// Get a short description for the command (first line of content, truncated)
+    pub fn description(&self) -> String {
+        let first_line = self.content.lines().next().unwrap_or("").trim();
+
+        if first_line.len() > 80 {
+            format!("{}...", &first_line[..77])
+        } else {
+            first_line.to_string()
+        }
+    }
+}
+
+/// Loads custom commands from the filesystem
+pub struct CustomCommandLoader {
+    /// Cache of loaded commands
+    commands: HashMap<String, CustomCommand>,
+    /// Timestamp of last load for cache invalidation
+    last_loaded: std::time::SystemTime,
+}
+
+impl CustomCommandLoader {
+    pub fn new() -> Self {
+        Self {
+            commands: HashMap::new(),
+            last_loaded: std::time::UNIX_EPOCH,
+        }
+    }
+
+    /// Load or reload all custom commands
+    pub fn load_commands(&mut self, project_root: Option<&Path>) -> Result<()> {
+        self.commands.clear();
+
+        // Load personal commands from ~/.codex/commands/
+        if let Some(home_dir) = dirs::home_dir() {
+            let user_commands_dir = home_dir.join(".codex").join("commands");
+            if user_commands_dir.exists() {
+                self.load_commands_from_directory(&user_commands_dir, CommandSource::User, None)?;
+            }
+        }
+
+        // Load project commands from .codex/commands/
+        if let Some(root) = project_root {
+            let project_commands_dir = root.join(".codex").join("commands");
+            if project_commands_dir.exists() {
+                self.load_commands_from_directory(
+                    &project_commands_dir,
+                    CommandSource::Project,
+                    None,
+                )?;
+            }
+        }
+
+        self.last_loaded = std::time::SystemTime::now();
+        Ok(())
+    }
+
+    /// Load commands from a specific directory
+    fn load_commands_from_directory(
+        &mut self,
+        dir: &Path,
+        source: CommandSource,
+        subdirectory: Option<String>,
+    ) -> Result<()> {
+        let entries = fs::read_dir(dir)
+            .with_context(|| format!("Failed to read directory: {}", dir.display()))?;
+
+        for entry in entries {
+            let entry = entry?;
+            let path = entry.path();
+
+            if path.is_file() && path.extension().and_then(|s| s.to_str()) == Some("md") {
+                // Load markdown file as command
+                if let Some(stem) = path.file_stem().and_then(|s| s.to_str()) {
+                    let content = fs::read_to_string(&path).with_context(|| {
+                        format!("Failed to read command file: {}", path.display())
+                    })?;
+
+                    let command = CustomCommand::new(
+                        stem.to_string(),
+                        content,
+                        source.clone(),
+                        subdirectory.clone(),
+                    );
+
+                    self.commands.insert(stem.to_string(), command);
+                }
+            } else if path.is_dir() {
+                // Recursively load commands from subdirectory
+                let subdir_name = path
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .map(|s| s.to_string());
+
+                self.load_commands_from_directory(&path, source.clone(), subdir_name)?;
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Get all loaded commands
+    pub fn get_commands(&self) -> &HashMap<String, CustomCommand> {
+        &self.commands
+    }
+
+    /// Get a specific command by name
+    pub fn get_command(&self, name: &str) -> Option<&CustomCommand> {
+        self.commands.get(name)
+    }
+
+    /// Check if commands need to be reloaded based on filesystem changes
+    pub fn needs_reload(&self, project_root: Option<&Path>) -> bool {
+        // For simplicity, we'll reload every minute. In a real implementation,
+        // you might want to use filesystem watching or check modification times
+        match self.last_loaded.elapsed() {
+            Ok(duration) => duration.as_secs() > 60,
+            Err(_) => true,
+        }
+    }
+}
+
+impl Default for CustomCommandLoader {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_custom_command_creation() {
+        let command = CustomCommand::new(
+            "test".to_string(),
+            "This is a test command with $ARGUMENTS".to_string(),
+            CommandSource::User,
+            None,
+        );
+
+        assert_eq!(command.name, "test");
+        assert!(command.supports_arguments);
+        assert_eq!(command.source, CommandSource::User);
+        assert_eq!(command.subdirectory, None);
+    }
+
+    #[test]
+    fn test_argument_replacement() {
+        let command = CustomCommand::new(
+            "fix-issue".to_string(),
+            "Fix issue #$ARGUMENTS in the codebase".to_string(),
+            CommandSource::Project,
+            None,
+        );
+
+        let prompt_with_args = command.generate_prompt(Some("123"));
+        assert_eq!(prompt_with_args, "Fix issue #123 in the codebase");
+
+        let prompt_without_args = command.generate_prompt(None);
+        assert_eq!(prompt_without_args, "Fix issue # in the codebase");
+    }
+
+    #[test]
+    fn test_display_name() {
+        let user_command = CustomCommand::new(
+            "review".to_string(),
+            "Review this code".to_string(),
+            CommandSource::User,
+            None,
+        );
+        assert_eq!(user_command.display_name(), "review (user)");
+
+        let project_command = CustomCommand::new(
+            "component".to_string(),
+            "Create a component".to_string(),
+            CommandSource::Project,
+            Some("frontend".to_string()),
+        );
+        assert_eq!(
+            project_command.display_name(),
+            "component (project:frontend)"
+        );
+    }
+
+    #[test]
+    fn test_command_loader() -> Result<()> {
+        let temp_dir = TempDir::new()?;
+        let commands_dir = temp_dir.path().join("commands");
+        fs::create_dir_all(&commands_dir)?;
+
+        // Create a test command file
+        fs::write(
+            commands_dir.join("optimize.md"),
+            "Analyze the performance of this code and suggest three specific optimizations:",
+        )?;
+
+        // Create a subdirectory with another command
+        let frontend_dir = commands_dir.join("frontend");
+        fs::create_dir_all(&frontend_dir)?;
+        fs::write(
+            frontend_dir.join("component.md"),
+            "Create a React component for $ARGUMENTS",
+        )?;
+
+        let mut loader = CustomCommandLoader::new();
+        loader.load_commands_from_directory(&commands_dir, CommandSource::Project, None)?;
+
+        let commands = loader.get_commands();
+        assert_eq!(commands.len(), 2);
+
+        let optimize_cmd = commands.get("optimize").unwrap();
+        assert_eq!(optimize_cmd.name, "optimize");
+        assert!(!optimize_cmd.supports_arguments);
+
+        let component_cmd = commands.get("component").unwrap();
+        assert_eq!(component_cmd.name, "component");
+        assert!(component_cmd.supports_arguments);
+        assert_eq!(component_cmd.subdirectory, Some("frontend".to_string()));
+
+        Ok(())
+    }
+}

--- a/codex-rs/tui/src/custom_commands.rs
+++ b/codex-rs/tui/src/custom_commands.rs
@@ -33,9 +33,9 @@ impl CustomSlashCommand {
         let first_line = self.content.lines().next().unwrap_or("").trim();
 
         if first_line.is_empty() {
-            format!("Custom command {}", source_indicator)
+            format!("Custom command {source_indicator}")
         } else {
-            format!("{} {}", first_line, source_indicator)
+            format!("{first_line} {source_indicator}")
         }
     }
 
@@ -104,7 +104,7 @@ impl CustomCommandManager {
                     .to_string();
 
                 let new_subdirectory = match &subdirectory {
-                    Some(parent) => Some(format!("{}:{}", parent, subdir_name)),
+                    Some(parent) => Some(format!("{parent}:{subdir_name}")),
                     None => Some(subdir_name),
                 };
 

--- a/codex-rs/tui/src/custom_commands.rs
+++ b/codex-rs/tui/src/custom_commands.rs
@@ -1,0 +1,230 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+
+/// A custom slash command loaded from a markdown file
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct CustomSlashCommand {
+    /// The command name (derived from filename)
+    pub name: String,
+    /// The command description/content from the markdown file
+    pub content: String,
+    /// The source type (user or project)
+    pub source: CommandSource,
+    /// The subdirectory path (for organization)
+    pub subdirectory: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum CommandSource {
+    User,
+    Project,
+}
+
+impl CustomSlashCommand {
+    /// Get the display name for the command (includes subdirectory if present)
+    pub fn display_name(&self) -> String {
+        match &self.subdirectory {
+            Some(subdir) => format!("{} ({})", self.name, subdir),
+            None => self.name.clone(),
+        }
+    }
+
+    /// Get the description with source indicator
+    pub fn description(&self) -> String {
+        let source_indicator = match self.source {
+            CommandSource::User => "(user)",
+            CommandSource::Project => "(project)",
+        };
+
+        // Take first line of content as description, fallback to source indicator
+        let first_line = self.content.lines().next().unwrap_or("").trim();
+
+        if first_line.is_empty() {
+            format!("Custom command {}", source_indicator)
+        } else {
+            format!("{} {}", first_line, source_indicator)
+        }
+    }
+
+    /// Get the prompt content with arguments substituted
+    pub fn get_prompt(&self, arguments: &str) -> String {
+        if arguments.is_empty() {
+            self.content.clone()
+        } else {
+            self.content.replace("$ARGUMENTS", arguments)
+        }
+    }
+}
+
+/// Manager for loading and caching custom slash commands
+pub struct CustomCommandManager {
+    commands: HashMap<String, CustomSlashCommand>,
+}
+
+impl CustomCommandManager {
+    pub fn new() -> Self {
+        Self {
+            commands: HashMap::new(),
+        }
+    }
+
+    /// Load all custom commands from both user and project directories
+    pub fn load_commands(
+        &mut self,
+        codex_home: &Path,
+        project_root: &Path,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.commands.clear();
+
+        // Load user commands from ~/.codex/commands
+        let user_commands_dir = codex_home.join("commands");
+        if user_commands_dir.exists() {
+            self.load_commands_from_directory(&user_commands_dir, CommandSource::User, None)?;
+        }
+
+        // Load project commands from .codex/commands
+        let project_commands_dir = project_root.join(".codex").join("commands");
+        if project_commands_dir.exists() {
+            self.load_commands_from_directory(&project_commands_dir, CommandSource::Project, None)?;
+        }
+
+        Ok(())
+    }
+
+    /// Load commands from a specific directory, handling subdirectories recursively
+    fn load_commands_from_directory(
+        &mut self,
+        dir: &Path,
+        source: CommandSource,
+        subdirectory: Option<String>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if path.is_dir() {
+                // Recursively load from subdirectory
+                let subdir_name = path
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .unwrap_or("")
+                    .to_string();
+
+                let new_subdirectory = match &subdirectory {
+                    Some(parent) => Some(format!("{}:{}", parent, subdir_name)),
+                    None => Some(subdir_name),
+                };
+
+                self.load_commands_from_directory(&path, source.clone(), new_subdirectory)?;
+            } else if path.extension().and_then(|ext| ext.to_str()) == Some("md") {
+                // Load markdown file as command
+                if let Some(command) =
+                    self.load_command_from_file(&path, source.clone(), subdirectory.clone())?
+                {
+                    self.commands.insert(command.name.clone(), command);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Load a single command from a markdown file
+    fn load_command_from_file(
+        &self,
+        path: &Path,
+        source: CommandSource,
+        subdirectory: Option<String>,
+    ) -> Result<Option<CustomSlashCommand>, Box<dyn std::error::Error>> {
+        let content = fs::read_to_string(path)?;
+
+        let name = path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .ok_or("Invalid filename")?
+            .to_string();
+
+        // Skip files that would conflict with built-in commands
+        if is_builtin_command(&name) {
+            return Ok(None);
+        }
+
+        Ok(Some(CustomSlashCommand {
+            name,
+            content: content.trim().to_string(),
+            source,
+            subdirectory,
+        }))
+    }
+
+    /// Get all loaded commands
+    pub fn get_commands(&self) -> Vec<&CustomSlashCommand> {
+        self.commands.values().collect()
+    }
+
+    /// Get a specific command by name
+    pub fn get_command(&self, name: &str) -> Option<&CustomSlashCommand> {
+        self.commands.get(name)
+    }
+
+    /// Check if a command exists
+    pub fn has_command(&self, name: &str) -> bool {
+        self.commands.contains_key(name)
+    }
+}
+
+/// Check if a command name conflicts with built-in commands
+fn is_builtin_command(name: &str) -> bool {
+    matches!(
+        name,
+        "new"
+            | "init"
+            | "compact"
+            | "diff"
+            | "mention"
+            | "status"
+            | "logout"
+            | "quit"
+            | "test-approval"
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_custom_command_creation() {
+        let cmd = CustomSlashCommand {
+            name: "test".to_string(),
+            content: "This is a test command with $ARGUMENTS".to_string(),
+            source: CommandSource::User,
+            subdirectory: None,
+        };
+
+        assert_eq!(cmd.display_name(), "test");
+        assert_eq!(cmd.get_prompt("hello"), "This is a test command with hello");
+        assert_eq!(cmd.get_prompt(""), "This is a test command with $ARGUMENTS");
+    }
+
+    #[test]
+    fn test_command_with_subdirectory() {
+        let cmd = CustomSlashCommand {
+            name: "component".to_string(),
+            content: "Create a component".to_string(),
+            source: CommandSource::Project,
+            subdirectory: Some("frontend".to_string()),
+        };
+
+        assert_eq!(cmd.display_name(), "component (frontend)");
+        assert!(cmd.description().contains("(project)"));
+    }
+
+    #[test]
+    fn test_builtin_command_detection() {
+        assert!(is_builtin_command("new"));
+        assert!(is_builtin_command("init"));
+        assert!(!is_builtin_command("custom-command"));
+    }
+}

--- a/codex-rs/tui/src/custom_commands.rs
+++ b/codex-rs/tui/src/custom_commands.rs
@@ -22,14 +22,6 @@ pub enum CommandSource {
 }
 
 impl CustomSlashCommand {
-    /// Get the display name for the command (includes subdirectory if present)
-    pub fn display_name(&self) -> String {
-        match &self.subdirectory {
-            Some(subdir) => format!("{} ({})", self.name, subdir),
-            None => self.name.clone(),
-        }
-    }
-
     /// Get the description with source indicator
     pub fn description(&self) -> String {
         let source_indicator = match self.source {
@@ -162,31 +154,13 @@ impl CustomCommandManager {
     pub fn get_commands(&self) -> Vec<&CustomSlashCommand> {
         self.commands.values().collect()
     }
-
-    /// Get a specific command by name
-    pub fn get_command(&self, name: &str) -> Option<&CustomSlashCommand> {
-        self.commands.get(name)
-    }
-
-    /// Check if a command exists
-    pub fn has_command(&self, name: &str) -> bool {
-        self.commands.contains_key(name)
-    }
 }
 
 /// Check if a command name conflicts with built-in commands
 fn is_builtin_command(name: &str) -> bool {
     matches!(
         name,
-        "new"
-            | "init"
-            | "compact"
-            | "diff"
-            | "mention"
-            | "status"
-            | "logout"
-            | "quit"
-            | "test-approval"
+        "new" | "init" | "compact" | "diff" | "mention" | "status" | "logout" | "quit" | "prompts"
     )
 }
 
@@ -203,7 +177,7 @@ mod tests {
             subdirectory: None,
         };
 
-        assert_eq!(cmd.display_name(), "test");
+        assert_eq!(cmd.name, "test");
         assert_eq!(cmd.get_prompt("hello"), "This is a test command with hello");
         assert_eq!(cmd.get_prompt(""), "This is a test command with $ARGUMENTS");
     }
@@ -217,7 +191,7 @@ mod tests {
             subdirectory: Some("frontend".to_string()),
         };
 
-        assert_eq!(cmd.display_name(), "component (frontend)");
+        assert_eq!(cmd.name, "component");
         assert!(cmd.description().contains("(project)"));
     }
 

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -166,9 +166,27 @@ pub(crate) fn new_session_info(
             Line::from("".dim()),
             Line::from(" To get started, describe a task or try one of these commands:".dim()),
             Line::from("".dim()),
-            Line::from(format!(" /init - {}", crate::slash_command::BuiltInSlashCommand::Init.description()).dim()),
-            Line::from(format!(" /status - {}", crate::slash_command::BuiltInSlashCommand::Status.description()).dim()),
-            Line::from(format!(" /diff - {}", crate::slash_command::BuiltInSlashCommand::Diff.description()).dim()),
+            Line::from(
+                format!(
+                    " /init - {}",
+                    crate::slash_command::BuiltInSlashCommand::Init.description()
+                )
+                .dim(),
+            ),
+            Line::from(
+                format!(
+                    " /status - {}",
+                    crate::slash_command::BuiltInSlashCommand::Status.description()
+                )
+                .dim(),
+            ),
+            Line::from(
+                format!(
+                    " /diff - {}",
+                    crate::slash_command::BuiltInSlashCommand::Diff.description()
+                )
+                .dim(),
+            ),
             Line::from("".dim()),
         ];
         PlainHistoryCell { lines }

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -2,7 +2,6 @@ use crate::colors::LIGHT_BLUE;
 use crate::diff_render::create_diff_summary;
 use crate::exec_command::relativize_to_home;
 use crate::exec_command::strip_bash_lc_and_escape;
-use crate::slash_command::SlashCommand;
 use crate::text_formatting::format_and_truncate_tool_result;
 use base64::Engine;
 use codex_ansi_escape::ansi_escape_line;
@@ -167,9 +166,9 @@ pub(crate) fn new_session_info(
             Line::from("".dim()),
             Line::from(" To get started, describe a task or try one of these commands:".dim()),
             Line::from("".dim()),
-            Line::from(format!(" /init - {}", SlashCommand::Init.description()).dim()),
-            Line::from(format!(" /status - {}", SlashCommand::Status.description()).dim()),
-            Line::from(format!(" /diff - {}", SlashCommand::Diff.description()).dim()),
+            Line::from(format!(" /init - {}", crate::slash_command::BuiltInSlashCommand::Init.description()).dim()),
+            Line::from(format!(" /status - {}", crate::slash_command::BuiltInSlashCommand::Status.description()).dim()),
+            Line::from(format!(" /diff - {}", crate::slash_command::BuiltInSlashCommand::Diff.description()).dim()),
             Line::from("".dim()),
         ];
         PlainHistoryCell { lines }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -30,6 +30,7 @@ mod citation_regex;
 mod cli;
 mod colors;
 mod common;
+mod custom_commands;
 pub mod custom_terminal;
 mod diff_render;
 mod exec_command;

--- a/codex-rs/tui/src/session_log.rs
+++ b/codex-rs/tui/src/session_log.rs
@@ -150,12 +150,13 @@ pub(crate) fn log_inbound_app_event(event: &AppEvent) {
             });
             LOGGER.write_json_line(value);
         }
-        AppEvent::DispatchCommand(cmd) => {
+        AppEvent::DispatchCommand(cmd, args) => {
             let value = json!({
                 "ts": now_ts(),
                 "dir": "to_tui",
                 "kind": "slash_command",
                 "command": format!("{:?}", cmd),
+                "arguments": args,
             });
             LOGGER.write_json_line(value);
         }

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -4,12 +4,23 @@ use strum_macros::EnumIter;
 use strum_macros::EnumString;
 use strum_macros::IntoStaticStr;
 
+use crate::custom_commands::CustomSlashCommand;
+
 /// Commands that can be invoked by starting a message with a leading slash.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SlashCommand {
+    // Built-in commands
+    BuiltIn(BuiltInSlashCommand),
+    // Custom commands loaded from files
+    Custom(CustomSlashCommand),
+}
+
+/// Built-in slash commands that are always available
 #[derive(
     Debug, Clone, Copy, PartialEq, Eq, Hash, EnumString, EnumIter, AsRefStr, IntoStaticStr,
 )]
 #[strum(serialize_all = "kebab-case")]
-pub enum SlashCommand {
+pub enum BuiltInSlashCommand {
     // DO NOT ALPHA-SORT! Enum order is presentation order in the popup, so
     // more frequently used commands should be listed first.
     New,
@@ -24,20 +35,22 @@ pub enum SlashCommand {
     TestApproval,
 }
 
-impl SlashCommand {
+impl BuiltInSlashCommand {
     /// User-visible description shown in the popup.
     pub fn description(self) -> &'static str {
         match self {
-            SlashCommand::New => "start a new chat during a conversation",
-            SlashCommand::Init => "create an AGENTS.md file with instructions for Codex",
-            SlashCommand::Compact => "summarize conversation to prevent hitting the context limit",
-            SlashCommand::Quit => "exit Codex",
-            SlashCommand::Diff => "show git diff (including untracked files)",
-            SlashCommand::Mention => "mention a file",
-            SlashCommand::Status => "show current session configuration and token usage",
-            SlashCommand::Logout => "log out of Codex",
+            BuiltInSlashCommand::New => "start a new chat during a conversation",
+            BuiltInSlashCommand::Init => "create an AGENTS.md file with instructions for Codex",
+            BuiltInSlashCommand::Compact => {
+                "summarize conversation to prevent hitting the context limit"
+            }
+            BuiltInSlashCommand::Quit => "exit Codex",
+            BuiltInSlashCommand::Diff => "show git diff (including untracked files)",
+            BuiltInSlashCommand::Mention => "mention a file",
+            BuiltInSlashCommand::Status => "show current session configuration and token usage",
+            BuiltInSlashCommand::Logout => "log out of Codex",
             #[cfg(debug_assertions)]
-            SlashCommand::TestApproval => "test approval request",
+            BuiltInSlashCommand::TestApproval => "test approval request",
         }
     }
 
@@ -48,7 +61,65 @@ impl SlashCommand {
     }
 }
 
+impl SlashCommand {
+    /// User-visible description shown in the popup.
+    pub fn description(&self) -> String {
+        match self {
+            SlashCommand::BuiltIn(builtin) => builtin.description().to_string(),
+            SlashCommand::Custom(custom) => custom.description(),
+        }
+    }
+
+    /// Command string without the leading '/'.
+    pub fn command(&self) -> String {
+        match self {
+            SlashCommand::BuiltIn(builtin) => builtin.command().to_string(),
+            SlashCommand::Custom(custom) => custom.name.clone(),
+        }
+    }
+
+    /// Get the prompt content for custom commands, or None for built-in commands
+    pub fn get_custom_prompt(&self, arguments: &str) -> Option<String> {
+        match self {
+            SlashCommand::BuiltIn(_) => None,
+            SlashCommand::Custom(custom) => Some(custom.get_prompt(arguments)),
+        }
+    }
+
+    pub fn is_builtin(&self) -> bool {
+        matches!(self, SlashCommand::BuiltIn(_))
+    }
+
+    pub fn is_custom(&self) -> bool {
+        matches!(self, SlashCommand::Custom(_))
+    }
+}
+
 /// Return all built-in commands in a Vec paired with their command string.
 pub fn built_in_slash_commands() -> Vec<(&'static str, SlashCommand)> {
-    SlashCommand::iter().map(|c| (c.command(), c)).collect()
+    BuiltInSlashCommand::iter()
+        .map(|c| (c.command(), SlashCommand::BuiltIn(c)))
+        .collect()
+}
+
+/// Create all available slash commands (built-in + custom)
+pub fn all_slash_commands(custom_commands: Vec<CustomSlashCommand>) -> Vec<(String, SlashCommand)> {
+    let mut all_commands: Vec<(String, SlashCommand)> = BuiltInSlashCommand::iter()
+        .map(|c| (c.command().to_string(), SlashCommand::BuiltIn(c)))
+        .collect();
+
+    // Add custom commands
+    for custom_cmd in custom_commands {
+        let name = custom_cmd.name.clone();
+        all_commands.push((name, SlashCommand::Custom(custom_cmd)));
+    }
+
+    // Sort built-in commands first, then custom commands, both alphabetically
+    all_commands.sort_by(|a, b| match (&a.1, &b.1) {
+        (SlashCommand::BuiltIn(_), SlashCommand::Custom(_)) => std::cmp::Ordering::Less,
+        (SlashCommand::Custom(_), SlashCommand::BuiltIn(_)) => std::cmp::Ordering::Greater,
+        _ => a.0.cmp(&b.0),
+    });
+
+    all_commands
 }

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -77,22 +77,6 @@ impl SlashCommand {
             SlashCommand::Custom(custom) => custom.name.clone(),
         }
     }
-
-    /// Get the prompt content for custom commands, or None for built-in commands
-    pub fn get_custom_prompt(&self, arguments: &str) -> Option<String> {
-        match self {
-            SlashCommand::BuiltIn(_) => None,
-            SlashCommand::Custom(custom) => Some(custom.get_prompt(arguments)),
-        }
-    }
-
-    pub fn is_builtin(&self) -> bool {
-        matches!(self, SlashCommand::BuiltIn(_))
-    }
-
-    pub fn is_custom(&self) -> bool {
-        matches!(self, SlashCommand::Custom(_))
-    }
 }
 
 /// Return all built-in commands in a Vec paired with their command string.


### PR DESCRIPTION
This PR adds support for custom slash commands. Users can create reusable commands by placing markdown files in ~/.codex/commands/ (user commands) or .codex/commands/ (project commands). 

Commands also support $ARGUMENTS placeholder substitution and appear in the existing slash command popup alongside built-in commands.

Mentioned in issues #913 and #2014.

Example usage with custom **accelerate** command:

<img width="1250" height="642" alt="ss 2025-08-19 at 22 20 03" src="https://github.com/user-attachments/assets/65892bfd-c8e3-4bd4-9117-2e0f9704d123" />


having 'chatwidget.rs' as its argument:

<img width="1012" height="674" alt="ss 2025-08-19 at 22 20 56" src="https://github.com/user-attachments/assets/4a789dbc-dc66-42d9-9f7f-f83e416bda3c" />

my **~/.codex** folder:

<img width="1137" height="387" alt="ss 2025-08-19 at 22 24 03" src="https://github.com/user-attachments/assets/8291ad07-7a33-4b10-91df-257f36e6e14e" />
