### PR TITLE
core: write explicit [projects] tables for trusted projects

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1273,8 +1273,9 @@ disable_response_storage = true
         // Seed config.toml with an inline project entry under [projects]
         let config_path = codex_home.path().join(CONFIG_TOML_FILE);
         let path_str = project_dir.path().to_string_lossy();
+        // Use a literal-quoted key so Windows backslashes don't require escaping
         let initial = format!(
-            "[projects]\n\"{}\" = {{ trust_level = \"untrusted\" }}\n",
+            "[projects]\n'{}' = {{ trust_level = \"untrusted\" }}\n",
             path_str
         );
         std::fs::create_dir_all(codex_home.path())?;

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -271,10 +271,14 @@ pub fn set_project_trusted(codex_home: &Path, project_path: &Path) -> anyhow::Re
     // "/path/to/project" = { trust_level = "trusted" }
     let project_key = project_path.to_string_lossy().to_string();
 
-    // Ensure top-level `projects` exists as a non-inline, explicit table
+    // Ensure top-level `projects` exists as a non-inline, explicit table. If it
+    // exists but was previously represented as a non-table (e.g., inline),
+    // replace it with an explicit table.
     {
         let root = doc.as_table_mut();
-        if !root.contains_key("projects") {
+        let needs_table = !root.contains_key("projects")
+            || root.get("projects").and_then(|i| i.as_table()).is_none();
+        if needs_table {
             root.insert("projects", toml_edit::table());
         }
     }
@@ -283,11 +287,15 @@ pub fn set_project_trusted(codex_home: &Path, project_path: &Path) -> anyhow::Re
             "projects table missing after initialization"
         ));
     };
-    // Ensure we emit an explicit [projects] header
-    projects_tbl.set_implicit(false);
 
-    // Ensure the per-project entry is its own explicit table
-    if !projects_tbl.contains_key(project_key.as_str()) {
+    // Ensure the per-project entry is its own explicit table. If it exists but
+    // is not a table (e.g., an inline table), replace it with an explicit table.
+    let needs_proj_table = !projects_tbl.contains_key(project_key.as_str())
+        || projects_tbl
+            .get(project_key.as_str())
+            .and_then(|i| i.as_table())
+            .is_none();
+    if needs_proj_table {
         projects_tbl.insert(project_key.as_str(), toml_edit::table());
     }
     let Some(proj_tbl) = projects_tbl
@@ -1256,4 +1264,52 @@ disable_response_storage = true
 
         Ok(())
     }
+
+    #[test]
+    fn test_set_project_trusted_converts_inline_to_explicit() -> anyhow::Result<()> {
+        let codex_home = TempDir::new().unwrap();
+        let project_dir = TempDir::new().unwrap();
+
+        // Seed config.toml with an inline project entry under [projects]
+        let config_path = codex_home.path().join(CONFIG_TOML_FILE);
+        let path_str = project_dir.path().to_string_lossy();
+        let initial = format!(
+            "[projects]\n\"{}\" = {{ trust_level = \"untrusted\" }}\n",
+            path_str
+        );
+        std::fs::create_dir_all(codex_home.path())?;
+        std::fs::write(&config_path, initial)?;
+
+        // Run the function; it should convert to explicit tables and set trusted
+        set_project_trusted(codex_home.path(), project_dir.path())?;
+
+        let contents = std::fs::read_to_string(&config_path)?;
+
+        // Should not contain inline table representation anymore (accept both quote styles)
+        let inline_double = format!("\"{}\" = {{ trust_level = \"trusted\" }}", path_str);
+        let inline_single = format!("'{}' = {{ trust_level = \"trusted\" }}", path_str);
+        assert!(
+            !contents.contains(&inline_double) && !contents.contains(&inline_single),
+            "config.toml should not contain inline project table anymore:\n{}",
+            contents
+        );
+
+        // And explicit child table header for the project
+        let project_key_double = format!("[projects.\"{}\"]", path_str);
+        let project_key_single = format!("[projects.'{}']", path_str);
+        assert!(
+            contents.contains(&project_key_double) || contents.contains(&project_key_single),
+            "missing explicit project table header: expected to find `{}` or `{}` in:\n{}",
+            project_key_double,
+            project_key_single,
+            contents
+        );
+
+        // And the trust level value
+        assert!(contents.contains("trust_level = \"trusted\""));
+
+        Ok(())
+    }
+
+    // No test enforcing the presence of a standalone [projects] header.
 }

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1233,12 +1233,17 @@ disable_response_storage = true
             contents
         );
 
-        // Verify the explicit table for the project exists
-        let project_key = format!("[projects.\"{}\"]", project_dir.path().to_string_lossy());
+        // Verify the explicit table for the project exists. toml_edit may choose
+        // either basic (double-quoted) or literal (single-quoted) strings for keys
+        // containing backslashes (e.g., on Windows). Accept both forms.
+        let path_str = project_dir.path().to_string_lossy();
+        let project_key_double = format!("[projects.\"{}\"]", path_str);
+        let project_key_single = format!("[projects.'{}']", path_str);
         assert!(
-            contents.contains(&project_key),
-            "missing explicit project table header: expected to find `{}` in:\n{}",
-            project_key,
+            contents.contains(&project_key_double) || contents.contains(&project_key_single),
+            "missing explicit project table header: expected to find `{}` or `{}` in:\n{}",
+            project_key_double,
+            project_key_single,
             contents
         );
 


### PR DESCRIPTION
all of my trust_level settings in my ~/.codex/config.toml were on one line.