### PR TITLE
scroll instead of clear on boot

### DIFF
--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -74,9 +74,10 @@ pub fn init() -> Result<Terminal> {
     // Instead of clearing the screen (which can drop scrollback in some terminals),
     // scroll existing lines up until the cursor reaches the top, then start at (0, 0).
     if let Ok((_x, y)) = cursor::position()
-        && y > 0 {
-            execute!(stdout(), ScrollUp(y))?;
-        }
+        && y > 0
+    {
+        execute!(stdout(), ScrollUp(y))?;
+    }
     execute!(stdout(), MoveTo(0, 0))?;
 
     let backend = CrosstermBackend::new(stdout());

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 use crossterm::SynchronizedUpdate;
+use crossterm::cursor;
 use crossterm::cursor::MoveTo;
 use crossterm::event::DisableBracketedPaste;
 use crossterm::event::EnableBracketedPaste;
@@ -15,8 +16,7 @@ use crossterm::event::KeyEventKind;
 use crossterm::event::KeyboardEnhancementFlags;
 use crossterm::event::PopKeyboardEnhancementFlags;
 use crossterm::event::PushKeyboardEnhancementFlags;
-use crossterm::terminal::Clear;
-use crossterm::terminal::ClearType;
+use crossterm::terminal::ScrollUp;
 use ratatui::backend::Backend;
 use ratatui::backend::CrosstermBackend;
 use ratatui::crossterm::execute;
@@ -71,8 +71,13 @@ pub fn init() -> Result<Terminal> {
 
     set_panic_hook();
 
-    // Clear screen and move cursor to top-left before drawing UI
-    execute!(stdout(), Clear(ClearType::All), MoveTo(0, 0))?;
+    // Instead of clearing the screen (which can drop scrollback in some terminals),
+    // scroll existing lines up until the cursor reaches the top, then start at (0, 0).
+    if let Ok((_x, y)) = cursor::position()
+        && y > 0 {
+            execute!(stdout(), ScrollUp(y))?;
+        }
+    execute!(stdout(), MoveTo(0, 0))?;
 
     let backend = CrosstermBackend::new(stdout());
     let tui = CustomTerminal::with_options(backend)?;


### PR DESCRIPTION
this actually works fine already in iterm without this change, but Terminal.app adds a bunch of excess whitespace when we clear all.

https://github.com/user-attachments/assets/c5bd1809-c2ed-4daa-a148-944d2df52876

