### PR TITLE
feat: add support for per-profile MCP servers

### DIFF
--- a/codex-rs/core/src/config_profile.rs
+++ b/codex-rs/core/src/config_profile.rs
@@ -1,6 +1,8 @@
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::path::PathBuf;
 
+use crate::config_types::McpServerConfig;
 use crate::protocol::AskForApproval;
 use codex_protocol::config_types::ReasoningEffort;
 use codex_protocol::config_types::ReasoningSummary;
@@ -32,6 +34,11 @@ pub struct ConfigProfile {
     /// Optional feature toggles scoped to this profile.
     #[serde(default)]
     pub features: Option<crate::features::FeaturesToml>,
+    /// Optional MCP servers defined within this profile.
+    ///
+    /// When provided, these entries are merged into the top-level
+    /// `mcp_servers` map during config loading.
+    pub mcp_servers: Option<HashMap<String, McpServerConfig>>,
 }
 
 impl From<ConfigProfile> for codex_app_server_protocol::Profile {

--- a/docs/config.md
+++ b/docs/config.md
@@ -217,6 +217,15 @@ model_provider = "openai"
 approval_policy = "on-failure"
 ```
 
+Profiles can also include MCP servers that are merged into the global list
+when the profile is active:
+
+```toml
+[profiles.zdr.mcp_servers.echo]
+command = "node"
+args = ["echo-mcp.js"]
+```
+
 Users can specify config values at multiple levels. Order of precedence is as follows:
 
 1. custom command-line argument, e.g., `--model o3`
@@ -437,6 +446,31 @@ codex mcp login SERVER_NAME
 # Log out from a streamable HTTP server that supports oauth
 codex mcp logout SERVER_NAME
 ```
+
+### Per-profile MCP servers
+
+You can also declare MCP servers inside a profile. Profile-scoped servers are
+merged into the top-level `mcp_servers` when that profile is active. If a
+server key exists in both places, the profile definition wins.
+
+Example:
+
+```toml
+[mcp_servers.global-tools]
+command = "npx"
+args = ["-y", "global-mcp"]
+
+[profiles.o3]
+model = "o3"
+
+[profiles.o3.mcp_servers.project-tools]
+command = "npx"
+args = ["-y", "project-mcp"]
+```
+
+Running with `--profile o3` will make both `global-tools` and `project-tools`
+available; if `project-tools` also appeared at the top level, the profile
+definition would take precedence.
 
 ## Examples of useful MCPs
 


### PR DESCRIPTION
## What

- Adds optional `mcp_servers to profiles.<name>` in config.
- Merges profile‑scoped servers into the global mcp_servers when that profile is
active.
- Top‑level entries take precedence on key conflicts.
- Updates docs and adds a unit test.

## Backwards Compatibility

- No breaking changes:
    - Existing configs with only top-level mcp_servers continue to work.
    - Profile mcp_servers are optional.
    - No changes to sandbox env vars or unrelated behavior.

## Usage Example

```toml
[mcp_servers.global-tools]
command = "npx"
args = ["-y", "global-mcp"]

[profiles.o3]
model = "o3"

[profiles.o3.mcp_servers.project-tools]
command = "npx"
args = ["-y", "project-mcp"]
```

## Affected Crates

- codex-core (implementation + tests)
- docs (configuration guide)

Closes #3023.