### PR TITLE
bring back CoT with config toggle

### DIFF
--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -74,7 +74,16 @@ pub enum HistoryPersistence {
 
 /// Collection of settings that are specific to the TUI.
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]
-pub struct Tui {}
+pub struct Tui {
+    /// If true, show the model's thinking (reasoning) live in the TUI chat.
+    /// Defaults to `false` to match current behavior; opt-in via config.toml.
+    /// Example:
+    ///
+    /// [tui]
+    /// show_agent_reasoning = true
+    #[serde(default)]
+    pub show_agent_reasoning: Option<bool>,
+}
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct SandboxWorkspaceWrite {

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -4,6 +4,7 @@ use codex_core::config::Config;
 use ratatui::text::Line;
 
 use super::HeaderEmitter;
+use super::HeaderLabel;
 use super::StreamState;
 
 /// Sink for history insertions and animation control.
@@ -47,6 +48,17 @@ impl StreamController {
         Self {
             config,
             header: HeaderEmitter::new(),
+            state: StreamState::new(),
+            active: false,
+            finishing_after_drain: false,
+        }
+    }
+
+    /// Create a stream controller with a specific header label (e.g., "thinking").
+    pub(crate) fn with_label(config: Config, label: HeaderLabel) -> Self {
+        Self {
+            config,
+            header: HeaderEmitter::with_label(label),
             state: StreamState::new(),
             active: false,
             finishing_after_drain: false,
@@ -126,6 +138,7 @@ impl StreamController {
                 sink.insert_history_cell(Box::new(history_cell::AgentMessageCell::new(
                     out_lines,
                     self.header.maybe_emit_header(),
+                    self.header.current_label(),
                 )));
             }
 
@@ -161,6 +174,7 @@ impl StreamController {
             sink.insert_history_cell(Box::new(history_cell::AgentMessageCell::new(
                 step.history,
                 self.header.maybe_emit_header(),
+                self.header.current_label(),
             )));
         }
 

--- a/codex-rs/tui/src/streaming/mod.rs
+++ b/codex-rs/tui/src/streaming/mod.rs
@@ -38,13 +38,25 @@ impl StreamState {
 pub(crate) struct HeaderEmitter {
     emitted_this_turn: bool,
     emitted_in_stream: bool,
+    label: HeaderLabel,
+}
+
+#[derive(Copy, Clone, Debug)]
+pub(crate) enum HeaderLabel {
+    Codex,
+    Thinking,
 }
 
 impl HeaderEmitter {
     pub(crate) fn new() -> Self {
+        Self::with_label(HeaderLabel::Codex)
+    }
+
+    pub(crate) fn with_label(label: HeaderLabel) -> Self {
         Self {
             emitted_this_turn: false,
             emitted_in_stream: false,
+            label,
         }
     }
 
@@ -70,5 +82,18 @@ impl HeaderEmitter {
         } else {
             false
         }
+    }
+
+    /// Return the configured label for this emitter (e.g., Codex or Thinking).
+    pub(crate) fn current_label(&self) -> HeaderLabel {
+        self.label
+    }
+}
+
+pub(crate) fn render_header_line(label: HeaderLabel) -> ratatui::text::Line<'static> {
+    use ratatui::style::Stylize;
+    match label {
+        HeaderLabel::Codex => ratatui::text::Line::from("codex".magenta().bold()),
+        HeaderLabel::Thinking => ratatui::text::Line::from("thinking".magenta().italic()),
     }
 }


### PR DESCRIPTION
Brings back chain-of-thought display in TUI via config option.

PR #2316 hid CoT by default. This adds [tui].show_agent_reasoning to make it optional:

```toml
[tui]
show_agent_reasoning = true
```

<img width="1555" height="327" alt="image" src="https://github.com/user-attachments/assets/eddab988-03ee-4df5-b05c-1a6986876ec1" />


Defaults to false to maintain current behavior.