### PR TITLE
chore: try switching to `cargo nextest` to speed up CI builds

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -74,7 +74,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@1.89
-      - uses: taiki-e/install-action@v2
+      - uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2
         with:
           tool: cargo-shear
           version: 1.5.1
@@ -178,12 +178,17 @@ jobs:
           find . -name Cargo.toml -mindepth 2 -maxdepth 2 -print0 \
             | xargs -0 -n1 -I{} bash -c 'cd "$(dirname "{}")" && cargo check --profile ${{ matrix.profile }}'
 
-      - name: cargo test
+      - uses: taiki-e/install-action@0c5db7f7f897c03b771660e91d065338615679f4 # v2
+        with:
+          tool: nextest
+          version: 0.9.103
+
+      - name: tests
         id: test
-        # `cargo test` takes too long for release builds to run them on every PR
+        # Tests take too long for release builds to run them on every PR.
         if: ${{ matrix.profile != 'release' }}
         continue-on-error: true
-        run: cargo test --all-features --target ${{ matrix.target }} --profile ${{ matrix.profile }}
+        run: cargo nextest run --all-features --target ${{ matrix.target }}
         env:
           RUST_BACKTRACE: 1
 


### PR DESCRIPTION
I started looking at https://nexte.st/ because I was interested in a test harness that lets a test dynamically declare itself "skipped," which would be a nice alternative to this pattern:

https://github.com/openai/codex/blob/4c46490e53076e807fd2068aa68c5a0e636d8b5f/codex-rs/core/tests/suite/cli_stream.rs#L22-L27

ChatGPT pointed me at https://nexte.st/, which also claims to be "up to 3x as fast as cargo test." Locally, in `codex-rs`, I see

- `cargo nextest run` finishes in 19s
- `cargo test` finishes in 37s

Though looking at CI, the wins are quite as big, presumably because my laptop has more cores than our GitHub runners (which is a separate issue...). Comparing the [CI jobs from this PR](https://github.com/openai/codex/actions/runs/17561325162/job/49878216246?pr=3323) with that of a [recent open PR](https://github.com/openai/codex/actions/runs/17561066581/job/49877342753?pr=3321):

|                                                 | `cargo test` | `cargo nextest` |
| ----------------------------------------------- | ------------ | --------------- |
| `macos-14 - aarch64-apple-darwin`               | 2m16s        | 1m51s           |
| `macos-14 - aarch64-apple-darwin`               | 5m04s        | 3m44s           |
| `ubuntu-24.04 - x86_64-unknown-linux-musl`      | 2m02s        | 1m56s           |
| `ubuntu-24.04-arm - aarch64-unknown-linux-musl` | 2m01s        | 1m35s           |
| `windows-latest - x86_64-pc-windows-msvc`       | 3m07s        | 2m53s           |
| `windows-11-arm - aarch64-pc-windows-msvc`      | 3m10s        | 2m45s           |

I thought that, to start, we would only make this change in CI before declaring it the "official" way for the team to run the test suite.

Though unfortunately, I do not believe that `cargo nextest` _actually_ supports a dynamic skip feature, so I guess I'll have to keep looking? Some related discussions:

- https://internals.rust-lang.org/t/pre-rfc-skippable-tests/14611
- https://internals.rust-lang.org/t/skippable-tests/21260
