### PR TITLE
feat: add MCP tool filtering with exclude_tools and include_tools

### DIFF
--- a/codex-rs/core/tests/mcp_tool_filtering_integration.rs
+++ b/codex-rs/core/tests/mcp_tool_filtering_integration.rs
@@ -1,0 +1,109 @@
+//! Integration tests for MCP tool filtering functionality.
+
+use codex_core::config_types::McpServerConfig;
+use std::collections::HashMap;
+
+#[test]
+fn test_mcp_tool_filtering_config_parsing() {
+    // Test that the new configuration fields are properly parsed
+    let config_toml = r#"
+[mcp_servers.test_server]
+command = "npx"
+args = ["-y", "test-mcp-server"]
+env = { "API_KEY" = "test-key" }
+exclude_tools = ["dangerous_tool", "bad_tool"]
+"#;
+
+    let config: toml::Value = toml::from_str(config_toml).unwrap();
+    let mcp_servers = config.get("mcp_servers").unwrap();
+    let server_config = mcp_servers.get("test_server").unwrap();
+
+    // Convert to string and parse directly
+    let server_config_str = toml::to_string(server_config).unwrap();
+    let mcp_config: McpServerConfig = toml::from_str(&server_config_str).unwrap();
+
+    assert_eq!(mcp_config.command, "npx");
+    assert_eq!(mcp_config.args, vec!["-y", "test-mcp-server"]);
+    assert_eq!(
+        mcp_config.env.unwrap().get("API_KEY"),
+        Some(&"test-key".to_string())
+    );
+    assert_eq!(
+        mcp_config.exclude_tools,
+        Some(vec!["dangerous_tool".to_string(), "bad_tool".to_string()])
+    );
+    assert_eq!(mcp_config.include_tools, None);
+}
+
+#[test]
+fn test_mcp_tool_filtering_config_include_tools() {
+    let config_toml = r#"
+[mcp_servers.test_server]
+command = "npx"
+args = ["-y", "test-mcp-server"]
+include_tools = ["safe_tool", "readonly_tool"]
+"#;
+
+    let config: toml::Value = toml::from_str(config_toml).unwrap();
+    let mcp_servers = config.get("mcp_servers").unwrap();
+    let server_config = mcp_servers.get("test_server").unwrap();
+
+    // Convert to string and parse directly
+    let server_config_str = toml::to_string(server_config).unwrap();
+    let mcp_config: McpServerConfig = toml::from_str(&server_config_str).unwrap();
+
+    assert_eq!(
+        mcp_config.include_tools,
+        Some(vec!["safe_tool".to_string(), "readonly_tool".to_string()])
+    );
+    assert_eq!(mcp_config.exclude_tools, None);
+}
+
+#[test]
+fn test_mcp_tool_filtering_config_validation() {
+    // Test that validation works correctly
+    let valid_config = McpServerConfig {
+        command: "test".to_string(),
+        args: vec![],
+        env: None,
+        exclude_tools: Some(vec!["bad_tool".to_string()]),
+        include_tools: None,
+    };
+    assert!(valid_config.validate().is_ok());
+
+    let invalid_config = McpServerConfig {
+        command: "test".to_string(),
+        args: vec![],
+        env: None,
+        exclude_tools: Some(vec!["bad_tool".to_string()]),
+        include_tools: Some(vec!["good_tool".to_string()]),
+    };
+    assert!(invalid_config.validate().is_err());
+    assert_eq!(
+        invalid_config.validate().unwrap_err(),
+        "exclude_tools and include_tools cannot both be specified"
+    );
+}
+
+#[test]
+fn test_mcp_tool_filtering_config_serialization() {
+    // Test that the configuration can be serialized and deserialized
+    let config = McpServerConfig {
+        command: "npx".to_string(),
+        args: vec!["-y".to_string(), "test-server".to_string()],
+        env: Some(HashMap::from([
+            ("API_KEY".to_string(), "test-key".to_string()),
+            ("DEBUG".to_string(), "true".to_string()),
+        ])),
+        exclude_tools: Some(vec!["dangerous_tool".to_string(), "bad_tool".to_string()]),
+        include_tools: None,
+    };
+
+    // Serialize to TOML
+    let toml_string = toml::to_string(&config).unwrap();
+
+    // Deserialize back
+    let deserialized: McpServerConfig = toml::from_str(&toml_string).unwrap();
+
+    assert_eq!(config, deserialized);
+}

