### PR TITLE
feat: enable Streamable HTTP MCP servers & lazy loading of tools

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -868,7 +868,10 @@ name = "codex-mcp-client"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "eventsource-stream",
+ "futures",
  "mcp-types",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",

--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -3,4 +3,4 @@
 This file has moved. Please see the latest configuration documentation here:
 
 - Full config docs: [docs/config.md](../docs/config.md)
-- MCP servers section: [docs/config.md#mcp_servers](../docs/config.md#mcp_servers) 
+- MCP servers section: [docs/config.md#mcp_servers](../docs/config.md#mcp_servers)

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -12,14 +12,25 @@ use serde::Serialize;
 use strum_macros::Display;
 
 #[derive(Deserialize, Debug, Clone, PartialEq)]
-pub struct McpServerConfig {
-    pub command: String,
+#[serde(untagged)]
+pub enum McpServerConfig {
+    /// MCP server launched as a subprocess that communicates over stdio.
+    Stdio {
+        command: String,
 
-    #[serde(default)]
-    pub args: Vec<String>,
+        #[serde(default)]
+        args: Vec<String>,
 
-    #[serde(default)]
-    pub env: Option<HashMap<String, String>>,
+        #[serde(default)]
+        env: Option<HashMap<String, String>>,
+    },
+    /// MCP server reachable via the Streamable HTTP transport.
+    StreamableHttp {
+        url: String,
+
+        #[serde(default)]
+        headers: Option<HashMap<String, String>>,
+    },
 }
 
 #[derive(Deserialize, Debug, Copy, Clone, PartialEq)]

--- a/codex-rs/mcp-client/Cargo.toml
+++ b/codex-rs/mcp-client/Cargo.toml
@@ -11,6 +11,9 @@ anyhow = "1"
 mcp-types = { path = "../mcp-types" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+eventsource-stream = "0.2.3"
+futures = "0.3"
+reqwest = { version = "0.12", features = ["json", "stream"] }
 tracing = { version = "0.1.41", features = ["log"] }
 tracing-subscriber = { version = "0.3", features = ["fmt", "env-filter"] }
 tokio = { version = "1", features = [

--- a/docs/config.md
+++ b/docs/config.md
@@ -360,6 +360,11 @@ Should be represented as follows in `~/.codex/config.toml`:
 command = "npx"
 args = ["-y", "mcp-server"]
 env = { "API_KEY" = "value" }
+
+# Streamable HTTP remote servers
+[mcp_servers.my_mcp_sever]
+url = "https://{the-actual-domain-here}/mcp"
+# headers = { Authorization = "Bearer {token}" }
 ```
 
 ## disable_response_storage


### PR DESCRIPTION
This pull request adds the following features:
1. Add Streamable HTTP MCP server support
2.  Lazy loading of MCP server tools without blocking the shell initialization (resolves #2335)

If we want only 2. (lazy loading), I can send a separate pull request for it.