### PR TITLE
Make web search approval per-turn

### DIFF
--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -257,3 +257,5 @@ mod tests {
         assert!(v.get("text").is_none());
     }
 }
+
+// (No ToolChoice support; tool selection remains "auto".)

--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -257,5 +257,3 @@ mod tests {
         assert!(v.get("text").is_none());
     }
 }
-
-// (No ToolChoice support; tool selection remains "auto".)

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -963,6 +963,7 @@ impl Session {
             false
         }
     }
+
 }
 
 impl Drop for Session {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -65,8 +65,8 @@ use crate::mcp_tool_call::handle_mcp_tool_call;
 use crate::model_family::find_family_for_model;
 use crate::openai_model_info::get_model_info;
 use crate::openai_tools::ApplyPatchToolArgs;
-use crate::openai_tools::ToolsConfig;
 use crate::openai_tools::OpenAiTool;
+use crate::openai_tools::ToolsConfig;
 use crate::openai_tools::ToolsConfigParams;
 use crate::openai_tools::get_openai_tools;
 use crate::parse_command::parse_command;
@@ -1605,7 +1605,6 @@ async fn run_turn(
     if sess.consume_enable_web_search_next_turn() {
         tools.push(OpenAiTool::WebSearch {});
     } else if matches!(turn_context.approval_policy, AskForApproval::Never) {
-        // YOLO: allow native web_search and hide request tool for direct use.
         let has_web = tools.iter().any(|t| matches!(t, OpenAiTool::WebSearch {}));
         if !has_web {
             tools.push(OpenAiTool::WebSearch {});
@@ -2133,13 +2132,15 @@ async fn handle_function_call(
                         },
                     }
                 }
-                ReviewDecision::Denied | ReviewDecision::Abort => ResponseInputItem::FunctionCallOutput {
-                    call_id,
-                    output: FunctionCallOutputPayload {
-                        content: "denied".to_string(),
-                        success: Some(false),
-                    },
-                },
+                ReviewDecision::Denied | ReviewDecision::Abort => {
+                    ResponseInputItem::FunctionCallOutput {
+                        call_id,
+                        output: FunctionCallOutputPayload {
+                            content: "denied".to_string(),
+                            success: Some(false),
+                        },
+                    }
+                }
             }
         }
         "container.exec" | "shell" => {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1913,6 +1913,13 @@ async fn run_compact_task(
         }
     }
 
+    // Prune history to keep only the summarized assistant message before
+    // signaling completion so the next request sees the compacted context.
+    {
+        let mut state = sess.state.lock_unchecked();
+        state.history.keep_last_messages(1);
+    }
+
     sess.remove_task(&sub_id);
     let event = Event {
         id: sub_id.clone(),
@@ -1928,9 +1935,6 @@ async fn run_compact_task(
         }),
     };
     sess.send_event(event).await;
-
-    let mut state = sess.state.lock_unchecked();
-    state.history.keep_last_messages(1);
 }
 
 async fn handle_response_item(

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -963,7 +963,6 @@ impl Session {
             false
         }
     }
-
 }
 
 impl Drop for Session {

--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -337,7 +337,7 @@ fn create_web_search_request_tool() -> OpenAiTool {
     );
     OpenAiTool::Function(ResponsesApiTool {
         name: "web_search_request".to_string(),
-        description: "Request user approval to perform a web search with the given query"
+        description: "Request user approval to perform a web search with the given query. If approved, you must call the native web_search (or web.run) tool on your next turn using the approved query before answering."
             .to_string(),
         strict: false,
         parameters: JsonSchema::Object {

--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -664,7 +664,7 @@ mod tests {
 
         assert_eq_tool_names(
             &tools,
-            &["local_shell", "update_plan", "web_search_request"],
+            &["local_shell", "update_plan", "web_search_request", "view_image"],
         );
     }
 
@@ -683,7 +683,10 @@ mod tests {
         });
         let tools = get_openai_tools(&config, Some(HashMap::new()));
 
-        assert_eq_tool_names(&tools, &["shell", "update_plan", "web_search"]);
+        assert_eq_tool_names(
+            &tools,
+            &["shell", "update_plan", "web_search_request", "view_image"],
+        );
     }
 
     #[test]
@@ -742,6 +745,7 @@ mod tests {
             &[
                 "shell",
                 "web_search_request",
+                "view_image",
                 "test_server/do_something_cool",
             ],
         );
@@ -859,6 +863,8 @@ mod tests {
             &tools,
             &[
                 "shell",
+                "web_search_request",
+                "view_image",
                 "test_server/cool",
                 "test_server/do",
                 "test_server/something",
@@ -903,7 +909,10 @@ mod tests {
             )])),
         );
 
