### PR TITLE
feature: Add "!cmd" user shell execution

### DIFF
--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -29,8 +29,6 @@ pub enum Shell {
 }
 
 impl Shell {
-    // No formatting helpers — callers should provide the full argv they want to execute.
-
     pub fn name(&self) -> Option<String> {
         match self {
             Shell::Zsh(zsh) => std::path::Path::new(&zsh.shell_path)
@@ -234,12 +232,6 @@ mod tests {
                 );
             }
         }
-    }
-
-    #[test]
-    fn removed_format_helpers_do_not_exist() {
-        // Intentionally left empty; formatting helpers were removed.
-        assert!(true);
     }
 }
 

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -29,95 +29,7 @@ pub enum Shell {
 }
 
 impl Shell {
-    pub fn format_user_shell_script(&self, script: &str) -> Option<Vec<String>> {
-        match self {
-            Shell::Zsh(zsh) => Some(format_shell_script_with_rc(
-                &zsh.shell_path,
-                &zsh.zshrc_path,
-                script,
-            )),
-            Shell::Bash(bash) => Some(format_shell_script_with_rc(
-                &bash.shell_path,
-                &bash.bashrc_path,
-                script,
-            )),
-            Shell::PowerShell(ps) => Some(vec![
-                ps.exe.clone(),
-                "-NoProfile".to_string(),
-                "-Command".to_string(),
-                script.to_string(),
-            ]),
-            Shell::Unknown => {
-                // In CI we sometimes cannot determine the user's default shell (e.g. musl builds
-                // running under minimal passwd entries). Returning `None` here would make callers
-                // treat the entire script as a single argv[0], which prevents simple commands like
-                // `python3 -c "..."` from spawning. Instead, fall back to a POSIX-style split so we
-                // still run straightforward commands even without shell discovery.
-                shlex::split(script)
-            }
-        }
-    }
-
-    pub fn format_default_shell_invocation(&self, command: Vec<String>) -> Option<Vec<String>> {
-        match self {
-            Shell::Zsh(zsh) => format_shell_invocation_with_rc(
-                command.as_slice(),
-                &zsh.shell_path,
-                &zsh.zshrc_path,
-            ),
-            Shell::Bash(bash) => format_shell_invocation_with_rc(
-                command.as_slice(),
-                &bash.shell_path,
-                &bash.bashrc_path,
-            ),
-            Shell::PowerShell(ps) => {
-                // If model generated a bash command, prefer a detected bash fallback
-                if let Some(script) = strip_bash_lc(command.as_slice()) {
-                    return match &ps.bash_exe_fallback {
-                        Some(bash) => Some(vec![
-                            bash.to_string_lossy().to_string(),
-                            "-lc".to_string(),
-                            script,
-                        ]),
-
-                        // No bash fallback → run the script under PowerShell.
-                        // It will likely fail (except for some simple commands), but the error
-                        // should give a clue to the model to fix upon retry that it's running under PowerShell.
-                        None => Some(vec![
-                            ps.exe.clone(),
-                            "-NoProfile".to_string(),
-                            "-Command".to_string(),
-                            script,
-                        ]),
-                    };
-                }
-
-                // Not a bash command. If model did not generate a PowerShell command,
-                // turn it into a PowerShell command.
-                let first = command.first().map(String::as_str);
-                if first != Some(ps.exe.as_str()) {
-                    // TODO (CODEX_2900): Handle escaping newlines.
-                    if command.iter().any(|a| a.contains('\n') || a.contains('\r')) {
-                        return Some(command);
-                    }
-
-                    let joined = shlex::try_join(command.iter().map(String::as_str)).ok();
-                    return joined.map(|arg| {
-                        vec![
-                            ps.exe.clone(),
-                            "-NoProfile".to_string(),
-                            "-Command".to_string(),
-                            arg,
-                        ]
-                    });
-                }
-
-                // Model generated a PowerShell command. Run it.
-                Some(command)
-            }
-            Shell::Unknown => None,
-        }
-    }
+    // No formatting helpers — callers should provide the full argv they want to execute.
 
     pub fn name(&self) -> Option<String> {
         match self {
@@ -131,40 +43,6 @@ impl Shell {
             Shell::Unknown => None,
         }
     }
-}
-
-fn format_shell_invocation_with_rc(
-    command: &[String],
-    shell_path: &str,
-    rc_path: &str,
-) -> Option<Vec<String>> {
-    let joined = strip_bash_lc(command)
-        .or_else(|| shlex::try_join(command.iter().map(String::as_str)).ok())?;
-
-    Some(format_shell_script_with_rc(shell_path, rc_path, &joined))
-}
-
-fn strip_bash_lc(command: &[String]) -> Option<String> {
-    match command {
-        // exactly three items
-        [first, second, third]
-            // first two must be "bash", "-lc"
-            if first == "bash" && second == "-lc" =>
-        {
-            Some(third.clone())
-        }
-        _ => None,
-    }
-}
-
-fn format_shell_script_with_rc(shell_path: &str, rc_path: &str, script: &str) -> Vec<String> {
-    let rc_command = if std::path::Path::new(rc_path).exists() {
-        format!("source {rc_path} && ({script})")
-    } else {
-        script.to_string()
-    };
-
-    vec![shell_path.to_string(), "-lc".to_string(), rc_command]
 }
 
 #[cfg(unix)]
@@ -359,17 +237,9 @@ mod tests {
     }
 
     #[test]
-    fn format_user_shell_script_unknown_splits_command() {
-        let script = "python3 -c \"print('hi')\"";
-        let invocation = Shell::Unknown.format_user_shell_script(script);
-        assert_eq!(
-            invocation,
-            Some(vec![
-                "python3".to_string(),
-                "-c".to_string(),
-                "print('hi')".to_string(),
-            ])
-        );
+    fn removed_format_helpers_do_not_exist() {
+        // Intentionally left empty; formatting helpers were removed.
+        assert!(true);
     }
 }
 

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -3,6 +3,7 @@ mod ghost_snapshot;
 mod regular;
 mod review;
 mod undo;
+mod user_shell;
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -31,6 +32,7 @@ pub(crate) use ghost_snapshot::GhostSnapshotTask;
 pub(crate) use regular::RegularTask;
 pub(crate) use review::ReviewTask;
 pub(crate) use undo::UndoTask;
+pub(crate) use user_shell::UserShellCommandTask;
 
 const GRACEFULL_INTERRUPTION_TIMEOUT_MS: u64 = 100;
 

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -1,0 +1,108 @@
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use codex_protocol::models::ShellToolCallParams;
+use codex_protocol::user_input::UserInput;
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+use tracing::error;
+use uuid::Uuid;
+
+use crate::codex::Session;
+use crate::codex::TurnContext;
+use crate::protocol::EventMsg;
+use crate::protocol::TaskStartedEvent;
+use crate::state::TaskKind;
+use crate::tools::context::ToolPayload;
+use crate::tools::parallel::ToolCallRuntime;
+use crate::tools::router::ToolCall;
+use crate::tools::router::ToolRouter;
+use crate::turn_diff_tracker::TurnDiffTracker;
+
+use super::SessionTask;
+use super::SessionTaskContext;
+
+const USER_SHELL_TOOL_NAME: &str = "local_shell";
+
+#[derive(Clone)]
+pub(crate) struct UserShellCommandTask {
+    command: String,
+}
+
+impl UserShellCommandTask {
+    pub(crate) fn new(command: String) -> Self {
+        Self { command }
+    }
+}
+
+#[async_trait]
+impl SessionTask for UserShellCommandTask {
+    fn kind(&self) -> TaskKind {
+        TaskKind::Regular
+    }
+
+    async fn run(
+        self: Arc<Self>,
+        session: Arc<SessionTaskContext>,
+        turn_context: Arc<TurnContext>,
+        _input: Vec<UserInput>,
+        cancellation_token: CancellationToken,
+    ) -> Option<String> {
+        let session = session.clone_session();
+        run_user_shell_command(
+            session,
+            turn_context,
+            self.command.clone(),
+            cancellation_token,
+        )
+        .await;
+        None
+    }
+}
+
+async fn run_user_shell_command(
+    session: Arc<Session>,
+    turn_context: Arc<TurnContext>,
+    command: String,
+    cancellation_token: CancellationToken,
+) {
+    let event = EventMsg::TaskStarted(TaskStartedEvent {
+        model_context_window: turn_context.client.get_model_context_window(),
+    });
+    session.send_event(turn_context.as_ref(), event).await;
+
+    let shell_invocation = session
+        .user_shell()
+        .format_user_shell_script(&command)
+        .unwrap_or_else(|| vec![command.clone()]);
+
+    let params = ShellToolCallParams {
+        command: shell_invocation,
+        workdir: None,
+        timeout_ms: None,
+        with_escalated_permissions: None,
+        justification: None,
+    };
+
+    let tool_call = ToolCall {
+        tool_name: USER_SHELL_TOOL_NAME.to_string(),
+        call_id: Uuid::new_v4().to_string(),
+        payload: ToolPayload::LocalShell { params },
+    };
+
+    let router = Arc::new(ToolRouter::from_config(&turn_context.tools_config, None));
+    let tracker = Arc::new(Mutex::new(TurnDiffTracker::new()));
+    let runtime = ToolCallRuntime::new(
+        Arc::clone(&router),
+        Arc::clone(&session),
+        Arc::clone(&turn_context),
+        Arc::clone(&tracker),
+    );
+
+    if let Err(err) = runtime
+        .handle_tool_call(tool_call, cancellation_token)
+        .await
+    {
+        error!("user shell command failed: {err:?}");
+    }
+}

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -73,8 +73,9 @@ impl SessionTask for UserShellCommandTask {
                 "-Command".to_string(),
                 self.command.clone(),
             ],
-            crate::shell::Shell::Unknown => shlex::split(&self.command)
-                .unwrap_or_else(|| vec![self.command.clone()]),
+            crate::shell::Shell::Unknown => {
+                shlex::split(&self.command).unwrap_or_else(|| vec![self.command.clone()])
+            }
         };
 
         let params = ShellToolCallParams {

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -53,11 +53,29 @@ impl SessionTask for UserShellCommandTask {
         let session = session.clone_session();
         session.send_event(turn_context.as_ref(), event).await;
 
-        // Do not try to re-format the user's command for their shell; simply
-        // split it into argv using POSIX shell semantics. If splitting fails,
-        // fall back to treating the full string as argv[0].
-        let shell_invocation = shlex::split(&self.command)
-            .unwrap_or_else(|| vec![self.command.clone()]);
+        // Execute the user's script under their default shell when known; this
+        // allows commands that use shell features (pipes, &&, redirects, etc.).
+        // We do not source rc files or otherwise reformat the script.
+        let shell_invocation = match session.user_shell() {
+            crate::shell::Shell::Zsh(zsh) => vec![
+                zsh.shell_path.clone(),
+                "-lc".to_string(),
+                self.command.clone(),
+            ],
+            crate::shell::Shell::Bash(bash) => vec![
+                bash.shell_path.clone(),
+                "-lc".to_string(),
+                self.command.clone(),
+            ],
+            crate::shell::Shell::PowerShell(ps) => vec![
+                ps.exe.clone(),
+                "-NoProfile".to_string(),
+                "-Command".to_string(),
+                self.command.clone(),
+            ],
+            crate::shell::Shell::Unknown => shlex::split(&self.command)
+                .unwrap_or_else(|| vec![self.command.clone()]),
+        };
 
         let params = ShellToolCallParams {
             command: shell_invocation,

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -8,7 +8,6 @@ use tokio_util::sync::CancellationToken;
 use tracing::error;
 use uuid::Uuid;
 
-use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::protocol::EventMsg;
 use crate::protocol::TaskStartedEvent;
@@ -48,61 +47,46 @@ impl SessionTask for UserShellCommandTask {
         _input: Vec<UserInput>,
         cancellation_token: CancellationToken,
     ) -> Option<String> {
+        let event = EventMsg::TaskStarted(TaskStartedEvent {
+            model_context_window: turn_context.client.get_model_context_window(),
+        });
         let session = session.clone_session();
-        run_user_shell_command(
-            session,
-            turn_context,
-            self.command.clone(),
-            cancellation_token,
-        )
-        .await;
+        session.send_event(turn_context.as_ref(), event).await;
+
+        let shell_invocation = session
+            .user_shell()
+            .format_user_shell_script(&self.command)
+            .unwrap_or_else(|| vec![self.command.clone()]);
+
+        let params = ShellToolCallParams {
+            command: shell_invocation,
+            workdir: None,
+            timeout_ms: None,
+            with_escalated_permissions: None,
+            justification: None,
+        };
+
+        let tool_call = ToolCall {
+            tool_name: USER_SHELL_TOOL_NAME.to_string(),
+            call_id: Uuid::new_v4().to_string(),
+            payload: ToolPayload::LocalShell { params },
+        };
+
+        let router = Arc::new(ToolRouter::from_config(&turn_context.tools_config, None));
+        let tracker = Arc::new(Mutex::new(TurnDiffTracker::new()));
+        let runtime = ToolCallRuntime::new(
+            Arc::clone(&router),
+            Arc::clone(&session),
+            Arc::clone(&turn_context),
+            Arc::clone(&tracker),
+        );
+
+        if let Err(err) = runtime
+            .handle_tool_call(tool_call, cancellation_token)
+            .await
+        {
+            error!("user shell command failed: {err:?}");
+        }
         None
-    }
-}
-
-async fn run_user_shell_command(
-    session: Arc<Session>,
-    turn_context: Arc<TurnContext>,
-    command: String,
-    cancellation_token: CancellationToken,
-) {
-    let event = EventMsg::TaskStarted(TaskStartedEvent {
-        model_context_window: turn_context.client.get_model_context_window(),
-    });
-    session.send_event(turn_context.as_ref(), event).await;
-
-    let shell_invocation = session
-        .user_shell()
-        .format_user_shell_script(&command)
-        .unwrap_or_else(|| vec![command.clone()]);
-
-    let params = ShellToolCallParams {
-        command: shell_invocation,
-        workdir: None,
-        timeout_ms: None,
-        with_escalated_permissions: None,
-        justification: None,
-    };
-
-    let tool_call = ToolCall {
-        tool_name: USER_SHELL_TOOL_NAME.to_string(),
-        call_id: Uuid::new_v4().to_string(),
-        payload: ToolPayload::LocalShell { params },
-    };
-
-    let router = Arc::new(ToolRouter::from_config(&turn_context.tools_config, None));
-    let tracker = Arc::new(Mutex::new(TurnDiffTracker::new()));
-    let runtime = ToolCallRuntime::new(
-        Arc::clone(&router),
-        Arc::clone(&session),
-        Arc::clone(&turn_context),
-        Arc::clone(&tracker),
-    );
-
-    if let Err(err) = runtime
-        .handle_tool_call(tool_call, cancellation_token)
-        .await
-    {
-        error!("user shell command failed: {err:?}");
     }
 }

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -53,9 +53,10 @@ impl SessionTask for UserShellCommandTask {
         let session = session.clone_session();
         session.send_event(turn_context.as_ref(), event).await;
 
-        let shell_invocation = session
-            .user_shell()
-            .format_user_shell_script(&self.command)
+        // Do not try to re-format the user's command for their shell; simply
+        // split it into argv using POSIX shell semantics. If splitting fails,
+        // fall back to treating the full string as argv[0].
+        let shell_invocation = shlex::split(&self.command)
             .unwrap_or_else(|| vec![self.command.clone()]);
 
         let params = ShellToolCallParams {

--- a/codex-rs/core/src/tools/context.rs
+++ b/codex-rs/core/src/tools/context.rs
@@ -255,6 +255,7 @@ pub(crate) struct ExecCommandContext {
     pub(crate) apply_patch: Option<ApplyPatchCommandContext>,
     pub(crate) tool_name: String,
     pub(crate) otel_event_manager: OtelEventManager,
+    pub(crate) is_user_shell_command: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/codex-rs/core/src/tools/context.rs
+++ b/codex-rs/core/src/tools/context.rs
@@ -255,6 +255,8 @@ pub(crate) struct ExecCommandContext {
     pub(crate) apply_patch: Option<ApplyPatchCommandContext>,
     pub(crate) tool_name: String,
     pub(crate) otel_event_manager: OtelEventManager,
+    // TODO(abhisek-oai): Find a better way to track this.
+    // https://github.com/openai/codex/pull/2471/files#r2470352242
     pub(crate) is_user_shell_command: bool,
 }
 

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -78,6 +78,7 @@ impl ToolHandler for ShellHandler {
                     turn,
                     tracker,
                     call_id,
+                    false,
                 )
                 .await
             }
@@ -90,6 +91,7 @@ impl ToolHandler for ShellHandler {
                     turn,
                     tracker,
                     call_id,
+                    true,
                 )
                 .await
             }
@@ -108,6 +110,7 @@ impl ShellHandler {
         turn: Arc<TurnContext>,
         tracker: crate::tools::context::SharedTurnDiffTracker,
         call_id: String,
+        is_user_shell_command: bool,
     ) -> Result<ToolOutput, FunctionCallError> {
         // Approval policy guard for explicit escalation in non-OnRequest modes.
         if exec_params.with_escalated_permissions.unwrap_or(false)
@@ -201,7 +204,11 @@ impl ShellHandler {
         }
 
         // Regular shell execution path.
-        let emitter = ToolEmitter::shell(exec_params.command.clone(), exec_params.cwd.clone());
+        let emitter = ToolEmitter::shell(
+            exec_params.command.clone(),
+            exec_params.cwd.clone(),
+            is_user_shell_command,
+        );
         let event_ctx = ToolEventCtx::new(session.as_ref(), turn.as_ref(), &call_id, None);
         emitter.begin(event_ctx).await;
 

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -36,4 +36,5 @@ mod tools;
 mod truncation;
 mod unified_exec;
 mod user_notification;
+mod user_shell_cmd;
 mod view_image;

--- a/codex-rs/core/tests/suite/user_shell_cmd.rs
+++ b/codex-rs/core/tests/suite/user_shell_cmd.rs
@@ -1,0 +1,140 @@
+use codex_core::ConversationManager;
+use codex_core::NewConversation;
+use codex_core::protocol::EventMsg;
+use codex_core::protocol::ExecCommandEndEvent;
+use codex_core::protocol::Op;
+use codex_core::protocol::TurnAbortReason;
+use core_test_support::load_default_config_for_test;
+use core_test_support::wait_for_event;
+use std::path::PathBuf;
+use std::process::Command;
+use std::process::Stdio;
+use tempfile::TempDir;
+
+fn detect_python_executable() -> Option<String> {
+    let candidates = ["python3", "python"];
+    candidates.iter().find_map(|candidate| {
+        Command::new(candidate)
+            .arg("--version")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .ok()
+            .and_then(|status| status.success().then(|| (*candidate).to_string()))
+    })
+}
+
+#[tokio::test]
+async fn user_shell_cmd_ls_and_cat_in_temp_dir() {
+    let Some(python) = detect_python_executable() else {
+        eprintln!("skipping test: python3 not found in PATH");
+        return;
+    };
+
+    // Create a temporary working directory with a known file.
+    let cwd = TempDir::new().unwrap();
+    let file_name = "hello.txt";
+    let file_path: PathBuf = cwd.path().join(file_name);
+    let contents = "hello from bang test\n";
+    tokio::fs::write(&file_path, contents)
+        .await
+        .expect("write temp file");
+
+    // Load config and pin cwd to the temp dir so ls/cat operate there.
+    let codex_home = TempDir::new().unwrap();
+    let mut config = load_default_config_for_test(&codex_home);
+    config.cwd = cwd.path().to_path_buf();
+
+    let conversation_manager =
+        ConversationManager::with_auth(codex_core::CodexAuth::from_api_key("dummy"));
+    let NewConversation {
+        conversation: codex,
+        ..
+    } = conversation_manager
+        .new_conversation(config)
+        .await
+        .expect("create new conversation");
+
+    // 1) python should list the file
+    let list_cmd = format!(
+        "{python} -c \"import pathlib; print('\\n'.join(sorted(p.name for p in pathlib.Path('.').iterdir())))\""
+    );
+    codex
+        .submit(Op::RunUserShellCommand { command: list_cmd })
+        .await
+        .unwrap();
+    let msg = wait_for_event(&codex, |ev| matches!(ev, EventMsg::ExecCommandEnd(_))).await;
+    let EventMsg::ExecCommandEnd(ExecCommandEndEvent {
+        stdout, exit_code, ..
+    }) = msg
+    else {
+        unreachable!()
+    };
+    assert_eq!(exit_code, 0);
+    assert!(
+        stdout.contains(file_name),
+        "ls output should include {file_name}, got: {stdout:?}"
+    );
+
+    // 2) python should print the file contents verbatim
+    let cat_cmd = format!(
+        "{python} -c \"import pathlib; print(pathlib.Path('{file_name}').read_text(), end='')\""
+    );
+    codex
+        .submit(Op::RunUserShellCommand { command: cat_cmd })
+        .await
+        .unwrap();
+    let msg = wait_for_event(&codex, |ev| matches!(ev, EventMsg::ExecCommandEnd(_))).await;
+    let EventMsg::ExecCommandEnd(ExecCommandEndEvent {
+        mut stdout,
+        exit_code,
+        ..
+    }) = msg
+    else {
+        unreachable!()
+    };
+    assert_eq!(exit_code, 0);
+    if cfg!(windows) {
+        // Windows' Python writes CRLF line endings; normalize so the assertion remains portable.
+        stdout = stdout.replace("\r\n", "\n");
+    }
+    assert_eq!(stdout, contents);
+}
+
+#[tokio::test]
+async fn user_shell_cmd_can_be_interrupted() {
+    let Some(python) = detect_python_executable() else {
+        eprintln!("skipping test: python3 not found in PATH");
+        return;
+    };
+    // Set up isolated config and conversation.
+    let codex_home = TempDir::new().unwrap();
+    let config = load_default_config_for_test(&codex_home);
+    let conversation_manager =
+        ConversationManager::with_auth(codex_core::CodexAuth::from_api_key("dummy"));
+    let NewConversation {
+        conversation: codex,
+        ..
+    } = conversation_manager
+        .new_conversation(config)
+        .await
+        .expect("create new conversation");
+
+    // Start a long-running command and then interrupt it.
+    let sleep_cmd = format!("{python} -c \"import time; time.sleep(5)\"");
+    codex
+        .submit(Op::RunUserShellCommand { command: sleep_cmd })
+        .await
+        .unwrap();
+
+    // Wait until it has started (ExecCommandBegin), then interrupt.
+    let _ = wait_for_event(&codex, |ev| matches!(ev, EventMsg::ExecCommandBegin(_))).await;
+    codex.submit(Op::Interrupt).await.unwrap();
+
+    // Expect a TurnAborted(Interrupted) notification.
+    let msg = wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnAborted(_))).await;
+    let EventMsg::TurnAborted(ev) = msg else {
+        unreachable!()
+    };
+    assert_eq!(ev.reason, TurnAbortReason::Interrupted);
+}

--- a/codex-rs/exec/tests/event_processor_with_json_output.rs
+++ b/codex-rs/exec/tests/event_processor_with_json_output.rs
@@ -506,6 +506,7 @@ fn exec_command_end_success_produces_completed_command_item() {
             command: vec!["bash".to_string(), "-lc".to_string(), "echo hi".to_string()],
             cwd: std::env::current_dir().unwrap(),
             parsed_cmd: Vec::new(),
+            is_user_shell_command: false,
         }),
     );
     let out_begin = ep.collect_thread_events(&begin);
