### PR TITLE
fix(windows): Enable Ctrl+V image paste on Windows terminals

### DIFF
--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -298,10 +298,13 @@ impl Tui {
                     Some(Ok(event)) = crossterm_events.next() => {
                         match event {
                             // Detect Ctrl+V to attach an image from the clipboard.
+                            // Handle both Press and Release to work across all platforms:
+                            // - Windows typically sends Release events
+                            // - Linux/macOS typically send Press events
                             Event::Key(key_event @ KeyEvent {
                                 code: KeyCode::Char('v'),
                                 modifiers: KeyModifiers::CONTROL,
-                                kind: KeyEventKind::Press,
+                                kind: KeyEventKind::Press | KeyEventKind::Release,
                                 ..
                             }) => {
                                 match paste_image_to_temp_png() {


### PR DESCRIPTION
Fixes cases where Ctrl+V (or Ctrl+Shift+V) fails to attach images from the clipboard, particularly on Windows terminals.

- Windows generates Release events for Ctrl+V, while Linux/macOS generate Press events
- Updated event matching to handle both KeyEventKind::Press and KeyEventKind::Release
- Maintains backward compatibility across all platforms
- Fixes clipboard image paste not working on Windows systems

Fixes #2597 (primary Windows pasting bug)
Fixes #2221