### PR TITLE
feat(core): re-export InitialHistory from conversation_manager

### DIFF
--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -43,6 +43,7 @@ pub use model_provider_info::create_oss_provider_with_base_url;
 mod conversation_manager;
 mod event_mapping;
 pub use conversation_manager::ConversationManager;
+pub use conversation_manager::InitialHistory;
 pub use conversation_manager::NewConversation;
 // Re-export common auth types for workspace consumers
 pub use auth::AuthManager;


### PR DESCRIPTION
This commit adds a re-export for InitialHistory from the internal conversation_manager module in codex-core's lib.rs.

The `RolloutRecorder::get_rollout_history` method (exposed via `pub use rollout::RolloutRecorder;`, already present in lib.rs) returns an `InitialHistory` type, which is defined in the private conversation_manager module. Without this re-export, consumers of the public RolloutRecorder API would not be able to directly use the return type, as they cannot access the private module. This would result in an inconvenient experience where the method's return value cannot be handled without additional, non-obvious imports.

By adding `pub use conversation_manager::InitialHistory;`, we make InitialHistory available as `codex_core::InitialHistory`, improving API ergonomics for users of the rollout functionality while keeping the conversation_manager module internal.

No functional changes are made; this is a pure re-export for better usability.