### PR TITLE
Clear non-empty prompts with ctrl + c

### DIFF
--- a/codex-rs/tui/src/bottom_pane/bottom_pane_view.rs
+++ b/codex-rs/tui/src/bottom_pane/bottom_pane_view.rs
@@ -19,7 +19,7 @@ pub(crate) trait BottomPaneView {
 
     /// Handle Ctrl-C while this view is active.
     fn on_ctrl_c(&mut self, _pane: &mut BottomPane) -> CancellationEvent {
-        CancellationEvent::Ignored
+        CancellationEvent::NotHandled
     }
 
     /// Return the desired height of the view.

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -79,6 +79,7 @@ pub(crate) struct ChatComposer {
     has_focus: bool,
     attached_images: Vec<AttachedImage>,
     placeholder_text: String,
+    is_task_running: bool,
     // Non-bracketed paste burst tracker.
     paste_burst: PasteBurst,
     // When true, disables paste-burst logic and inserts characters immediately.
@@ -119,6 +120,7 @@ impl ChatComposer {
             has_focus: has_input_focus,
             attached_images: Vec::new(),
             placeholder_text,
+            is_task_running: false,
             paste_burst: PasteBurst::default(),
             disable_paste_burst: false,
             custom_prompts: Vec::new(),
@@ -1205,6 +1207,10 @@ impl ChatComposer {
         self.has_focus = has_focus;
     }
 
+    pub fn set_task_running(&mut self, running: bool) {
+        self.is_task_running = running;
+    }
+
     pub(crate) fn set_esc_backtrack_hint(&mut self, show: bool) {
         self.esc_backtrack_hint = show;
     }
@@ -1229,11 +1235,16 @@ impl WidgetRef for ChatComposer {
             ActivePopup::None => {
                 let bottom_line_rect = popup_rect;
                 let mut hint: Vec<Span<'static>> = if self.ctrl_c_quit_hint {
+                    let ctrl_c_followup = if self.is_task_running {
+                        " to interrupt"
+                    } else {
+                        " to quit"
+                    };
                     vec![
                         " ".into(),
                         key_hint::ctrl('C'),
                         " again".into(),
-                        " to quit".into(),
+                        ctrl_c_followup.into(),
                     ]
                 } else {
                     let newline_hint_key = if self.use_shift_enter_hint {

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -202,8 +202,8 @@ impl BottomPane {
                     self.set_composer_text(String::new());
                     self.show_ctrl_c_quit_hint();
                     CancellationEvent::Handled
-                }
-            },
+                };
+            }
         };
 
         let event = view.on_ctrl_c(self);
@@ -298,6 +298,7 @@ impl BottomPane {
 
     pub fn set_task_running(&mut self, running: bool) {
         self.is_task_running = running;
+        self.composer.set_task_running(running);
 
         if running {
             if self.status.is_none() {

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -200,7 +200,7 @@ impl BottomPane {
                     CancellationEvent::NotHandled
                 } else {
                     self.set_composer_text(String::new());
-                    self.clear_ctrl_c_quit_hint();
+                    self.show_ctrl_c_quit_hint();
                     CancellationEvent::Handled
                 }
             },

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1288,15 +1288,16 @@ impl ChatWidget {
 
     /// Handle Ctrl-C key press.
     fn on_ctrl_c(&mut self) {
-        if self.bottom_pane.on_ctrl_c() == CancellationEvent::Ignored {
-            if self.bottom_pane.is_task_running() {
-                self.submit_op(Op::Interrupt);
-            } else if self.bottom_pane.ctrl_c_quit_hint_visible() {
-                self.submit_op(Op::Shutdown);
-            } else {
-                self.bottom_pane.show_ctrl_c_quit_hint();
-            }
+        if self.bottom_pane.on_ctrl_c() == CancellationEvent::Handled {
+            return;
         }
+
+        if self.bottom_pane.is_task_running() {
+            self.submit_op(Op::Interrupt);
+            return;
+        }
+
+        self.submit_op(Op::Shutdown);
     }
 
     pub(crate) fn composer_is_empty(&self) -> bool {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1293,6 +1293,7 @@ impl ChatWidget {
         }
 
         if self.bottom_pane.is_task_running() {
+            self.bottom_pane.show_ctrl_c_quit_hint();
             self.submit_op(Op::Interrupt);
             return;
         }


### PR DESCRIPTION
This updates the ctrl + c behavior to clear the current prompt if there is text and you press ctrl + c.

I also updated the ctrl + c hint text to show `^c to interrupt` instead of `^c to quit` if there is an active conversation.

Two things I don't love:
1. You can currently interrupt a conversation with escape or ctrl + c (not related to this PR and maybe fine)
2. The bottom row hint text always says `^c to quit` but this PR doesn't really make that worse.



https://github.com/user-attachments/assets/6eddadec-0d84-4fa7-abcb-d6f5a04e5748


Fixes https://github.com/openai/codex/issues/3126