### PR TITLE
fix: drop Mutex before calling tx_approve.send()

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -657,9 +657,17 @@ impl Session {
     }
 
     pub fn notify_approval(&self, sub_id: &str, decision: ReviewDecision) {
-        let mut state = self.state.lock_unchecked();
-        if let Some(tx_approve) = state.pending_approvals.remove(sub_id) {
-            tx_approve.send(decision).ok();
+        let entry = {
+            let mut state = self.state.lock_unchecked();
+            state.pending_approvals.remove(sub_id)
+        };
+        match entry {
+            Some(tx_approve) => {
+                tx_approve.send(decision).ok();
+            }
+            None => {
+                warn!("No pending approval found for sub_id: {sub_id}");
+            }
         }
     }
 


### PR DESCRIPTION
This seems like it may fix a potential deadlock! Before, we were holding the lock for `codex_core::codex::State` (which has a bit of stuff) for longer than necessary, and in particular, while calling `send()` on the `oneshot::Sender<ReviewDecision>` that functions as a "callback" for an elicitation request.

I found this by looking at a case in CI where `test_shell_command_approval_triggers_elicitation` flaked (again...), but in the logs, I saw that the last output from the MCP server logs was:

```
[mcp stderr] 2025-08-29T04:59:20.351700Z DEBUG codex_core::codex: Submission sub=Submission { id: "0", op: ExecApproval { id: "1", decision: Approved } }
```

Tracing that code through, that means the server got to here:

https://github.com/openai/codex/blob/5d2d3002ef52cbb63aafc00f0c8883f160b80633/codex-rs/core/src/codex.rs#L1053

which leads to this handler:

https://github.com/openai/codex/blob/5d2d3002ef52cbb63aafc00f0c8883f160b80633/codex-rs/core/src/codex.rs#L1219-L1224

which calls into:

https://github.com/openai/codex/blob/5d2d3002ef52cbb63aafc00f0c8883f160b80633/codex-rs/core/src/codex.rs#L659-L664

which is the code I am modifying in this PR!
