### PR TITLE
do not schedule frames for Tui::Draw events in backtrack

### DIFF
--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -207,9 +207,9 @@ impl App {
             overlay.handle_event(tui, event)?;
             if overlay.is_done {
                 self.close_transcript_overlay(tui);
+                tui.frame_requester().schedule_frame();
             }
         }
-        tui.frame_requester().schedule_frame();
         Ok(())
     }
 


### PR DESCRIPTION
this was causing continuous rerendering when a transcript overlay was present