### PR TITLE
fix (most) doubled lines and hanging list markers

### DIFF
--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -126,62 +126,6 @@ fn final_answer_without_newline_is_flushed_immediately() {
     );
 }
 
-/*
-    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
-
-    // Start with a line that includes a newline so streaming activates.
-    chat.handle_codex_event(Event {
-        id: "t1".into(),
-        msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
-            delta: "Intro line.\n".into(),
-        }),
-    });
-
-    // Now stream a list item with the dash split across chunks: ["-", " some", " words"].
-    chat.handle_codex_event(Event {
-        id: "t1".into(),
-        msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent { delta: "-".into() }),
-    });
-    chat.handle_codex_event(Event {
-        id: "t1".into(),
-        msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
-            delta: " some".into(),
-        }),
-    });
-    chat.handle_codex_event(Event {
-        id: "t1".into(),
-        msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
-            delta: " words".into(),
-        }),
-    });
-
-    // Finalize the answer so any remaining buffered content is flushed.
-    chat.handle_codex_event(Event {
-        id: "t1".into(),
-        msg: EventMsg::AgentMessage(AgentMessageEvent {
-            message: "Intro line.\n- some words".into(),
-        }),
-    });
-
-    // Drain any inserted history and ensure no standalone '-' line was emitted.
-    let cells = drain_insert_history(&mut rx);
-    let mut found_dangling_dash = false;
-    for lines in cells {
-        for l in lines {
-            let s = l
-                .spans
-                .iter()
-                .map(|sp| sp.content.clone())
-                .collect::<String>();
-            if s.trim() == "-" {
-                found_dangling_dash = true;
-                break;
-            }
-        }
-    }
-    assert!(!found_dangling_dash, "should not emit a dangling '-' line");
-*/
-
 #[tokio::test(flavor = "current_thread")]
 async fn helpers_are_available_and_do_not_panic() {
     let (tx_raw, _rx) = unbounded_channel::<AppEvent>();

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -126,8 +126,8 @@ fn final_answer_without_newline_is_flushed_immediately() {
     );
 }
 
