### PR TITLE
fix: update gpt-5 stats

### DIFF
--- a/codex-rs/core/src/openai_model_info.rs
+++ b/codex-rs/core/src/openai_model_info.rs
@@ -79,13 +79,13 @@ pub(crate) fn get_model_info(model_family: &ModelFamily) -> Option<ModelInfo> {
         }),
 
         "gpt-5" => Some(ModelInfo {
-            context_window: 200_000,
-            max_output_tokens: 100_000,
+            context_window: 400_000,
+            max_output_tokens: 128_000,
         }),
 
         _ if slug.starts_with("codex-") => Some(ModelInfo {
-            context_window: 200_000,
-            max_output_tokens: 100_000,
+            context_window: 400_000,
+            max_output_tokens: 128_000,
         }),
 
         _ => None,


### PR DESCRIPTION
- To match what's on <https://platform.openai.com/docs/models/gpt-5>.