### PR TITLE
fix: tui default trusted settings should respect workspace write config

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1422,6 +1422,7 @@ dependencies = [
  "textwrap 0.16.2",
  "tokio",
  "tokio-stream",
+ "toml",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -4621,19 +4621,6 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
-dependencies = [
- "fuchsia-cprng",
- "libc",
- "rand_core 0.3.1",
- "rdrand",
- "winapi",
-]
-
-[[package]]
-name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -4672,21 +4659,6 @@ dependencies = [
  "ppv-lite86",
  "rand_core 0.9.3",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
-dependencies = [
- "rand_core 0.4.2",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
 
 [[package]]
 name = "rand_core"
@@ -6472,12 +6444,6 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
-
-[[package]]
-name = "unicode-linebreak"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-linebreak"

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1061,7 +1061,7 @@ dependencies = [
  "portable-pty",
  "predicates",
  "pretty_assertions",
- "rand",
+ "rand 0.9.2",
  "regex-lite",
  "reqwest",
  "seccompiler",
@@ -1200,7 +1200,7 @@ dependencies = [
  "codex-app-server-protocol",
  "codex-core",
  "core_test_support",
- "rand",
+ "rand 0.9.2",
  "reqwest",
  "serde",
  "serde_json",
@@ -1409,7 +1409,7 @@ dependencies = [
  "pathdiff",
  "pretty_assertions",
  "pulldown-cmark",
- "rand",
+ "rand 0.9.2",
  "ratatui",
  "regex-lite",
  "serde",
@@ -4114,7 +4114,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand",
+ "rand 0.9.2",
  "serde_json",
  "thiserror 2.0.16",
  "tokio",
@@ -4568,7 +4568,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand",
+ "rand 0.9.2",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4670,7 +4670,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4898,7 +4898,7 @@ dependencies = [
  "paste",
  "pin-project-lite",
  "process-wrap",
- "rand",
+ "rand 0.9.2",
  "reqwest",
  "rmcp-macros",
  "schemars 1.0.4",

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1061,7 +1061,7 @@ dependencies = [
  "portable-pty",
  "predicates",
  "pretty_assertions",
- "rand 0.9.2",
+ "rand",
  "regex-lite",
  "reqwest",
  "seccompiler",
@@ -1072,7 +1072,6 @@ dependencies = [
  "shlex",
  "similar",
  "strum_macros 0.27.2",
- "tempdir",
  "tempfile",
  "thiserror 2.0.16",
  "time",
@@ -1201,7 +1200,7 @@ dependencies = [
  "codex-app-server-protocol",
  "codex-core",
  "core_test_support",
- "rand 0.9.2",
+ "rand",
  "reqwest",
  "serde",
  "serde_json",
@@ -1410,7 +1409,7 @@ dependencies = [
  "pathdiff",
  "pretty_assertions",
  "pulldown-cmark",
- "rand 0.9.2",
+ "rand",
  "ratatui",
  "regex-lite",
  "serde",
@@ -4114,7 +4113,7 @@ dependencies = [
  "futures-util",
  "opentelemetry",
  "percent-encoding",
- "rand 0.9.2",
+ "rand",
  "serde_json",
  "thiserror 2.0.16",
  "tokio",
@@ -4568,7 +4567,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.3",
  "lru-slab",
- "rand 0.9.2",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4670,7 +4669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
+ "rand_core",
 ]
 
 [[package]]
@@ -4724,15 +4723,6 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.1",
-]
-
-[[package]]
-name = "rdrand"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
-dependencies = [
- "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -4828,15 +4818,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "reqwest"
 version = "0.12.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4916,7 +4897,7 @@ dependencies = [
  "paste",
  "pin-project-lite",
  "process-wrap",
- "rand 0.9.2",
+ "rand",
  "reqwest",
  "rmcp-macros",
  "schemars 1.0.4",
@@ -5856,16 +5837,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempdir"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
-dependencies = [
- "rand 0.4.6",
- "remove_dir_all",
-]
-
-[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6500,6 +6471,12 @@ name = "unicode-ident"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-linebreak"

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1072,6 +1072,7 @@ dependencies = [
  "shlex",
  "similar",
  "strum_macros 0.27.2",
+ "tempdir",
  "tempfile",
  "thiserror 2.0.16",
  "time",
@@ -2381,6 +2382,12 @@ checksum = "76ee7a02da4d231650c7cea31349b889be2f45ddb3ef3032d2ec8185f6313fd2"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "fuchsia-cprng"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
 
 [[package]]
 name = "futures"
@@ -4614,6 +4621,19 @@ dependencies = [
 
 [[package]]
 name = "rand"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
+dependencies = [
+ "fuchsia-cprng",
+ "libc",
+ "rand_core 0.3.1",
+ "rdrand",
+ "winapi",
+]
+
+[[package]]
+name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
@@ -4655,6 +4675,21 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a6fdeb83b075e8266dcc8762c22776f6877a63111121f5f8c7411e5be7eed4b"
+dependencies = [
+ "rand_core 0.4.2",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c33a3c44ca05fa6f1807d8e6743f3824e8509beca625669633be0acbdf509dc"
+
+[[package]]
+name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
@@ -4689,6 +4724,15 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.1",
+]
+
+[[package]]
+name = "rdrand"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "678054eb77286b51581ba43620cc911abf02758c91f93f479767aed0f90458b2"
+dependencies = [
+ "rand_core 0.3.1",
 ]
 
 [[package]]
@@ -4782,6 +4826,15 @@ name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "reqwest"
@@ -5800,6 +5853,16 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tempdir"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
+dependencies = [
+ "rand 0.4.6",
+ "remove_dir_all",
 ]
 
 [[package]]

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2384,12 +2384,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fuchsia-cprng"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06f77d526c1a601b7c4cdd98f54b5eaabffc14d5f2f0296febdc7f357c6d3ba"
-
-[[package]]
 name = "futures"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -46,7 +46,6 @@ sha1 = { workspace = true }
 shlex = { workspace = true }
 similar = { workspace = true }
 strum_macros = { workspace = true }
-tempdir = "0.3.7"
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true, features = [

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -46,6 +46,7 @@ sha1 = { workspace = true }
 shlex = { workspace = true }
 similar = { workspace = true }
 strum_macros = { workspace = true }
+tempdir = "0.3.7"
 tempfile = { workspace = true }
 thiserror = { workspace = true }
 time = { workspace = true, features = [

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -42,6 +42,7 @@ use codex_protocol::config_types::Verbosity;
 use codex_rmcp_client::OAuthCredentialsStoreMode;
 use dirs::home_dir;
 use serde::Deserialize;
+use similar::DiffableStr;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::io::ErrorKind;
@@ -233,6 +234,10 @@ pub struct Config {
 
     /// The active profile name used to derive this `Config` (if any).
     pub active_profile: Option<String>,
+
+    /// The currently active project config, resolved by checking if cwd:
+    /// is (1) part of a git repo, (2) a git worktree, or (3) just using the cwd
+    pub active_project: ProjectConfig,
 
     /// Tracks whether the Windows onboarding screen has been acknowledged.
     pub windows_wsl_setup_acknowledged: bool,
@@ -863,6 +868,15 @@ pub struct ProjectConfig {
     pub trust_level: Option<String>,
 }
 
+impl ProjectConfig {
+    pub fn is_trusted(&self) -> bool {
+        match &self.trust_level {
+            Some(trust_level) => trust_level == "trusted",
+            None => false,
+        }
+    }
+}
+
 #[derive(Deserialize, Debug, Clone, Default, PartialEq)]
 pub struct ToolsToml {
     #[serde(default, alias = "web_search_request")]
@@ -893,8 +907,13 @@ impl ConfigToml {
             .or(self.sandbox_mode)
             .or_else(|| {
                 // if no sandbox_mode is set, but user has marked directory as trusted, use WorkspaceWrite
-                self.is_cwd_trusted(resolved_cwd)
-                    .then_some(SandboxMode::WorkspaceWrite)
+                self.get_active_project(resolved_cwd).and_then(|p| {
+                    if p.is_trusted() {
+                        Some(SandboxMode::WorkspaceWrite)
+                    } else {
+                        None
+                    }
+                })
             })
             .unwrap_or_default();
         match resolved_sandbox_mode {
@@ -917,30 +936,26 @@ impl ConfigToml {
         }
     }
 
-    pub fn is_cwd_trusted(&self, resolved_cwd: &Path) -> bool {
+    /// Resolves the cwd to an existing project, or returns None if ConfigToml
+    /// does not contain a project corresponding to cwd or a git repo for cwd
+    pub fn get_active_project(&self, resolved_cwd: &Path) -> Option<ProjectConfig> {
         let projects = self.projects.clone().unwrap_or_default();
 
-        let is_path_trusted = |path: &Path| {
-            let path_str = path.to_string_lossy().to_string();
-            projects
-                .get(&path_str)
-                .map(|p| p.trust_level.as_deref() == Some("trusted"))
-                .unwrap_or(false)
-        };
-
-        // Fast path: exact cwd match
-        if is_path_trusted(resolved_cwd) {
-            return true;
+        if let Some(project_config) = projects.get(&resolved_cwd.to_string_lossy().to_string()) {
+            return Some(project_config.clone());
         }
 
-        // If cwd lives inside a git worktree, check whether the root git project
+        // If cwd lives inside a git repo/worktree, check whether the root git project
         // (the primary repository working directory) is trusted. This lets
         // worktrees inherit trust from the main project.
-        if let Some(root_project) = resolve_root_git_project_for_trust(resolved_cwd) {
-            return is_path_trusted(&root_project);
+        if let Some(repo_root) = resolve_root_git_project_for_trust(resolved_cwd)
+            && let Some(project_config_for_root) =
+                projects.get(&repo_root.to_string_lossy().to_string_lossy().to_string())
+        {
+            return Some(project_config_for_root.clone());
         }
 
-        false
+        None
     }
 
     pub fn get_config_profile(
@@ -1057,17 +1072,22 @@ impl Config {
                 }
             }
         };
+        let active_project = cfg
+            .get_active_project(&resolved_cwd)
+            .unwrap_or(ProjectConfig { trust_level: None });
 
         let sandbox_policy = cfg.derive_sandbox_policy(sandbox_mode, &resolved_cwd);
         let approval_policy = approval_policy_override
             .or(config_profile.approval_policy)
             .or(cfg.approval_policy)
-            .or_else(|| {
-                // If no explicit approval policy is set, but we trust cwd, default to OnRequest
-                cfg.is_cwd_trusted(&resolved_cwd)
-                    .then_some(AskForApproval::OnRequest)
-            })
-            .unwrap_or_else(AskForApproval::default);
+            .unwrap_or_else(|| {
+                if active_project.is_trusted() {
+                    // If no explicit approval policy is set, but we trust cwd, default to OnRequest
+                    AskForApproval::OnRequest
+                } else {
+                    AskForApproval::default()
+                }
+            });
         let did_user_set_custom_approval_policy_or_sandbox_mode = approval_policy_override
             .is_some()
             || config_profile.approval_policy.is_some()
@@ -1230,6 +1250,7 @@ impl Config {
             include_view_image_tool: include_view_image_tool_flag,
             features,
             active_profile: active_profile_name,
+            active_project,
             windows_wsl_setup_acknowledged: cfg.windows_wsl_setup_acknowledged.unwrap_or(false),
             disable_paste_burst: cfg.disable_paste_burst.unwrap_or(false),
             tui_notifications: cfg
@@ -2312,6 +2333,7 @@ model_verbosity = "high"
                 include_view_image_tool: true,
                 features: Features::with_defaults(),
                 active_profile: Some("o3".to_string()),
+                active_project: ProjectConfig { trust_level: None },
                 windows_wsl_setup_acknowledged: false,
                 disable_paste_burst: false,
                 tui_notifications: Default::default(),
@@ -2377,6 +2399,7 @@ model_verbosity = "high"
             include_view_image_tool: true,
             features: Features::with_defaults(),
             active_profile: Some("gpt3".to_string()),
+            active_project: ProjectConfig { trust_level: None },
             windows_wsl_setup_acknowledged: false,
             disable_paste_burst: false,
             tui_notifications: Default::default(),
@@ -2457,6 +2480,7 @@ model_verbosity = "high"
             include_view_image_tool: true,
             features: Features::with_defaults(),
             active_profile: Some("zdr".to_string()),
+            active_project: ProjectConfig { trust_level: None },
             windows_wsl_setup_acknowledged: false,
             disable_paste_burst: false,
             tui_notifications: Default::default(),
@@ -2523,6 +2547,7 @@ model_verbosity = "high"
             include_view_image_tool: true,
             features: Features::with_defaults(),
             active_profile: Some("gpt5".to_string()),
+            active_project: ProjectConfig { trust_level: None },
             windows_wsl_setup_acknowledged: false,
             disable_paste_burst: false,
             tui_notifications: Default::default(),

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -2535,6 +2535,24 @@ model_verbosity = "high"
     }
 
     #[test]
+    fn test_did_user_set_custom_approval_policy_or_sandbox_mode_defaults_no() -> anyhow::Result<()>
+    {
+        let fixture = create_test_fixture()?;
+
+        let config = Config::load_from_base_config_with_overrides(
+            fixture.cfg.clone(),
+            ConfigOverrides {
+                ..Default::default()
+            },
+            fixture.codex_home(),
+        )?;
+
+        assert!(config.did_user_set_custom_approval_policy_or_sandbox_mode);
+
+        Ok(())
+    }
+
+    #[test]
     fn test_set_project_trusted_writes_explicit_tables() -> anyhow::Result<()> {
         let project_dir = Path::new("/some/path");
         let mut doc = DocumentMut::new();

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -100,6 +100,10 @@ pub struct Config {
 
     pub sandbox_policy: SandboxPolicy,
 
+    /// True if the user passed in an override or set a value in config.toml
+    /// for either of approval_policy or sandbox_mode.
+    pub did_user_set_custom_approval_policy_or_sandbox_mode: bool,
+
     pub shell_environment_policy: ShellEnvironmentPolicy,
 
     /// When `true`, `AgentReasoning` events emitted by the backend will be
@@ -880,12 +884,18 @@ impl From<ToolsToml> for Tools {
 
 impl ConfigToml {
     /// Derive the effective sandbox policy from the configuration.
-    pub fn derive_sandbox_policy(
+    fn derive_sandbox_policy(
         &self,
         sandbox_mode_override: Option<SandboxMode>,
+        resolved_cwd: &Path,
     ) -> SandboxPolicy {
         let resolved_sandbox_mode = sandbox_mode_override
             .or(self.sandbox_mode)
+            .or_else(|| {
+                // if no sandbox_mode is set, but user has marked directory as trusted, use WorkspaceWrite
+                self.is_cwd_trusted(resolved_cwd)
+                    .then_some(SandboxMode::WorkspaceWrite)
+            })
             .unwrap_or_default();
         match resolved_sandbox_mode {
             SandboxMode::ReadOnly => SandboxPolicy::new_read_only_policy(),
@@ -989,7 +999,7 @@ impl Config {
             model,
             review_model: override_review_model,
             cwd,
-            approval_policy,
+            approval_policy: approval_policy_override,
             sandbox_mode,
             model_provider,
             config_profile: config_profile_key,
@@ -1029,7 +1039,42 @@ impl Config {
 
         let features = Features::from_config(&cfg, &config_profile, feature_overrides);
 
-        let sandbox_policy = cfg.derive_sandbox_policy(sandbox_mode);
+        let resolved_cwd = {
+            use std::env;
+
+            match cwd {
+                None => {
+                    tracing::info!("cwd not set, using current dir");
+                    env::current_dir()?
+                }
+                Some(p) if p.is_absolute() => p,
+                Some(p) => {
+                    // Resolve relative path against the current working directory.
+                    tracing::info!("cwd is relative, resolving against current dir");
+                    let mut current = env::current_dir()?;
+                    current.push(p);
+                    current
+                }
+            }
+        };
+
+        let sandbox_policy = cfg.derive_sandbox_policy(sandbox_mode, &resolved_cwd);
+        let approval_policy = approval_policy_override
+            .or(config_profile.approval_policy)
+            .or(cfg.approval_policy)
+            .or_else(|| {
+                // If no explicit approval policy is set, but we trust cwd, default to OnRequest
+                cfg.is_cwd_trusted(&resolved_cwd)
+                    .then_some(AskForApproval::OnRequest)
+            })
+            .unwrap_or_else(AskForApproval::default);
+        let did_user_set_custom_approval_policy_or_sandbox_mode = approval_policy_override
+            .is_some()
+            || config_profile.approval_policy.is_some()
+            || cfg.approval_policy.is_some()
+            // TODO: policy.sandbox_mode is not implemented
+            || sandbox_mode.is_some()
+            || cfg.sandbox_mode.is_some();
 
         let mut model_providers = built_in_model_providers();
         // Merge user-defined providers into the built-in list.
@@ -1052,25 +1097,6 @@ impl Config {
             .clone();
 
         let shell_environment_policy = cfg.shell_environment_policy.into();
-
-        let resolved_cwd = {
-            use std::env;
-
-            match cwd {
-                None => {
-                    tracing::info!("cwd not set, using current dir");
-                    env::current_dir()?
-                }
-                Some(p) if p.is_absolute() => p,
-                Some(p) => {
-                    // Resolve relative path against the current working directory.
-                    tracing::info!("cwd is relative, resolving against current dir");
-                    let mut current = env::current_dir()?;
-                    current.push(p);
-                    current
-                }
-            }
-        };
 
         let history = cfg.history.unwrap_or_default();
 
@@ -1149,6 +1175,7 @@ impl Config {
             cwd: resolved_cwd,
             approval_policy,
             sandbox_policy,
+            did_user_set_custom_approval_policy_or_sandbox_mode,
             shell_environment_policy,
             notify: cfg.notify,
             user_instructions,
@@ -1398,7 +1425,8 @@ network_access = false  # This should be ignored.
         let sandbox_mode_override = None;
         assert_eq!(
             SandboxPolicy::DangerFullAccess,
-            sandbox_full_access_cfg.derive_sandbox_policy(sandbox_mode_override)
+            sandbox_full_access_cfg
+                .derive_sandbox_policy(sandbox_mode_override, &PathBuf::from("/tmp/test"))
         );
 
         let sandbox_read_only = r#"
@@ -1413,7 +1441,8 @@ network_access = true  # This should be ignored.
         let sandbox_mode_override = None;
         assert_eq!(
             SandboxPolicy::ReadOnly,
-            sandbox_read_only_cfg.derive_sandbox_policy(sandbox_mode_override)
+            sandbox_read_only_cfg
+                .derive_sandbox_policy(sandbox_mode_override, &PathBuf::from("/tmp/test"))
         );
 
         let sandbox_workspace_write = r#"
@@ -1437,7 +1466,36 @@ exclude_slash_tmp = true
                 exclude_tmpdir_env_var: true,
                 exclude_slash_tmp: true,
             },
-            sandbox_workspace_write_cfg.derive_sandbox_policy(sandbox_mode_override)
+            sandbox_workspace_write_cfg
+                .derive_sandbox_policy(sandbox_mode_override, &PathBuf::from("/tmp/test"))
+        );
+
+        let sandbox_workspace_write = r#"
+sandbox_mode = "workspace-write"
+
+[sandbox_workspace_write]
+writable_roots = [
+    "/my/workspace",
+]
+exclude_tmpdir_env_var = true
+exclude_slash_tmp = true
+
+[projects."/tmp/test"]
+trust_level = "trusted"
+"#;
+
+        let sandbox_workspace_write_cfg = toml::from_str::<ConfigToml>(sandbox_workspace_write)
+            .expect("TOML deserialization should succeed");
+        let sandbox_mode_override = None;
+        assert_eq!(
+            SandboxPolicy::WorkspaceWrite {
+                writable_roots: vec![PathBuf::from("/my/workspace")],
+                network_access: false,
+                exclude_tmpdir_env_var: true,
+                exclude_slash_tmp: true,
+            },
+            sandbox_workspace_write_cfg
+                .derive_sandbox_policy(sandbox_mode_override, &PathBuf::from("/tmp/test"))
         );
     }
 
@@ -2224,6 +2282,7 @@ model_verbosity = "high"
                 model_provider: fixture.openai_provider.clone(),
                 approval_policy: AskForApproval::Never,
                 sandbox_policy: SandboxPolicy::new_read_only_policy(),
+                did_user_set_custom_approval_policy_or_sandbox_mode: true,
                 shell_environment_policy: ShellEnvironmentPolicy::default(),
                 user_instructions: None,
                 notify: None,
@@ -2288,6 +2347,7 @@ model_verbosity = "high"
             model_provider: fixture.openai_chat_completions_provider.clone(),
             approval_policy: AskForApproval::UnlessTrusted,
             sandbox_policy: SandboxPolicy::new_read_only_policy(),
+            did_user_set_custom_approval_policy_or_sandbox_mode: true,
             shell_environment_policy: ShellEnvironmentPolicy::default(),
             user_instructions: None,
             notify: None,
@@ -2367,6 +2427,7 @@ model_verbosity = "high"
             model_provider: fixture.openai_provider.clone(),
             approval_policy: AskForApproval::OnFailure,
             sandbox_policy: SandboxPolicy::new_read_only_policy(),
+            did_user_set_custom_approval_policy_or_sandbox_mode: true,
             shell_environment_policy: ShellEnvironmentPolicy::default(),
             user_instructions: None,
             notify: None,
@@ -2432,6 +2493,7 @@ model_verbosity = "high"
             model_provider: fixture.openai_provider.clone(),
             approval_policy: AskForApproval::OnFailure,
             sandbox_policy: SandboxPolicy::new_read_only_policy(),
+            did_user_set_custom_approval_policy_or_sandbox_mode: true,
             shell_environment_policy: ShellEnvironmentPolicy::default(),
             user_instructions: None,
             notify: None,

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1077,7 +1077,7 @@ impl Config {
             .unwrap_or(ProjectConfig { trust_level: None });
 
         let sandbox_policy = cfg.derive_sandbox_policy(sandbox_mode, &resolved_cwd);
-        let approval_policy = approval_policy_override
+        let mut approval_policy = approval_policy_override
             .or(config_profile.approval_policy)
             .or(cfg.approval_policy)
             .unwrap_or_else(|| {
@@ -1092,7 +1092,7 @@ impl Config {
             .is_some()
             || config_profile.approval_policy.is_some()
             || cfg.approval_policy.is_some()
-            // TODO: policy.sandbox_mode is not implemented
+            // TODO(#3034): profile.sandbox_mode is not implemented
             || sandbox_mode.is_some()
             || cfg.sandbox_mode.is_some();
 
@@ -1173,11 +1173,6 @@ impl Config {
         let review_model = override_review_model
             .or(cfg.review_model)
             .unwrap_or_else(default_review_model);
-
-        let mut approval_policy = approval_policy
-            .or(config_profile.approval_policy)
-            .or(cfg.approval_policy)
-            .unwrap_or_else(AskForApproval::default);
 
         if features.enabled(Feature::ApproveAll) {
             approval_policy = AskForApproval::OnRequest;

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -880,7 +880,10 @@ impl From<ToolsToml> for Tools {
 
 impl ConfigToml {
     /// Derive the effective sandbox policy from the configuration.
-    fn derive_sandbox_policy(&self, sandbox_mode_override: Option<SandboxMode>) -> SandboxPolicy {
+    pub fn derive_sandbox_policy(
+        &self,
+        sandbox_mode_override: Option<SandboxMode>,
+    ) -> SandboxPolicy {
         let resolved_sandbox_mode = sandbox_mode_override
             .or(self.sandbox_mode)
             .unwrap_or_default();

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -78,6 +78,7 @@ tokio = { workspace = true, features = [
     "signal",
 ] }
 tokio-stream = { workspace = true }
+toml = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -615,8 +615,20 @@ fn determine_repo_trust_state(
     } else if config_toml.is_cwd_trusted(&config.cwd) {
         // if the current cwd project is trusted and no config has been set
         // skip the trust flow and set the approval policy and sandbox mode
+        // Respect any workspace‑write settings from config.toml (e.g.,
+        // writable_roots, exclude_tmpdir_env_var, exclude_slash_tmp,
+        // network_access) instead of always using defaults.
         config.approval_policy = AskForApproval::OnRequest;
-        config.sandbox_policy = SandboxPolicy::new_workspace_write_policy();
+        config.sandbox_policy = if let Some(ws) = &config_toml.sandbox_workspace_write {
+            SandboxPolicy::WorkspaceWrite {
+                writable_roots: ws.writable_roots.clone(),
+                network_access: ws.network_access,
+                exclude_tmpdir_env_var: ws.exclude_tmpdir_env_var,
+                exclude_slash_tmp: ws.exclude_slash_tmp,
+            }
+        } else {
+            SandboxPolicy::new_workspace_write_policy()
+        };
         Ok(false)
     } else {
         // if none of the above conditions are met, show the trust screen

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -189,7 +189,7 @@ pub async fn run_main(
         }
     };
 
-    let config = load_config_or_exit(cli_kv_overrides.clone(), overrides.clone());
+    let config = load_config_or_exit(cli_kv_overrides.clone(), overrides.clone()).await;
 
     let active_profile = config.active_profile.clone();
     let log_dir = codex_core::config::log_dir(&config)?;
@@ -363,8 +363,12 @@ async fn run_ratatui_app(
     let should_show_trust_screen = should_show_trust_screen(&initial_config);
     let should_show_windows_wsl_screen =
         cfg!(target_os = "windows") && !initial_config.windows_wsl_setup_acknowledged;
-    let should_show_onboarding =
-        should_show_onboarding(login_status, &initial_config, should_show_trust_screen);
+    let should_show_onboarding = should_show_onboarding(
+        login_status,
+        &initial_config,
+        should_show_trust_screen,
+        should_show_windows_wsl_screen,
+    );
 
     let config = if should_show_onboarding {
         let onboarding_result = run_onboarding_app(
@@ -397,9 +401,11 @@ async fn run_ratatui_app(
             || onboarding_result
                 .directory_trust_decision
                 .map(|d| d == TrustDirectorySelection::Trust)
-                .or_else(false)
+                .unwrap_or(false)
         {
-            load_config_or_exit(cli_kv_overrides, overrides)
+            load_config_or_exit(cli_kv_overrides, overrides).await
+        } else {
+            initial_config
         }
     } else {
         initial_config
@@ -544,12 +550,12 @@ fn get_login_status(config: &Config) -> LoginStatus {
     }
 }
 
-fn load_config_or_exit(
+async fn load_config_or_exit(
     cli_kv_overrides: Vec<(String, toml::Value)>,
     overrides: ConfigOverrides,
 ) -> Config {
     #[allow(clippy::print_stderr)]
-    match Config::load_with_cli_overrides(cli_kv_overrides, overrides) {
+    match Config::load_with_cli_overrides(cli_kv_overrides, overrides).await {
         Ok(config) => config,
         Err(err) => {
             eprintln!("Error loading configuration: {err}");

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -615,10 +615,8 @@ fn determine_repo_trust_state(
     } else if config_toml.is_cwd_trusted(&config.cwd) {
         // if the current cwd project is trusted and no config has been set
         // skip the trust flow and set the approval policy and sandbox mode
-        // Respect any workspace‑write settings from config.toml (e.g.,
-        // writable_roots, exclude_tmpdir_env_var, exclude_slash_tmp,
-        // network_access) instead of always using defaults.
         config.approval_policy = AskForApproval::OnRequest;
+        // Respect workspace‑write settings from config.toml
         config.sandbox_policy = if config_toml.sandbox_workspace_write.is_some() {
             config_toml.derive_sandbox_policy(Some(SandboxMode::WorkspaceWrite))
         } else {

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -18,7 +18,6 @@ use codex_core::config::find_codex_home;
 use codex_core::config::load_config_as_toml_with_cli_overrides;
 use codex_core::find_conversation_path_by_id_str;
 use codex_core::protocol::AskForApproval;
-use codex_core::protocol::SandboxPolicy;
 use codex_ollama::DEFAULT_OSS_MODEL;
 use codex_protocol::config_types::SandboxMode;
 use opentelemetry_appender_tracing::layer::OpenTelemetryTracingBridge;
@@ -192,20 +191,10 @@ pub async fn run_main(
         }
     };
 
-    let mut config = {
-        // Load configuration and support CLI overrides.
+    let config = load_config_or_exit(cli_kv_overrides.clone(), overrides.clone());
 
-        #[allow(clippy::print_stderr)]
-        match Config::load_with_cli_overrides(cli_kv_overrides.clone(), overrides).await {
-            Ok(config) => config,
-            Err(err) => {
-                eprintln!("Error loading configuration: {err}");
-                std::process::exit(1);
-            }
-        }
-    };
-
-    // we load config.toml here to determine project state.
+    // TODO(dylan): expose project in Config, migrate active_profile below to use Config,
+    // and remove use of config_toml in tui
     #[allow(clippy::print_stderr)]
     let config_toml = {
         let codex_home = match find_codex_home() {
@@ -216,7 +205,7 @@ pub async fn run_main(
             }
         };
 
-        match load_config_as_toml_with_cli_overrides(&codex_home, cli_kv_overrides).await {
+        match load_config_as_toml_with_cli_overrides(&codex_home, cli_kv_overrides.clone()) {
             Ok(config_toml) => config_toml,
             Err(err) => {
                 eprintln!("Error loading config.toml: {err}");
@@ -230,13 +219,7 @@ pub async fn run_main(
         .clone()
         .or_else(|| config_toml.profile.clone());
 
-    let should_show_trust_screen = determine_repo_trust_state(
-        &mut config,
-        &config_toml,
-        approval_policy,
-        sandbox_mode,
-        cli_profile_override,
-    )?;
+    let should_show_trust_screen = determine_repo_trust_state(&config, &config_toml);
 
     let log_dir = codex_core::config::log_dir(&config)?;
     std::fs::create_dir_all(&log_dir)?;
@@ -303,18 +286,26 @@ pub async fn run_main(
         let _ = tracing_subscriber::registry().with(file_layer).try_init();
     };
 
-    run_ratatui_app(cli, config, active_profile, should_show_trust_screen)
-        .await
-        .map_err(|err| std::io::Error::other(err.to_string()))
+    run_ratatui_app(
+        cli,
+        config,
+        overrides,
+        cli_kv_overrides,
+        active_profile,
+        should_show_trust_screen,
+    )
+    .await
+    .map_err(|err| std::io::Error::other(err.to_string()))
 }
 
 async fn run_ratatui_app(
     cli: Cli,
-    config: Config,
+    mut config: Config,
+    overrides: ConfigOverrides,
+    cli_kv_overrides: Vec<(String, toml::Value)>,
     active_profile: Option<String>,
     should_show_trust_screen: bool,
 ) -> color_eyre::Result<AppExitInfo> {
-    let mut config = config;
     color_eyre::install()?;
 
     // Forward panic reports through tracing so they appear in the UI status
@@ -443,9 +434,9 @@ async fn run_ratatui_app(
         if should_show_windows_wsl_screen {
             config.windows_wsl_setup_acknowledged = true;
         }
-        if let Some(TrustDirectorySelection::Trust) = onboarding_result.directory_trust_decision {
-            config.approval_policy = AskForApproval::OnRequest;
-            config.sandbox_policy = SandboxPolicy::new_workspace_write_policy();
+        if let Some(TrustDirectorySelection::Trust) = directory_trust_decision {
+            // if the user made an explicit decision to trust the directory, reload the config
+            config = load_config_or_exit(cli_kv_overrides, overrides);
         }
     }
 
@@ -588,44 +579,35 @@ fn get_login_status(config: &Config) -> LoginStatus {
     }
 }
 
-/// Determine if user has configured a sandbox / approval policy,
-/// or if the current cwd project is trusted, and updates the config
-/// accordingly.
-fn determine_repo_trust_state(
-    config: &mut Config,
-    config_toml: &ConfigToml,
-    approval_policy_overide: Option<AskForApproval>,
-    sandbox_mode_override: Option<SandboxMode>,
-    config_profile_override: Option<String>,
-) -> std::io::Result<bool> {
-    let config_profile = config_toml.get_config_profile(config_profile_override)?;
+fn load_config_or_exit(
+    cli_kv_overrides: Vec<(String, toml::Value)>,
+    overrides: ConfigOverrides,
+) -> Config {
+    #[allow(clippy::print_stderr)]
+    match Config::load_with_cli_overrides(cli_kv_overrides, overrides) {
+        Ok(config) => config,
+        Err(err) => {
+            eprintln!("Error loading configuration: {err}");
+            std::process::exit(1);
+        }
+    }
+}
 
-    if approval_policy_overide.is_some() || sandbox_mode_override.is_some() {
+/// Determine if user has configured a sandbox / approval policy,
+/// or if the current cwd project is already trusted. If not, we need to
+/// show the trust screen.
+fn determine_repo_trust_state(config: &Config, config_toml: &ConfigToml) -> bool {
+    if config.did_user_set_custom_approval_policy_or_sandbox_mode {
         // if the user has overridden either approval policy or sandbox mode,
         // skip the trust flow
-        Ok(false)
-    } else if config_profile.approval_policy.is_some() {
-        // if the user has specified settings in a config profile, skip the trust flow
-        // todo: profile sandbox mode?
-        Ok(false)
-    } else if config_toml.approval_policy.is_some() || config_toml.sandbox_mode.is_some() {
-        // if the user has specified either approval policy or sandbox mode in config.toml
-        // skip the trust flow
-        Ok(false)
+        false
     } else if config_toml.is_cwd_trusted(&config.cwd) {
-        // if the current cwd project is trusted and no config has been set
-        // skip the trust flow and set the approval policy and sandbox mode
-        config.approval_policy = AskForApproval::OnRequest;
-        // Respect workspace‑write settings from config.toml
-        config.sandbox_policy = if config_toml.sandbox_workspace_write.is_some() {
-            config_toml.derive_sandbox_policy(Some(SandboxMode::WorkspaceWrite))
-        } else {
-            SandboxPolicy::new_workspace_write_policy()
-        };
-        Ok(false)
+        // if the current cwd project is already trusted, Config derives the policy.
+        // skip the trust flow
+        false
     } else {
         // if none of the above conditions are met, show the trust screen
-        Ok(true)
+        true
     }
 }
 

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -571,13 +571,9 @@ fn should_show_trust_screen(config: &Config) -> bool {
         // if the user has overridden either approval policy or sandbox mode,
         // skip the trust flow
         false
-    } else if config.active_project.is_trusted() {
-        // if the current cwd project is already trusted, Config derives the policy.
-        // skip the trust flow
-        false
     } else {
-        // if none of the above conditions are met, show the trust screen
-        true
+        // otherwise, skip iff the active project is trusted
+        !config.active_project.is_trusted()
     }
 }
 

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -307,7 +307,7 @@ async fn run_ratatui_app(
     // Show update banner in terminal history (instead of stderr) so it is visible
     // within the TUI scrollback. Building spans keeps styling consistent.
     #[cfg(not(debug_assertions))]
-    if let Some(latest_version) = updates::get_upgrade_version(&config) {
+    if let Some(latest_version) = updates::get_upgrade_version(&initial_config) {
         use crate::history_cell::padded_emoji;
         use crate::history_cell::with_border_with_inner_width;
         use ratatui::style::Stylize as _;

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -290,7 +290,7 @@ async fn run_ratatui_app(
 
         let skip_update_prompt = cli.prompt.as_ref().is_some_and(|prompt| !prompt.is_empty());
         if !skip_update_prompt {
-            match update_prompt::run_update_prompt_if_needed(&mut tui, &config).await? {
+            match update_prompt::run_update_prompt_if_needed(&mut tui, &initial_config).await? {
                 UpdatePromptOutcome::Continue => {}
                 UpdatePromptOutcome::RunUpdate(action) => {
                     crate::tui::restore()?;

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -112,7 +112,6 @@ use crate::onboarding::WSL_INSTRUCTIONS;
 use crate::onboarding::onboarding_screen::OnboardingScreenArgs;
 use crate::onboarding::onboarding_screen::run_onboarding_app;
 use crate::tui::Tui;
-use crate::tui::init;
 pub use cli::Cli;
 pub use markdown_render::render_markdown_text;
 pub use public_widgets::composer_input::ComposerAction;

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -13,9 +13,6 @@ use codex_core::INTERACTIVE_SESSION_SOURCES;
 use codex_core::RolloutRecorder;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
-use codex_core::config::ConfigToml;
-use codex_core::config::find_codex_home;
-use codex_core::config::load_config_as_toml_with_cli_overrides;
 use codex_core::find_conversation_path_by_id_str;
 use codex_core::protocol::AskForApproval;
 use codex_ollama::DEFAULT_OSS_MODEL;
@@ -115,6 +112,7 @@ use crate::onboarding::WSL_INSTRUCTIONS;
 use crate::onboarding::onboarding_screen::OnboardingScreenArgs;
 use crate::onboarding::onboarding_screen::run_onboarding_app;
 use crate::tui::Tui;
+use crate::tui::init;
 pub use cli::Cli;
 pub use markdown_render::render_markdown_text;
 pub use public_widgets::composer_input::ComposerAction;
@@ -193,34 +191,7 @@ pub async fn run_main(
 
     let config = load_config_or_exit(cli_kv_overrides.clone(), overrides.clone());
 
-    // TODO(dylan): expose project in Config, migrate active_profile below to use Config,
-    // and remove use of config_toml in tui
-    #[allow(clippy::print_stderr)]
-    let config_toml = {
-        let codex_home = match find_codex_home() {
-            Ok(codex_home) => codex_home,
-            Err(err) => {
-                eprintln!("Error finding codex home: {err}");
-                std::process::exit(1);
-            }
-        };
-
-        match load_config_as_toml_with_cli_overrides(&codex_home, cli_kv_overrides.clone()) {
-            Ok(config_toml) => config_toml,
-            Err(err) => {
-                eprintln!("Error loading config.toml: {err}");
-                std::process::exit(1);
-            }
-        }
-    };
-
-    let cli_profile_override = cli.config_profile.clone();
-    let active_profile = cli_profile_override
-        .clone()
-        .or_else(|| config_toml.profile.clone());
-
-    let should_show_trust_screen = determine_repo_trust_state(&config, &config_toml);
-
+    let active_profile = config.active_profile.clone();
     let log_dir = codex_core::config::log_dir(&config)?;
     std::fs::create_dir_all(&log_dir)?;
     // Open (or create) your log file, appending to it.
@@ -286,25 +257,17 @@ pub async fn run_main(
         let _ = tracing_subscriber::registry().with(file_layer).try_init();
     };
 
-    run_ratatui_app(
-        cli,
-        config,
-        overrides,
-        cli_kv_overrides,
-        active_profile,
-        should_show_trust_screen,
-    )
-    .await
-    .map_err(|err| std::io::Error::other(err.to_string()))
+    run_ratatui_app(cli, config, overrides, cli_kv_overrides, active_profile)
+        .await
+        .map_err(|err| std::io::Error::other(err.to_string()))
 }
 
 async fn run_ratatui_app(
     cli: Cli,
-    mut config: Config,
+    initial_config: Config,
     overrides: ConfigOverrides,
     cli_kv_overrides: Vec<(String, toml::Value)>,
     active_profile: Option<String>,
-    should_show_trust_screen: bool,
 ) -> color_eyre::Result<AppExitInfo> {
     color_eyre::install()?;
 
@@ -393,27 +356,25 @@ async fn run_ratatui_app(
     }
 
     // Initialize high-fidelity session event logging if enabled.
-    session_log::maybe_init(&config);
+    session_log::maybe_init(&initial_config);
 
-    let auth_manager = AuthManager::shared(config.codex_home.clone(), false);
-    let login_status = get_login_status(&config);
+    let auth_manager = AuthManager::shared(initial_config.codex_home.clone(), false);
+    let login_status = get_login_status(&initial_config);
+    let should_show_trust_screen = should_show_trust_screen(&initial_config);
     let should_show_windows_wsl_screen =
-        cfg!(target_os = "windows") && !config.windows_wsl_setup_acknowledged;
-    let should_show_onboarding = should_show_onboarding(
-        login_status,
-        &config,
-        should_show_trust_screen,
-        should_show_windows_wsl_screen,
-    );
-    if should_show_onboarding {
+        cfg!(target_os = "windows") && !initial_config.windows_wsl_setup_acknowledged;
+    let should_show_onboarding =
+        should_show_onboarding(login_status, &initial_config, should_show_trust_screen);
+
+    let config = if should_show_onboarding {
         let onboarding_result = run_onboarding_app(
             OnboardingScreenArgs {
+                show_login_screen: should_show_login_screen(login_status, &initial_config),
                 show_windows_wsl_screen: should_show_windows_wsl_screen,
-                show_login_screen: should_show_login_screen(login_status, &config),
                 show_trust_screen: should_show_trust_screen,
                 login_status,
                 auth_manager: auth_manager.clone(),
-                config: config.clone(),
+                config: initial_config.clone(),
             },
             &mut tui,
         )
@@ -431,14 +392,18 @@ async fn run_ratatui_app(
                 update_action: None,
             });
         }
-        if should_show_windows_wsl_screen {
-            config.windows_wsl_setup_acknowledged = true;
+        // if the user acknowledged windows or made an explicit decision ato trust the directory, reload the config accordingly
+        if should_show_windows_wsl_screen
+            || onboarding_result
+                .directory_trust_decision
+                .map(|d| d == TrustDirectorySelection::Trust)
+                .or_else(false)
+        {
+            load_config_or_exit(cli_kv_overrides, overrides)
         }
-        if let Some(TrustDirectorySelection::Trust) = directory_trust_decision {
-            // if the user made an explicit decision to trust the directory, reload the config
-            config = load_config_or_exit(cli_kv_overrides, overrides);
-        }
-    }
+    } else {
+        initial_config
+    };
 
     // Determine resume behavior: explicit id, then resume last, then picker.
     let resume_selection = if let Some(id_str) = cli.resume_session_id.as_deref() {
@@ -596,12 +561,12 @@ fn load_config_or_exit(
 /// Determine if user has configured a sandbox / approval policy,
 /// or if the current cwd project is already trusted. If not, we need to
 /// show the trust screen.
-fn determine_repo_trust_state(config: &Config, config_toml: &ConfigToml) -> bool {
+fn should_show_trust_screen(config: &Config) -> bool {
     if config.did_user_set_custom_approval_policy_or_sandbox_mode {
         // if the user has overridden either approval policy or sandbox mode,
         // skip the trust flow
         false
-    } else if config_toml.is_cwd_trusted(&config.cwd) {
+    } else if config.active_project.is_trusted() {
         // if the current cwd project is already trusted, Config derives the policy.
         // skip the trust flow
         false

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -619,13 +619,8 @@ fn determine_repo_trust_state(
         // writable_roots, exclude_tmpdir_env_var, exclude_slash_tmp,
         // network_access) instead of always using defaults.
         config.approval_policy = AskForApproval::OnRequest;
-        config.sandbox_policy = if let Some(ws) = &config_toml.sandbox_workspace_write {
-            SandboxPolicy::WorkspaceWrite {
-                writable_roots: ws.writable_roots.clone(),
-                network_access: ws.network_access,
-                exclude_tmpdir_env_var: ws.exclude_tmpdir_env_var,
-                exclude_slash_tmp: ws.exclude_slash_tmp,
-            }
+        config.sandbox_policy = if config_toml.sandbox_workspace_write.is_some() {
+            config_toml.derive_sandbox_policy(Some(SandboxMode::WorkspaceWrite))
         } else {
             SandboxPolicy::new_workspace_write_policy()
         };


### PR DESCRIPTION
## Summary
When using the trusted state during tui startup, we created a new WorkspaceWrite policy without checking the config.toml for a `sandbox_workspace_write` field. This would result in us setting the sandbox_mode as workspace-write, but ignoring the field if the user had set `sandbox_workspace_write` without also setting `sandbox_mode` in the config.toml. This PR adds support for respecting `sandbox_workspace_write` setting in config.toml in the trusted directory flow, and adds tests to cover this case.

## Testing
- [x] Added unit tests