### PR TITLE
parse cd foo && ... for exec and apply_patch

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -636,6 +636,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "once_cell",
  "pretty_assertions",
  "similar",
  "tempfile",

--- a/codex-rs/apply-patch/Cargo.toml
+++ b/codex-rs/apply-patch/Cargo.toml
@@ -20,6 +20,7 @@ similar = "2.7.0"
 thiserror = "2.0.12"
 tree-sitter = "0.25.8"
 tree-sitter-bash = "0.25.0"
+once_cell = "1"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -318,6 +318,12 @@ fn extract_apply_patch_from_bash(
     //
     // Overall, we want to be conservative and only match the intended forms, as other
     // forms are likely to be model errors, or incorrectly interpreted by later code.
+    //
+    // If you're editing this query, it's helpful to start by creating a debugging binary
+    // which will let you see the AST of an arbitrary bash script passed in, and optionally
+    // also run an arbitrary query against the AST. This is useful for understanding
+    // how tree-sitter parses the script and whether the query syntax is correct. Be sure
+    // to test both positive and negative cases.
     static APPLY_PATCH_QUERY: Lazy<Query> = Lazy::new(|| {
         let language = BASH.into();
         #[expect(clippy::expect_used)]

--- a/codex-rs/apply-patch/src/parser.rs
+++ b/codex-rs/apply-patch/src/parser.rs
@@ -175,7 +175,11 @@ fn parse_patch_text(patch: &str, mode: ParseMode) -> Result<ApplyPatchArgs, Pars
         remaining_lines = &remaining_lines[hunk_lines..]
     }
     let patch = lines.join("\n");
-    Ok(ApplyPatchArgs { hunks, patch })
+    Ok(ApplyPatchArgs {
+        hunks,
+        patch,
+        workdir: None,
+    })
 }
 
 /// Checks the start and end lines of the patch text for `apply_patch`,
@@ -586,7 +590,8 @@ fn test_parse_patch_lenient() {
         parse_patch_text(&patch_text_in_heredoc, ParseMode::Lenient),
         Ok(ApplyPatchArgs {
             hunks: expected_patch.clone(),
-            patch: patch_text.to_string()
+            patch: patch_text.to_string(),
+            workdir: None,
         })
     );
 
@@ -599,7 +604,8 @@ fn test_parse_patch_lenient() {
         parse_patch_text(&patch_text_in_single_quoted_heredoc, ParseMode::Lenient),
         Ok(ApplyPatchArgs {
             hunks: expected_patch.clone(),
-            patch: patch_text.to_string()
+            patch: patch_text.to_string(),
+            workdir: None,
         })
     );
 
@@ -612,7 +618,8 @@ fn test_parse_patch_lenient() {
         parse_patch_text(&patch_text_in_double_quoted_heredoc, ParseMode::Lenient),
         Ok(ApplyPatchArgs {
             hunks: expected_patch.clone(),
-            patch: patch_text.to_string()
+            patch: patch_text.to_string(),
+            workdir: None,
         })
     );
 


### PR DESCRIPTION
sometimes the model likes to run "cd foo && ..." instead of using the workdir parameter of exec. handle them roughly the same.