### PR TITLE
Fix link to model providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,7 +293,7 @@ they'll be committed to your working directory.
 
 Codex also allows you to use other providers that support the OpenAI Chat Completions (or Responses) API.
 
-To do so, you must first define custom [providers](./config.md#model_providers) in `~/.codex/config.toml`. For example, the provider for a standard Ollama setup would be defined as follows:
+To do so, you must first define custom [providers](./codex-rs/config.md#model_providers) in `~/.codex/config.toml`. For example, the provider for a standard Ollama setup would be defined as follows:
 
 ```toml
 [model_providers.ollama]


### PR DESCRIPTION
## What
Fix broken link to custom providers in the documentation.

## Why
The current link is incorrect, which can confuse contributors/users trying to find provider setup details.

## How
Updated the link to point to the correct doc.
