### PR TITLE
[context] Add env context to every turn with gitinfo

### DIFF
--- a/codex-rs/core/prompt.md
+++ b/codex-rs/core/prompt.md
@@ -134,6 +134,13 @@ If completing the user's task requires writing or modifying files, your code and
 - Do not use one-letter variable names unless explicitly requested.
 - NEVER output inline citations like "【F:README.md†L5-L14】" in your outputs. The CLI is not able to render these so they will just be broken in the UI. Instead, if you output valid filepaths, users will be able to click on them to open the files in their editor.
 
+## Git awareness
+
+Before starting a task and while making changes, read the `environment_context` provided by the harness and use it to guide your actions:
+
+- Git info: review `Current git info` (`commit`, `branch`, `remote`) to align with the user’s context and check if the user has made other edits.
+
+
 ## Testing your work
 
 If the codebase has tests or the ability to build or run, you should use them to verify that your work is complete. Generally, your testing philosophy should be to start as specific as possible to the code you changed so that you can catch issues efficiently, then make your way to broader tests as you build confidence. If there's no test for the code you changed, and if the adjacent patterns in the codebases show that there's a logical place for you to add a test, you may do so. However, do not add tests to codebases with no tests, or where the patterns don't indicate so.

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -2,6 +2,8 @@ use serde::Deserialize;
 use serde::Serialize;
 use strum_macros::Display as DeriveDisplay;
 
+use crate::git_info::GitInfo;
+use crate::git_info::fmt_for_env_context;
 use crate::models::ContentItem;
 use crate::models::ResponseItem;
 use crate::protocol::AskForApproval;
@@ -28,6 +30,7 @@ pub(crate) struct EnvironmentContext {
     pub approval_policy: AskForApproval,
     pub sandbox_mode: SandboxMode,
     pub network_access: NetworkAccess,
+    pub git_info: Option<GitInfo>,
 }
 
 impl EnvironmentContext {
@@ -35,6 +38,7 @@ impl EnvironmentContext {
         cwd: PathBuf,
         approval_policy: AskForApproval,
         sandbox_policy: SandboxPolicy,
+        git_info: Option<GitInfo>,
     ) -> Self {
         Self {
             cwd,
@@ -55,6 +59,7 @@ impl EnvironmentContext {
                     }
                 }
             },
+            git_info,
         }
     }
 }
@@ -69,6 +74,7 @@ impl Display for EnvironmentContext {
         writeln!(f, "Approval policy: {}", self.approval_policy)?;
         writeln!(f, "Sandbox mode: {}", self.sandbox_mode)?;
         writeln!(f, "Network access: {}", self.network_access)?;
+        writeln!(f, "{}", fmt_for_env_context(self.git_info.as_ref()))?;
         Ok(())
     }
 }

--- a/codex-rs/core/src/git_info.rs
+++ b/codex-rs/core/src/git_info.rs
@@ -45,7 +45,7 @@ pub async fn collect_git_info(cwd: &Path) -> Option<GitInfo> {
         run_git_command_with_timeout(&["rev-parse", "HEAD"], cwd),
         run_git_command_with_timeout(&["rev-parse", "--abbrev-ref", "HEAD"], cwd),
         run_git_command_with_timeout(&["remote", "get-url", "origin"], cwd),
-        run_git_command_with_timeout(&["diff", "--stat", "HEAD"], cwd),
+        run_git_command_with_timeout(&["status", "-unormal", "--porcelain"], cwd),
     );
 
     let mut git_info = GitInfo {
@@ -83,13 +83,11 @@ pub async fn collect_git_info(cwd: &Path) -> Option<GitInfo> {
     }
 
     // Process diff stat
-    if let Some(output) = diff_result {
-        if output.status.success() {
-            if let Ok(diff_stat) = String::from_utf8(output.stdout) {
+    if let Some(output) = diff_result
+        && output.status.success()
+            && let Ok(diff_stat) = String::from_utf8(output.stdout) {
                 git_info.diff_stat = Some(diff_stat.trim().to_string());
             }
-        }
-    }
 
     Some(git_info)
 }


### PR DESCRIPTION
## Summary
WIP to provide environment context on the start of every turn, and include git info

## Testing
- [ ] Add unit tests
- [ ] vibes locally