### PR TITLE
Fix: Sign in appear even if using other providers.

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -652,6 +652,12 @@ fn should_show_onboarding(
 }
 
 fn should_show_login_screen(login_status: LoginStatus, config: &Config) -> bool {
+    // Only show the login screen for providers that actually require OpenAI auth
+    // (OpenAI or equivalents). For OSS/other providers, skip login entirely.
+    if !config.model_provider.requires_openai_auth {
+        return false;
+    }
+
     match login_status {
         LoginStatus::NotAuthenticated => true,
         LoginStatus::AuthMode(method) => method != config.preferred_auth_method,


### PR DESCRIPTION
We shouldn't show the login screen when using other providers.