### PR TITLE
docs: #2650  Add a link to Github releases to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 You can install any of these versions: `npm install -g codex@version`
 
+> [!IMPORTANT]
+> This file is no longer maintained. For newer release notes, visit https://github.com/openai/codex/releases instead.
+
 ## `0.1.2505172129`
 
 ### 🪲 Bug Fixes


### PR DESCRIPTION
Since the file is no longer maintained, we should navigate visitors to the GitHub releases page.

Resolves #2650