### PR TITLE
[exec] Enable update_plan tool by default for exec mode

### DIFF
--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -146,7 +146,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         model_provider,
         codex_linux_sandbox_exe,
         base_instructions: None,
-        include_plan_tool: None,
+        include_plan_tool: Some(true),
         include_apply_patch_tool: None,
         include_view_image_tool: None,
         show_raw_agent_reasoning: oss.then_some(true),


### PR DESCRIPTION
## Summary
Allow the model to use the update_plan tool in exec mode, since it is referenced in our prompt.

## Testing
- [x] tested locally and confirmed the model uses the plan tool