### PR TITLE
fix issue #2713: adding support for alt+ctrl+h to delete backward word

### DIFF
--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -232,6 +232,13 @@ impl TextArea {
                 ..
             } => self.insert_str("\n"),
             KeyEvent {
+                code: KeyCode::Char('h'),
+                modifiers,
+                ..
+            } if modifiers == (KeyModifiers::CONTROL | KeyModifiers::ALT) => {
+                self.delete_backward_word()
+            },
+            KeyEvent {
                 code: KeyCode::Backspace,
                 modifiers: KeyModifiers::ALT,
                 ..
@@ -1169,6 +1176,30 @@ mod tests {
         // ^F (U+0006) should move right
         t.input(KeyEvent::new(KeyCode::Char('\u{0006}'), KeyModifiers::NONE));
         assert_eq!(t.cursor(), 2);
+    }
+
+    #[test]
+    fn delete_backward_word_alt_keys() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        // Test the custom Alt+Ctrl+h binding
+        let mut t = ta_with("hello world");
+        t.set_cursor(t.text().len()); // cursor at the end
+        t.input(KeyEvent::new(
+            KeyCode::Char('h'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        ));
+        assert_eq!(t.text(), "hello ");
+        assert_eq!(t.cursor(), 6);
+
+        // Test the standard Alt+Backspace binding
+        let mut t = ta_with("hello world");
+        t.set_cursor(t.text().len()); // cursor at the end
+        t.input(KeyEvent::new(KeyCode::Backspace, KeyModifiers::ALT));
+        assert_eq!(t.text(), "hello ");
+        assert_eq!(t.cursor(), 6);
     }
 
     #[test]

--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -1203,6 +1203,32 @@ mod tests {
     }
 
     #[test]
+    fn ctrl_h_backspace() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        // Test Ctrl+H as backspace
+        let mut t = ta_with("hello");
+        t.set_cursor(3); // cursor after 'l'
+        t.input(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::CONTROL));
+        assert_eq!(t.text(), "helo");
+        assert_eq!(t.cursor(), 2);
+
+        // Test Ctrl+H at beginning (should be no-op)
+        t.set_cursor(0);
+        t.input(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::CONTROL));
+        assert_eq!(t.text(), "helo");
+        assert_eq!(t.cursor(), 0);
+
+        // Test Ctrl+H at end
+        t.set_cursor(t.text().len());
+        t.input(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::CONTROL));
+        assert_eq!(t.text(), "hel");
+        assert_eq!(t.cursor(), 3);
+    }
+
+    #[test]
     fn cursor_vertical_movement_across_lines_and_bounds() {
         let mut t = ta_with("short\nloooooooooong\nmid");
         // Place cursor on second line, column 5

--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -1145,10 +1145,6 @@ mod tests {
 
     #[test]
     fn control_b_and_f_move_cursor() {
-        use crossterm::event::KeyCode;
-        use crossterm::event::KeyEvent;
-        use crossterm::event::KeyModifiers;
-
         let mut t = ta_with("abcd");
         t.set_cursor(1);
 
@@ -1161,10 +1157,6 @@ mod tests {
 
     #[test]
     fn control_b_f_fallback_control_chars_move_cursor() {
-        use crossterm::event::KeyCode;
-        use crossterm::event::KeyEvent;
-        use crossterm::event::KeyModifiers;
-
         let mut t = ta_with("abcd");
         t.set_cursor(2);
 
@@ -1180,10 +1172,6 @@ mod tests {
 
     #[test]
     fn delete_backward_word_alt_keys() {
-        use crossterm::event::KeyCode;
-        use crossterm::event::KeyEvent;
-        use crossterm::event::KeyModifiers;
-
         // Test the custom Alt+Ctrl+h binding
         let mut t = ta_with("hello world");
         t.set_cursor(t.text().len()); // cursor at the end
@@ -1203,28 +1191,24 @@ mod tests {
     }
 
     #[test]
-    fn ctrl_h_backspace() {
-        use crossterm::event::KeyCode;
-        use crossterm::event::KeyEvent;
-        use crossterm::event::KeyModifiers;
-
+    fn control_h_backspace() {
         // Test Ctrl+H as backspace
-        let mut t = ta_with("hello");
-        t.set_cursor(3); // cursor after 'l'
+        let mut t = ta_with("12345");
+        t.set_cursor(3); // cursor after '3'
         t.input(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::CONTROL));
-        assert_eq!(t.text(), "helo");
+        assert_eq!(t.text(), "1245");
         assert_eq!(t.cursor(), 2);
 
         // Test Ctrl+H at beginning (should be no-op)
         t.set_cursor(0);
         t.input(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::CONTROL));
-        assert_eq!(t.text(), "helo");
+        assert_eq!(t.text(), "1245");
         assert_eq!(t.cursor(), 0);
 
         // Test Ctrl+H at end
         t.set_cursor(t.text().len());
         t.input(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::CONTROL));
-        assert_eq!(t.text(), "hel");
+        assert_eq!(t.text(), "124");
         assert_eq!(t.cursor(), 3);
     }
 


### PR DESCRIPTION
This pr addresses the fix for https://github.com/openai/codex/issues/2713 

### Changes:
  - Added key handler for `Alt+Ctrl+H` → `delete_backward_word()`
  - Added test coverage in `delete_backward_word_alt_keys()` that verifies both:
    - Standard `Alt+Backspace` binding continues to work
    - New `Alt+Ctrl+H` binding works correctly for backward word deletion

### Testing:
  The test ensures both key combinations produce identical behavior:
  - Delete the previous word from "hello world" → "hello "
  - Cursor positioned correctly after deletion

###  Backward Compatibility:
  This change is backward compatible - existing `Alt+Backspace` functionality remains unchanged while adding support for the terminal-specific `Alt+Ctrl+H` variant