### PR TITLE
feat(tui): add Ctrl+V “paste image” hint to composer footer

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -1235,6 +1235,8 @@ impl WidgetRef for ChatComposer {
                         Span::from(" send   "),
                         newline_hint_key.set_style(key_hint_style),
                         Span::from(" newline   "),
+                        "Ctrl+V".set_style(key_hint_style),
+                        Span::from(" paste image   "),
                         "Ctrl+T".set_style(key_hint_style),
                         Span::from(" transcript   "),
                         "Ctrl+C".set_style(key_hint_style),

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__backspace_after_pastes.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__backspace_after_pastes.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "▌                                                                                                   "
-" ⏎ send   Ctrl+J newline   Ctrl+V paste image  Ctrl+T transcript   Ctrl+C quit                     "
+" ⏎ send   Ctrl+J newline   Ctrl+V paste image   Ctrl+T transcript   Ctrl+C quit                     "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__backspace_after_pastes.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__backspace_after_pastes.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "▌                                                                                                   "
-" ⏎ send   Ctrl+J newline   Ctrl+T transcript   Ctrl+C quit                                          "
+" ⏎ send   Ctrl+J newline   Ctrl+V paste image  Ctrl+T transcript   Ctrl+C quit                     "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__empty.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__empty.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "▌                                                                                                   "
-" ⏎ send   Ctrl+J newline   Ctrl+V paste image  Ctrl+T transcript   Ctrl+C quit                     "
+" ⏎ send   Ctrl+J newline   Ctrl+V paste image   Ctrl+T transcript   Ctrl+C quit                     "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__empty.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__empty.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "▌                                                                                                   "
-" ⏎ send   Ctrl+J newline   Ctrl+T transcript   Ctrl+C quit                                          "
+" ⏎ send   Ctrl+J newline   Ctrl+V paste image  Ctrl+T transcript   Ctrl+C quit                     "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__large.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__large.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "▌                                                                                                   "
-" ⏎ send   Ctrl+J newline   Ctrl+V paste image  Ctrl+T transcript   Ctrl+C quit                     "
+" ⏎ send   Ctrl+J newline   Ctrl+V paste image   Ctrl+T transcript   Ctrl+C quit                     "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__large.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__large.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "▌                                                                                                   "
-" ⏎ send   Ctrl+J newline   Ctrl+T transcript   Ctrl+C quit                                          "
+" ⏎ send   Ctrl+J newline   Ctrl+V paste image  Ctrl+T transcript   Ctrl+C quit                     "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__multiple_pastes.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__multiple_pastes.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "▌                                                                                                   "
-" ⏎ send   Ctrl+J newline   Ctrl+V paste image  Ctrl+T transcript   Ctrl+C quit                     "
+" ⏎ send   Ctrl+J newline   Ctrl+V paste image   Ctrl+T transcript   Ctrl+C quit                     "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__multiple_pastes.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__multiple_pastes.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "▌                                                                                                   "
-" ⏎ send   Ctrl+J newline   Ctrl+T transcript   Ctrl+C quit                                          "
+" ⏎ send   Ctrl+J newline   Ctrl+V paste image  Ctrl+T transcript   Ctrl+C quit                     "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "▌                                                                                                   "
-" ⏎ send   Ctrl+J newline   Ctrl+V paste image  Ctrl+T transcript   Ctrl+C quit                     "
+" ⏎ send   Ctrl+J newline   Ctrl+V paste image   Ctrl+T transcript   Ctrl+C quit                     "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "▌                                                                                                   "
-" ⏎ send   Ctrl+J newline   Ctrl+T transcript   Ctrl+C quit                                          "
+" ⏎ send   Ctrl+J newline   Ctrl+V paste image  Ctrl+T transcript   Ctrl+C quit                     "

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_widget_active.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_widget_active.snap
@@ -7,5 +7,5 @@ expression: terminal.backend()
 " Analyzing (0s • Esc to interrupt)                                              "
 "                                                                                "
 "▌ Ask Codex to do anything                                                      "
-" ⏎ send   Ctrl+J newline   Ctrl+V paste image  Ctrl+T transcript   Ctrl+C quit "
+" ⏎ send   Ctrl+J newline   Ctrl+V paste image   Ctrl+T transcript   Ctrl+C quit "
 "                                                                                "

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_widget_active.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_widget_active.snap
@@ -7,5 +7,5 @@ expression: terminal.backend()
 " Analyzing (0s • Esc to interrupt)                                              "
 "                                                                                "
 "▌ Ask Codex to do anything                                                      "
-" ⏎ send   Ctrl+J newline   Ctrl+T transcript   Ctrl+C quit                      "
+" ⏎ send   Ctrl+J newline   Ctrl+V paste image  Ctrl+T transcript   Ctrl+C quit "
 "                                                                                "


### PR DESCRIPTION
adding CTRL+V image paste hint to composer footer and updating TUI snapshots; think the footer might be getting a bit too long now, but splitting it into two lines feels like too much

closes https://github.com/openai/codex/issues/2730
___
(self explanatory but here's an AI-written description 🦭)

- **What**: Add a “Ctrl+V paste image” hint to the chat composer footer.
- **Why**: Ctrl+V image paste already works (via arboard); surfacing it improves discoverability alongside
existing “send/newline/transcript/quit” hints.
- **How**:
    - Render hint in codex-rs/tui/src/bottom_pane/chat_composer.rs after “Ctrl+T transcript”, using the
same cyan key style.
    - Update related TUI snapshots under codex-rs/tui/src/bottom_pane/snapshots/ and codex-rs/tui/src/
chatwidget/snapshots/.
- **UX considerations**:
    - Considered two-line footer but deferred as too heavy for a small, additive hint.
    - Considered abbreviating to “paste img” but stayed with “image” to match existing tone (“newline”,
“transcript”, “quit”).
    - On narrow widths the right side truncates; the most important hints (send/newline/paste image)
remain leftmost. Maybe follow up with width-aware elision to drop less-critical items first?
- **Scope**: UI copy only; no changes to key handling or paste logic.
- **Tests**: Snapshot expectations updated; no behavior changes.


<img width="1988" height="974" alt="CleanShot 2025-08-27 at 02 32 27@2x" src="https://github.com/user-attachments/assets/c1fdfddd-01e1-4c31-acdb-54abcf1a53d7" />
