### PR TITLE
fix #2897: add authentication check before network requests to prevent unnecessary retries

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -140,6 +140,7 @@ impl ModelClient {
     }
 
     pub async fn stream(&self, prompt: &Prompt) -> Result<ResponseStream> {
+        self.ensure_authenticate()?;
         match self.provider.wire_api {
             WireApi::Responses => self.stream_responses(prompt).await,
             WireApi::Chat => {
@@ -180,6 +181,43 @@ impl ModelClient {
                 Ok(ResponseStream { rx_event: rx })
             }
         }
+    }
+
+    fn ensure_authenticate(&self) -> Result<()> {
+        if let Some(_path) = &*CODEX_RS_SSE_FIXTURE {
+            return Ok(());
+        }
+
+        // If this provider requires OpenAI-style auth, ensure we have credentials before
+        // attempting any network calls. This prevents long retries and surfaces a clear
+        // error immediately when the user is not logged in or has no API key configured.
+        if self.provider.requires_openai_auth {
+            // Check for an API key provided via provider-specific env var, if any.
+            let api_key_available = match self.provider.api_key() {
+                Ok(Some(_)) => true,
+                Ok(None) => crate::auth::read_openai_api_key_from_env().is_some(),
+                // If the provider declares an env var but it's missing, we still allow
+                // proceeding when a ChatGPT-style auth is available; otherwise, bubble
+                // the env-var guidance up to the caller.
+                Err(err) => {
+                    let has_auth = self.auth_manager.as_ref().and_then(|m| m.auth()).is_some();
+                    if has_auth {
+                        false
+                    } else {
+                        return Err(err);
+                    }
+                }
+            };
+
+            // Otherwise, check whether the session has an auth token (ChatGPT/API key via AuthManager).
+            let has_auth =
+                api_key_available || self.auth_manager.as_ref().and_then(|m| m.auth()).is_some();
+
+            if !has_auth {
+                return Err(crate::error::CodexErr::NotAuthenticated);
+            }
+        }
+        Ok(())
     }
 
     /// Implementation for the OpenAI *Responses* experimental API.

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1928,6 +1928,7 @@ async fn run_turn(
                 return Err(CodexErr::UsageLimitReached(e));
             }
             Err(CodexErr::UsageNotIncluded) => return Err(CodexErr::UsageNotIncluded),
+            Err(CodexErr::NotAuthenticated) => return Err(CodexErr::NotAuthenticated),
             Err(e) => {
                 // Use the configured provider-specific stream retry budget.
                 let max_retries = turn_context.client.get_provider().stream_max_retries();

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -121,6 +121,11 @@ pub enum CodexErr {
     #[error("{0}")]
     RetryLimit(RetryLimitReachedError),
 
+    /// Attempted to send a message to a provider that requires authentication
+    /// while no credentials were available (neither API key nor ChatGPT token).
+    #[error("not authenticated: please log in (run `codex login`) or set an API key")]
+    NotAuthenticated,
+
     /// Agent loop died unexpectedly
     #[error("internal error; agent loop died unexpectedly")]
     InternalAgentDied,


### PR DESCRIPTION
# What I Changed

1. Early auth guard in codex-core: Added CodexErr::NotAuthenticated with a clear message: "not authenticated: please log in (run codex login) or set an API key".
2. Auth preflight in stream(): In codex_core::client::ModelClient::stream, added a preflight check for providers that require authentication:
   - If a provider-specific API key env var is present, proceed
   - Else, if an AuthManager token exists, proceed
   - Else:
     - If the provider declared a required env var but it's missing, return that precise EnvVar error
     - Otherwise, return NotAuthenticated immediately (no HTTP attempts, no retries)
3. Non-retryable error handling: In codex_core::codex::run_turn, treated NotAuthenticated as non-retryable (same as EnvVar), so the agent does not sit in "Working" and repeatedly retry.

## Why This Fix Issue

Previously, when not logged in, requests would still be attempted, leading to a prolonged "Working" state. Now, if you press Ctrl+C on the login screen and try to send a message without being authenticated, Codex returns an error immediately, avoiding the infinite "Working" loop.

## Files Touched

- codex-rs/core/src/error.rs: Added NotAuthenticated error variant.
- codex-rs/core/src/client.rs: Added auth preflight in stream().
- codex-rs/core/src/codex.rs: Marked NotAuthenticated as non‑retryable in run_turn.