### PR TITLE
fix: specify --profile to `cargo clippy` in CI

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: cargo clippy
         id: clippy
-        run: cargo clippy --target ${{ matrix.target }} --all-features --tests -- -D warnings
+        run: cargo clippy --target ${{ matrix.target }} --all-features --tests --profile ${{ matrix.profile }} -- -D warnings
 
       # Running `cargo build` from the workspace root builds the workspace using
       # the union of all features from third-party crates. This can mask errors

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -64,8 +64,6 @@ mod chatwidget_stream_tests;
 
 #[cfg(not(debug_assertions))]
 mod updates;
-#[cfg(not(debug_assertions))]
-use color_eyre::owo_colors::OwoColorize;
 
 pub use cli::Cli;
 


### PR DESCRIPTION
Today we had a breakage in the release build that went unnoticed by CI. Here is what happened:

- https://github.com/openai/codex/pull/2242 originally added some logic to do release builds to prevent this from happening
- https://github.com/openai/codex/pull/2276 undid that change to try to speed things up by removing the step to build all the individual crates in release mode, assuming the `cargo check` call was sufficient coverage, which it would have been, had it specified `--profile`

This PR adds `--profile` to the `cargo check` step so we should get the desired coverage from our build matrix.

Indeed, enabling this in our CI uncovered a warning that is only present in release mode that was going unnoticed.