### PR TITLE
Set a user agent suffix when used as a mcp server

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -843,6 +843,7 @@ dependencies = [
  "anyhow",
  "clap",
  "codex-protocol",
+ "mcp-types",
  "ts-rs",
 ]
 

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2684,6 +2684,7 @@ dependencies = [
  "codex-mcp-server",
  "codex-protocol",
  "mcp-types",
+ "os_info",
  "pretty_assertions",
  "serde",
  "serde_json",

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -785,6 +785,7 @@ dependencies = [
  "codex-protocol",
  "mcp-types",
  "mcp_test_support",
+ "os_info",
  "pretty_assertions",
  "schemars 0.8.22",
  "serde",

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2681,6 +2681,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "codex-core",
  "codex-mcp-server",
  "codex-protocol",
  "mcp-types",

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -17,7 +17,7 @@ use anyhow::Result;
 use anyhow::anyhow;
 use codex_mcp_client::McpClient;
 use mcp_types::ClientCapabilities;
-use mcp_types::Implementation;
+use mcp_types::McpClientInfo;
 use mcp_types::Tool;
 
 use serde_json::json;
@@ -159,7 +159,7 @@ impl McpConnectionManager {
                                 // indicates this should be an empty object.
                                 elicitation: Some(json!({})),
                             },
-                            client_info: Implementation {
+                            client_info: McpClientInfo {
                                 name: "codex-mcp-client".to_owned(),
                                 version: env!("CARGO_PKG_VERSION").to_owned(),
                                 title: Some("Codex".into()),

--- a/codex-rs/mcp-client/src/main.rs
+++ b/codex-rs/mcp-client/src/main.rs
@@ -17,10 +17,10 @@ use anyhow::Context;
 use anyhow::Result;
 use codex_mcp_client::McpClient;
 use mcp_types::ClientCapabilities;
-use mcp_types::Implementation;
 use mcp_types::InitializeRequestParams;
 use mcp_types::ListToolsRequestParams;
 use mcp_types::MCP_SCHEMA_VERSION;
+use mcp_types::McpClientInfo;
 use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
@@ -60,7 +60,7 @@ async fn main() -> Result<()> {
             sampling: None,
             elicitation: None,
         },
-        client_info: Implementation {
+        client_info: McpClientInfo {
             name: "codex-mcp-client".to_owned(),
             version: env!("CARGO_PKG_VERSION").to_owned(),
             title: Some("Codex".to_string()),

--- a/codex-rs/mcp-server/Cargo.toml
+++ b/codex-rs/mcp-server/Cargo.toml
@@ -41,6 +41,7 @@ uuid = { version = "1", features = ["serde", "v4"] }
 [dev-dependencies]
 assert_cmd = "2"
 mcp_test_support = { path = "tests/common" }
+os_info = "3.12.0"
 pretty_assertions = "1.4.1"
 tempfile = "3"
 wiremock = "0.6"

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -91,7 +91,6 @@ impl MessageProcessor {
         // Hold on to the ID so we can respond.
         let request_id = request.id.clone();
 
-        tracing::error!("[GABE] Trying from {request:?}");
         let client_request = match McpClientRequest::try_from(request) {
             Ok(client_request) => client_request,
             Err(e) => {

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -14,6 +14,7 @@ use codex_protocol::mcp_protocol::ConversationId;
 use codex_core::AuthManager;
 use codex_core::ConversationManager;
 use codex_core::config::Config;
+use codex_core::default_client::get_codex_user_agent;
 use codex_core::protocol::Submission;
 use mcp_types::CallToolRequestParams;
 use mcp_types::CallToolResult;
@@ -224,10 +225,11 @@ impl MessageProcessor {
             },
             instructions: None,
             protocol_version: params.protocol_version.clone(),
-            server_info: mcp_types::Implementation {
+            server_info: mcp_types::McpServerInfo {
                 name: "codex-mcp-server".to_string(),
                 version: env!("CARGO_PKG_VERSION").to_string(),
                 title: Some("Codex".to_string()),
+                user_agent: get_codex_user_agent(),
             },
         };
 

--- a/codex-rs/mcp-server/tests/common/Cargo.toml
+++ b/codex-rs/mcp-server/tests/common/Cargo.toml
@@ -9,9 +9,11 @@ path = "lib.rs"
 [dependencies]
 anyhow = "1"
 assert_cmd = "2"
+codex-core = { path = "../../../core" }
 codex-mcp-server = { path = "../.." }
 codex-protocol = { path = "../../../protocol" }
 mcp-types = { path = "../../../mcp-types" }
+os_info = "3.12.0"
 pretty_assertions = "1.4.1"
 serde = { version = "1" }
 serde_json = "1"
@@ -21,5 +23,4 @@ tokio = { version = "1", features = [
     "process",
     "rt-multi-thread",
 ] }
-os_info = "3.12.0"
 wiremock = "0.6"

--- a/codex-rs/mcp-server/tests/common/Cargo.toml
+++ b/codex-rs/mcp-server/tests/common/Cargo.toml
@@ -21,4 +21,5 @@ tokio = { version = "1", features = [
     "process",
     "rt-multi-thread",
 ] }
+os_info = "3.12.0"
 wiremock = "0.6"

--- a/codex-rs/mcp-server/tests/common/mcp_process.rs
+++ b/codex-rs/mcp-server/tests/common/mcp_process.rs
@@ -26,13 +26,13 @@ use codex_protocol::mcp_protocol::SendUserTurnParams;
 
 use mcp_types::CallToolRequestParams;
 use mcp_types::ClientCapabilities;
-use mcp_types::Implementation;
 use mcp_types::InitializeRequestParams;
 use mcp_types::JSONRPC_VERSION;
 use mcp_types::JSONRPCMessage;
 use mcp_types::JSONRPCNotification;
 use mcp_types::JSONRPCRequest;
 use mcp_types::JSONRPCResponse;
+use mcp_types::McpClientInfo;
 use mcp_types::ModelContextProtocolNotification;
 use mcp_types::ModelContextProtocolRequest;
 use mcp_types::RequestId;
@@ -111,7 +111,7 @@ impl McpProcess {
                 roots: None,
                 sampling: None,
             },
-            client_info: Implementation {
+            client_info: McpClientInfo {
                 name: "elicitation test".into(),
                 title: Some("Elicitation Test".into()),
                 version: "0.0.0".into(),

--- a/codex-rs/mcp-server/tests/common/mcp_process.rs
+++ b/codex-rs/mcp-server/tests/common/mcp_process.rs
@@ -129,6 +129,8 @@ impl McpProcess {
         .await?;
 
         let initialized = self.read_jsonrpc_message().await?;
+        let os_info = os_info::get();
+
         assert_eq!(
             JSONRPCMessage::Response(JSONRPCResponse {
                 jsonrpc: JSONRPC_VERSION.into(),
@@ -143,7 +145,7 @@ impl McpProcess {
                         "name": "codex-mcp-server",
                         "title": "Codex",
                         "version": "0.0.0",
-                        "user_agent": "codex_cli_rs/0.0.0 (Mac OS 15.6.1; arm64) vscode/1.5.11 (elicitation test; 0.0.0)"
+                        "user_agent": format!("codex_cli_rs/0.0.0 ({}; {}) vscode/1.5.11 (elicitation test; 0.0.0)", os_info.os_type(), os_info.version())
                     },
                     "protocolVersion": mcp_types::MCP_SCHEMA_VERSION
                 })

--- a/codex-rs/mcp-server/tests/common/mcp_process.rs
+++ b/codex-rs/mcp-server/tests/common/mcp_process.rs
@@ -130,7 +130,13 @@ impl McpProcess {
 
         let initialized = self.read_jsonrpc_message().await?;
         let os_info = os_info::get();
-
+        let user_agent = format!(
+            "codex_cli_rs/0.0.0 ({} {}; {}) {} (elicitation test; 0.0.0)",
+            os_info.os_type(),
+            os_info.version(),
+            os_info.architecture().unwrap_or("unknown"),
+            codex_core::terminal::user_agent()
+        );
         assert_eq!(
             JSONRPCMessage::Response(JSONRPCResponse {
                 jsonrpc: JSONRPC_VERSION.into(),
@@ -145,7 +151,7 @@ impl McpProcess {
                         "name": "codex-mcp-server",
                         "title": "Codex",
                         "version": "0.0.0",
-                        "user_agent": format!("codex_cli_rs/0.0.0 ({}; {}) vscode/1.5.11 (elicitation test; 0.0.0)", os_info.os_type(), os_info.version())
+                        "user_agent": user_agent
                     },
                     "protocolVersion": mcp_types::MCP_SCHEMA_VERSION
                 })

--- a/codex-rs/mcp-server/tests/common/mcp_process.rs
+++ b/codex-rs/mcp-server/tests/common/mcp_process.rs
@@ -142,7 +142,8 @@ impl McpProcess {
                     "serverInfo": {
                         "name": "codex-mcp-server",
                         "title": "Codex",
-                        "version": "0.0.0"
+                        "version": "0.0.0",
+                        "user_agent": "codex_cli_rs/0.0.0 (Mac OS 15.6.1; arm64) vscode/1.5.11 (elicitation test; 0.0.0)"
                     },
                     "protocolVersion": mcp_types::MCP_SCHEMA_VERSION
                 })

--- a/codex-rs/mcp-server/tests/suite/user_agent.rs
+++ b/codex-rs/mcp-server/tests/suite/user_agent.rs
@@ -1,4 +1,3 @@
-use codex_core::default_client::get_codex_user_agent;
 use codex_protocol::mcp_protocol::GetUserAgentResponse;
 use mcp_test_support::McpProcess;
 use mcp_test_support::to_response;
@@ -34,11 +33,18 @@ async fn get_user_agent_returns_current_codex_user_agent() {
     .expect("getUserAgent timeout")
     .expect("getUserAgent response");
 
+    let os_info = os_info::get();
+    let user_agent = format!(
+        "codex_cli_rs/0.0.0 ({} {}; {}) {} (elicitation test; 0.0.0)",
+        os_info.os_type(),
+        os_info.version(),
+        os_info.architecture().unwrap_or("unknown"),
+        codex_core::terminal::user_agent()
+    );
+
     let received: GetUserAgentResponse =
         to_response(response).expect("deserialize getUserAgent response");
-    let expected = GetUserAgentResponse {
-        user_agent: get_codex_user_agent(),
-    };
+    let expected = GetUserAgentResponse { user_agent };
 
     assert_eq!(received, expected);
 }

--- a/codex-rs/mcp-types/src/lib.rs
+++ b/codex-rs/mcp-types/src/lib.rs
@@ -482,11 +482,21 @@ pub struct ImageContent {
 
 /// Describes the name and version of an MCP implementation, with an optional title for UI representation.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, TS)]
-pub struct Implementation {
+pub struct McpClientInfo {
     pub name: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
     pub version: String,
+}
+
+/// Describes the name and version of an MCP implementation, with an optional title for UI representation.
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, TS)]
+pub struct McpServerInfo {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub title: Option<String>,
+    pub version: String,
+    pub user_agent: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, TS)]
@@ -502,7 +512,7 @@ impl ModelContextProtocolRequest for InitializeRequest {
 pub struct InitializeRequestParams {
     pub capabilities: ClientCapabilities,
     #[serde(rename = "clientInfo")]
-    pub client_info: Implementation,
+    pub client_info: McpClientInfo,
     #[serde(rename = "protocolVersion")]
     pub protocol_version: String,
 }
@@ -516,7 +526,7 @@ pub struct InitializeResult {
     #[serde(rename = "protocolVersion")]
     pub protocol_version: String,
     #[serde(rename = "serverInfo")]
-    pub server_info: Implementation,
+    pub server_info: McpServerInfo,
 }
 
 impl From<InitializeResult> for serde_json::Value {

--- a/codex-rs/mcp-types/tests/suite/initialize.rs
+++ b/codex-rs/mcp-types/tests/suite/initialize.rs
@@ -1,10 +1,10 @@
 use mcp_types::ClientCapabilities;
 use mcp_types::ClientRequest;
-use mcp_types::Implementation;
 use mcp_types::InitializeRequestParams;
 use mcp_types::JSONRPC_VERSION;
 use mcp_types::JSONRPCMessage;
 use mcp_types::JSONRPCRequest;
+use mcp_types::McpClientInfo;
 use mcp_types::RequestId;
 use serde_json::json;
 
@@ -58,7 +58,7 @@ fn deserialize_initialize_request() {
                 sampling: None,
                 elicitation: None,
             },
-            client_info: Implementation {
+            client_info: McpClientInfo {
                 name: "acme-client".into(),
                 title: Some("Acme".to_string()),
                 version: "1.2.3".into(),

--- a/codex-rs/protocol-ts/Cargo.toml
+++ b/codex-rs/protocol-ts/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1"
+mcp-types = { path = "../mcp-types" }
 codex-protocol = { path = "../protocol" }
 ts-rs = "11"
 clap = { version = "4", features = ["derive"] }

--- a/codex-rs/protocol-ts/src/lib.rs
+++ b/codex-rs/protocol-ts/src/lib.rs
@@ -16,6 +16,7 @@ pub fn generate_ts(out_dir: &Path, prettier: Option<&Path>) -> Result<()> {
     ensure_dir(out_dir)?;
 
     // Generate TS bindings
+    mcp_types::InitializeResult::export_all_to(out_dir)?;
     codex_protocol::mcp_protocol::ConversationId::export_all_to(out_dir)?;
     codex_protocol::mcp_protocol::InputItem::export_all_to(out_dir)?;
     codex_protocol::mcp_protocol::ClientRequest::export_all_to(out_dir)?;


### PR DESCRIPTION
This automatically adds a user agent suffix whenever the CLI is used as a MCP server