### PR TITLE
ZSH on UNIX system and better detection

### DIFF
--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -10,6 +10,12 @@ pub struct ZshShell {
 }
 
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
+pub struct BashShell {
+    shell_path: String,
+    bashrc_path: String,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub struct PowerShellConfig {
     exe: String, // Executable name or path, e.g. "pwsh" or "powershell.exe".
     bash_exe_fallback: Option<PathBuf>, // In case the model generates a bash command.
@@ -18,6 +24,7 @@ pub struct PowerShellConfig {
 #[derive(Debug, PartialEq, Eq, Clone, Serialize, Deserialize)]
 pub enum Shell {
     Zsh(ZshShell),
+    Bash(BashShell),
     PowerShell(PowerShellConfig),
     Unknown,
 }
@@ -26,22 +33,10 @@ impl Shell {
     pub fn format_default_shell_invocation(&self, command: Vec<String>) -> Option<Vec<String>> {
         match self {
             Shell::Zsh(zsh) => {
-                if !std::path::Path::new(&zsh.zshrc_path).exists() {
-                    return None;
-                }
-
-                let mut result = vec![zsh.shell_path.clone()];
-                result.push("-lc".to_string());
-
-                let joined = strip_bash_lc(&command)
-                    .or_else(|| shlex::try_join(command.iter().map(|s| s.as_str())).ok());
-
-                if let Some(joined) = joined {
-                    result.push(format!("source {} && ({joined})", zsh.zshrc_path));
-                } else {
-                    return None;
-                }
-                Some(result)
+                format_shell_invocation_with_rc(&command, &zsh.shell_path, &zsh.zshrc_path)
+            }
+            Shell::Bash(bash) => {
+                format_shell_invocation_with_rc(&command, &bash.shell_path, &bash.bashrc_path)
             }
             Shell::PowerShell(ps) => {
                 // If model generated a bash command, prefer a detected bash fallback
@@ -97,10 +92,33 @@ impl Shell {
             Shell::Zsh(zsh) => std::path::Path::new(&zsh.shell_path)
                 .file_name()
                 .map(|s| s.to_string_lossy().to_string()),
+            Shell::Bash(bash) => std::path::Path::new(&bash.shell_path)
+                .file_name()
+                .map(|s| s.to_string_lossy().to_string()),
             Shell::PowerShell(ps) => Some(ps.exe.clone()),
             Shell::Unknown => None,
         }
     }
+}
+
+fn format_shell_invocation_with_rc(
+    command: &Vec<String>,
+    shell_path: &str,
+    rc_path: &str,
+) -> Option<Vec<String>> {
+    if !std::path::Path::new(rc_path).exists() {
+        return None;
+    }
+
+    let mut result = vec![shell_path.to_string()];
+    result.push("-lc".to_string());
+
+    let joined = strip_bash_lc(command)
+        .or_else(|| shlex::try_join(command.iter().map(|s| s.as_str())).ok())?;
+
+    result.push(format!("source {rc_path} && ({joined})"));
+
+    Some(result)
 }
 
 fn strip_bash_lc(command: &Vec<String>) -> Option<String> {
@@ -116,7 +134,8 @@ fn strip_bash_lc(command: &Vec<String>) -> Option<String> {
     }
 }
 
-fn get_zsh_shell() -> Option<ZshShell> {
+#[cfg(unix)]
+fn detect_default_user_shell() -> Shell {
     use libc::getpwuid;
     use libc::getuid;
     use std::ffi::CStr;
@@ -129,66 +148,29 @@ fn get_zsh_shell() -> Option<ZshShell> {
             let shell_path = CStr::from_ptr((*pw).pw_shell)
                 .to_string_lossy()
                 .into_owned();
+            let home_path = CStr::from_ptr((*pw).pw_dir).to_string_lossy().into_owned();
 
             if shell_path.contains("zsh") {
-                let home_path = CStr::from_ptr((*pw).pw_dir).to_string_lossy().into_owned();
-
-                return Some(ZshShell {
+                return Shell::Zsh(ZshShell {
                     shell_path,
                     zshrc_path: format!("{home_path}/.zshrc"),
                 });
             }
-        }
-    }
-    None
-}
 
-#[cfg(target_os = "macos")]
-pub async fn default_user_shell() -> Shell {
-    use tokio::process::Command;
-    use whoami;
-
-    let user = whoami::username();
-    let home = format!("/Users/{user}");
-
-    if let Some(zsh) = get_zsh_shell() {
-        return Shell::Zsh(zsh);
-    }
-
-    let output = Command::new("dscl")
-        .args([".", "-read", &home, "UserShell"])
-        .output()
-        .await
-        .ok();
-    match output {
-        Some(o) => {
-            if !o.status.success() {
-                return Shell::Unknown;
+            if shell_path.contains("bash") {
+                return Shell::Bash(BashShell {
+                    shell_path,
+                    bashrc_path: format!("{home_path}/.bashrc"),
+                });
             }
-            let stdout = String::from_utf8_lossy(&o.stdout);
-            for line in stdout.lines() {
-                if let Some(shell_path) = line.strip_prefix("UserShell: ")
-                    && shell_path.ends_with("/zsh")
-                {
-                    return Shell::Zsh(ZshShell {
-                        shell_path: shell_path.to_string(),
-                        zshrc_path: format!("{home}/.zshrc"),
-                    });
-                }
-            }
-
-            Shell::Unknown
         }
-        _ => Shell::Unknown,
-    }
-}
-
-#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
-pub async fn default_user_shell() -> Shell {
-    if let Some(zsh) = get_zsh_shell() {
-        return Shell::Zsh(zsh);
     }
     Shell::Unknown
+}
+
+#[cfg(unix)]
+pub async fn default_user_shell() -> Shell {
+    detect_default_user_shell()
 }
 
 #[cfg(target_os = "windows")]
@@ -231,6 +213,11 @@ pub async fn default_user_shell() -> Shell {
     }
 }
 
+#[cfg(all(not(target_os = "windows"), not(unix)))]
+pub async fn default_user_shell() -> Shell {
+    Shell::Unknown
+}
+
 #[cfg(test)]
 #[cfg(target_os = "macos")]
 mod tests {
@@ -263,6 +250,16 @@ mod tests {
         let shell = Shell::Zsh(ZshShell {
             shell_path: "/bin/zsh".to_string(),
             zshrc_path: "/does/not/exist/.zshrc".to_string(),
+        });
+        let actual_cmd = shell.format_default_shell_invocation(vec!["myecho".to_string()]);
+        assert_eq!(actual_cmd, None);
+    }
+
+    #[tokio::test]
+    async fn test_run_with_profile_bashrc_not_exists() {
+        let shell = Shell::Bash(BashShell {
+            shell_path: "/bin/bash".to_string(),
+            bashrc_path: "/does/not/exist/.bashrc".to_string(),
         });
         let actual_cmd = shell.format_default_shell_invocation(vec!["myecho".to_string()]);
         assert_eq!(actual_cmd, None);
@@ -341,6 +338,94 @@ mod tests {
 
             assert_eq!(actual_cmd, Some(expected_cmd));
             // Actually run the command and check output/exit code
+            let output = process_exec_tool_call(
+                ExecParams {
+                    command: actual_cmd.unwrap(),
+                    cwd: PathBuf::from(temp_home.path()),
+                    timeout_ms: None,
+                    env: HashMap::from([(
+                        "HOME".to_string(),
+                        temp_home.path().to_str().unwrap().to_string(),
+                    )]),
+                    with_escalated_permissions: None,
+                    justification: None,
+                },
+                SandboxType::None,
+                &SandboxPolicy::DangerFullAccess,
+                &None,
+                None,
+            )
+            .await
+            .unwrap();
+
+            assert_eq!(output.exit_code, 0, "input: {input:?} output: {output:?}");
+            if let Some(expected) = expected_output {
+                assert_eq!(
+                    output.stdout.text, expected,
+                    "input: {input:?} output: {output:?}"
+                );
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn test_run_with_profile_bash_escaping_and_execution() {
+        let shell_path = "/bin/bash";
+
+        let cases = vec![
+            (
+                vec!["myecho"],
+                vec![shell_path, "-lc", "source BASHRC_PATH && (myecho)"],
+                Some("It works!\n"),
+            ),
+            (
+                vec!["bash", "-lc", "echo 'single' \"double\""],
+                vec![
+                    shell_path,
+                    "-lc",
+                    "source BASHRC_PATH && (echo 'single' \"double\")",
+                ],
+                Some("single double\n"),
+            ),
+        ];
+
+        for (input, expected_cmd, expected_output) in cases {
+            use std::collections::HashMap;
+
+            use crate::exec::ExecParams;
+            use crate::exec::SandboxType;
+            use crate::exec::process_exec_tool_call;
+            use crate::protocol::SandboxPolicy;
+
+            let temp_home = tempfile::tempdir().unwrap();
+            let bashrc_path = temp_home.path().join(".bashrc");
+            std::fs::write(
+                &bashrc_path,
+                r#"
+                    set -x
+                    function myecho {
+                        echo 'It works!'
+                    }
+                    "#,
+            )
+            .unwrap();
+            let shell = Shell::Bash(BashShell {
+                shell_path: shell_path.to_string(),
+                bashrc_path: bashrc_path.to_str().unwrap().to_string(),
+            });
+
+            let actual_cmd = shell
+                .format_default_shell_invocation(input.iter().map(|s| s.to_string()).collect());
+            let expected_cmd = expected_cmd
+                .iter()
+                .map(|s| {
+                    s.replace("BASHRC_PATH", bashrc_path.to_str().unwrap())
+                        .to_string()
+                })
+                .collect();
+
+            assert_eq!(actual_cmd, Some(expected_cmd));
+
             let output = process_exec_tool_call(
                 ExecParams {
                     command: actual_cmd.unwrap(),


### PR DESCRIPTION
* Update the shell detection of UNIX systems
* Add support for `bash` shells
* Add support for `zsh` on UNIX system

Globally, reduce the specificity of MacOS code by considering it as a UNIX system for shell detection