### PR TITLE
Include apply_patch tool for oss models from gpt-oss providers with different naming convention (e.g. `openai/gpt-oss-*`)

### DIFF
--- a/codex-rs/core/src/model_family.rs
+++ b/codex-rs/core/src/model_family.rs
@@ -103,7 +103,7 @@ pub fn find_family_for_model(slug: &str) -> Option<ModelFamily> {
             slug, "gpt-4.1",
             needs_special_apply_patch_instructions: true,
         )
-    } else if slug.starts_with("gpt-oss") {
+    } else if slug.contains("gpt-oss") {
         model_family!(slug, "gpt-oss", apply_patch_tool_type: Some(ApplyPatchToolType::Function))
     } else if slug.starts_with("gpt-4o") {
         simple_model_family!(slug, "gpt-4o")

--- a/codex-rs/core/src/model_family.rs
+++ b/codex-rs/core/src/model_family.rs
@@ -103,7 +103,7 @@ pub fn find_family_for_model(slug: &str) -> Option<ModelFamily> {
             slug, "gpt-4.1",
             needs_special_apply_patch_instructions: true,
         )
-    } else if slug.contains("gpt-oss") {
+    } else if slug.starts_with("gpt-oss") || slug.starts_with("openai/gpt-oss") {
         model_family!(slug, "gpt-oss", apply_patch_tool_type: Some(ApplyPatchToolType::Function))
     } else if slug.starts_with("gpt-4o") {
         simple_model_family!(slug, "gpt-4o")


### PR DESCRIPTION
Model providers like Groq, Openrouter, AWS Bedrock, VertexAI and others typically prefix the name of gpt-oss models with `openai`, e.g. `openai/gpt-oss-120b`.

This PR is to match the model name slug using `contains` instead of `starts_with` to ensure that the `apply_patch` tool is included in the tools for models names like `openai/gpt-oss-120b`

Without this, the gpt-oss models will often try to call the `apply_patch` tool directly instead of via the `shell` command, leading to validation errors.

I have run all the local checks.

Note: The gpt-oss models from non-Ollama providers are typically run via a profile with a different base_url (instead of with the `--oss` flag)