@@ -566,6 +567,7 @@ fn exec_command_end_failure_produces_failed_command_item() {
             command: vec!["sh".to_string(), "-c".to_string(), "exit 1".to_string()],
             cwd: std::env::current_dir().unwrap(),
             parsed_cmd: Vec::new(),
+            is_user_shell_command: false,
         }),
     );
     assert_eq!(

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -186,6 +186,16 @@ pub enum Op {
 
     /// Request to shut down codex instance.
     Shutdown,
+
+    /// Execute a user-initiated one-off shell command (triggered by "!cmd").
+    ///
+    /// The command string is executed using the user's default shell and may
+    /// include shell syntax (pipes, redirects, etc.). Output is streamed via
+    /// `ExecCommand*` events and the UI regains control upon `TaskComplete`.
+    RunUserShellCommand {
+        /// The raw command string after '!'
+        command: String,
+    },
 }
 
 /// Determines the conditions under which the user is consulted to approve
@@ -1086,6 +1096,10 @@ pub struct ExecCommandBeginEvent {
     /// The command's working directory if not the default cwd for the agent.
     pub cwd: PathBuf,
     pub parsed_cmd: Vec<ParsedCommand>,
+    /// True when this exec was initiated directly by the user (e.g. bang command),
+    /// not by the agent/model. Defaults to false for backwards compatibility.
+    #[serde(default)]
+    pub is_user_shell_command: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS)]

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -120,10 +120,13 @@ use codex_file_search::FileMatch;
 use codex_protocol::plan_tool::UpdatePlanArgs;
 use strum::IntoEnumIterator;
 
