### PR TITLE
Saved prompts: transcript redaction + per-submission custom instructions

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1820,6 +1820,25 @@ model_verbosity = "high"
     }
 
     #[test]
+    fn config_toml_can_disable_saved_prompt_redaction() -> std::io::Result<()> {
+        let mut fixture = create_test_fixture()?;
+        // Set redact_saved_prompt_body = false in the base config
+        fixture.cfg.redact_saved_prompt_body = Some(false);
+
+        let overrides = ConfigOverrides {
+            cwd: Some(fixture.cwd()),
+            ..Default::default()
+        };
+        let cfg: Config = Config::load_from_base_config_with_overrides(
+            fixture.cfg.clone(),
+            overrides,
+            fixture.codex_home(),
+        )?;
+        assert_eq!(cfg.redact_saved_prompt_body, false);
+        Ok(())
+    }
+
+    #[test]
     fn test_set_project_trusted_writes_explicit_tables() -> anyhow::Result<()> {
         let project_dir = Path::new("/some/path");
         let mut doc = DocumentMut::new();

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1622,6 +1622,7 @@ model_verbosity = "high"
                 include_view_image_tool: true,
                 active_profile: Some("o3".to_string()),
                 disable_paste_burst: false,
+                redact_saved_prompt_body: true,
             },
             o3_profile_config
         );

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -190,6 +190,9 @@ pub struct Config {
     /// All characters are inserted as they are received, and no buffering
     /// or placeholder replacement will occur for fast keypress bursts.
     pub disable_paste_burst: bool,
+    /// When true (default), redact saved prompt bodies in transcript and show
+    /// only the typed command (e.g., "/saved-prompt"). When false, show full body.
+    pub redact_saved_prompt_body: bool,
 }
 
 impl Config {
@@ -701,6 +704,10 @@ pub struct ConfigToml {
     /// All characters are inserted as they are received, and no buffering
     /// or placeholder replacement will occur for fast keypress bursts.
     pub disable_paste_burst: Option<bool>,
+
+    /// When true, the UI transcript will redact the body of saved prompts and
+    /// display only the typed command (e.g., "/mdc"). Defaults to true.
+    pub redact_saved_prompt_body: Option<bool>,
 }
 
 impl From<ConfigToml> for UserSavedConfig {
@@ -841,6 +848,7 @@ pub struct ConfigOverrides {
     pub include_view_image_tool: Option<bool>,
     pub show_raw_agent_reasoning: Option<bool>,
     pub tools_web_search_request: Option<bool>,
+    pub redact_saved_prompt_body: Option<bool>,
 }
 
 impl Config {
@@ -869,6 +877,7 @@ impl Config {
             include_view_image_tool,
             show_raw_agent_reasoning,
             tools_web_search_request: override_tools_web_search_request,
+            redact_saved_prompt_body: _,
         } = overrides;
 
         let active_profile_name = config_profile_key
@@ -940,6 +949,11 @@ impl Config {
 
         let include_view_image_tool = include_view_image_tool
             .or(cfg.tools.as_ref().and_then(|t| t.view_image))
+            .unwrap_or(true);
+
+        let redact_saved_prompt_body = overrides
+            .redact_saved_prompt_body
+            .or(cfg.redact_saved_prompt_body)
             .unwrap_or(true);
 
         let model = model
@@ -1044,6 +1058,7 @@ impl Config {
             include_view_image_tool,
             active_profile: active_profile_name,
             disable_paste_burst: cfg.disable_paste_burst.unwrap_or(false),
+            redact_saved_prompt_body,
         };
         Ok(config)
     }
@@ -1664,6 +1679,7 @@ model_verbosity = "high"
             include_view_image_tool: true,
             active_profile: Some("gpt3".to_string()),
             disable_paste_burst: false,
+            redact_saved_prompt_body: true,
         };
 
         assert_eq!(expected_gpt3_profile_config, gpt3_profile_config);
@@ -1736,6 +1752,7 @@ model_verbosity = "high"
             include_view_image_tool: true,
             active_profile: Some("zdr".to_string()),
             disable_paste_burst: false,
+            redact_saved_prompt_body: true,
         };
 
         assert_eq!(expected_zdr_profile_config, zdr_profile_config);
@@ -1794,6 +1811,7 @@ model_verbosity = "high"
             include_view_image_tool: true,
             active_profile: Some("gpt5".to_string()),
             disable_paste_burst: false,
+            redact_saved_prompt_body: true,
         };
 
         assert_eq!(expected_gpt5_profile_config, gpt5_profile_config);

