### PR TITLE
fix: update build cache key in .github/workflows/codex.yml

### DIFF
--- a/.github/workflows/codex.yml
+++ b/.github/workflows/codex.yml
@@ -52,7 +52,7 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             ${{ github.workspace }}/codex-rs/target/
-          key: cargo-ubuntu-24.04-x86_64-unknown-linux-gnu-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-ubuntu-24.04-x86_64-unknown-linux-gnu-dev-${{ hashFiles('**/Cargo.lock') }}
 
       # Note it is possible that the `verify` step internal to Run Codex will
       # fail, in which case the work to setup the repo was worthless :(


### PR DESCRIPTION
Change to match `.github/workflows/rust-ci.yml`, which was updated in https://github.com/openai/codex/pull/2242:

https://github.com/openai/codex/blob/250ae37c8492f475b5f2af3f7a9f3e96973b2657/.github/workflows/rust-ci.yml#L120-L128