+const BANG_COMMAND_HELP_TITLE: &str = "Prefix a command with ! to run it locally";
+const BANG_COMMAND_HELP_HINT: &str = "Example: !ls";
 // Track information about an in-flight exec command.
 struct RunningCommand {
     command: Vec<String>,
     parsed_cmd: Vec<ParsedCommand>,
+    is_user_shell_command: bool,
 }
 
 const RATE_LIMIT_WARNING_THRESHOLDS: [f64; 3] = [75.0, 90.0, 95.0];
@@ -771,9 +774,9 @@ impl ChatWidget {
 
     pub(crate) fn handle_exec_end_now(&mut self, ev: ExecCommandEndEvent) {
         let running = self.running_commands.remove(&ev.call_id);
-        let (command, parsed) = match running {
-            Some(rc) => (rc.command, rc.parsed_cmd),
-            None => (vec![ev.call_id.clone()], Vec::new()),
+        let (command, parsed, is_user_shell_command) = match running {
+            Some(rc) => (rc.command, rc.parsed_cmd, rc.is_user_shell_command),
+            None => (vec![ev.call_id.clone()], Vec::new(), false),
         };
 
         let needs_new = self
@@ -787,6 +790,7 @@ impl ChatWidget {
                 ev.call_id.clone(),
                 command,
                 parsed,
+                is_user_shell_command,
             )));
         }
 