-#[test]
-fn dash_split_deltas_do_not_emit_standalone_dash_line() {
+// (removed dash-split chatwidget test; covered at collector level)
+/*
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
 
     // Start with a line that includes a newline so streaming activates.
@@ -181,7 +181,7 @@ fn dash_split_deltas_do_not_emit_standalone_dash_line() {
         }
     }
     assert!(!found_dangling_dash, "should not emit a dangling '-' line");
-}
+*/
 
 #[tokio::test(flavor = "current_thread")]
 async fn helpers_are_available_and_do_not_panic() {

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -126,7 +126,6 @@ fn final_answer_without_newline_is_flushed_immediately() {
     );
 }
 
-// (removed dash-split chatwidget test; covered at collector level)
 /*
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
 

--- a/codex-rs/tui/src/markdown.rs
+++ b/codex-rs/tui/src/markdown.rs
@@ -438,22 +438,19 @@ mod tests {
 
     #[test]
     fn tui_markdown_splits_ordered_marker_and_text() {
-        // Validate behavior originates from tui_markdown, not our helpers.
+        // For an isolated ordered item, tui_markdown keeps it on one line.
         let rendered = tui_markdown::from_str("1. Tight item\n");
         let lines: Vec<String> = rendered
             .lines
             .iter()
-            .map(|l| l
-                .spans
-                .iter()
-                .map(|s| s.content.clone())
-                .collect::<String>())
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.clone())
+                    .collect::<String>()
+            })
             .collect();
-        assert_eq!(
-            lines,
-            vec!["1. ".to_string(), "Tight item".to_string()],
-            "expected tui_markdown to emit marker and content as separate lines"
-        );
+        assert_eq!(lines, vec!["1. Tight item".to_string()]);
     }
 
     #[test]
@@ -462,20 +459,22 @@ mod tests {
         use std::path::Path;
         let cwd = Path::new("/");
         let mut out = Vec::new();
-        append_markdown_with_opener_and_cwd("1. Tight item\n", &mut out, UriBasedFileOpener::None, cwd);
+        append_markdown_with_opener_and_cwd(
+            "1. Tight item\n",
+            &mut out,
+            UriBasedFileOpener::None,
+            cwd,
+        );
         let lines: Vec<String> = out
             .iter()
-            .map(|l| l
-                .spans
-                .iter()
-                .map(|s| s.content.clone())
-                .collect::<String>())
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.clone())
+                    .collect::<String>()
+            })
             .collect();
-        assert_eq!(
-            lines,
-            vec!["1. ".to_string(), "Tight item".to_string()],
-            "our helper preserves tui_markdown's split for ordered list items"
-        );
+        assert_eq!(lines, vec!["1. Tight item".to_string()]);
     }
 
     #[test]
@@ -556,11 +555,12 @@ mod tests {
         let lines: Vec<String> = rendered
             .lines
             .iter()
-            .map(|l| l
-                .spans
-                .iter()
-                .map(|s| s.content.clone())
-                .collect::<String>())
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.clone())
+                    .collect::<String>()
+            })
             .collect();
         assert!(
             lines.contains(&"1. ".to_string()) && lines.contains(&"Tight item".to_string()),

--- a/codex-rs/tui/src/markdown.rs
+++ b/codex-rs/tui/src/markdown.rs
@@ -524,7 +524,10 @@ Tight item
 Another tight item
 3. 
 Loose item"#;
-        assert_eq!(joined, expected, "unexpected tui_markdown shape: {joined:?}");
+        assert_eq!(
+            joined, expected,
+            "unexpected tui_markdown shape: {joined:?}"
+        );
     }
 
     #[test]
@@ -555,11 +558,12 @@ Loose item"#;
 
         let lines: Vec<String> = out
             .iter()
-            .map(|l| l
-                .spans
-                .iter()
-                .map(|s| s.content.clone())
-                .collect::<String>())
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.clone())
+                    .collect::<String>()
+            })
             .collect();
 
         // Expect to find the ordered list line rendered as a single line,
@@ -569,7 +573,9 @@ Loose item"#;
             "expected '1. Tight item' rendered as a single line; got: {lines:?}"
         );
         assert!(
-            !lines.windows(2).any(|w| w[0].trim_end() == "1." && w[1] == "Tight item"),
+            !lines
+                .windows(2)
+                .any(|w| w[0].trim_end() == "1." && w[1] == "Tight item"),
             "did not expect a split into ['1.', 'Tight item']; got: {lines:?}"
         );
     }

--- a/codex-rs/tui/src/markdown_stream.rs
+++ b/codex-rs/tui/src/markdown_stream.rs
@@ -65,6 +65,21 @@ impl MarkdownStreamCollector {
         {
             complete_line_count -= 1;
         }
+        // Heuristic: if the buffer ends with a double newline and the last non-blank
+        // rendered line looks like a list bullet with inline content (e.g., "- item"),
+        // defer committing that line. Subsequent context (e.g., another list item)
+        // can cause the renderer to split the bullet marker and text into separate
+        // logical lines ("- " then "item"), which would otherwise duplicate content.
+        if self.buffer.ends_with("\n\n") && complete_line_count > 0 {
+            let last = &rendered[complete_line_count - 1];
+            let mut text = String::new();
+            for s in &last.spans {
+                text.push_str(&s.content);
+            }
+            if text.starts_with("- ") && text.trim() != "-" {
+                complete_line_count = complete_line_count.saturating_sub(1);
+            }
+        }
         if !self.buffer.ends_with('\n') {
             complete_line_count = complete_line_count.saturating_sub(1);
             // If we're inside an unclosed fenced code block, also drop the
@@ -72,6 +87,38 @@ impl MarkdownStreamCollector {
             if is_inside_unclosed_fence(&source) {
                 complete_line_count = complete_line_count.saturating_sub(1);
             }
+            // If the next (incomplete) line appears to begin a list item,
+            // also defer the previous completed line because the renderer may
+            // retroactively treat it as part of the list (e.g., ordered list item 1).
+            if let Some(last_nl) = source.rfind('\n') {
+                let tail = &source[last_nl + 1..];
+                if starts_with_list_marker(tail) {
+                    complete_line_count = complete_line_count.saturating_sub(1);
+                }
+            }
+        }
+
+        // Conservatively withhold trailing list-like lines (unordered or ordered)
+        // because streaming mid-item can cause the renderer to later split or
+        // restructure them (e.g., duplicating content or separating the marker).
+        // Only defers lines at the end of the out slice so previously committed
+        // lines remain stable.
+        if complete_line_count > self.committed_line_count {
+            let mut safe_count = complete_line_count;
+            while safe_count > self.committed_line_count {
+                let l = &rendered[safe_count - 1];
+                let mut text = String::new();
+                for s in &l.spans {
+                    text.push_str(&s.content);
+                }
+                let listish = is_potentially_volatile_list_line(&text);
+                if listish {
+                    safe_count -= 1;
+                    continue;
+                }
+                break;
+            }
+            complete_line_count = safe_count;
         }
 
         if self.committed_line_count >= complete_line_count {
@@ -84,6 +131,20 @@ impl MarkdownStreamCollector {
         // the entire block together. This avoids stray backticks and misformatted content.
         if is_inside_unclosed_fence(&source) {
             return Vec::new();
+        }
+
+        // Additional conservative hold-back: if exactly one short, plain word
+        // line would be emitted, defer it. This avoids committing a lone word
+        // that might become the first ordered-list item once the next delta
+        // arrives (e.g., next line starts with "2 " or "2. ").
+        if out_slice.len() == 1 {
+            let mut s = String::new();
+            for sp in &out_slice[0].spans {
+                s.push_str(&sp.content);
+            }
+            if is_short_plain_word(&s) {
+                return Vec::new();
+            }
         }
 
         let out = out_slice.to_vec();
@@ -116,6 +177,75 @@ impl MarkdownStreamCollector {
         self.clear();
         out
     }
+}
+
+#[inline]
+fn is_potentially_volatile_list_line(text: &str) -> bool {
+    let t = text.trim_end();
+    if t == "-" || t == "*" || t == "- " || t == "* " {
+        return true;
+    }
+    if t.starts_with("- ") || t.starts_with("* ") {
+        return true;
+    }
+    // ordered list like "1. " or "23. "
+    let mut it = t.chars().peekable();
+    let mut saw_digit = false;
+    while let Some(&ch) = it.peek() {
+        if ch.is_ascii_digit() {
+            saw_digit = true;
+            it.next();
+            continue;
+        }
+        break;
+    }
+    if saw_digit && it.peek() == Some(&'.') {
+        // consume '.'
+        it.next();
+        if it.peek() == Some(&' ') {
+            return true;
+        }
+    }
+    false
+}
+
+#[inline]
+fn starts_with_list_marker(text: &str) -> bool {
+    let t = text.trim_start();
+    if t.starts_with("- ") || t.starts_with("* ") || t.starts_with("-\t") || t.starts_with("*\t") {
+        return true;
+    }
+    // ordered list marker like "1 ", "1. ", "23 ", "23. "
+    let mut it = t.chars().peekable();
+    let mut saw_digit = false;
+    while let Some(&ch) = it.peek() {
+        if ch.is_ascii_digit() {
+            saw_digit = true;
+            it.next();
+        } else {
+            break;
+        }
+    }
+    if !saw_digit {
+        return false;
+    }
+    match it.peek() {
+        Some('.') => {
+            it.next();
+            matches!(it.peek(), Some(' '))
+        }
+        Some(' ') => true,
+        _ => false,
+    }
+}
+
+#[inline]
+fn is_short_plain_word(s: &str) -> bool {
+    let t = s.trim();
+    if t.is_empty() || t.len() > 5 {
+        return false;
+    }
+    t.chars().all(|c| c.is_alphanumeric())
 }
 
 /// fence helpers are provided by `crate::render::markdown_utils`
@@ -441,7 +571,12 @@ mod tests {
         lines_to_plain_strings(&lines)
     }
 
-    // (diagnostic helper removed)
+    fn mismatch(deltas: &[&str], cfg: &Config) -> bool {
+        let full: String = deltas.iter().copied().collect();
+        let streamed = stream_strings_from_deltas(deltas, cfg);
+        let rendered = render_full_strings(&full, cfg);
+        streamed != rendered
+    }
 
     /// Greedily minimize a failing delta sequence to the shortest (by element count)
     // (diagnostic minimizer removed)
@@ -570,6 +705,324 @@ mod tests {
             streamed_strs, rendered_all_strs,
             "streamed output should match full render without dangling '-' lines"
         );
+    }
+
+    #[test]
+    fn loose_vs_tight_list_items_streaming_matches_full() {
+        let cfg = test_config();
+        // Deltas extracted from the session log around 2025-08-27T00:33:18.216Z
+        let deltas = vec![
+            "\n\n",
+            "Loose",
+            " vs",
+            ".",
+            " tight",
+            " list",
+            " items",
+            ":\n",
+            "1",
+            ".",
+            " Tight",
+            " item",
+            "\n",
+            "2",
+            ".",
+            " Another",
+            " tight",
+            " item",
+            "\n\n",
+            "1",
+            ".",
+            " Loose",
+            " item",
+            " with",
+            " its",
+            " own",
+            " paragraph",
+            ".\n\n",
+            "  ",
+            " This",
+            " paragraph",
+            " belongs",
+            " to",
+            " the",
+            " same",
+            " list",
+            " item",
+            ".\n\n",
+            "2",
+            ".",
+            " Second",
+            " loose",
+            " item",
+            " with",
+            " a",
+            " nested",
+            " list",
+            " after",
+            " a",
+            " blank",
+            " line",
+            ".\n\n",
+            "  ",
+            " -",
+            " Nested",
+            " bullet",
+            " under",
+            " a",
+            " loose",
+            " item",
+            "\n",
+            "  ",
+            " -",
+            " Another",
+            " nested",
+            " bullet",
+            "\n\n",
+        ];
+
+        let streamed = simulate_stream_markdown_for_tests(&deltas, true, &cfg);
+        let streamed_strs = lines_to_plain_strings(&streamed);
+
+        let full: String = deltas.iter().copied().collect();
+        let mut rendered_all: Vec<ratatui::text::Line<'static>> = Vec::new();
+        crate::markdown::append_markdown(&full, &mut rendered_all, &cfg);
+        let rendered_all_strs = lines_to_plain_strings(&rendered_all);
+
+        assert_eq!(
+            streamed_strs, rendered_all_strs,
+            "loose/tight list streaming should equal full render"
+        );
+
+        // Also assert exact expected plain strings for clarity.
+        let expected = vec![
+            "Loose vs. tight list items:".to_string(),
+            "".to_string(),
+            "1. ".to_string(),
+            "Tight item".to_string(),
+            "2. ".to_string(),
+            "Another tight item".to_string(),
+            "3. ".to_string(),
+            "Loose item with its own paragraph.".to_string(),
+            "".to_string(),
+            "This paragraph belongs to the same list item.".to_string(),
+            "4. ".to_string(),
+            "Second loose item with a nested list after a blank line.".to_string(),
+            "    - Nested bullet under a loose item".to_string(),
+            "    - Another nested bullet".to_string(),
+        ];
+        assert_eq!(streamed_strs, expected, "expected exact rendered lines for loose/tight section");
+    }
+
+    // Targeted tests derived from fuzz findings. Each asserts streamed == full render.
+
+    #[test]
+    fn fuzz_class_bare_dash_then_task_item() {
+        let cfg = test_config();
+        // Case similar to: ["two\n", "- \n* [x] done "]
+        let deltas = vec!["two\n", "- \n* [x] done \n"];
+        let streamed = simulate_stream_markdown_for_tests(&deltas, true, &cfg);
+        let streamed_strs = lines_to_plain_strings(&streamed);
+        let full: String = deltas.iter().copied().collect();
+        let mut rendered: Vec<ratatui::text::Line<'static>> = Vec::new();
+        crate::markdown::append_markdown(&full, &mut rendered, &cfg);
+        let rendered_strs = lines_to_plain_strings(&rendered);
+        assert_eq!(streamed_strs, rendered_strs);
+    }
+
+    #[test]
+    fn fuzz_class_bullet_duplication_variant_1() {
+        let cfg = test_config();
+        // Case similar to: ["aph.\n- let one\n- bull", "et two\n\n  second paragraph "]
+        let deltas = vec![
+            "aph.\n- let one\n- bull",
+            "et two\n\n  second paragraph \n",
+        ];
+        let streamed = simulate_stream_markdown_for_tests(&deltas, true, &cfg);
+        let streamed_strs = lines_to_plain_strings(&streamed);
+        let full: String = deltas.iter().copied().collect();
+        let mut rendered: Vec<ratatui::text::Line<'static>> = Vec::new();
+        crate::markdown::append_markdown(&full, &mut rendered, &cfg);
+        let rendered_strs = lines_to_plain_strings(&rendered);
+        assert_eq!(streamed_strs, rendered_strs);
+    }
+
+    #[test]
+    fn fuzz_class_bullet_duplication_variant_2() {
+        let cfg = test_config();
+        // Case similar to: ["- e\n  c", "e\n- bullet two\n\n  second paragraph in bullet two\n"]
+        let deltas = vec![
+            "- e\n  c",
+            "e\n- bullet two\n\n  second paragraph in bullet two\n",
+        ];
+        let streamed = simulate_stream_markdown_for_tests(&deltas, true, &cfg);
+        let streamed_strs = lines_to_plain_strings(&streamed);
+        let full: String = deltas.iter().copied().collect();
+        let mut rendered: Vec<ratatui::text::Line<'static>> = Vec::new();
+        crate::markdown::append_markdown(&full, &mut rendered, &cfg);
+        let rendered_strs = lines_to_plain_strings(&rendered);
+        assert_eq!(streamed_strs, rendered_strs);
+    }
+
+    #[test]
+    fn fuzz_class_ordered_list_split_weirdness() {
+        let cfg = test_config();
+        // Case similar to: ["one\n2", " two\n- \n* [x] d"]
+        let deltas = vec!["one\n2", " two\n- \n* [x] d\n"];
+        let streamed = simulate_stream_markdown_for_tests(&deltas, true, &cfg);
+        let streamed_strs = lines_to_plain_strings(&streamed);
+        let full: String = deltas.iter().copied().collect();
+        let mut rendered: Vec<ratatui::text::Line<'static>> = Vec::new();
+        crate::markdown::append_markdown(&full, &mut rendered, &cfg);
+        let rendered_strs = lines_to_plain_strings(&rendered);
+        assert_eq!(streamed_strs, rendered_strs);
+    }
+
+    // --- Fuzzing helpers and tests ---
+
+    fn minimize_failing_deltas(mut deltas: Vec<String>, cfg: &Config) -> Vec<String> {
+        // Only attempt to shrink if it mismatches.
+        if !mismatch(&deltas.iter().map(|s| s.as_str()).collect::<Vec<_>>(), cfg) {
+            return deltas;
+        }
+        let mut changed = true;
+        while changed {
+            changed = false;
+            // Try single removals.
+            let mut best: Option<Vec<String>> = None;
+            for i in 0..deltas.len() {
+                let mut cand = deltas.clone();
+                cand.remove(i);
+                let cand_refs = cand.iter().map(|s| s.as_str()).collect::<Vec<_>>();
+                if mismatch(&cand_refs, cfg) {
+                    if best.as_ref().map(|b| cand.len() < b.len()).unwrap_or(true) {
+                        best = Some(cand);
+                    }
+                }
+            }
+            if let Some(b) = best {
+                deltas = b;
+                changed = true;
+                continue;
+            }
+            // Try merges of adjacent chunks.
+            for i in 0..(deltas.len().saturating_sub(1)) {
+                let mut cand = deltas.clone();
+                let merged = format!("{}{}", cand[i], cand[i + 1]);
+                cand[i] = merged;
+                cand.remove(i + 1);
+                let cand_refs = cand.iter().map(|s| s.as_str()).collect::<Vec<_>>();
+                if mismatch(&cand_refs, cfg) {
+                    deltas = cand;
+                    changed = true;
+                    break;
+                }
+            }
+        }
+        deltas
+    }
+
+    fn sample_markdown_input() -> String {
+        // Roughly 10 lines with varied list styles and edge cases.
+        // - Loose list with a blank line, nested/continued content
+        // - Ordered list
+        // - Bare dash line edge case
+        // - Task list style
+        let lines = vec![
+            "Intro paragraph.",
+            "- bullet one",
+            "  continuation under bullet one",
+            "- bullet two",
+            "",
+            "  second paragraph in bullet two",
+            "1. number one",
+            "2. number two",
+            "- ",
+            "* [x] done task",
+        ];
+        let mut s = String::new();
+        for (i, l) in lines.iter().enumerate() {
+            s.push_str(l);
+            // End every line with a newline to normalize
+            if i + 1 < lines.len() || !l.ends_with('\n') {
+                s.push('\n');
+            }
+        }
+        s
+    }
+
+    fn random_chunking(src: &str, rng: &mut impl rand::Rng) -> Vec<String> {
+        // Split at character boundaries to keep UTF-8 valid
+        let mut cut_positions: Vec<usize> = src.char_indices().map(|(i, _)| i).collect();
+        cut_positions.push(src.len());
+        // Choose a random number of cuts, biased to produce small and medium chunks
+        let max_cuts = (cut_positions.len() / 4).max(4);
+        let cuts = rng.gen_range(1..=max_cuts);
+        // Sample unique positions (excluding 0)
+        use rand::seq::SliceRandom;
+        let mut choices = cut_positions.clone();
+        choices.retain(|&p| p != 0);
+        choices.shuffle(rng);
+        let mut picks = choices.into_iter().take(cuts).collect::<Vec<_>>();
+        picks.push(src.len());
+        picks.sort_unstable();
+        picks.dedup();
+        let mut out = Vec::new();
+        let mut last = 0usize;
+        for p in picks {
+            if p > last {
+                out.push(src[last..p].to_string());
+                last = p;
+            }
+        }
+        if last < src.len() {
+            out.push(src[last..].to_string());
+        }
+        out
+    }
+
+    /// Fuzz the way markdown gets split into deltas and compare streamed vs full render.
+    /// Ignored by default; prints minimized failing cases it discovers.
+    #[test]
+    #[ignore]
+    fn fuzz_markdown_chunking_variants() {
+        use rand::{Rng, SeedableRng};
+        let cfg = test_config();
+        let src = sample_markdown_input();
+        let mut rng = rand::rngs::StdRng::seed_from_u64(0xC0D3C0DE_u64);
+        let mut found: Vec<Vec<String>> = Vec::new();
+
+        let iters = 2000usize;
+        for _ in 0..iters {
+            let chunks = random_chunking(&src, &mut rng);
+            let refs = chunks.iter().map(|s| s.as_str()).collect::<Vec<_>>();
+            if mismatch(&refs, &cfg) {
+                let minimized = minimize_failing_deltas(chunks.clone(), &cfg);
+                // Avoid storing duplicates
+                if !found.iter().any(|c| c == &minimized) {
+                    found.push(minimized);
+                }
+            }
+        }
+
+        // Sort by chunk count ascending for readability
+        found.sort_by_key(|v| v.len());
+        eprintln!("Discovered {} distinct failing chunkings", found.len());
+        for (i, case) in found.iter().take(10).enumerate() {
+            eprintln!("Case #{i} ({} chunks):", case.len());
+            for (j, s) in case.iter().enumerate() {
+                eprintln!("  [{j}] {:?}", s);
+            }
+            // Also show the streamed vs. full for the minimized case
+            let refs = case.iter().map(|s| s.as_str()).collect::<Vec<_>>();
+            let streamed = stream_strings_from_deltas(&refs, &cfg);
+            let rendered = render_full_strings(&refs.join(""), &cfg);
+            eprintln!("  streamed: {:?}", streamed);
+            eprintln!("  rendered: {:?}", rendered);
+        }
+
+        // Do not assert; this is for discovery. Keep as informational.
+        assert!(true);
     }
 
     // (removed heavy diagnostic tests)

--- a/codex-rs/tui/src/markdown_stream.rs
+++ b/codex-rs/tui/src/markdown_stream.rs
@@ -598,8 +598,6 @@ mod tests {
         );
     }
 
-    // (removed experimental dash-split tests)
-
     #[test]
     fn utf8_boundary_safety_and_wide_chars() {
         let cfg = test_config();
@@ -859,10 +857,6 @@ mod tests {
         assert_eq!(streamed_strs, rendered_strs);
     }
 
-    // cleaned up: removed heavy fuzzing helpers and ignored test
-
-    // (removed heavy diagnostic tests)
-
     fn coalesce_ordered_markers_for_tests(lines: &mut Vec<ratatui::text::Line<'static>>) {
         let mut i = 0usize;
         while i + 1 < lines.len() {
@@ -906,7 +900,6 @@ mod tests {
         }
     }
 
-
     fn coalesce_ordered_marker_strings(lines: &mut Vec<String>) {
         let mut i = 0usize;
         while i + 1 < lines.len() {
@@ -919,5 +912,4 @@ mod tests {
             }
         }
     }
-
 }

--- a/codex-rs/tui/src/markdown_stream.rs
+++ b/codex-rs/tui/src/markdown_stream.rs
@@ -243,6 +243,7 @@ mod tests {
     use super::*;
     use codex_core::config::Config;
     use codex_core::config::ConfigOverrides;
+    use std::cmp::Ordering;
 
     fn test_config() -> Config {
         let overrides = ConfigOverrides {
@@ -428,6 +429,82 @@ mod tests {
             .collect()
     }
 
+    // --- Minimization and fuzz helpers (debug/analysis) ---
+
+    fn render_full_strings(src: &str, cfg: &Config) -> Vec<String> {
+        let mut out: Vec<ratatui::text::Line<'static>> = Vec::new();
+        crate::markdown::append_markdown(src, &mut out, cfg);
+        lines_to_plain_strings(&out)
+    }
+
+    fn stream_strings_from_deltas(deltas: &[&str], cfg: &Config) -> Vec<String> {
+        let lines = simulate_stream_markdown_for_tests(deltas, true, cfg);
+        lines_to_plain_strings(&lines)
+    }
+
+    fn mismatch(deltas: &[&str], cfg: &Config) -> bool {
+        let full: String = deltas.iter().copied().collect();
+        let streamed = stream_strings_from_deltas(deltas, cfg);
+        let rendered = render_full_strings(&full, cfg);
+        streamed != rendered
+    }
+
+    /// Greedily minimize a failing delta sequence to the shortest (by element count)
+    /// that still reproduces the mismatch. Returns the minimized sequence as Vec<String>.
+    fn minimize_failing_deltas(mut deltas: Vec<String>, cfg: &Config) -> Vec<String> {
+        // Early exit if not failing.
+        if !mismatch(&deltas.iter().map(|s| s.as_str()).collect::<Vec<_>>(), cfg) {
+            return deltas;
+        }
+
+        // Try removals first until fixed point.
+        let mut changed = true;
+        while changed {
+            changed = false;
+            let mut best: Option<Vec<String>> = None;
+            for i in 0..deltas.len() {
+                let mut cand = deltas.clone();
+                cand.remove(i);
+                let cand_refs = cand.iter().map(|s| s.as_str()).collect::<Vec<_>>();
+                if mismatch(&cand_refs, cfg) {
+                    match &best {
+                        None => best = Some(cand),
+                        Some(b) => {
+                            if cand.len().cmp(&b.len()) == Ordering::Less {
+                                best = Some(cand);
+                            }
+                        }
+                    }
+                }
+            }
+            if let Some(b) = best {
+                deltas = b;
+                changed = true;
+                continue;
+            }
+
+            // Try merging adjacent elements.
+            let mut merged_any = false;
+            for i in 0..(deltas.len().saturating_sub(1)) {
+                let mut cand = deltas.clone();
+                let merged = format!("{}{}", cand[i], cand[i + 1]);
+                cand[i] = merged;
+                cand.remove(i + 1);
+                let cand_refs = cand.iter().map(|s| s.as_str()).collect::<Vec<_>>();
+                if mismatch(&cand_refs, cfg) {
+                    deltas = cand;
+                    changed = true;
+                    merged_any = true;
+                    break;
+                }
+            }
+            if merged_any {
+                continue;
+            }
+        }
+        deltas
+    }
+
     #[test]
     fn lists_and_fences_commit_without_duplication() {
         let cfg = test_config();
@@ -458,6 +535,55 @@ mod tests {
         assert_eq!(
             streamed2_str, rendered_all2_str,
             "fence streaming should equal full render without duplication"
+        );
+    }
+
+    #[test]
+    fn dash_split_across_chunks_does_not_dangle() {
+        let cfg = test_config();
+
+        // Repro: deltas that arrive as ["-", " some", " words\n"] should not
+        // produce a dangling history line with just "-" followed by
+        // "some words". The streamed result should match a full render.
+        let deltas = vec!["-", " some", " words\n"];
+        let streamed = simulate_stream_markdown_for_tests(&deltas, true, &cfg);
+        let streamed_str = lines_to_plain_strings(&streamed);
+
+        let mut rendered_all: Vec<ratatui::text::Line<'static>> = Vec::new();
+        crate::markdown::append_markdown("- some words\n", &mut rendered_all, &cfg);
+        let rendered_all_str = lines_to_plain_strings(&rendered_all);
+
+        assert_eq!(
+            streamed_str, rendered_all_str,
+            "dash-split streaming should equal full render without dangling '-' line"
+        );
+    }
+
+    #[test]
+    fn dash_split_then_newline_in_middle_of_delta_does_not_commit_dash() {
+        let cfg = test_config();
+        let mut c = super::MarkdownStreamCollector::new();
+
+        // Seed some preceding content that commits cleanly.
+        c.push_delta("Intro line.\n");
+        let _ = c.commit_complete_lines(&cfg);
+
+        // Now stream a list item split as ["-", " some", " words"], but do not
+        // include a newline yet.
+        c.push_delta("-");
+        c.push_delta(" some");
+
+        // Next delta contains a newline early, but ends without one, which triggers
+        // a commit while the buffer does not end in a newline. This used to cause
+        // the solitary "-" to be considered a completed line and emitted.
+        c.push_delta("\ntrailing");
+        let out = c.commit_complete_lines(&cfg);
+        let texts = lines_to_plain_strings(&out);
+
+        // Ensure we did not emit a dangling dash line.
+        assert!(
+            !texts.iter().any(|s| s == "-"),
+            "should not emit a standalone '-' line: {texts:?}"
         );
     }
 
@@ -529,5 +655,195 @@ mod tests {
             head_idx > para_idx,
             "heading should not merge with paragraph: {texts:?}"
         );
+    }
+
+    #[test]
+    fn loose_list_with_split_dashes_matches_full_render() {
+        let cfg = test_config();
+        // Minimized failing sequence discovered by the helper: two chunks
+        // that still reproduce the mismatch.
+        let deltas = vec!["- item.\n\n", "-"];
+
+        let streamed = simulate_stream_markdown_for_tests(&deltas, true, &cfg);
+        let streamed_strs = lines_to_plain_strings(&streamed);
+
+        let full: String = deltas.iter().copied().collect();
+        let mut rendered_all: Vec<ratatui::text::Line<'static>> = Vec::new();
+        crate::markdown::append_markdown(&full, &mut rendered_all, &cfg);
+        let rendered_all_strs = lines_to_plain_strings(&rendered_all);
+
+        assert_eq!(
+            streamed_strs, rendered_all_strs,
+            "streamed output should match full render without dangling '-' lines"
+        );
+    }
+
+    /// Exhaustive-ish search to find the shortest failing chunking for a given source.
+    /// Ignored by default since it can be slow. Run with:
+    ///   cargo test -p codex-tui find_min_failing_chunking -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn find_min_failing_chunking() {
+        let cfg = test_config();
+        let src = "Loose list (multi-paragraph items)\n- This item has two paragraphs. The second paragraph is still part of this item.\n\n Here’s the second paragraph, indented to remain within the same bullet.\n- Next item after a loose break.\n\n";
+
+        // Choose candidate split points: after every space, after every dash, and after newlines.
+        let bytes = src.as_bytes();
+        let mut splits = Vec::new();
+        for i in 1..bytes.len() {
+            let c = bytes[i - 1] as char;
+            if c == ' ' || c == '-' || c == '\n' {
+                splits.push(i);
+            }
+        }
+        // Cap the number of splits to keep combinations manageable.
+        if splits.len() > 18 {
+            splits.truncate(18);
+        }
+
+        let mut best: Option<Vec<String>> = None;
+        let n = splits.len();
+        // Iterate all bitmasks selecting which splits to keep as boundaries.
+        let total = 1usize << n;
+        for mask in 0..total {
+            let mut last = 0usize;
+            let mut chunks: Vec<String> = Vec::new();
+            for (bit, &pos) in splits.iter().enumerate() {
+                if (mask >> bit) & 1 == 1 {
+                    chunks.push(src[last..pos].to_string());
+                    last = pos;
+                }
+            }
+            if last < src.len() {
+                chunks.push(src[last..].to_string());
+            }
+            let refs = chunks.iter().map(|s| s.as_str()).collect::<Vec<_>>();
+            if mismatch(&refs, &cfg) {
+                // Greedily minimize this failing candidate further.
+                let minimized = minimize_failing_deltas(chunks.clone(), &cfg);
+                if best
+                    .as_ref()
+                    .map(|b| minimized.len() < b.len())
+                    .unwrap_or(true)
+                {
+                    best = Some(minimized);
+                }
+            }
+        }
+
+        if let Some(b) = best {
+            eprintln!("Shortest failing chunks ({}):", b.len());
+            for (i, s) in b.iter().enumerate() {
+                eprintln!("  [{}] {:?}", i, s);
+            }
+        } else {
+            eprintln!("No failing chunking found under the capped search.");
+        }
+
+        // This is a diagnostic test; do not assert failure so it remains useful after a fix.
+        assert!(true);
+    }
+
+    /// Determinism check: run the same failing sequence many times and ensure
+    /// the mismatch outcome is consistent. Ignored by default due to runtime.
+    #[test]
+    #[ignore]
+    fn streaming_behavior_is_deterministic_for_failing_case() {
+        let cfg = test_config();
+        let deltas = vec![
+            "Loose list (multi-paragraph items)\n",
+            "-",
+            " This item has two paragraphs. The second paragraph is still part of this item.\n\n",
+            " Here’s the second paragraph, indented to remain within the same bullet.\n",
+            "- Next item after a loose break.\n\n",
+        ];
+        let refs = deltas.iter().map(|s| *s).collect::<Vec<_>>();
+        let first = mismatch(&refs, &cfg);
+        let mut consistent = true;
+        for _ in 0..200 {
+            let now = mismatch(&refs, &cfg);
+            if now != first {
+                consistent = false;
+                break;
+            }
+        }
+        if !consistent {
+            panic!("nondeterministic mismatch outcome detected");
+        }
+    }
+
+    /// Greedy minimization starting from a known failing delta sequence.
+    /// Prints the minimized sequence and length. Ignored by default.
+    #[test]
+    #[ignore]
+    fn minimize_known_failing_sequence() {
+        let cfg = test_config();
+        let seed = vec![
+            "Loose".to_string(),
+            " list".to_string(),
+            " (".to_string(),
+            "multi".to_string(),
+            "-par".to_string(),
+            "agraph".to_string(),
+            " items".to_string(),
+            ")\n".to_string(),
+            "-".to_string(),
+            " This".to_string(),
+            " item".to_string(),
+            " has".to_string(),
+            " two".to_string(),
+            " paragraphs".to_string(),
+            ".".to_string(),
+            " The".to_string(),
+            " second".to_string(),
+            " paragraph".to_string(),
+            " is".to_string(),
+            " still".to_string(),
+            " part".to_string(),
+            " of".to_string(),
+            " this".to_string(),
+            " item".to_string(),
+            ".\n\n".to_string(),
+            " ".to_string(),
+            " Here".to_string(),
+            "’s".to_string(),
+            " the".to_string(),
+            " second".to_string(),
+            " paragraph".to_string(),
+            ",".to_string(),
+            " ind".to_string(),
+            "ented".to_string(),
+            " to".to_string(),
+            " remain".to_string(),
+            " within".to_string(),
+            " the".to_string(),
+            " same".to_string(),
+            " bullet".to_string(),
+            ".\n".to_string(),
+            "-".to_string(),
+            " Next".to_string(),
+            " item".to_string(),
+            " after".to_string(),
+            " a".to_string(),
+            " loose".to_string(),
+            " break".to_string(),
+            ".\n\n".to_string(),
+        ];
+
+        // Ensure seed actually mismatches to begin with.
+        let seed_refs = seed.iter().map(|s| s.as_str()).collect::<Vec<_>>();
+        if !mismatch(&seed_refs, &cfg) {
+            eprintln!("Seed does not reproduce mismatch; nothing to minimize.");
+            return;
+        }
+
+        let minimized = minimize_failing_deltas(seed, &cfg);
+        eprintln!("Minimized chunks ({}):", minimized.len());
+        for (i, s) in minimized.iter().enumerate() {
+            eprintln!("  [{}] {:?}", i, s);
+        }
+
+        // Keep as informational; do not assert.
+        assert!(true);
     }
 }

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -214,3 +214,186 @@ impl StreamController {
         self.finalize(true, sink)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_core::config::Config;
+    use codex_core::config::ConfigOverrides;
+    use std::cell::RefCell;
+
+    fn test_config() -> Config {
+        let overrides = ConfigOverrides {
+            cwd: std::env::current_dir().ok(),
+            ..Default::default()
+        };
+        match Config::load_with_cli_overrides(vec![], overrides) {
+            Ok(c) => c,
+            Err(e) => panic!("load test config: {e}"),
+        }
+    }
+
+    struct TestSink {
+        pub lines: RefCell<Vec<Vec<Line<'static>>>>,
+    }
+    impl TestSink {
+        fn new() -> Self {
+            Self { lines: RefCell::new(Vec::new()) }
+        }
+    }
+    impl HistorySink for TestSink {
+        fn insert_history(&self, lines: Vec<Line<'static>>) {
+            self.lines.borrow_mut().push(lines);
+        }
+        fn start_commit_animation(&self) {}
+        fn stop_commit_animation(&self) {}
+    }
+
+    fn lines_to_plain_strings(lines: &[ratatui::text::Line<'_>]) -> Vec<String> {
+        lines
+            .iter()
+            .map(|l| {
+                l.spans
+                    .iter()
+                    .map(|s| s.content.clone())
+                    .collect::<Vec<_>>()
+                    .join("")
+            })
+            .collect()
+    }
+
+    #[test]
+    fn controller_loose_vs_tight_with_commit_ticks_matches_full() {
+        let cfg = test_config();
+        let mut ctrl = StreamController::new(cfg.clone());
+        let sink = TestSink::new();
+        ctrl.begin(&sink);
+
+        // Exact deltas from the session log (section: Loose vs. tight list items)
+        let deltas = vec![
+            "\n\n",
+            "Loose",
+            " vs",
+            ".",
+            " tight",
+            " list",
+            " items",
+            ":\n",
+            "1",
+            ".",
+            " Tight",
+            " item",
+            "\n",
+            "2",
+            ".",
+            " Another",
+            " tight",
+            " item",
+            "\n\n",
+            "1",
+            ".",
+            " Loose",
+            " item",
+            " with",
+            " its",
+            " own",
+            " paragraph",
+            ".\n\n",
+            "  ",
+            " This",
+            " paragraph",
+            " belongs",
+            " to",
+            " the",
+            " same",
+            " list",
+            " item",
+            ".\n\n",
+            "2",
+            ".",
+            " Second",
+            " loose",
+            " item",
+            " with",
+            " a",
+            " nested",
+            " list",
+            " after",
+            " a",
+            " blank",
+            " line",
+            ".\n\n",
+            "  ",
+            " -",
+            " Nested",
+            " bullet",
+            " under",
+            " a",
+            " loose",
+            " item",
+            "\n",
+            "  ",
+            " -",
+            " Another",
+            " nested",
+            " bullet",
+            "\n\n",
+        ];
+
+        // Simulate streaming with a commit tick attempt after each delta.
+        for d in &deltas {
+            ctrl.push_and_maybe_commit(d, &sink);
+            let _ = ctrl.on_commit_tick(&sink);
+        }
+        // Finalize and flush remaining lines now.
+        let _ = ctrl.finalize(true, &sink);
+
+        // Flatten sink output and strip the header that the controller inserts (blank + "codex").
+        let mut flat: Vec<ratatui::text::Line<'static>> = Vec::new();
+        for batch in sink.lines.borrow().iter() {
+            for l in batch {
+                flat.push(l.clone());
+            }
+        }
+        // Drop leading blank and header line if present.
+        if !flat.is_empty() {
+            if lines_to_plain_strings(&[flat[0].clone()])[0].is_empty() {
+                flat.remove(0);
+            }
+        }
+        if !flat.is_empty() {
+            let s0 = lines_to_plain_strings(&[flat[0].clone()])[0].clone();
+            if s0 == "codex" {
+                flat.remove(0);
+            }
+        }
+        let streamed = lines_to_plain_strings(&flat);
+
+        // Full render of the same source
+        let source: String = deltas.iter().copied().collect();
+        let mut rendered: Vec<ratatui::text::Line<'static>> = Vec::new();
+        crate::markdown::append_markdown(&source, &mut rendered, &cfg);
+        let rendered_strs = lines_to_plain_strings(&rendered);
+
+        assert_eq!(streamed, rendered_strs);
+
+        // Also assert exact expected plain strings for clarity.
+        let expected = vec![
+            "Loose vs. tight list items:".to_string(),
+            "".to_string(),
+            "1. ".to_string(),
+            "Tight item".to_string(),
+            "2. ".to_string(),
+            "Another tight item".to_string(),
+            "3. ".to_string(),
+            "Loose item with its own paragraph.".to_string(),
+            "".to_string(),
+            "This paragraph belongs to the same list item.".to_string(),
+            "4. ".to_string(),
+            "Second loose item with a nested list after a blank line.".to_string(),
+            "    - Nested bullet under a loose item".to_string(),
+            "    - Another nested bullet".to_string(),
+        ];
+        assert_eq!(streamed, expected, "expected exact rendered lines for loose/tight section");
+    }
+}

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -238,7 +238,9 @@ mod tests {
     }
     impl TestSink {
         fn new() -> Self {
-            Self { lines: RefCell::new(Vec::new()) }
+            Self {
+                lines: RefCell::new(Vec::new()),
+            }
         }
     }
     impl HistorySink for TestSink {
@@ -356,11 +358,10 @@ mod tests {
             }
         }
         // Drop leading blank and header line if present.
-        if !flat.is_empty() {
-            if lines_to_plain_strings(&[flat[0].clone()])[0].is_empty() {
+        if !flat.is_empty()
+            && lines_to_plain_strings(&[flat[0].clone()])[0].is_empty() {
                 flat.remove(0);
             }
-        }
         if !flat.is_empty() {
             let s0 = lines_to_plain_strings(&[flat[0].clone()])[0].clone();
             if s0 == "codex" {
@@ -394,6 +395,9 @@ mod tests {
             "    - Nested bullet under a loose item".to_string(),
             "    - Another nested bullet".to_string(),
         ];
-        assert_eq!(streamed, expected, "expected exact rendered lines for loose/tight section");
+        assert_eq!(
+            streamed, expected,
+            "expected exact rendered lines for loose/tight section"
+        );
     }
 }

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -374,9 +374,6 @@ mod tests {
         let source: String = deltas.iter().copied().collect();
         let mut rendered: Vec<ratatui::text::Line<'static>> = Vec::new();
         crate::markdown::append_markdown(&source, &mut rendered, &cfg);
-        // Coalesce ordered list markers in the baseline to match streaming coalescing
-        let mut rendered = rendered;
-        coalesce_ordered_for_tests(&mut rendered);
         let rendered_strs = lines_to_plain_strings(&rendered);
 
         assert_eq!(streamed, rendered_strs);
@@ -385,12 +382,16 @@ mod tests {
         let expected = vec![
             "Loose vs. tight list items:".to_string(),
             "".to_string(),
-            "1. Tight item".to_string(),
-            "2. Another tight item".to_string(),
-            "3. Loose item with its own paragraph.".to_string(),
+            "1. ".to_string(),
+            "Tight item".to_string(),
+            "2. ".to_string(),
+            "Another tight item".to_string(),
+            "3. ".to_string(),
+            "Loose item with its own paragraph.".to_string(),
             "".to_string(),
             "This paragraph belongs to the same list item.".to_string(),
-            "4. Second loose item with a nested list after a blank line.".to_string(),
+            "4. ".to_string(),
+            "Second loose item with a nested list after a blank line.".to_string(),
             "    - Nested bullet under a loose item".to_string(),
             "    - Another nested bullet".to_string(),
         ];
@@ -398,48 +399,5 @@ mod tests {
             streamed, expected,
             "expected exact rendered lines for loose/tight section"
         );
-    }
-}
-#[cfg(test)]
-fn coalesce_ordered_for_tests(lines: &mut Vec<Line<'static>>) {
-    let mut i = 0usize;
-    while i + 1 < lines.len() {
-        let a = lines[i]
-            .spans
-            .iter()
-            .map(|s| s.content.clone())
-            .collect::<String>();
-        let b = lines[i + 1]
-            .spans
-            .iter()
-            .map(|s| s.content.clone())
-            .collect::<String>();
-        if is_ordered_marker_only_test(&a) {
-            lines[i] = Line::from(format!("{}{}", a, b));
-            lines.remove(i + 1);
-        } else {
-            i += 1;
-        }
-    }
-}
-#[cfg(test)]
-fn is_ordered_marker_only_test(s: &str) -> bool {
-    let t = s.trim_end();
-    let mut it = t.chars().peekable();
-    let mut saw_digit = false;
-    while let Some(&ch) = it.peek() {
-        if ch.is_ascii_digit() {
-            saw_digit = true;
-            it.next();
-        } else {
-            break;
-        }
-    }
-    if !saw_digit || it.next() != Some('.') {
-        return false;
-    }
-    match it.next() {
-        Some(' ') | None => it.next().is_none(),
-        _ => false,
     }
 }

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -358,10 +358,9 @@ mod tests {
             }
         }
         // Drop leading blank and header line if present.
-        if !flat.is_empty()
-            && lines_to_plain_strings(&[flat[0].clone()])[0].is_empty() {
-                flat.remove(0);
-            }
+        if !flat.is_empty() && lines_to_plain_strings(&[flat[0].clone()])[0].is_empty() {
+            flat.remove(0);
+        }
         if !flat.is_empty() {
             let s0 = lines_to_plain_strings(&[flat[0].clone()])[0].clone();
             if s0 == "codex" {


### PR DESCRIPTION
This was mostly written by codex under heavy guidance via test cases drawn from logged session data and fuzzing. It also uncovered some bugs in tui_markdown, which will in some cases split a list marker from the list item content. We're not addressing those bugs for now.