### PR TITLE
Fix flakiness in shell command approval test

### DIFF
--- a/codex-rs/mcp-server/tests/codex_tool.rs
+++ b/codex-rs/mcp-server/tests/codex_tool.rs
@@ -86,9 +86,7 @@ async fn shell_command_approval_triggers_elicitation() -> anyhow::Result<()> {
     )
     .await??;
 
-    // This is the first request from the server, so the id should be 0 given
-    // how things are currently implemented.
-    let elicitation_request_id = RequestId::Integer(0);
+    let elicitation_request_id = elicitation_request.id.clone();
     let params = serde_json::from_value::<ExecApprovalElicitRequestParams>(
         elicitation_request
             .params


### PR DESCRIPTION
## Summary
- read the shell exec approval request's actual id instead of assuming it is always 0
- use that id when validating and responding in the test

## Testing
- `cargo test -p codex-mcp-server test_shell_command_approval_triggers_elicitation`

------
https://chatgpt.com/codex/tasks/task_i_68a6ab9c732c832c81522cbf11812be0