### PR TITLE
disallow some slash commands while a task is running

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -751,12 +751,20 @@ impl ChatWidget {
     }
 
     fn dispatch_command(&mut self, cmd: SlashCommand) {
+        if !cmd.available_during_task() && self.bottom_pane.is_task_running() {
+            let message = format!(
+                "'/'{}' is disabled while a task is in progress.",
+                cmd.command()
+            );
+            self.add_to_history(history_cell::new_error_event(message));
+            self.request_redraw();
+            return;
+        }
         match cmd {
             SlashCommand::New => {
                 self.app_event_tx.send(AppEvent::NewSession);
             }
             SlashCommand::Init => {
-                // Guard: do not run if a task is active.
                 const INIT_PROMPT: &str = include_str!("../prompt_for_init_command.md");
                 self.submit_text_message(INIT_PROMPT.to_string());
             }

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -52,6 +52,24 @@ impl SlashCommand {
     pub fn command(self) -> &'static str {
         self.into()
     }
+
+    /// Whether this command can be run while a task is in progress.
+    pub fn available_during_task(self) -> bool {
+        match self {
+            SlashCommand::New
+            | SlashCommand::Init
+            | SlashCommand::Compact
+            | SlashCommand::Model
+            | SlashCommand::Approvals
+            | SlashCommand::Logout => false,
+            SlashCommand::Diff
+            | SlashCommand::Mention
+            | SlashCommand::Status
+            | SlashCommand::Mcp
+            | SlashCommand::Quit
+            | SlashCommand::TestApproval => true,
+        }
+    }
 }
 
 /// Return all built-in commands in a Vec paired with their command string.


### PR DESCRIPTION
/new, /init, /models, /approvals, etc. don't work correctly during a turn. disable them.