### PR TITLE
if a command parses as a patch, do not attempt to run it

### DIFF
--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -903,10 +903,10 @@ mod tests {
         let patch = "*** Begin Patch\n*** Add File: foo\n+hi\n*** End Patch".to_string();
         let args = vec![patch];
         let dir = tempdir().unwrap();
-        match maybe_parse_apply_patch_verified(&args, dir.path()) {
-            MaybeApplyPatchVerified::CorrectnessError(ApplyPatchError::ImplicitInvocation) => {}
-            other => panic!("expected ImplicitInvocation error, got {other:?}"),
-        }
+        assert!(matches!(
+            maybe_parse_apply_patch_verified(&args, dir.path()),
+            MaybeApplyPatchVerified::CorrectnessError(ApplyPatchError::ImplicitInvocation)
+        ));
     }
 
     #[test]
@@ -914,10 +914,10 @@ mod tests {
         let script = "*** Begin Patch\n*** Add File: foo\n+hi\n*** End Patch";
         let args = args_bash(script);
         let dir = tempdir().unwrap();
-        match maybe_parse_apply_patch_verified(&args, dir.path()) {
-            MaybeApplyPatchVerified::CorrectnessError(ApplyPatchError::ImplicitInvocation) => {}
-            other => panic!("expected ImplicitInvocation error, got {other:?}"),
-        }
+        assert!(matches!(
+            maybe_parse_apply_patch_verified(&args, dir.path()),
+            MaybeApplyPatchVerified::CorrectnessError(ApplyPatchError::ImplicitInvocation)
+        ));
     }
 
     #[test]

--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -41,7 +41,9 @@ pub enum ApplyPatchError {
     #[error("{0}")]
     ComputeReplacements(String),
     /// A raw patch body was provided without an explicit `apply_patch` invocation.
-    #[error("patch detected without explicit call to apply_patch")]
+    #[error(
+        "patch detected without explicit call to apply_patch. Rerun as [\"apply_patch\", \"<patch>\"]"
+    )]
     ImplicitInvocation,
 }
 


### PR DESCRIPTION
sometimes the model forgets to actually invoke `apply_patch` and puts a patch as the script body. trying to execute this as bash sometimes creates files named `,` or `{` or does other unknown things, so catch this situation and return an error to the model.