### PR TITLE
[apply-patch] Handle multiple context lines

### DIFF
--- a/codex-rs/exec/tests/fixtures/sse_apply_patch_context_update.json
+++ b/codex-rs/exec/tests/fixtures/sse_apply_patch_context_update.json
@@ -1,0 +1,25 @@
+[
+  {
+    "type": "response.output_item.done",
+    "item": {
+      "type": "custom_tool_call",
+      "name": "apply_patch",
+      "input": "*** Begin Patch\n*** Update File: app.py\n@@ class BaseClass:\n@@   def method():\n-    return False\n+    return True\n*** End Patch",
+      "call_id": "__ID__"
+    }
+  },
+  {
+    "type": "response.completed",
+    "response": {
+      "id": "__ID__",
+      "usage": {
+        "input_tokens": 0,
+        "input_tokens_details": null,
+        "output_tokens": 0,
+        "output_tokens_details": null,
+        "total_tokens": 0
+      },
+      "output": []
+    }
+  }
+]


### PR DESCRIPTION
## Summary
Fixes #2578 - the following example would be considered incorrect, despite it being valid according to our system instructions and our official Lark grammar.

```
*** Begin Patch
*** Update File: src/app.py
@@ class BaseClass
@@     def method():
- old_line
+ new_line
*** End Patch
```

## Testing
- [x] Added unit tests