### PR TITLE
Improved resiliency of two auth-related tests

### DIFF
--- a/codex-rs/mcp-server/tests/suite/auth.rs
+++ b/codex-rs/mcp-server/tests/suite/auth.rs
@@ -41,7 +41,7 @@ async fn get_auth_status_no_auth() {
     let codex_home = TempDir::new().unwrap_or_else(|e| panic!("create tempdir: {e}"));
     create_config_toml(codex_home.path()).expect("write config.toml");
 
-    let mut mcp = McpProcess::new(codex_home.path())
+    let mut mcp = McpProcess::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)])
         .await
         .expect("spawn mcp process");
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize())

--- a/codex-rs/mcp-server/tests/suite/login.rs
+++ b/codex-rs/mcp-server/tests/suite/login.rs
@@ -46,7 +46,7 @@ async fn logout_chatgpt_removes_auth() {
     login_with_api_key(codex_home.path(), "sk-test-key").expect("seed api key");
     assert!(codex_home.path().join("auth.json").exists());
 
-    let mut mcp = McpProcess::new(codex_home.path())
+    let mut mcp = McpProcess::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)])
         .await
         .expect("spawn mcp process");
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize())


### PR DESCRIPTION
This PR improves two existing auth-related tests. They were failing when run in an environment where an `OPENAI_API_KEY` env variable was defined. The change makes them more resilient.
