### PR TITLE
core: Fix 400 'Instructions are not valid' with ChatGPT

### DIFF
--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -38,7 +38,7 @@ pub(crate) async fn stream_chat_completions(
     // Build messages array
     let mut messages = Vec::<serde_json::Value>::new();
 
-    let full_instructions = prompt.get_full_instructions(model_family);
+    let full_instructions = prompt.get_full_instructions(model_family, true, false);
     messages.push(json!({"role": "system", "content": full_instructions}));
 
     let input = prompt.get_formatted_input();


### PR DESCRIPTION
Fix this bug
https://github.com/openai/codex/issues/3202



- Rebuild instructions per attempt based on current auth mode
- Ignore overrides and skip apply_patch text for ChatGPT
- Add single fallback retry with built-in instructions only
- Extend Prompt::get_full_instructions to allow ignoring overrides
- Update Responses/ChatCompletions call sites and tests

