### PR TITLE
fix: install zstd on the windows-11-arm image used to cut a release

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -111,6 +111,11 @@ jobs:
             cp target/${{ matrix.target }}/release/codex "$dest/codex-${{ matrix.target }}"
           fi
 
+      - if: ${{ matrix.runner == 'windows-11-arm' }}
+        name: Install zstd
+        shell: powershell
+        run: choco install -y zstandard
+
       - name: Compress artifacts
         shell: bash
         run: |


### PR DESCRIPTION
https://github.com/openai/codex/pull/3062 added `windows-11-arm` to the list of images used for building, but the job to build an alpha just failed:

https://github.com/openai/codex/actions/runs/17415565601

with this error:

```
Creating archive: codex-aarch64-pc-windows-msvc.exe.zip

Add new data to archive: 1 file, 20484096 bytes (20 MiB)


Files read from disk: 1
Archive size: 7869619 bytes (7686 KiB)
Everything is Ok
C:\a\_temp\0e71926f-4d8a-42ae-a337-a9627acc9c57.sh: line 34: zstd: command not found
```

so allegedly this should fix it? I'm surprised this was not necessary for the `windows-latest` image, though.