### PR TITLE
feat: #2616 save chat history as suggestions during the same session

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer_history.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer_history.rs
@@ -135,6 +135,19 @@ impl ChatComposerHistory {
         }
     }
 
+    /// Return the tail of the most recent history entry that starts with `prefix`.
+    pub(crate) fn suggest(&self, prefix: &str) -> Option<String> {
+        if prefix.is_empty() {
+            return None;
+        }
+        self.local_history
+            .iter()
+            .rev()
+            .chain(self.fetched_history.values())
+            .find(|entry| entry.starts_with(prefix) && entry.len() > prefix.len())
+            .map(|entry| entry[prefix.len()..].to_string())
+    }
+
     /// Integrate a GetHistoryEntryResponse event.
     pub fn on_entry_response(
         &mut self,


### PR DESCRIPTION
This pull request aims to resolves #2616 by adding auto-completion suggestions using the past prompts you use in the same session. If you type the same prefix with past prompts, a suggestion shows up and you can select it by hitting tab key. See the screenshot below:

<img width="600" src="https://github.com/user-attachments/assets/4f023e4c-c5f7-4737-b137-ed8b38342d73" />
