### PR TITLE
core: add support for user defined event hooks

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -17,6 +17,7 @@ use crate::model_provider_info::built_in_model_providers;
 use crate::openai_model_info::get_model_info;
 use crate::protocol::AskForApproval;
 use crate::protocol::SandboxPolicy;
+use crate::user_notification::EventHooks;
 use anyhow::Context;
 use codex_protocol::config_types::ReasoningEffort;
 use codex_protocol::config_types::ReasoningSummary;
@@ -121,6 +122,9 @@ pub struct Config {
     /// TUI notifications preference. When set, the TUI will send OSC 9 notifications on approvals
     /// and turn completions when not focused.
     pub tui_notifications: Notifications,
+
+    /// Event hooks configuration for different events (agent finished, user input, etc.)
+    pub hooks: EventHooks,
 
     /// The directory that should be treated as the current working directory
     /// for the session. All relative paths inside the business-logic layer are
@@ -634,6 +638,10 @@ pub struct ConfigToml {
     #[serde(default)]
     pub notify: Option<Vec<String>>,
 
+    /// Event hooks configuration for different events.
+    #[serde(default)]
+    pub hooks: Option<EventHooks>,
+
     /// System instructions.
     pub instructions: Option<String>,
 
@@ -1007,6 +1015,7 @@ impl Config {
             sandbox_policy,
             shell_environment_policy,
             notify: cfg.notify,
+            hooks: cfg.hooks.unwrap_or_default(),
             user_instructions,
             base_instructions,
             mcp_servers: cfg.mcp_servers,
@@ -1631,6 +1640,7 @@ model_verbosity = "high"
                 shell_environment_policy: ShellEnvironmentPolicy::default(),
                 user_instructions: None,
                 notify: None,
+                hooks: EventHooks::default(),
                 cwd: fixture.cwd(),
                 mcp_servers: HashMap::new(),
                 model_providers: fixture.model_provider_map.clone(),
@@ -1689,6 +1699,7 @@ model_verbosity = "high"
             shell_environment_policy: ShellEnvironmentPolicy::default(),
             user_instructions: None,
             notify: None,
+            hooks: EventHooks::default(),
             cwd: fixture.cwd(),
             mcp_servers: HashMap::new(),
             model_providers: fixture.model_provider_map.clone(),
@@ -1762,6 +1773,7 @@ model_verbosity = "high"
             shell_environment_policy: ShellEnvironmentPolicy::default(),
             user_instructions: None,
             notify: None,
+            hooks: EventHooks::default(),
             cwd: fixture.cwd(),
             mcp_servers: HashMap::new(),
             model_providers: fixture.model_provider_map.clone(),
@@ -1821,6 +1833,7 @@ model_verbosity = "high"
             shell_environment_policy: ShellEnvironmentPolicy::default(),
             user_instructions: None,
             notify: None,
+            hooks: EventHooks::default(),
             cwd: fixture.cwd(),
             mcp_servers: HashMap::new(),
             model_providers: fixture.model_provider_map.clone(),

--- a/codex-rs/core/src/state/service.rs
+++ b/codex-rs/core/src/state/service.rs
@@ -11,6 +11,7 @@ pub(crate) struct SessionServices {
     pub(crate) session_manager: ExecSessionManager,
     pub(crate) unified_exec_manager: UnifiedExecSessionManager,
     pub(crate) notifier: UserNotifier,
+    pub(crate) hooks: crate::user_notification::EventHooks,
     pub(crate) rollout: Mutex<Option<RolloutRecorder>>,
     pub(crate) codex_linux_sandbox_exe: Option<PathBuf>,
     pub(crate) user_shell: crate::shell::Shell,

--- a/codex-rs/core/src/user_notification.rs
+++ b/codex-rs/core/src/user_notification.rs
@@ -57,6 +57,94 @@ pub(crate) enum UserNotification {
         /// The last message sent by the assistant in the turn.
         last_assistant_message: Option<String>,
     },
+
+    #[serde(rename_all = "kebab-case")]
+    UserInputRequired {
+        turn_id: String,
+
+        /// The reason user input is required (e.g., "approval", "confirmation", "input")
+        reason: String,
+
+        /// Additional context about what input is needed
+        message: Option<String>,
+    },
+
+    #[serde(rename_all = "kebab-case")]
+    SessionStarted {
+        session_id: String,
+
+        /// Working directory for the session
+        cwd: String,
+    },
+
+    #[serde(rename_all = "kebab-case")]
+    SessionEnded { session_id: String },
+
+    #[serde(rename_all = "kebab-case")]
+    ToolExecutionStarted {
+        turn_id: String,
+
+        /// Name of the tool being executed
+        tool_name: String,
+
+        /// Tool arguments
+        tool_args: Option<serde_json::Value>,
+    },
+
+    #[serde(rename_all = "kebab-case")]
+    ToolExecutionCompleted {
+        turn_id: String,
+
+        /// Name of the tool that was executed
+        tool_name: String,
+
+        /// Whether the execution was successful
+        success: bool,
+
+        /// Error message if execution failed
+        error_message: Option<String>,
+    },
+}
+
+/// Configuration for event hooks
+#[derive(Debug, Clone, PartialEq, serde::Deserialize, Default)]
+pub struct EventHooks {
+    /// Hooks to run when agent turn completes
+    pub agent_turn_complete: Option<Vec<String>>,
+
+    /// Hooks to run when user input is required
+    pub user_input_required: Option<Vec<String>>,
+
+    /// Hooks to run when session starts
+    pub session_started: Option<Vec<String>>,
+
+    /// Hooks to run when session ends
+    pub session_ended: Option<Vec<String>>,
+
+    /// Hooks to run when tool execution starts
+    pub tool_execution_started: Option<Vec<String>>,
+
+    /// Hooks to run when tool execution completes
+    pub tool_execution_completed: Option<Vec<String>>,
+}
+
+impl EventHooks {
+    /// Get the hooks configured for a specific notification type
+    pub(crate) fn get_hooks_for_notification(
+        &self,
+        notification: &UserNotification,
+    ) -> Option<&Vec<String>> {
+        match notification {
+            UserNotification::AgentTurnComplete { .. } => self.agent_turn_complete.as_ref(),
+            UserNotification::UserInputRequired { .. } => self.user_input_required.as_ref(),
+            UserNotification::SessionStarted { .. } => self.session_started.as_ref(),
+            UserNotification::SessionEnded { .. } => self.session_ended.as_ref(),
+            UserNotification::ToolExecutionStarted { .. } => self.tool_execution_started.as_ref(),
+            UserNotification::ToolExecutionCompleted { .. } => {
+                self.tool_execution_completed.as_ref()
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -79,5 +167,77 @@ mod tests {
             r#"{"type":"agent-turn-complete","turn-id":"12345","input-messages":["Rename `foo` to `bar` and update the callsites."],"last-assistant-message":"Rename complete and verified `cargo build` succeeds."}"#
         );
         Ok(())
+    }
+
+    #[test]
+    fn test_user_input_required_notification() {
+        let notification = UserNotification::UserInputRequired {
+            turn_id: "67890".to_string(),
+            reason: "approval".to_string(),
+            message: Some("Approve file deletion?".to_string()),
+        };
+        let serialized = serde_json::to_string(&notification).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"type":"user-input-required","turn-id":"67890","reason":"approval","message":"Approve file deletion?"}"#
+        );
+    }
+
+    #[test]
+    fn test_session_started_notification() {
+        let notification = UserNotification::SessionStarted {
+            session_id: "abc123".to_string(),
+            cwd: "/path/to/project".to_string(),
+        };
+        let serialized = serde_json::to_string(&notification).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"type":"session-started","session-id":"abc123","cwd":"/path/to/project"}"#
+        );
+    }
+
+    #[test]
+    fn test_tool_execution_started_notification() {
+        let notification = UserNotification::ToolExecutionStarted {
+            turn_id: "turn123".to_string(),
+            tool_name: "bash".to_string(),
+            tool_args: Some(serde_json::json!({"command": "ls -la"})),
+        };
+        let serialized = serde_json::to_string(&notification).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"type":"tool-execution-started","turn-id":"turn123","tool-name":"bash","tool-args":{"command":"ls -la"}}"#
+        );
+    }
+
+    #[test]
+    fn test_event_hooks_get_hooks_for_notification() {
+        let hooks = EventHooks {
+            agent_turn_complete: Some(vec!["hook1".to_string(), "hook2".to_string()]),
+            user_input_required: Some(vec!["input-hook".to_string()]),
+            ..Default::default()
+        };
+
+        let notification = UserNotification::AgentTurnComplete {
+            turn_id: "test".to_string(),
+            input_messages: vec![],
+            last_assistant_message: None,
+        };
+
+        assert_eq!(
+            hooks.get_hooks_for_notification(&notification),
+            Some(&vec!["hook1".to_string(), "hook2".to_string()])
+        );
+
+        let input_notification = UserNotification::UserInputRequired {
+            turn_id: "test".to_string(),
+            reason: "approval".to_string(),
+            message: None,
+        };
+
+        assert_eq!(
+            hooks.get_hooks_for_notification(&input_notification),
+            Some(&vec!["input-hook".to_string()])
+        );
     }
 }

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -1,0 +1,224 @@
+# Codex Event Hooks
+
+Codex supports configurable event hooks that allow you to execute custom scripts when specific events occur during agent interactions. This enables you to integrate Codex with external tools, notification systems, or custom automation workflows.
+
+## Configuration
+
+Event hooks are configured in your `~/.codex/config.toml` file under the `[hooks]` section. Each hook type accepts an array of command strings that will be executed when the event occurs.
+
+```toml
+[hooks]
+agent_turn_complete = ["notify-send 'Codex' 'Agent finished'"]
+user_input_required = ["play /System/Library/Sounds/Glass.aiff"]
+session_started = ["echo 'Session started' >> ~/.codex/session.log"]
+session_ended = ["echo 'Session ended' >> ~/.codex/session.log"]
+tool_execution_started = ["echo 'Tool started' >> ~/.codex/tools.log"]
+tool_execution_completed = ["echo 'Tool completed' >> ~/.codex/tools.log"]
+```
+
+## Available Hook Events
+
+### `agent_turn_complete`
+Triggered when the agent finishes processing a user request and provides a complete response.
+
+**JSON Payload Example:**
+```json
+{
+  "type": "agent-turn-complete",
+  "turn-id": "12345",
+  "input-messages": ["Please rename the function foo to bar"],
+  "last-assistant-message": "Function renamed successfully and tests pass"
+}
+```
+
+### `user_input_required`
+Triggered when the agent needs user approval or input (e.g., command execution approval).
+
+**JSON Payload Example:**
+```json
+{
+  "type": "user-input-required",
+  "turn-id": "67890",
+  "reason": "approval",
+  "message": "Approve file deletion?"
+}
+```
+
+### `session_started`
+Triggered when a new Codex session begins.
+
+**JSON Payload Example:**
+```json
+{
+  "type": "session-started",
+  "session-id": "abc123",
+  "cwd": "/path/to/project"
+}
+```
+
+### `session_ended`
+Triggered when a Codex session ends.
+
+**JSON Payload Example:**
+```json
+{
+  "type": "session-ended",
+  "session-id": "abc123"
+}
+```
+
+### `tool_execution_started`
+Triggered when the agent begins executing a tool (e.g., bash command).
+
+**JSON Payload Example:**
+```json
+{
+  "type": "tool-execution-started",
+  "turn-id": "turn123",
+  "tool-name": "bash",
+  "tool-args": {
+    "command": "ls -la",
+    "cwd": "/path/to/project"
+  }
+}
+```
+
+### `tool_execution_completed`
+Triggered when the agent finishes executing a tool.
+
+**JSON Payload Example:**
+```json
+{
+  "type": "tool-execution-completed",
+  "turn-id": "turn123",
+  "tool-name": "bash",
+  "success": true,
+  "error-message": null
+}
+```
+
+## Hook Command Format
+
+Each hook command is specified as a string that will be parsed using simple whitespace splitting. The JSON payload for the event is automatically appended as the last argument to your command.
+
+### Examples
+
+**Simple notification:**
+```toml
+agent_turn_complete = ["notify-send 'Codex' 'Task complete'"]
+```
+
+**Custom script with arguments:**
+```toml
+agent_turn_complete = ["/path/to/my-script.sh --codex-event"]
+```
+
+**Multiple hooks for the same event:**
+```toml
+agent_turn_complete = [
+    "notify-send 'Codex' 'Task complete'",
+    "/path/to/log-completion.sh",
+    "osascript -e 'display notification \"Task complete\" with title \"Codex\"'"
+]
+```
+
+## Script Examples
+
+### Basic Notification Script
+
+```bash
+#!/bin/bash
+# save as ~/.codex/hooks/notify.sh
+
+EVENT_JSON="$1"
+EVENT_TYPE=$(echo "$EVENT_JSON" | jq -r '.type')
+
+case "$EVENT_TYPE" in
+    "agent-turn-complete")
+        notify-send "Codex" "Agent finished processing your request"
+        ;;
+    "user-input-required")
+        notify-send "Codex" "Your input is required" --urgency=critical
+        ;;
+    "tool-execution-started")
+        TOOL_NAME=$(echo "$EVENT_JSON" | jq -r '.["tool-name"]')
+        notify-send "Codex" "Executing $TOOL_NAME"
+        ;;
+esac
+```
+
+### Session Logging Script
+
+```bash
+#!/bin/bash
+# save as ~/.codex/hooks/session-log.sh
+
+EVENT_JSON="$1"
+EVENT_TYPE=$(echo "$EVENT_JSON" | jq -r '.type')
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+LOG_FILE="$HOME/.codex/session.log"
+
+echo "[$TIMESTAMP] $EVENT_TYPE: $EVENT_JSON" >> "$LOG_FILE"
+```
+
+### Integration with Task Management
+
+```python
+#!/usr/bin/env python3
+# save as ~/.codex/hooks/task-tracker.py
+
+import json
+import sys
+import requests
+from datetime import datetime
+
+def main():
+    if len(sys.argv) < 2:
+        return
+    
+    event_data = json.loads(sys.argv[1])
+    event_type = event_data.get('type')
+    
+    if event_type == 'agent-turn-complete':
+        # Update task management system
+        task_data = {
+            'title': f"Codex task completed",
+            'description': event_data.get('last-assistant-message', ''),
+            'completed_at': datetime.now().isoformat(),
+            'turn_id': event_data.get('turn-id')
+        }
+        
+        # Post to your task management API
+        # requests.post('https://api.your-task-system.com/tasks', json=task_data)
+        print(f"Task completed: {event_data.get('turn-id')}")
+
+if __name__ == '__main__':
+    main()
+```
+
+## Legacy Compatibility
+
+The existing `notify` configuration is still supported for backward compatibility:
+
+```toml
+# This will receive all events (same as before)
+notify = ["notify-send", "Codex"]
+
+# New event-specific hooks can be used alongside legacy notify
+[hooks]
+agent_turn_complete = ["/path/to/completion-specific-hook.sh"]
+```
+
+## Error Handling
+
+- Hook commands are executed as fire-and-forget processes
+- Hook failures do not interrupt the main Codex workflow
+- Failed hook executions are logged but do not affect agent functionality
+- Invalid JSON serialization errors are logged
+
+## Security Considerations
+
+- Hook commands are executed with the same permissions as the Codex process
+- Be careful when using hooks with untrusted input
+- Consider using absolute paths for hook scripts
+- Validate and sanitize any data extracted from the JSON payload in your scripts

