### PR TITLE
UI: Make slash commands bold in welcome message

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -242,10 +242,54 @@ pub(crate) fn new_session_info(
             Line::from("".dim()),
             Line::from(" To get started, describe a task or try one of these commands:".dim()),
             Line::from("".dim()),
-            Line::from(format!(" /init - {}", SlashCommand::Init.description()).dim()),
-            Line::from(format!(" /status - {}", SlashCommand::Status.description()).dim()),
-            Line::from(format!(" /approvals - {}", SlashCommand::Approvals.description()).dim()),
-            Line::from(format!(" /model - {}", SlashCommand::Model.description()).dim()),
+            Line::from(vec![
+                Span::styled(
+                    " /init",
+                    Style::default()
+                        .add_modifier(Modifier::BOLD)
+                        .fg(Color::White),
+                ),
+                Span::styled(
+                    format!(" - {}", SlashCommand::Init.description()),
+                    Style::default().dim(),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled(
+                    " /status",
+                    Style::default()
+                        .add_modifier(Modifier::BOLD)
+                        .fg(Color::White),
+                ),
+                Span::styled(
+                    format!(" - {}", SlashCommand::Status.description()),
+                    Style::default().dim(),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled(
+                    " /approvals",
+                    Style::default()
+                        .add_modifier(Modifier::BOLD)
+                        .fg(Color::White),
+                ),
+                Span::styled(
+                    format!(" - {}", SlashCommand::Approvals.description()),
+                    Style::default().dim(),
+                ),
+            ]),
+            Line::from(vec![
+                Span::styled(
+                    " /model",
+                    Style::default()
+                        .add_modifier(Modifier::BOLD)
+                        .fg(Color::White),
+                ),
+                Span::styled(
+                    format!(" - {}", SlashCommand::Model.description()),
+                    Style::default().dim(),
+                ),
+            ]),
         ];
         PlainHistoryCell { lines }
     } else if config.model == model {


### PR DESCRIPTION
## What
Make slash commands (/init, /status, /approvals, /model) bold and white in the welcome message for better visibility.
<img width="990" height="286" alt="image" src="https://github.com/user-attachments/assets/13f90e96-b84a-4659-aab4-576d84a31af7" />


## Why
The current welcome message displays all text in a dimmed style, making the slash commands less prominent. Users need to quickly identify available commands when starting Codex.

## How
Modified `tui/src/history_cell.rs` in the `new_session_info` function to:
- Split each command line into separate spans
- Apply bold white styling to command text (`/init`, `/status`, etc.)
- Keep descriptions dimmed for visual contrast
- Maintain existing layout and spacing

## Test plan
- [ ] Run the TUI and verify commands appear bold in the welcome message
- [ ] Ensure descriptions remain dimmed for readability
- [ ] Confirm all existing tests pass