### PR TITLE
Add configurable initialize timeout to MCP server config

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -391,7 +391,8 @@ impl Session {
         // - load history metadata
         let rollout_fut = RolloutRecorder::new(&config, conversation_id, user_instructions.clone());
 
-        let mcp_fut = McpConnectionManager::new(config.mcp_servers.clone());
+        let mcp_fut =
+            McpConnectionManager::new(config.mcp_servers.clone(), config.mcp_initialize_timeout_s);
         let default_shell_fut = shell::default_user_shell();
         let history_meta_fut = crate::message_history::history_metadata(&config);
 

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -114,6 +114,10 @@ pub struct Config {
     /// Definition for MCP servers that Codex can reach out to for tool calls.
     pub mcp_servers: HashMap<String, McpServerConfig>,
 
+    /// Global default for MCP initialization timeout, in seconds. Used when a
+    /// per‑server timeout is not specified.
+    pub mcp_initialize_timeout_s: Option<u64>,
+
     /// Combined provider map (defaults merged with user-defined overrides).
     pub model_providers: HashMap<String, ModelProviderInfo>,
 
@@ -422,6 +426,10 @@ pub struct ConfigToml {
     /// Definition for MCP servers that Codex can reach out to for tool calls.
     #[serde(default)]
     pub mcp_servers: HashMap<String, McpServerConfig>,
+
+    /// Global default for MCP initialization timeout, in seconds. Used when a
+    /// per‑server timeout is not specified.
+    pub mcp_initialize_timeout_s: Option<u64>,
 
     /// User-defined provider entries that extend/override the built-in list.
     #[serde(default)]
@@ -795,6 +803,7 @@ impl Config {
             user_instructions,
             base_instructions,
             mcp_servers: cfg.mcp_servers,
+            mcp_initialize_timeout_s: cfg.mcp_initialize_timeout_s,
             model_providers,
             project_doc_max_bytes: cfg.project_doc_max_bytes.unwrap_or(PROJECT_DOC_MAX_BYTES),
             codex_home,
@@ -1185,6 +1194,7 @@ model_verbosity = "high"
                 notify: None,
                 cwd: fixture.cwd(),
                 mcp_servers: HashMap::new(),
+                mcp_initialize_timeout_s: None,
                 model_providers: fixture.model_provider_map.clone(),
                 project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
                 codex_home: fixture.codex_home(),
@@ -1242,6 +1252,7 @@ model_verbosity = "high"
             notify: None,
             cwd: fixture.cwd(),
             mcp_servers: HashMap::new(),
+            mcp_initialize_timeout_s: None,
             model_providers: fixture.model_provider_map.clone(),
             project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
             codex_home: fixture.codex_home(),
@@ -1314,6 +1325,7 @@ model_verbosity = "high"
             notify: None,
             cwd: fixture.cwd(),
             mcp_servers: HashMap::new(),
+            mcp_initialize_timeout_s: None,
             model_providers: fixture.model_provider_map.clone(),
             project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
             codex_home: fixture.codex_home(),
@@ -1372,6 +1384,7 @@ model_verbosity = "high"
             notify: None,
             cwd: fixture.cwd(),
             mcp_servers: HashMap::new(),
+            mcp_initialize_timeout_s: None,
             model_providers: fixture.model_provider_map.clone(),
             project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
             codex_home: fixture.codex_home(),

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -18,6 +18,10 @@ pub struct McpServerConfig {
 
     #[serde(default)]
     pub env: Option<HashMap<String, String>>,
+
+    /// Timeout for MCP initialization handshake, in seconds.
+    #[serde(default)]
+    pub initialize_timeout_s: Option<u64>,
 }
 
 #[derive(Deserialize, Debug, Copy, Clone, PartialEq)]

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -127,7 +127,12 @@ impl McpConnectionManager {
             }
 
             join_set.spawn(async move {
-                let McpServerConfig { command, args, env } = cfg;
+                let McpServerConfig {
+                    command,
+                    args,
+                    env,
+                    initialize_timeout_s,
+                } = cfg;
                 let client_res = McpClient::new_stdio_client(
                     command.into(),
                     args.into_iter().map(OsString::from).collect(),
@@ -154,7 +159,9 @@ impl McpConnectionManager {
                             protocol_version: mcp_types::MCP_SCHEMA_VERSION.to_owned(),
                         };
                         let initialize_notification_params = None;
-                        let timeout = Some(Duration::from_secs(10));
+                        let timeout = initialize_timeout_s
+                            .map(Duration::from_secs)
+                            .or(Some(Duration::from_secs(10)));
                         match client
                             .initialize(params, initialize_notification_params, timeout)
                             .await

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -36,7 +36,10 @@ The Codex CLI can be configured to leverage MCP servers by defining an [`mcp_ser
 command = "npx"
 args = ["-y", "mcp-server"]
 env = { "API_KEY" = "value" }
-# Optional: override the MCP initialize handshake timeout (seconds)
+# Optional timeouts (seconds)
+# Global default for all MCP servers
+# mcp_initialize_timeout_s = 12
+# Per‑server override for the initialize handshake
 # initialize_timeout_s = 15
 ```
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -36,6 +36,8 @@ The Codex CLI can be configured to leverage MCP servers by defining an [`mcp_ser
 command = "npx"
 args = ["-y", "mcp-server"]
 env = { "API_KEY" = "value" }
+# Optional: override the MCP initialize handshake timeout (seconds)
+# initialize_timeout_s = 15
 ```
 
 > [!TIP]

--- a/docs/config.md
+++ b/docs/config.md
@@ -358,6 +358,8 @@ Should be represented as follows in `~/.codex/config.toml`:
 command = "npx"
 args = ["-y", "mcp-server"]
 env = { "API_KEY" = "value" }
+# Optional: override the MCP initialize handshake timeout (seconds)
+# initialize_timeout_s = 15
 ```
 
 ## shell_environment_policy
@@ -574,6 +576,7 @@ Options that are specific to the TUI.
 | `mcp_servers.<id>.command` | string | MCP server launcher command. |
 | `mcp_servers.<id>.args` | array<string> | MCP server args. |
 | `mcp_servers.<id>.env` | map<string,string> | MCP server env vars. |
+| `mcp_servers.<id>.initialize_timeout_s` | number | Timeout for the MCP initialize handshake (seconds). Default: 10. |
 | `model_providers.<id>.name` | string | Display name. |
 | `model_providers.<id>.base_url` | string | API base URL. |
 | `model_providers.<id>.env_key` | string | Env var for API key. |

--- a/docs/config.md
+++ b/docs/config.md
@@ -360,6 +360,16 @@ args = ["-y", "mcp-server"]
 env = { "API_KEY" = "value" }
 # Optional: override the MCP initialize handshake timeout (seconds)
 # initialize_timeout_s = 15
+
+### MCP initialize timeout precedence
+
+You can set a global default initialize timeout for all MCP servers and still override it per server. Precedence:
+
+1. Per‑server `initialize_timeout_s`
+2. Global `mcp_initialize_timeout_s`
+3. Built‑in default: 10 seconds
+# Optional: override the MCP initialize handshake timeout (seconds)
+# initialize_timeout_s = 15
 ```
 
 ## shell_environment_policy
@@ -577,6 +587,7 @@ Options that are specific to the TUI.
 | `mcp_servers.<id>.args` | array<string> | MCP server args. |
 | `mcp_servers.<id>.env` | map<string,string> | MCP server env vars. |
 | `mcp_servers.<id>.initialize_timeout_s` | number | Timeout for the MCP initialize handshake (seconds). Default: 10. |
+| `mcp_initialize_timeout_s` | number | Global default MCP initialize timeout (seconds) used when a server does not specify `initialize_timeout_s`. |
 | `model_providers.<id>.name` | string | Display name. |
 | `model_providers.<id>.base_url` | string | API base URL. |
 | `model_providers.<id>.env_key` | string | Env var for API key. |


### PR DESCRIPTION
Introduces a seconds-based initialization timeout for MCP. Supports both per‑server and global configuration with clear precedence.

  Behavior

  - Precedence:
      - Per‑server: mcp_servers..initialize_timeout_s
      - Global: mcp_initialize_timeout_s
      - Default: 10 seconds

  Changes

  - core
      - config_types: add initialize_timeout_s to McpServerConfig
      - config: add mcp_initialize_timeout_s to Config/ConfigToml and wire through
      - mcp_connection_manager: accept global timeout and apply precedence
      - codex: pass global timeout into connection manager
  - docs
      - config.md and advanced.md updated with new keys and examples

  Testing

  - cargo fmt
  - cargo clippy --tests -p codex-core
  - cargo test --all-features

  Related issues

- #3324 
- #3311
- #3289 
- #3245 
- #3144
- #2346 
- #3196 
- #2335
- #2905 

and potentially more.