### PR TITLE
Added CLI version to `/status` output

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -950,6 +950,12 @@ pub(crate) fn new_status_output(
 
     lines.push("".into());
 
+    // 💻 Client
+    let cli_version = env!("CARGO_PKG_VERSION");
+    lines.push(vec![padded_emoji("💻").into(), "Client".bold()].into());
+    lines.push(vec!["  • CLI Version: ".into(), cli_version.into()].into());
+    lines.push("".into());
+
     // 📊 Token Usage
     lines.push(vec!["📊 ".into(), "Token Usage".bold()].into());
     if let Some(session_id) = session_id {

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -951,7 +951,7 @@ pub(crate) fn new_status_output(
     lines.push("".into());
 
     // 💻 Client
-    let cli_version = env!("CARGO_PKG_VERSION");
+    let cli_version = crate::version::current_version();
     lines.push(vec![padded_emoji("💻").into(), "Client".bold()].into());
     lines.push(vec!["  • CLI Version: ".into(), cli_version.into()].into());
     lines.push("".into());

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -951,7 +951,7 @@ pub(crate) fn new_status_output(
     lines.push("".into());
 
     // 💻 Client
-    let cli_version = crate::version::current_version();
+    let cli_version = crate::version::CODEX_CLI_VERSION;
     lines.push(vec![padded_emoji("💻").into(), "Client".bold()].into());
     lines.push(vec!["  • CLI Version: ".into(), cli_version.into()].into());
     lines.push("".into());

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -58,6 +58,7 @@ mod streaming;
 mod text_formatting;
 mod tui;
 mod user_approval_widget;
+mod version;
 mod wrapping;
 
 // Internal vt100-based replay tests live as a separate source file to keep them

--- a/codex-rs/tui/src/updates.rs
+++ b/codex-rs/tui/src/updates.rs
@@ -11,7 +11,7 @@ use std::path::PathBuf;
 use codex_core::config::Config;
 use codex_core::default_client::create_client;
 
-use crate::version::current_version;
+use crate::version::CODEX_CLI_VERSION;
 
 pub fn get_upgrade_version(config: &Config) -> Option<String> {
     let version_file = version_filepath(config);
@@ -33,8 +33,7 @@ pub fn get_upgrade_version(config: &Config) -> Option<String> {
     }
 
     info.and_then(|info| {
-        let current_version = current_version();
-        if is_newer(&info.latest_version, current_version).unwrap_or(false) {
+        if is_newer(&info.latest_version, CODEX_CLI_VERSION).unwrap_or(false) {
             Some(info.latest_version)
         } else {
             None

--- a/codex-rs/tui/src/updates.rs
+++ b/codex-rs/tui/src/updates.rs
@@ -11,6 +11,8 @@ use std::path::PathBuf;
 use codex_core::config::Config;
 use codex_core::default_client::create_client;
 
+use crate::version::current_version;
+
 pub fn get_upgrade_version(config: &Config) -> Option<String> {
     let version_file = version_filepath(config);
     let info = read_version_info(&version_file).ok();
@@ -31,7 +33,7 @@ pub fn get_upgrade_version(config: &Config) -> Option<String> {
     }
 
     info.and_then(|info| {
-        let current_version = env!("CARGO_PKG_VERSION");
+        let current_version = current_version();
         if is_newer(&info.latest_version, current_version).unwrap_or(false) {
             Some(info.latest_version)
         } else {

--- a/codex-rs/tui/src/version.rs
+++ b/codex-rs/tui/src/version.rs
@@ -1,0 +1,14 @@
+/// Returns the current Codex CLI version as embedded at compile time.
+pub fn current_version() -> &'static str {
+    env!("CARGO_PKG_VERSION")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn current_version_matches_env() {
+        assert_eq!(current_version(), env!("CARGO_PKG_VERSION"));
+    }
+}

--- a/codex-rs/tui/src/version.rs
+++ b/codex-rs/tui/src/version.rs
@@ -1,14 +1,2 @@
-/// Returns the current Codex CLI version as embedded at compile time.
-pub fn current_version() -> &'static str {
-    env!("CARGO_PKG_VERSION")
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn current_version_matches_env() {
-        assert_eq!(current_version(), env!("CARGO_PKG_VERSION"));
-    }
-}
+/// The current Codex CLI version as embedded at compile time.
+pub const CODEX_CLI_VERSION: &str = env!("CARGO_PKG_VERSION");


### PR DESCRIPTION
This PR adds the CLI version to the `/status` output.

This addresses feature request #2767