### PR TITLE
[apply-patch] Fix applypatch for heredocs

### DIFF
--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -22,6 +22,8 @@ use tree_sitter_bash::LANGUAGE as BASH;
 /// Detailed instructions for gpt-4.1 on how to use the `apply_patch` tool.
 pub const APPLY_PATCH_TOOL_INSTRUCTIONS: &str = include_str!("../apply_patch_tool_instructions.md");
 
+const APPLY_PATCH_COMMANDS: [&str; 2] = ["apply_patch", "applypatch"];
+
 #[derive(Debug, Error, PartialEq)]
 pub enum ApplyPatchError {
     #[error(transparent)]
@@ -82,7 +84,6 @@ pub struct ApplyPatchArgs {
 }
 
 pub fn maybe_parse_apply_patch(argv: &[String]) -> MaybeApplyPatch {
-    const APPLY_PATCH_COMMANDS: [&str; 2] = ["apply_patch", "applypatch"];
     match argv {
         [cmd, body] if APPLY_PATCH_COMMANDS.contains(&cmd.as_str()) => match parse_patch(body) {
             Ok(source) => MaybeApplyPatch::Body(source),
@@ -264,7 +265,10 @@ pub fn maybe_parse_apply_patch_verified(argv: &[String], cwd: &Path) -> MaybeApp
 fn extract_heredoc_body_from_apply_patch_command(
     src: &str,
 ) -> std::result::Result<String, ExtractHeredocError> {
-    if !src.trim_start().starts_with("apply_patch") {
+    if !APPLY_PATCH_COMMANDS
+        .iter()
+        .any(|cmd| src.trim_start().starts_with(cmd))
+    {
         return Err(ExtractHeredocError::CommandDidNotStartWithApplyPatch);
     }
 
@@ -780,7 +784,7 @@ PATCH"#,
         let args = strs_to_strings(&[
             "bash",
             "-lc",
-            r#"apply_patch <<'PATCH'
+            r#"applypatch <<'PATCH'
 *** Begin Patch
 *** Add File: foo
 +hi


### PR DESCRIPTION
## Summary
Follow up to #2186 for #2072 - we added handling for `applypatch` in default commands, but forgot to add detection to the heredocs logic.

## Testing
- [x] Added unit tests