### PR TITLE
feat: move session ID bullet in /status

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -537,13 +537,6 @@ pub(crate) fn new_status_output(
         sandbox_name.into(),
     ]));
 
-    if let Some(session_id) = session_id {
-        lines.push(Line::from(vec![
-            "  • Session ID: ".into(),
-            session_id.to_string().into(),
-        ]));
-    }
-
     lines.push(Line::from(""));
 
     // 👤 Account (only if ChatGPT tokens exist), shown under the first block
@@ -608,6 +601,12 @@ pub(crate) fn new_status_output(
 
     // 📊 Token Usage
     lines.push(Line::from(vec!["📊 ".into(), "Token Usage".bold()]));
+    if let Some(session_id) = session_id {
+        lines.push(Line::from(vec![
+            "  • Session ID: ".into(),
+            session_id.to_string().into(),
+        ]));
+    }
     // Input: <input> [+ <cached> cached]
     let mut input_line_spans: Vec<Span<'static>> = vec![
         "  • Input: ".into(),


### PR DESCRIPTION
## Summary
- just want to declutter the top level workspace section

## Testing
- `just fmt`
- `just fix` *(fails: error[E0658] let expressions in this position are unstable in codex-protocol)*
- `cargo test -p codex-tui` *(fails: error[E0658] let expressions in this position are unstable)*

------
https://chatgpt.com/codex/tasks/task_i_68a4a7311dbc832caf14f52e0fbaf9c2