### PR TITLE
Fix failing CI

### DIFF
--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -96,7 +96,7 @@ fn write_auth_json(
         "OPENAI_API_KEY": openai_api_key,
         "tokens": tokens,
         // RFC3339 datetime; value doesn't matter for these tests
-        "last_refresh": "2025-08-06T20:41:36.232376Z",
+        "last_refresh": chrono::Utc::now(),
     });
 
     std::fs::write(


### PR DESCRIPTION
In this test, the ChatGPT token path is used, and the auth layer tries to refresh the token if it thinks the token is “old.” Your helper writes a fixed last_refresh timestamp that has now aged past the 28‑day threshold, so the code attempts a real refresh against auth.openai.com, never reaches the mock, and you end up with received_requests().await.unwrap() being empty.