### PR TITLE
feat(mcp): per-server startup timeout

### DIFF
--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -19,13 +19,12 @@ pub struct McpServerConfig {
     #[serde(default)]
     pub env: Option<HashMap<String, String>>,
 
-    /// Startup timeout in milliseconds for initializing MCP server & initially listing tools
+    /// Startup timeout in milliseconds for initializing MCP server & initially listing tools.
     #[serde(default)]
     pub startup_timeout_ms: Option<u64>,
 }
 
 #[derive(Deserialize, Debug, Copy, Clone, PartialEq)]
-
 pub enum UriBasedFileOpener {
     #[serde(rename = "vscode")]
     VsCode,

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -19,12 +19,13 @@ pub struct McpServerConfig {
     #[serde(default)]
     pub env: Option<HashMap<String, String>>,
 
-    /// Startup timeout in milliseconds for initializing MCP server & initialially listing tools
+    /// Startup timeout in milliseconds for initializing MCP server & initially listing tools
     #[serde(default)]
     pub startup_timeout_ms: Option<u64>,
 }
 
 #[derive(Deserialize, Debug, Copy, Clone, PartialEq)]
+
 pub enum UriBasedFileOpener {
     #[serde(rename = "vscode")]
     VsCode,

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -18,6 +18,10 @@ pub struct McpServerConfig {
 
     #[serde(default)]
     pub env: Option<HashMap<String, String>>,
+
+    /// Timeout in milliseconds for starting the server and listing tools.
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
 }
 
 #[derive(Deserialize, Debug, Copy, Clone, PartialEq)]

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -19,9 +19,9 @@ pub struct McpServerConfig {
     #[serde(default)]
     pub env: Option<HashMap<String, String>>,
 
-    /// Timeout in milliseconds for starting the server and listing tools.
+    /// Startup timeout in milliseconds for initializing MCP server & initialially listing tools
     #[serde(default)]
-    pub timeout_ms: Option<u64>,
+    pub startup_timeout_ms: Option<u64>,
 }
 
 #[derive(Deserialize, Debug, Copy, Clone, PartialEq)]

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -37,7 +37,7 @@ use crate::config_types::McpServerConfig;
 const MCP_TOOL_NAME_DELIMITER: &str = "__";
 const MAX_TOOL_NAME_LENGTH: usize = 64;
 
-/// Default timeout for initializing MCP server & initially listing tools
+/// Default timeout for initializing MCP server & initially listing tools.
 const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Map that holds a startup error for every MCP server that could **not** be

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -257,7 +257,7 @@ async fn list_all_tools(clients: &HashMap<String, ManagedClient>) -> Result<Vec<
     // Spawn one task per server so we can query them concurrently. This
     // keeps the overall latency roughly at the slowest server instead of
     // the cumulative latency.
-    for (server_name, managed_client) in clients.iter() {
+    for (server_name, managed_client) in clients {
         let server_name_cloned = server_name.clone();
         let client_clone = managed_client.client.clone();
         let startup_timeout = managed_client.startup_timeout;

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -172,15 +172,7 @@ impl McpConnectionManager {
                             .await
                         {
                             Ok(_response) => (server_name, Ok((client, timeout))),
-                            Err(e) => {
-                                let (stdout, stderr) = client.output_snippet().await;
-                                let err = anyhow!(
-                                    "initialize failed: {e}\nstdout:\n{}\nstderr:\n{}",
-                                    stdout.join("\n"),
-                                    stderr.join("\n")
-                                );
-                                (server_name, Err(err))
-                            }
+                            Err(e) => (server_name, Err(e)),
                         }
                     }
                     Err(e) => (server_name, Err(e.into())),

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -229,15 +229,14 @@ impl McpConnectionManager {
         arguments: Option<serde_json::Value>,
         timeout: Option<Duration>,
     ) -> Result<mcp_types::CallToolResult> {
-        let managed_client = self
+        let client = self
             .clients
             .get(server)
             .ok_or_else(|| anyhow!("unknown MCP server '{server}'"))?
             .client
             .clone();
 
-        managed_client
-            .client
+        client
             .call_tool(tool.to_string(), arguments, timeout)
             .await
             .with_context(|| format!("tool call failed for `{server}/{tool}`"))

--- a/codex-rs/mcp-client/src/mcp_client.rs
+++ b/codex-rs/mcp-client/src/mcp_client.rs
@@ -12,6 +12,7 @@
 //! issue requests and receive strongly-typed results.
 
 use std::collections::HashMap;
+use std::collections::VecDeque;
 use std::ffi::OsString;
 use std::sync::Arc;
 use std::sync::atomic::AtomicI64;
@@ -56,6 +57,9 @@ use tracing::warn;
 /// client API and the IO tasks.
 const CHANNEL_CAPACITY: usize = 128;
 
+/// How many lines of STDOUT/STDERR output to retain for debugging purposes.
+const CAPTURED_OUTPUT_LINES: usize = 20;
+
 /// Internal representation of a pending request sender.
 type PendingSender = oneshot::Sender<JSONRPCMessage>;
 
@@ -76,6 +80,12 @@ pub struct McpClient {
 
     /// Monotonically increasing counter used to generate request IDs.
     id_counter: AtomicI64,
+
+    /// Ring buffer of the most recent lines read from the server's STDOUT.
+    stdout_log: Arc<Mutex<VecDeque<String>>>,
+
+    /// Ring buffer of the most recent lines read from the server's STDERR.
+    stderr_log: Arc<Mutex<VecDeque<String>>>,
 }
 
 impl McpClient {
@@ -93,7 +103,7 @@ impl McpClient {
             .envs(create_env_for_mcp_server(env))
             .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
-            .stderr(std::process::Stdio::null())
+            .stderr(std::process::Stdio::piped())
             // As noted in the `kill_on_drop` documentation, the Tokio runtime makes
             // a "best effort" to reap-after-exit to avoid zombie processes, but it
             // is not a guarantee.
@@ -108,9 +118,17 @@ impl McpClient {
             .stdout
             .take()
             .ok_or_else(|| std::io::Error::other("failed to capture child stdout"))?;
+        let stderr = child
+            .stderr
+            .take()
+            .ok_or_else(|| std::io::Error::other("failed to capture child stderr"))?;
 
         let (outgoing_tx, mut outgoing_rx) = mpsc::channel::<JSONRPCMessage>(CHANNEL_CAPACITY);
         let pending: Arc<Mutex<HashMap<i64, PendingSender>>> = Arc::new(Mutex::new(HashMap::new()));
+        let stdout_log: Arc<Mutex<VecDeque<String>>> =
+            Arc::new(Mutex::new(VecDeque::with_capacity(CAPTURED_OUTPUT_LINES)));
+        let stderr_log: Arc<Mutex<VecDeque<String>>> =
+            Arc::new(Mutex::new(VecDeque::with_capacity(CAPTURED_OUTPUT_LINES)));
 
         // Spawn writer task. It listens on the `outgoing_rx` channel and
         // writes messages to the child's STDIN.
@@ -141,10 +159,18 @@ impl McpClient {
         // STDOUT and dispatches responses to the pending map.
         let reader_handle = {
             let pending = pending.clone();
+            let stdout_log = stdout_log.clone();
             let mut lines = BufReader::new(stdout).lines();
 
             tokio::spawn(async move {
                 while let Ok(Some(line)) = lines.next_line().await {
+                    {
+                        let mut log = stdout_log.lock().await;
+                        if log.len() == CAPTURED_OUTPUT_LINES {
+                            log.pop_front();
+                        }
+                        log.push_back(line.clone());
+                    }
                     debug!("MCP message from server: {line}");
                     match serde_json::from_str::<JSONRPCMessage>(&line) {
                         Ok(JSONRPCMessage::Response(resp)) => {
@@ -170,17 +196,37 @@ impl McpClient {
             })
         };
 
+        let stderr_handle = {
+            let stderr_log = stderr_log.clone();
+            let mut lines = BufReader::new(stderr).lines();
+
+            tokio::spawn(async move {
+                while let Ok(Some(line)) = lines.next_line().await {
+                    {
+                        let mut log = stderr_log.lock().await;
+                        if log.len() == CAPTURED_OUTPUT_LINES {
+                            log.pop_front();
+                        }
+                        log.push_back(line.clone());
+                    }
+                    debug!("MCP stderr from server: {line}");
+                }
+            })
+        };
+
         // We intentionally *detach* the tasks. They will keep running in the
         // background as long as their respective resources (channels/stdin/
-        // stdout) are alive. Dropping `McpClient` cancels the tasks due to
+        // stdout/stderr) are alive. Dropping `McpClient` cancels the tasks due to
         // dropped resources.
-        let _ = (writer_handle, reader_handle);
+        let _ = (writer_handle, reader_handle, stderr_handle);
 
         Ok(Self {
             child,
             outgoing_tx,
             pending,
             id_counter: AtomicI64::new(1),
+            stdout_log,
+            stderr_log,
         })
     }
 
@@ -345,6 +391,20 @@ impl McpClient {
         let params = CallToolRequestParams { name, arguments };
         debug!("MCP tool call: {params:?}");
         self.send_request::<CallToolRequest>(params, timeout).await
+    }
+
+    /// Return the most recent lines of STDOUT and STDERR produced by the
+    /// server. The buffers are limited to `CAPTURED_OUTPUT_LINES` lines each.
+    pub async fn output_snippet(&self) -> (Vec<String>, Vec<String>) {
+        let stdout = {
+            let guard = self.stdout_log.lock().await;
+            guard.iter().cloned().collect()
+        };
+        let stderr = {
+            let guard = self.stderr_log.lock().await;
+            guard.iter().cloned().collect()
+        };
+        (stdout, stderr)
     }
 
     /// Internal helper: route a JSON-RPC *response* object to the pending map.

--- a/docs/config.md
+++ b/docs/config.md
@@ -336,7 +336,7 @@ Defines the list of MCP servers that Codex can consult for tool use. Currently, 
 
 **Note:** Codex may cache the list of tools and resources from an MCP server so that Codex can include this information in context at startup without spawning all the servers. This is designed to save resources by loading MCP servers lazily.
 
-Each server may set `startup_timeout_ms` to adjust how long Codex waits for it to start and respond to a tools listing. The default is `10000` (10 seconds).
+Each server may set `startup_timeout_ms` to adjust how long Codex waits for it to start and respond to a tools listing. The default is `10_000` (10 seconds).
 
 This config option is comparable to how Claude and Cursor define `mcpServers` in their respective JSON config files, though because Codex uses TOML for its config language, the format is slightly different. For example, the following config in JSON:
 
@@ -363,7 +363,7 @@ command = "npx"
 args = ["-y", "mcp-server"]
 env = { "API_KEY" = "value" }
 # Optional: override the default 10s startup timeout
-startup_timeout_ms = 20000
+startup_timeout_ms = 20_000
 ```
 
 ## disable_response_storage
@@ -588,7 +588,7 @@ Options that are specific to the TUI.
 | `mcp_servers.<id>.command` | string | MCP server launcher command. |
 | `mcp_servers.<id>.args` | array<string> | MCP server args. |
 | `mcp_servers.<id>.env` | map<string,string> | MCP server env vars. |
-| `mcp_servers.<id>.startup_timeout_ms` | number | Startup timeout in milliseconds (default: 10000). Timeout is applied both for initializing MCP server and initially listing tools. |
+| `mcp_servers.<id>.startup_timeout_ms` | number | Startup timeout in milliseconds (default: 10_000). Timeout is applied both for initializing MCP server and initially listing tools. |
 | `model_providers.<id>.name` | string | Display name. |
 | `model_providers.<id>.base_url` | string | API base URL. |
 | `model_providers.<id>.env_key` | string | Env var for API key. |

--- a/docs/config.md
+++ b/docs/config.md
@@ -336,7 +336,7 @@ Defines the list of MCP servers that Codex can consult for tool use. Currently, 
 
 **Note:** Codex may cache the list of tools and resources from an MCP server so that Codex can include this information in context at startup without spawning all the servers. This is designed to save resources by loading MCP servers lazily.
 
-Each server may set `timeout_ms` to adjust how long Codex waits for it to start and respond to a tools listing. The default is `10000` (10 seconds).
+Each server may set `startup_timeout_ms` to adjust how long Codex waits for it to start and respond to a tools listing. The default is `10000` (10 seconds).
 
 This config option is comparable to how Claude and Cursor define `mcpServers` in their respective JSON config files, though because Codex uses TOML for its config language, the format is slightly different. For example, the following config in JSON:
 
@@ -363,7 +363,7 @@ command = "npx"
 args = ["-y", "mcp-server"]
 env = { "API_KEY" = "value" }
 # Optional: override the default 10s startup timeout
-timeout_ms = 20000
+startup_timeout_ms = 20000
 ```
 
 ## disable_response_storage

--- a/docs/config.md
+++ b/docs/config.md
@@ -336,6 +336,8 @@ Defines the list of MCP servers that Codex can consult for tool use. Currently, 
 
 **Note:** Codex may cache the list of tools and resources from an MCP server so that Codex can include this information in context at startup without spawning all the servers. This is designed to save resources by loading MCP servers lazily.
 
+Each server may set `timeout_ms` to adjust how long Codex waits for it to start and respond to a tools listing. The default is `10000` (10 seconds).
+
 This config option is comparable to how Claude and Cursor define `mcpServers` in their respective JSON config files, though because Codex uses TOML for its config language, the format is slightly different. For example, the following config in JSON:
 
 ```json
@@ -360,6 +362,8 @@ Should be represented as follows in `~/.codex/config.toml`:
 command = "npx"
 args = ["-y", "mcp-server"]
 env = { "API_KEY" = "value" }
+# Optional: override the default 10s startup timeout
+timeout_ms = 20000
 ```
 
 ## disable_response_storage
@@ -584,6 +588,7 @@ Options that are specific to the TUI.
 | `mcp_servers.<id>.command` | string | MCP server launcher command. |
 | `mcp_servers.<id>.args` | array<string> | MCP server args. |
 | `mcp_servers.<id>.env` | map<string,string> | MCP server env vars. |
+| `mcp_servers.<id>.timeout_ms` | number | Startup timeout in milliseconds (default: 10000). |
 | `model_providers.<id>.name` | string | Display name. |
 | `model_providers.<id>.base_url` | string | API base URL. |
 | `model_providers.<id>.env_key` | string | Env var for API key. |

--- a/docs/config.md
+++ b/docs/config.md
@@ -588,7 +588,7 @@ Options that are specific to the TUI.
 | `mcp_servers.<id>.command` | string | MCP server launcher command. |
 | `mcp_servers.<id>.args` | array<string> | MCP server args. |
 | `mcp_servers.<id>.env` | map<string,string> | MCP server env vars. |
-| `mcp_servers.<id>.timeout_ms` | number | Startup timeout in milliseconds (default: 10000). |
+| `mcp_servers.<id>.startup_timeout_ms` | number | Startup timeout in milliseconds (default: 10000). Timeout is applied both for initializing MCP server and initially listing tools. |
 | `model_providers.<id>.name` | string | Display name. |
 | `model_providers.<id>.base_url` | string | API base URL. |
 | `model_providers.<id>.env_key` | string | Env var for API key. |


### PR DESCRIPTION
Seeing timeouts on certain, slow mcp server starting up when codex is invoked. Before this change, the timeout was a hard-coded 10s. Need the ability to define arbitrary timeouts on a per-server basis.

## Summary of changes

- Add startup_timeout_ms to McpServerConfig with 10s default when unset
- Use per-server timeout for initialize and tools/list
- Introduce ManagedClient to store client and timeout; rename LIST_TOOLS_TIMEOUT to DEFAULT_STARTUP_TIMEOUT
- Update docs to document startup_timeout_ms with example and options table
