### PR TITLE
chore: add rust-lang.rust-analyzer and vadimcn.vscode-lldb to the list of recommended extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,11 @@
 {
     "recommendations": [
+        "rust-lang.rust-analyzer",
         "tamasfe.even-better-toml",
+        "vadimcn.vscode-lldb",
+
+        // Useful if touching files in .github/workflows, though most
+        // contributors will not be doing that?
+        // "github.vscode-github-actions",
     ]
 }


### PR DESCRIPTION
`rust-lang.rust-analyzer` is clearly something all contributors should install.

`vadimcn.vscode-lldb` is maybe debatable, but I think this is often better that print-debugging.