### PR TITLE
chore: upgrade to actions/setup-node@v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,33 +14,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 22
-
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.8.1
           run_install: false
 
-      - name: Get pnpm store directory
-        id: pnpm-cache
-        shell: bash
-        run: |
-          echo "store_path=$(pnpm store path --silent)" >> $GITHUB_OUTPUT
-
-      - name: Setup pnpm cache
-        uses: actions/cache@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
         with:
-          path: ${{ steps.pnpm-cache.outputs.store_path }}
-          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
-          restore-keys: |
-            ${{ runner.os }}-pnpm-store-
+          node-version: 22
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       # Run all tasks using workspace filters
 


### PR DESCRIPTION
Dependabot tried to automatically upgrade us to `actions/setup-node@v5` in https://github.com/openai/codex/pull/3293, but it broke our CI. Note this upgrade has breaking changes:

https://github.com/actions/setup-node/releases/tag/v5.0.0

I think the problem was that `v5` was correctly reading our `packageManager` line here:

https://github.com/openai/codex/blob/e2b3053b2b9c39fd9a83ec3172318db64d31dc56/package.json#L24

and then tried to run `pnpm`, but couldn't because it wasn't available yet. This PR:

- moves `pnpm/action-setup` before `actions/setup-node`
- drops `version` from our `pnpm/action-setup` step because it is not necessary when it is specified in `package.json` (which it is in our case), so leaving it here ran the risk of the two getting out of sync
- upgrades `actions/setup-node` from `v4` to `v5`
- deletes the two custom steps we had to enable Node.js caching since `v5` claims to do this for us now
- adds `--frozen-lockfile` to our `pnpm install` invocation, which seemed like something we should have always had there