### PR TITLE
Add support for AGENTS.local.md files

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1159,15 +1159,19 @@ pub(crate) fn new_status_output(
     };
     lines.push(vec!["  • Sandbox: ".into(), sandbox_name.into()].into());
 
-    // AGENTS.md files discovered via core's project_doc logic
+    // AGENTS files discovered via core's project_doc logic
     let agents_list = {
         match discover_project_doc_paths(config) {
             Ok(paths) => {
                 let mut rels: Vec<String> = Vec::new();
                 for p in paths {
+                    let fname = p
+                        .file_name()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or("AGENTS.md");
                     let display = if let Some(parent) = p.parent() {
                         if parent == config.cwd {
-                            "AGENTS.md".to_string()
+                            fname.to_string()
                         } else {
                             let mut cur = config.cwd.as_path();
                             let mut ups = 0usize;
@@ -1182,7 +1186,7 @@ pub(crate) fn new_status_output(
                             }
                             if reached {
                                 let up = format!("..{}", std::path::MAIN_SEPARATOR);
-                                format!("{}AGENTS.md", up.repeat(ups))
+                                format!("{}{}", up.repeat(ups), fname)
                             } else if let Ok(stripped) = p.strip_prefix(&config.cwd) {
                                 stripped.display().to_string()
                             } else {

--- a/docs/config.md
+++ b/docs/config.md
@@ -576,7 +576,7 @@ This is analogous to `model_context_window`, but for the maximum number of outpu
 
 ## project_doc_max_bytes
 
-Maximum number of bytes to read from an `AGENTS.md` file to include in the instructions sent with the first turn of a session. Defaults to 32 KiB.
+Maximum number of bytes to read from an `AGENTS.md` file (including per‑directory `AGENTS.local.md`) to include in the instructions sent with the first turn of a session. Defaults to 32 KiB.
 
 ## tui
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -61,11 +61,11 @@ Below are a few bite-size examples you can copy-paste. Replace the text in quote
 
 ### Memory with AGENTS.md
 
-You can give Codex extra instructions and guidance using `AGENTS.md` files. Codex looks for `AGENTS.md` files in the following places, and merges them top-down:
+You can give Codex extra instructions and guidance using `AGENTS.md` files. Codex looks for `AGENTS.md` files (and per‑directory overrides named `AGENTS.local.md`) in the following places, and merges them top‑down:
 
 1. `~/.codex/AGENTS.md` - personal global guidance
-2. `AGENTS.md` at repo root - shared project notes
-3. `AGENTS.md` in the current working directory - sub-folder/feature specifics
+2. `AGENTS.md` at repo root (and `AGENTS.local.md` if present) - shared project notes
+3. `AGENTS.md` in the current working directory (and `AGENTS.local.md` if present) - sub‑folder/feature specifics
 
 For more information on how to use AGENTS.md, see the [official AGENTS.md documentation](https://agents.md/).
 


### PR DESCRIPTION
## Related Issue
Related to discussion: This extends the existing AGENTS.md functionality to support local overrides.

## What?
Adds support for AGENTS.local.md files alongside existing AGENTS.md files in project documentation discovery.

## Why?
Allows developers to have local, per-directory configuration files that extend project documentation without modifying shared AGENTS.md files. This enables personal customizations and local development overrides.

## How?
- Extended `CANDIDATE_FILENAMES` to include both `AGENTS.md` and `AGENTS.local.md`
- Modified discovery logic to include all matching files in order (base first, then local)
- Updated TUI display to show both file types when present
- Added comprehensive test coverage for the new functionality
- Updated documentation to reflect the new capability

## Type of Change
- [x] New feature (non-breaking change which adds functionality)

## Testing
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have tested this change manually and it works as expected

## Code Quality Checklist
- [x] I have run all local checks: `cargo test && cargo clippy --tests && cargo fmt -- --config imports_granularity=Item`
- [x] My code follows the existing style and conventions
- [x] I have made corresponding changes to the documentation (if applicable)
- [x] My commits are atomic (each compiles and tests pass)