### PR TITLE
fix(conversation_history): dedupe the assistant messages

### DIFF
--- a/codex-rs/core/src/conversation_history.rs
+++ b/codex-rs/core/src/conversation_history.rs
@@ -112,8 +112,8 @@ fn is_api_message(message: &ResponseItem) -> bool {
         | ResponseItem::FunctionCall { .. }
         | ResponseItem::CustomToolCall { .. }
         | ResponseItem::CustomToolCallOutput { .. }
-        | ResponseItem::LocalShellCall { .. }
-        | ResponseItem::Reasoning { .. } => true,
+        | ResponseItem::LocalShellCall { .. } => true,
+        ResponseItem::Reasoning { .. } => false,
         ResponseItem::Other => false,
     }
 }


### PR DESCRIPTION
Here is what we see in the request:
<img width="1840" height="1178" alt="Screenshot 2025-08-25 at 9 35 37 PM" src="https://github.com/user-attachments/assets/86a27115-844b-47ee-bdfa-35225e5149b0" />

As you can see, there are two duplicate assistant responses.

Asking the model, we see that it is aware of them.

```output
codex
Hi! Ready when you are—what should we tackle in codex-rs? I can run tests, scan the repo, or make a targeted change.

user
tell me all the messages you see in our conversation history (even if they are duplicates)

I am trying to debug something.

[...]
Conversation History

- User 1: <user_instructions> ... We need to include this in full as written.
- User 2: <environment_context> Current working directory: /Users/brain/Coding/snipeship/codex/codex-rs ... We’ll include this too.
- User 3: hello
- Assistant 1: Hey! What would you like to do in codex-rs? I can explore the repo, run tests, or make targeted changes.
- Assistant 2: same again.
- User 4: helloooo
- Assistant 3: Hi! Ready when you are—what should we tackle in codex-rs? I can run tests, scan the repo, or make a targeted change.
- Assistant 4: same again.
- User 5: tell me all the messages you see in our conversation history (even if they are duplicates).

I see two duplicate assistant messages; want me to run a quick check for the CLI bug? If you'd like system or developer messages included, I can add them. I omitted
internal system/developer setup messages; say if you want those too.
```

---

This pull request refines how assistant messages are merged in the `ConversationHistory` to handle cases where non-message items (like reasoning) are interleaved, and improves message deduplication and updating logic. It also adds new helper functions and more comprehensive tests to ensure correct behavior, especially around message merging and id upgrades.

### Message merging improvements

* The logic for merging adjacent assistant messages in `ConversationHistory::record_items` now merges with the most recent prior assistant message, skipping over any interleaved non-message items (such as reasoning), and handles cases where the final message is a superset or identical to the previous message, including id upgrades.

### Helper functions

* Added the `concat_output_text` function to concatenate all `OutputText` fragments in a message's content, used to compare message text when merging.

### Testing enhancements

* Added new test helpers (`assistant_msg_with_id`, `reasoning`) and new test cases to verify merging across reasoning items, upgrading ids when messages are identical, and replacing content when the final message is a superset. [[1]](diffhunk://#diff-d20f15dab38e44d260cd2bf2713227756c4216d273c77400b4217155623495bbR208-R226) [[2]](diffhunk://#diff-d20f15dab38e44d260cd2bf2713227756c4216d273c77400b4217155623495bbR310-R366)

### Documentation updates

* Updated the comment on `is_api_message` to clarify that `Reasoning` items are currently persisted for forwarding purposes, reflecting actual behavior.

closes #2697 