### PR TITLE
Login UX fix: MacOS secure login with native browser companion app

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -191,3 +191,18 @@ jobs:
           # Otherwise require the jobs to have succeeded
           [[ '${{ needs.general.result }}' == 'success' ]] || { echo 'general failed'; exit 1; }
           [[ '${{ needs.lint_build_test.result }}' == 'success' ]] || { echo 'matrix failed'; exit 1; }
+
+  # --- Focused macOS test job for native browser flow ------------------------
+  macos-native-login-tests:
+    name: macOS native login tests
+    runs-on: macos-14
+    needs: changed
+    if: ${{ needs.changed.outputs.codex == 'true' || needs.changed.outputs.workflows == 'true' || github.event_name == 'push' }}
+    defaults:
+      run:
+        working-directory: codex-rs
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@1.89
+      - name: Run login crate tests (macOS)
+        run: cargo test -p codex-login --test all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ You can install any of these versions: `npm install -g codex@version`
 ### 🧰 Dev
 
 - Introduced typed `LoginError` for native browser flow (no string matching), enabling clear CLI behavior on abort vs error.
+- Added macOS-only native browser login tests (success, abort, state mismatch, token-exchange failure) and Unix file-permissions check for `auth.json`.
+- Added a macOS-only CI job to run the login crate tests.
+- Refactored Swift helper embedding to be single-sourced and built as a universal binary (arm64 + x86_64) during macOS builds; non-macOS builds do not include the helper.
+- CLI confirm now only prompts when a persisted `auth.json` exists (env-only API key does not trigger an "already logged in" prompt).
 
 ## `0.1.2505172129`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 You can install any of these versions: `npm install -g codex@version`
 
+## Unreleased
+
+### 🚀 Features
+
+- feat(login): macOS native browser login via `codex login --browser` using a tiny WKWebView helper; intercepts localhost callback without a local server; macOS-only with build-time embedded helper and runtime on-demand fallback. Docs in `docs/macos-native-browser-login.md`.
+
+### 🪄 UX
+
+- macOS helper window has proper menus (About/Quit, Cut/Copy/Paste/Select All), copy/paste enabled, clear title.
+- Closing the helper window cleanly aborts login (no reopen); CLI prints a neutral “Login aborted…” message.
+- Success message shows a ✅ and includes email/plan when available.
+
+### 🧰 Dev
+
+- Introduced typed `LoginError` for native browser flow (no string matching), enabling clear CLI behavior on abort vs error.
+
 ## `0.1.2505172129`
 
 ### 🪲 Bug Fixes

