### PR TITLE
Fix #2759: preserve interrupted assistant messages in conversation history

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1247,6 +1247,11 @@ async fn submission_loop(
                 });
             }
 
+            Op::AddPartialMessageToConversation { message } => {
+                debug!("Adding partial message to conversation history: {message:?}");
+                sess.record_conversation_items(&[message]).await;
+            }
+
             Op::GetHistoryEntryRequest { offset, log_id } => {
                 let config = config.clone();
                 let tx_event = sess.tx_event.clone();

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1248,7 +1248,6 @@ async fn submission_loop(
             }
 
             Op::AddPartialMessageToConversation { message } => {
-                debug!("Adding partial message to conversation history: {message:?}");
                 sess.record_conversation_items(&[message]).await;
             }
 

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -136,6 +136,13 @@ pub enum Op {
         text: String,
     },
 
+    /// Add a partial assistant message to the conversation history during interruption.
+    /// This ensures interrupted streaming content is preserved for the AI agent context.
+    AddPartialMessageToConversation {
+        /// The partial assistant message to be added to conversation history.
+        message: ResponseItem,
+    },
+
     /// Request a single history entry identified by `log_id` + `offset`.
     GetHistoryEntryRequest { offset: usize, log_id: u64 },
 

--- a/codex-rs/tui/src/markdown_stream.rs
+++ b/codex-rs/tui/src/markdown_stream.rs
@@ -12,6 +12,7 @@ use crate::render::markdown_utils::strip_empty_fenced_code_blocks;
 pub(crate) struct MarkdownStreamCollector {
     buffer: String,
     committed_line_count: usize,
+    committed_raw_content: String,
 }
 
 impl MarkdownStreamCollector {
@@ -19,6 +20,7 @@ impl MarkdownStreamCollector {
         Self {
             buffer: String::new(),
             committed_line_count: 0,
+            committed_raw_content: String::new(),
         }
     }
 
@@ -31,6 +33,7 @@ impl MarkdownStreamCollector {
     pub fn clear(&mut self) {
         self.buffer.clear();
         self.committed_line_count = 0;
+        self.committed_raw_content.clear();
     }
 
     /// Replace the buffered content and mark that the first `committed_count`
@@ -39,6 +42,8 @@ impl MarkdownStreamCollector {
         self.buffer.clear();
         self.buffer.push_str(s);
         self.committed_line_count = committed_count;
+        // For simplicity, assume all content up to the committed count is committed
+        self.committed_raw_content = s.to_string();
     }
 
     pub fn push_delta(&mut self, delta: &str) {
@@ -148,8 +153,33 @@ impl MarkdownStreamCollector {
         }
 
         let out = out_slice.to_vec();
+
+        // Update committed raw content when we actually commit new content
+        if !out.is_empty() {
+            self.update_committed_raw_content();
+        }
+
         self.committed_line_count = complete_line_count;
         out
+    }
+
+    /// Update the committed raw content to include all complete lines from the buffer.
+    /// This tracks what raw content has been committed so it can be extracted during interruption.
+    fn update_committed_raw_content(&mut self) {
+        // Simple approach: committed content is all complete lines (ending with \n) in the buffer
+        let buffer_lines: Vec<&str> = self.buffer.lines().collect();
+        let complete_line_count = if self.buffer.ends_with('\n') {
+            buffer_lines.len()
+        } else {
+            buffer_lines.len().saturating_sub(1) // Last line is incomplete
+        };
+
+        if complete_line_count > 0 {
+            self.committed_raw_content = buffer_lines[..complete_line_count].join("\n");
+            if complete_line_count < buffer_lines.len() || self.buffer.ends_with('\n') {
+                self.committed_raw_content.push('\n');
+            }
+        }
     }
 
     /// Finalize the stream: emit all remaining lines beyond the last commit.
@@ -173,9 +203,24 @@ impl MarkdownStreamCollector {
             rendered[self.committed_line_count..].to_vec()
         };
 
+        // When finalizing, the committed content is the entire buffer
+        if !out.is_empty() {
+            self.committed_raw_content = self.buffer.clone();
+        }
+
         // Reset collector state for next stream.
         self.clear();
         out
+    }
+
+    /// Extract the raw markdown content that has been committed so far.
+    /// This returns exactly what would appear in chat history.
+    pub fn extract_committable_content(&self, _config: &Config) -> Option<String> {
+        if self.committed_raw_content.trim().is_empty() {
+            None
+        } else {
+            Some(self.committed_raw_content.clone())
+        }
     }
 }
 

--- a/codex-rs/tui/src/markdown_stream.rs
+++ b/codex-rs/tui/src/markdown_stream.rs
@@ -212,16 +212,6 @@ impl MarkdownStreamCollector {
         self.clear();
         out
     }
-
-    /// Extract the raw markdown content that has been committed so far.
-    /// This returns exactly what would appear in chat history.
-    pub fn extract_committable_content(&self, _config: &Config) -> Option<String> {
-        if self.committed_raw_content.trim().is_empty() {
-            None
-        } else {
-            Some(self.committed_raw_content.clone())
-        }
-    }
 }
 
 #[inline]

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -4,6 +4,21 @@ use ratatui::text::Line;
 use super::HeaderEmitter;
 use super::StreamState;
 
