### PR TITLE
tui: link docs when no MCP servers configured

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -641,6 +641,15 @@ pub(crate) fn empty_mcp_output() -> PlainHistoryCell {
         Line::from(vec!["🔌  ".into(), "MCP Tools".bold()]),
         Line::from(""),
         Line::from("  • No MCP servers configured.".italic()),
+        Line::from(vec![
+            "    See the ".into(),
+            Span::styled(
+                "\u{1b}]8;;https://github.com/openai/codex/blob/main/codex-rs/config.md#mcp_servers\u{7}MCP docs\u{1b}]8;;\u{7}",
+                Style::default().add_modifier(Modifier::UNDERLINED),
+            ),
+            " to configure them.".into(),
+        ])
+        .style(Style::default().add_modifier(Modifier::DIM)),
         Line::from(""),
     ];
 


### PR DESCRIPTION
## Summary
- point users to the MCP configuration docs when `/mcp` finds no servers

## Testing
- `cargo test -p codex-tui` *(fails: snapshot assertion for diff_render::tests::ui_snapshot_add_details)*
- `cargo insta pending-snapshots -p codex-tui` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_i_68a57672f50c832cb6dbddf060c902f6