### PR TITLE
avoid error when /compact response has no token_usage (#2417)

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2810,15 +2810,15 @@ async fn drain_to_completed(
                 response_id: _,
                 token_usage,
             }) => {
-                if let Some(token_usage) = token_usage {
-                    sess.tx_event
-                        .send(Event {
-                            id: sub_id.to_string(),
-                            msg: EventMsg::TokenCount(token_usage),
-                        })
-                        .await
-                        .ok();
-                }
+                let token_usage = token_usage.unwrap_or_default();
+                sess.tx_event
+                    .send(Event {
+                        id: sub_id.to_string(),
+                        msg: EventMsg::TokenCount(token_usage),
+                    })
+                    .await
+                    .ok();
+
                 return Ok(());
             }
             Ok(_) => continue,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2810,22 +2810,15 @@ async fn drain_to_completed(
                 response_id: _,
                 token_usage,
             }) => {
-                let token_usage = match token_usage {
-                    Some(usage) => usage,
-                    None => {
-                        return Err(CodexErr::Stream(
-                            "token_usage was None in ResponseEvent::Completed".into(),
-                            None,
-                        ));
-                    }
-                };
-                sess.tx_event
-                    .send(Event {
-                        id: sub_id.to_string(),
-                        msg: EventMsg::TokenCount(token_usage),
-                    })
-                    .await
-                    .ok();
+                if let Some(token_usage) = token_usage {
+                    sess.tx_event
+                        .send(Event {
+                            id: sub_id.to_string(),
+                            msg: EventMsg::TokenCount(token_usage),
+                        })
+                        .await
+                        .ok();
+                }
                 return Ok(());
             }
             Ok(_) => continue,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2810,6 +2810,8 @@ async fn drain_to_completed(
                 response_id: _,
                 token_usage,
             }) => {
+                // some providers don't return token usage, so we default
+                // TODO: consider approximate token usage
                 let token_usage = token_usage.unwrap_or_default();
                 sess.tx_event
                     .send(Event {


### PR DESCRIPTION
**Context**  
When running `/compact`, `drain_to_completed` would throw an error if `token_usage` was `None` in `ResponseEvent::Completed`. This made the command fail even though everything else had succeeded.  

**What changed**  
- Instead of erroring, we now just check `if let Some(token_usage)` before sending the event.  
- If it’s missing, we skip it and move on.  

**Why**  
This makes `AgentTask::compact()` behave in the same way as `AgentTask::spawn()`, which also doesn’t error out when `token_usage` isn’t available. Keeps things consistent and avoids unnecessary failures.  

**Fixes**  
Closes #2417 