### PR TITLE
Auto-approve DangerFullAccess patches on non-sandboxed platforms

### DIFF
--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -53,6 +53,11 @@ pub fn assess_patch_safety(
         // paths outside the project.
         match get_platform_sandbox() {
             Some(sandbox_type) => SafetyCheck::AutoApprove { sandbox_type },
+            None if matches!(sandbox_policy, SandboxPolicy::DangerFullAccess) => {
+                SafetyCheck::AutoApprove {
+                    sandbox_type: SandboxType::None,
+                }
+            }
             None => SafetyCheck::AskUser,
         }
     } else if policy == AskForApproval::Never {

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -53,7 +53,9 @@ pub fn assess_patch_safety(
         // paths outside the project.
         match get_platform_sandbox() {
             Some(sandbox_type) => SafetyCheck::AutoApprove { sandbox_type },
-            None if matches!(sandbox_policy, SandboxPolicy::DangerFullAccess) => {
+            None if sandbox_policy == &SandboxPolicy::DangerFullAccess => {
+                // If the user has explicitly requested DangerFullAccess, then
+                // we can auto-approve even without a sandbox.
                 SafetyCheck::AutoApprove {
                     sandbox_type: SandboxType::None,
                 }


### PR DESCRIPTION
**What?**
Auto-approve patches when `SandboxPolicy::DangerFullAccess` is enabled on platforms without sandbox support.
Changes in `codex-rs/core/src/safety.rs`: return `SafetyCheck::AutoApprove { sandbox_type: SandboxType::None }` when no sandbox is available and DangerFullAccess is set.

**Why?**
On platforms lacking sandbox support, requiring explicit user approval despite `DangerFullAccess` being explicitly enabled adds friction without additional safety. This aligns behavior with the stated policy intent.

**How?**
Extend `assess_patch_safety` match:

* If `get_platform_sandbox()` returns `Some`, keep `AutoApprove { sandbox_type }`.
* If `None` **and** `SandboxPolicy::DangerFullAccess`, return `AutoApprove { SandboxType::None }`.
* Otherwise, fall back to `AskUser`.

**Tests**

* Local checks:
  ```bash
  cargo test && cargo clippy --tests && cargo fmt -- --config imports_granularity=Item
  ```
  (Additionally: `just fmt`, `just fix -p codex-core`, `cargo check -p codex-core`.)

**Docs**
No user-facing CLI changes. No README/help updates needed.

**Risk/Impact**
Reduces prompts on non-sandboxed platforms when DangerFullAccess is explicitly chosen; consistent with policy semantics.