+/// Helper function to extract plain text from ratatui Lines
+fn extract_text_from_lines(lines: &[Line<'static>]) -> String {
+    lines
+        .iter()
+        .map(|line| {
+            let line_text: String = line
+                .spans
+                .iter()
+                .map(|span| span.content.as_ref())
+                .collect();
+            format!("{line_text}\n")
+        })
+        .collect()
+}
+
 /// Sink for history insertions and animation control.
 pub(crate) trait HistorySink {
     fn insert_history(&self, lines: Vec<Line<'static>>);
@@ -38,6 +53,8 @@ pub(crate) struct StreamController {
     state: StreamState,
     active: bool,
     finishing_after_drain: bool,
+    /// Track content that has actually been displayed to users for synchronization
+    displayed_content: String,
 }
 
 impl StreamController {
@@ -48,6 +65,7 @@ impl StreamController {
             state: StreamState::new(),
             active: false,
             finishing_after_drain: false,
+            displayed_content: String::new(),
         }
     }
 
@@ -63,22 +81,20 @@ impl StreamController {
         self.state.clear();
         self.active = false;
         self.finishing_after_drain = false;
+        self.displayed_content.clear();
         // leave header state unchanged; caller decides when to reset
     }
 
     /// Extract any partial streaming content as a plain text string.
     /// This is used during interruption to preserve partial messages
-    /// before clearing the stream. Uses the same logic as chat history
-    /// to only extract committable content.
+    /// before clearing the stream. Returns exactly what was displayed to users.
     pub(crate) fn extract_partial_content(&self) -> Option<String> {
-        if !self.active || !self.state.has_seen_delta {
+        if !self.active || self.displayed_content.is_empty() {
             return None;
         }
 
-        // Use the same logic as chat history to only extract committable content
-        self.state
-            .collector
-            .extract_committable_content(&self.config)
+        // Return the content that was actually displayed to users
+        Some(self.displayed_content.clone())
     }
 
     fn emit_header_if_needed(&mut self, out_lines: &mut Lines) -> bool {
@@ -139,6 +155,10 @@ impl StreamController {
                 out_lines.extend(step.history);
             }
             if !out_lines.is_empty() {
+                // Track the content that's being displayed when flushing immediately
+                self.displayed_content
+                    .push_str(&extract_text_from_lines(&out_lines));
+
                 let mut lines_with_header: Lines = Vec::new();
                 self.emit_header_if_needed(&mut lines_with_header);
                 lines_with_header.extend(out_lines);
@@ -147,6 +167,7 @@ impl StreamController {
 
             // Cleanup
             self.state.clear();
+            self.displayed_content.clear();
             // Allow a subsequent block in this turn to emit its header.
             self.header.allow_reemit_in_turn();
             // Also clear the per-stream emitted flag so the header can render again.
@@ -174,6 +195,10 @@ impl StreamController {
         }
         let step = { self.state.step() };
         if !step.history.is_empty() {
+            // Track the content that's being displayed to users
+            self.displayed_content
+                .push_str(&extract_text_from_lines(&step.history));
+
             let mut lines: Lines = Vec::new();
             self.emit_header_if_needed(&mut lines);
             let mut out = lines;
@@ -187,6 +212,7 @@ impl StreamController {
             if self.finishing_after_drain {
                 // Reset and notify
                 self.state.clear();
+                self.displayed_content.clear();
                 // Allow a subsequent block in this turn to emit its header.
                 self.header.allow_reemit_in_turn();
                 // Also clear the per-stream emitted flag so the header can render again.

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -66,6 +66,21 @@ impl StreamController {
         // leave header state unchanged; caller decides when to reset
     }
 
+    /// Extract any partial streaming content as a plain text string.
+    /// This is used during interruption to preserve partial messages
+    /// before clearing the stream. Uses the same logic as chat history
+    /// to only extract committable content.
+    pub(crate) fn extract_partial_content(&self) -> Option<String> {
+        if !self.active || !self.state.has_seen_delta {
+            return None;
+        }
+
+        // Use the same logic as chat history to only extract committable content
+        self.state
+            .collector
+            .extract_committable_content(&self.config)
+    }
+
     fn emit_header_if_needed(&mut self, out_lines: &mut Lines) -> bool {
         self.header.maybe_emit(out_lines)
     }


### PR DESCRIPTION
## What
- Closes #2759
- Adds support for capturing and persisting partial assistant messages when a stream is interrupted.

## Why
Currently, if a user interrupts a streaming response, the visible text on screen is discarded and not recorded in session history.  
This causes the model to "forget" what it just said when the user follows up, breaking continuity.  

## How
- **protocol.rs**
  - Added new operation: `Op::AddPartialMessageToConversation { message: ResponseItem }`.

- **core/codex.rs**
  - Implemented handling of the new op by calling `sess.record_conversation_items(&[message])`.

- **tui/chatwidget.rs**
  - Updated `on_interrupted_turn`:
    - Extracts any partial content from the active stream.
    - Wraps it as an assistant `ResponseItem::Message`.
    - Sends it via `Op::AddPartialMessageToConversation` so it is persisted.
    - Logs errors if sending fails.

- **tui/streaming/controller.rs**
  - Added `displayed_content` field to `StreamController` to track what text has been shown to the user.
  - Implemented `extract_partial_content()` to return the visible content before clearing.
  - Ensured `displayed_content` is updated on flush and cleared on reset.