### PR TITLE
chore: try to make it easier to debug the flakiness of test_shell_command_approval_triggers_elicitation

### DIFF
--- a/codex-rs/mcp-server/tests/common/mcp_process.rs
+++ b/codex-rs/mcp-server/tests/common/mcp_process.rs
@@ -283,6 +283,7 @@ impl McpProcess {
     }
 
     async fn send_jsonrpc_message(&mut self, message: JSONRPCMessage) -> anyhow::Result<()> {
+        eprintln!("writing message to stdin: {message:?}");
         let payload = serde_json::to_string(&message)?;
         self.stdin.write_all(payload.as_bytes()).await?;
         self.stdin.write_all(b"\n").await?;
@@ -294,13 +295,15 @@ impl McpProcess {
         let mut line = String::new();
         self.stdout.read_line(&mut line).await?;
         let message = serde_json::from_str::<JSONRPCMessage>(&line)?;
+        eprintln!("read message from stdout: {message:?}");
         Ok(message)
     }
 
     pub async fn read_stream_until_request_message(&mut self) -> anyhow::Result<JSONRPCRequest> {
+        eprintln!("in read_stream_until_request_message()");
+
         loop {
             let message = self.read_jsonrpc_message().await?;
-            eprint!("message: {message:?}");
 
             match message {
                 JSONRPCMessage::Notification(_) => {
@@ -323,10 +326,10 @@ impl McpProcess {
         &mut self,
         request_id: RequestId,
     ) -> anyhow::Result<JSONRPCResponse> {
+        eprintln!("in read_stream_until_response_message({request_id:?})");
+
         loop {
             let message = self.read_jsonrpc_message().await?;
-            eprint!("message: {message:?}");
-
             match message {
                 JSONRPCMessage::Notification(_) => {
                     eprintln!("notification: {message:?}");
@@ -352,8 +355,6 @@ impl McpProcess {
     ) -> anyhow::Result<mcp_types::JSONRPCError> {
         loop {
             let message = self.read_jsonrpc_message().await?;
-            eprint!("message: {message:?}");
-
             match message {
                 JSONRPCMessage::Notification(_) => {
                     eprintln!("notification: {message:?}");
@@ -377,10 +378,10 @@ impl McpProcess {
         &mut self,
         method: &str,
     ) -> anyhow::Result<JSONRPCNotification> {
+        eprintln!("in read_stream_until_notification_message({method})");
+
         loop {
             let message = self.read_jsonrpc_message().await?;
-            eprint!("message: {message:?}");
-
             match message {
                 JSONRPCMessage::Notification(notification) => {
                     if notification.method == method {
@@ -405,10 +406,10 @@ impl McpProcess {
     pub async fn read_stream_until_legacy_task_complete_notification(
         &mut self,
     ) -> anyhow::Result<JSONRPCNotification> {
+        eprintln!("in read_stream_until_legacy_task_complete_notification()");
+
         loop {
             let message = self.read_jsonrpc_message().await?;
-            eprint!("message: {message:?}");
-
             match message {
                 JSONRPCMessage::Notification(notification) => {
                     let is_match = if notification.method == "codex/event" {
@@ -427,6 +428,8 @@ impl McpProcess {
 
                     if is_match {
                         return Ok(notification);
+                    } else {
+                        eprintln!("ignoring notification: {notification:?}");
                     }
                 }
                 JSONRPCMessage::Request(_) => {


### PR DESCRIPTION
`test_shell_command_approval_triggers_elicitation()` is one of a number of integration tests that we have observed to be flaky on GitHub CI, so this PR tries to reduce the flakiness _and_ to provide us with more information when it flakes. Specifically:

- Changed the command that we use to trigger the elicitation from `git init` to `python3 -c 'import pathlib; pathlib.Path(r"{}").touch()'` because running `git` seems more likely to invite variance.
- Increased the timeout to wait for the task response from 10s to 20s.
- Added more logging.