### PR TITLE
fix: use a more efficient wire format for ExecCommandOutputDeltaEvent.chunk

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -923,6 +923,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
+ "serde_with",
  "strum 0.27.2",
  "strum_macros 0.27.2",
  "tracing",

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -26,7 +26,6 @@ use crate::protocol::SandboxPolicy;
 use crate::seatbelt::spawn_command_under_seatbelt;
 use crate::spawn::StdioPolicy;
 use crate::spawn::spawn_child_async;
-use serde_bytes::ByteBuf;
 
 const DEFAULT_TIMEOUT_MS: u64 = 10_000;
 
@@ -369,7 +368,7 @@ async fn read_capped<R: AsyncRead + Unpin + Send + 'static>(
                 } else {
                     ExecOutputStream::Stdout
                 },
-                chunk: ByteBuf::from(chunk),
+                chunk,
             });
             let event = Event {
                 id: stream.sub_id.clone(),

--- a/codex-rs/protocol/Cargo.toml
+++ b/codex-rs/protocol/Cargo.toml
@@ -17,6 +17,7 @@ mime_guess = "2.0.5"
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1"
+serde_with = "3.14.0"
 strum = "0.27.2"
 strum_macros = "0.27.2"
 tracing = "0.1.41"

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -15,7 +15,7 @@ use mcp_types::CallToolResult;
 use mcp_types::Tool as McpTool;
 use serde::Deserialize;
 use serde::Serialize;
-use serde_bytes::ByteBuf;
+use serde_with::serde_as;
 use strum_macros::Display;
 use ts_rs::TS;
 use uuid::Uuid;
@@ -782,14 +782,15 @@ pub enum ExecOutputStream {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde_as]
 pub struct ExecCommandOutputDeltaEvent {
     /// Identifier for the ExecCommandBegin that produced this chunk.
     pub call_id: String,
     /// Which stream produced this chunk.
     pub stream: ExecOutputStream,
     /// Raw bytes from the stream (may not be valid UTF-8).
-    #[serde(with = "serde_bytes")]
-    pub chunk: ByteBuf,
+    #[serde_as(as = "Base64")]
+    pub chunk: Vec<u8>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]


### PR DESCRIPTION
When serializing to JSON, the existing solution created an enormous array of ints, which is far more bytes on the wire than a base64-encoded string would be.