### PR TITLE
Bugfix: Prevents `brew install codex` in comment to be executed

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,16 @@
 
 ### Installing and running Codex CLI
 
-Install globally with your preferred package manager:
+Install globally with your preferred package manager. If you use npm:
 
 ```shell
-npm install -g @openai/codex  # Alternatively: `brew install codex`
+npm install -g @openai/codex
+```
+
+Alternatively, if you use Homebrew:
+
+```shell
+brew install codex
 ```
 
 Then simply run `codex` to get started:


### PR DESCRIPTION
The default install command causes unexpected code to be executed:

```
npm install -g @openai/codex # Alternatively: `brew install codex`
```

The problem is some environment will treat # as literal string, not start of comment. Therefore the user will execute this instead (because it's in backtick)

```
brew install codex
```

And then the npm command will error (because it's trying to install package #)