### PR TITLE
core: restore bullet formatting rule to satisfy instruction validatio…

### DIFF
--- a/codex-rs/core/prompt.md
+++ b/codex-rs/core/prompt.md
@@ -228,6 +228,7 @@ You are producing plain text that will later be styled by the CLI. Follow these 
 **Bullets**
 
 - Use `-` followed by a space for every bullet.
+- Bold the keyword, then colon + concise description.
 - Merge related points when possible; avoid a bullet for every trivial detail.
 - Keep bullets to one line unless breaking for clarity is unavoidable.
 - Group into short lists (4–6 bullets) ordered by importance.


### PR DESCRIPTION
### Summary
- Restore a removed bullet formatting rule to satisfy instruction validation and avoid 400 “Instructions are not valid” responses.

### What
- In `codex-rs/core/prompt.md` under “Bullets,” reintroduce:
  - “Bold the keyword, then colon + concise description.”

### Why
- PR `#3121` removed this line. The Responses API rejects instructions without this formatting guideline, causing 400 errors on first turn (`"Instructions are not valid"`). Restoring it aligns prompt formatting with service-side validation.

### Impact
- Eliminates 400 on first turn after build from main.
- No behavior change to tools or execution; documentation/instructions-only.

### Testing
- Core tests pass.
- Manual: launch TUI and send a message; the 400 error does not appear.

### Files Changed
- `codex-rs/core/prompt.md`

### Related Issues
- Fixes `#3149` (and references `#3121`).