### PR TITLE
package size optimization via npm postinstall (~100MB -> ~20MB)

### DIFF
--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -8,55 +8,9 @@ import { fileURLToPath } from "url";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-const { platform, arch } = process;
-
-let targetTriple = null;
-switch (platform) {
-  case "linux":
-  case "android":
-    switch (arch) {
-      case "x64":
-        targetTriple = "x86_64-unknown-linux-musl";
-        break;
-      case "arm64":
-        targetTriple = "aarch64-unknown-linux-musl";
-        break;
-      default:
-        break;
-    }
-    break;
-  case "darwin":
-    switch (arch) {
-      case "x64":
-        targetTriple = "x86_64-apple-darwin";
-        break;
-      case "arm64":
-        targetTriple = "aarch64-apple-darwin";
-        break;
-      default:
-        break;
-    }
-    break;
-  case "win32":
-    switch (arch) {
-      case "x64":
-        targetTriple = "x86_64-pc-windows-msvc.exe";
-        break;
-      case "arm64":
-      // We do not build this today, fall through...
-      default:
-        break;
-    }
-    break;
-  default:
-    break;
-}
-
-if (!targetTriple) {
-  throw new Error(`Unsupported platform: ${platform} (${arch})`);
-}
-
-const binaryPath = path.join(__dirname, "..", "bin", `codex-${targetTriple}`);
+// Simple binary path - post install script ensures the correct one exists
+const binaryName = process.platform === 'win32' ? 'codex.exe' : 'codex';
+const binaryPath = path.join(__dirname, "..", "bin", binaryName);
 
 // Use an asynchronous spawn instead of spawnSync so that Node is able to
 // respond to signals (e.g. Ctrl-C / SIGINT) while the native binary is

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-dev",
   "license": "Apache-2.0",
   "bin": {
-    "codex-test": "bin/codex.js"
+    "codex": "bin/codex.js"
   },
   "type": "module",
   "engines": {

--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-dev",
   "license": "Apache-2.0",
   "bin": {
-    "codex": "bin/codex.js"
+    "codex-test": "bin/codex.js"
   },
   "type": "module",
   "engines": {
@@ -11,14 +11,20 @@
   },
   "files": [
     "bin",
-    "dist"
+    "postinstall.js"
   ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openai/codex.git"
   },
+  "scripts": {
+    "postinstall": "node postinstall.js"
+  },
+  "binaryVersion": "rust-v0.27.0",
   "dependencies": {
-    "@vscode/ripgrep": "^1.15.14"
+    "@vscode/ripgrep": "^1.15.14",
+    "https-proxy-agent": "^7.0.5",
+    "tar-stream": "^3.1.7"
   },
   "devDependencies": {
     "prettier": "^3.3.3"

--- a/codex-cli/postinstall.js
+++ b/codex-cli/postinstall.js
@@ -1,0 +1,225 @@
+#!/usr/bin/env node
+/**
+ * Codex CLI postinstall script
+ * Downloads platform-specific binary to reduce package size
+ */
+
+import fs from "fs";
+import path from "path";
+import { pipeline } from "stream/promises";
+import { createGunzip } from "zlib";
+import { fileURLToPath } from "url";
+import { extract } from "tar-stream";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function getPlatformInfo() {
+  const { platform, arch } = process;
+
+  let targetTriple = null;
+  switch (platform) {
+    case "linux":
+    case "android":
+      switch (arch) {
+        case "x64":
+          targetTriple = "x86_64-unknown-linux-musl";
+          break;
+        case "arm64":
+          targetTriple = "aarch64-unknown-linux-musl";
+          break;
+      }
+      break;
+    case "darwin":
+      switch (arch) {
+        case "x64":
+          targetTriple = "x86_64-apple-darwin";
+          break;
+        case "arm64":
+          targetTriple = "aarch64-apple-darwin";
+          break;
+      }
+      break;
+    case "win32":
+      switch (arch) {
+        case "x64":
+          targetTriple = "x86_64-pc-windows-msvc.exe";
+          break;
+        case "arm64":
+        // We do not build this today, fall through...
+        default:
+          break;
+      }
+      break;
+  }
+
+  if (!targetTriple) {
+    throw new Error(`Unsupported platform: ${platform} (${arch})`);
+  }
+
+  return { targetTriple, platform, arch };
+}
+
+// Fetch with optional proxy support
+async function createFetch() {
+  try {
+    const { HttpsProxyAgent } = await import("https-proxy-agent");
+    const proxyUrl = process.env.HTTPS_PROXY || process.env.HTTP_PROXY;
+
+    if (proxyUrl) {
+      const agent = new HttpsProxyAgent(proxyUrl);
+      return (url, options = {}) => fetch(url, { ...options, agent });
+    }
+  } catch {
+    if (process.env.DEBUG) {
+      console.log("Using built-in fetch (no proxy agent)");
+    }
+  }
+  return fetch;
+}
+
+// Retry wrapper for fetch
+async function fetchWithRetry(fetchFn, url, retries = 3) {
+  let lastError;
+  for (let i = 0; i < retries; i++) {
+    try {
+      const res = await fetchFn(url);
+      if (res.ok) return res;
+      throw new Error(`HTTP ${res.status} ${res.statusText}`);
+    } catch (err) {
+      lastError = err;
+      if (process.env.DEBUG) {
+        console.log(`Fetch attempt ${i + 1} failed: ${err.message}`);
+      }
+      if (i < retries - 1) {
+        await new Promise((r) => setTimeout(r, 2 ** i * 1000));
+      }
+    }
+  }
+  throw lastError;
+}
+
+// Extract binary from tar.gz
+async function extractBinaryFromTarGz(
+  response,
+  outputPath,
+  expectedBinaryName,
+) {
+  const extractStream = extract();
+  let found = false;
+  let extractedFilename = null;
+
+  return new Promise((resolve, reject) => {
+    extractStream.on("entry", (header, stream, next) => {
+      const baseName = path.basename(header.name);
+      if (header.type === "file" && baseName === expectedBinaryName) {
+        found = true;
+        extractedFilename = baseName;
+
+        const writeStream = fs.createWriteStream(outputPath);
+        stream.pipe(writeStream);
+
+        writeStream.on("finish", next);
+        writeStream.on("error", reject);
+      } else {
+        stream.on("end", next);
+        stream.resume();
+      }
+    });
+
+    extractStream.on("finish", () => {
+      if (!found) {
+        reject(new Error("Binary not found in tar archive"));
+      } else {
+        resolve(extractedFilename);
+      }
+    });
+
+    extractStream.on("error", reject);
+
+    pipeline(response.body, createGunzip(), extractStream).catch(reject);
+  });
+}
+
+// Download platform-specific binary
+async function downloadBinary(targetTriple) {
+  const packageJson = JSON.parse(
+    await fs.promises.readFile(path.join(__dirname, "package.json"), "utf8"),
+  );
+
+  const binaryVersion = packageJson.binaryVersion;
+
+  const downloadBinaryName = `codex-${targetTriple}`;
+  const localBinaryName = process.platform === "win32" ? "codex.exe" : "codex";
+  const downloadUrl =
+    `https://github.com/openai/codex/releases/download/` +
+    `${binaryVersion}/${downloadBinaryName}.tar.gz`;
+
+  const binDir = path.join(__dirname, "bin");
+  await fs.promises.mkdir(binDir, { recursive: true });
+
+  const outputPath = path.join(binDir, localBinaryName);
+
+  if (process.env.DEBUG) {
+    console.log(`Download target: ${downloadBinaryName}`);
+    console.log(`URL: ${downloadUrl}`);
+  } else {
+    console.log(`Downloading ${downloadBinaryName}...`);
+  }
+
+  try {
+    const fetchFn = await createFetch();
+    const response = await fetchWithRetry(fetchFn, downloadUrl, 3);
+
+    if (!response.ok) {
+      throw new Error(
+        `Download failed: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    if (process.env.DEBUG) {
+      console.log(`Extracting ${downloadBinaryName} to ${outputPath}`);
+    }
+
+    const extractedFilename = await extractBinaryFromTarGz(
+      response,
+      outputPath,
+      downloadBinaryName,
+    );
+
+    if (process.platform !== "win32") {
+      await fs.promises.chmod(outputPath, 0o755);
+    }
+
+    console.log(`Installed: ${extractedFilename} -> ${localBinaryName}`);
+  } catch (error) {
+    try {
+      await fs.promises.unlink(outputPath);
+    } catch {}
+    throw error;
+  }
+}
+
+// Main execution
+async function main() {
+  try {
+    const { targetTriple } = getPlatformInfo();
+    if (process.env.DEBUG) {
+      console.log(`Detected platform: ${targetTriple}`);
+    }
+
+    await downloadBinary(targetTriple);
+
+    console.log(`Codex CLI installation completed!`);
+  } catch (error) {
+    console.error("Postinstall failed:", error.message);
+    console.error("\nTroubleshooting:");
+    console.error("   1. Check your internet connection");
+    console.error("   2. Verify the GitHub release exists for your platform");
+    console.error("   3. Check proxy settings if in a corporate environment");
+    console.error("   4. Run with DEBUG=1 for verbose logs");
+    process.exit(1);
+  }
+}
+
+main();

--- a/codex-cli/scripts/stage_release.sh
+++ b/codex-cli/scripts/stage_release.sh
@@ -106,9 +106,8 @@ jq --arg version "$VERSION" \
 
 # 2. Copy postinstall script for platform-specific binary downloads
 
-cp postinstall.js "$TMPDIR/postinstall.js"
-
 echo "Using postinstall approach - binaries will be downloaded per platform"
+cp postinstall.js "$TMPDIR/postinstall.js"
 
 popd >/dev/null
 

--- a/codex-cli/scripts/stage_release.sh
+++ b/codex-cli/scripts/stage_release.sh
@@ -104,9 +104,11 @@ jq --arg version "$VERSION" \
     '.version = $version' \
     package.json > "$TMPDIR/package.json"
 
-# 2. Native runtime deps (sandbox plus optional Rust binaries)
+# 2. Copy postinstall script for platform-specific binary downloads
 
-./scripts/install_native_deps.sh --workflow-url "$WORKFLOW_URL" "$TMPDIR"
+cp postinstall.js "$TMPDIR/postinstall.js"
+
+echo "Using postinstall approach - binaries will be downloaded per platform"
 
 popd >/dev/null
 


### PR DESCRIPTION
Addressing issue #2766 
This change optimizes the npm package size by downloading platform-specific binaries during installation instead of bundling all platform binaries in the package.


## Changes in Node Modules on Client

### Before (Bundle Approach)
```
npm package:
└── bin/
    ├── codex.js (platform detection)
    ├── codex-x86_64-apple-darwin
    ├── codex-aarch64-apple-darwin  
    ├── codex-x86_64-unknown-linux-musl
    ├── codex-aarch64-unknown-linux-musl
    └── codex-x86_64-pc-windows-msvc.exe
├── package.json
└── node_modules/
```

### After (Postinstall Approach)
```
npm package:
└── bin/
    ├── codex.js    
    ├── codex (installed by postinstall.js)
├── postinstall.js (binary downloader)
├── package.json
└── node_modules/

Installation process:
1. npm install downloads lightweight package
2. postinstall.js runs automatically
3. Downloads only needed binary from GitHub releases
```

### Advantages

- Smaller download size, and smaller storage on client
- Don't check platform and architecture everytime we start

## Implementation Details

### Postinstall Script (`postinstall.js`)
- Detects platform using same logic as `bin/codex.js`
- Downloads from `https://github.com/openai/codex/releases/download/{version}/codex-{platform}.tar.gz`

### Release Process Changes
- `stage_release.sh` no longer calls `install_native_deps.sh`
- Creates lightweight package with `postinstall.js`
- GitHub releases still provide all platform binaries as before

### Error Handling
- Clear error messages for unsupported platforms
- Fallback when proxy configuration needed

## Testing
Check out test package here: https://www.npmjs.com/package/@vinay7/codex-test
```bash
# Test local package
cd codex-cli
npm pack

# Test postinstall directly
node postinstall.js

# I published same package to my namespace in npm registry for testing. Can verify this
npm install -g @vinay7/codex-test
```
## Release
 Will be using `binaryVersion` in package.json followed by `npm publish` 
 ```json 
 "binaryVersion": "rust-v0.27.0"
```

## Rollback Plan

If issues arise, revert by:
1. Remove `postinstall.js` and script reference from `package.json`
2. Restore `install_native_deps.sh` call in `stage_release.sh`
3. Re-release with bundled binaries

## Dependencies Added
- `https-proxy-agent: ^7.0.5` - proxy support (~2MB)
- `tar-stream: ^3.1.7` - tar stream parser (~30KB)
