### PR TITLE
Fix: Preserve '@' prefix in file path autocomplete #2779

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -675,14 +675,15 @@ impl ChatComposer {
 
         // Replace the slice `[start_idx, end_idx)` with the chosen path and a trailing space.
         let mut new_text =
-            String::with_capacity(text.len() - (end_idx - start_idx) + path.len() + 1);
+            String::with_capacity(text.len() - (end_idx - start_idx) + path.len() + 2);
         new_text.push_str(&text[..start_idx]);
+        new_text.push('@');
         new_text.push_str(path);
         new_text.push(' ');
         new_text.push_str(&text[end_idx..]);
 
         self.textarea.set_text(&new_text);
-        let new_cursor = start_idx.saturating_add(path.len()).saturating_add(1);
+        let new_cursor = start_idx.saturating_add(path.len()).saturating_add(2);
         self.textarea.set_cursor(new_cursor);
     }
 


### PR DESCRIPTION
### Context  
Fixes #2779 – when autocompleting file paths preceded by `@`, the prefix is currently dropped. For example, typing `@REA` and selecting `README.md` yields `README.md` instead of `@README.md`.  

### Root Cause  
The completion logic does not restore the leading `@` when applying the suggestion.  

### Solution  
Ensure the `@` prefix is preserved and prepended to the completed path.  

### Why This Matters  
Preserving the `@` allows developers to continue modifying autocompleted paths and still receive further suggestions, since the path remains valid with the `@` prefix. Moreover, prompts containing `@path` are correctly interpreted by the LLM, so retaining the prefix after completion is both accurate and useful.  

---  
Closes #2779.  
