### PR TITLE
docs: fix broken link to AGENTS.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,7 +48,7 @@ You can give Codex extra instructions and guidance using `AGENTS.md` files. Code
 2. `AGENTS.md` at repo root - shared project notes
 3. `AGENTS.md` in the current working directory - sub-folder/feature specifics
 
-For more information on how to use AGENTS.md, see the [official AGENTS.md documentation](./agents.md).
+For more information on how to use AGENTS.md, see the [official AGENTS.md documentation](../AGENTS.md).
 
 ### Tips & shortcuts
 


### PR DESCRIPTION
Fixes #2962.

The link to AGENTS.md in docs/getting-started.md was pointing to ./agents.md, which doesn’t exist. Updated it to ../AGENTS.md to reference the file in the repo root.

This corrects the broken link in the “Memory & Project Docs” section.

# External (non-OpenAI) Pull Request Requirements

Before opening this Pull Request, please read the dedicated "Contributing" markdown file or your PR may be closed:
https://github.com/openai/codex/blob/main/docs/contributing.md

If your PR conforms to our contribution guidelines, replace this text with a detailed and high quality description of your changes.
