### PR TITLE
Added images to `UserMessageEvent`

### DIFF
--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -695,6 +695,8 @@ pub struct UserMessageEvent {
     pub message: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kind: Option<InputMessageKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub images: Option<Vec<String>>,
 }
 
 impl<T, U> From<(T, U)> for InputMessageKind

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -144,6 +144,7 @@ fn resumed_initial_messages_render_history() {
             EventMsg::UserMessage(UserMessageEvent {
                 message: "hello from user".to_string(),
                 kind: Some(InputMessageKind::Plain),
+                images: None,
             }),
             EventMsg::AgentMessage(AgentMessageEvent {
                 message: "assistant reply".to_string(),


### PR DESCRIPTION
This PR adds an `images` field to the existing `UserMessageEvent` so we can encode zero or more images associated with a user message. This allows images to be restored when conversations are restored.