### PR TITLE
[onboarding] only try to resolve root for git project in TrustDirectoryWidget if in a git repo

### DIFF
--- a/codex-rs/tui/src/onboarding/trust_directory.rs
+++ b/codex-rs/tui/src/onboarding/trust_directory.rs
@@ -160,3 +160,142 @@ impl TrustDirectoryWidget {
         self.selection = Some(TrustDirectorySelection::DontTrust);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn create_test_widget(cwd: PathBuf, is_git_repo: bool) -> TrustDirectoryWidget {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        TrustDirectoryWidget {
+            codex_home: temp_dir.path().to_path_buf(),
+            cwd,
+            is_git_repo,
+            selection: None,
+            highlighted: TrustDirectorySelection::Trust,
+            error: None,
+        }
+    }
+
+    async fn create_test_git_repo(temp_dir: &TempDir) -> PathBuf {
+        let repo_path = temp_dir.path().join("repo");
+        fs::create_dir(&repo_path).expect("Failed to create repo dir");
+
+        let envs = vec![
+            ("GIT_CONFIG_GLOBAL", "/dev/null"),
+            ("GIT_CONFIG_NOSYSTEM", "1"),
+        ];
+
+        // Initialize git repo
+        tokio::process::Command::new("git")
+            .envs(envs.clone())
+            .args(["init"])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .expect("Failed to init git repo");
+
+        // Configure git user (required for commits)
+        tokio::process::Command::new("git")
+            .envs(envs.clone())
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .expect("Failed to set git user name");
+
+        tokio::process::Command::new("git")
+            .envs(envs.clone())
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .expect("Failed to set git user email");
+
+        // Create a test file and commit it
+        let test_file = repo_path.join("test.txt");
+        fs::write(&test_file, "test content").expect("Failed to write test file");
+
+        tokio::process::Command::new("git")
+            .envs(envs.clone())
+            .args(["add", "."])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .expect("Failed to add files");
+
+        tokio::process::Command::new("git")
+            .envs(envs.clone())
+            .args(["commit", "-m", "Initial commit"])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .expect("Failed to commit");
+
+        repo_path
+    }
+
+    #[test]
+    fn test_handle_trust_non_git_directory() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let non_git_path = temp_dir.path().join("not_git");
+        fs::create_dir(&non_git_path).expect("Failed to create non-git dir");
+
+        let mut widget = create_test_widget(non_git_path.clone(), false);
+
+        widget.handle_trust();
+
+        // Should complete without error and set selection to Trust
+        assert_eq!(widget.selection, Some(TrustDirectorySelection::Trust));
+        assert!(widget.error.is_none());
+    }
+
+    #[test]
+    fn test_handle_trust_non_git_repo() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let non_git_path = temp_dir.path().join("not_git");
+        fs::create_dir(&non_git_path).expect("Failed to create non-git dir");
+        let sapling_dir = non_git_path.join(".sl");
+        fs::create_dir(&sapling_dir).expect("Failed to create test cwd");
+
+        let mut widget = create_test_widget(non_git_path.clone(), false);
+
+        widget.handle_trust();
+
+        // Should complete without error and set selection to Trust
+        assert_eq!(widget.selection, Some(TrustDirectorySelection::Trust));
+        assert!(widget.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_handle_trust_git_directory() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let git_repo_path = create_test_git_repo(&temp_dir).await;
+
+        let mut widget = create_test_widget(git_repo_path.clone(), true);
+
+        widget.handle_trust();
+
+        // Should complete without error and set selection to Trust
+        assert_eq!(widget.selection, Some(TrustDirectorySelection::Trust));
+        assert!(widget.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_handle_trust_git_subdirectory() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let git_repo_path = create_test_git_repo(&temp_dir).await;
+        let subdir = git_repo_path.join("subdir");
+        fs::create_dir(&subdir).expect("Failed to create subdir");
+
+        let mut widget = create_test_widget(subdir.clone(), true);
+
+        widget.handle_trust();
+
+        // Should complete without error and set selection to Trust
+        assert_eq!(widget.selection, Some(TrustDirectorySelection::Trust));
+        assert!(widget.error.is_none());
+    }
+}

--- a/codex-rs/tui/src/onboarding/trust_directory.rs
+++ b/codex-rs/tui/src/onboarding/trust_directory.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use codex_core::config::set_project_trusted;
 use codex_core::git_info::resolve_root_git_project_for_trust;
+use codex_core::util::is_inside_git_repo;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use ratatui::buffer::Buffer;
@@ -145,8 +146,13 @@ impl StepStateProvider for TrustDirectoryWidget {
 
 impl TrustDirectoryWidget {
     fn handle_trust(&mut self) {
-        let target =
-            resolve_root_git_project_for_trust(&self.cwd).unwrap_or_else(|| self.cwd.clone());
+        // Only try to resolve the Git project root when `cwd` is inside a Git repo.
+        let target = if is_inside_git_repo(&self.cwd) {
+            resolve_root_git_project_for_trust(&self.cwd).unwrap_or_else(|| self.cwd.clone())
+        } else {
+            self.cwd.clone()
+        };
+
         if let Err(e) = set_project_trusted(&self.codex_home, &target) {
             tracing::error!("Failed to set project trusted: {e:?}");
             self.error = Some(format!("Failed to set trust for {}: {e}", target.display()));


### PR DESCRIPTION

Summary:

I have read the CLA Document and I hereby sign the CLA

This commit adds a short circut in `handle_trust()` - there is no need to call `resolve_root_git_project_for_trust()`, which spawns a `git` subprocess, if we're not in a git repo in the first place.

Test Plan:
`cargo test && cargo clippy --tests && cargo fmt -- --config imports_granularity=Item`

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/2976).
* #2977
* __->__ #2976
* #2975