### PR TITLE
tui: fix extra blank lines in streamed agent messages

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -191,10 +191,15 @@ impl App {
                 self.transcript_lines.extend(cell_transcript.clone());
                 let mut display = cell.display_lines(tui.terminal.last_known_screen_size.width);
                 if !display.is_empty() {
-                    if self.has_emitted_history_lines {
-                        display.insert(0, Line::from(""));
-                    } else {
-                        self.has_emitted_history_lines = true;
+                    // Only insert a separating blank line for new cells that are not
+                    // part of an ongoing stream. Streaming continuations should not
+                    // accrue extra blank lines between chunks.
+                    if !cell.is_stream_continuation() {
+                        if self.has_emitted_history_lines {
+                            display.insert(0, Line::from(""));
+                        } else {
+                            self.has_emitted_history_lines = true;
+                        }
                     }
                     if self.overlay.is_some() {
                         self.deferred_history_lines.extend(display);


### PR DESCRIPTION
Fixes excessive blank lines appearing during agent message streaming.

- Only insert a separator blank line for new, non-streaming history cells.
- Streaming continuations now append without adding a spacer, eliminating extra gaps between chunks.

Affected area: TUI display of agent messages (tui/src/app.rs).
