### PR TITLE
fix: #2486 Enable accessing kern.argmax in sandbox mode

### DIFF
--- a/codex-rs/core/src/seatbelt_base_policy.sbpl
+++ b/codex-rs/core/src/seatbelt_base_policy.sbpl
@@ -52,6 +52,7 @@
   (sysctl-name "hw.physicalcpu_max")
   (sysctl-name "hw.tbfrequency_compat")
   (sysctl-name "hw.vectorunit")
+  (sysctl-name "kern.argmax")
   (sysctl-name "kern.hostname")
   (sysctl-name "kern.maxfilesperproc")
   (sysctl-name "kern.osproductversion")


### PR DESCRIPTION
This pull request resolves #2486 