### PR TITLE
[onboarding] make directory trusting flow aware of non-Git repos

### DIFF
--- a/codex-rs/core/src/util.rs
+++ b/codex-rs/core/src/util.rs
@@ -13,24 +13,30 @@ pub(crate) fn backoff(attempt: u64) -> Duration {
     Duration::from_millis((base as f64 * jitter) as u64)
 }
 
-/// Return `true` if the project folder specified by the `Config` is inside a
-/// Git repository.
-///
-/// The check walks up the directory hierarchy looking for a `.git` file or
-/// directory (note `.git` can be a file that contains a `gitdir` entry). This
-/// approach does **not** require the `git` binary or the `git2` crate and is
-/// therefore fairly lightweight.
-///
-/// Note that this does **not** detect *work‑trees* created with
-/// `git worktree add` where the checkout lives outside the main repository
-/// directory. If you need Codex to work from such a checkout simply pass the
-/// `--allow-no-git-exec` CLI flag that disables the repo requirement.
-pub fn is_inside_git_repo(base_dir: &Path) -> bool {
+/// Helper: walk up from `base_dir` and return `true` if any marker in `markers`
+/// is found at a parent directory. Semantics:
+///   - ".sl" : returns true only if the path is a directory.
+///   - ".hg" : returns true only if the path is a directory.
+///   - ".svn" : returns true only if the path is a directory.
+///   - any other marker (including `.git`): `.exists()`.
+fn is_inside_any_marker(base_dir: &Path, markers: &[&str]) -> bool {
+    fn marker_matches(dir: &Path, marker: &str) -> bool {
+        let p = dir.join(marker);
+        match marker {
+            ".sl" => p.is_dir(),
+            ".hg" => p.is_dir(),
+            ".svn" => p.is_dir(),
+            _ => p.exists(),
+        }
+    }
+
     let mut dir = base_dir.to_path_buf();
 
     loop {
-        if dir.join(".git").exists() {
-            return true;
+        for &m in markers {
+            if marker_matches(&dir, m) {
+                return true;
+            }
         }
 
         // Pop one component (go up one directory).  `pop` returns false when
@@ -41,4 +47,215 @@ pub fn is_inside_git_repo(base_dir: &Path) -> bool {
     }
 
     false
+}
+
+/// Return `true` if the project folder specified by the `Config` is inside a
+/// Git repository.
+///
+/// The check walks up the directory hierarchy looking for a `.git` **file or
+/// directory** (note `.git` can be a file that contains a `gitdir` entry). This
+/// approach does **not** require the `git` binary or the `git2` crate and is
+/// therefore fairly lightweight.
+///
+/// Note that this does **not** detect *work‑trees* created with
+/// `git worktree add` where the checkout lives outside the main repository
+/// directory. If you need Codex to work from such a checkout simply pass the
+/// `--allow-no-git-exec` CLI flag that disables the repo requirement.
+pub fn is_inside_git_repo(base_dir: &Path) -> bool {
+    is_inside_any_marker(base_dir, &[".git"])
+}
+
+/// Return `true` if the project folder specified by the `Config` is inside a
+/// repository (Currently checks for Git, Sapling, Mercurial, and Subversion).
+pub fn is_inside_repo(base_dir: &Path) -> bool {
+    is_inside_any_marker(base_dir, &[".git", ".sl", ".hg", ".svn"])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
+
+    fn mkdir<P: AsRef<Path>>(p: P) {
+        fs::create_dir_all(p).unwrap();
+    }
+
+    fn touch<P: AsRef<Path>>(p: P) {
+        fs::write(p, b"").unwrap();
+    }
+
+    fn nested_under(root: &Path) -> PathBuf {
+        let nested = root.join("a").join("b").join("c");
+        mkdir(&nested);
+        nested
+    }
+
+    #[test]
+    fn detect_git_directory_from_root() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        mkdir(&repo);
+
+        mkdir(repo.join(".git"));
+
+        assert!(is_inside_git_repo(&repo), "should detect .git directory");
+        assert!(
+            is_inside_repo(&repo),
+            "is_inside_repo should accept .git directory"
+        );
+    }
+
+    #[test]
+    fn detect_git_file() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        mkdir(&repo);
+
+        // .git as a *file* (common for worktrees/submodules with a gitdir file)
+        touch(repo.join(".git"));
+
+        assert!(is_inside_git_repo(&repo), "should detect .git file");
+        assert!(
+            is_inside_repo(&repo),
+            "is_inside_repo should accept .git file"
+        );
+    }
+
+    #[test]
+    fn detect_git_directory_in_subdir() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        mkdir(&repo);
+
+        mkdir(repo.join(".git"));
+
+        let base = nested_under(&repo);
+        assert!(is_inside_git_repo(&base), "should detect .git directory");
+        assert!(
+            is_inside_repo(&base),
+            "is_inside_repo should accept .git directory"
+        );
+    }
+
+    #[test]
+    fn detect_git_file_in_subdir() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        mkdir(&repo);
+
+        // .git as a *file* (common for worktrees/submodules with a gitdir file)
+        touch(repo.join(".git"));
+
+        let base = nested_under(&repo);
+        assert!(is_inside_git_repo(&base), "should detect .git file");
+        assert!(
+            is_inside_repo(&base),
+            "is_inside_repo should accept .git file"
+        );
+    }
+
+    #[test]
+    fn detect_sapling_directory() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        mkdir(&repo);
+
+        mkdir(repo.join(".sl"));
+
+        assert!(
+            is_inside_repo(&repo),
+            "is_inside_repo should accept .sl directory"
+        );
+    }
+
+    #[test]
+    fn detect_sapling_directory_in_subdir() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        mkdir(&repo);
+
+        mkdir(repo.join(".sl"));
+
+        let base = nested_under(&repo);
+        assert!(
+            is_inside_repo(&base),
+            "is_inside_repo should accept .sl directory"
+        );
+    }
+
+    #[test]
+    fn sapling_file_not_accepted() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        mkdir(&repo);
+
+        // .sl as a *file* does NOT count as a repo marker
+        touch(repo.join(".sl"));
+
+        assert!(
+            !is_inside_repo(&repo),
+            "is_inside_repo must reject .sl file (directory only)"
+        );
+        assert!(
+            !is_inside_git_repo(&repo),
+            "is_inside_git_repo should remain false without .git"
+        );
+    }
+
+    #[test]
+    fn detect_mercurial_directory() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        mkdir(&repo);
+
+        mkdir(repo.join(".hg"));
+
+        assert!(
+            is_inside_repo(&repo),
+            "is_inside_repo should accept .hg directory"
+        );
+    }
+
+    #[test]
+    fn detect_subversion_directory() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        mkdir(&repo);
+
+        mkdir(repo.join(".svn"));
+
+        assert!(
+            is_inside_repo(&repo),
+            "is_inside_repo should accept .svn directory"
+        );
+    }
+
+    #[test]
+    fn no_markers_returns_false() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        mkdir(&repo);
+
+        let base = nested_under(&repo);
+        assert!(!is_inside_git_repo(&base));
+        assert!(!is_inside_repo(&base));
+    }
+
+    #[test]
+    fn both_markers_present() {
+        let tmp = TempDir::new().unwrap();
+        let repo = tmp.path().join("repo");
+        mkdir(&repo);
+
+        // .sl as directory and .git as file simultaneously
+        mkdir(repo.join(".sl"));
+        touch(repo.join(".git"));
+
+        let base = nested_under(&repo);
+        assert!(is_inside_git_repo(&base));
+        assert!(is_inside_repo(&base));
+    }
 }

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -45,8 +45,12 @@ pub struct Cli {
     pub cwd: Option<PathBuf>,
 
     /// Allow running Codex outside a Git repository.
-    #[arg(long = "skip-git-repo-check", default_value_t = false)]
-    pub skip_git_repo_check: bool,
+    #[arg(
+        long = "skip-repo-check",
+        alias = "skip-git-repo-check",
+        default_value_t = false
+    )]
+    pub skip_repo_check: bool,
 
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -19,7 +19,7 @@ use codex_core::protocol::EventMsg;
 use codex_core::protocol::InputItem;
 use codex_core::protocol::Op;
 use codex_core::protocol::TaskCompleteEvent;
