### PR TITLE
fix: stop using actions/cache@v4 for release builds

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -79,15 +79,6 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ${{ github.workspace }}/codex-rs/target/
-          key: cargo-release-${{ matrix.runner }}-${{ matrix.target }}-release-${{ hashFiles('**/Cargo.lock') }}
 
       - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl'}}
         name: Install musl build tools


### PR DESCRIPTION
Currently, some of our release builds only take 5 minutes while the Windows build takes closer to 12 minutes. For the Windows build, 1m20s of that is spent in the **Post Run actions/cache@v4** step (though admittedly we don't warm up the release build cache for Windows during or PRs).

https://github.com/openai/codex/actions/runs/17316007990

