### PR TITLE
fix: drop Mutexes earlier in MCP server

### DIFF
--- a/codex-rs/mcp-client/src/mcp_client.rs
+++ b/codex-rs/mcp-client/src/mcp_client.rs
@@ -365,7 +365,11 @@ impl McpClient {
             }
         };
 
-        if let Some(tx) = pending.lock().await.remove(&id) {
+        let tx_opt = {
+            let mut guard = pending.lock().await;
+            guard.remove(&id)
+        };
+        if let Some(tx) = tx_opt {
             // Ignore send errors – the receiver might have been dropped.
             let _ = tx.send(JSONRPCMessage::Response(resp));
         } else {
@@ -383,7 +387,11 @@ impl McpClient {
             RequestId::String(_) => return, // see comment above
         };
 
-        if let Some(tx) = pending.lock().await.remove(&id) {
+        let tx_opt = {
+            let mut guard = pending.lock().await;
+            guard.remove(&id)
+        };
+        if let Some(tx) = tx_opt {
             let _ = tx.send(JSONRPCMessage::Error(err));
         }
     }


### PR DESCRIPTION
After finding https://github.com/openai/codex/pull/2876 on my own, I asked Codex to audit the codebase for similar issues and it found these two cases in `mcp-client/src/mcp_client.rs` where we are holding the mutex on a `Arc<Mutex<HashMap>>` longer than necessary.