-use codex_core::util::is_inside_git_repo;
+use codex_core::util::is_inside_repo;
 use codex_login::AuthManager;
 use codex_ollama::DEFAULT_OSS_MODEL;
 use codex_protocol::config_types::SandboxMode;
@@ -42,7 +42,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         full_auto,
         dangerously_bypass_approvals_and_sandbox,
         cwd,
-        skip_git_repo_check,
+        skip_repo_check,
         color,
         last_message_file,
         json: json_mode,
@@ -183,8 +183,8 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
     // is using.
     event_processor.print_config_summary(&config, &prompt);
 
-    if !skip_git_repo_check && !is_inside_git_repo(&config.cwd.to_path_buf()) {
-        eprintln!("Not inside a trusted directory and --skip-git-repo-check was not specified.");
+    if !skip_repo_check && !is_inside_repo(&config.cwd.to_path_buf()) {
+        eprintln!("Not inside a trusted directory and --skip-repo-check was not specified.");
         std::process::exit(1);
     }
 

--- a/codex-rs/tui/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui/src/onboarding/onboarding_screen.rs
@@ -1,4 +1,4 @@
-use codex_core::util::is_inside_git_repo;
+use codex_core::util::is_inside_repo;
 use codex_login::AuthManager;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
@@ -88,18 +88,18 @@ impl OnboardingScreen {
                 auth_manager,
             }))
         }
