### PR TITLE
[apply-patch] Add binary to path

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -95,7 +95,7 @@ jobs:
           sudo apt install -y musl-tools pkg-config
 
       - name: Cargo build
-        run: cargo build --target ${{ matrix.target }} --release --bin codex
+        run: cargo build --target ${{ matrix.target }} --release --bin codex --bin apply-patch
 
       - name: Stage artifacts
         shell: bash
@@ -105,8 +105,10 @@ jobs:
 
           if [[ "${{ matrix.runner }}" == windows* ]]; then
             cp target/${{ matrix.target }}/release/codex.exe "$dest/codex-${{ matrix.target }}.exe"
+            cp target/${{ matrix.target }}/release/apply-patch.exe "$dest/apply-patch-${{ matrix.target }}.exe"
           else
             cp target/${{ matrix.target }}/release/codex "$dest/codex-${{ matrix.target }}"
+            cp target/${{ matrix.target }}/release/apply-patch "$dest/apply-patch-${{ matrix.target }}"
           fi
 
       - name: Compress artifacts

--- a/codex-cli/scripts/install_native_deps.sh
+++ b/codex-cli/scripts/install_native_deps.sh
@@ -75,17 +75,27 @@ gh run download --dir "$ARTIFACTS_DIR" --repo openai/codex "$WORKFLOW_ID"
 # x64 Linux
 zstd -d "$ARTIFACTS_DIR/x86_64-unknown-linux-musl/codex-x86_64-unknown-linux-musl.zst" \
     -o "$BIN_DIR/codex-x86_64-unknown-linux-musl"
+zstd -d "$ARTIFACTS_DIR/x86_64-unknown-linux-musl/apply-patch-x86_64-unknown-linux-musl.zst" \
+    -o "$BIN_DIR/apply-patch-x86_64-unknown-linux-musl"
 # ARM64 Linux
 zstd -d "$ARTIFACTS_DIR/aarch64-unknown-linux-musl/codex-aarch64-unknown-linux-musl.zst" \
     -o "$BIN_DIR/codex-aarch64-unknown-linux-musl"
+zstd -d "$ARTIFACTS_DIR/aarch64-unknown-linux-musl/apply-patch-aarch64-unknown-linux-musl.zst" \
+    -o "$BIN_DIR/apply-patch-aarch64-unknown-linux-musl"
 # x64 macOS
 zstd -d "$ARTIFACTS_DIR/x86_64-apple-darwin/codex-x86_64-apple-darwin.zst" \
     -o "$BIN_DIR/codex-x86_64-apple-darwin"
+zstd -d "$ARTIFACTS_DIR/x86_64-apple-darwin/apply-patch-x86_64-apple-darwin.zst" \
+    -o "$BIN_DIR/apply-patch-x86_64-apple-darwin"
 # ARM64 macOS
 zstd -d "$ARTIFACTS_DIR/aarch64-apple-darwin/codex-aarch64-apple-darwin.zst" \
     -o "$BIN_DIR/codex-aarch64-apple-darwin"
+zstd -d "$ARTIFACTS_DIR/aarch64-apple-darwin/apply-patch-aarch64-apple-darwin.zst" \
+    -o "$BIN_DIR/apply-patch-aarch64-apple-darwin"
 # x64 Windows
 zstd -d "$ARTIFACTS_DIR/x86_64-pc-windows-msvc/codex-x86_64-pc-windows-msvc.exe.zst" \
     -o "$BIN_DIR/codex-x86_64-pc-windows-msvc.exe"
+zstd -d "$ARTIFACTS_DIR/x86_64-pc-windows-msvc/apply-patch-x86_64-pc-windows-msvc.exe.zst" \
+    -o "$BIN_DIR/apply-patch-x86_64-pc-windows-msvc.exe"
 
 echo "Installed native dependencies into $BIN_DIR"

--- a/codex-cli/scripts/install_native_deps.sh
+++ b/codex-cli/scripts/install_native_deps.sh
@@ -75,27 +75,32 @@ gh run download --dir "$ARTIFACTS_DIR" --repo openai/codex "$WORKFLOW_ID"
 # x64 Linux
 zstd -d "$ARTIFACTS_DIR/x86_64-unknown-linux-musl/codex-x86_64-unknown-linux-musl.zst" \
     -o "$BIN_DIR/codex-x86_64-unknown-linux-musl"
