### PR TITLE
[fix] emoji padding

### DIFF
--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__interrupt_exec_marks_failed.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__interrupt_exec_marks_failed.snap
@@ -3,4 +3,4 @@ source: tui/src/chatwidget/tests.rs
 expression: exec_blob
 ---
 >_
-  ✗ ⌨️ sleep 1
+  ✗ ⌨  sleep 1

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1207,7 +1207,7 @@ fn stream_error_is_rendered_to_history() {
     let cells = drain_insert_history(&mut rx);
     assert!(!cells.is_empty(), "expected a history cell for StreamError");
     let blob = lines_to_single_string(cells.last().unwrap());
-    assert!(blob.contains("⚠ "));
+    assert!(blob.contains("⚠  "));
     assert!(blob.contains("stream error:"));
     assert!(blob.contains("idle timeout waiting for SSE"));
 }


### PR DESCRIPTION
- We use emojis as bullet icons of sorts, and in some common terminals like Terminal or iTerm, these can render with insufficient padding between the emoji and following text.
- This PR makes emoji look better in Terminal and iTerm, at the expense of Ghostty. (All default fonts.)

# Terminal

<img width="420" height="123" alt="image" src="https://github.com/user-attachments/assets/93590703-e35a-4781-a697-881d7ec95598" />

# iTerm

<img width="465" height="163" alt="image" src="https://github.com/user-attachments/assets/f11e6558-d2db-4727-bb7e-2b61eed0a3b1" />

# Ghostty

<img width="485" height="142" alt="image" src="https://github.com/user-attachments/assets/7a7b021f-5238-4672-8066-16cd1da32dc6" />

