### PR TITLE
Add spacing to timer duration formats

### DIFF
--- a/codex-rs/common/src/elapsed.rs
+++ b/codex-rs/common/src/elapsed.rs
@@ -2,7 +2,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 /// Returns a string representing the elapsed time since `start_time` like
-/// "1m15s" or "1.50s".
+/// "1m 15s" or "1.50s".
 pub fn format_elapsed(start_time: Instant) -> String {
     format_duration(start_time.elapsed())
 }
@@ -12,7 +12,7 @@ pub fn format_elapsed(start_time: Instant) -> String {
 /// Formatting rules:
 /// * < 1 s  ->  "{milli}ms"
 /// * < 60 s ->  "{sec:.2}s" (two decimal places)
-/// * >= 60 s ->  "{min}m{sec:02}s"
+/// * >= 60 s ->  "{min}m {sec:02}s"
 pub fn format_duration(duration: Duration) -> String {
     let millis = duration.as_millis() as i64;
     format_elapsed_millis(millis)
@@ -26,7 +26,7 @@ fn format_elapsed_millis(millis: i64) -> String {
     } else {
         let minutes = millis / 60_000;
         let seconds = (millis % 60_000) / 1000;
-        format!("{minutes}m{seconds:02}s")
+        format!("{minutes}m {seconds:02}s")
     }
 }
 
@@ -61,12 +61,18 @@ mod tests {
     fn test_format_duration_minutes() {
         // Durations ≥ 1 minute should be printed mmss.
         let dur = Duration::from_millis(75_000); // 1m15s
-        assert_eq!(format_duration(dur), "1m15s");
+        assert_eq!(format_duration(dur), "1m 15s");
 
         let dur_exact = Duration::from_millis(60_000); // 1m0s
-        assert_eq!(format_duration(dur_exact), "1m00s");
+        assert_eq!(format_duration(dur_exact), "1m 00s");
 
         let dur_long = Duration::from_millis(3_601_000);
-        assert_eq!(format_duration(dur_long), "60m01s");
+        assert_eq!(format_duration(dur_long), "60m 01s");
+    }
+
+    #[test]
+    fn test_format_duration_one_hour_has_space() {
+        let dur_hour = Duration::from_millis(3_600_000);
+        assert_eq!(format_duration(dur_hour), "60m 00s");
     }
 }

--- a/codex-rs/tui/src/status_indicator_widget.rs
+++ b/codex-rs/tui/src/status_indicator_widget.rs
@@ -32,7 +32,7 @@ pub(crate) struct StatusIndicatorWidget {
 }
 
 // Format elapsed seconds into a compact human-friendly form used by the status line.
-// Examples: 0s, 59s, 1m00s, 59m59s, 1h00m00s, 2h03m09s
+// Examples: 0s, 59s, 1m 00s, 59m 59s, 1h 00m 00s, 2h 03m 09s
 fn fmt_elapsed_compact(elapsed_secs: u64) -> String {
     if elapsed_secs < 60 {
         return format!("{elapsed_secs}s");
@@ -40,12 +40,12 @@ fn fmt_elapsed_compact(elapsed_secs: u64) -> String {
     if elapsed_secs < 3600 {
         let minutes = elapsed_secs / 60;
         let seconds = elapsed_secs % 60;
-        return format!("{minutes}m{seconds:02}s");
+        return format!("{minutes}m {seconds:02}s");
     }
     let hours = elapsed_secs / 3600;
     let minutes = (elapsed_secs % 3600) / 60;
     let seconds = elapsed_secs % 60;
-    format!("{hours}h{minutes:02}m{seconds:02}s")
+    format!("{hours}h {minutes:02}m {seconds:02}s")
 }
 
 impl StatusIndicatorWidget {
@@ -209,13 +209,13 @@ mod tests {
         assert_eq!(fmt_elapsed_compact(0), "0s");
         assert_eq!(fmt_elapsed_compact(1), "1s");
         assert_eq!(fmt_elapsed_compact(59), "59s");
-        assert_eq!(fmt_elapsed_compact(60), "1m00s");
-        assert_eq!(fmt_elapsed_compact(61), "1m01s");
-        assert_eq!(fmt_elapsed_compact(3 * 60 + 5), "3m05s");
-        assert_eq!(fmt_elapsed_compact(59 * 60 + 59), "59m59s");
-        assert_eq!(fmt_elapsed_compact(3600), "1h00m00s");
-        assert_eq!(fmt_elapsed_compact(3600 + 60 + 1), "1h01m01s");
-        assert_eq!(fmt_elapsed_compact(25 * 3600 + 2 * 60 + 3), "25h02m03s");
+        assert_eq!(fmt_elapsed_compact(60), "1m 00s");
+        assert_eq!(fmt_elapsed_compact(61), "1m 01s");
+        assert_eq!(fmt_elapsed_compact(3 * 60 + 5), "3m 05s");
+        assert_eq!(fmt_elapsed_compact(59 * 60 + 59), "59m 59s");
+        assert_eq!(fmt_elapsed_compact(3600), "1h 00m 00s");
+        assert_eq!(fmt_elapsed_compact(3600 + 60 + 1), "1h 01m 01s");
+        assert_eq!(fmt_elapsed_compact(25 * 3600 + 2 * 60 + 3), "25h 02m 03s");
     }
 
     #[test]


### PR DESCRIPTION
<img width="426" height="28" alt="image" src="https://github.com/user-attachments/assets/b281aca3-3c8d-4b88-a017-5d2f8ea9f3d5" />