-        assert_eq_tool_names(&tools, &["shell", "web_search", "dash/search"]);
+        assert_eq_tool_names(
+            &tools,
+            &["shell", "web_search_request", "view_image", "dash/search"],
+        );
 
         assert_eq!(
             tools[3],
@@ -962,7 +971,7 @@ mod tests {
 
         assert_eq_tool_names(
             &tools,
-            &["shell", "web_search", "view_image", "dash/paginate"],
+            &["shell", "web_search_request", "view_image", "dash/paginate"],
         );
         assert_eq!(
             tools[3],
@@ -1017,7 +1026,10 @@ mod tests {
             )])),
         );
 
-        assert_eq_tool_names(&tools, &["shell", "web_search", "view_image", "dash/tags"]);
+        assert_eq_tool_names(
+            &tools,
+            &["shell", "web_search_request", "view_image", "dash/tags"],
+        );
         assert_eq!(
             tools[3],
             OpenAiTool::Function(ResponsesApiTool {
@@ -1074,7 +1086,10 @@ mod tests {
             )])),
         );
 
-        assert_eq_tool_names(&tools, &["shell", "web_search", "view_image", "dash/value"]);
+        assert_eq_tool_names(
+            &tools,
+            &["shell", "web_search_request", "view_image", "dash/value"],
+        );
         assert_eq!(
             tools[3],
             OpenAiTool::Function(ResponsesApiTool {

--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -662,7 +662,10 @@ mod tests {
         });
         let tools = get_openai_tools(&config, Some(HashMap::new()));
 
-        assert_eq_tool_names(&tools, &["local_shell", "update_plan", "web_search"]);
+        assert_eq_tool_names(
+            &tools,
+            &["local_shell", "update_plan", "web_search_request"],
+        );
     }
 
     #[test]
@@ -736,7 +739,11 @@ mod tests {
 
         assert_eq_tool_names(
             &tools,
-            &["shell", "web_search", "test_server/do_something_cool"],
+            &[
+                "shell",
+                "web_search_request",
+                "test_server/do_something_cool",
+            ],
         );
 
         assert_eq!(
@@ -847,7 +854,7 @@ mod tests {
         ]);
 
         let tools = get_openai_tools(&config, Some(tools_map));
-        // Expect shell first, then approval tool, then MCP tools sorted by name.
+        // Expect shell first, then search approval tool, then MCP tools sorted by name.
         assert_eq_tool_names(
             &tools,
             &[

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -191,7 +191,13 @@ async fn prompt_tools_are_consistent_across_requests() {
     let expected_instructions: &str = include_str!("../../prompt.md");
     // our internal implementation is responsible for keeping tools in sync
     // with the OpenAI schema, so we just verify the tool presence here
-    let expected_tools_names: &[&str] = &["shell", "update_plan", "apply_patch", "view_image"];
+    let expected_tools_names: &[&str] = &[
+        "shell",
+        "update_plan",
+        "apply_patch",
+        "web_search_request",
+        "view_image",
+    ];
     let body0 = requests[0].body_json::<serde_json::Value>().unwrap();
     assert_eq!(
         body0["instructions"],

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -363,7 +363,9 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                 }
             }
             EventMsg::WebSearchBegin(WebSearchBeginEvent { call_id: _, query }) => {
-                ts_println!(self, "🌐 {query}");
+                if query.trim() != "Searching Web..." {
+                    ts_println!(self, "🌐 {query}");
+                }
             }
             EventMsg::PatchApplyBegin(PatchApplyBeginEvent {
                 call_id,

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -356,8 +356,14 @@ impl ChatWidget {
     }
 
     fn on_web_search_begin(&mut self, ev: WebSearchBeginEvent) {
+        // If we don't have the actual query, show a generic label instead of nothing.
+        let label = if ev.query.trim() == "Searching Web..." {
+            "Searched the web".to_string()
+        } else {
+            ev.query
+        };
         self.flush_answer_stream_with_separator();
-        self.add_to_history(history_cell::new_web_search_call(ev.query));
+        self.add_to_history(history_cell::new_web_search_call(label));
     }
 
     fn on_get_history_entry_response(

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -356,14 +356,11 @@ impl ChatWidget {
     }
 
     fn on_web_search_begin(&mut self, ev: WebSearchBeginEvent) {
-        // If we don't have the actual query, show a generic label instead of nothing.
-        let label = if ev.query.trim() == "Searching Web..." {
-            "Searched the web".to_string()
-        } else {
-            ev.query
-        };
+        if ev.query.trim() == "Searching Web..." {
+            return;
+        }
         self.flush_answer_stream_with_separator();
-        self.add_to_history(history_cell::new_web_search_call(label));
+        self.add_to_history(history_cell::new_web_search_call(ev.query));
     }
 
     fn on_get_history_entry_response(

--- a/codex-rs/tui/src/user_approval_widget.rs
+++ b/codex-rs/tui/src/user_approval_widget.rs
@@ -151,9 +151,14 @@ impl UserApprovalWidget {
                 );
 
                 contents.push(Line::from(""));
-                if let Some(reason) = reason {
+                // Suppress the generic reason line for web_search approvals to
+                // keep the UI concise.
+                let is_web_search = command.first().map(|s| s == "web_search").unwrap_or(false);
+                if !is_web_search {
+                    if let Some(reason) = reason {
                     contents.push(Line::from(reason.clone().italic()));
                     contents.push(Line::from(""));
+                    }
                 }
                 Paragraph::new(contents).wrap(Wrap { trim: false })
             }
@@ -388,7 +393,13 @@ impl WidgetRef for &UserApprovalWidget {
         ])
         .areas(response_chunk.inner(Margin::new(1, 0)));
         let title = match &self.approval_request {
-            ApprovalRequest::Exec { .. } => "Allow command?",
+            ApprovalRequest::Exec { command, .. } => {
+                if command.first().map(|s| s == "web_search").unwrap_or(false) {
+                    "Allow search?"
+                } else {
+                    "Allow command?"
+                }
+            }
             ApprovalRequest::ApplyPatch { .. } => "Apply changes?",
         };
         Line::from(title).render(title_area, buf);

--- a/codex-rs/tui/src/user_approval_widget.rs
+++ b/codex-rs/tui/src/user_approval_widget.rs
@@ -151,13 +151,11 @@ impl UserApprovalWidget {
                 );
 
                 contents.push(Line::from(""));
-                // Suppress the generic reason line for web_search approvals to
-                // keep the UI concise.
                 let is_web_search = command.first().map(|s| s == "web_search").unwrap_or(false);
                 if !is_web_search {
                     if let Some(reason) = reason {
-                    contents.push(Line::from(reason.clone().italic()));
-                    contents.push(Line::from(""));
+                        contents.push(Line::from(reason.clone().italic()));
+                        contents.push(Line::from(""));
                     }
                 }
                 Paragraph::new(contents).wrap(Wrap { trim: false })

--- a/codex-rs/tui/src/user_approval_widget.rs
+++ b/codex-rs/tui/src/user_approval_widget.rs
@@ -152,11 +152,9 @@ impl UserApprovalWidget {
 
                 contents.push(Line::from(""));
                 let is_web_search = command.first().map(|s| s == "web_search").unwrap_or(false);
-                if !is_web_search {
-                    if let Some(reason) = reason {
-                        contents.push(Line::from(reason.clone().italic()));
-                        contents.push(Line::from(""));
-                    }
+                if !is_web_search && let Some(reason) = reason {
+                    contents.push(Line::from(reason.clone().italic()));
+                    contents.push(Line::from(""));
                 }
                 Paragraph::new(contents).wrap(Wrap { trim: false })
             }


### PR DESCRIPTION
Replaces the --search flag with a per-turn approval flow for web search, showing the user the search query. 

The Responses API search tool only shows the query _after_ the request, but we want the user to see the query _before_ approval. We work around this by wrapping web search in a function tool, web_search_request { query }. `query` is shown to the user for the approval, and upon approval, we expose the native web_search tool for the next turn. Tool choice remains “auto” for provider compatibility. When in yolo mode (AskForApproval=Never) we hide the wrapper and expose web_search directly.