--- a/codex-rs/core/src/rollout/recorder.rs
+++ b/codex-rs/core/src/rollout/recorder.rs
@@ -293,8 +293,6 @@ impl RolloutRecorder {
     }
 }
 
-// Note: rollout files are used for resume; do not redact or truncate persisted items here.
-
 struct LogFileInfo {
     /// Opened file handle to the rollout file.
     file: File,

--- a/codex-rs/core/src/rollout/recorder.rs
+++ b/codex-rs/core/src/rollout/recorder.rs
@@ -293,6 +293,8 @@ impl RolloutRecorder {
     }
 }
 
+// Note: rollout files are used for resume; do not redact or truncate persisted items here.
+
 struct LogFileInfo {
     /// Opened file handle to the rollout file.
     file: File,

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -162,6 +162,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         include_view_image_tool: None,
         show_raw_agent_reasoning: oss.then_some(true),
         tools_web_search_request: None,
+        redact_saved_prompt_body: None,
     };
     // Parse `-c` overrides.
     let cli_kv_overrides = match config_overrides.parse_overrides() {

--- a/codex-rs/mcp-server/src/codex_message_processor.rs
+++ b/codex-rs/mcp-server/src/codex_message_processor.rs
@@ -1270,6 +1270,7 @@ fn derive_config_from_params(
         include_view_image_tool: None,
         show_raw_agent_reasoning: None,
         tools_web_search_request: None,
+        redact_saved_prompt_body: None,
     };
 
     let cli_overrides = cli_overrides

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -165,6 +165,7 @@ impl CodexToolCallParam {
             include_view_image_tool: None,
             show_raw_agent_reasoning: None,
             tools_web_search_request: None,
+            redact_saved_prompt_body: None,
         };
 
         let cli_overrides = cli_overrides

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -72,6 +72,15 @@ pub struct Cli {
     #[arg(long = "search", default_value_t = false)]
     pub web_search: bool,
 
+    /// Show saved prompt body in transcript instead of redacted command.
+    /// This disables redaction for saved prompts.
+    #[arg(long = "show-saved-prompt", default_value_t = false)]
+    pub show_saved_prompt: bool,
+
+    /// Alias for --show-saved-prompt.
+    #[arg(long = "no-redact-saved-prompt", default_value_t = false, hide = true)]
+    pub no_redact_saved_prompt: bool,
+
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,
 }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -137,6 +137,11 @@ pub async fn run_main(
         include_view_image_tool: None,
         show_raw_agent_reasoning: cli.oss.then_some(true),
         tools_web_search_request: cli.web_search.then_some(true),
+        redact_saved_prompt_body: if cli.show_saved_prompt || cli.no_redact_saved_prompt {
+            Some(false)
+        } else {
+            None
+        },
     };
     let raw_overrides = cli.config_overrides.raw_overrides.clone();
     let overrides_cli = codex_common::CliConfigOverrides { raw_overrides };

--- a/docs/config.md
+++ b/docs/config.md
@@ -631,3 +631,4 @@ Options that are specific to the TUI.
 | `responses_originator_header_internal_override` | string | Override `originator` header value. |
 | `projects.<path>.trust_level` | string | Mark project/worktree as trusted (only `"trusted"` is recognized). |
 | `tools.web_search` | boolean | Enable web search tool (alias: `web_search_request`) (default: false). |
+| `redact_saved_prompt_body` | boolean | When true (default), transcript shows only the typed command for saved prompts (e.g., `/my-prompt`); when false, shows the full saved prompt body. |

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -26,3 +26,24 @@ You can disable this redaction and show the saved prompt body instead:
   - `redact_saved_prompt_body = false` (default is `true`)
 
 When redaction is disabled, the transcript will display the full saved prompt body as the user message.
+
+### Custom instructions for saved prompts
+
+You can append a custom instruction after the saved prompt name when sending it. This lets you specialize a reusable prompt at submission time.
+
+- How to use:
+  - Type the saved prompt name, then a space, then your instruction. Example:
+    - `/my-prompt Please focus on performance trade‑offs`
+  - Multiline instructions are supported. Example:
+    - `/my-prompt\nSummarize key steps as a checklist.\nKeep answers concise.`
+
+- What you’ll see:
+  - The transcript shows exactly what you typed: `/my-prompt <your instruction>` (including newlines).
+  - If redaction is enabled (default), the saved prompt body is still hidden in the transcript. You will see only the command and your instruction.
+
+- What Codex sends to the model:
+  - Codex wraps both your custom instruction and the saved prompt body to make your instruction high priority. The model receives a message that includes your instruction and then the saved prompt content.
+
+- Turning redaction off:
+  - CLI: pass `--show-saved-prompt` (alias: `--no-redact-saved-prompt`).
+  - Config: set `redact_saved_prompt_body = false`.

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -13,3 +13,16 @@ Save frequently used prompts as Markdown files and reuse them quickly from the s
 - Notes:
   - Files with names that collide with built‑in commands (e.g. `/init`) are ignored and won’t appear.
   - New or changed files are discovered on session start. If you add a new prompt while Codex is running, start a new session to pick it up.
+
+### Transcript redaction of saved prompts
+
+By default, when you submit a saved prompt via the slash popup, Codex sends the prompt file’s body to the model but shows only the typed command in the transcript (for example, `/my-prompt`). This keeps long or sensitive prompt bodies out of the visible chat log while still using their contents.
+
+You can disable this redaction and show the saved prompt body instead:
+
+- CLI flag (interactive TUI):
+  - `--show-saved-prompt` (alias: `--no-redact-saved-prompt`)
+- Config file (config.toml):
+  - `redact_saved_prompt_body = false` (default is `true`)
+
+When redaction is disabled, the transcript will display the full saved prompt body as the user message.


### PR DESCRIPTION
Supersedes #3358 (locked after accidental close).
Closes #3013.

## Why
Reduce clutter and improve privacy: saved prompts can be very large (hundreds of lines). By default, their bodies are redacted from the transcript, and only the user-typed command is shown (e.g., /name). Users can override via CLI/config.
Enable flexibility: add per-submission custom instructions. A single saved prompt can be reused with different runtime directives without hard-coding variants.
Ensure resume shows exactly what the user saw: transcript text (verbatim/pretty) is persisted separately from the expanded model context.
Privacy: rollout remains unredacted to preserve resume correctness; logs/traces avoid leaking prompt bodies.

## Before
Transcript always showed the full saved prompt body as the user message.
No support for appending custom instructions to saved prompts.
Resume reconstructed initial messages from expanded rollout content, so users could see long bodies instead of the short form.
Logs could include template text.

## What We Did (Overview)
- **Transcript redaction**: transcript renders exactly what the user typed (/<name> or /<name> <instruction>). The full saved prompt body is still sent to the agent.
- **User control**: CLI flags (--show-saved-prompt, alias --no-redact-saved-prompt) and config key `redact_saved_prompt_body` (default true).
- **Custom instructions**: /<name> <instruction> (multiline supported). Agent receives a structured Directive where priority is explicit (CustomInstruction > SavedPrompt). Both parts wrapped in CDATA for robustness.
- **Queue vs execute UX**: while a task is running, the queue shows only what the user typed; on execute, redaction policy applies — ON shows the typed command, OFF shows a human-readable layout (“Custom instruction:” → “Saved prompt:”) via `pretty_unredacted`.
- **Rollout persistence**: alongside expanded `ResponseItem`, core now also persists transcript-only `EventMsg::UserMessage(message=shown)` so resume displays exactly what the user saw live.
- **Privacy**: rollout stays authoritative and unredacted; logs/traces avoid verbose prompt bodies.
- **Docs**: prompts.md and config.md updated.

## After
By default, the transcript shows only what the user typed; bodies stay private unless redaction is disabled.
Saved prompts become significantly more flexible due to per-submission instructions.
Queues stay concise; execution history can render expanded context when redaction is OFF.
Resume faithfully replays transcript text (`EventMsg`), while model context is restored from expanded `ResponseItem`.
Existing saved prompts without arguments continue to work unchanged; default redaction is opt-out via CLI/config.
Privacy: transcript/logs are redacted; rollout remains intact for resume.
All tests green; workspace builds and lints clean.

## Technical Details
- **TUI**: introduce `SubmittedWithDisplay { text, display, pretty_unredacted }`. History uses `display` (redaction ON) or `pretty_unredacted` (redaction OFF). Agent always uses `text`.
- **Composer**: extract multiline custom instruction; build Directive with explicit priority. Provide `pretty_unredacted` layout (“Custom instruction:” then “Saved prompt:”) when redaction OFF.
- **ChatWidget**: queue always shows `display_text`; history selects `display_text` vs `pretty_unredacted` based on config; send `Op::AddToHistory { text: shown }`.
- **Core**: handle `Op::AddToHistory` by appending to cross-session history and persisting transcript-only `EventMsg::UserMessage`. Expanded context still persisted as `ResponseItem`.
- **Config/CLI**: add `redact_saved_prompt_body` key; wire CLI flags --show-saved-prompt / --no-redact-saved-prompt.
- **CLI tests**: override logic inline; test-only helper verifies flags. Removed unused helper to satisfy clippy.
- **Cross-crate**: exec and mcp-server initializers updated with `redact_saved_prompt_body: None`; core tests updated.

## Tests Added / Updated
- `selecting_custom_prompt_submits_file_contents` (updated)
- `selecting_custom_prompt_with_instruction_wraps_and_displays_typed` (added)
- `custom_prompt_shows_command_in_history` (added)
- `custom_prompt_shows_body_when_redaction_disabled` (added)
- `custom_instruction_with_cdata_terminator_does_not_panic_and_is_included` (added)
- CLI override tests (added):
  - `flag_show_saved_prompt_sets_override_false`
  - `alias_no_redact_saved_prompt_sets_override_false`
  - `default_no_flag_sets_no_override`

## Docs
- `prompts.md`: sections “Transcript redaction of saved prompts” and “Custom instructions for saved prompts”.
- `config.md`: new key `redact_saved_prompt_body`.


### Relation to #3164

This PR builds on the same motivation as #3164 (supporting arguments for saved prompts and keeping transcripts clean), but takes a slightly different approach:

- #3164 passes user input through `$PROMPT_ARGUMENT` and relies on template logic to handle it.
- This PR instead keeps saved prompts unchanged and provides the user’s inline instruction as high-priority context before the saved prompt (`CustomInstruction > SavedPrompt`).

Both approaches aim to make saved prompts more flexible. The difference here is mainly in UX: this PR avoids requiring template authors to add `$ARGUMENTS` handling, letting the model interpret both the instruction and the saved prompt directly. For users, this should feel simpler and more natural, while `$PROMPT_ARGUMENT` remains available for cases where deterministic parsing is preferred.

