### PR TITLE
Show loading state when @ search results are pending

### DIFF
--- a/codex-rs/tui/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/command_popup.rs
@@ -195,7 +195,15 @@ impl WidgetRef for CommandPopup {
                 })
                 .collect()
         };
-        render_rows(area, buf, &rows_all, &self.state, MAX_POPUP_ROWS, false);
+        render_rows(
+            area,
+            buf,
+            &rows_all,
+            &self.state,
+            MAX_POPUP_ROWS,
+            false,
+            "no matches",
+        );
     }
 }
 

--- a/codex-rs/tui/src/bottom_pane/file_search_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/file_search_popup.rs
@@ -132,11 +132,20 @@ impl WidgetRef for &FileSearchPopup {
                 .collect()
         };
 
-        if self.waiting && rows_all.is_empty() {
-            // Render a minimal waiting stub using the shared renderer (no rows -> "no matches").
-            render_rows(area, buf, &[], &self.state, MAX_POPUP_ROWS, false);
+        let empty_message = if self.waiting {
+            "loading..."
         } else {
-            render_rows(area, buf, &rows_all, &self.state, MAX_POPUP_ROWS, false);
-        }
+            "no matches"
+        };
+
+        render_rows(
+            area,
+            buf,
+            &rows_all,
+            &self.state,
+            MAX_POPUP_ROWS,
+            false,
+            empty_message,
+        );
     }
 }

--- a/codex-rs/tui/src/bottom_pane/list_selection_view.rs
+++ b/codex-rs/tui/src/bottom_pane/list_selection_view.rs
@@ -230,7 +230,15 @@ impl BottomPaneView for ListSelectionView {
             })
             .collect();
         if rows_area.height > 0 {
-            render_rows(rows_area, buf, &rows, &self.state, MAX_POPUP_ROWS, true);
+            render_rows(
+                rows_area,
+                buf,
+                &rows,
+                &self.state,
+                MAX_POPUP_ROWS,
+                true,
+                "no matches",
+            );
         }
 
         if let Some(hint) = &self.footer_hint {

--- a/codex-rs/tui/src/bottom_pane/selection_popup_common.rs
+++ b/codex-rs/tui/src/bottom_pane/selection_popup_common.rs
@@ -35,11 +35,12 @@ pub(crate) fn render_rows(
     state: &ScrollState,
     max_results: usize,
     _dim_non_selected: bool,
+    empty_message: &str,
 ) {
     let mut rows: Vec<Row> = Vec::new();
     if rows_all.is_empty() {
         rows.push(Row::new(vec![Cell::from(Line::from(Span::styled(
-            "no matches",
+            empty_message,
             Style::default().add_modifier(Modifier::ITALIC | Modifier::DIM),
         )))]));
     } else {


### PR DESCRIPTION
## Summary
- allow selection popups to specify their empty state message
- show a "loading..." placeholder in the file search popup while matches are pending
- update other popup call sites to continue using a "no matches" message

## Testing
- just fmt
- just fix -p codex-tui
- cargo test -p codex-tui

------
https://chatgpt.com/codex/tasks/task_i_68b73e956e90832caf4d04a75fcc9c46