### PR TITLE
[config] Detect git worktrees for project trust

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -503,10 +503,26 @@ impl ConfigToml {
     pub fn is_cwd_trusted(&self, resolved_cwd: &Path) -> bool {
         let projects = self.projects.clone().unwrap_or_default();
 
-        projects
+        // Fast path: exact cwd match
+        if projects
             .get(&resolved_cwd.to_string_lossy().to_string())
             .map(|p| p.trust_level.clone().unwrap_or("".to_string()) == "trusted")
             .unwrap_or(false)
+        {
+            return true;
+        }
+
+        // If cwd lives inside a git worktree, check whether the root git project
+        // (the primary repository working directory) is trusted. This lets
+        // worktrees inherit trust from the main project.
+        if let Some(root_project) = resolve_root_git_project_for_trust(resolved_cwd) {
+            return projects
+                .get(&root_project.to_string_lossy().to_string())
+                .map(|p| p.trust_level.clone().unwrap_or("".to_string()) == "trusted")
+                .unwrap_or(false);
+        }
+
+        false
     }
 
     pub fn get_config_profile(
@@ -529,6 +545,66 @@ impl ConfigToml {
             None => Ok(ConfigProfile::default()),
         }
     }
+}
+
+/// Resolve the path that should be used for trust checks when running inside a
+/// git worktree.
+///
+/// Behavior:
+/// - If `cwd` is not inside a git repository, returns `None`.
+/// - If `cwd` is inside a regular git repository (with a `.git` directory at
+///   the repository root), returns `None` to fall back to the original logic
+///   (trust by exact cwd or ancestor project entries). We intentionally do not
+///   change behavior for non-worktree repos.
+/// - If `cwd` is inside a linked worktree (where the repo root contains a
+///   `.git` file that points at `<main>/.git/worktrees/<name>`), returns the
+///   path to the main repository working directory (parent of `<main>/.git`).
+pub fn resolve_root_git_project_for_trust(cwd: &Path) -> Option<PathBuf> {
+    // Walk up to find the first directory containing a `.git` entry
+    let mut dir = cwd;
+    if !dir.is_dir() {
+        dir = cwd.parent()?;
+    }
+
+    let mut cur = dir.to_path_buf();
+    while cur.parent().is_some() {
+        let git_marker = cur.join(".git");
+        if git_marker.is_dir() {
+            // Regular repo (not a worktree) — do not alter trust target
+            return None;
+        }
+        if git_marker.is_file() {
+            // Likely a worktree checkout. Parse `gitdir: <path>`.
+            if let Ok(s) = std::fs::read_to_string(&git_marker) {
+                let s = s.trim();
+                let prefix = "gitdir:";
+                if let Some(rest) = s.strip_prefix(prefix) {
+                    let target = rest.trim();
+                    let gitdir_path = PathBuf::from(target);
+                    // If this points to `<main>/.git/worktrees/<name>`, then the
+                    // main .git dir is its parent().parent(). The main project
+                    // working directory is then parent of that .git dir.
+                    if let Some(parent) = gitdir_path.parent()
+                        && parent
+                            .file_name()
+                            .map(|n| n == "worktrees")
+                            .unwrap_or(false)
+                        && let Some(main_git_dir) = parent.parent()
+                        && let Some(main_project_root) = main_git_dir.parent()
+                    {
+                        return Some(main_project_root.to_path_buf());
+                    }
+                }
+            }
+            // If we cannot parse or it isn't a worktrees path, do not special‑case.
+            return None;
+        }
+
+        if !cur.pop() {
+            break;
+        }
+    }
+    None
 }
 
 /// Optional overrides for user configuration (e.g., from CLI flags).

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -507,7 +507,7 @@ impl ConfigToml {
         // Fast path: exact cwd match
         if projects
             .get(&resolved_cwd.to_string_lossy().to_string())
-            .map(|p| p.trust_level.clone().unwrap_or("".to_string()) == "trusted")
+            .map(|p| p.trust_level.as_deref() == Some("trusted"))
             .unwrap_or(false)
         {
             return true;

--- a/codex-rs/core/src/git_info.rs
+++ b/codex-rs/core/src/git_info.rs
@@ -794,8 +794,6 @@ mod tests {
         assert_eq!(state.sha, GitSha::new(&remote_sha));
     }
 
-    // --- resolve_root_git_project_for_trust tests ---
-
     #[test]
     fn resolve_root_git_project_for_trust_returns_none_outside_repo() {
         let tmp = TempDir::new().expect("tempdir");
@@ -810,7 +808,6 @@ mod tests {
         // Simulate a normal repo by creating a .git directory at the root
         std::fs::create_dir_all(repo.join(".git")).unwrap();
 
-        // Calling from repo root or nested dir should leave trust unchanged (None)
         assert!(resolve_root_git_project_for_trust(&repo).is_none());
         assert!(resolve_root_git_project_for_trust(&repo.join("sub/dir")).is_none());
     }

--- a/codex-rs/core/src/git_info.rs
+++ b/codex-rs/core/src/git_info.rs
@@ -450,11 +450,9 @@ pub fn resolve_root_git_project_for_trust(cwd: &Path) -> Option<PathBuf> {
     while cur.parent().is_some() {
         let git_marker = cur.join(".git");
         if git_marker.is_dir() {
-            // Regular repo (not a worktree) — do not alter trust target
-            return None;
+            return Some(cur);
         }
         if git_marker.is_file() {
-            // Likely a worktree checkout. Parse `gitdir: <path>`.
             if let Ok(s) = std::fs::read_to_string(&git_marker) {
                 let s = s.trim();
                 let prefix = "gitdir:";
@@ -808,8 +806,14 @@ mod tests {
         // Simulate a normal repo by creating a .git directory at the root
         std::fs::create_dir_all(repo.join(".git")).unwrap();
 
-        assert!(resolve_root_git_project_for_trust(&repo).is_none());
-        assert!(resolve_root_git_project_for_trust(&repo.join("sub/dir")).is_none());
+        assert_eq!(
+            resolve_root_git_project_for_trust(&repo),
+            Some(repo.clone())
+        );
+        assert_eq!(
+            resolve_root_git_project_for_trust(&repo),
+            Some(repo.clone())
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/onboarding/trust_directory.rs
+++ b/codex-rs/tui/src/onboarding/trust_directory.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
-use codex_core::config::resolve_root_git_project_for_trust;
 use codex_core::config::set_project_trusted;
+use codex_core::git_info::resolve_root_git_project_for_trust;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use ratatui::buffer::Buffer;

--- a/codex-rs/tui/src/onboarding/trust_directory.rs
+++ b/codex-rs/tui/src/onboarding/trust_directory.rs
@@ -1,5 +1,6 @@
 use std::path::PathBuf;
 
+use codex_core::config::resolve_root_git_project_for_trust;
 use codex_core::config::set_project_trusted;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
@@ -144,10 +145,11 @@ impl StepStateProvider for TrustDirectoryWidget {
 
 impl TrustDirectoryWidget {
     fn handle_trust(&mut self) {
-        if let Err(e) = set_project_trusted(&self.codex_home, &self.cwd) {
+        let target =
+            resolve_root_git_project_for_trust(&self.cwd).unwrap_or_else(|| self.cwd.clone());
+        if let Err(e) = set_project_trusted(&self.codex_home, &target) {
             tracing::error!("Failed to set project trusted: {e:?}");
-            self.error = Some(e.to_string());
-            // self.error = Some("Failed to set project trusted".to_string());
+            self.error = Some(format!("Failed to set trust for {}: {e}", target.display()));
         }
 
         self.selection = Some(TrustDirectorySelection::Trust);


### PR DESCRIPTION
## Summary
When resolving our current directory as a project, we want to be a little bit more clever:
1. If we're in a sub-directory of a git repo, resolve our project against the root of the git repo
2. If we're in a git worktree, resolve the project against the root of the git repo

## Testing
- [x] Added unit tests
- [x] Confirmed locally with a git worktree (the one i was using for this feature)