-zstd -d "$ARTIFACTS_DIR/x86_64-unknown-linux-musl/apply-patch-x86_64-unknown-linux-musl.zst" \
-    -o "$BIN_DIR/apply-patch-x86_64-unknown-linux-musl"
+if [ -f "$ARTIFACTS_DIR/x86_64-unknown-linux-musl/apply-patch-x86_64-unknown-linux-musl.zst" ]; then
+  zstd -d "$ARTIFACTS_DIR/x86_64-unknown-linux-musl/apply-patch-x86_64-unknown-linux-musl.zst" -o "$BIN_DIR/apply-patch-x86_64-unknown-linux-musl"
+fi
 # ARM64 Linux
 zstd -d "$ARTIFACTS_DIR/aarch64-unknown-linux-musl/codex-aarch64-unknown-linux-musl.zst" \
     -o "$BIN_DIR/codex-aarch64-unknown-linux-musl"
-zstd -d "$ARTIFACTS_DIR/aarch64-unknown-linux-musl/apply-patch-aarch64-unknown-linux-musl.zst" \
-    -o "$BIN_DIR/apply-patch-aarch64-unknown-linux-musl"
+if [ -f "$ARTIFACTS_DIR/aarch64-unknown-linux-musl/apply-patch-aarch64-unknown-linux-musl.zst" ]; then
+  zstd -d "$ARTIFACTS_DIR/aarch64-unknown-linux-musl/apply-patch-aarch64-unknown-linux-musl.zst" -o "$BIN_DIR/apply-patch-aarch64-unknown-linux-musl"
+fi
 # x64 macOS
 zstd -d "$ARTIFACTS_DIR/x86_64-apple-darwin/codex-x86_64-apple-darwin.zst" \
     -o "$BIN_DIR/codex-x86_64-apple-darwin"
-zstd -d "$ARTIFACTS_DIR/x86_64-apple-darwin/apply-patch-x86_64-apple-darwin.zst" \
-    -o "$BIN_DIR/apply-patch-x86_64-apple-darwin"
+if [ -f "$ARTIFACTS_DIR/x86_64-apple-darwin/apply-patch-x86_64-apple-darwin.zst" ]; then
+  zstd -d "$ARTIFACTS_DIR/x86_64-apple-darwin/apply-patch-x86_64-apple-darwin.zst" -o "$BIN_DIR/apply-patch-x86_64-apple-darwin"
+fi
 # ARM64 macOS
 zstd -d "$ARTIFACTS_DIR/aarch64-apple-darwin/codex-aarch64-apple-darwin.zst" \
     -o "$BIN_DIR/codex-aarch64-apple-darwin"
-zstd -d "$ARTIFACTS_DIR/aarch64-apple-darwin/apply-patch-aarch64-apple-darwin.zst" \
-    -o "$BIN_DIR/apply-patch-aarch64-apple-darwin"
+if [ -f "$ARTIFACTS_DIR/aarch64-apple-darwin/apply-patch-aarch64-apple-darwin.zst" ]; then
+  zstd -d "$ARTIFACTS_DIR/aarch64-apple-darwin/apply-patch-aarch64-apple-darwin.zst" -o "$BIN_DIR/apply-patch-aarch64-apple-darwin"
+fi
 # x64 Windows
 zstd -d "$ARTIFACTS_DIR/x86_64-pc-windows-msvc/codex-x86_64-pc-windows-msvc.exe.zst" \
     -o "$BIN_DIR/codex-x86_64-pc-windows-msvc.exe"
-zstd -d "$ARTIFACTS_DIR/x86_64-pc-windows-msvc/apply-patch-x86_64-pc-windows-msvc.exe.zst" \
-    -o "$BIN_DIR/apply-patch-x86_64-pc-windows-msvc.exe"
+if [ -f "$ARTIFACTS_DIR/x86_64-pc-windows-msvc/apply-patch-x86_64-pc-windows-msvc.exe.zst" ]; then
+  zstd -d "$ARTIFACTS_DIR/x86_64-pc-windows-msvc/apply-patch-x86_64-pc-windows-msvc.exe.zst" -o "$BIN_DIR/apply-patch-x86_64-pc-windows-msvc.exe"
+fi
 
 echo "Installed native dependencies into $BIN_DIR"

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -635,6 +635,7 @@ name = "codex-apply-patch"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "pretty_assertions",
  "similar",
  "tempfile",

