### PR TITLE
Enable Dependabot updates for Rust toolchain

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -24,3 +24,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+  - package-ecosystem: rust-toolchain
+    directory: codex-rs
+    schedule:
+      interval: weekly


### PR DESCRIPTION
This change allows Dependabot to update the Rust toolchain version defined in `rust-toolchain.toml`. See [Dependabot now supports Rust toolchain updates - GitHub Changelog](https://github.blog/changelog/2025-08-19-dependabot-now-supports-rust-toolchain-updates/) for more details.