--- a/example-hooks-config.toml
+++ b/example-hooks-config.toml
@@ -1,0 +1,38 @@
+# Example configuration for event hooks in Codex
+# This would go in your ~/.codex/config.toml file
+
+[hooks]
+# Hook that runs when agent finishes a turn
+agent_turn_complete = [
+    "notify-send 'Codex' 'Agent finished processing your request'",
+    "/usr/local/bin/my-completion-script"
+]
+
+# Hook that runs when user input is required (e.g., approval requests)
+user_input_required = [
+    "notify-send 'Codex' 'User input required'",
+    "play /System/Library/Sounds/Glass.aiff"
+]
+
+# Hook that runs when a session starts
+session_started = [
+    "echo 'Codex session started' >> ~/.codex/session.log"
+]
+
+# Hook that runs when a session ends
+session_ended = [
+    "echo 'Codex session ended' >> ~/.codex/session.log"
+]
+
+# Hook that runs when tool execution starts
+tool_execution_started = [
+    "echo 'Tool execution started' >> ~/.codex/tools.log"
+]
+
+# Hook that runs when tool execution completes
+tool_execution_completed = [
+    "echo 'Tool execution completed' >> ~/.codex/tools.log"
+]
+
+# Legacy notify command (still supported for backward compatibility)
+notify = ["notify-send", "Codex"]


### PR DESCRIPTION
This PR adds support for user defined event hooks (similar feature to what already exists in Claude Code).

It's an attempted fix for: https://github.com/openai/codex/issues/2109

See the second commit for usage and example configuration!
