### PR TITLE
docs(conversation_history): update API message definition

### DIFF
--- a/codex-rs/core/src/conversation_history.rs
+++ b/codex-rs/core/src/conversation_history.rs
@@ -61,7 +61,7 @@ impl ConversationHistory {
     }
 }
 
-/// Anything that is not a system message or "reasoning" message is considered
+/// Anything that is not a system message or "Other" is considered
 /// an API message.
 fn is_api_message(message: &ResponseItem) -> bool {
     match message {


### PR DESCRIPTION
This is a minor PR that updates the `is_api_message` comment in `conversation_history.rs` to match the implementation.

The current (& inaccurate) comment can be confusing for newcomers and/or agents working on this file.