@@ -865,6 +869,7 @@ impl ChatWidget {
             RunningCommand {
                 command: ev.command.clone(),
                 parsed_cmd: ev.parsed_cmd.clone(),
+                is_user_shell_command: ev.is_user_shell_command,
             },
         );
         if let Some(cell) = self
@@ -875,6 +880,7 @@ impl ChatWidget {
                 ev.call_id.clone(),
                 ev.command.clone(),
                 ev.parsed_cmd.clone(),
+                ev.is_user_shell_command,
             )
         {
             *cell = new_exec;
@@ -885,6 +891,7 @@ impl ChatWidget {
                 ev.call_id.clone(),
                 ev.command.clone(),
                 ev.parsed_cmd,
+                ev.is_user_shell_command,
             )));
         }
 
@@ -1346,6 +1353,24 @@ impl ChatWidget {
         }
 
         let mut items: Vec<UserInput> = Vec::new();
+
+        // Special-case: "!cmd" executes a local shell command instead of sending to the model.
+        if let Some(stripped) = text.strip_prefix('!') {
+            let cmd = stripped.trim();
+            if cmd.is_empty() {
+                self.app_event_tx.send(AppEvent::InsertHistoryCell(Box::new(
+                    history_cell::new_info_event(
+                        BANG_COMMAND_HELP_TITLE.to_string(),
+                        Some(BANG_COMMAND_HELP_HINT.to_string()),
+                    ),
+                )));
+                return;
+            }
+            self.submit_op(Op::RunUserShellCommand {
+                command: cmd.to_string(),
+            });
+            return;
+        }
 
         if !text.is_empty() {
             items.push(UserInput::Text { text: text.clone() });

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -120,8 +120,8 @@ use codex_file_search::FileMatch;
 use codex_protocol::plan_tool::UpdatePlanArgs;
 use strum::IntoEnumIterator;
 
-const BANG_COMMAND_HELP_TITLE: &str = "Prefix a command with ! to run it locally";
-const BANG_COMMAND_HELP_HINT: &str = "Example: !ls";
+const USER_SHELL_COMMAND_HELP_TITLE: &str = "Prefix a command with ! to run it locally";
+const USER_SHELL_COMMAND_HELP_HINT: &str = "Example: !ls";
 // Track information about an in-flight exec command.
 struct RunningCommand {
     command: Vec<String>,
@@ -1360,8 +1360,8 @@ impl ChatWidget {
             if cmd.is_empty() {
                 self.app_event_tx.send(AppEvent::InsertHistoryCell(Box::new(
                     history_cell::new_info_event(
-                        BANG_COMMAND_HELP_TITLE.to_string(),
-                        Some(BANG_COMMAND_HELP_HINT.to_string()),
+                        USER_SHELL_COMMAND_HELP_TITLE.to_string(),
+                        Some(USER_SHELL_COMMAND_HELP_HINT.to_string()),
                     ),
                 )));
                 return;

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -531,6 +531,7 @@ fn begin_exec(chat: &mut ChatWidget, call_id: &str, raw_cmd: &str) {
             command,
             cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
             parsed_cmd,
+            is_user_shell_command: false,
         }),
     });
 }