--- a/README.md
+++ b/README.md
@@ -104,6 +104,16 @@ Each archive contains a single entry with the platform baked into the name (e.g.
 
 Run `codex` and select **Sign in with ChatGPT**. You'll need a Plus, Pro, or Team ChatGPT account, and will get access to our latest models, including `gpt-5`, at no extra cost to your plan. (Enterprise is coming soon.)
 
+On macOS, you can alternatively complete the login using a native browser helper (no localhost server) with:
+
+```bash
+codex login --browser
+```
+
+This opens a small WKWebView window to complete authentication and intercepts the final redirect locally, avoiding browser blocks on `http://localhost` callbacks. Requires macOS and Xcode Command Line Tools (`swiftc`).
+
+See docs/macos-native-browser-login.md for details, requirements, and troubleshooting.
+
 > Important: If you've used the Codex CLI before, follow these steps to migrate from usage-based billing with your API key:
 >
 > 1. Update the CLI and ensure `codex --version` is `0.20.0` or later
@@ -424,11 +434,12 @@ Help us improve by filing issues or submitting PRs (see the section below for ho
 
 ## CLI reference
 
-| Command            | Purpose                            | Example                         |
-| ------------------ | ---------------------------------- | ------------------------------- |
-| `codex`            | Interactive TUI                    | `codex`                         |
-| `codex "..."`      | Initial prompt for interactive TUI | `codex "fix lint errors"`       |
-| `codex exec "..."` | Non-interactive "automation mode"  | `codex exec "explain utils.ts"` |
+| Command                 | Purpose                             | Example                         |
+| ----------------------- | ----------------------------------- | ------------------------------- |
+| `codex`                 | Interactive TUI                     | `codex`                         |
+| `codex "..."`           | Initial prompt for interactive TUI  | `codex "fix lint errors"`       |
+| `codex exec "..."`      | Non-interactive "automation mode"   | `codex exec "explain utils.ts"` |
+| `codex login --browser` | macOS native browser login (WKWebView) | `codex login --browser`         |
 
 Key flags: `--model/-m`, `--ask-for-approval/-a`.
 

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -853,6 +853,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "tempfile",
  "thiserror 2.0.12",
@@ -1272,6 +1273,19 @@ dependencies = [
  "darling_core",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "dashmap"
+version = "5.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "978747c1d849a7d2ee5e8adc0159961c48fb7e5db2f06af6723b80123bb53856"
+dependencies = [
+ "cfg-if",
+ "hashbrown 0.14.5",
+ "lock_api",
+ "once_cell",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -4418,6 +4432,31 @@ dependencies = [
  "cfg-if",
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "serial_test"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e56dd856803e253c8f298af3f4d7eb0ae5e23a737252cd90bb4f3b435033b2d"
+dependencies = [
+ "dashmap",
+ "futures",
+ "lazy_static",
+ "log",
+ "parking_lot",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]

--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -235,10 +235,10 @@ async fn maybe_confirm_relogin(config: &Config) -> bool {
                 prompt.push_str(&format!("  • Plan: {}\n", plan));
             }
         }
-    } else if existing.mode == AuthMode::ApiKey {
-        if let Ok(token) = existing.get_token().await {
-            prompt.push_str(&format!("  • API key: {}\n", safe_format_key(&token)));
-        }
+    } else if existing.mode == AuthMode::ApiKey
+        && let Ok(token) = existing.get_token().await
+    {
+        prompt.push_str(&format!("  • API key: {}\n", safe_format_key(&token)));
     }
     eprintln!("{}", prompt);
     eprint!("Proceed to start a new login? [y/N]: ");

--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -4,11 +4,11 @@ use codex_core::config::ConfigOverrides;
 use codex_login::AuthMode;
 use codex_login::CLIENT_ID;
 use codex_login::CodexAuth;
+use codex_login::LoginError;
 use codex_login::OPENAI_API_KEY_ENV_VAR;
 use codex_login::ServerOptions;
 use codex_login::login_with_api_key;
 use codex_login::login_with_native_browser;
-use codex_login::LoginError;
 use codex_login::logout;
 use codex_login::run_login_server;
 use std::env;
@@ -59,7 +59,8 @@ pub async fn run_login_with_browser(cli_config_overrides: CliConfigOverrides) ->
             // Load details to show a friendly summary
             match CodexAuth::from_codex_home(&config.codex_home, config.preferred_auth_method) {
                 Ok(Some(auth)) => {
-                    let mut summary = String::from("✅ Successfully logged in using native browser");
+                    let mut summary =
+                        String::from("✅ Successfully logged in using native browser");
                     if let Ok(tokens) = auth.get_token_data().await {
                         if let Some(email) = tokens.id_token.email.as_deref() {
                             summary.push_str(&format!(" – {}", email));
@@ -89,7 +90,7 @@ pub async fn run_login_with_browser(cli_config_overrides: CliConfigOverrides) ->
                 eprintln!("Error logging in with native browser: {other}");
                 std::process::exit(1);
             }
-        }
+        },
     }
 }
 
@@ -211,9 +212,11 @@ async fn maybe_confirm_relogin(config: &Config) -> bool {
     }
 
     // If auth.json exists, load and present details for confirmation.
-    let Some(existing) = CodexAuth::from_codex_home(&config.codex_home, config.preferred_auth_method)
-        .ok()
-        .flatten() else {
+    let Some(existing) =
+        CodexAuth::from_codex_home(&config.codex_home, config.preferred_auth_method)
+            .ok()
+            .flatten()
+    else {
         return true;
     };
 
@@ -245,7 +248,6 @@ async fn maybe_confirm_relogin(config: &Config) -> bool {
     let answer = buf.trim().to_ascii_lowercase();
     matches!(answer.as_str(), "y" | "yes")
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -108,6 +108,10 @@ struct LoginCommand {
     #[arg(long = "api-key", value_name = "API_KEY")]
     api_key: Option<String>,
 
+    /// Use a native browser helper to complete login (macOS only).
+    #[arg(long = "browser", default_value_t = false)]
+    browser: bool,
+
     #[command(subcommand)]
     action: Option<LoginSubcommand>,
 }
@@ -170,6 +174,8 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
                 None => {
                     if let Some(api_key) = login_cli.api_key {
                         run_login_with_api_key(login_cli.config_overrides, api_key).await;
+                    } else if login_cli.browser {
+                        codex_cli::login::run_login_with_browser(login_cli.config_overrides).await;
                     } else {
                         run_login_with_chatgpt(login_cli.config_overrides).await;
                     }

--- a/codex-rs/login/Cargo.toml
+++ b/codex-rs/login/Cargo.toml
@@ -2,6 +2,7 @@
 edition = "2024"
 name = "codex-login"
 version = { workspace = true }
+build = "build.rs"
 
 [lints]
 workspace = true

--- a/codex-rs/login/Cargo.toml
+++ b/codex-rs/login/Cargo.toml
@@ -33,3 +33,4 @@ webbrowser = "1.0"
 [dev-dependencies]
 pretty_assertions = "1.4.1"
 tempfile = "3"
+serial_test = "2"

--- a/codex-rs/login/build.rs
+++ b/codex-rs/login/build.rs
@@ -12,7 +12,13 @@ fn main() {
         return;
     }
 
-    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
+    let out_dir = match env::var("OUT_DIR") {
+        Ok(v) => PathBuf::from(v),
+        Err(_) => {
+            println!("cargo:warning=OUT_DIR not set; skipping Swift helper embed");
+            return;
+        }
+    };
     let helper_out = out_dir.join("codex-auth-helper");
     let swift_src = PathBuf::from("src/native_browser_helper.swift");
 
@@ -48,10 +54,8 @@ fn main() {
                 .arg(&swift_src)
                 .arg("-o")
                 .arg(out);
-            if let Ok(status) = cmd.status() {
-                if status.success() {
-                    return true;
-                }
+            if let Ok(status) = cmd.status() && status.success() {
+                return true;
             }
         }
         false

--- a/codex-rs/login/build.rs
+++ b/codex-rs/login/build.rs
@@ -54,7 +54,9 @@ fn main() {
                 .arg(&swift_src)
                 .arg("-o")
                 .arg(out);
-            if let Ok(status) = cmd.status() && status.success() {
+            if let Ok(status) = cmd.status()
+                && status.success()
+            {
                 return true;
             }
         }

--- a/codex-rs/login/build.rs
+++ b/codex-rs/login/build.rs
@@ -1,0 +1,48 @@
+use std::env;
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+fn main() {
+    // Always rerun if the Swift helper changes.
+    println!("cargo:rerun-if-changed=src/native_browser_helper.swift");
+
+    let target_os = env::var("CARGO_CFG_TARGET_OS").unwrap_or_default();
+    if target_os != "macos" {
+        return;
+    }
+
+    let out_dir = PathBuf::from(env::var("OUT_DIR").expect("OUT_DIR not set"));
+    let helper_out = out_dir.join("codex-auth-helper");
+    let swift_src = PathBuf::from("src/native_browser_helper.swift");
+
+    // Attempt to compile with various invocations to maximize compatibility.
+    let candidates: &[&[&str]] = &[
+        &["swiftc", "-O", "-framework", "Cocoa", "-framework", "WebKit"],
+        &["/usr/bin/swiftc", "-O", "-framework", "Cocoa", "-framework", "WebKit"],
+        &["xcrun", "swiftc", "-O", "-framework", "Cocoa", "-framework", "WebKit"],
+    ];
+
+    let mut built = false;
+    for base in candidates {
+        let mut cmd = Command::new(base[0]);
+        cmd.args(&base[1..])
+            .arg(swift_src.as_os_str())
+            .arg("-o")
+            .arg(&helper_out);
+        match cmd.status() {
+            Ok(status) if status.success() => {
+                built = true;
+                break;
+            }
+            _ => {}
+        }
+    }
+
+    if !built {
+        // Ensure an empty placeholder exists so include_bytes! compiles; runtime will fallback.
+        let _ = fs::write(&helper_out, &[] as &[u8]);
+        println!("cargo:warning=Failed to compile Swift helper; runtime will attempt on-demand compile.");
+    }
+}
+

--- a/codex-rs/login/build.rs
+++ b/codex-rs/login/build.rs
@@ -16,33 +16,71 @@ fn main() {
     let helper_out = out_dir.join("codex-auth-helper");
     let swift_src = PathBuf::from("src/native_browser_helper.swift");
 
-    // Attempt to compile with various invocations to maximize compatibility.
-    let candidates: &[&[&str]] = &[
-        &["swiftc", "-O", "-framework", "Cocoa", "-framework", "WebKit"],
-        &["/usr/bin/swiftc", "-O", "-framework", "Cocoa", "-framework", "WebKit"],
-        &["xcrun", "swiftc", "-O", "-framework", "Cocoa", "-framework", "WebKit"],
-    ];
+    // Resolve SDK path when available (xcrun)
+    let sdk_path = Command::new("xcrun")
+        .args(["--sdk", "macosx", "--show-sdk-path"])
+        .output()
+        .ok()
+        .and_then(|o| if o.status.success() { Some(String::from_utf8_lossy(&o.stdout).trim().to_string()) } else { None });
 
-    let mut built = false;
-    for base in candidates {
-        let mut cmd = Command::new(base[0]);
-        cmd.args(&base[1..])
-            .arg(swift_src.as_os_str())
-            .arg("-o")
-            .arg(&helper_out);
-        match cmd.status() {
-            Ok(status) if status.success() => {
-                built = true;
-                break;
+    // Helper to compile an arch-specific binary
+    let compile_arch = |arch: &str, out: &PathBuf| -> bool {
+        // Prefer `xcrun swiftc`, then `swiftc`, then explicit path
+        let candidates: &[&[&str]] = &[
+            &["xcrun", "swiftc"],
+            &["swiftc"],
+            &["/usr/bin/swiftc"],
+        ];
+        for base in candidates {
+            let mut cmd = Command::new(base[0]);
+            cmd.args(&base[1..]);
+            cmd.arg("-target").arg(format!("{}-apple-macos12.0", arch));
+            if let Some(ref sdk) = sdk_path { cmd.arg("-sdk").arg(sdk); }
+            cmd.arg("-O")
+               .arg("-framework").arg("Cocoa")
+               .arg("-framework").arg("WebKit")
+               .arg(&swift_src)
+               .arg("-o").arg(out);
+            if let Ok(status) = cmd.status() {
+                if status.success() { return true; }
             }
-            _ => {}
+        }
+        false
+    };
+
+    let arm_out = out_dir.join("codex-auth-helper-arm64");
+    let x86_out = out_dir.join("codex-auth-helper-x86_64");
+    let mut embedded_ok = false;
+
+    let arm_ok = compile_arch("arm64", &arm_out);
+    let x86_ok = compile_arch("x86_64", &x86_out);
+
+    if arm_ok && x86_ok {
+        // lipo into a universal binary
+        let status = Command::new("xcrun")
+            .args(["lipo", "-create", "-output"]) 
+            .arg(&helper_out)
+            .arg(&arm_out)
+            .arg(&x86_out)
+            .status()
+            .ok();
+        if matches!(status, Some(s) if s.success()) {
+            embedded_ok = true;
         }
     }
-
-    if !built {
+    if !embedded_ok {
+        // Fall back to single-arch success
+        if arm_ok {
+            let _ = fs::copy(&arm_out, &helper_out);
+            embedded_ok = helper_out.exists();
+        } else if x86_ok {
+            let _ = fs::copy(&x86_out, &helper_out);
+            embedded_ok = helper_out.exists();
+        }
+    }
+    if !embedded_ok {
         // Ensure an empty placeholder exists so include_bytes! compiles; runtime will fallback.
         let _ = fs::write(&helper_out, &[] as &[u8]);
         println!("cargo:warning=Failed to compile Swift helper; runtime will attempt on-demand compile.");
     }
 }
-

--- a/codex-rs/login/src/error.rs
+++ b/codex-rs/login/src/error.rs
@@ -26,4 +26,3 @@ pub enum LoginError {
     #[error(transparent)]
     Io(#[from] std::io::Error),
 }
-

--- a/codex-rs/login/src/error.rs
+++ b/codex-rs/login/src/error.rs
@@ -1,0 +1,29 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum LoginError {
+    #[error("native browser login aborted")]
+    Aborted,
+
+    #[error("native browser login is only supported on macOS at this time")]
+    UnsupportedOs,
+
+    #[error("native browser helper compile failed: {0}")]
+    HelperCompileFailed(String),
+
+    #[error("native browser helper returned invalid response")]
+    InvalidHelperResponse,
+
+    #[error("oauth state mismatch")]
+    StateMismatch,
+
+    #[error("token exchange failed: {0}")]
+    TokenExchangeFailed(String),
+
+    #[error(transparent)]
+    Network(#[from] reqwest::Error),
+
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+}
+

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -26,10 +26,10 @@ pub use native_browser::login_with_native_browser;
 
 mod auth_manager;
 mod error;
+mod native_browser;
 mod pkce;
 mod server;
 mod token_data;
-mod native_browser;
 
 pub const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 pub const OPENAI_API_KEY_ENV_VAR: &str = "OPENAI_API_KEY";
@@ -102,6 +102,15 @@ impl CodexAuth {
         preferred_auth_method: AuthMode,
     ) -> std::io::Result<Option<CodexAuth>> {
         load_auth(codex_home, true, preferred_auth_method)
+    }
+
+    /// Loads auth from persisted auth.json only, ignoring OPENAI_API_KEY.
+    /// Useful for components that must reflect explicit user opt-in only.
+    pub fn from_codex_home_persisted_only(
+        codex_home: &Path,
+        preferred_auth_method: AuthMode,
+    ) -> std::io::Result<Option<CodexAuth>> {
+        load_auth(codex_home, false, preferred_auth_method)
     }
 
     pub async fn get_token_data(&self) -> Result<TokenData, std::io::Error> {

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -22,16 +22,20 @@ pub use crate::server::ShutdownHandle;
 pub use crate::server::run_login_server;
 pub use crate::token_data::TokenData;
 use crate::token_data::parse_id_token;
+pub use native_browser::login_with_native_browser;
 
 mod auth_manager;
+mod error;
 mod pkce;
 mod server;
 mod token_data;
+mod native_browser;
 
 pub const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
 pub const OPENAI_API_KEY_ENV_VAR: &str = "OPENAI_API_KEY";
 pub use auth_manager::AuthManager;
 pub use codex_protocol::mcp_protocol::AuthMode;
+pub use error::LoginError;
 
 #[derive(Debug, Clone)]
 pub struct CodexAuth {

--- a/codex-rs/login/src/native_browser.rs
+++ b/codex-rs/login/src/native_browser.rs
@@ -289,14 +289,13 @@ fn jwt_auth_claims(jwt: &str) -> serde_json::Map<String, serde_json::Value> {
             return serde_json::Map::new();
         }
     };
-    if let Ok(bytes) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload_b64) {
-        if let Ok(mut v) = serde_json::from_slice::<serde_json::Value>(&bytes)
-            && let Some(obj) = v
-                .get_mut("https://api.openai.com/auth")
-                .and_then(|x| x.as_object_mut())
-        {
-            return obj.clone();
-        }
+    if let Ok(bytes) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload_b64)
+        && let Ok(mut v) = serde_json::from_slice::<serde_json::Value>(&bytes)
+        && let Some(obj) = v
+            .get_mut("https://api.openai.com/auth")
+            .and_then(|x| x.as_object_mut())
+    {
+        return obj.clone();
     }
     serde_json::Map::new()
 }

--- a/codex-rs/login/src/native_browser.rs
+++ b/codex-rs/login/src/native_browser.rs
@@ -1,26 +1,51 @@
 use std::path::Path;
 use std::process::Stdio;
 
+use crate::AuthDotJson;
 use crate::CLIENT_ID;
+use crate::LoginError;
 use crate::get_auth_file;
+use crate::pkce::generate_pkce;
 use crate::token_data::TokenData;
 use crate::token_data::parse_id_token;
-use crate::AuthDotJson;
-use crate::pkce::generate_pkce;
-use crate::LoginError;
 
 #[cfg(target_os = "macos")]
 pub async fn login_with_native_browser(codex_home: &Path) -> Result<(), LoginError> {
     // Build PKCE + state
     let pkce = generate_pkce();
+    // Allow tests to force the OAuth state for deterministic helper JSON (debug builds only).
+    #[cfg(debug_assertions)]
+    let state = std::env::var("CODEX_LOGIN_FORCE_STATE").unwrap_or_else(|_| generate_state());
+    #[cfg(not(debug_assertions))]
     let state = generate_state();
 
     // Use the existing localhost callback URI, but we won't actually run a server.
     let redirect_uri = format!("http://localhost:{}/auth/callback", 1455u16);
-    let issuer = DEFAULT_ISSUER;
-    let auth_url = build_authorize_url(issuer, CLIENT_ID, &redirect_uri, &pkce.code_challenge, &state);
+    // Allow tests to override the issuer base via env var (debug builds only).
+    #[cfg(debug_assertions)]
+    let issuer = std::env::var("CODEX_LOGIN_ISSUER_BASE").unwrap_or_else(|_| DEFAULT_ISSUER.to_string());
+    #[cfg(not(debug_assertions))]
+    let issuer = DEFAULT_ISSUER.to_string();
+    let auth_url = build_authorize_url(
+        &issuer,
+        CLIENT_ID,
+        &redirect_uri,
+        &pkce.code_challenge,
+        &state,
+    );
 
     // Compile Swift helper and run it to open a WKWebView and intercept the callback.
+    // In debug builds, allow bypassing the helper UI via an injected capture.
+    #[cfg(debug_assertions)]
+    let capture = match std::env::var("CODEX_LOGIN_TEST_HELPER_JSON") {
+        Ok(val) => {
+            if val == "ABORT" { return Err(LoginError::Aborted); }
+            serde_json::from_str::<AuthCodeCapture>(&val)
+                .map_err(|_| LoginError::InvalidHelperResponse)?
+        }
+        Err(_) => compile_and_run_swift_helper(&auth_url, &state).await?,
+    };
+    #[cfg(not(debug_assertions))]
     let capture = compile_and_run_swift_helper(&auth_url, &state).await?;
     if capture.state != state {
         return Err(LoginError::StateMismatch);
@@ -30,13 +55,29 @@ pub async fn login_with_native_browser(codex_home: &Path) -> Result<(), LoginErr
     }
 
     // Exchange code for tokens
-    let tokens = exchange_code_for_tokens(issuer, CLIENT_ID, &redirect_uri, &pkce.code_verifier, &capture.code).await?;
+    let tokens = exchange_code_for_tokens(
+        &issuer,
+        CLIENT_ID,
+        &redirect_uri,
+        &pkce.code_verifier,
+        &capture.code,
+    )
+    .await?;
 
     // Optionally obtain API key via token-exchange
-    let api_key = obtain_api_key(issuer, CLIENT_ID, &tokens.id_token).await.ok();
+    let api_key = obtain_api_key(&issuer, CLIENT_ID, &tokens.id_token)
+        .await
+        .ok();
 
     // Persist tokens
-    persist_tokens(codex_home, api_key, &tokens.id_token, &tokens.access_token, &tokens.refresh_token).await
+    persist_tokens(
+        codex_home,
+        api_key,
+        &tokens.id_token,
+        &tokens.access_token,
+        &tokens.refresh_token,
+    )
+    .await
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -107,7 +148,11 @@ async fn exchange_code_for_tokens(
     code: &str,
 ) -> Result<ExchangedTokens, LoginError> {
     #[derive(serde::Deserialize)]
-    struct TokenResponse { id_token: String, access_token: String, refresh_token: String }
+    struct TokenResponse {
+        id_token: String,
+        access_token: String,
+        refresh_token: String,
+    }
 
     let client = reqwest::Client::new();
     let resp = client
@@ -126,13 +171,23 @@ async fn exchange_code_for_tokens(
         return Err(LoginError::TokenExchangeFailed(resp.status().to_string()));
     }
     let tokens: TokenResponse = resp.json().await?;
-    Ok(ExchangedTokens { id_token: tokens.id_token, access_token: tokens.access_token, refresh_token: tokens.refresh_token })
+    Ok(ExchangedTokens {
+        id_token: tokens.id_token,
+        access_token: tokens.access_token,
+        refresh_token: tokens.refresh_token,
+    })
 }
 
 #[cfg(target_os = "macos")]
-async fn obtain_api_key(issuer: &str, client_id: &str, id_token: &str) -> Result<String, LoginError> {
+async fn obtain_api_key(
+    issuer: &str,
+    client_id: &str,
+    id_token: &str,
+) -> Result<String, LoginError> {
     #[derive(serde::Deserialize)]
-    struct ExchangeResp { access_token: String }
+    struct ExchangeResp {
+        access_token: String,
+    }
 
     let client = reqwest::Client::new();
     let resp = client
@@ -172,20 +227,28 @@ async fn persist_tokens(
         use chrono::Utc;
         use std::fs;
         let auth_file = get_auth_file(&codex_home);
-        if let Some(parent) = auth_file.parent() {
-            if !parent.exists() {
+        if let Some(parent) = auth_file.parent()
+            && !parent.exists() {
                 fs::create_dir_all(parent)?;
             }
-        }
         let mut auth = match crate::try_read_auth_json(&auth_file) {
             Ok(a) => a,
-            Err(_) => AuthDotJson { openai_api_key: None, tokens: None, last_refresh: None },
+            Err(_) => AuthDotJson {
+                openai_api_key: None,
+                tokens: None,
+                last_refresh: None,
+            },
         };
-        if let Some(key) = api_key { auth.openai_api_key = Some(key); }
+        if let Some(key) = api_key {
+            auth.openai_api_key = Some(key);
+        }
         let tokens = auth.tokens.get_or_insert_with(TokenData::default);
         tokens.id_token = parse_id_token(&id_token_owned).map_err(std::io::Error::other)?;
         // Extract account ID if present
-        if let Some(acc) = jwt_auth_claims(&id_token_owned).get("chatgpt_account_id").and_then(|v| v.as_str()) {
+        if let Some(acc) = jwt_auth_claims(&id_token_owned)
+            .get("chatgpt_account_id")
+            .and_then(|v| v.as_str())
+        {
             tokens.account_id = Some(acc.to_string());
         }
         tokens.access_token = access_token_owned;
@@ -206,7 +269,9 @@ async fn persist_tokens(
         file.write_all(json_data.as_bytes())?;
         file.flush()?;
         Ok::<(), std::io::Error>(())
-    }).await.map_err(|e| std::io::Error::other(format!("persist task failed: {e}")))?;
+    })
+    .await
+    .map_err(|e| std::io::Error::other(format!("persist task failed: {e}")))?;
     result.map_err(LoginError::from)
 }
 
@@ -216,137 +281,22 @@ fn jwt_auth_claims(jwt: &str) -> serde_json::Map<String, serde_json::Value> {
     let mut parts = jwt.split('.');
     let (_h, payload_b64, _s) = match (parts.next(), parts.next(), parts.next()) {
         (Some(h), Some(p), Some(s)) if !h.is_empty() && !p.is_empty() && !s.is_empty() => (h, p, s),
-        _ => { return serde_json::Map::new(); }
+        _ => {
+            return serde_json::Map::new();
+        }
     };
-    match base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload_b64) {
-        Ok(bytes) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
-            Ok(mut v) => {
-                if let Some(obj) = v.get_mut("https://api.openai.com/auth").and_then(|x| x.as_object_mut()) { return obj.clone(); }
-            }
-            Err(_) => {}
-        },
-        Err(_) => {}
-    }
+    if let Ok(bytes) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload_b64) { if let Ok(mut v) = serde_json::from_slice::<serde_json::Value>(&bytes)
+    && let Some(obj) = v
+        .get_mut("https://api.openai.com/auth")
+        .and_then(|x| x.as_object_mut())
+    {
+        return obj.clone();
+    } }
     serde_json::Map::new()
 }
 
 #[cfg(target_os = "macos")]
-const SWIFT_HELPER_SRC: &str = r#"import Cocoa
-import WebKit
-
-final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, NSWindowDelegate {
-    private var didComplete = false
-    private var window: NSWindow!
-    private var webView: WKWebView!
-    private var authorizeURL: URL!
-    private var expectedState: String!
-
-    func applicationDidFinishLaunching(_ notification: Notification) {
-        buildMenus()
-        let args = CommandLine.arguments
-        guard let urlIdx = args.firstIndex(of: "--authorize-url").flatMap({ idx in
-            idx + 1 < args.count ? idx + 1 : nil
-        }), let stateIdx = args.firstIndex(of: "--state").flatMap({ idx in
-            idx + 1 < args.count ? idx + 1 : nil }) else {
-            fputs("usage: codex-auth-helper --authorize-url <URL> --state <STATE>\n", stderr)
-            NSApp.terminate(nil)
-            return
-        }
-        guard let authURL = URL(string: args[urlIdx]) else {
-            fputs("invalid authorize url\n", stderr)
-            NSApp.terminate(nil)
-            return
-        }
-        self.authorizeURL = authURL
-        self.expectedState = args[stateIdx]
-
-        let config = WKWebViewConfiguration()
-        config.websiteDataStore = .nonPersistent()
-
-        webView = WKWebView(frame: .zero, configuration: config)
-        webView.navigationDelegate = self
-
-        window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 720, height: 820),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable],
-            backing: .buffered,
-            defer: false
-        )
-        window.center()
-        window.title = "Codex – Sign in to OpenAI"
-        window.contentView = webView
-        window.delegate = self
-        window.makeKeyAndOrderFront(nil)
-        window.makeFirstResponder(webView)
-        NSApp.activate(ignoringOtherApps: true)
-
-        webView.load(URLRequest(url: authorizeURL))
-    }
-
-    // Close behavior: treat closing the window as an abort and exit non‑zero.
-    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { true }
-    func windowWillClose(_ notification: Notification) { exit(didComplete ? 0 : 2) }
-
-    private func buildMenus() {
-        let mainMenu = NSMenu()
-        let appName = ProcessInfo.processInfo.processName
-
-        let appMenuItem = NSMenuItem()
-        let appMenu = NSMenu(title: appName)
-        appMenu.addItem(withTitle: "About \(appName)", action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
-        appMenu.addItem(NSMenuItem.separator())
-        appMenu.addItem(withTitle: "Quit \(appName)", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
-        appMenuItem.submenu = appMenu
-
-        let editMenuItem = NSMenuItem()
-        let editMenu = NSMenu(title: "Edit")
-        editMenu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
-        editMenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
-        editMenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
-        editMenu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
-        editMenuItem.submenu = editMenu
-
-        mainMenu.addItem(appMenuItem)
-        mainMenu.addItem(editMenuItem)
-        NSApp.mainMenu = mainMenu
-    }
-
-    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-        guard let url = navigationAction.request.url else { decisionHandler(.allow); return }
-        if url.scheme == "http", (url.host == "localhost" || url.host == "127.0.0.1"), url.path.hasPrefix("/auth/callback") {
-            if let comps = URLComponents(url: url, resolvingAgainstBaseURL: false) {
-                let qp = Dictionary(uniqueKeysWithValues: (comps.queryItems ?? []).map { ($0.name, $0.value ?? "") })
-                let code = qp["code"] ?? ""
-                let state = qp["state"] ?? ""
-                if code.isEmpty { fputs("missing authorization code\n", stderr) }
-                else if state != expectedState { fputs("state mismatch\n", stderr) }
-                else {
-                    didComplete = true
-                    let payload = "{\"code\":\"\(code)\",\"state\":\"\(state)\"}\n"
-                    if let data = payload.data(using: .utf8) { FileHandle.standardOutput.write(data) }
-                }
-            }
-            decisionHandler(.cancel)
-            NSApp.terminate(nil)
-            return
-        }
-        decisionHandler(.allow)
-    }
-
-    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        fputs("navigation error: \(error)\n", stderr)
-    }
-    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        fputs("provisional nav error: \(error)\n", stderr)
-    }
-}
-
-let app = NSApplication.shared
-app.setActivationPolicy(.regular)
-let delegate = AppDelegate()
-app.delegate = delegate
-app.run()
-"#;
+const SWIFT_HELPER_SRC: &str = include_str!("native_browser_helper.swift");
 
 // Prefer an embedded helper produced at build time (see build.rs). If the embedded
 // bytes are empty or execution fails, we fall back to compiling the helper on demand.
@@ -354,9 +304,23 @@ app.run()
 static EMBEDDED_HELPER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/codex-auth-helper"));
 
 #[cfg(target_os = "macos")]
-async fn compile_and_run_swift_helper(authorize_url: &str, state: &str) -> Result<AuthCodeCapture, LoginError> {
-    // If embedded helper is present (non-empty), try running it first.
-    if !EMBEDDED_HELPER.is_empty() {
+async fn compile_and_run_swift_helper(
+    authorize_url: &str,
+    state: &str,
+) -> Result<AuthCodeCapture, LoginError> {
+    // Testing seam: allow injecting a fake helper result or abort.
+    #[cfg(any(test, debug_assertions))]
+    if let Ok(val) = std::env::var("CODEX_LOGIN_TEST_HELPER_JSON") {
+        if val == "ABORT" {
+            return Err(LoginError::Aborted);
+        }
+        return serde_json::from_str::<AuthCodeCapture>(&val)
+            .map_err(|_| LoginError::InvalidHelperResponse);
+    }
+
+    // If embedded helper is present (non-empty), try running it first unless disabled.
+    let disable_embedded = std::env::var("CODEX_LOGIN_DISABLE_EMBEDDED_HELPER").is_ok();
+    if !disable_embedded && !EMBEDDED_HELPER.is_empty() {
         use std::fs;
         use std::io::Write;
         use std::os::unix::fs::PermissionsExt;
@@ -372,7 +336,10 @@ async fn compile_and_run_swift_helper(authorize_url: &str, state: &str) -> Resul
         fs::set_permissions(&helper_bin, perms)?;
 
         let mut cmd = tokio::process::Command::new(&helper_bin);
-        cmd.arg("--authorize-url").arg(authorize_url).arg("--state").arg(state);
+        cmd.arg("--authorize-url")
+            .arg(authorize_url)
+            .arg("--state")
+            .arg(state);
         cmd.env("NSUnbufferedIO", "YES");
         cmd.stdout(Stdio::piped()).stderr(Stdio::inherit());
         match cmd.output().await {
@@ -398,15 +365,19 @@ async fn compile_and_run_swift_helper(authorize_url: &str, state: &str) -> Resul
 }
 
 #[cfg(target_os = "macos")]
-async fn compile_and_run_swift_helper_fallback(authorize_url: &str, state: &str) -> Result<AuthCodeCapture, LoginError> {
+async fn compile_and_run_swift_helper_fallback(
+    authorize_url: &str,
+    state: &str,
+) -> Result<AuthCodeCapture, LoginError> {
+    use rand::RngCore;
     use std::fs;
     use std::io::Write;
-    use rand::RngCore;
 
     // Create a temp dir and paths
     let mut rand_bytes = [0u8; 8];
     rand::thread_rng().fill_bytes(&mut rand_bytes);
-    let temp_dir = std::env::temp_dir().join(format!("codex-auth-{:x}", u64::from_le_bytes(rand_bytes)));
+    let temp_dir =
+        std::env::temp_dir().join(format!("codex-auth-{:x}", u64::from_le_bytes(rand_bytes)));
     fs::create_dir_all(&temp_dir)?;
     let swift_src = temp_dir.join("CodexAuthHelper.swift");
     let helper_bin = temp_dir.join("codex-auth-helper");
@@ -418,27 +389,71 @@ async fn compile_and_run_swift_helper_fallback(authorize_url: &str, state: &str)
 
     // Try to compile via swiftc (or xcrun swiftc)
     let compile_cmds: Vec<Vec<String>> = vec![
-        vec!["swiftc".into(), "-O".into(), "-framework".into(), "Cocoa".into(), "-framework".into(), "WebKit".into(), swift_src.to_string_lossy().into(), "-o".into(), helper_bin.to_string_lossy().into()],
-        vec!["/usr/bin/swiftc".into(), "-O".into(), "-framework".into(), "Cocoa".into(), "-framework".into(), "WebKit".into(), swift_src.to_string_lossy().into(), "-o".into(), helper_bin.to_string_lossy().into()],
-        vec!["xcrun".into(), "swiftc".into(), "-O".into(), "-framework".into(), "Cocoa".into(), "-framework".into(), "WebKit".into(), swift_src.to_string_lossy().into(), "-o".into(), helper_bin.to_string_lossy().into()],
+        vec![
+            "swiftc".into(),
+            "-O".into(),
+            "-framework".into(),
+            "Cocoa".into(),
+            "-framework".into(),
+            "WebKit".into(),
+            swift_src.to_string_lossy().into(),
+            "-o".into(),
+            helper_bin.to_string_lossy().into(),
+        ],
+        vec![
+            "/usr/bin/swiftc".into(),
+            "-O".into(),
+            "-framework".into(),
+            "Cocoa".into(),
+            "-framework".into(),
+            "WebKit".into(),
+            swift_src.to_string_lossy().into(),
+            "-o".into(),
+            helper_bin.to_string_lossy().into(),
+        ],
+        vec![
+            "xcrun".into(),
+            "swiftc".into(),
+            "-O".into(),
+            "-framework".into(),
+            "Cocoa".into(),
+            "-framework".into(),
+            "WebKit".into(),
+            swift_src.to_string_lossy().into(),
+            "-o".into(),
+            helper_bin.to_string_lossy().into(),
+        ],
     ];
 
     let mut compiled = false;
     for argv in compile_cmds {
         let mut cmd = tokio::process::Command::new(&argv[0]);
         cmd.args(&argv[1..]);
-        match cmd.stdout(Stdio::null()).stderr(Stdio::piped()).status().await {
-            Ok(status) if status.success() => { compiled = true; break; }
+        match cmd
+            .stdout(Stdio::null())
+            .stderr(Stdio::piped())
+            .status()
+            .await
+        {
+            Ok(status) if status.success() => {
+                compiled = true;
+                break;
+            }
             Ok(_) | Err(_) => { /* try next */ }
         }
     }
     if !compiled {
-        return Err(LoginError::HelperCompileFailed("swiftc not found or compile failed".to_string()));
+        return Err(LoginError::HelperCompileFailed(
+            "swiftc not found or compile failed".to_string(),
+        ));
     }
 
     // Run helper
     let mut cmd = tokio::process::Command::new(&helper_bin);
-    cmd.arg("--authorize-url").arg(authorize_url).arg("--state").arg(state);
+    cmd.arg("--authorize-url")
+        .arg(authorize_url)
+        .arg("--state")
+        .arg(state);
     cmd.env("NSUnbufferedIO", "YES");
     cmd.stdout(Stdio::piped()).stderr(Stdio::inherit());
     let output = cmd.output().await?;
@@ -446,6 +461,77 @@ async fn compile_and_run_swift_helper_fallback(authorize_url: &str, state: &str)
         return Err(LoginError::Aborted);
     }
     let stdout = String::from_utf8_lossy(&output.stdout);
-    let capture: AuthCodeCapture = serde_json::from_str(stdout.trim()).map_err(|_| LoginError::InvalidHelperResponse)?;
+    let capture: AuthCodeCapture =
+        serde_json::from_str(stdout.trim()).map_err(|_| LoginError::InvalidHelperResponse)?;
     Ok(capture)
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests_macos {
+    use super::*;
+    use base64::Engine;
+
+    #[test]
+    fn authorize_url_contains_required_params() {
+        let url = build_authorize_url(
+            "https://issuer.example",
+            "client123",
+            "http://localhost:1455/auth/callback",
+            "challengeXYZ",
+            "stateABC",
+        );
+        assert!(url.starts_with("https://issuer.example/oauth/authorize?"));
+        for needle in [
+            "response_type=code",
+            "client_id=client123",
+            "redirect_uri=http%3A%2F%2Flocalhost%3A1455%2Fauth%2Fcallback",
+            "scope=openid%20profile%20email%20offline_access",
+            "code_challenge=challengeXYZ",
+            "code_challenge_method=S256",
+            "id_token_add_organizations=true",
+            "codex_cli_simplified_flow=true",
+            "state=stateABC",
+        ] {
+            assert!(url.contains(needle), "missing query param: {needle}");
+        }
+    }
+
+    #[test]
+    fn jwt_auth_claims_extracts_nested_fields() {
+        #[derive(serde::Serialize)]
+        struct Header { alg: &'static str, typ: &'static str }
+        let header = Header { alg: "none", typ: "JWT" };
+        let payload = serde_json::json!({
+            "https://api.openai.com/auth": {
+                "chatgpt_plan_type": "pro",
+                "chatgpt_account_id": "acc-42"
+            }
+        });
+        let b64 = |b: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b);
+        let jwt = format!(
+            "{}.{}.{}",
+            b64(&serde_json::to_vec(&header).unwrap()),
+            b64(&serde_json::to_vec(&payload).unwrap()),
+            b64(b"sig")
+        );
+        let claims = jwt_auth_claims(&jwt);
+        assert_eq!(claims.get("chatgpt_plan_type").and_then(|v| v.as_str()), Some("pro"));
+        assert_eq!(claims.get("chatgpt_account_id").and_then(|v| v.as_str()), Some("acc-42"));
+    }
+}
+
+#[cfg(all(test, not(target_os = "macos")))]
+mod tests_non_macos {
+    use super::*;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn native_browser_is_unsupported() {
+        let dir = tempdir().unwrap();
+        let res = login_with_native_browser(dir.path()).await;
+        match res {
+            Err(LoginError::UnsupportedOs) => {}
+            other => panic!("unexpected result: {:?}", other),
+        }
+    }
 }

--- a/codex-rs/login/src/native_browser.rs
+++ b/codex-rs/login/src/native_browser.rs
@@ -1,0 +1,451 @@
+use std::path::Path;
+use std::process::Stdio;
+
+use crate::CLIENT_ID;
+use crate::get_auth_file;
+use crate::token_data::TokenData;
+use crate::token_data::parse_id_token;
+use crate::AuthDotJson;
+use crate::pkce::generate_pkce;
+use crate::LoginError;
+
+#[cfg(target_os = "macos")]
+pub async fn login_with_native_browser(codex_home: &Path) -> Result<(), LoginError> {
+    // Build PKCE + state
+    let pkce = generate_pkce();
+    let state = generate_state();
+
+    // Use the existing localhost callback URI, but we won't actually run a server.
+    let redirect_uri = format!("http://localhost:{}/auth/callback", 1455u16);
+    let issuer = DEFAULT_ISSUER;
+    let auth_url = build_authorize_url(issuer, CLIENT_ID, &redirect_uri, &pkce.code_challenge, &state);
+
+    // Compile Swift helper and run it to open a WKWebView and intercept the callback.
+    let capture = compile_and_run_swift_helper(&auth_url, &state).await?;
+    if capture.state != state {
+        return Err(LoginError::StateMismatch);
+    }
+    if capture.code.is_empty() {
+        return Err(LoginError::InvalidHelperResponse);
+    }
+
+    // Exchange code for tokens
+    let tokens = exchange_code_for_tokens(issuer, CLIENT_ID, &redirect_uri, &pkce.code_verifier, &capture.code).await?;
+
+    // Optionally obtain API key via token-exchange
+    let api_key = obtain_api_key(issuer, CLIENT_ID, &tokens.id_token).await.ok();
+
+    // Persist tokens
+    persist_tokens(codex_home, api_key, &tokens.id_token, &tokens.access_token, &tokens.refresh_token).await
+}
+
+#[cfg(not(target_os = "macos"))]
+pub async fn login_with_native_browser(_codex_home: &Path) -> Result<(), LoginError> {
+    Err(LoginError::UnsupportedOs)
+}
+
+const DEFAULT_ISSUER: &str = "https://auth.openai.com";
+
+#[cfg(target_os = "macos")]
+fn build_authorize_url(
+    issuer: &str,
+    client_id: &str,
+    redirect_uri: &str,
+    code_challenge: &str,
+    state: &str,
+) -> String {
+    let query = vec![
+        ("response_type", "code"),
+        ("client_id", client_id),
+        ("redirect_uri", redirect_uri),
+        ("scope", "openid profile email offline_access"),
+        ("code_challenge", code_challenge),
+        ("code_challenge_method", "S256"),
+        ("id_token_add_organizations", "true"),
+        ("codex_cli_simplified_flow", "true"),
+        ("state", state),
+    ];
+    let qs = query
+        .into_iter()
+        .map(|(k, v)| format!("{}={}", k, urlencoding::encode(v)))
+        .collect::<Vec<_>>()
+        .join("&");
+    format!("{issuer}/oauth/authorize?{qs}")
+}
+
+#[cfg(target_os = "macos")]
+fn generate_state() -> String {
+    use base64::Engine;
+    use rand::RngCore;
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+// (first version removed; see embedded-first version below)
+
+#[cfg(target_os = "macos")]
+#[derive(serde::Deserialize)]
+struct AuthCodeCapture {
+    code: String,
+    state: String,
+}
+
+#[cfg(target_os = "macos")]
+struct ExchangedTokens {
+    id_token: String,
+    access_token: String,
+    refresh_token: String,
+}
+
+#[cfg(target_os = "macos")]
+async fn exchange_code_for_tokens(
+    issuer: &str,
+    client_id: &str,
+    redirect_uri: &str,
+    code_verifier: &str,
+    code: &str,
+) -> Result<ExchangedTokens, LoginError> {
+    #[derive(serde::Deserialize)]
+    struct TokenResponse { id_token: String, access_token: String, refresh_token: String }
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{issuer}/oauth/token"))
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(format!(
+            "grant_type=authorization_code&code={}&redirect_uri={}&client_id={}&code_verifier={}",
+            urlencoding::encode(code),
+            urlencoding::encode(redirect_uri),
+            urlencoding::encode(client_id),
+            urlencoding::encode(code_verifier)
+        ))
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        return Err(LoginError::TokenExchangeFailed(resp.status().to_string()));
+    }
+    let tokens: TokenResponse = resp.json().await?;
+    Ok(ExchangedTokens { id_token: tokens.id_token, access_token: tokens.access_token, refresh_token: tokens.refresh_token })
+}
+
+#[cfg(target_os = "macos")]
+async fn obtain_api_key(issuer: &str, client_id: &str, id_token: &str) -> Result<String, LoginError> {
+    #[derive(serde::Deserialize)]
+    struct ExchangeResp { access_token: String }
+
+    let client = reqwest::Client::new();
+    let resp = client
+        .post(format!("{issuer}/oauth/token"))
+        .header("Content-Type", "application/x-www-form-urlencoded")
+        .body(format!(
+            "grant_type={}&client_id={}&requested_token={}&subject_token={}&subject_token_type={}",
+            urlencoding::encode("urn:ietf:params:oauth:grant-type:token-exchange"),
+            urlencoding::encode(client_id),
+            urlencoding::encode("openai-api-key"),
+            urlencoding::encode(id_token),
+            urlencoding::encode("urn:ietf:params:oauth:token-type:id_token")
+        ))
+        .send()
+        .await?;
+    if !resp.status().is_success() {
+        return Err(LoginError::TokenExchangeFailed(resp.status().to_string()));
+    }
+    let body: ExchangeResp = resp.json().await?;
+    Ok(body.access_token)
+}
+
+#[cfg(target_os = "macos")]
+async fn persist_tokens(
+    codex_home: &Path,
+    api_key: Option<String>,
+    id_token: &str,
+    access_token: &str,
+    refresh_token: &str,
+) -> Result<(), LoginError> {
+    // Own strings for 'static spawn_blocking closure
+    let id_token_owned = id_token.to_owned();
+    let access_token_owned = access_token.to_owned();
+    let refresh_token_owned = refresh_token.to_owned();
+    let codex_home = codex_home.to_path_buf();
+    let result = tokio::task::spawn_blocking(move || {
+        use chrono::Utc;
+        use std::fs;
+        let auth_file = get_auth_file(&codex_home);
+        if let Some(parent) = auth_file.parent() {
+            if !parent.exists() {
+                fs::create_dir_all(parent)?;
+            }
+        }
+        let mut auth = match crate::try_read_auth_json(&auth_file) {
+            Ok(a) => a,
+            Err(_) => AuthDotJson { openai_api_key: None, tokens: None, last_refresh: None },
+        };
+        if let Some(key) = api_key { auth.openai_api_key = Some(key); }
+        let tokens = auth.tokens.get_or_insert_with(TokenData::default);
+        tokens.id_token = parse_id_token(&id_token_owned).map_err(std::io::Error::other)?;
+        // Extract account ID if present
+        if let Some(acc) = jwt_auth_claims(&id_token_owned).get("chatgpt_account_id").and_then(|v| v.as_str()) {
+            tokens.account_id = Some(acc.to_string());
+        }
+        tokens.access_token = access_token_owned;
+        tokens.refresh_token = refresh_token_owned;
+        auth.last_refresh = Some(Utc::now());
+
+        // Write file (0600)
+        let json_data = serde_json::to_string_pretty(&auth)?;
+        let mut opts = std::fs::OpenOptions::new();
+        opts.truncate(true).write(true).create(true);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::OpenOptionsExt;
+            opts.mode(0o600);
+        }
+        let mut file = opts.open(&auth_file)?;
+        use std::io::Write as _;
+        file.write_all(json_data.as_bytes())?;
+        file.flush()?;
+        Ok::<(), std::io::Error>(())
+    }).await.map_err(|e| std::io::Error::other(format!("persist task failed: {e}")))?;
+    result.map_err(LoginError::from)
+}
+
+#[cfg(target_os = "macos")]
+fn jwt_auth_claims(jwt: &str) -> serde_json::Map<String, serde_json::Value> {
+    use base64::Engine;
+    let mut parts = jwt.split('.');
+    let (_h, payload_b64, _s) = match (parts.next(), parts.next(), parts.next()) {
+        (Some(h), Some(p), Some(s)) if !h.is_empty() && !p.is_empty() && !s.is_empty() => (h, p, s),
+        _ => { return serde_json::Map::new(); }
+    };
+    match base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload_b64) {
+        Ok(bytes) => match serde_json::from_slice::<serde_json::Value>(&bytes) {
+            Ok(mut v) => {
+                if let Some(obj) = v.get_mut("https://api.openai.com/auth").and_then(|x| x.as_object_mut()) { return obj.clone(); }
+            }
+            Err(_) => {}
+        },
+        Err(_) => {}
+    }
+    serde_json::Map::new()
+}
+
+#[cfg(target_os = "macos")]
+const SWIFT_HELPER_SRC: &str = r#"import Cocoa
+import WebKit
+
+final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, NSWindowDelegate {
+    private var didComplete = false
+    private var window: NSWindow!
+    private var webView: WKWebView!
+    private var authorizeURL: URL!
+    private var expectedState: String!
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        buildMenus()
+        let args = CommandLine.arguments
+        guard let urlIdx = args.firstIndex(of: "--authorize-url").flatMap({ idx in
+            idx + 1 < args.count ? idx + 1 : nil
+        }), let stateIdx = args.firstIndex(of: "--state").flatMap({ idx in
+            idx + 1 < args.count ? idx + 1 : nil }) else {
+            fputs("usage: codex-auth-helper --authorize-url <URL> --state <STATE>\n", stderr)
+            NSApp.terminate(nil)
+            return
+        }
+        guard let authURL = URL(string: args[urlIdx]) else {
+            fputs("invalid authorize url\n", stderr)
+            NSApp.terminate(nil)
+            return
+        }
+        self.authorizeURL = authURL
+        self.expectedState = args[stateIdx]
+
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .nonPersistent()
+
+        webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = self
+
+        window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 720, height: 820),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.center()
+        window.title = "Codex – Sign in to OpenAI"
+        window.contentView = webView
+        window.delegate = self
+        window.makeKeyAndOrderFront(nil)
+        window.makeFirstResponder(webView)
+        NSApp.activate(ignoringOtherApps: true)
+
+        webView.load(URLRequest(url: authorizeURL))
+    }
+
+    // Close behavior: treat closing the window as an abort and exit non‑zero.
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { true }
+    func windowWillClose(_ notification: Notification) { exit(didComplete ? 0 : 2) }
+
+    private func buildMenus() {
+        let mainMenu = NSMenu()
+        let appName = ProcessInfo.processInfo.processName
+
+        let appMenuItem = NSMenuItem()
+        let appMenu = NSMenu(title: appName)
+        appMenu.addItem(withTitle: "About \(appName)", action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
+        appMenu.addItem(NSMenuItem.separator())
+        appMenu.addItem(withTitle: "Quit \(appName)", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        appMenuItem.submenu = appMenu
+
+        let editMenuItem = NSMenuItem()
+        let editMenu = NSMenu(title: "Edit")
+        editMenu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+        editMenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+        editMenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        editMenu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+        editMenuItem.submenu = editMenu
+
+        mainMenu.addItem(appMenuItem)
+        mainMenu.addItem(editMenuItem)
+        NSApp.mainMenu = mainMenu
+    }
+
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard let url = navigationAction.request.url else { decisionHandler(.allow); return }
+        if url.scheme == "http", (url.host == "localhost" || url.host == "127.0.0.1"), url.path.hasPrefix("/auth/callback") {
+            if let comps = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+                let qp = Dictionary(uniqueKeysWithValues: (comps.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+                let code = qp["code"] ?? ""
+                let state = qp["state"] ?? ""
+                if code.isEmpty { fputs("missing authorization code\n", stderr) }
+                else if state != expectedState { fputs("state mismatch\n", stderr) }
+                else {
+                    didComplete = true
+                    let payload = "{\"code\":\"\(code)\",\"state\":\"\(state)\"}\n"
+                    if let data = payload.data(using: .utf8) { FileHandle.standardOutput.write(data) }
+                }
+            }
+            decisionHandler(.cancel)
+            NSApp.terminate(nil)
+            return
+        }
+        decisionHandler(.allow)
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        fputs("navigation error: \(error)\n", stderr)
+    }
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        fputs("provisional nav error: \(error)\n", stderr)
+    }
+}
+
+let app = NSApplication.shared
+app.setActivationPolicy(.regular)
+let delegate = AppDelegate()
+app.delegate = delegate
+app.run()
+"#;
+
+// Prefer an embedded helper produced at build time (see build.rs). If the embedded
+// bytes are empty or execution fails, we fall back to compiling the helper on demand.
+#[cfg(target_os = "macos")]
+static EMBEDDED_HELPER: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/codex-auth-helper"));
+
+#[cfg(target_os = "macos")]
+async fn compile_and_run_swift_helper(authorize_url: &str, state: &str) -> Result<AuthCodeCapture, LoginError> {
+    // If embedded helper is present (non-empty), try running it first.
+    if !EMBEDDED_HELPER.is_empty() {
+        use std::fs;
+        use std::io::Write;
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp_dir = std::env::temp_dir().join(format!("codex-embedded-{}", std::process::id()));
+        fs::create_dir_all(&temp_dir)?;
+        let helper_bin = temp_dir.join("codex-auth-helper");
+        let mut f = fs::File::create(&helper_bin)?;
+        f.write_all(EMBEDDED_HELPER)?;
+        f.flush()?;
+        let mut perms = fs::metadata(&helper_bin)?.permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&helper_bin, perms)?;
+
+        let mut cmd = tokio::process::Command::new(&helper_bin);
+        cmd.arg("--authorize-url").arg(authorize_url).arg("--state").arg(state);
+        cmd.env("NSUnbufferedIO", "YES");
+        cmd.stdout(Stdio::piped()).stderr(Stdio::inherit());
+        match cmd.output().await {
+            Ok(output) => {
+                if output.status.success() {
+                    let stdout = String::from_utf8_lossy(&output.stdout);
+                    if let Ok(capture) = serde_json::from_str::<AuthCodeCapture>(stdout.trim()) {
+                        return Ok(capture);
+                    }
+                    // Ran successfully but output malformed → treat as error, do NOT reopen.
+                    return Err(LoginError::InvalidHelperResponse);
+                } else {
+                    // Helper exited non‑zero (likely user closed the window). Do NOT reopen.
+                    return Err(LoginError::Aborted);
+                }
+            }
+            Err(_) => { /* fall through to on-demand compile */ }
+        }
+    }
+
+    // Fallback: compile Swift source now and run it
+    compile_and_run_swift_helper_fallback(authorize_url, state).await
+}
+
+#[cfg(target_os = "macos")]
+async fn compile_and_run_swift_helper_fallback(authorize_url: &str, state: &str) -> Result<AuthCodeCapture, LoginError> {
+    use std::fs;
+    use std::io::Write;
+    use rand::RngCore;
+
+    // Create a temp dir and paths
+    let mut rand_bytes = [0u8; 8];
+    rand::thread_rng().fill_bytes(&mut rand_bytes);
+    let temp_dir = std::env::temp_dir().join(format!("codex-auth-{:x}", u64::from_le_bytes(rand_bytes)));
+    fs::create_dir_all(&temp_dir)?;
+    let swift_src = temp_dir.join("CodexAuthHelper.swift");
+    let helper_bin = temp_dir.join("codex-auth-helper");
+
+    // Write Swift source
+    let mut f = fs::File::create(&swift_src)?;
+    f.write_all(SWIFT_HELPER_SRC.as_bytes())?;
+    f.flush()?;
+
+    // Try to compile via swiftc (or xcrun swiftc)
+    let compile_cmds: Vec<Vec<String>> = vec![
+        vec!["swiftc".into(), "-O".into(), "-framework".into(), "Cocoa".into(), "-framework".into(), "WebKit".into(), swift_src.to_string_lossy().into(), "-o".into(), helper_bin.to_string_lossy().into()],
+        vec!["/usr/bin/swiftc".into(), "-O".into(), "-framework".into(), "Cocoa".into(), "-framework".into(), "WebKit".into(), swift_src.to_string_lossy().into(), "-o".into(), helper_bin.to_string_lossy().into()],
+        vec!["xcrun".into(), "swiftc".into(), "-O".into(), "-framework".into(), "Cocoa".into(), "-framework".into(), "WebKit".into(), swift_src.to_string_lossy().into(), "-o".into(), helper_bin.to_string_lossy().into()],
+    ];
+
+    let mut compiled = false;
+    for argv in compile_cmds {
+        let mut cmd = tokio::process::Command::new(&argv[0]);
+        cmd.args(&argv[1..]);
+        match cmd.stdout(Stdio::null()).stderr(Stdio::piped()).status().await {
+            Ok(status) if status.success() => { compiled = true; break; }
+            Ok(_) | Err(_) => { /* try next */ }
+        }
+    }
+    if !compiled {
+        return Err(LoginError::HelperCompileFailed("swiftc not found or compile failed".to_string()));
+    }
+
+    // Run helper
+    let mut cmd = tokio::process::Command::new(&helper_bin);
+    cmd.arg("--authorize-url").arg(authorize_url).arg("--state").arg(state);
+    cmd.env("NSUnbufferedIO", "YES");
+    cmd.stdout(Stdio::piped()).stderr(Stdio::inherit());
+    let output = cmd.output().await?;
+    if !output.status.success() {
+        return Err(LoginError::Aborted);
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let capture: AuthCodeCapture = serde_json::from_str(stdout.trim()).map_err(|_| LoginError::InvalidHelperResponse)?;
+    Ok(capture)
+}

--- a/codex-rs/login/src/native_browser.rs
+++ b/codex-rs/login/src/native_browser.rs
@@ -23,7 +23,8 @@ pub async fn login_with_native_browser(codex_home: &Path) -> Result<(), LoginErr
     let redirect_uri = format!("http://localhost:{}/auth/callback", 1455u16);
     // Allow tests to override the issuer base via env var (debug builds only).
     #[cfg(debug_assertions)]
-    let issuer = std::env::var("CODEX_LOGIN_ISSUER_BASE").unwrap_or_else(|_| DEFAULT_ISSUER.to_string());
+    let issuer =
+        std::env::var("CODEX_LOGIN_ISSUER_BASE").unwrap_or_else(|_| DEFAULT_ISSUER.to_string());
     #[cfg(not(debug_assertions))]
     let issuer = DEFAULT_ISSUER.to_string();
     let auth_url = build_authorize_url(
@@ -39,7 +40,9 @@ pub async fn login_with_native_browser(codex_home: &Path) -> Result<(), LoginErr
     #[cfg(debug_assertions)]
     let capture = match std::env::var("CODEX_LOGIN_TEST_HELPER_JSON") {
         Ok(val) => {
-            if val == "ABORT" { return Err(LoginError::Aborted); }
+            if val == "ABORT" {
+                return Err(LoginError::Aborted);
+            }
             serde_json::from_str::<AuthCodeCapture>(&val)
                 .map_err(|_| LoginError::InvalidHelperResponse)?
         }
@@ -228,9 +231,10 @@ async fn persist_tokens(
         use std::fs;
         let auth_file = get_auth_file(&codex_home);
         if let Some(parent) = auth_file.parent()
-            && !parent.exists() {
-                fs::create_dir_all(parent)?;
-            }
+            && !parent.exists()
+        {
+            fs::create_dir_all(parent)?;
+        }
         let mut auth = match crate::try_read_auth_json(&auth_file) {
             Ok(a) => a,
             Err(_) => AuthDotJson {
@@ -285,13 +289,15 @@ fn jwt_auth_claims(jwt: &str) -> serde_json::Map<String, serde_json::Value> {
             return serde_json::Map::new();
         }
     };
-    if let Ok(bytes) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload_b64) { if let Ok(mut v) = serde_json::from_slice::<serde_json::Value>(&bytes)
-    && let Some(obj) = v
-        .get_mut("https://api.openai.com/auth")
-        .and_then(|x| x.as_object_mut())
-    {
-        return obj.clone();
-    } }
+    if let Ok(bytes) = base64::engine::general_purpose::URL_SAFE_NO_PAD.decode(payload_b64) {
+        if let Ok(mut v) = serde_json::from_slice::<serde_json::Value>(&bytes)
+            && let Some(obj) = v
+                .get_mut("https://api.openai.com/auth")
+                .and_then(|x| x.as_object_mut())
+        {
+            return obj.clone();
+        }
+    }
     serde_json::Map::new()
 }
 
@@ -499,8 +505,14 @@ mod tests_macos {
     #[test]
     fn jwt_auth_claims_extracts_nested_fields() {
         #[derive(serde::Serialize)]
-        struct Header { alg: &'static str, typ: &'static str }
-        let header = Header { alg: "none", typ: "JWT" };
+        struct Header {
+            alg: &'static str,
+            typ: &'static str,
+        }
+        let header = Header {
+            alg: "none",
+            typ: "JWT",
+        };
         let payload = serde_json::json!({
             "https://api.openai.com/auth": {
                 "chatgpt_plan_type": "pro",
@@ -515,8 +527,14 @@ mod tests_macos {
             b64(b"sig")
         );
         let claims = jwt_auth_claims(&jwt);
-        assert_eq!(claims.get("chatgpt_plan_type").and_then(|v| v.as_str()), Some("pro"));
-        assert_eq!(claims.get("chatgpt_account_id").and_then(|v| v.as_str()), Some("acc-42"));
+        assert_eq!(
+            claims.get("chatgpt_plan_type").and_then(|v| v.as_str()),
+            Some("pro")
+        );
+        assert_eq!(
+            claims.get("chatgpt_account_id").and_then(|v| v.as_str()),
+            Some("acc-42")
+        );
     }
 }
 

--- a/codex-rs/login/src/native_browser_helper.swift
+++ b/codex-rs/login/src/native_browser_helper.swift
@@ -1,0 +1,117 @@
+import Cocoa
+import WebKit
+
+final class AppDelegate: NSObject, NSApplicationDelegate, WKNavigationDelegate, NSWindowDelegate {
+    private var didComplete = false
+    private var window: NSWindow!
+    private var webView: WKWebView!
+    private var authorizeURL: URL!
+    private var expectedState: String!
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        buildMenus()
+        let args = CommandLine.arguments
+        guard let urlIdx = args.firstIndex(of: "--authorize-url").flatMap({ idx in
+            idx + 1 < args.count ? idx + 1 : nil
+        }), let stateIdx = args.firstIndex(of: "--state").flatMap({ idx in
+            idx + 1 < args.count ? idx + 1 : nil }) else {
+            fputs("usage: codex-auth-helper --authorize-url <URL> --state <STATE>\n", stderr)
+            NSApp.terminate(nil)
+            return
+        }
+        guard let authURL = URL(string: args[urlIdx]) else {
+            fputs("invalid authorize url\n", stderr)
+            NSApp.terminate(nil)
+            return
+        }
+        self.authorizeURL = authURL
+        self.expectedState = args[stateIdx]
+
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .nonPersistent()
+
+        webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = self
+
+        window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 720, height: 820),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.center()
+        window.title = "Codex – Sign in to OpenAI"
+        window.contentView = webView
+        window.delegate = self
+        window.makeKeyAndOrderFront(nil)
+        window.makeFirstResponder(webView)
+        NSApp.activate(ignoringOtherApps: true)
+
+        webView.load(URLRequest(url: authorizeURL))
+    }
+
+    // Close behavior: treat closing the window as an abort and exit non‑zero.
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool { true }
+    func windowWillClose(_ notification: Notification) { exit(didComplete ? 0 : 2) }
+
+    private func buildMenus() {
+        let mainMenu = NSMenu()
+        let appName = ProcessInfo.processInfo.processName
+
+        // App menu
+        let appMenuItem = NSMenuItem()
+        let appMenu = NSMenu(title: appName)
+        appMenu.addItem(withTitle: "About \(appName)", action: #selector(NSApplication.orderFrontStandardAboutPanel(_:)), keyEquivalent: "")
+        appMenu.addItem(NSMenuItem.separator())
+        appMenu.addItem(withTitle: "Quit \(appName)", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        appMenuItem.submenu = appMenu
+
+        // Edit menu (enables Cmd+C/V, etc.)
+        let editMenuItem = NSMenuItem()
+        let editMenu = NSMenu(title: "Edit")
+        editMenu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+        editMenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+        editMenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+        editMenu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+        editMenuItem.submenu = editMenu
+
+        mainMenu.addItem(appMenuItem)
+        mainMenu.addItem(editMenuItem)
+        NSApp.mainMenu = mainMenu
+    }
+
+    func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
+        guard let url = navigationAction.request.url else { decisionHandler(.allow); return }
+        if url.scheme == "http", (url.host == "localhost" || url.host == "127.0.0.1"), url.path.hasPrefix("/auth/callback") {
+            if let comps = URLComponents(url: url, resolvingAgainstBaseURL: false) {
+                let qp = Dictionary(uniqueKeysWithValues: (comps.queryItems ?? []).map { ($0.name, $0.value ?? "") })
+                let code = qp["code"] ?? ""
+                let state = qp["state"] ?? ""
+                if code.isEmpty { fputs("missing authorization code\n", stderr) }
+                else if state != expectedState { fputs("state mismatch\n", stderr) }
+                else {
+                    didComplete = true
+                    let payload = "{\"code\":\"\(code)\",\"state\":\"\(state)\"}\n"
+                    if let data = payload.data(using: .utf8) { FileHandle.standardOutput.write(data) }
+                }
+            }
+            decisionHandler(.cancel)
+            NSApp.terminate(nil)
+            return
+        }
+        decisionHandler(.allow)
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        fputs("navigation error: \(error)\n", stderr)
+    }
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        fputs("provisional nav error: \(error)\n", stderr)
+    }
+}
+
+let app = NSApplication.shared
+app.setActivationPolicy(.regular)
+let delegate = AppDelegate()
+app.delegate = delegate
+app.run()

--- a/codex-rs/login/tests/suite/mod.rs
+++ b/codex-rs/login/tests/suite/mod.rs
@@ -1,2 +1,4 @@
 // Aggregates all former standalone integration tests as modules.
 mod login_server_e2e;
+#[cfg(target_os = "macos")]
+mod native_browser;

--- a/codex-rs/login/tests/suite/native_browser.rs
+++ b/codex-rs/login/tests/suite/native_browser.rs
@@ -1,0 +1,240 @@
+#![allow(clippy::unwrap_used)]
+
+use std::net::SocketAddr;
+use std::net::TcpListener;
+use std::thread;
+
+use base64::Engine;
+use codex_login::login_with_native_browser;
+use codex_login::LoginError;
+use tempfile::tempdir;
+use std::sync::{Mutex, OnceLock};
+
+// Skip tests when running in a sandbox with network disabled.
+const CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR: &str = "CODEX_SANDBOX_NETWORK_DISABLED";
+
+#[inline]
+fn set_env(key: &str, val: &str) {
+    // Environment mutation is unsafe in Rust 2024 due to global process state.
+    unsafe { std::env::set_var(key, val) }
+}
+
+#[inline]
+fn unset_env(key: &str) {
+    unsafe { std::env::remove_var(key) }
+}
+
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+#[cfg(target_os = "macos")]
+fn start_mock_issuer() -> (SocketAddr, thread::JoinHandle<()>) {
+    // Bind to a random available port
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tiny_http::Server::from_listener(listener, None).unwrap();
+
+    let handle = thread::spawn(move || {
+        while let Ok(mut req) = server.recv() {
+            let url = req.url().to_string();
+            if url.starts_with("/oauth/token") {
+                // Read body (application/x-www-form-urlencoded)
+                let mut body = String::new();
+                let _ = req.as_reader().read_to_string(&mut body);
+
+                // Decide which grant
+                if body.contains("grant_type=authorization_code") {
+                    // Build minimal JWT with plan=pro and email
+                    #[derive(serde::Serialize)]
+                    struct Header { alg: &'static str, typ: &'static str }
+                    let header = Header { alg: "none", typ: "JWT" };
+                    let payload = serde_json::json!({
+                        "email": "user@example.com",
+                        "https://api.openai.com/auth": {
+                            "chatgpt_plan_type": "pro",
+                            "chatgpt_account_id": "acc-123"
+                        }
+                    });
+                    let b64 = |b: &[u8]| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b);
+                    let header_bytes = serde_json::to_vec(&header).unwrap();
+                    let payload_bytes = serde_json::to_vec(&payload).unwrap();
+                    let id_token = format!("{}.{}.{}", b64(&header_bytes), b64(&payload_bytes), b64(b"sig"));
+
+                    let tokens = serde_json::json!({
+                        "id_token": id_token,
+                        "access_token": "access-abc",
+                        "refresh_token": "refresh-abc",
+                    });
+                    let data = serde_json::to_vec(&tokens).unwrap();
+                    let mut resp = tiny_http::Response::from_data(data);
+                    resp.add_header(
+                        tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap(),
+                    );
+                    let _ = req.respond(resp);
+                } else if body.contains("grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Atoken-exchange")
+                    && body.contains("requested_token=openai-api-key")
+                {
+                    let exchange = serde_json::json!({ "access_token": "sk-test-api-key" });
+                    let data = serde_json::to_vec(&exchange).unwrap();
+                    let mut resp = tiny_http::Response::from_data(data);
+                    resp.add_header(
+                        tiny_http::Header::from_bytes(&b"Content-Type"[..], &b"application/json"[..]).unwrap(),
+                    );
+                    let _ = req.respond(resp);
+                } else {
+                    let _ = req.respond(tiny_http::Response::from_string("bad request").with_status_code(400));
+                }
+            } else {
+                let _ = req.respond(tiny_http::Response::from_string("not found").with_status_code(404));
+            }
+        }
+    });
+
+    (addr, handle)
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn persists_auth_json_on_success() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() {
+        println!("Skipping native browser test due to network-disabled sandbox");
+        return;
+    }
+
+    let (issuer_addr, _h) = start_mock_issuer();
+    let issuer = format!("http://{}:{}", issuer_addr.ip(), issuer_addr.port());
+
+    // Force deterministic helper output (bypass UI) and state.
+    set_env("CODEX_LOGIN_ISSUER_BASE", &issuer);
+    set_env("CODEX_LOGIN_FORCE_STATE", "state-ok");
+    set_env("CODEX_LOGIN_TEST_HELPER_JSON", r#"{"code":"abc","state":"state-ok"}"#);
+
+    let tmp = tempdir().unwrap();
+    let codex_home = tmp.path().to_path_buf();
+
+    login_with_native_browser(&codex_home)
+        .await
+        .expect("native login should succeed");
+
+    // Validate auth.json
+    let auth_path = codex_home.join("auth.json");
+    let data = std::fs::read_to_string(&auth_path).unwrap();
+    let json: serde_json::Value = serde_json::from_str(&data).unwrap();
+    assert_eq!(json["OPENAI_API_KEY"], serde_json::json!("sk-test-api-key"));
+    assert_eq!(json["tokens"]["access_token"], "access-abc");
+    assert_eq!(json["tokens"]["refresh_token"], "refresh-abc");
+    assert_eq!(json["tokens"]["account_id"], "acc-123");
+    // cleanup env for other tests
+    unset_env("CODEX_LOGIN_ISSUER_BASE");
+    unset_env("CODEX_LOGIN_FORCE_STATE");
+    unset_env("CODEX_LOGIN_TEST_HELPER_JSON");
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn abort_propagates_from_helper() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() {
+        println!("Skipping native browser test due to network-disabled sandbox");
+        return;
+    }
+
+    // Helper aborts before any network requests.
+    set_env("CODEX_LOGIN_TEST_HELPER_JSON", "ABORT");
+    let tmp = tempdir().unwrap();
+    let err = login_with_native_browser(tmp.path()).await.unwrap_err();
+    assert!(matches!(err, LoginError::Aborted));
+    unset_env("CODEX_LOGIN_TEST_HELPER_JSON");
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn state_mismatch_is_rejected() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() {
+        println!("Skipping native browser test due to network-disabled sandbox");
+        return;
+    }
+
+    set_env("CODEX_LOGIN_FORCE_STATE", "expected");
+    set_env("CODEX_LOGIN_TEST_HELPER_JSON", r#"{"code":"abc","state":"wrong"}"#);
+    let tmp = tempdir().unwrap();
+    let err = login_with_native_browser(tmp.path()).await.unwrap_err();
+    assert!(matches!(err, LoginError::StateMismatch));
+    unset_env("CODEX_LOGIN_FORCE_STATE");
+    unset_env("CODEX_LOGIN_TEST_HELPER_JSON");
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn invalid_helper_json_is_rejected() {
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() { return; }
+    set_env("CODEX_LOGIN_TEST_HELPER_JSON", "not-json");
+    let tmp = tempdir().unwrap();
+    let err = login_with_native_browser(tmp.path()).await.unwrap_err();
+    match err {
+        LoginError::InvalidHelperResponse => {}
+        other => panic!("unexpected error: {other:?}"),
+    }
+    unset_env("CODEX_LOGIN_TEST_HELPER_JSON");
+}
+
+#[cfg(target_os = "macos")]
+#[tokio::test]
+async fn token_exchange_failure_is_bubbled() {
+    use tiny_http::Server;
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() { return; }
+
+    // Issuer always responds 500 to /oauth/token for the first exchange
+    let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = Server::from_listener(listener, None).unwrap();
+    let _h = std::thread::spawn(move || {
+        while let Ok(req) = server.recv() {
+            if req.url().starts_with("/oauth/token") {
+                let _ = req.respond(tiny_http::Response::from_string("oops").with_status_code(500));
+            } else {
+                let _ = req.respond(tiny_http::Response::from_string("not found").with_status_code(404));
+            }
+        }
+    });
+    let issuer = format!("http://{}:{}", addr.ip(), addr.port());
+    set_env("CODEX_LOGIN_ISSUER_BASE", &issuer);
+    set_env("CODEX_LOGIN_FORCE_STATE", "s");
+    set_env("CODEX_LOGIN_TEST_HELPER_JSON", r#"{"code":"abc","state":"s"}"#);
+    let tmp = tempdir().unwrap();
+    let err = login_with_native_browser(tmp.path()).await.unwrap_err();
+    match err {
+        LoginError::TokenExchangeFailed(_) => {}
+        other => panic!("unexpected error: {other:?}"),
+    }
+    unset_env("CODEX_LOGIN_ISSUER_BASE");
+    unset_env("CODEX_LOGIN_FORCE_STATE");
+    unset_env("CODEX_LOGIN_TEST_HELPER_JSON");
+}
+
+#[cfg(all(target_os = "macos", unix))]
+#[tokio::test]
+async fn auth_json_permissions_are_restrictive() {
+    use std::os::unix::fs::PermissionsExt;
+    let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() { return; }
+
+    let (issuer_addr, _h) = start_mock_issuer();
+    let issuer = format!("http://{}:{}", issuer_addr.ip(), issuer_addr.port());
+    set_env("CODEX_LOGIN_ISSUER_BASE", &issuer);
+    set_env("CODEX_LOGIN_FORCE_STATE", "state-ok");
+    set_env("CODEX_LOGIN_TEST_HELPER_JSON", r#"{"code":"abc","state":"state-ok"}"#);
+
+    let tmp = tempdir().unwrap();
+    login_with_native_browser(tmp.path()).await.unwrap();
+    let p = tmp.path().join("auth.json");
+    let mode = std::fs::metadata(&p).unwrap().permissions().mode();
+    // Only user perms should be set (rw------- => 0o600)
+    assert_eq!(mode & 0o077, 0, "group/other permissions should be zero");
+    unset_env("CODEX_LOGIN_ISSUER_BASE");
+    unset_env("CODEX_LOGIN_FORCE_STATE");
+    unset_env("CODEX_LOGIN_TEST_HELPER_JSON");
+}

--- a/codex-rs/login/tests/suite/native_browser.rs
+++ b/codex-rs/login/tests/suite/native_browser.rs
@@ -118,6 +118,7 @@ fn start_mock_issuer() -> (SocketAddr, thread::JoinHandle<()>) {
 
 #[cfg(target_os = "macos")]
 #[tokio::test]
+#[serial_test::serial]
 async fn persists_auth_json_on_success() {
     if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() {
         println!("Skipping native browser test due to network-disabled sandbox");
@@ -164,6 +165,7 @@ async fn persists_auth_json_on_success() {
 
 #[cfg(target_os = "macos")]
 #[tokio::test]
+#[serial_test::serial]
 async fn abort_propagates_from_helper() {
     if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() {
         println!("Skipping native browser test due to network-disabled sandbox");
@@ -186,6 +188,7 @@ async fn abort_propagates_from_helper() {
 
 #[cfg(target_os = "macos")]
 #[tokio::test]
+#[serial_test::serial]
 async fn state_mismatch_is_rejected() {
     if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() {
         println!("Skipping native browser test due to network-disabled sandbox");
@@ -212,8 +215,11 @@ async fn state_mismatch_is_rejected() {
 
 #[cfg(target_os = "macos")]
 #[tokio::test]
+#[serial_test::serial]
 async fn invalid_helper_json_is_rejected() {
-    if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() { return; }
+    if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() {
+        return;
+    }
     {
         let _lock = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
         set_env("CODEX_LOGIN_TEST_HELPER_JSON", "not-json");
@@ -232,9 +238,12 @@ async fn invalid_helper_json_is_rejected() {
 
 #[cfg(target_os = "macos")]
 #[tokio::test]
+#[serial_test::serial]
 async fn token_exchange_failure_is_bubbled() {
     use tiny_http::Server;
-    if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() { return; }
+    if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() {
+        return;
+    }
 
     // Issuer always responds 500 to /oauth/token for the first exchange
     let listener = TcpListener::bind(("127.0.0.1", 0)).unwrap();
@@ -276,6 +285,7 @@ async fn token_exchange_failure_is_bubbled() {
 
 #[cfg(all(target_os = "macos", unix))]
 #[tokio::test]
+#[serial_test::serial]
 async fn auth_json_permissions_are_restrictive() {
     use std::os::unix::fs::PermissionsExt;
     if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() {

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -1862,7 +1862,7 @@ mod tests {
                 composer.handle_paste(paste.clone());
                 composer
                     .textarea
-                    .set_cursor((placeholder.len() - pos_from_end) as usize);
+                    .set_cursor(placeholder.len() - pos_from_end);
                 composer.handle_key_event(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
                 let result = (
                     composer.textarea.text().contains(&placeholder),

--- a/docs/macos-native-browser-login.md
+++ b/docs/macos-native-browser-login.md
@@ -1,0 +1,63 @@
+# macOS Native Browser Login (WKWebView)
+
+Codex can complete ChatGPT authentication using a tiny macOS helper that opens a real browser context (WebKit/WKWebView) and intercepts the final redirect to `http://localhost/.../auth/callback`. This avoids issues where desktop browsers refuse to follow an `https` → `http` redirect for localhost, and removes the need to run a local HTTP server.
+
+## When to use it
+
+- You’re on macOS and your default browser blocks the `http://localhost` callback.
+- You want a seamless login from the CLI without copying URLs or running a local login server.
+
+## Usage
+
+```bash
+codex login --browser
+```
+
+This opens a small window titled “Codex – Sign in to OpenAI.” After you complete login, the window closes automatically and Codex persists your credentials to `$CODEX_HOME/auth.json` (defaults to `~/.codex/auth.json`).
+
+Notes:
+- This feature is currently macOS-only. On other platforms, `codex login --browser` will print a friendly “not supported” message.
+- The helper uses a non‑persistent `WKWebsiteDataStore` and only returns the OAuth `code` and `state` to the CLI. The CLI exchanges tokens and performs secure persistence.
+- Basic macOS menus are available (About, Quit, Cut/Copy/Paste/Select All). Copy/paste (⌘C/⌘V) works in all form fields.
+- Closing the window aborts login (non-zero exit). The CLI prints a neutral “Login aborted…” message and does not reopen the helper.
+
+## Requirements (macOS)
+
+- macOS 12+
+- Xcode Command Line Tools (for `swiftc`) — run: `xcode-select --install`
+
+The Swift helper is compiled automatically during `cargo build` for macOS and embedded into the binary. At runtime, Codex prefers the embedded helper. If the embedded helper is missing (e.g., build environment lacked `swiftc`), Codex will attempt to compile the helper on-demand when you run `codex login --browser`.
+
+## How it works (high level)
+
+1. The CLI generates PKCE + state and constructs the regular authorize URL with `redirect_uri=http://localhost:1455/auth/callback`.
+2. A tiny helper app opens that URL in `WKWebView`.
+3. When the page tries to navigate to `http://localhost/.../auth/callback`, the helper intercepts the navigation (via `WKNavigationDelegate`), extracts `code` and `state`, cancels the load, prints JSON to stdout, and exits.
+4. The CLI validates `state`, exchanges the `code` for tokens, and optionally performs a token exchange for an API Key (when available). Finally, it persists tokens to `auth.json` and prints a success message that includes basic account details (e.g., email, plan) when available.
+
+Exit codes and messages:
+- Success: prints “✅ Successfully logged in using native browser …” and exits 0.
+- Aborted by user (window closed): prints “Login aborted (native browser window closed)” and exits 2.
+- Other failures: prints a concise error and exits 1.
+
+## Troubleshooting
+
+- “swiftc not found” during `cargo build`:
+  - Install Xcode Command Line Tools: `xcode-select --install`. Rebuild.
+  - If build still cannot compile the helper, the runtime will try an on‑demand compile the first time you run `codex login --browser`.
+- The window opens but then closes without logging in:
+  - Ensure the login completed and no network policy blocked the flow. Run again and check terminal output for errors.
+- Using a non‑macOS platform:
+  - This feature is macOS‑only for now; use the standard `codex login` flow or the “device authorization” path.
+
+## Security considerations
+
+- The helper runs with an ephemeral (non‑persistent) WebKit data store.
+- The helper returns only `code`/`state` to the CLI. Token exchange and persistence happen in the CLI process.
+- The CLI writes `auth.json` with mode `0600` on Unix systems.
+
+## Implementation overview
+
+- CLI flag: `codex login --browser` (in `codex-rs/cli`).
+- Helper build: `codex-rs/login/build.rs` compiles `src/native_browser_helper.swift` to `OUT_DIR/codex-auth-helper` on macOS and embeds it into the Rust crate.
+- Runtime: `codex-rs/login/src/native_browser.rs` prefers the embedded helper; otherwise falls back to compiling an embedded Swift source string on-demand.

--- a/docs/release_management.md
+++ b/docs/release_management.md
@@ -45,3 +45,9 @@ Once everything builds, a Homebrew admin has to approve the PR. Again, the whole
 For reference, our Homebrew formula lives at:
 
 https://github.com/Homebrew/homebrew-core/blob/main/Formula/c/codex.rb
+
+## Platform-specific notes (macOS helper)
+
+- The macOS login flow uses a tiny Swift helper (WKWebView). Our macOS builds embed this helper as a universal binary (arm64 + x86_64) so a single release artifact works on both Apple Silicon and Intel Macs.
+- The helper is only compiled/embedded on macOS targets. Linux and Windows builds do not include it.
+- If the build machine lacks Xcode Command Line Tools (`swiftc`), the build script will warn and embed an empty placeholder; users can still run `codex login --browser` if their runtime machine has `swiftc` installed (the CLI will compile the helper on-demand the first time it is needed).


### PR DESCRIPTION
> [!NOTE]
> Coded with codex 0.23.0 GPT-5 Pro reasoning=high

> [!IMPORTANT]
> **Not ready to merge. PoC state.** I'll put more work on this if this feature makes sense for OpenaAI Codex team. If your auth server supports OAuth 2.0 Device Authorization Grant this PR / feature may not add value.

<img width="1021" height="801" alt="Screenshot 2025-08-27 at 01 21 14" src="https://github.com/user-attachments/assets/d518de40-5786-413e-b2f0-7d74369261c0" />

On macOS, localhost-based login is fragile: modern browsers and network controls often block or challenge https→http redirects or insecure HTTP loads at all. 

Running a local HTTP server adds friction (ports, firewall prompts, timeouts). This PR replaces that fragile step on macOS with a **tiny native helper app (WKWebView)**. The helper opens the authorize URL, intercepts the localhost callback purely inside WebKit, and returns only the OAuth code/state to the CLI. The CLI performs PKCE state validation, token exchange, and secure persistence — no local server or external browser redirect needed. This hardens security, improves reliability, and streamlines the user experience.

Summary
- Adds a macOS-native browser companion app (WKWebView) to complete ChatGPT login without a local HTTP server.
- Intercepts the localhost callback inside the helper; only returns code/state to the CLI for token exchange and persistence.
- PKCE + state validation is enforced by the CLI; auth.json persisted with restrictive permissions.

Key Changes
- New CLI path: `codex login --browser` (macOS only)
  - Swift helper opens the authorize URL; intercepts `http://localhost/.../auth/callback` in WKWebView.
  - Emits `{"code","state"}` JSON to stdout; exits. The CLI exchanges tokens and persists credentials.
  - Menus enabled (About/Quit, Cut/Copy/Paste/Select All). Copy/paste works in form fields.
  - Closing the window cleanly aborts login (exit code 2). CLI prints a neutral “Login aborted …” message.
- CLI UX/security
  - Re-login prompt now only when a persisted `auth.json` exists. An env-only `OPENAI_API_KEY` no longer triggers “already logged in”.
  - Success includes a ✅ plus basic details (email/plan) when available; errors are clear and typed.
- Typed errors
  - New `LoginError` enum: `Aborted`, `UnsupportedOs`, `StateMismatch`, `InvalidHelperResponse`, `TokenExchangeFailed`, `Network`, `Io`, etc., with clear CLI handling.
- Build (macOS)
  - Build-time embedding: `login/build.rs` now compiles a universal (arm64 + x86_64) helper and embeds it into the crate on macOS only.
  - Fallback: If build-time embedding fails (no swiftc SDK), runtime can compile on-demand the first time `codex login --browser` runs (requires `swiftc`).
  - Non‑macOS targets do not compile or embed the helper.
- MCP reporting
  - `getAuthStatus`/`logout` reflect persisted auth (`auth.json`) rather than ambient env-only keys (clear “logged in” semantics for tools/clients).

Documentation
- `docs/macos-native-browser-login.md`
  - Usage, requirements (Xcode CLT / `swiftc`), universal helper build, runtime fallback.
  - Behavior, troubleshooting, security notes, and high-level design.
- `docs/release_management.md`
  - Platform-specific notes: macOS builds embed a universal helper; Linux/Windows do not include it.

CI
- `.github/workflows/rust-ci.yml`
  - Added a macOS-only job that runs the login crate test suite on macos-14.
  - Existing matrix unchanged 
    - [ ] we can make the new job required if desired.

Tests
- Login crate (macOS-only integration tests):
  - Success: persists tokens + API key via local `tiny_http` issuer stub.
  - Abort: helper abort yields `LoginError::Aborted`.
  - State mismatch: forced state vs helper mismatch yields `LoginError::StateMismatch`.
  - Token exchange failure: 500 from issuer yields `LoginError::TokenExchangeFailed`.
  - Unix file permissions: `auth.json` written with `0600` (no group/other perms).
- Inline unit tests:
  - authorize URL has all required params in `native_browser.rs`.
  - nested claims parsing from JWT works.
  - Non-mac path returns `UnsupportedOs`.
- Determinism for mac tests: debug-only env seams (issuer/state/helper-json) used; tests serialize env to avoid races.

Security Considerations
- Helper uses a non-persistent `WKWebsiteDataStore`.
- Helper returns only code/state; tokens do not leave the helper.
- Strict state validation; explicit abort handling.
- `auth.json` stored with restrictive permissions on Unix.

Build & Distribution
- macOS release builds embed a universal helper (arm64 + x86_64). Linux/Windows exclude the helper entirely.
- If `swiftc` is missing at build time, we warn and rely on on-demand compile when the feature is used on a machine with `swiftc`.
- Optional notarization guidance (for zipped releases) available; Homebrew builds from source and does not require signing/notarization.

Backward Compatibility
- Default login (without `--browser`) is unchanged.
- Non-macOS: `codex login --browser` shows a friendly “only supported on macOS” error.
- MCP `getAuthStatus`/`logout` semantics improved to reflect persisted auth only (explicit user opt-in).

How To Verify
- macOS:
  - `cargo build --release`
  - Verify helper: `xcrun lipo -info target/release/build/codex-login-*/out/codex-auth-helper` shows `x86_64 arm64`.
  - Run: `./target/release/codex login --browser`
    - Window appears; completing login persists `auth.json` to `~/.codex/auth.json`. Closing window exits 2 with “Login aborted …”.
- Linux/Windows:
  - `cargo build --release --target <gnu/musl/msvc>`; no helper present; `--browser` prints not supported.

Files of Interest (diff summary)
- `.github/workflows/rust-ci.yml`: add macOS login test job
- `CHANGELOG.md`: add feature/UX/CI notes
- `README.md`: mention/usage addition for `--browser`
- `codex-rs/cli/src/main.rs`: add `--browser` flag wiring
- `codex-rs/cli/src/login.rs`: logic/UX for re-login confirmation; native path handling
- `codex-rs/login/Cargo.toml`: enable `build.rs`
- `codex-rs/login/build.rs`: compile universal helper (per-arch + lipo), fallback, embedding
- `codex-rs/login/src/error.rs`: new typed `LoginError`
- `codex-rs/login/src/lib.rs`: exported APIs; persisted-only helper; auth helpers
- `codex-rs/login/src/native_browser.rs`: native flow implementation, debug-only test seams, early helper bypass
- `codex-rs/login/src/native_browser_helper.swift`: helper source (single-sourced)
- `codex-rs/login/tests/suite/{mod.rs,native_browser.rs}`: macOS integration tests
- `codex-rs/mcp-server/src/codex_message_processor.rs`: persisted-only auth reporting in getAuthStatus/logout
- `docs/macos-native-browser-login.md`: user / dev docs
- `docs/release_management.md`: platform-specific notes

Open Questions / Next Steps
- Do we want to make the macOS-only test job required for PRs?
- Optional: add notarization steps for macOS artifacts in the release workflow for smoother Gatekeeper behavior if we publish zip downloads.
- Future parity: consider Windows/Linux equivalents for a native browser-assisted flow.

Thank you for reviewing!

---

I have read the CLA Document and I hereby sign the CLA