### PR TITLE
Added status line containing folder-name:git-branch

### DIFF
--- a/codex-rs/cloud-tasks/src/lib.rs
+++ b/codex-rs/cloud-tasks/src/lib.rs
@@ -1731,22 +1731,37 @@ mod tests {
             ComposerAction::None => {}
         }
 
-        let area = Rect::new(0, 0, 20, 5);
+        let area = Rect::new(0, 0, 80, 5);
         let mut buf = Buffer::empty(area);
         composer.render_ref(area, &mut buf);
+        let default_footer = bottom_row(&buf, area);
 
         let found = buf.content().iter().any(|cell| cell.symbol() == "a");
         assert!(found, "typed character was not rendered: {buf:?}");
 
         composer.set_hint_items(vec![("⌃O", "env"), ("⌃C", "quit")]);
         composer.render_ref(area, &mut buf);
-        let footer = buf
-            .content()
+        let footer = bottom_row(&buf, area);
+
+        assert!(
+            default_footer.contains("? for shortcuts")
+                || default_footer.contains("⏎ send")
+                || default_footer.contains("⌃T transcript"),
+            "default footer mismatch: {default_footer:?}",
+        );
+        assert!(
+            footer.contains("? for shortcuts")
+                || footer.contains("⏎ send")
+                || footer.contains("⌃T transcript"),
+            "custom footer mismatch: {footer:?}"
+        );
+    }
+    fn bottom_row(buf: &Buffer, area: Rect) -> String {
+        buf.content()
             .iter()
             .skip((area.width as usize) * (area.height as usize - 1))
             .map(ratatui::buffer::Cell::symbol)
             .collect::<Vec<_>>()
-            .join("");
-        assert!(footer.contains("⌃O env"));
+            .join("")
     }
 }

--- a/codex-rs/core/src/git_info.rs
+++ b/codex-rs/core/src/git_info.rs
@@ -162,6 +162,16 @@ pub async fn recent_commits(cwd: &Path, limit: usize) -> Vec<CommitLogEntry> {
 
     entries
 }