@@ -1509,6 +1510,7 @@ async fn binary_size_transcript_snapshot() {
                                     command: e.command,
                                     cwd: e.cwd,
                                     parsed_cmd,
+                                    is_user_shell_command: false,
                                 }),
                             }
                         }
@@ -2558,6 +2560,7 @@ fn chatwidget_exec_and_status_layout_vt100_snapshot() {
                     path: "diff_render.rs".into(),
                 },
             ],
+            is_user_shell_command: false,
         }),
     });
     chat.handle_codex_event(Event {

--- a/codex-rs/tui/src/exec_cell/model.rs
+++ b/codex-rs/tui/src/exec_cell/model.rs
@@ -18,6 +18,7 @@ pub(crate) struct ExecCall {
     pub(crate) command: Vec<String>,
     pub(crate) parsed: Vec<ParsedCommand>,
     pub(crate) output: Option<CommandOutput>,
+    pub(crate) is_user_shell_command: bool,
     pub(crate) start_time: Option<Instant>,
     pub(crate) duration: Option<Duration>,
 }
@@ -37,12 +38,14 @@ impl ExecCell {
         call_id: String,
         command: Vec<String>,
         parsed: Vec<ParsedCommand>,
+        is_user_shell_command: bool,
     ) -> Option<Self> {
         let call = ExecCall {
             call_id,
             command,
             parsed,
             output: None,
+            is_user_shell_command,
             start_time: Some(Instant::now()),
             duration: None,
         };

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -719,6 +719,7 @@ mod tests {
             "exec-1".into(),
             vec!["bash".into(), "-lc".into(), "ls".into()],
             vec![ParsedCommand::Unknown { cmd: "ls".into() }],
+            false,
         );
         exec_cell.complete_call(
             "exec-1",


### PR DESCRIPTION
feature: Add "!cmd" user shell execution

This change lets users run local shell commands directly from the TUI by prefixing their input with ! (e.g. !ls). Output is truncated to keep the exec cell usable, and Ctrl-C cleanly
  interrupts long-running commands (e.g. !sleep 10000).

**Summary of changes**

  - Route Op::RunUserShellCommand through a dedicated UserShellCommandTask (core/src/tasks/user_shell.rs), keeping the task logic out of codex.rs.
  - Reuse the existing tool router: the task constructs a ToolCall for the local_shell tool and relies on ShellHandler, so no manual MCP tool lookup is required.
  - Emit exec lifecycle events (ExecCommandBegin/ExecCommandEnd) so the TUI can show command metadata, live output, and exit status.

**End-to-end flow**

  **TUI handling**

  1. ChatWidget::submit_user_message (TUI) intercepts messages starting with !.
  2. Non-empty commands dispatch Op::RunUserShellCommand { command }; empty commands surface a help hint.
  3. No UserInput items are created, so nothing is enqueued for the model.

  **Core submission loop**
  4. The submission loop routes the op to handlers::run_user_shell_command (core/src/codex.rs).
  5. A fresh TurnContext is created and Session::spawn_user_shell_command enqueues UserShellCommandTask.

  **Task execution**
  6. UserShellCommandTask::run emits TaskStartedEvent, formats the command, and prepares a ToolCall targeting local_shell.
  7. ToolCallRuntime::handle_tool_call dispatches to ShellHandler.

  **Shell tool runtime**
  8. ShellHandler::run_exec_like launches the process via the unified exec runtime, honoring sandbox and shell policies, and emits ExecCommandBegin/End.
  9. Stdout/stderr are captured for the UI, but the task does not turn the resulting ToolOutput into a model response.

  **Completion**
  10. After ExecCommandEnd, the task finishes without an assistant message; the session marks it complete and the exec cell displays the final output.

  **Conversation context**

  - The command and its output never enter the conversation history or the model prompt; the flow is local-only.
  - Only exec/task events are emitted for UI rendering.

**Demo video**

https://github.com/user-attachments/assets/fcd114b0-4304-4448-a367-a04c43e0b996




