### PR TITLE
fix: add missing boolean parameter to openai_tools test function

### DIFF
--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -724,6 +724,7 @@ mod tests {
             SandboxPolicy::ReadOnly,
             false,
             false,
+            true,
             /*use_experimental_streamable_shell_tool*/ false,
         );
 

--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -783,6 +783,7 @@ mod tests {
             &tools,
             &[
                 "shell",
+                "web_search",
                 "test_server/cool",
                 "test_server/do",
                 "test_server/something",


### PR DESCRIPTION
## Why
An upstream interface change landed before #2611 and caused the new test to fail to build.

## What
Update to match the parameters introduced upstream.
No behavior change; tests-only.