### PR TITLE
fix: fix missing spacing in review decision response

### DIFF
--- a/codex-rs/tui/src/user_approval_widget.rs
+++ b/codex-rs/tui/src/user_approval_widget.rs
@@ -285,7 +285,7 @@ impl UserApprovalWidget<'_> {
                                 "✔ ".fg(Color::Green),
                                 "You ".into(),
                                 "approved".bold(),
-                                "codex to run ".into(),
+                                " codex to run ".into(),
                             ],
                             cmd,
                             vec![" every time this session".bold()],


### PR DESCRIPTION
This PR fixes a display issue inside the user approval widget:

<img width="396" height="62" alt="Screenshot 2025-08-19 at 16 42 13" src="https://github.com/user-attachments/assets/a67da78b-7e9c-4f65-8b56-06644713ce8f" />

The other review decision responses are already properly formatted. Thanks!