### PR TITLE
Replace config.responses_originator_header_internal_override with CODEX_INTERNAL_ORIGINATOR_OVERRIDE_ENV_VAR

### DIFF
--- a/codex-rs/chatgpt/src/apply_command.rs
+++ b/codex-rs/chatgpt/src/apply_command.rs
@@ -31,7 +31,7 @@ pub async fn run_apply_command(
         ConfigOverrides::default(),
     )?;
 
-    init_chatgpt_token_from_auth(&config.codex_home, &config.responses_originator_header).await?;
+    init_chatgpt_token_from_auth(&config.codex_home).await?;
 
     let task_response = get_task(&config, apply_cli.task_id).await?;
     apply_diff_from_task(task_response, cwd).await

--- a/codex-rs/chatgpt/src/chatgpt_client.rs
+++ b/codex-rs/chatgpt/src/chatgpt_client.rs
@@ -13,10 +13,10 @@ pub(crate) async fn chatgpt_get_request<T: DeserializeOwned>(
     path: String,
 ) -> anyhow::Result<T> {
     let chatgpt_base_url = &config.chatgpt_base_url;
-    init_chatgpt_token_from_auth(&config.codex_home, &config.responses_originator_header).await?;
+    init_chatgpt_token_from_auth(&config.codex_home).await?;
 
     // Make direct HTTP request to ChatGPT backend API with the token
-    let client = create_client(&config.responses_originator_header);
+    let client = create_client();
     let url = format!("{chatgpt_base_url}{path}");
 
     let token =

--- a/codex-rs/chatgpt/src/chatgpt_token.rs
+++ b/codex-rs/chatgpt/src/chatgpt_token.rs
@@ -19,11 +19,8 @@ pub fn set_chatgpt_token_data(value: TokenData) {
 }
 
 /// Initialize the ChatGPT token from auth.json file
-pub async fn init_chatgpt_token_from_auth(
-    codex_home: &Path,
-    originator: &str,
-) -> std::io::Result<()> {
-    let auth = CodexAuth::from_codex_home(codex_home, AuthMode::ChatGPT, originator)?;
+pub async fn init_chatgpt_token_from_auth(codex_home: &Path) -> std::io::Result<()> {
+    let auth = CodexAuth::from_codex_home(codex_home, AuthMode::ChatGPT)?;
     if let Some(auth) = auth {
         let token_data = auth.get_token_data().await?;
         set_chatgpt_token_data(token_data);

--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -12,8 +12,8 @@ use codex_protocol::mcp_protocol::AuthMode;
 use std::env;
 use std::path::PathBuf;
 
-pub async fn login_with_chatgpt(codex_home: PathBuf, originator: String) -> std::io::Result<()> {
-    let opts = ServerOptions::new(codex_home, CLIENT_ID.to_string(), originator);
+pub async fn login_with_chatgpt(codex_home: PathBuf) -> std::io::Result<()> {
+    let opts = ServerOptions::new(codex_home, CLIENT_ID.to_string());
     let server = run_login_server(opts)?;
 
     eprintln!(
@@ -27,12 +27,7 @@ pub async fn login_with_chatgpt(codex_home: PathBuf, originator: String) -> std:
 pub async fn run_login_with_chatgpt(cli_config_overrides: CliConfigOverrides) -> ! {
     let config = load_config_or_exit(cli_config_overrides);
 
-    match login_with_chatgpt(
-        config.codex_home,
-        config.responses_originator_header.clone(),
-    )
-    .await
-    {
+    match login_with_chatgpt(config.codex_home).await {
         Ok(_) => {
             eprintln!("Successfully logged in");
             std::process::exit(0);
@@ -65,11 +60,7 @@ pub async fn run_login_with_api_key(
 pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {
     let config = load_config_or_exit(cli_config_overrides);
 
-    match CodexAuth::from_codex_home(
-        &config.codex_home,
-        config.preferred_auth_method,
-        &config.responses_originator_header,
-    ) {
+    match CodexAuth::from_codex_home(&config.codex_home, config.preferred_auth_method) {
         Ok(Some(auth)) => match auth.mode {
             AuthMode::ApiKey => match auth.get_token().await {
                 Ok(api_key) => {

--- a/codex-rs/cli/src/proto.rs
+++ b/codex-rs/cli/src/proto.rs
@@ -40,7 +40,6 @@ pub async fn run_main(opts: ProtoCli) -> anyhow::Result<()> {
     let conversation_manager = ConversationManager::new(AuthManager::shared(
         config.codex_home.clone(),
         config.preferred_auth_method,
-        config.responses_originator_header.clone(),
     ));
     let NewConversation {
         conversation_id: _,

--- a/codex-rs/core/src/auth.rs
+++ b/codex-rs/core/src/auth.rs
@@ -75,9 +75,8 @@ impl CodexAuth {
     pub fn from_codex_home(
         codex_home: &Path,
         preferred_auth_method: AuthMode,
-        originator: &str,
     ) -> std::io::Result<Option<CodexAuth>> {
-        load_auth(codex_home, true, preferred_auth_method, originator)
+        load_auth(codex_home, true, preferred_auth_method)
     }
 
     pub async fn get_token_data(&self) -> Result<TokenData, std::io::Error> {
@@ -173,7 +172,7 @@ impl CodexAuth {
             mode: AuthMode::ChatGPT,
             auth_file: PathBuf::new(),
             auth_dot_json,
-            client: crate::default_client::create_client("codex_cli_rs"),
+            client: crate::default_client::create_client(),
         }
     }
 
@@ -188,10 +187,7 @@ impl CodexAuth {
     }
 
     pub fn from_api_key(api_key: &str) -> Self {
-        Self::from_api_key_with_client(
-            api_key,
-            crate::default_client::create_client(crate::default_client::DEFAULT_ORIGINATOR),
-        )
+        Self::from_api_key_with_client(api_key, crate::default_client::create_client())
     }
 }
 
@@ -232,13 +228,12 @@ fn load_auth(
     codex_home: &Path,
     include_env_var: bool,
     preferred_auth_method: AuthMode,
-    originator: &str,
 ) -> std::io::Result<Option<CodexAuth>> {
     // First, check to see if there is a valid auth.json file. If not, we fall
     // back to AuthMode::ApiKey using the OPENAI_API_KEY environment variable
     // (if it is set).
     let auth_file = get_auth_file(codex_home);
-    let client = crate::default_client::create_client(originator);
+    let client = crate::default_client::create_client();
     let auth_dot_json = match try_read_auth_json(&auth_file) {
         Ok(auth) => auth,
         // If auth.json does not exist, try to read the OPENAI_API_KEY from the
@@ -473,7 +468,7 @@ mod tests {
             auth_dot_json,
             auth_file: _,
             ..
-        } = super::load_auth(codex_home.path(), false, AuthMode::ChatGPT, "codex_cli_rs")
+        } = super::load_auth(codex_home.path(), false, AuthMode::ChatGPT)
             .unwrap()
             .unwrap();
         assert_eq!(None, api_key);
@@ -525,7 +520,7 @@ mod tests {
             auth_dot_json,
             auth_file: _,
             ..
-        } = super::load_auth(codex_home.path(), false, AuthMode::ChatGPT, "codex_cli_rs")
+        } = super::load_auth(codex_home.path(), false, AuthMode::ChatGPT)
             .unwrap()
             .unwrap();
         assert_eq!(None, api_key);
@@ -576,7 +571,7 @@ mod tests {
             auth_dot_json,
             auth_file: _,
             ..
-        } = super::load_auth(codex_home.path(), false, AuthMode::ChatGPT, "codex_cli_rs")
+        } = super::load_auth(codex_home.path(), false, AuthMode::ChatGPT)
             .unwrap()
             .unwrap();
         assert_eq!(Some("sk-test-key".to_string()), api_key);
@@ -596,7 +591,7 @@ mod tests {
         )
         .unwrap();
 
-        let auth = super::load_auth(dir.path(), false, AuthMode::ChatGPT, "codex_cli_rs")
+        let auth = super::load_auth(dir.path(), false, AuthMode::ChatGPT)
             .unwrap()
             .unwrap();
         assert_eq!(auth.mode, AuthMode::ApiKey);
@@ -680,7 +675,6 @@ mod tests {
 #[derive(Debug)]
 pub struct AuthManager {
     codex_home: PathBuf,
-    originator: String,
     inner: RwLock<CachedAuth>,
 }
 
@@ -689,13 +683,12 @@ impl AuthManager {
     /// preferred auth method. Errors loading auth are swallowed; `auth()` will
     /// simply return `None` in that case so callers can treat it as an
     /// unauthenticated state.
-    pub fn new(codex_home: PathBuf, preferred_auth_mode: AuthMode, originator: String) -> Self {
-        let auth = CodexAuth::from_codex_home(&codex_home, preferred_auth_mode, &originator)
+    pub fn new(codex_home: PathBuf, preferred_auth_mode: AuthMode) -> Self {
+        let auth = CodexAuth::from_codex_home(&codex_home, preferred_auth_mode)
             .ok()
             .flatten();
         Self {
             codex_home,
-            originator,
             inner: RwLock::new(CachedAuth {
                 preferred_auth_mode,
                 auth,
@@ -712,7 +705,6 @@ impl AuthManager {
         };
         Arc::new(Self {
             codex_home: PathBuf::new(),
-            originator: "codex_cli_rs".to_string(),
             inner: RwLock::new(cached),
         })
     }
@@ -734,7 +726,7 @@ impl AuthManager {
     /// whether the auth value changed.
     pub fn reload(&self) -> bool {
         let preferred = self.preferred_auth_method();
-        let new_auth = CodexAuth::from_codex_home(&self.codex_home, preferred, &self.originator)
+        let new_auth = CodexAuth::from_codex_home(&self.codex_home, preferred)
             .ok()
             .flatten();
         if let Ok(mut guard) = self.inner.write() {
@@ -755,12 +747,8 @@ impl AuthManager {
     }
 
     /// Convenience constructor returning an `Arc` wrapper.
-    pub fn shared(
-        codex_home: PathBuf,
-        preferred_auth_mode: AuthMode,
-        originator: String,
-    ) -> Arc<Self> {
-        Arc::new(Self::new(codex_home, preferred_auth_mode, originator))
+    pub fn shared(codex_home: PathBuf, preferred_auth_mode: AuthMode) -> Arc<Self> {
+        Arc::new(Self::new(codex_home, preferred_auth_mode))
     }
 
     /// Attempt to refresh the current auth token (if any). On success, reload

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -84,7 +84,7 @@ impl ModelClient {
         summary: ReasoningSummaryConfig,
         conversation_id: ConversationId,
     ) -> Self {
-        let client = create_client(&config.responses_originator_header);
+        let client = create_client();
 
         Self {
             config,

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -40,8 +40,6 @@ pub(crate) const PROJECT_DOC_MAX_BYTES: usize = 32 * 1024; // 32 KiB
 
 const CONFIG_TOML_FILE: &str = "config.toml";
 
-const DEFAULT_RESPONSES_ORIGINATOR_HEADER: &str = "codex_cli_rs";
-
 /// Application configuration loaded from disk and merged with overrides.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Config {
@@ -168,9 +166,6 @@ pub struct Config {
     pub include_apply_patch_tool: bool,
 
     pub tools_web_search_request: bool,
-
-    /// The value for the `originator` header included with Responses API requests.
-    pub responses_originator_header: String,
 
     /// If set to `true`, the API key will be signed with the `originator` header.
     pub preferred_auth_method: AuthMode,
@@ -478,9 +473,6 @@ pub struct ConfigToml {
 
     pub experimental_use_exec_command_tool: Option<bool>,
 
-    /// The value for the `originator` header included with Responses API requests.
-    pub responses_originator_header_internal_override: Option<String>,
-
     pub projects: Option<HashMap<String, ProjectConfig>>,
 
     /// If set to `true`, the API key will be signed with the `originator` header.
@@ -773,10 +765,6 @@ impl Config {
             Self::get_base_instructions(experimental_instructions_path, &resolved_cwd)?;
         let base_instructions = base_instructions.or(file_base_instructions);
 
-        let responses_originator_header: String = cfg
-            .responses_originator_header_internal_override
-            .unwrap_or(DEFAULT_RESPONSES_ORIGINATOR_HEADER.to_owned());
-
         let config = Self {
             model,
             model_family,
@@ -826,7 +814,6 @@ impl Config {
             include_plan_tool: include_plan_tool.unwrap_or(false),
             include_apply_patch_tool: include_apply_patch_tool.unwrap_or(false),
             tools_web_search_request,
-            responses_originator_header,
             preferred_auth_method: cfg.preferred_auth_method.unwrap_or(AuthMode::ChatGPT),
             use_experimental_streamable_shell_tool: cfg
                 .experimental_use_exec_command_tool
@@ -1203,7 +1190,6 @@ model_verbosity = "high"
                 include_plan_tool: false,
                 include_apply_patch_tool: false,
                 tools_web_search_request: false,
-                responses_originator_header: "codex_cli_rs".to_string(),
                 preferred_auth_method: AuthMode::ChatGPT,
                 use_experimental_streamable_shell_tool: false,
                 include_view_image_tool: true,
@@ -1260,7 +1246,6 @@ model_verbosity = "high"
             include_plan_tool: false,
             include_apply_patch_tool: false,
             tools_web_search_request: false,
-            responses_originator_header: "codex_cli_rs".to_string(),
             preferred_auth_method: AuthMode::ChatGPT,
             use_experimental_streamable_shell_tool: false,
             include_view_image_tool: true,
@@ -1332,7 +1317,6 @@ model_verbosity = "high"
             include_plan_tool: false,
             include_apply_patch_tool: false,
             tools_web_search_request: false,
-            responses_originator_header: "codex_cli_rs".to_string(),
             preferred_auth_method: AuthMode::ChatGPT,
             use_experimental_streamable_shell_tool: false,
             include_view_image_tool: true,
@@ -1390,7 +1374,6 @@ model_verbosity = "high"
             include_plan_tool: false,
             include_apply_patch_tool: false,
             tools_web_search_request: false,
-            responses_originator_header: "codex_cli_rs".to_string(),
             preferred_auth_method: AuthMode::ChatGPT,
             use_experimental_streamable_shell_tool: false,
             include_view_image_tool: true,

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -190,7 +190,6 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
     let conversation_manager = ConversationManager::new(AuthManager::shared(
         config.codex_home.clone(),
         config.preferred_auth_method,
-        config.responses_originator_header.clone(),
     ));
     let NewConversation {
         conversation_id: _,

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -16,6 +16,7 @@ use base64::Engine;
 use chrono::Utc;
 use codex_core::auth::AuthDotJson;
 use codex_core::auth::get_auth_file;
+use codex_core::default_client::ORIGINATOR;
 use codex_core::token_data::TokenData;
 use codex_core::token_data::parse_id_token;
 use rand::RngCore;
@@ -35,11 +36,10 @@ pub struct ServerOptions {
     pub port: u16,
     pub open_browser: bool,
     pub force_state: Option<String>,
-    pub originator: String,
 }
 
 impl ServerOptions {
-    pub fn new(codex_home: PathBuf, client_id: String, originator: String) -> Self {
+    pub fn new(codex_home: PathBuf, client_id: String) -> Self {
         Self {
             codex_home,
             client_id: client_id.to_string(),
@@ -47,7 +47,6 @@ impl ServerOptions {
             port: DEFAULT_PORT,
             open_browser: true,
             force_state: None,
-            originator,
         }
     }
 }
@@ -103,14 +102,7 @@ pub fn run_login_server(opts: ServerOptions) -> io::Result<LoginServer> {
     let server = Arc::new(server);
 
     let redirect_uri = format!("http://localhost:{actual_port}/auth/callback");
-    let auth_url = build_authorize_url(
-        &opts.issuer,
-        &opts.client_id,
-        &redirect_uri,
-        &pkce,
-        &state,
-        &opts.originator,
-    );
+    let auth_url = build_authorize_url(&opts.issuer, &opts.client_id, &redirect_uri, &pkce, &state);
 
     if opts.open_browser {
         let _ = webbrowser::open(&auth_url);
@@ -311,7 +303,6 @@ fn build_authorize_url(
     redirect_uri: &str,
     pkce: &PkceCodes,
     state: &str,
-    originator: &str,
 ) -> String {
     let query = vec![
         ("response_type", "code"),
@@ -323,7 +314,7 @@ fn build_authorize_url(
         ("id_token_add_organizations", "true"),
         ("codex_cli_simplified_flow", "true"),
         ("state", state),
-        ("originator", originator),
+        ("originator", ORIGINATOR.value.as_str()),
     ];
     let qs = query
         .into_iter()

--- a/codex-rs/login/tests/suite/login_server_e2e.rs
+++ b/codex-rs/login/tests/suite/login_server_e2e.rs
@@ -102,7 +102,6 @@ async fn end_to_end_login_flow_persists_auth_json() {
         port: 0,
         open_browser: false,
         force_state: Some(state),
-        originator: "test_originator".to_string(),
     };
     let server = run_login_server(opts).unwrap();
     let login_port = server.actual_port;
@@ -161,7 +160,6 @@ async fn creates_missing_codex_home_dir() {
         port: 0,
         open_browser: false,
         force_state: Some(state),
-        originator: "test_originator".to_string(),
     };
     let server = run_login_server(opts).unwrap();
     let login_port = server.actual_port;
@@ -202,7 +200,6 @@ async fn cancels_previous_login_server_when_port_is_in_use() {
         port: 0,
         open_browser: false,
         force_state: Some("cancel_state".to_string()),
-        originator: "test_originator".to_string(),
     };
 
     let first_server = run_login_server(first_opts).unwrap();
@@ -221,7 +218,6 @@ async fn cancels_previous_login_server_when_port_is_in_use() {
         port: login_port,
         open_browser: false,
         force_state: Some("cancel_state_2".to_string()),
-        originator: "test_originator".to_string(),
     };
 
     let second_server = run_login_server(second_opts).unwrap();

--- a/codex-rs/mcp-server/src/codex_message_processor.rs
+++ b/codex-rs/mcp-server/src/codex_message_processor.rs
@@ -198,11 +198,7 @@ impl CodexMessageProcessor {
 
         let opts = LoginServerOptions {
             open_browser: false,
-            ..LoginServerOptions::new(
-                config.codex_home.clone(),
-                CLIENT_ID.to_string(),
-                config.responses_originator_header.clone(),
-            )
+            ..LoginServerOptions::new(config.codex_home.clone(), CLIENT_ID.to_string())
         };
 
         enum LoginChatGptReply {
@@ -403,7 +399,7 @@ impl CodexMessageProcessor {
     }
 
     async fn get_user_agent(&self, request_id: RequestId) {
-        let user_agent = get_codex_user_agent(Some(&self.config.responses_originator_header));
+        let user_agent = get_codex_user_agent();
         let response = GetUserAgentResponse { user_agent };
         self.outgoing.send_response(request_id, response).await;
     }

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -54,11 +54,8 @@ impl MessageProcessor {
         config: Arc<Config>,
     ) -> Self {
         let outgoing = Arc::new(outgoing);
-        let auth_manager = AuthManager::shared(
-            config.codex_home.clone(),
-            config.preferred_auth_method,
-            config.responses_originator_header.clone(),
-        );
+        let auth_manager =
+            AuthManager::shared(config.codex_home.clone(), config.preferred_auth_method);
         let conversation_manager = Arc::new(ConversationManager::new(auth_manager.clone()));
         let codex_message_processor = CodexMessageProcessor::new(
             auth_manager,

--- a/codex-rs/mcp-server/tests/suite/user_agent.rs
+++ b/codex-rs/mcp-server/tests/suite/user_agent.rs
@@ -1,4 +1,3 @@
-use codex_core::default_client::DEFAULT_ORIGINATOR;
 use codex_core::default_client::get_codex_user_agent;
 use codex_protocol::mcp_protocol::GetUserAgentResponse;
 use mcp_test_support::McpProcess;
@@ -38,7 +37,7 @@ async fn get_user_agent_returns_current_codex_user_agent() {
     let received: GetUserAgentResponse =
         to_response(response).expect("deserialize getUserAgent response");
     let expected = GetUserAgentResponse {
-        user_agent: get_codex_user_agent(Some(DEFAULT_ORIGINATOR)),
+        user_agent: get_codex_user_agent(),
     };
 
     assert_eq!(received, expected);

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -312,11 +312,7 @@ async fn run_ratatui_app(
         ..
     } = cli;
 
-    let auth_manager = AuthManager::shared(
-        config.codex_home.clone(),
-        config.preferred_auth_method,
-        config.responses_originator_header.clone(),
-    );
+    let auth_manager = AuthManager::shared(config.codex_home.clone(), config.preferred_auth_method);
     let login_status = get_login_status(&config);
     let should_show_onboarding =
         should_show_onboarding(login_status, &config, should_show_trust_screen);
@@ -400,11 +396,7 @@ fn get_login_status(config: &Config) -> LoginStatus {
         // Reading the OpenAI API key is an async operation because it may need
         // to refresh the token. Block on it.
         let codex_home = config.codex_home.clone();
-        match CodexAuth::from_codex_home(
-            &codex_home,
-            config.preferred_auth_method,
-            &config.responses_originator_header,
-        ) {
+        match CodexAuth::from_codex_home(&codex_home, config.preferred_auth_method) {
             Ok(Some(auth)) => LoginStatus::AuthMode(auth.mode),
             Ok(None) => LoginStatus::NotAuthenticated,
             Err(err) => {

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -2,7 +2,6 @@
 
 use codex_core::AuthManager;
 use codex_core::auth::CLIENT_ID;
-use codex_core::config::Config;
 use codex_login::ServerOptions;
 use codex_login::ShutdownHandle;
 use codex_login::run_login_server;
@@ -114,7 +113,6 @@ pub(crate) struct AuthModeWidget {
     pub login_status: LoginStatus,
     pub preferred_auth_method: AuthMode,
     pub auth_manager: Arc<AuthManager>,
-    pub config: Config,
 }
 
 impl AuthModeWidget {
@@ -316,11 +314,7 @@ impl AuthModeWidget {
         }
 
         self.error = None;
-        let opts = ServerOptions::new(
-            self.codex_home.clone(),
-            CLIENT_ID.to_string(),
-            self.config.responses_originator_header.clone(),
-        );
+        let opts = ServerOptions::new(self.codex_home.clone(), CLIENT_ID.to_string());
         match run_login_server(opts) {
             Ok(child) => {
                 let sign_in_state = self.sign_in_state.clone();

--- a/codex-rs/tui/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui/src/onboarding/onboarding_screen.rs
@@ -85,7 +85,6 @@ impl OnboardingScreen {
                 login_status,
                 auth_manager,
                 preferred_auth_method,
-                config,
             }))
         }
         let is_git_repo = get_git_repo_root(&cwd).is_some();

--- a/codex-rs/tui/src/updates.rs
+++ b/codex-rs/tui/src/updates.rs
@@ -24,9 +24,8 @@ pub fn get_upgrade_version(config: &Config) -> Option<String> {
         // Refresh the cached latest version in the background so TUI startup
         // isn’t blocked by a network call. The UI reads the previously cached
         // value (if any) for this run; the next run shows the banner if needed.
-        let originator = config.responses_originator_header.clone();
         tokio::spawn(async move {
-            check_for_update(&version_file, &originator)
+            check_for_update(&version_file)
                 .await
                 .inspect_err(|e| tracing::error!("Failed to update version: {e}"))
         });
@@ -65,10 +64,10 @@ fn read_version_info(version_file: &Path) -> anyhow::Result<VersionInfo> {
     Ok(serde_json::from_str(&contents)?)
 }
 
-async fn check_for_update(version_file: &Path, originator: &str) -> anyhow::Result<()> {
+async fn check_for_update(version_file: &Path) -> anyhow::Result<()> {
     let ReleaseInfo {
         tag_name: latest_tag_name,
-    } = create_client(originator)
+    } = create_client()
         .get(LATEST_RELEASE_URL)
         .send()
         .await?


### PR DESCRIPTION
The previous config approach had a few issues:
1. It is part of the config but not designed to be used externally
2. It had to be wired through many places (look at the +/- on this PR
3. It wasn't guaranteed to be set consistently everywhere because we don't have a super well defined way that configs stack. For example, the extension would configure during newConversation but anything that happened outside of that (like login) wouldn't get it.

This env var approach is cleaner and also creates one less thing we have to deal with when coming up with a better holistic story around configs.

One downside is that I removed the unit test testing for the override because I don't want to deal with setting the global env or spawning child processes and figuring out how to introspect their originator header. The new code is sufficiently simple and I tested it e2e that I feel as if this is still worth it.