### PR TITLE
feat: Add approval pending notifications for command execution and file modifications

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -663,18 +663,12 @@ impl Session {
         let mut changes = Vec::new();
         for (path, change) in action.changes() {
             let (operation, new_path) = match change {
-                ApplyPatchFileChange::Add { .. } => ("A".to_string(), None),
-                ApplyPatchFileChange::Delete => ("D".to_string(), None),
-                ApplyPatchFileChange::Update { move_path, .. } => {
-                    if let Some(new_path) = move_path {
-                        ("R".to_string(), Some(new_path.clone()))
-                    } else {
-                        ("M".to_string(), None)
-                    }
-                }
+                ApplyPatchFileChange::Add { .. } => ("A", None),
+                ApplyPatchFileChange::Delete => ("D", None),
+                ApplyPatchFileChange::Update { move_path, .. } => ("M", move_path.clone()),
             };
             changes.push(FileChangeInfo {
-                operation,
+                operation: operation.to_string(),
                 path: path.clone(),
                 new_path,
             });

--- a/codex-rs/core/src/user_notification.rs
+++ b/codex-rs/core/src/user_notification.rs
@@ -16,6 +16,17 @@ pub(crate) enum UserNotification {
         /// The last message sent by the assistant in the turn.
         last_assistant_message: Option<String>,
     },
+    
+    #[serde(rename_all = "kebab-case")]
+    PendingUserApproval {
+        turn_id: String,
+        
+        /// The type of approval being requested (e.g., "command_approval", "file_approval")
+        approval_type: String,
+        
+        /// Description of what is being requested
+        description: String,
+    },
 }
 
 #[cfg(test)]
@@ -35,6 +46,20 @@ mod tests {
         assert_eq!(
             serialized,
             r#"{"type":"agent-turn-complete","turn-id":"12345","input-messages":["Rename `foo` to `bar` and update the callsites."],"last-assistant-message":"Rename complete and verified `cargo build` succeeds."}"#
+        );
+    }
+
+    #[test]
+    fn test_pending_user_approval_notification() {
+        let notification = UserNotification::PendingUserApproval {
+            turn_id: "67890".to_string(),
+            approval_type: "command_approval".to_string(),
+            description: "Waiting for approval to execute: rm -rf /tmp/test".to_string(),
+        };
+        let serialized = serde_json::to_string(&notification).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"type":"pending-user-approval","turn-id":"67890","approval-type":"command_approval","description":"Waiting for approval to execute: rm -rf /tmp/test"}"#
         );
     }
 }

--- a/codex-rs/core/src/user_notification.rs
+++ b/codex-rs/core/src/user_notification.rs
@@ -1,4 +1,5 @@
 use serde::Serialize;
+use std::path::PathBuf;
 
 /// User can configure a program that will receive notifications. Each
 /// notification is serialized as JSON and passed as an argument to the
@@ -16,17 +17,26 @@ pub(crate) enum UserNotification {
         /// The last message sent by the assistant in the turn.
         last_assistant_message: Option<String>,
     },
-    
+
     #[serde(rename_all = "kebab-case")]
