### PR TITLE
Docs: improve config reference and add config.toml.example

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Codex CLI supports [MCP servers](./docs/advanced.md#model-context-protocol-mcp).
 
 ### Configuration
 
-Codex CLI supports a rich set of configuration options, with preferences stored in `~/.codex/config.toml`. For full configuration options, see [Configuration](./docs/config.md).
+Codex CLI supports a rich set of configuration options, with preferences stored in `~/.codex/config.toml`. For a starter file you can copy, see [config.toml.example](./docs/config.toml.example). For full configuration options, see [Configuration](./docs/config.md).
 
 ---
 
@@ -99,4 +99,3 @@ Codex CLI supports a rich set of configuration options, with preferences stored 
 ## License
 
 This repository is licensed under the [Apache-2.0 License](LICENSE).
-

--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -19,7 +19,7 @@ While we are [working to close the gap between the TypeScript and Rust implement
 
 ### Config
 
-Codex supports a rich set of configuration options. Note that the Rust CLI uses `config.toml` instead of `config.json`. See [`docs/config.md`](../docs/config.md) for details.
+Codex supports a rich set of configuration options. Note that the Rust CLI uses `config.toml` instead of `config.json`. A copy‑ready starter file is available at [`docs/config.toml.example`](../docs/config.toml.example). For full details, see [`docs/config.md`](../docs/config.md).
 
 ### Model Context Protocol Support
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -39,4 +39,7 @@ env = { "API_KEY" = "value" }
 ```
 
 > [!TIP]
+> Looking for a starter config you can copy? See [`config.toml.example`](./config.toml.example).
+
+> [!TIP]
 > It is somewhat experimental, but the Codex CLI can also be run as an MCP _server_ via `codex mcp`. If you launch it with an MCP client such as `npx @modelcontextprotocol/inspector codex mcp` and send it a `tools/list` request, you will see that there is only one tool, `codex`, that accepts a grab-bag of inputs, including a catch-all `config` map for anything you might want to override. Feel free to play around with it and provide feedback via GitHub issues. 

--- a/docs/config.toml.example
+++ b/docs/config.toml.example
@@ -1,0 +1,128 @@
+# Codex CLI configuration example
+#
+# Copy or rename this file to: ~/.codex/config.toml
+# Then edit values to match your setup.
+
+# --- Core settings ---------------------------------------------------------
+
+# Model to use (default is "gpt-5").
+model = "gpt-5"
+
+# When to ask for permission to run commands: "untrusted", "on-failure",
+# "on-request" (default), or "never".
+approval_policy = "on-request"
+
+# Sandboxing policy for command execution: "read-only" (default),
+# "workspace-write", or "danger-full-access".
+sandbox_mode = "read-only"
+
+# URI scheme for clickable file citations: "vscode" (default), "vscode-insiders",
+# "windsurf", "cursor", or "none" to disable hyperlinks.
+file_opener = "vscode"
+
+# Optional: toggle visibility of agent reasoning messages in output.
+# hide_agent_reasoning = false
+# show_raw_agent_reasoning = false
+
+# Optional: Responses API reasoning controls (when supported by the model).
+# model_reasoning_effort = "medium"     # minimal|low|medium|high
+# model_reasoning_summary = "auto"       # auto|concise|detailed|none
+# model_verbosity = "medium"             # low|medium|high (GPT‑5 family)
+
+# Optional: disable server-side response storage (required for ZDR accounts).
+# disable_response_storage = false
+
+# --- Sandbox: workspace-write options -------------------------------------
+
+# Only used when sandbox_mode = "workspace-write".
+# [sandbox_workspace_write]
+# writable_roots = ["/Users/YOU/.pyenv/shims"]
+# network_access = false
+# exclude_tmpdir_env_var = false
+# exclude_slash_tmp = false
+
+# --- Shell environment policy ---------------------------------------------
+
+# Control which environment variables are passed to spawned processes.
+[shell_environment_policy]
+# inherit can be: "all" (default), "core", or "none"
+inherit = "all"
+# When false (default), filter out names containing KEY or TOKEN (case-insensitive)
+ignore_default_excludes = false
+# Additional excludes (case-insensitive globs), e.g., "AWS_*", "AZURE_*"
+exclude = []
+# Force-set / override values
+set = {}
+# If non-empty, only variables matching one of these patterns are kept
+include_only = []
+
+# --- History ---------------------------------------------------------------
+
+[history]
+# "save-all" (default) or "none"
+persistence = "save-all"
+# max_bytes is currently ignored (not enforced)
+# max_bytes = 1048576
+
+# --- Tools -----------------------------------------------------------------
+
+[tools]
+# Enable web search (alias: web_search_request). Default is false.
+web_search = false
+# Enable the image attachment tool. Default is true when unset.
+# view_image = true
+
+# --- Providers -------------------------------------------------------------
+
+# Built-in providers:
+#   • openai (Responses API) — default provider; base can be overridden with OPENAI_BASE_URL
+#   • oss    (Chat Completions) — defaults to http://localhost:11434/v1 or CODEX_OSS_BASE_URL
+
+# To use OpenAI Chat Completions instead of Responses, define a provider:
+# [model_providers.openai-chat-completions]
+# name = "OpenAI using Chat Completions"
+# base_url = "https://api.openai.com/v1"
+# env_key = "OPENAI_API_KEY"
+# wire_api = "chat"
+# request_max_retries = 4
+# stream_max_retries = 5
+# stream_idle_timeout_ms = 300000
+
+# Azure requires api-version in query params and typically uses Chat Completions:
+# [model_providers.azure]
+# name = "Azure"
+# base_url = "https://YOUR_PROJECT_NAME.openai.azure.com/openai"
+# env_key = "AZURE_OPENAI_API_KEY"
+# query_params = { api-version = "2025-04-01-preview" }
+# wire_api = "chat"
+
+# --- Profiles --------------------------------------------------------------
+
+# Uncomment to select a default profile (can be overridden with --profile)
+# profile = "o3"
+
+[profiles.o3]
+model = "o3"
+model_provider = "openai"
+approval_policy = "never"
+model_reasoning_effort = "high"
+model_reasoning_summary = "detailed"
+
+[profiles.gpt3]
+model = "gpt-3.5-turbo"
+model_provider = "openai-chat-completions"
+
+# --- MCP Servers -----------------------------------------------------------
+
+# Example MCP server (commented out so copy-paste won't try to start it):
+# [mcp_servers.my-server]
+# command = "npx"
+# args = ["-y", "mcp-server"]
+# env = { "API_KEY" = "value" }
+
+# --- Notifications ---------------------------------------------------------
+
+# Program is executed with a single JSON argument when a turn completes.
+# Example on macOS using a custom script:
+# notify = ["python3", "/Users/YOU/.codex/notify.py"]
+


### PR DESCRIPTION
- Summary:
    - Overhauled docs/config.md to fix defaults, valid values, and clarify usage:
    - Default model is "gpt-5"; default approval_policy is "on-request".
    - Documented built-in providers: "openai" (Responses API; endpoint differs for ChatGPT sign-in vs API key) and "oss" (Chat Completions).
    - Correct per-provider defaults: request_max_retries=4, stream_max_retries=5, stream_idle_timeout_ms=300000.
    - Corrected shell environment filtering defaults to KEY/TOKEN only.
    - Improved the config reference table (clear allowed values and defaults; linked sandbox/auth docs).
    - Expanded examples: OpenAI Chat Completions, Azure with api-version, local OSS, workspace-write sandbox, MCP, profiles, shell env policy.
    - Replaced “unless-allow-listed” with the accepted value “untrusted”.
- Added a comprehensive starter file docs/config.toml.example for users to copy to ~/.codex/config.toml, with safe commented sections (providers, sandbox, shell env, profiles, MCP, notify).
- Updated README.md and codex-rs/README.md to link to docs/config.toml.example.
- Added a tip in docs/advanced.md (MCP section) linking to docs/config.toml.example.
- Rationale:
    - The previous docs lacked a clear, copyable example and had conflicting defaults. This consolidates accurate, code-validated settings in a single place and improves onboarding.
- Validation:
    - Defaults and accepted values cross-checked against Rust sources:
    - Defaults: core/src/config.rs, core/src/model_provider_info.rs, protocol/config_types.rs.
    - Responses endpoints and OPENAI_BASE_URL behavior: core/src/model_provider_info.rs and chatgpt client usage.
- Example TOML validates structurally; sections are commented to prevent accidental side effects (e.g., MCP, notify).
- Links verified: docs/config.md#mcp_servers, docs/sandbox.md, docs/authentication.md, docs/config.toml.example.
- Impact:
    - Documentation only; no behavior changes.
