### PR TITLE
docs: add tip for setting default profile in configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,16 @@ model = "mistral"
 
 This way, you can specify one command-line argument (.e.g., `--profile o3`, `--profile mistral`) to override multiple settings together.
 
+> [!TIP]
+> To make a custom profile like `o3` the default (so you can run just `codex` instead of `codex --profile o3`), set `profile = "o3"` at the top level of `~/.codex/config.toml`:
+>
+> ```toml
+> # ~/.codex/config.toml
+> profile = "o3"
+> ```
+>
+> Now `codex` will automatically use the `o3` profile settings, no need for `--profile o3` each time.
+
 </details>
 
 Codex can run fully locally against an OpenAI-compatible OSS host (like Ollama) using the `--oss` flag:


### PR DESCRIPTION
## Summary
- Added a tip in the README explaining how to set a default profile in the configuration
- Users can now understand how to avoid typing `--profile` flag repeatedly

## What
This PR adds documentation in the "Using Open Source Models" section that explains how to set a custom profile as the default by adding `profile = "o3"` at the top level of `~/.codex/config.toml`.

## Why
Users who frequently use custom profiles (like `o3` or `mistral`) currently need to specify `--profile` with every command. This documentation helps them configure a default profile for a smoother workflow.

## How
Added a tip box with clear instructions and example configuration showing how to set the `profile` parameter in the config file.

## Testing
- Documentation-only change
- Verified markdown formatting is correct
- Example provided follows existing configuration patterns in the codebase