### PR TITLE
refactor: remove AttachImage tui event

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -183,15 +183,6 @@ impl App {
                         },
                     )?;
                 }
-                TuiEvent::AttachImage {
-                    path,
-                    width,
-                    height,
-                    format_label,
-                } => {
-                    self.chat_widget
-                        .attach_image(path, width, height, format_label);
-                }
             }
         }
         Ok(true)

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -57,6 +57,7 @@ use crate::bottom_pane::CancellationEvent;
 use crate::bottom_pane::InputResult;
 use crate::bottom_pane::SelectionAction;
 use crate::bottom_pane::SelectionItem;
+use crate::clipboard_paste::paste_image_to_temp_png;
 use crate::get_git_diff::get_git_diff;
 use crate::history_cell;
 use crate::history_cell::CommandOutput;
@@ -741,6 +742,17 @@ impl ChatWidget {
                 ..
             } => {
                 self.on_ctrl_c();
+                return;
+            }
+            KeyEvent {
+                code: KeyCode::Char('v'),
+                modifiers: KeyModifiers::CONTROL,
+                kind: KeyEventKind::Press,
+                ..
+            } => {
+                if let Ok((path, info)) = paste_image_to_temp_png() {
+                    self.attach_image(path, info.width, info.height, info.encoded_format.label());
+                }
                 return;
             }
             other if other.kind == KeyEventKind::Press => {


### PR DESCRIPTION
TuiEvent is supposed to be purely events that come from the "driver", i.e. events from the terminal. Everything app-specific should be an AppEvent. In this case, it didn't need to be an event at all.