### PR TITLE
tui: preserve AltGr (Ctrl+Alt) printable chars on Windows when typing and during paste burst

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -45,6 +45,18 @@ use std::path::PathBuf;
 use std::time::Duration;
 use std::time::Instant;
 
+#[cfg(windows)]
+#[inline]
+fn is_altgr(mods: KeyModifiers) -> bool {
+    mods.contains(KeyModifiers::ALT) && mods.contains(KeyModifiers::CONTROL)
+}
+
+#[cfg(not(windows))]
+#[inline]
+fn is_altgr(_mods: KeyModifiers) -> bool {
+    false
+}
+
 /// If the pasted content exceeds this number of characters, replace it with a
 /// placeholder in the UI.
 const LARGE_PASTE_CHAR_THRESHOLD: usize = 1000;
@@ -881,9 +893,12 @@ impl ChatComposer {
             ..
         } = input
         {
-            let has_ctrl_or_alt =
-                modifiers.contains(KeyModifiers::CONTROL) || modifiers.contains(KeyModifiers::ALT);
-            if !has_ctrl_or_alt {
+            // Treat Windows AltGr (ALT|CONTROL) as a plain char to preserve symbols
+            // like backslash, backtick, brackets, etc., when typing or pasting.
+            let is_plain_char = (!modifiers.contains(KeyModifiers::CONTROL)
+                && !modifiers.contains(KeyModifiers::ALT))
+                || is_altgr(modifiers);
+            if is_plain_char {
                 // Non-ASCII characters (e.g., from IMEs) can arrive in quick bursts and be
                 // misclassified by paste heuristics. Flush any active burst buffer and insert
                 // non-ASCII characters directly.
@@ -952,9 +967,11 @@ impl ChatComposer {
         } = input;
         match code {
             KeyCode::Char(_) => {
-                let has_ctrl_or_alt = modifiers.contains(KeyModifiers::CONTROL)
-                    || modifiers.contains(KeyModifiers::ALT);
-                if has_ctrl_or_alt {
+                // Treat Windows AltGr (ALT|CONTROL) as a plain char: keep burst window.
+                let is_plain_char = (!modifiers.contains(KeyModifiers::CONTROL)
+                    && !modifiers.contains(KeyModifiers::ALT))
+                    || is_altgr(modifiers);
+                if !is_plain_char {
                     self.paste_burst.clear_window_after_non_char();
                 }
             }

--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -14,6 +14,18 @@ use textwrap::Options;
 use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
+#[cfg(windows)]
+#[inline]
+fn is_altgr(mods: KeyModifiers) -> bool {
+    mods.contains(KeyModifiers::ALT) && mods.contains(KeyModifiers::CONTROL)
+}
+
+#[cfg(not(windows))]
+#[inline]
+fn is_altgr(_mods: KeyModifiers) -> bool {
+    false
+}
+
 #[derive(Debug, Clone)]
 struct TextElement {
     range: Range<usize>,
@@ -222,6 +234,12 @@ impl TextArea {
                 modifiers: KeyModifiers::NONE | KeyModifiers::SHIFT,
                 ..
             } => self.insert_str(&c.to_string()),
+            // Windows AltGr generates ALT|CONTROL; treat as a plain character input
+            KeyEvent {
+                code: KeyCode::Char(c),
+                modifiers,
+                ..
+            } if is_altgr(modifiers) => self.insert_str(&c.to_string()),
             KeyEvent {
                 code: KeyCode::Char('j' | 'm'),
                 modifiers: KeyModifiers::CONTROL,


### PR DESCRIPTION
<img width="1645" height="708" alt="{A162F2BD-63D6-4097-B4F8-CF7CFAFFF6A6}" src="https://github.com/user-attachments/assets/d5c3aedb-d233-4254-9b30-51b411ea2476" />

#

Summary
- Fixes lost characters produced via AltGr on Windows (e.g., \, `, >, ^, #, [, ], {, }, |, ~) in the TUI prompt. Also preserves Windows paths like C:\Users\… during non‑bracketed paste/fast typing.

What
- Add a Windows‑only AltGr detector (ALT|CONTROL).
- TextArea: treat KeyCode::Char with ALT|CONTROL as ordinary input on Windows and insert directly.
- ChatComposer: treat AltGr as a “plain char” for paste‑burst heuristics, so AltGr characters are buffered and flushed like normal keystrokes; keep the burst window instead of clearing it.

Why
- On Windows, terminals report AltGr as Ctrl+Alt. Historically, the input path skipped Char events with Ctrl/Alt to preserve meta bindings (Alt+f/Alt+b), which dropped AltGr characters when typing or pasting (non‑bracketed). This affected common scenarios like pasting Windows paths.

Impact
- Windows: characters typed/pasted via AltGr are preserved; Windows paths retain backslashes.
- macOS/Linux: unchanged. The AltGr handling is gated by cfg(windows) and meta bindings like Alt+f/Alt+b continue to work.

Notes
- Complements #3154 (which fixes AltGr insertion in TextArea). This PR additionally addresses paste‑burst handling so fast bursts of AltGr characters are not filtered out.
- Alt+Backspace remains the word‑delete gesture. On Windows, AltGr+h produces a character; the dedicated word‑delete gesture still exists via Alt+Backspace.

Validation
- cargo fmt in codex-rs completes.
- Manual checks on Windows:
  - Type and paste characters: \, `, >, ^, #, [, ], {, }, |, ~.
  - Paste a Windows path (C:\Users\matej\Desktop\html-test) into the prompt, verify backslashes are preserved.
- Scope: TUI only; does not alter macOS/Linux code paths.

Files Changed
- codex-rs/tui/src/bottom_pane/textarea.rs
- codex-rs/tui/src/bottom_pane/chat_composer.rs