### PR TITLE
fix(cli): improve completion command to detect current shell 

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -81,8 +81,8 @@ enum Subcommand {
 #[derive(Debug, Parser)]
 struct CompletionCommand {
     /// Shell to generate completions for
-    #[clap(value_enum, default_value_t = Shell::Bash)]
-    shell: Shell,
+    #[clap(value_enum)]
+    shell: Option<Shell>,
 }
 
 #[derive(Debug, Parser)]
@@ -231,5 +231,6 @@ fn prepend_config_flags(
 fn print_completion(cmd: CompletionCommand) {
     let mut app = MultitoolCli::command();
     let name = "codex";
-    generate(cmd.shell, &mut app, name, &mut std::io::stdout());
+    let shell = cmd.shell.unwrap_or_else(|| Shell::from_env().unwrap_or(Shell::Bash));
+    generate(shell, &mut app, name, &mut std::io::stdout());
 }


### PR DESCRIPTION
Previously, `codex completion` without arguments always returned bash completion script regardless of the current shell, which was not useful for users running fish, zsh, or other shells.

This pr modifies the completion command to:
- Automatically detect the current shell type when no argument is provided
- Return the appropriate completion script for the detected shell
- Fall back to bash only when shell detection fails