### PR TITLE
Bug fix: deduplicate assistant messages

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1770,11 +1770,6 @@ async fn try_run_turn(
                 return Ok(output);
             }
             ResponseEvent::OutputTextDelta(delta) => {
-                {
-                    let mut st = sess.state.lock_unchecked();
-                    st.history.append_assistant_text(&delta);
-                }
-
                 let event = Event {
                     id: sub_id.to_string(),
                     msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent { delta }),

--- a/codex-rs/core/src/conversation_history.rs
+++ b/codex-rs/core/src/conversation_history.rs
@@ -28,49 +28,7 @@ impl ConversationHistory {
                 continue;
             }
 
-            // Merge adjacent assistant messages into a single history entry.
-            // This prevents duplicates when a partial assistant message was
-            // streamed into history earlier in the turn and the final full
-            // message is recorded at turn end.
-            match (&*item, self.items.last_mut()) {
-                (
-                    ResponseItem::Message {
-                        role: new_role,
-                        content: new_content,
-                        ..
-                    },
-                    Some(ResponseItem::Message {
-                        role: last_role,
-                        content: last_content,
-                        ..
-                    }),
-                ) if new_role == "assistant" && last_role == "assistant" => {
-                    append_text_content(last_content, new_content);
-                }
-                _ => {
-                    self.items.push(item.clone());
-                }
-            }
-        }
-    }
-
-    /// Append a text `delta` to the latest assistant message, creating a new
-    /// assistant entry if none exists yet (e.g. first delta for this turn).
-    pub(crate) fn append_assistant_text(&mut self, delta: &str) {
-        match self.items.last_mut() {
-            Some(ResponseItem::Message { role, content, .. }) if role == "assistant" => {
-                append_text_delta(content, delta);
-            }
-            _ => {
-                // Start a new assistant message with the delta.
-                self.items.push(ResponseItem::Message {
-                    id: None,
-                    role: "assistant".to_string(),
-                    content: vec![codex_protocol::models::ContentItem::OutputText {
-                        text: delta.to_string(),
-                    }],
-                });
-            }
+            self.items.push(item.clone());
         }
     }
 
@@ -118,34 +76,6 @@ fn is_api_message(message: &ResponseItem) -> bool {
     }
 }
 
-/// Helper to append the textual content from `src` into `dst` in place.
-fn append_text_content(
-    dst: &mut Vec<codex_protocol::models::ContentItem>,
-    src: &Vec<codex_protocol::models::ContentItem>,
-) {
-    for c in src {
-        if let codex_protocol::models::ContentItem::OutputText { text } = c {
-            append_text_delta(dst, text);
-        }
-    }
-}
-
-/// Append a single text delta to the last OutputText item in `content`, or
-/// push a new OutputText item if none exists.
-fn append_text_delta(content: &mut Vec<codex_protocol::models::ContentItem>, delta: &str) {
-    if let Some(codex_protocol::models::ContentItem::OutputText { text }) = content
-        .iter_mut()
-        .rev()
-        .find(|c| matches!(c, codex_protocol::models::ContentItem::OutputText { .. }))
-    {
-        text.push_str(delta);
-    } else {
-        content.push(codex_protocol::models::ContentItem::OutputText {
-            text: delta.to_string(),
-        });
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -177,29 +107,6 @@ mod tests {
         let a1 = assistant_msg("Hello");
         let a2 = assistant_msg(", world!");
         h.record_items([&a1, &a2]);
-
-        let items = h.contents();
-        assert_eq!(
-            items,
-            vec![ResponseItem::Message {
-                id: None,
-                role: "assistant".to_string(),
-                content: vec![ContentItem::OutputText {
-                    text: "Hello, world!".to_string()
-                }]
-            }]
-        );
-    }
-
-    #[test]
-    fn append_assistant_text_creates_and_appends() {
-        let mut h = ConversationHistory::default();
-        h.append_assistant_text("Hello");
-        h.append_assistant_text(", world");
-
-        // Now record a final full assistant message and verify it merges.
-        let final_msg = assistant_msg("!");
-        h.record_items([&final_msg]);
 
         let items = h.contents();
         assert_eq!(

--- a/codex-rs/core/src/conversation_history.rs
+++ b/codex-rs/core/src/conversation_history.rs
@@ -102,26 +102,6 @@ mod tests {
     }
 
     #[test]
-    fn merges_adjacent_assistant_messages() {
-        let mut h = ConversationHistory::default();
-        let a1 = assistant_msg("Hello");
-        let a2 = assistant_msg(", world!");
-        h.record_items([&a1, &a2]);
-
-        let items = h.contents();
-        assert_eq!(
-            items,
-            vec![ResponseItem::Message {
-                id: None,
-                role: "assistant".to_string(),
-                content: vec![ContentItem::OutputText {
-                    text: "Hello, world!".to_string()
-                }]
-            }]
-        );
-    }
-
-    #[test]
     fn filters_non_api_messages() {
         let mut h = ConversationHistory::default();
         // System message is not an API message; Other is ignored.

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -67,7 +67,6 @@ fn write_auth_json(
     account_id: Option<&str>,
 ) -> String {
     use base64::Engine as _;
-    // hard-coded JSON tail only; no dynamic construction from previous requests
 
     let header = json!({ "alg": "none", "typ": "JWT" });
     let payload = json!({

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -12,6 +12,7 @@ use codex_login::CodexAuth;
 use core_test_support::load_default_config_for_test;
 use core_test_support::load_sse_fixture_with_id;
 use core_test_support::wait_for_event;
+use serde_json::json;
 use tempfile::TempDir;
 use wiremock::Mock;
 use wiremock::MockServer;
@@ -844,7 +845,6 @@ async fn history_dedupes_streamed_and_final_messages_across_turns() {
     let requests = server.received_requests().await.unwrap();
     assert_eq!(requests.len(), 3, "expected 3 requests (one per turn)");
 
-    use serde_json::json;
     // Replace full-array compare with tail-only raw JSON compare using a single hard-coded value.
     let r3_tail_expected = serde_json::json!([
         {


### PR DESCRIPTION
We are treating assistant messages in a different way than other messages which resulted in a duplicated history.

See #2698