### PR TITLE
fix(tui): separate stream-error logs from user message in edit prefill

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -904,6 +904,7 @@ pub(crate) fn new_error_event(message: String) -> PlainHistoryCell {
 
 pub(crate) fn new_stream_error_event(message: String) -> PlainHistoryCell {
     let lines: Vec<Line<'static>> = vec![
+        "".into(),
         vec![
             padded_emoji("⚠").magenta().bold(),
             " ".into(),


### PR DESCRIPTION
Fixes https://github.com/openai/codex/issues/2755

### Before
https://github.com/user-attachments/assets/c85024f7-db5e-4f8c-97d6-6f58456a9e43 

### After 
https://github.com/user-attachments/assets/ece411d4-2872-495c-9dc3-b6b160c2fced

### Solution
Add a leading blank line to the stream-error history cell (`new_stream_error_event`, like `new_error_event`) so it renders as an independent block.