-    PendingUserApproval {
+    PendingCommandApproval {
         turn_id: String,
-        
-        /// The type of approval being requested (e.g., "command_approval", "file_approval")
-        approval_type: String,
-        
-        /// Description of what is being requested
-        description: String,
+        command: Vec<String>,
     },
+
+    #[serde(rename_all = "kebab-case")]
+    PendingFileApproval {
+        turn_id: String,
+        changes: Vec<FileChangeInfo>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub(crate) struct FileChangeInfo {
+    pub operation: String, // "A", "D", "M", "R"
+    pub path: PathBuf,
+    pub new_path: Option<PathBuf>, // For rename operations
 }
 
 #[cfg(test)]
@@ -50,16 +60,49 @@ mod tests {
     }
 
     #[test]
-    fn test_pending_user_approval_notification() {
-        let notification = UserNotification::PendingUserApproval {
+    fn test_pending_command_approval_notification() {
+        let notification = UserNotification::PendingCommandApproval {
             turn_id: "67890".to_string(),
-            approval_type: "command_approval".to_string(),
-            description: "Waiting for approval to execute: rm -rf /tmp/test".to_string(),
+            command: vec!["rm".to_string(), "-rf".to_string(), "/tmp/test".to_string()],
         };
         let serialized = serde_json::to_string(&notification).unwrap();
         assert_eq!(
             serialized,
-            r#"{"type":"pending-user-approval","turn-id":"67890","approval-type":"command_approval","description":"Waiting for approval to execute: rm -rf /tmp/test"}"#
+            r#"{"type":"pending-command-approval","turn-id":"67890","command":["rm","-rf","/tmp/test"]}"#
+        );
+    }
+
+    #[test]
+    fn test_pending_file_approval_notification() {
+        let notification = UserNotification::PendingFileApproval {
+            turn_id: "12345".to_string(),
+            changes: vec![
+                FileChangeInfo {
+                    operation: "A".to_string(),
+                    path: "/path/to/new_file.rs".into(),
+                    new_path: None,
+                },
+                FileChangeInfo {
+                    operation: "D".to_string(),
+                    path: "/path/to/deleted_file.rs".into(),
+                    new_path: None,
+                },
+                FileChangeInfo {
+                    operation: "M".to_string(),
+                    path: "/path/to/existing.rs".into(),
+                    new_path: None,
+                },
+                FileChangeInfo {
+                    operation: "R".to_string(),
+                    path: "/path/to/old_file.rs".into(),
+                    new_path: Some("/path/to/renamed_file.rs".into()),
+                },
+            ],
+        };
+        let serialized = serde_json::to_string(&notification).unwrap();
+        assert_eq!(
+            serialized,
+            r#"{"type":"pending-file-approval","turn-id":"12345","changes":[{"operation":"A","path":"/path/to/new_file.rs","new-path":null},{"operation":"D","path":"/path/to/deleted_file.rs","new-path":null},{"operation":"M","path":"/path/to/existing.rs","new-path":null},{"operation":"R","path":"/path/to/old_file.rs","new-path":"/path/to/renamed_file.rs"}]}"#
         );
     }
 }

--- a/codex-rs/core/src/user_notification.rs
+++ b/codex-rs/core/src/user_notification.rs
@@ -34,7 +34,7 @@ pub(crate) enum UserNotification {
 #[derive(Debug, Clone, PartialEq, Serialize)]
 #[serde(rename_all = "kebab-case")]
 pub(crate) struct FileChangeInfo {
-    pub operation: String, // "A", "D", "M", "R"
+    pub operation: String, // "A", "D", "M"
     pub path: PathBuf,
     pub new_path: Option<PathBuf>, // For rename operations
 }
@@ -93,7 +93,7 @@ mod tests {
                     new_path: None,
                 },
                 FileChangeInfo {
-                    operation: "R".to_string(),
+                    operation: "M".to_string(),
                     path: "/path/to/old_file.rs".into(),
                     new_path: Some("/path/to/renamed_file.rs".into()),
                 },
@@ -102,7 +102,7 @@ mod tests {
         let serialized = serde_json::to_string(&notification).unwrap();
         assert_eq!(
             serialized,
-            r#"{"type":"pending-file-approval","turn-id":"12345","changes":[{"operation":"A","path":"/path/to/new_file.rs","new-path":null},{"operation":"D","path":"/path/to/deleted_file.rs","new-path":null},{"operation":"M","path":"/path/to/existing.rs","new-path":null},{"operation":"R","path":"/path/to/old_file.rs","new-path":"/path/to/renamed_file.rs"}]}"#
+            r#"{"type":"pending-file-approval","turn-id":"12345","changes":[{"operation":"A","path":"/path/to/new_file.rs","new-path":null},{"operation":"D","path":"/path/to/deleted_file.rs","new-path":null},{"operation":"M","path":"/path/to/existing.rs","new-path":null},{"operation":"M","path":"/path/to/old_file.rs","new-path":"/path/to/renamed_file.rs"}]}"#
         );
     }
 }


### PR DESCRIPTION
## Summary

issue: #2961

Adds approval pending notifications that alert users when command execution or file modifications require approval, providing structured information about what is awaiting approval.

## What Changed

- Added new notification types for approval pending states:
  - PendingCommandApproval: Notifies when shell command execution requires approval
  - PendingFileApproval: Notifies when file modifications require approval
- Structured command information: Command notifications include the full command as an array of strings
- Structured file change information: File notifications include an array of FileChangeInfo objects with:
  - operation: Operation type ("A", "D", "M" for Add/Delete/Modify)
  - path: File path being modified
  - new_path: Destination path for rename operations (optional)
- Added FileChangeInfo struct to represent individual file operations

## Why This Change

Users can now be alerted when:

- Commands are waiting for execution approval
- File modifications are waiting for approval

## How It Works

Command approval notifications:
```
{
  "type": "pending-command-approval",
  "turn-id": "123",
  "command": ["rm", "-rf", "/tmp/test"]
}
```

File approval notifications:
```
{
  "type": "pending-file-approval",
  "turn-id": "12345",
  "changes": [
    { "operation": "A", "path": "/path/to/new_file.rs", "new-path": null },
    { "operation": "D", "path": "/path/to/deleted_file.rs", "new-path": null },
    { "operation": "M", "path": "/path/to/existing.rs", "new-path": null },
    { "operation": "M", "path": "/path/to/old_file.rs", "new-path": "/path/to/renamed_file.rs"}
  ]
}
```

## Testing

- All tests passing
- New tests added for both notification types