### PR TITLE
Add trailing newline to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,4 @@ Codex CLI supports a rich set of configuration options, with preferences stored 
 
 This repository is licensed under the [Apache-2.0 License](LICENSE).
 
+


### PR DESCRIPTION
## Summary
- add a trailing newline at the end of the README for consistent formatting

## Testing
- No tests were run (not required for documentation-only changes)

------
https://chatgpt.com/codex/tasks/task_i_68b7e248c5f48320b8184eb8af6bf176