### PR TITLE
fix: remove unnecessary flush() calls

### DIFF
--- a/codex-rs/mcp-client/src/mcp_client.rs
+++ b/codex-rs/mcp-client/src/mcp_client.rs
@@ -129,10 +129,7 @@ impl McpClient {
                                 error!("failed to write newline to child stdin");
                                 break;
                             }
-                            if stdin.flush().await.is_err() {
-                                error!("failed to flush child stdin");
-                                break;
-                            }
+                            // No explicit flush needed on a pipe; write_all is sufficient.
                         }
                         Err(e) => error!("failed to serialize JSONRPCMessage: {e}"),
                     }

--- a/codex-rs/mcp-server/src/lib.rs
+++ b/codex-rs/mcp-server/src/lib.rs
@@ -134,10 +134,6 @@ pub async fn run_main(
                         error!("Failed to write newline to stdout: {e}");
                         break;
                     }
-                    if let Err(e) = stdout.flush().await {
-                        error!("Failed to flush stdout: {e}");
-                        break;
-                    }
                 }
                 Err(e) => error!("Failed to serialize JSONRPCMessage: {e}"),
             }


### PR DESCRIPTION
Because we are writing to a pipe, these `flush()` calls are unnecessary, so removing these saves us one syscall per write in these two cases.