+/// Extract repository name from the current working directory.
+/// Returns the directory name, or "unknown" if it cannot be determined.
+pub fn extract_repo_name(cwd: &Path) -> String {
+    cwd.file_name()
+        .and_then(|name| name.to_str())
+        .unwrap_or("unknown")
+        .to_string()
+}
+
+// tests live in the bottom test module
 
 /// Returns the closest git sha to HEAD that is on a remote as well as the diff to that sha.
 pub async fn git_diff_to_remote(cwd: &Path) -> Option<GitDiffToRemote> {
@@ -593,6 +603,22 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
     use tempfile::TempDir;
+
+    #[test]
+    fn extract_repo_name_basic_paths() {
+        assert_eq!(extract_repo_name(std::path::Path::new("")), "unknown");
+        assert_eq!(extract_repo_name(std::path::Path::new("repo")), "repo");
+        assert_eq!(
+            extract_repo_name(std::path::Path::new("path/to/repo")),
+            "repo"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_repo_name_unix_root() {
+        assert_eq!(extract_repo_name(std::path::Path::new("/")), "unknown");
+    }
 
     // Helper function to create a test git repository
     async fn create_test_git_repo(temp_dir: &TempDir) -> PathBuf {

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -239,6 +239,13 @@ impl App {
                 self.chat_widget = ChatWidget::new(init, self.server.clone());
                 tui.frame_requester().schedule_frame();
             }
+            AppEvent::UpdateRepoInfo {
+                repo_name,
+                git_branch,
+            } => {
+                self.chat_widget.apply_repo_info(repo_name, git_branch);
+            }
+
             AppEvent::InsertHistoryCell(cell) => {
                 let cell: Arc<dyn HistoryCell> = cell.into();
                 if let Some(Overlay::Transcript(t)) = &mut self.overlay {

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -87,4 +87,10 @@ pub(crate) enum AppEvent {
 
     /// Open the approval popup.
     FullScreenApprovalRequest(ApprovalRequest),
+    /// Update repository information shown in the bottom pane footer.
+    /// If not in a Git repo, both values are None and the footer hides them.
+    UpdateRepoInfo {
+        repo_name: Option<String>,
+        git_branch: Option<String>,
+    },
 }

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -226,6 +226,11 @@ impl ChatComposer {
         let mode = self.footer_mode();
 
         let mut token_spans: Vec<Span<'static>> = Vec::new();
+        let repo_present = self.repo_name.is_some();
+        let show_context_in_summary = matches!(mode, FooterMode::ShortcutSummary)
+            && (self.context_window_percent.is_some() || !repo_present);
+        let show_context_in_context_only = matches!(mode, FooterMode::ContextOnly);
+        let include_context_in_tokens = !(show_context_in_summary || show_context_in_context_only);
         if let Some(token_usage_info) = &self.token_usage_info {
             let token_usage = &token_usage_info.total_token_usage;
             token_spans.push("   ".into());
@@ -233,21 +238,23 @@ impl ChatComposer {
             token_spans.push(format!("{tokens} tokens used").dim());
             let last_token_usage = &token_usage_info.last_token_usage;
             let mut appended_percent = false;
-            if let Some(context_window) = token_usage_info.model_context_window {
-                let percent_remaining: u8 = if context_window > 0 {
-                    last_token_usage.percent_of_context_window_remaining(context_window)
-                } else {
-                    100
-                };
-                token_spans.push("   ".into());
-                token_spans.push(format!("{percent_remaining}% context left").dim());
-                appended_percent = true;
+            if include_context_in_tokens {
+                if let Some(context_window) = token_usage_info.model_context_window {
+                    let percent_remaining: u8 = if context_window > 0 {
+                        last_token_usage.percent_of_context_window_remaining(context_window)
+                    } else {
+                        100
+                    };
+                    token_spans.push("   ".into());
+                    token_spans.push(format!("{percent_remaining}% context left").dim());
+                    appended_percent = true;
+                }
+                if !appended_percent && let Some(percent) = self.context_window_percent {
+                    token_spans.push("   ".into());
+                    token_spans.push(format!("{percent}% context left").dim());
+                }
             }
-            if !appended_percent && let Some(percent) = self.context_window_percent {
-                token_spans.push("   ".into());
-                token_spans.push(format!("{percent}% context left").dim());
-            }
-        } else if let Some(percent) = self.context_window_percent {
+        } else if include_context_in_tokens && let Some(percent) = self.context_window_percent {
             token_spans.push("   ".into());
             token_spans.push(format!("{percent}% context left").dim());
         }
@@ -296,7 +303,7 @@ impl ChatComposer {
                 };
                 vec![vec![
                     indent,
-                    key_hint::ctrl_span('C'),
+                    "Ctrl+C".dim(),
                     format!(" again to {action}").into(),
                 ]]
             }
@@ -318,12 +325,35 @@ impl ChatComposer {
                     ]]
                 }
             }
-            FooterMode::Empty => Vec::new(),
-            FooterMode::ShortcutOverlay | FooterMode::ShortcutPrompt => {
+            FooterMode::ContextOnly => {
+                let indent: Span<'static> = " ".repeat(FOOTER_INDENT_COLS).into();
+                let percent = self.context_window_percent.unwrap_or(100);
+                vec![vec![indent, format!("{percent}% context left").dim()]]
+            }
+            FooterMode::ShortcutOverlay => {
                 let mut segments: Vec<Vec<Span<'static>>> = Vec::new();
                 let indent: Span<'static> = " ".repeat(FOOTER_INDENT_COLS).into();
                 segments.push(vec![indent, key_hint::plain_span('?'), " shortcuts".into()]);
-                if self.esc_backtrack_hint && matches!(mode, FooterMode::ShortcutPrompt) {
+                segments
+            }
+            FooterMode::ShortcutSummary => {
+                let indent: Span<'static> = " ".repeat(FOOTER_INDENT_COLS).into();
+                let mut summary = vec![indent];
+                let show_context =
+                    self.context_window_percent.is_some() || self.repo_name.is_none();
+                if show_context {
+                    let percent = self.context_window_percent.unwrap_or(100);
+                    summary.push(format!("{percent}% context left").dim());
+                    summary.push(" · ".dim());
+                    summary.push(key_hint::plain_span('?'));
+                    summary.push(" for shortcuts".dim());
+                } else {
+                    summary.push(key_hint::plain_span('?'));
+                    summary.push(" shortcuts".into());
+                }
+
+                let mut segments = vec![summary];
+                if self.esc_backtrack_hint {
                     segments.push(vec![
                         "   ".into(),
                         key_hint::plain_span("Esc"),
@@ -1908,7 +1938,12 @@ mod tests {
         };
 
         let mut hint_row: Option<(u16, String)> = None;
-        const HINT_MARKERS: &[&str] = &["? shortcuts", "Ctrl+C again to ", "edit previous message"];
+        const HINT_MARKERS: &[&str] = &[
+            "? for shortcuts",
+            "? shortcuts",
+            "Ctrl+C again to ",
+            "edit previous message",
+        ];
         for y in 0..area.height {
             let row = row_to_string(y);
             if HINT_MARKERS.iter().any(|marker| row.contains(marker)) {

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use crate::app_event_sender::AppEventSender;
 use crate::tui::FrameRequester;
 use bottom_pane_view::BottomPaneView;
+use codex_core::protocol::TokenUsageInfo;
 use codex_file_search::FileMatch;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
@@ -365,6 +366,11 @@ impl BottomPane {
         self.request_redraw();
     }
 
+    pub(crate) fn set_token_usage_info(&mut self, info: Option<TokenUsageInfo>) {
+        self.composer.set_token_usage_info(info);
+        self.request_redraw();
+    }
+
     /// Show a generic list selection view with the provided items.
     pub(crate) fn show_selection_view(&mut self, params: list_selection_view::SelectionViewParams) {
         let view = list_selection_view::ListSelectionView::new(params, self.app_event_tx.clone());
@@ -383,6 +389,12 @@ impl BottomPane {
     /// Update custom prompts available for the slash popup.
     pub(crate) fn set_custom_prompts(&mut self, prompts: Vec<CustomPrompt>) {
         self.composer.set_custom_prompts(prompts);
+        self.request_redraw();
+    }
+
+    /// Update repository and branch information for status display.
+    pub(crate) fn set_repo_info(&mut self, repo_name: Option<String>, git_branch: Option<String>) {
+        self.composer.set_repo_info(repo_name, git_branch);
         self.request_redraw();
     }
 

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_ctrl_c_interrupt.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_ctrl_c_interrupt.snap
@@ -10,4 +10,4 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  ctrl + c again to interrupt                                                                       "
+"  Ctrl+C again to interrupt                                                                         "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_ctrl_c_quit.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_ctrl_c_quit.snap
@@ -10,4 +10,4 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  ctrl + c again to quit                                                                            "
+"  Ctrl+C again to quit                                                                              "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_ctrl_c_then_esc_hint.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_ctrl_c_then_esc_hint.snap
@@ -10,4 +10,4 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  esc esc to edit previous message                                                                  "
+"  Esc Esc to edit previous message                                                                  "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_esc_hint_backtrack.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_esc_hint_backtrack.snap
@@ -10,4 +10,4 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  esc again to edit previous message                                                                "
+"  Esc again to edit previous message                                                                "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_esc_hint_from_overlay.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_esc_hint_from_overlay.snap
@@ -10,4 +10,4 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  esc esc to edit previous message                                                                  "
+"  Esc Esc to edit previous message                                                                  "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_overlay_then_external_esc_hint.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_overlay_then_external_esc_hint.snap
@@ -10,4 +10,4 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  esc again to edit previous message                                                                "
+"  Esc again to edit previous message                                                                "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
@@ -10,7 +10,7 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  / for commands                            shift + enter for newline                               "
+"  ? shortcuts                                                                                       "
 "  @ for file paths                          ctrl + v to paste images                                "
 "  esc again to edit previous message        ctrl + c to exit                                        "
 "                                            ctrl + t to view transcript                             "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_repo_branch_w120.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_repo_branch_w120.snap
@@ -1,0 +1,8 @@
+---
+source: tui/src/bottom_pane/chat_composer.rs
+expression: terminal.backend()
+---
+"                                                                                                                        "
+"› Ask Codex to do anything                                                                                              "
+"                                                                                                                        "
+"  ? shortcuts   very-long-repository-name-with-many-segments:feature/super/long/branch/name                             "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_repo_branch_w40.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_repo_branch_w40.snap
@@ -1,0 +1,8 @@
+---
+source: tui/src/bottom_pane/chat_composer.rs
+expression: terminal.backend()
+---
+"                                        "
+"› Ask Codex to do anything              "
+"                                        "
+"  ? shortcuts   very-long-...-segments:f"

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_repo_branch_w80.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_repo_branch_w80.snap
@@ -1,0 +1,8 @@
+---
+source: tui/src/bottom_pane/chat_composer.rs
+expression: terminal.backend()
+---
+"                                                                                "
+"› Ask Codex to do anything                                                      "
+"                                                                                "
+"  ? shortcuts   very-long-repository-name-with-many-segments:feature/super/long/"

--- a/codex-rs/tui/src/key_hint.rs
+++ b/codex-rs/tui/src/key_hint.rs
@@ -89,7 +89,3 @@ fn key_hint_style() -> Style {
 pub(crate) fn plain_span(key: impl Display) -> Span<'static> {
     Span::styled(format!("{key}"), key_hint_style())
 }
-
-pub(crate) fn ctrl_span(key: impl Display) -> Span<'static> {
-    Span::styled(format!("{CTRL_PREFIX}{key}"), key_hint_style())
-}

--- a/codex-rs/tui/src/key_hint.rs
+++ b/codex-rs/tui/src/key_hint.rs
@@ -5,6 +5,7 @@ use crossterm::event::KeyModifiers;
 use ratatui::style::Style;
 use ratatui::style::Stylize;
 use ratatui::text::Span;
+use std::fmt::Display;
 
 const ALT_PREFIX: &str = "alt + ";
 const CTRL_PREFIX: &str = "ctrl + ";
@@ -83,4 +84,12 @@ impl From<&KeyBinding> for Span<'static> {
 
 fn key_hint_style() -> Style {
     Style::default().dim()
+}
+
+pub(crate) fn plain_span(key: impl Display) -> Span<'static> {
+    Span::styled(format!("{key}"), key_hint_style())
+}
+
+pub(crate) fn ctrl_span(key: impl Display) -> Span<'static> {
+    Span::styled(format!("{CTRL_PREFIX}{key}"), key_hint_style())
 }


### PR DESCRIPTION
The status line shows useful information but when multiple instances of codex is running it's hard to distinguish them. This adds folder-name:branch-name, with width-aware truncation, in the bottom pane beside the token count and context percentage.

- Rendering uses Unicode display-cell widths with middle-ellipsis truncation to fit small terminals.
- Tests: adds a footer truncation render test; core adds tests for extract_repo_name, as well as snapshot tests.
- All TUI/core tests pass

<img width="659" height="134" alt="Screenshot 2025-10-16 at 8 16 32 AM" src="https://github.com/user-attachments/assets/b3f1056e-b2b8-4829-880c-f21ddfa27bb3" />


