### PR TITLE
tui: catch get_cursor_position errors

### DIFF
--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -403,7 +403,10 @@ impl Tui {
     ) -> Result<Option<PreparedResumeAction>> {
         match action {
             ResumeAction::RealignInline => {
-                let cursor_pos = self.terminal.get_cursor_position()?;
+                let cursor_pos = self
+                    .terminal
+                    .get_cursor_position()
+                    .unwrap_or(self.terminal.last_known_cursor_pos);
                 Ok(Some(PreparedResumeAction::RealignViewport(
                     ratatui::layout::Rect::new(0, cursor_pos.y, 0, 0),
                 )))
@@ -496,8 +499,9 @@ impl Tui {
             let terminal = &mut self.terminal;
             let screen_size = terminal.size()?;
             let last_known_screen_size = terminal.last_known_screen_size;
-            if screen_size != last_known_screen_size {
-                let cursor_pos = terminal.get_cursor_position()?;
+            if screen_size != last_known_screen_size
+                && let Ok(cursor_pos) = terminal.get_cursor_position()
+            {
                 let last_known_cursor_pos = terminal.last_known_cursor_pos;
                 if cursor_pos.y != last_known_cursor_pos.y {
                     let cursor_delta = cursor_pos.y as i32 - last_known_cursor_pos.y as i32;


### PR DESCRIPTION
still seeing errors with reading back the cursor position in some cases; adding catches everywhere we might run into this.