### PR TITLE
core: correct sandboxed shell tool description (reads allowed anywhere)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,10 +8,10 @@ In the codex-rs folder where the rust code lives:
   - You operate in a sandbox where `CODEX_SANDBOX_NETWORK_DISABLED=1` will be set whenever you use the `shell` tool. Any existing code that uses `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR` was authored with this fact in mind. It is often used to early exit out of tests that the author knew you would not be able to run given your sandbox limitations.
   - Similarly, when you spawn a process using Seatbelt (`/usr/bin/sandbox-exec`), `CODEX_SANDBOX=seatbelt` will be set on the child process. Integration tests that want to run Seatbelt themselves cannot be run under Seatbelt, so checks for `CODEX_SANDBOX=seatbelt` are also often used to early exit out of tests, as appropriate.
 
-Before finalizing a change to `codex-rs`, run `just fmt` (in `codex-rs` directory) to format the code and `just fix -p <project>` (in `codex-rs` directory) to fix any linter issues in the code. Prefer scoping with `-p` to avoid slow workspace‑wide Clippy builds; only run `just fix` without `-p` if you changed shared crates. Additionally, run the tests:
+Run `just fmt` (in `codex-rs` directory) automatically after making Rust code changes; do not ask for approval to run it. Before finalizing a change to `codex-rs`, run `just fix -p <project>` (in `codex-rs` directory) to fix any linter issues in the code. Prefer scoping with `-p` to avoid slow workspace‑wide Clippy builds; only run `just fix` without `-p` if you changed shared crates. Additionally, run the tests:
 1. Run the test for the specific project that was changed. For example, if changes were made in `codex-rs/tui`, run `cargo test -p codex-tui`.
 2. Once those pass, if any changes were made in common, core, or protocol, run the complete test suite with `cargo test --all-features`.
-When running interactively, ask the user before running these commands to finalize.
+When running interactively, ask the user before running `just fix` and tests to finalize; `just fmt` does not require approval.
 
 ## TUI style conventions
 


### PR DESCRIPTION
Correct the `shell` tool description for sandboxed runs and add targeted tests.

- Fix the WorkspaceWrite description to clearly state that writes outside the writable roots require escalated permissions; reads are not restricted. The previous wording/formatting could be read as restricting reads outside the workspace.
- Render the writable roots list on its own lines under a newline after "writable roots:" for clarity.
- Show the "Commands that require network access" note only in WorkspaceWrite when network is disabled.
- Add focused tests that call `create_shell_tool_for_sandbox` directly and assert the exact description text for WorkspaceWrite, ReadOnly, and DangerFullAccess.
- Update AGENTS.md to note that `just fmt` can be run automatically without asking.