--- a/codex-rs/examples/mcp_tool_filtering.toml
+++ b/codex-rs/examples/mcp_tool_filtering.toml
@@ -1,0 +1,52 @@
+# Example configuration demonstrating MCP tool filtering
+# This file shows how to use the new exclude_tools and include_tools features
+
+# Example 1: Supabase MCP with migration tools excluded
+[mcp_servers.supabase]
+args = ["-y", "@supabase/mcp-server"]
+command = "npx"
+env = { "SUPABASE_URL" = "your-supabase-url", "SUPABASE_ANON_KEY" = "your-anon-key" }
+# Exclude migration tools to handle them locally with version control
+exclude_tools = ["apply_migration", "create_migration", "rollback_migration"]
+
+# Example 2: Database MCP with only read-only operations
+[mcp_servers.database]
+args = ["-y", "@database/mcp-server"]
+command = "npx"
+env = { "DATABASE_URL" = "your-database-url" }
+# Include only safe read-only operations
+include_tools = [
+    "list_tables",
+    "describe_schema",
+    "query_data",
+    "get_table_info",
+]
+
+# Example 3: File system MCP with dangerous operations excluded
+[mcp_servers.filesystem]
+args = ["-y", "@filesystem/mcp-server"]
+command = "npx"
+env = { "BASE_PATH" = "/safe/workspace" }
+# Exclude dangerous file operations
+exclude_tools = ["delete_file", "delete_directory", "move_file", "chmod"]
+
+# Example 4: Git MCP with write operations excluded
+[mcp_servers.git]
+args = ["-y", "@git/mcp-server"]
+command = "npx"
+env = { "REPO_PATH" = "." }
+# Exclude git write operations for safety
+exclude_tools = ["commit", "push", "reset", "checkout", "merge", "rebase"]
+
+# Example 5: API MCP with only specific endpoints
+[mcp_servers.api]
+args = ["-y", "@api/mcp-server"]
+command = "npx"
+env = { "API_BASE_URL" = "https://api.example.com", "API_KEY" = "your-api-key" }
+# Include only safe GET operations
+include_tools = [
+    "get_user_info",
+    "list_projects",
+    "get_project_details",
+    "search_documents",
+]

--- a/docs/config.md
+++ b/docs/config.md
@@ -358,7 +358,26 @@ Should be represented as follows in `~/.codex/config.toml`:
 command = "npx"
 args = ["-y", "mcp-server"]
 env = { "API_KEY" = "value" }
+
+# Optional: Exclude specific tools from this server
+exclude_tools = ["apply_migration", "create_migration"]
+
+# Optional: Include only specific tools (mutually exclusive with exclude_tools)
+# include_tools = ["list_tables", "describe_schema"]
 ```
+
+### Tool Filtering
+
+You can control which tools are available from each MCP server:
+
+- **`exclude_tools`**: Completely removes the specified tools from the context. These tools will not be available to the AI model.
+- **`include_tools`**: Only makes the specified tools available. All other tools from the server will be excluded.
+- **Mutually exclusive**: You cannot specify both `exclude_tools` and `include_tools` for the same server.
+
+Example use cases:
+- **Supabase MCP**: Exclude migration tools to handle them locally with version control
+- **Database MCP**: Include only read-only operations for security
+- **File MCP**: Exclude dangerous operations like `delete_file`
 
 ## shell_environment_policy
 


### PR DESCRIPTION
## 🎯 **Feature: MCP Tool Filtering**

### **What**
Adds the ability to exclude or include specific tools from MCP servers, allowing users to control which tools are available to the AI model.

### **Why**
Addresses [issue #2963](https://github.com/openai/codex/issues/2963) - users want to exclude dangerous operations (like migrations) from MCP servers while keeping read-only operations.

### **How**
- **`exclude_tools`**: Completely removes specified tools from context
- **`include_tools`**: Only makes specified tools available (whitelist)
- **Mutually exclusive**: Cannot specify both options
- **Validation**: Configuration errors caught at startup
- **Backward compatible**: Existing configs continue to work

### **Configuration Example**
```toml
[mcp_servers.supabase]
command = "npx"
args = ["-y", "@supabase/mcp-server"]
exclude_tools = ["apply_migration", "create_migration"]
```

### **Testing**
- ✅ Unit tests for filtering logic
- ✅ Integration tests for config parsing
- ✅ All existing tests pass
- ✅ Backward compatibility verified

### **Documentation**
- ✅ Updated `docs/config.md` with tool filtering section
- ✅ Added example configuration file
- ✅ Included real-world use cases

### **Breaking Changes**
None - fully backward compatible.

### **Checklist**
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests added/updated
- [x] Documentation updated
- [x] No breaking changes
- [x] CLA signed (will be done via bot)