### PR TITLE
Do not send reasoning item IDs

### DIFF
--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -49,7 +49,7 @@ pub enum ResponseItem {
         content: Vec<ContentItem>,
     },
     Reasoning {
-        #[serde(default)]
+        #[serde(default, skip_serializing)]
         id: String,
         summary: Vec<ReasoningItemReasoningSummary>,
         #[serde(default, skip_serializing_if = "should_serialize_reasoning_content")]


### PR DESCRIPTION
Response API doesn't require IDs on reasoning items anymore. 

Fixes: https://github.com/openai/codex/issues/3292