### PR TITLE
check if write cycle is active for stream on agent message

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -184,6 +184,9 @@ impl ChatWidget {
     }
 
     fn on_agent_message(&mut self, message: String) {
+        if !self.stream.is_write_cycle_active() {
+            return;
+        }
         let sink = AppEventHistorySink(self.app_event_tx.clone());
         let finished = self.stream.apply_final_answer(&message, &sink);
         self.handle_if_stream_finished(finished);


### PR DESCRIPTION
We are seeing duplicate final messages in the TUI. It’s hard to pinpoint and reproduce this behavior, but the only places where we could potentially get duplicate messages flushed are `on_agent_message` and `on_task_complete`, specifically if we reorder messages and receive `EventMsg::TaskComplete` before `EventMsg::AgentMessage`.  

To prevent this behavior, we can check if a write cycle is active for the stream when handling an agent message.
