### PR TITLE
fix(nix): build git+ deps via allowBuiltinFetchGit and use rust-bin toolchain (#512)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744463964,
-        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "lastModified": 1756266583,
+        "narHash": "sha256-cr748nSmpfvnhqSXPiCfUPxRz2FJnvf/RjJGvFfaCsM=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "rev": "8a6d5427d99ec71c64f0b93d45778c889005d9c2",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746844454,
-        "narHash": "sha256-GcUWDQUDRYrD34ol90KGUpjbVcOfUNbv0s955jPecko=",
+        "lastModified": 1756348497,
+        "narHash": "sha256-xJp3VnoYh4kpsaKFO/7SsGbwOz7pI1ZmjbqpXEuR2cw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "be092436d4c0c303b654e4007453b69c0e33009e",
+        "rev": "0adf92c70d23fb4f703aea5d3ebb51ac65994f7f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
- Switch to rust-bin.fromRustupToolchainFile + rustPlatform so the actual toolchain is used consistently, independent of pinned nixpkgs.
- Set cargoLock = { lockFile = ./Cargo.lock; allowBuiltinFetchGit = true; } to avoid manual outputHashes for git+ sources (e.g., ratatui).
- Update locked inputs (rust-overlay) so 1.88.0 is available; prior lock lacked this toolchain.

Background: before this change, buildRustPackage failed on the vendored git dependency (ratatui) without outputHashes, and then failed due to an older rustPlatform/toolchain complaining about unstable features. Using rust-bin.fromRustupToolchainFile makes following toolchain updates straightforward and fixes the build.