### PR TITLE
docs: fix broken link to the "Memory with AGENTS.md" section in codex/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Codex CLI supports a rich set of configuration options, with preferences stored 
   - [CLI usage](./docs/getting-started.md#cli-usage)
   - [Running with a prompt as input](./docs/getting-started.md#running-with-a-prompt-as-input)
   - [Example prompts](./docs/getting-started.md#example-prompts)
-  - [Memory with AGENTS.md](./docs/getting-started.md#memory--project-docs)
+  - [Memory with AGENTS.md](./docs/getting-started.md#memory-with-agentsmd)
   - [Configuration](./docs/config.md)
 - [**Sandbox & approvals**](./docs/sandbox.md)
 - [**Authentication**](./docs/authentication.md)


### PR DESCRIPTION
Fixes https://github.com/openai/codex/issues/3299

Updated the link in README.md so that it correctly points to the [Memory with AGENTS.md](https://github.com/openai/codex/blob/main/docs/getting-started.md#memory-with-agentsmd) section, ensuring users are directed to the right location.