### PR TITLE
fix: #2148 add comma to group three digits in numbers

### DIFF
--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -25,6 +25,7 @@ use codex_core::protocol::TaskCompleteEvent;
 use codex_core::protocol::TurnAbortReason;
 use codex_core::protocol::TurnDiffEvent;
 use codex_core::protocol::WebSearchBeginEvent;
+use codex_core::protocol::format_token_count;
 use owo_colors::OwoColorize;
 use owo_colors::Style;
 use shlex::try_join;
@@ -189,7 +190,8 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                 return CodexStatus::InitiateShutdown;
             }
             EventMsg::TokenCount(token_usage) => {
-                ts_println!(self, "tokens used: {}", token_usage.blended_total());
+                let tokens = format_token_count(token_usage.blended_total());
+                ts_println!(self, "tokens used: {tokens}");
             }
             EventMsg::AgentMessageDelta(AgentMessageDeltaEvent { delta }) => {
                 if !self.answer_started {

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -1,4 +1,5 @@
 use codex_core::protocol::TokenUsage;
+use codex_core::protocol::format_token_count;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyModifiers;
@@ -1153,8 +1154,9 @@ impl WidgetRef for &ChatComposer {
                 if let Some(token_usage_info) = &self.token_usage_info {
                     let token_usage = &token_usage_info.total_token_usage;
                     hint.push(Span::from("   "));
+                    let tokens = format_token_count(token_usage.blended_total());
                     hint.push(
-                        Span::from(format!("{} tokens used", token_usage.blended_total()))
+                        Span::from(format!("{tokens} tokens used"))
                             .style(Style::default().add_modifier(Modifier::DIM)),
                     );
                     let last_token_usage = &token_usage_info.last_token_usage;

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -18,6 +18,7 @@ use codex_core::protocol::McpInvocation;
 use codex_core::protocol::SandboxPolicy;
 use codex_core::protocol::SessionConfiguredEvent;
 use codex_core::protocol::TokenUsage;
+use codex_core::protocol::format_token_count;
 use codex_login::get_auth_file;
 use codex_login::try_read_auth_json;
 use codex_protocol::parse_command::ParsedCommand;
@@ -734,23 +735,24 @@ pub(crate) fn new_status_output(
     // Input: <input> [+ <cached> cached]
     let mut input_line_spans: Vec<Span<'static>> = vec![
         "  • Input: ".into(),
-        usage.non_cached_input().to_string().into(),
+        format_token_count(usage.non_cached_input()).into(),
     ];
     if let Some(cached) = usage.cached_input_tokens
         && cached > 0
     {
-        input_line_spans.push(format!(" (+ {cached} cached)").into());
+        let cached_tokens = format_token_count(cached);
+        input_line_spans.push(format!(" (+ {cached_tokens} cached)").into());
     }
     lines.push(Line::from(input_line_spans));
     // Output: <output>
     lines.push(Line::from(vec![
         "  • Output: ".into(),
-        usage.output_tokens.to_string().into(),
+        format_token_count(usage.output_tokens).into(),
     ]));
     // Total: <total>
     lines.push(Line::from(vec![
         "  • Total: ".into(),
-        usage.blended_total().to_string().into(),
+        format_token_count(usage.blended_total()).into(),
     ]));
 
     PlainHistoryCell { lines }


### PR DESCRIPTION
This pull request resolves #2148 and I personally this is better in terms of readability

### Before:

>15894 (+ 93056 cached)


```
📊 Token Usage
  • Input: 15894 (+ 93056 cached)
  • Output: 3810
  • Total: 19704
```

>1195 tokens used

```
codex
Hey! What do you want to tackle in codex-rs? I can explore the repo, run tests, or implement a change—point me at a crate or issue.

▌ Ask Codex to do anything
 ⏎ send   Shift+⏎ newline   Ctrl+C quit   1195 tokens used   96% context left
```

### After:

>15,894 (+ 93,056 cached)

```
📊 Token Usage
  • Input: 15,894 (+ 93,056 cached)
  • Output: 3,810
  • Total: 19,704
```

>1,179 tokens used

```
codex
Hey! What’s up?
Want me to tackle something in codex-rs—tests, a bug, or a feature?

▌ Improve documentation in @filename
 ⏎ send   Shift+⏎ newline   Ctrl+C quit   1,179 tokens used   99% context left
```

