### PR TITLE
chore: require uninlined_format_args from clippy

### DIFF
--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -34,6 +34,7 @@ rust = {}
 
 [workspace.lints.clippy]
 expect_used = "deny"
+uninlined_format_args = "deny"
 unwrap_used = "deny"
 
 [profile.release]

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1317,9 +1317,9 @@ disable_response_storage = true
 
         let raw_path = project_dir.path().to_string_lossy();
         let path_str = if raw_path.contains('\\') {
-            format!("'{}'", raw_path)
+            format!("'{raw_path}'")
         } else {
-            format!("\"{}\"", raw_path)
+            format!("\"{raw_path}\"")
         };
         let expected = format!(
             r#"[projects.{path_str}]
@@ -1340,9 +1340,9 @@ trust_level = "trusted"
         let config_path = codex_home.path().join(CONFIG_TOML_FILE);
         let raw_path = project_dir.path().to_string_lossy();
         let path_str = if raw_path.contains('\\') {
-            format!("'{}'", raw_path)
+            format!("'{raw_path}'")
         } else {
-            format!("\"{}\"", raw_path)
+            format!("\"{raw_path}\"")
         };
         // Use a quoted key so backslashes don't require escaping on Windows
         let initial = format!(

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -85,23 +85,21 @@ impl EnvironmentContext {
         }
         if let Some(approval_policy) = self.approval_policy {
             lines.push(format!(
-                "  <approval_policy>{}</approval_policy>",
-                approval_policy
+                "  <approval_policy>{approval_policy}</approval_policy>"
             ));
         }
         if let Some(sandbox_mode) = self.sandbox_mode {
-            lines.push(format!("  <sandbox_mode>{}</sandbox_mode>", sandbox_mode));
+            lines.push(format!("  <sandbox_mode>{sandbox_mode}</sandbox_mode>"));
         }
         if let Some(network_access) = self.network_access {
             lines.push(format!(
-                "  <network_access>{}</network_access>",
-                network_access
+                "  <network_access>{network_access}</network_access>"
             ));
         }
         if let Some(shell) = self.shell
             && let Some(shell_name) = shell.name()
         {
-            lines.push(format!("  <shell>{}</shell>", shell_name));
+            lines.push(format!("  <shell>{shell_name}</shell>"));
         }
         lines.push(ENVIRONMENT_CONTEXT_END.to_string());
         lines.join("\n")

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -170,15 +170,15 @@ fn format_reset_duration(total_secs: u64) -> String {
     let mut parts: Vec<String> = Vec::new();
     if days > 0 {
         let unit = if days == 1 { "day" } else { "days" };
-        parts.push(format!("{} {}", days, unit));
+        parts.push(format!("{days} {unit}"));
     }
     if hours > 0 {
         let unit = if hours == 1 { "hour" } else { "hours" };
-        parts.push(format!("{} {}", hours, unit));
+        parts.push(format!("{hours} {unit}"));
     }
     if minutes > 0 {
         let unit = if minutes == 1 { "minute" } else { "minutes" };
-        parts.push(format!("{} {}", minutes, unit));
+        parts.push(format!("{minutes} {unit}"));
     }
 
     if parts.is_empty() {

--- a/codex-rs/core/src/exec_command/session_manager.rs
+++ b/codex-rs/core/src/exec_command/session_manager.rs
@@ -359,10 +359,7 @@ fn truncate_middle(s: &str, max_bytes: usize) -> (String, Option<u64>) {
     let est_tokens = (s.len() as u64).div_ceil(4);
     if max_bytes == 0 {
         // Cannot keep any content; still return a full marker (never truncated).
-        return (
-            format!("…{} tokens truncated…", est_tokens),
-            Some(est_tokens),
-        );
+        return (format!("…{est_tokens} tokens truncated…"), Some(est_tokens));
     }
 
     // Helper to truncate a string to a given byte length on a char boundary.
@@ -406,16 +403,13 @@ fn truncate_middle(s: &str, max_bytes: usize) -> (String, Option<u64>) {
     // Refine marker length and budgets until stable. Marker is never truncated.
     let mut guess_tokens = est_tokens; // worst-case: everything truncated
     for _ in 0..4 {
-        let marker = format!("…{} tokens truncated…", guess_tokens);
+        let marker = format!("…{guess_tokens} tokens truncated…");
         let marker_len = marker.len();
         let keep_budget = max_bytes.saturating_sub(marker_len);
         if keep_budget == 0 {
             // No room for any content within the cap; return a full, untruncated marker
             // that reflects the entire truncated content.
-            return (
-                format!("…{} tokens truncated…", est_tokens),
-                Some(est_tokens),
-            );
+            return (format!("…{est_tokens} tokens truncated…"), Some(est_tokens));
         }
 
         let left_budget = keep_budget / 2;
@@ -441,14 +435,11 @@ fn truncate_middle(s: &str, max_bytes: usize) -> (String, Option<u64>) {
     }
 
     // Fallback: use last guess to build output.
-    let marker = format!("…{} tokens truncated…", guess_tokens);
+    let marker = format!("…{guess_tokens} tokens truncated…");
     let marker_len = marker.len();
     let keep_budget = max_bytes.saturating_sub(marker_len);
     if keep_budget == 0 {
-        return (
-            format!("…{} tokens truncated…", est_tokens),
-            Some(est_tokens),
-        );
+        return (format!("…{est_tokens} tokens truncated…"), Some(est_tokens));
     }
     let left_budget = keep_budget / 2;
     let right_budget = keep_budget - left_budget;

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -418,7 +418,7 @@ async fn prefers_chatgpt_token_when_config_prefers_chatgpt() {
         match CodexAuth::from_codex_home(codex_home.path(), config.preferred_auth_method) {
             Ok(Some(auth)) => codex_login::AuthManager::from_auth_for_testing(auth),
             Ok(None) => panic!("No CodexAuth found in codex_home"),
-            Err(e) => panic!("Failed to load CodexAuth: {}", e),
+            Err(e) => panic!("Failed to load CodexAuth: {e}"),
         };
     let conversation_manager = ConversationManager::new(auth_manager);
     let NewConversation {
@@ -499,7 +499,7 @@ async fn prefers_apikey_when_config_prefers_apikey_even_with_chatgpt_tokens() {
         match CodexAuth::from_codex_home(codex_home.path(), config.preferred_auth_method) {
             Ok(Some(auth)) => codex_login::AuthManager::from_auth_for_testing(auth),
             Ok(None) => panic!("No CodexAuth found in codex_home"),
-            Err(e) => panic!("Failed to load CodexAuth: {}", e),
+            Err(e) => panic!("Failed to load CodexAuth: {e}"),
         };
     let conversation_manager = ConversationManager::new(auth_manager);
     let NewConversation {

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -280,7 +280,7 @@ async fn prefixes_context_and_instructions_once_and_consistently_across_requests
 {}</environment_context>"#,
         cwd.path().to_string_lossy(),
         match shell.name() {
-            Some(name) => format!("  <shell>{}</shell>\n", name),
+            Some(name) => format!("  <shell>{name}</shell>\n"),
             None => String::new(),
         }
     );

--- a/codex-rs/exec/tests/suite/common.rs
+++ b/codex-rs/exec/tests/suite/common.rs
@@ -28,7 +28,7 @@ impl Respond for SeqResponder {
             Some(body) => wiremock::ResponseTemplate::new(200)
                 .insert_header("content-type", "text/event-stream")
                 .set_body_raw(
-                    load_sse_fixture_with_id_from_str(body, &format!("request_{}", call_num)),
+                    load_sse_fixture_with_id_from_str(body, &format!("request_{call_num}")),
                     "text/event-stream",
                 ),
             None => panic!("no response for {call_num}"),
@@ -63,7 +63,7 @@ pub(crate) async fn run_e2e_exec_test(cwd: &Path, response_streams: Vec<String>)
         .current_dir(cwd.clone())
         .env("CODEX_HOME", cwd.clone())
         .env("OPENAI_API_KEY", "dummy")
-        .env("OPENAI_BASE_URL", format!("{}/v1", uri))
+        .env("OPENAI_BASE_URL", format!("{uri}/v1"))
         .arg("--skip-git-repo-check")
         .arg("-s")
         .arg("danger-full-access")

--- a/codex-rs/mcp-server/src/outgoing_message.rs
+++ b/codex-rs/mcp-server/src/outgoing_message.rs
@@ -123,7 +123,7 @@ impl OutgoingMessageSender {
     }
 
     pub(crate) async fn send_server_notification(&self, notification: ServerNotification) {
-        let method = format!("codex/event/{}", notification);
+        let method = format!("codex/event/{notification}");
         let params = match serde_json::to_value(&notification) {
             Ok(serde_json::Value::Object(mut map)) => map.remove("data"),
             _ => None,


### PR DESCRIPTION

- added `uninlined_format_args` to `[workspace.lints.clippy]` in the `Cargo.toml` for the workspace
- ran `cargo clippy --tests --fix`
- ran `just fmt`
