### PR TITLE
tui: render keyboard icon with emoji variation selector (⌨️)

### DIFF
--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__interrupt_exec_marks_failed.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__interrupt_exec_marks_failed.snap
@@ -3,4 +3,4 @@ source: tui/src/chatwidget/tests.rs
 expression: exec_blob
 ---
 >_
-  ✗ ⌨  sleep 1
+  ✗ ⌨️  sleep 1

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -396,7 +396,7 @@ fn new_parsed_command(
             ParsedCommand::Format { .. } => padded_emoji_with("✨", "Formatting"),
             ParsedCommand::Test { cmd } => padded_emoji_with("🧪", cmd),
             ParsedCommand::Lint { cmd, .. } => padded_emoji_with("🧹", cmd),
-            ParsedCommand::Unknown { cmd } => padded_emoji_with("⌨", cmd),
+            ParsedCommand::Unknown { cmd } => padded_emoji_with("⌨️", cmd),
             ParsedCommand::Noop { cmd } => padded_emoji_with("🔄", cmd),
         };
         // Prefix: two spaces, marker, space. Continuations align under the text block.


### PR DESCRIPTION
Use emoji variation selector (VS16) for the keyboard icon so it consistently renders as emoji (⌨️) rather than text (⌨) across terminals.

Touches TUI command rendering for unknown parsed commands. No behavior change beyond display.
