### PR TITLE
transcript hint

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -1130,6 +1130,8 @@ impl WidgetRef for &ChatComposer {
                         Span::from(" send   "),
                         newline_hint_key.set_style(key_hint_style),
                         Span::from(" newline   "),
+                        "Ctrl+T".set_style(key_hint_style),
+                        Span::from(" transcript   "),
                         "Ctrl+C".set_style(key_hint_style),
                         Span::from(" quit"),
                     ]

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__backspace_after_pastes.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__backspace_after_pastes.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "▌                                                                                                   "
-" ⏎ send   Ctrl+J newline   Ctrl+C quit                                                              "
+" ⏎ send   Ctrl+J newline   Ctrl+T transcript   Ctrl+C quit                                          "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__empty.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__empty.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "▌                                                                                                   "
-" ⏎ send   Ctrl+J newline   Ctrl+C quit                                                              "
+" ⏎ send   Ctrl+J newline   Ctrl+T transcript   Ctrl+C quit                                          "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__large.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__large.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "▌                                                                                                   "
-" ⏎ send   Ctrl+J newline   Ctrl+C quit                                                              "
+" ⏎ send   Ctrl+J newline   Ctrl+T transcript   Ctrl+C quit                                          "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__multiple_pastes.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__multiple_pastes.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "▌                                                                                                   "
-" ⏎ send   Ctrl+J newline   Ctrl+C quit                                                              "
+" ⏎ send   Ctrl+J newline   Ctrl+T transcript   Ctrl+C quit                                          "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "▌                                                                                                   "
-" ⏎ send   Ctrl+J newline   Ctrl+C quit                                                              "
+" ⏎ send   Ctrl+J newline   Ctrl+T transcript   Ctrl+C quit                                          "


### PR DESCRIPTION
Adds a hint to use ctrl-t to view transcript for more details

<img width="475" height="49" alt="image" src="https://github.com/user-attachments/assets/6ff650eb-ed54-4699-be04-3c50f0f8f631" />
