### PR TITLE
[feat] Simplfy command approval UI

### DIFF
--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -530,7 +530,7 @@ mod tests {
         // Push an approval modal (e.g., command approval) which should hide the status view.
         pane.push_approval_request(exec_request());
 
-        // Simulate pressing 'n' (deny) on the modal.
+        // Simulate pressing 'n' (No) on the modal.
         use crossterm::event::KeyCode;
         use crossterm::event::KeyEvent;
         use crossterm::event::KeyModifiers;

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_exec.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_exec.snap
@@ -8,6 +8,6 @@ expression: terminal.backend()
 "Model wants to run a command                                                    "
 "                                                                                "
 "▌Allow command?                                                                 "
-"▌ Yes   Always   No   No, provide feedback                                      "
+"▌ Yes   Always   No, provide feedback                                           "
 "▌ Approve and run the command                                                   "
 "                                                                                "

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_patch.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_patch.snap
@@ -8,6 +8,6 @@ expression: terminal.backend()
 "This will grant write access to /tmp for the remainder of this session.         "
 "                                                                                "
 "▌Apply changes?                                                                 "
-"▌ Yes   No   No, provide feedback                                               "
+"▌ Yes   No, provide feedback                                                    "
 "▌ Approve and apply the changes                                                 "
 "                                                                                "

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_widget_and_approval_modal.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_widget_and_approval_modal.snap
@@ -8,6 +8,6 @@ expression: terminal.backend()
 "Codex wants to run a command                                                    "
 "                                                                                "
 "▌Allow command?                                                                 "
-"▌ Yes   Always   No   No, provide feedback                                      "
+"▌ Yes   Always   No, provide feedback                                           "
 "▌ Approve and run the command                                                   "
 "                                                                                "

--- a/codex-rs/tui/src/user_approval_widget.rs
+++ b/codex-rs/tui/src/user_approval_widget.rs
@@ -69,20 +69,9 @@ static COMMAND_SELECT_OPTIONS: LazyLock<Vec<SelectOption>> = LazyLock::new(|| {
             decision: ReviewDecision::ApprovedForSession,
         },
         SelectOption {
-            label: Line::from(vec!["N".underlined(), "o".into()]),
-            description: "Do not run the command",
-            key: KeyCode::Char('n'),
-            decision: ReviewDecision::Denied,
-        },
-        SelectOption {
-            label: Line::from(vec![
-                "No, ".into(),
-                "provide ".into(),
-                "f".underlined(),
-                "eedback".into(),
-            ]),
+            label: Line::from(vec!["N".underlined(), "o, provide feedback".into()]),
             description: "Do not run the command; provide feedback",
-            key: KeyCode::Char('f'),
+            key: KeyCode::Char('n'),
             decision: ReviewDecision::Abort,
         },
     ]
@@ -97,20 +86,9 @@ static PATCH_SELECT_OPTIONS: LazyLock<Vec<SelectOption>> = LazyLock::new(|| {
             decision: ReviewDecision::Approved,
         },
         SelectOption {
-            label: Line::from(vec!["N".underlined(), "o".into()]),
-            description: "Do not apply the changes",
-            key: KeyCode::Char('n'),
-            decision: ReviewDecision::Denied,
-        },
-        SelectOption {
-            label: Line::from(vec![
-                "No, ".into(),
-                "provide ".into(),
-                "f".underlined(),
-                "eedback".into(),
-            ]),
+            label: Line::from(vec!["N".underlined(), "o, provide feedback".into()]),
             description: "Do not apply the changes; provide feedback",
-            key: KeyCode::Char('f'),
+            key: KeyCode::Char('n'),
             decision: ReviewDecision::Abort,
         },
     ]


### PR DESCRIPTION
- Removed the plain "No" option, which confused the model,
  since we already have the "No, provide feedback" option,
  which works better.

# Before

<img width="476" height="168" alt="image" src="https://github.com/user-attachments/assets/6e783d9f-dec9-4610-9cad-8442eb377a90" />

# After

<img width="553" height="175" alt="image" src="https://github.com/user-attachments/assets/3cdae582-3366-47bc-9753-288930df2324" />