### PR TITLE
tui: avoid panic when active exec cell area is zero height

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1290,14 +1290,13 @@ impl WidgetRef for &ChatWidget {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
         let [active_cell_area, bottom_pane_area] = self.layout_areas(area);
         (&self.bottom_pane).render(bottom_pane_area, buf);
-        if active_cell_area.height > 0 && self.active_exec_cell.is_some() {
+        if !active_cell_area.is_empty()
+            && let Some(cell) = &self.active_exec_cell
+        {
             let mut active_cell_area = active_cell_area;
             active_cell_area.y = active_cell_area.y.saturating_add(1);
             active_cell_area.height -= 1;
-            self.active_exec_cell
-                .as_ref()
-                .unwrap()
-                .render_ref(active_cell_area, buf);
+            cell.render_ref(active_cell_area, buf);
         }
     }
 }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1290,11 +1290,14 @@ impl WidgetRef for &ChatWidget {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
         let [active_cell_area, bottom_pane_area] = self.layout_areas(area);
         (&self.bottom_pane).render(bottom_pane_area, buf);
-        if let Some(cell) = &self.active_exec_cell {
+        if active_cell_area.height > 0 && self.active_exec_cell.is_some() {
             let mut active_cell_area = active_cell_area;
-            active_cell_area.y += 1;
+            active_cell_area.y = active_cell_area.y.saturating_add(1);
             active_cell_area.height -= 1;
-            cell.render_ref(active_cell_area, buf);
+            self.active_exec_cell
+                .as_ref()
+                .unwrap()
+                .render_ref(active_cell_area, buf);
         }
     }
 }


### PR DESCRIPTION
#### Summary
Avoid a potential panic when rendering the active execution cell when the allocated area has zero height.

#### Changes
- Guard rendering with `active_cell_area.height > 0` and presence of `active_exec_cell`.
- Use `saturating_add(1)` for the Y offset to avoid overflow.
- Render via `active_exec_cell.as_ref().unwrap().render_ref(...)` after the explicit `is_some` check.
