### PR TITLE
Fix: Adapt pr template with correct link following doc refacto

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 # External (non-OpenAI) Pull Request Requirements
 
-Before opening this Pull Request, please read the "Contributing" section of the README or your PR may be closed:
-https://github.com/openai/codex#contributing
+Before opening this Pull Request, please read the dedicated "Contributing" markdown file or your PR may be closed:
+https://github.com/openai/codex/blob/main/docs/contributing.md
 
 If your PR conforms to our contribution guidelines, replace this text with a detailed and high quality description of your changes.


### PR DESCRIPTION
This PR fixes the link of contributing page in Pull Request template to the right one following the migration of the section to a dedicated file.