### PR TITLE
fix: leverage windows-11-arm for Windows ARM builds

### DIFF
--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -21,6 +21,10 @@
         "windows-x86_64": {
           "regex": "^codex-x86_64-pc-windows-msvc\\.exe\\.zst$",
           "path": "codex.exe"
+        },
+        "windows-aarch64": {
+          "regex": "^codex-aarch64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex.exe"
         }
       }
     }

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -100,6 +100,9 @@ jobs:
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
             profile: dev
+          - runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
+            profile: dev
 
           # Also run representative release builds on Mac and Linux because
           # there could be release-only build errors we want to catch.
@@ -113,6 +116,9 @@ jobs:
             profile: release
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
+            profile: release
+          - runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
             profile: release
 
     steps:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -72,6 +72,8 @@ jobs:
             target: aarch64-unknown-linux-gnu
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
+          - runner: windows-11-arm
+            target: aarch64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
This is in support of https://github.com/openai/codex/issues/2979.

Once we have a release out, we can update the npm module and the VS Code extension to take advantage of this.