-        let is_git_repo = is_inside_git_repo(&cwd);
-        let highlighted = if is_git_repo {
+        let is_repo = is_inside_repo(&cwd);
+        let highlighted = if is_repo {
             TrustDirectorySelection::Trust
         } else {
-            // Default to not trusting the directory if it's not a git repo.
+            // Default to not trusting the directory if it's not a repo.
             TrustDirectorySelection::DontTrust
         };
         if show_trust_screen {
             steps.push(Step::TrustDirectory(TrustDirectoryWidget {
                 cwd,
                 codex_home,
-                is_git_repo,
+                is_repo,
                 selection: None,
                 highlighted,
                 error: None,

--- a/codex-rs/tui/src/onboarding/trust_directory.rs
+++ b/codex-rs/tui/src/onboarding/trust_directory.rs
@@ -160,3 +160,142 @@ impl TrustDirectoryWidget {
         self.selection = Some(TrustDirectorySelection::DontTrust);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn create_test_widget(cwd: PathBuf, is_git_repo: bool) -> TrustDirectoryWidget {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        TrustDirectoryWidget {
+            codex_home: temp_dir.path().to_path_buf(),
+            cwd,
+            is_git_repo,
+            selection: None,
+            highlighted: TrustDirectorySelection::Trust,
+            error: None,
+        }
+    }
+
+    async fn create_test_git_repo(temp_dir: &TempDir) -> PathBuf {
+        let repo_path = temp_dir.path().join("repo");
+        fs::create_dir(&repo_path).expect("Failed to create repo dir");
+
+        let envs = vec![
+            ("GIT_CONFIG_GLOBAL", "/dev/null"),
+            ("GIT_CONFIG_NOSYSTEM", "1"),
+        ];
+
+        // Initialize git repo
+        tokio::process::Command::new("git")
+            .envs(envs.clone())
+            .args(["init"])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .expect("Failed to init git repo");
+
+        // Configure git user (required for commits)
+        tokio::process::Command::new("git")
+            .envs(envs.clone())
+            .args(["config", "user.name", "Test User"])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .expect("Failed to set git user name");
+
+        tokio::process::Command::new("git")
+            .envs(envs.clone())
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .expect("Failed to set git user email");
+
+        // Create a test file and commit it
+        let test_file = repo_path.join("test.txt");
+        fs::write(&test_file, "test content").expect("Failed to write test file");
+
+        tokio::process::Command::new("git")
+            .envs(envs.clone())
+            .args(["add", "."])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .expect("Failed to add files");
+
+        tokio::process::Command::new("git")
+            .envs(envs.clone())
+            .args(["commit", "-m", "Initial commit"])
+            .current_dir(&repo_path)
+            .output()
+            .await
+            .expect("Failed to commit");
+
+        repo_path
+    }
+
+    #[test]
+    fn test_handle_trust_non_git_directory() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let non_git_path = temp_dir.path().join("not_git");
+        fs::create_dir(&non_git_path).expect("Failed to create non-git dir");
+
+        let mut widget = create_test_widget(non_git_path.clone(), false);
+
+        widget.handle_trust();
+
+        // Should complete without error and set selection to Trust
+        assert_eq!(widget.selection, Some(TrustDirectorySelection::Trust));
+        assert!(widget.error.is_none());
+    }
+
+    #[test]
+    fn test_handle_trust_non_git_repo() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let non_git_path = temp_dir.path().join("not_git");
+        fs::create_dir(&non_git_path).expect("Failed to create non-git dir");
+        let sapling_dir = non_git_path.join(".sl");
+        fs::create_dir(&sapling_dir).expect("Failed to create test cwd");
+
+        let mut widget = create_test_widget(non_git_path.clone(), false);
+
+        widget.handle_trust();
+
+        // Should complete without error and set selection to Trust
+        assert_eq!(widget.selection, Some(TrustDirectorySelection::Trust));
+        assert!(widget.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_handle_trust_git_directory() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let git_repo_path = create_test_git_repo(&temp_dir).await;
+
+        let mut widget = create_test_widget(git_repo_path.clone(), true);
+
+        widget.handle_trust();
+
+        // Should complete without error and set selection to Trust
+        assert_eq!(widget.selection, Some(TrustDirectorySelection::Trust));
+        assert!(widget.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_handle_trust_git_subdirectory() {
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let git_repo_path = create_test_git_repo(&temp_dir).await;
+        let subdir = git_repo_path.join("subdir");
+        fs::create_dir(&subdir).expect("Failed to create subdir");
+
+        let mut widget = create_test_widget(subdir.clone(), true);
+
+        widget.handle_trust();
+
+        // Should complete without error and set selection to Trust
+        assert_eq!(widget.selection, Some(TrustDirectorySelection::Trust));
+        assert!(widget.error.is_none());
+    }
+}

--- a/codex-rs/tui/src/onboarding/trust_directory.rs
+++ b/codex-rs/tui/src/onboarding/trust_directory.rs
@@ -2,6 +2,7 @@ use std::path::PathBuf;
 
 use codex_core::config::set_project_trusted;
 use codex_core::git_info::resolve_root_git_project_for_trust;
+use codex_core::util::is_inside_git_repo;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use ratatui::buffer::Buffer;
@@ -145,8 +146,13 @@ impl StepStateProvider for TrustDirectoryWidget {
 
 impl TrustDirectoryWidget {
     fn handle_trust(&mut self) {
-        let target =
-            resolve_root_git_project_for_trust(&self.cwd).unwrap_or_else(|| self.cwd.clone());
+        // Only try to resolve the Git project root when `cwd` is inside a Git repo.
+        let target = if is_inside_git_repo(&self.cwd) {
+            resolve_root_git_project_for_trust(&self.cwd).unwrap_or_else(|| self.cwd.clone())
+        } else {
+            self.cwd.clone()
+        };
+
         if let Err(e) = set_project_trusted(&self.codex_home, &target) {
             tracing::error!("Failed to set project trusted: {e:?}");
             self.error = Some(format!("Failed to set trust for {}: {e}", target.display()));

--- a/codex-rs/tui/src/onboarding/trust_directory.rs
+++ b/codex-rs/tui/src/onboarding/trust_directory.rs
@@ -26,7 +26,7 @@ use super::onboarding_screen::StepState;
 pub(crate) struct TrustDirectoryWidget {
     pub codex_home: PathBuf,
     pub cwd: PathBuf,
-    pub is_git_repo: bool,
+    pub is_repo: bool,
     pub selection: Option<TrustDirectorySelection>,
     pub highlighted: TrustDirectorySelection,
     pub error: Option<String>,
@@ -52,7 +52,7 @@ impl WidgetRef for &TrustDirectoryWidget {
             Line::from(""),
         ];
 
-        if self.is_git_repo {
+        if self.is_repo {
             lines.push(Line::from(
                 "  Since this folder is version controlled, you may wish to allow Codex",
             ));
@@ -77,7 +77,7 @@ impl WidgetRef for &TrustDirectoryWidget {
                 }
             };
 
-        if self.is_git_repo {
+        if self.is_repo {
             lines.push(create_option(
                 0,
                 TrustDirectorySelection::Trust,
@@ -173,12 +173,12 @@ mod tests {
     use std::fs;
     use tempfile::TempDir;
 
-    fn create_test_widget(cwd: PathBuf, is_git_repo: bool) -> TrustDirectoryWidget {
+    fn create_test_widget(cwd: PathBuf, is_repo: bool) -> TrustDirectoryWidget {
         let temp_dir = TempDir::new().expect("Failed to create temp dir");
         TrustDirectoryWidget {
             codex_home: temp_dir.path().to_path_buf(),
             cwd,
-            is_git_repo,
+            is_repo,
             selection: None,
             highlighted: TrustDirectorySelection::Trust,
             error: None,


### PR DESCRIPTION
### Summary:

I have read the CLA Document and I hereby sign the CLA

This PR teaches TrustDirectoryWidget to check for more than just Git repos. I was using codex with a repo cloned with [Sapling](https://sapling-scm.com/) and got a prompt saying "Since this folder is not version controlled, we recommend requiring...". This is incorrect - I'm using Sapling so the directory is version controlled, just not with Git.

It also adds an optimization via a short circuit in `handle_trust()` - there is no need to call `resolve_root_git_project_for_trust()`, which spawns a `git` subprocess, if we're not in a git repo in the first place. Happy to remove this or make it a separate PR, I'd just stack this as two PRs but submitting a stacked PR with Sapling is messy for the reviewer unless they are using [ReviewStack](https://sapling-scm.com/docs/addons/reviewstack).

### Test Plan:
`cargo test && cargo clippy --tests && cargo fmt -- --config imports_granularity=Item`

`cargo run --bin codex`

before: trust prompt shows in Sapling cloned repo

<img width="1340" height="672" alt="Screenshot 2025-08-31 at 1 58 17 AM" src="https://github.com/user-attachments/assets/effa0136-b6b6-4481-a1da-d41835cd35e4" />

after: trust prompt doesn't appear in Sapling cloned repo

<img width="1340" height="672" alt="Screenshot 2025-08-31 at 1 59 35 AM" src="https://github.com/user-attachments/assets/73bb80ad-6550-4e30-8f4c-7a9c27652e1b" />