--- a/codex-rs/apply-patch/Cargo.toml
+++ b/codex-rs/apply-patch/Cargo.toml
@@ -6,6 +6,10 @@ version = { workspace = true }
 [lib]
 name = "codex_apply_patch"
 path = "src/lib.rs"
+ 
+[[bin]]
+name = "apply-patch"
+path = "src/main.rs"
 
 [lints]
 workspace = true

--- a/codex-rs/apply-patch/Cargo.toml
+++ b/codex-rs/apply-patch/Cargo.toml
@@ -24,3 +24,4 @@ tree-sitter-bash = "0.25.0"
 [dev-dependencies]
 pretty_assertions = "1.4.1"
 tempfile = "3.13.0"
+assert_cmd = "2"

--- a/codex-rs/apply-patch/src/main.rs
+++ b/codex-rs/apply-patch/src/main.rs
@@ -1,0 +1,40 @@
+use std::io::Write;
+use std::process::ExitCode;
+
+fn main() -> ExitCode {
+    // Expect exactly one argument: the full apply_patch payload.
+    let mut args = std::env::args_os();
+    // argv[0]
+    let _argv0 = args.next();
+
+    let patch_arg = match args.next() {
+        Some(arg) => match arg.into_string() {
+            Ok(s) => s,
+            Err(_) => {
+                eprintln!("Error: apply-patch requires a UTF-8 PATCH argument.");
+                return ExitCode::from(1);
+            }
+        },
+        None => {
+            eprintln!("Usage: apply-patch '<apply_patch_payload>'");
+            return ExitCode::from(2);
+        }
+    };
+
+    // Refuse extra args to avoid ambiguity.
+    if args.next().is_some() {
+        eprintln!("Error: apply-patch accepts exactly one argument.");
+        return ExitCode::from(2);
+    }
+
+    let mut stdout = std::io::stdout();
+    let mut stderr = std::io::stderr();
+    match codex_apply_patch::apply_patch(&patch_arg, &mut stdout, &mut stderr) {
+        Ok(()) => {
+            // Flush to ensure output ordering when used in pipelines.
+            let _ = stdout.flush();
+            ExitCode::from(0)
+        }
+        Err(_) => ExitCode::from(1),
+    }
+}

--- a/codex-rs/apply-patch/tests/cli.rs
+++ b/codex-rs/apply-patch/tests/cli.rs
@@ -1,0 +1,48 @@
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+use assert_cmd::prelude::*;
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+#[test]
+fn test_apply_patch_cli_add_and_update() -> anyhow::Result<()> {
+    let tmp = tempdir()?;
+    let file = "cli_test.txt";
+    let absolute_path = tmp.path().join(file);
+
+    // 1) Add a file
+    let add_patch = format!(
+        r#"*** Begin Patch
+*** Add File: {file}
++hello
+*** End Patch"#
+    );
+    Command::cargo_bin("apply-patch")
+        .expect("should find apply-patch binary")
+        .arg(add_patch)
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(format!("Success. Updated the following files:\nA {file}\n"));
+    assert_eq!(fs::read_to_string(&absolute_path)?, "hello\n");
+
+    // 2) Update the file
+    let update_patch = format!(
+        r#"*** Begin Patch
+*** Update File: {file}
+@@
+-hello
++world
+*** End Patch"#
+    );
+    Command::cargo_bin("apply-patch")
+        .expect("should find apply-patch binary")
+        .arg(update_patch)
+        .current_dir(tmp.path())
+        .assert()
+        .success()
+        .stdout(format!("Success. Updated the following files:\nM {file}\n"));
+    assert_eq!(fs::read_to_string(&absolute_path)?, "world\n");
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
Infrequently, certain models will try to use apply_patch as a real bash command. This should decrease dramatically with #2539 and #2576, but I'm opening this as a potential additional fix just in case. Dropping apply_patch as a binary on the PATH will help us reliably catch cases outlined in #2235, without going down the rabbit hole of trying to catch every invocation at the tool call level

## Testing
WIP