### PR TITLE
Bug fix: ignore Enter on empty input to avoid queuing blank messages

### DIFF
--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -241,6 +241,20 @@ fn open_fixture(name: &str) -> std::fs::File {
 }
 
 #[test]
+fn empty_enter_during_task_does_not_queue() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual();
+
+    // Simulate running task so submissions would normally be queued.
+    chat.bottom_pane.set_task_running(true);
+
+    // Press Enter with an empty composer.
+    chat.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    // Ensure nothing was queued.
+    assert!(chat.queued_user_messages.is_empty());
+}
+
+#[test]
 fn alt_up_edits_most_recent_queued_message() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual();
 


### PR DESCRIPTION
## Summary
Pressing Enter with an empty composer was treated as a submission, which queued a blank message while a task was running. This PR suppresses submission when there is no text and no attachments.

## Root Cause

- ChatComposer returned Submitted even when the trimmed text was empty. ChatWidget then queued it during a running task, leading to an empty item appearing in the queued list and being popped later with no effect.

## Changes
- ChatComposer Enter handling: if trimmed text is empty and there are no attached images, return None instead of Submitted.
- No changes to ChatWidget; behavior naturally stops queuing blanks at the source.

## Code Paths

- Modified: `tui/src/bottom_pane/chat_composer.rs`
- Tests added:
    - `tui/src/bottom_pane/chat_composer.rs`: `empty_enter_returns_none`
    - `tui/src/chatwidget/tests.rs`: `empty_enter_during_task_does_not_queue`

## Result

### Before

https://github.com/user-attachments/assets/a40e2f6d-42ba-4a82-928b-8f5458f5884d

### After


https://github.com/user-attachments/assets/958900b7-a566-44fc-b16c-b80380739c92

