### PR TITLE
Issue #3216

### DIFF
--- a/codex-rs/core/src/default_client.rs
+++ b/codex-rs/core/src/default_client.rs
@@ -28,6 +28,7 @@ pub fn create_client(originator: &str) -> reqwest::Client {
         // Set UA via dedicated helper to avoid header validation pitfalls
         .user_agent(ua)
         .default_headers(headers)
+        .pool_max_idle_per_host(0)
         .build()
     {
         Ok(client) => client,


### PR DESCRIPTION
Summary
Ensure every Codex invocation uses a fresh HTTP connection by disabling reqwest’s connection pooling with pool_max_idle_per_host(0), preventing infinite reuse loops when codex exec is launched from within Codex
Testing
✅ cargo clippy -p codex-core
⚠️ cargo test -p codex-core (failed: called Result::unwrap() on an Err value: NotPresent – missing required environment variable)
⚠️ cargo test --all-features (failed: called Result::unwrap() on an Err value: NotPresent – missing required environment variable)