### PR TITLE
feat: Add undo capability

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -723,6 +723,7 @@ impl Session {
                 user_explicitly_approved_this_action,
                 changes,
             }) => {
+                self.clear_last_undo_patch();
                 turn_diff_tracker.on_patch_begin(&changes);
 
                 EventMsg::PatchApplyBegin(PatchApplyBeginEvent {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -816,6 +816,12 @@ impl Session {
                             }
                             Err(error) => {
                                 warn!("failed to prepare undo patch: {error:#}");
+                                self.clear_last_undo_patch();
+                                self.notify_background_event(
+                                    &context.sub_id,
+                                    format!("Undo is unavailable for this turn: {error:#}"),
+                                )
+                                .await;
                             }
                         }
                     }
@@ -827,6 +833,17 @@ impl Session {
                 }
                 Err(error) => {
                     warn!("failed to compute unified diff: {error:#}");
+                    if *exit_code == 0 {
+                        self.clear_last_undo_patch();
+                        self
+                            .notify_background_event(
+                                &context.sub_id,
+                                format!(
+                                    "Undo is unavailable for this turn: failed to compute diff: {error:#}"
+                                ),
+                            )
+                            .await;
+                    }
                 }
             }
         }

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -58,6 +58,9 @@ pub enum Op {
         items: Vec<InputItem>,
     },
 
+    /// Undo the most recently applied turn diff using the local git repo.
+    UndoLastTurnDiff,
+
     /// Similar to [`Op::UserInput`], but contains additional context required
     /// for a turn of a [`crate::codex_conversation::CodexConversation`].
     UserTurn {
@@ -1008,6 +1011,7 @@ pub enum TurnAbortReason {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use pretty_assertions::assert_eq;
 
     /// Serialize Event to verify that its JSON representation has the expected
     /// amount of nesting.

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1268,20 +1268,21 @@ impl ChatWidget {
         })];
 
         let items = vec![
-        SelectionItem {
-            name: "Undo last turn diff".to_string(),
-            description: Some(
-                "Revert files that Codex changed during the most recent turn.".to_string(),
-            ),
-            is_current: false,
-            actions: undo_actions,
-        },
-        SelectionItem {
-            name: "Cancel".to_string(),
-            description: Some("Close without undoing any files.".to_string()),
-            is_current: false,
-            actions: Vec::new(),
-        }];
+            SelectionItem {
+                name: "Undo last turn diff".to_string(),
+                description: Some(
+                    "Revert files that Codex changed during the most recent turn.".to_string(),
+                ),
+                is_current: false,
+                actions: undo_actions,
+            },
+            SelectionItem {
+                name: "Cancel".to_string(),
+                description: Some("Close without undoing any files.".to_string()),
+                is_current: false,
+                actions: Vec::new(),
+            },
+        ];
 
         self.bottom_pane.show_selection_view(
             "Undo last Codex turn?".to_string(),

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1267,21 +1267,21 @@ impl ChatWidget {
             tx.send(AppEvent::CodexOp(Op::UndoLastTurnDiff));
         })];
 
-        let mut items = Vec::new();
-        items.push(SelectionItem {
+        let items = vec![
+        SelectionItem {
             name: "Undo last turn diff".to_string(),
             description: Some(
                 "Revert files that Codex changed during the most recent turn.".to_string(),
             ),
             is_current: false,
             actions: undo_actions,
-        });
-        items.push(SelectionItem {
+        },
+        SelectionItem {
             name: "Cancel".to_string(),
             description: Some("Close without undoing any files.".to_string()),
             is_current: false,
             actions: Vec::new(),
-        });
+        }];
 
         self.bottom_pane.show_selection_view(
             "Undo last Codex turn?".to_string(),

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -862,6 +862,10 @@ impl ChatWidget {
                     tx.send(AppEvent::DiffResult(text));
                 });
             }
+            SlashCommand::Undo => {
+                self.app_event_tx
+                    .send(AppEvent::CodexOp(Op::UndoLastTurnDiff));
+            }
             SlashCommand::Mention => {
                 self.insert_str("@");
             }

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1064,6 +1064,11 @@ pub(crate) fn new_stream_error_event(message: String) -> PlainHistoryCell {
     PlainHistoryCell { lines }
 }
 
+pub(crate) fn new_background_event(message: String) -> PlainHistoryCell {
+    let lines: Vec<Line<'static>> = vec![vec![padded_emoji("ℹ️").into(), message.into()].into()];
+    PlainHistoryCell { lines }
+}
+
 /// Render a user‑friendly plan update styled like a checkbox todo list.
 pub(crate) fn new_plan_update(update: UpdatePlanArgs) -> PlanUpdateCell {
     let UpdatePlanArgs { explanation, plan } = update;

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -18,6 +18,7 @@ pub enum SlashCommand {
     Init,
     Compact,
     Diff,
+    Undo,
     Mention,
     Status,
     Mcp,
@@ -36,6 +37,7 @@ impl SlashCommand {
             SlashCommand::Compact => "summarize conversation to prevent hitting the context limit",
             SlashCommand::Quit => "exit Codex",
             SlashCommand::Diff => "show git diff (including untracked files)",
+            SlashCommand::Undo => "undo the last turn diff applied by Codex",
             SlashCommand::Mention => "mention a file",
             SlashCommand::Status => "show current session configuration and token usage",
             SlashCommand::Model => "choose what model and reasoning effort to use",
@@ -63,6 +65,7 @@ impl SlashCommand {
             | SlashCommand::Approvals
             | SlashCommand::Logout => false,
             SlashCommand::Diff
+            | SlashCommand::Undo
             | SlashCommand::Mention
             | SlashCommand::Status
             | SlashCommand::Mcp


### PR DESCRIPTION
## Summary

  - Track the last successful apply-patch diff in Session so Codex can build and send an undo
  patch after a turn.
  - Add a new /undo slash command with confirmation flow, history rendering, and tests
  covering both undo command behavior and background events.
  - Extend the exec/patch event pipeline to emit background notifications, capture undo
  patches, and surface them in the TUI history.