### PR TITLE
show diff output in the pager

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -818,9 +818,8 @@ impl ChatWidget {
         self.request_redraw();
     }
 
-    pub(crate) fn add_diff_output(&mut self, diff_output: String) {
+    pub(crate) fn on_diff_complete(&mut self) {
         self.bottom_pane.set_task_running(false);
-        self.add_to_history(history_cell::new_diff_output(diff_output));
         self.mark_needs_redraw();
     }
 

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -506,19 +506,6 @@ pub(crate) fn new_completed_mcp_tool_call(
     Box::new(PlainHistoryCell { lines })
 }
 
-pub(crate) fn new_diff_output(message: String) -> PlainHistoryCell {
-    let mut lines: Vec<Line<'static>> = Vec::new();
-    lines.push(Line::from("/diff".magenta()));
-
-    if message.trim().is_empty() {
-        lines.push(Line::from("No changes detected.".italic()));
-    } else {
-        lines.extend(message.lines().map(ansi_escape_line));
-    }
-
-    lines.push(Line::from(""));
-    PlainHistoryCell { lines }
-}
 
 pub(crate) fn new_status_output(
     config: &Config,

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -506,7 +506,6 @@ pub(crate) fn new_completed_mcp_tool_call(
     Box::new(PlainHistoryCell { lines })
 }
 
-
 pub(crate) fn new_status_output(
     config: &Config,
     usage: &TokenUsage,

--- a/codex-rs/tui/src/transcript_app.rs
+++ b/codex-rs/tui/src/transcript_app.rs
@@ -21,6 +21,7 @@ pub(crate) struct TranscriptApp {
     pub(crate) transcript_lines: Vec<Line<'static>>,
     pub(crate) scroll_offset: usize,
     pub(crate) is_done: bool,
+    title: String,
 }
 
 impl TranscriptApp {
@@ -29,6 +30,16 @@ impl TranscriptApp {
             transcript_lines,
             scroll_offset: 0,
             is_done: false,
+            title: "T R A N S C R I P T".to_string(),
+        }
+    }
+
+    pub(crate) fn with_title(transcript_lines: Vec<Line<'static>>, title: String) -> Self {
+        Self {
+            transcript_lines,
+            scroll_offset: 0,
+            is_done: false,
+            title,
         }
     }
 
@@ -114,8 +125,11 @@ impl TranscriptApp {
             } => {
                 self.scroll_offset = usize::MAX;
             }
-            _ => {}
+            _ => {
+                return;
+            }
         }
+        tui.frame_requester().schedule_frame();
     }
 
     fn scroll_area(&self, area: Rect) -> Rect {
@@ -130,9 +144,8 @@ impl TranscriptApp {
         Span::from("/ ".repeat(area.width as usize / 2))
             .dim()
             .render_ref(area, buf);
-        Span::from("/ T R A N S C R I P T")
-            .dim()
-            .render_ref(area, buf);
+        let header = format!("/ {}", self.title);
+        Span::from(header).dim().render_ref(area, buf);
 
         // Main content area (excludes header and bottom status section)
         let content_area = self.scroll_area(area);


### PR DESCRIPTION
this shows `/diff` output in an overlay like the transcript, instead of dumping it into history.


https://github.com/user-attachments/assets/48e79b65-7f66-45dd-97b3-d5c627ac7349

