### PR TITLE
tweak "failed to find expected lines" message in apply_patch

### DIFF
--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -726,9 +726,9 @@ fn compute_replacements(
             line_index = start_idx + pattern.len();
         } else {
             return Err(ApplyPatchError::ComputeReplacements(format!(
-                "Failed to find expected lines {:?} in {}",
-                chunk.old_lines,
-                path.display()
+                "Failed to find expected lines in {}:\n{}",
+                path.display(),
+                chunk.old_lines.join("\n"),
             )));
         }
     }


### PR DESCRIPTION
It was hard for me to read the expected lines as a `["one", "two", "three"]` array, maybe not so hard for the model but probably not having to un-escape in its head would help it out :)