### PR TITLE
fix: add check to ensure output of generate_mcp_types.py matches codex-rs/mcp-types/src/lib.rs

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -62,6 +62,8 @@ jobs:
           components: rustfmt
       - name: cargo fmt
         run: cargo fmt -- --config imports_granularity=Item --check
+      - name: Verify codegen for mcp-types
+        run: ./mcp-types/check_lib_rs.py
 
   cargo_shear:
     name: cargo shear

--- a/codex-rs/mcp-types/check_lib_rs.py
+++ b/codex-rs/mcp-types/check_lib_rs.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> int:
+    crate_dir = Path(__file__).resolve().parent
+    generator = crate_dir / "generate_mcp_types.py"
+
+    result = subprocess.run(
+        [sys.executable, str(generator), "--check"],
+        cwd=crate_dir,
+        check=False,
+    )
+    return result.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
As a follow-up to https://github.com/openai/codex/pull/3439, this adds a CI job to ensure the codegen script has to be updated in order to change `codex-rs/mcp-types/src/lib.rs`.