### PR TITLE
Fix bash detection failure in VS Code Codex extension on Windows under certain conditions

### DIFF
--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -98,6 +98,7 @@ pub async fn default_user_shell() -> Shell {
         .unwrap_or(false);
     let bash_exe = if Command::new("bash.exe")
         .arg("--version")
+        .stdin(std::process::Stdio::null())
         .output()
         .await
         .ok()


### PR DESCRIPTION
Found that the VS Code Codex extension throws “Error starting conversation” when initializing a conversation with Git for Windows’ bash on PATH.
Debugging showed the bash-detection logic did not return as expected; this change makes it reliable in that scenario.
Possibly related to issue #2841.