### PR TITLE
chore: rust-release.yml should update the latest-alpha-cli branch

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -219,3 +219,22 @@ jobs:
         with:
           tag: ${{ github.ref_name }}
           config: .github/dotslash-config.json
+
+  update-branch:
+    name: Update latest-alpha-cli branch
+    permissions:
+      contents: write
+    needs: release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Update latest-alpha-cli branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          gh api \
+            repos/${GITHUB_REPOSITORY}/git/refs/heads/latest-alpha-cli \
+            -X PATCH \
+            -f sha="${GITHUB_SHA}" \
+            -f force=true


### PR DESCRIPTION
This updates `rust-release.yml` so that the last step of creating a release entails updating the `latest-alpha-cli` branch to point to the tag used to create the latest release. This will facilitate building automation to identify the most recent alpha release of Codex CLI (though note this branch could also point to an official release, as it is implemented today).

This introduces a new job, `update-branch`, which depends on the `release` job. I made it separate from the `release` job because `update-branch` needs the `contents: write` permission, so this limits the amount of work we do with that permission.

Note I also created a branch protection rule for `latest-alpha-cli` that:

- specifies repository admins as the only members of the bypass list
- only those with bypass permissions can create, update, or delete this branch
- this branch requires a linear history
- note that force pushes _are_ allowed

This is the first step in fixing https://github.com/openai/codex/issues/3098.