### PR TITLE
Bug fix: reliably detect UserMessage boundaries via typed spans

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -207,15 +207,17 @@ impl App {
             }
             AppEvent::InsertHistoryCell(cell) => {
                 let mut cell_transcript = cell.transcript_lines();
+                let mut prepend_line_count = 0;
                 if !cell.is_stream_continuation() && !self.transcript_lines.is_empty() {
                     cell_transcript.insert(0, Line::from(""));
+                    prepend_line_count += 1;
                 }
                 if let Some(Overlay::Transcript(t)) = &mut self.overlay {
                     t.insert_lines(cell_transcript.clone());
                     tui.frame_requester().schedule_frame();
                 }
                 // Compute absolute indices before extending transcript
-                let start = self.transcript_lines.len();
+                let start = self.transcript_lines.len() + prepend_line_count;
                 if let Some(span) = cell.message_span()
                     && matches!(cell.kind(), crate::history_cell::MessageKind::User)
                 {

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -318,11 +318,8 @@ impl App {
                 kind: KeyEventKind::Press,
                 ..
             } => {
-                // Enter alternate screen and set viewport to full size.
-                let _ = tui.enter_alt_screen();
-                let (lines, _spans) = self.build_transcript_flattened();
-                self.overlay = Some(Overlay::new_transcript(lines));
-                tui.frame_requester().schedule_frame();
+                // Delegate to helper to open transcript overlay.
+                self.open_transcript_overlay(tui);
             }
             // Esc primes/advances backtracking only in normal (not working) mode
             // with an empty composer. In any other state, forward Esc so the
@@ -368,29 +365,5 @@ impl App {
                 // Ignore Release key events.
             }
         };
-    }
-
-    /// Build flattened transcript lines and absolute user spans on demand.
-    /// This replaces the previous persistent `transcript_lines`/`user_spans` state.
-    pub(crate) fn build_transcript_flattened(&self) -> (Vec<Line<'static>>, Vec<(usize, usize)>) {
-        let mut out: Vec<Line<'static>> = Vec::new();
-        let mut spans: Vec<(usize, usize)> = Vec::new();
-        for cell in &self.transcript_cells {
-            let is_stream = cell.is_stream_continuation();
-            let mut lines = cell.transcript_lines();
-            if !is_stream && !out.is_empty() && !lines.is_empty() {
-                out.push("".into());
-            }
-            let start = out.len();
-            if let Some(span) = cell.message_span()
-                && matches!(cell.kind(), crate::history_cell::MessageKind::User)
-            {
-                let header_abs = start.saturating_add(span.header_offset);
-                let end_abs = header_abs.saturating_add(1).saturating_add(span.body_len);
-                spans.push((header_abs, end_abs));
-            }
-            out.append(&mut lines);
-        }
-        (out, spans)
     }
 }

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -174,16 +174,8 @@ impl App {
         tui: &tui::Tui,
         requested_n: usize,
     ) -> (usize, Option<usize>, Option<(usize, usize)>) {
-        let nth = backtrack_helpers::normalize_backtrack_n(
-            &self.transcript_lines,
-            &self.user_spans,
-            requested_n,
-        );
-        let header_idx = backtrack_helpers::find_nth_last_user_header_index(
-            &self.transcript_lines,
-            &self.user_spans,
-            nth,
-        );
+        let nth = backtrack_helpers::normalize_backtrack_n(&self.user_spans, requested_n);
+        let header_idx = backtrack_helpers::find_nth_last_user_header_index(&self.user_spans, nth);
         let offset = header_idx.map(|idx| {
             backtrack_helpers::wrapped_offset_before(
                 &self.transcript_lines,
@@ -191,11 +183,7 @@ impl App {
                 tui.terminal.viewport_area.width,
             )
         });
-        let hl = backtrack_helpers::highlight_range_for_nth_last_user(
-            &self.transcript_lines,
-            &self.user_spans,
-            nth,
-        );
+        let hl = backtrack_helpers::highlight_range_for_nth_last_user(&self.user_spans, nth);
         (nth, offset, hl)
     }
 
@@ -359,11 +347,9 @@ impl App {
 
     /// Trim transcript_lines to preserve only content up to the selected user message.
     fn trim_transcript_for_backtrack(&mut self, drop_count: usize) {
-        if let Some(cut_idx) = backtrack_helpers::find_nth_last_user_header_index(
-            &self.transcript_lines,
-            &self.user_spans,
-            drop_count,
-        ) {
+        if let Some(cut_idx) =
+            backtrack_helpers::find_nth_last_user_header_index(&self.user_spans, drop_count)
+        {
             self.transcript_lines.truncate(cut_idx);
             // Drop any user spans whose header lies at or beyond the cut index.
             self.user_spans.retain(|(header, _)| *header < cut_idx);

--- a/codex-rs/tui/src/backtrack_helpers.rs
+++ b/codex-rs/tui/src/backtrack_helpers.rs
@@ -2,7 +2,6 @@ use ratatui::text::Line;
 
 /// Convenience: compute the highlight range for the Nth last user message.
 pub(crate) fn highlight_range_for_nth_last_user(
-    _lines: &[Line<'_>],
     user_spans: &[(usize, usize)],
     n: usize,
 ) -> Option<(usize, usize)> {
@@ -22,7 +21,6 @@ pub(crate) fn wrapped_offset_before(lines: &[Line<'_>], header_idx: usize, width
 /// Find the header index for the Nth last user message in the transcript.
 /// Returns `None` if `n == 0` or there are fewer than `n` user messages.
 pub(crate) fn find_nth_last_user_header_index(
-    _lines: &[Line<'_>],
     user_spans: &[(usize, usize)],
     n: usize,
 ) -> Option<usize> {
@@ -37,11 +35,7 @@ pub(crate) fn find_nth_last_user_header_index(
 /// - Returns `0` if there are no user messages.
 /// - Returns `n` if the Nth last user message exists.
 /// - Otherwise wraps to `1` (the most recent user message).
-pub(crate) fn normalize_backtrack_n(
-    _lines: &[Line<'_>],
-    user_spans: &[(usize, usize)],
-    n: usize,
-) -> usize {
+pub(crate) fn normalize_backtrack_n(user_spans: &[(usize, usize)], n: usize) -> usize {
     if n == 0 {
         return 0;
     }
@@ -112,23 +106,23 @@ mod tests {
 
     #[test]
     fn normalize_wraps_to_one_when_past_oldest() {
-        let (lines, spans) = transcript_with_users(2);
-        assert_eq!(normalize_backtrack_n(&lines, &spans, 1), 1);
-        assert_eq!(normalize_backtrack_n(&lines, &spans, 2), 2);
+        let (_, spans) = transcript_with_users(2);
+        assert_eq!(normalize_backtrack_n(&spans, 1), 1);
+        assert_eq!(normalize_backtrack_n(&spans, 2), 2);
         // Requesting 3rd when only 2 exist wraps to 1
-        assert_eq!(normalize_backtrack_n(&lines, &spans, 3), 1);
+        assert_eq!(normalize_backtrack_n(&spans, 3), 1);
     }
 
     #[test]
     fn normalize_returns_zero_when_no_user_messages() {
-        let (lines, spans) = transcript_with_users(0);
-        assert_eq!(normalize_backtrack_n(&lines, &spans, 1), 0);
-        assert_eq!(normalize_backtrack_n(&lines, &spans, 5), 0);
+        let (_, spans) = transcript_with_users(0);
+        assert_eq!(normalize_backtrack_n(&spans, 1), 0);
+        assert_eq!(normalize_backtrack_n(&spans, 5), 0);
     }
 
     #[test]
     fn normalize_keeps_valid_n() {
-        let (lines, spans) = transcript_with_users(3);
-        assert_eq!(normalize_backtrack_n(&lines, &spans, 2), 2);
+        let (_, spans) = transcript_with_users(3);
+        assert_eq!(normalize_backtrack_n(&spans, 2), 2);
     }
 }

--- a/codex-rs/tui/src/backtrack_helpers.rs
+++ b/codex-rs/tui/src/backtrack_helpers.rs
@@ -2,11 +2,15 @@ use ratatui::text::Line;
 
 /// Convenience: compute the highlight range for the Nth last user message.
 pub(crate) fn highlight_range_for_nth_last_user(
-    lines: &[Line<'_>],
+    _lines: &[Line<'_>],
+    user_spans: &[(usize, usize)],
     n: usize,
 ) -> Option<(usize, usize)> {
-    let header = find_nth_last_user_header_index(lines, n)?;
-    Some(highlight_range_from_header(lines, header))
+    if n == 0 {
+        return None;
+    }
+    let idx = user_spans.len().checked_sub(n)?;
+    user_spans.get(idx).copied()
 }
 
 /// Compute the wrapped display-line offset before `header_idx`, for a given width.
@@ -17,97 +21,69 @@ pub(crate) fn wrapped_offset_before(lines: &[Line<'_>], header_idx: usize, width
 
 /// Find the header index for the Nth last user message in the transcript.
 /// Returns `None` if `n == 0` or there are fewer than `n` user messages.
-pub(crate) fn find_nth_last_user_header_index(lines: &[Line<'_>], n: usize) -> Option<usize> {
+pub(crate) fn find_nth_last_user_header_index(
+    _lines: &[Line<'_>],
+    user_spans: &[(usize, usize)],
+    n: usize,
+) -> Option<usize> {
     if n == 0 {
         return None;
     }
-    let mut found = 0usize;
-    for (idx, line) in lines.iter().enumerate().rev() {
-        let content: String = line
-            .spans
-            .iter()
-            .map(|s| s.content.as_ref())
-            .collect::<Vec<_>>()
-            .join("");
-        if content.trim() == "user" {
-            found += 1;
-            if found == n {
-                return Some(idx);
-            }
-        }
-    }
-    None
+    let idx = user_spans.len().checked_sub(n)?;
+    user_spans.get(idx).map(|(h, _)| *h)
 }
 
 /// Normalize a requested backtrack step `n` against the available user messages.
 /// - Returns `0` if there are no user messages.
 /// - Returns `n` if the Nth last user message exists.
 /// - Otherwise wraps to `1` (the most recent user message).
-pub(crate) fn normalize_backtrack_n(lines: &[Line<'_>], n: usize) -> usize {
+pub(crate) fn normalize_backtrack_n(
+    _lines: &[Line<'_>],
+    user_spans: &[(usize, usize)],
+    n: usize,
+) -> usize {
     if n == 0 {
         return 0;
     }
-    if find_nth_last_user_header_index(lines, n).is_some() {
+    if user_spans.len() >= n {
         return n;
     }
-    if find_nth_last_user_header_index(lines, 1).is_some() {
-        1
-    } else {
-        0
-    }
+    if user_spans.is_empty() { 0 } else { 1 }
 }
 
 /// Extract the text content of the Nth last user message.
 /// The message body is considered to be the lines following the "user" header
 /// until the first blank line.
-pub(crate) fn nth_last_user_text(lines: &[Line<'_>], n: usize) -> Option<String> {
-    let header_idx = find_nth_last_user_header_index(lines, n)?;
-    extract_message_text_after_header(lines, header_idx)
-}
-
-/// Extract message text starting after `header_idx` until the first blank line.
-fn extract_message_text_after_header(lines: &[Line<'_>], header_idx: usize) -> Option<String> {
-    let start = header_idx + 1;
-    let mut out: Vec<String> = Vec::new();
-    for line in lines.iter().skip(start) {
-        let is_blank = line
-            .spans
-            .iter()
-            .all(|s| s.content.as_ref().trim().is_empty());
-        if is_blank {
-            break;
-        }
-        let text: String = line
-            .spans
-            .iter()
-            .map(|s| s.content.as_ref())
-            .collect::<Vec<_>>()
-            .join("");
-        out.push(text);
+pub(crate) fn nth_last_user_text(
+    lines: &[Line<'_>],
+    user_spans: &[(usize, usize)],
+    n: usize,
+) -> Option<String> {
+    if n == 0 {
+        return None;
     }
+    let idx = user_spans.len().checked_sub(n)?;
+    let (header, end) = user_spans.get(idx).copied()?;
+    let start = header.saturating_add(1);
+    if start >= end || start >= lines.len() {
+        return None;
+    }
+    let end = end.min(lines.len());
+    let out: Vec<String> = lines[start..end]
+        .iter()
+        .map(|line| {
+            line.spans
+                .iter()
+                .map(|s| s.content.as_ref())
+                .collect::<Vec<_>>()
+                .join("")
+        })
+        .collect();
     if out.is_empty() {
         None
     } else {
         Some(out.join("\n"))
     }
-}
-
-/// Given a header index, return the inclusive range for the message block
-/// [header_idx, end) where end is the first blank line after the header or the
-/// end of the transcript.
-fn highlight_range_from_header(lines: &[Line<'_>], header_idx: usize) -> (usize, usize) {
-    let mut end = header_idx + 1;
-    while end < lines.len() {
-        let is_blank = lines[end]
-            .spans
-            .iter()
-            .all(|s| s.content.as_ref().trim().is_empty());
-        if is_blank {
-            break;
-        }
-        end += 1;
-    }
-    (header_idx, end)
 }
 
 #[cfg(test)]
@@ -118,36 +94,41 @@ mod tests {
         s.to_string().into()
     }
 
-    fn transcript_with_users(count: usize) -> Vec<Line<'static>> {
-        // Build a transcript with `count` user messages, each followed by one body line and a blank line.
-        let mut v = Vec::new();
+    fn transcript_with_users(count: usize) -> (Vec<Line<'static>>, Vec<(usize, usize)>) {
+        // Build transcript lines and user spans as [header..end) where end excludes the last body line.
+        let mut lines: Vec<Line<'static>> = Vec::new();
+        let mut spans: Vec<(usize, usize)> = Vec::new();
         for i in 0..count {
-            v.push(line("user"));
-            v.push(line(&format!("message {i}")));
-            v.push(line(""));
+            // Simulate the structure produced by UserHistoryCell: blank, header, body
+            lines.push(line(""));
+            let header = lines.len();
+            lines.push(line("user"));
+            lines.push(line(&format!("message {i}")));
+            let end = header + 1 + 1; // header + 1 (body begins) + body_len(1)
+            spans.push((header, end));
         }
-        v
+        (lines, spans)
     }
 
     #[test]
     fn normalize_wraps_to_one_when_past_oldest() {
-        let lines = transcript_with_users(2);
-        assert_eq!(normalize_backtrack_n(&lines, 1), 1);
-        assert_eq!(normalize_backtrack_n(&lines, 2), 2);
+        let (lines, spans) = transcript_with_users(2);
+        assert_eq!(normalize_backtrack_n(&lines, &spans, 1), 1);
+        assert_eq!(normalize_backtrack_n(&lines, &spans, 2), 2);
         // Requesting 3rd when only 2 exist wraps to 1
-        assert_eq!(normalize_backtrack_n(&lines, 3), 1);
+        assert_eq!(normalize_backtrack_n(&lines, &spans, 3), 1);
     }
 
     #[test]
     fn normalize_returns_zero_when_no_user_messages() {
-        let lines = transcript_with_users(0);
-        assert_eq!(normalize_backtrack_n(&lines, 1), 0);
-        assert_eq!(normalize_backtrack_n(&lines, 5), 0);
+        let (lines, spans) = transcript_with_users(0);
+        assert_eq!(normalize_backtrack_n(&lines, &spans, 1), 0);
+        assert_eq!(normalize_backtrack_n(&lines, &spans, 5), 0);
     }
 
     #[test]
     fn normalize_keeps_valid_n() {
-        let lines = transcript_with_users(3);
-        assert_eq!(normalize_backtrack_n(&lines, 2), 2);
+        let (lines, spans) = transcript_with_users(3);
+        assert_eq!(normalize_backtrack_n(&lines, &spans, 2), 2);
     }
 }


### PR DESCRIPTION

Fixes https://github.com/openai/codex/issues/2755
Replaces #2757 to fix root cause.

## Summary
  - Replace fragile string-based detection of user messages with typed metadata and span indices for backtracking.
  - Scope remains “User”-only typing; all other cells stay “Other”.
  - Backtracking logic is extracted and simplified with a consistent Esc/Enter flow across main and overlay views.

## Root cause
Backtrack relied on rendered text parsing (“user” header join/trim), which loses type info and misidentifies boundaries.

## Fix
- Add `MessageKind` (`User|Other`) and `MessageSpan` to `HistoryCell` (default keeps existing cells unchanged).
- Introduce `UserHistoryCell` and return it from `new_user_prompt` (transcript rendering unchanged).
- Replace `transcript_lines` with `transcript_cells` in App.
- Compute flattened transcript and absolute user spans on demand via `build_transcript_flattened()`. 

## Before

https://github.com/user-attachments/assets/64b262be-92c9-4159-b695-99e457cad56e

## After

https://github.com/user-attachments/assets/144b32a7-484e-462b-93ca-cfbb3cc66740

