### PR TITLE
Render approval modal options vertically

### DIFF
--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_exec.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_exec.snap
@@ -1,12 +1,14 @@
 ---
 source: tui/src/chatwidget/tests.rs
-assertion_line: 728
 expression: terminal.backend()
 ---
 "                                                                                "
 "this is a test reason such as one that would be produced by the model           "
 "                                                                                "
 "▌Allow command?                                                                 "
-"▌ Yes   Always   No, provide feedback                                           "
+"▌> 1. Yes                                                                       "
+"▌  2. Always                                                                    "
+"▌  3. No, provide feedback                                                      "
+"▌                                                                               "
 "▌ Approve and run the command                                                   "
 "                                                                                "

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_exec_no_reason.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_exec_no_reason.snap
@@ -4,6 +4,9 @@ expression: terminal.backend()
 ---
 "                                                                                "
 "▌Allow command?                                                                 "
-"▌ Yes   Always   No, provide feedback                                           "
+"▌> 1. Yes                                                                       "
+"▌  2. Always                                                                    "
+"▌  3. No, provide feedback                                                      "
+"▌                                                                               "
 "▌ Approve and run the command                                                   "
 "                                                                                "

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_patch.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approval_modal_patch.snap
@@ -1,6 +1,5 @@
 ---
 source: tui/src/chatwidget/tests.rs
-assertion_line: 794
 expression: terminal.backend()
 ---
 "                                                                                "
@@ -9,6 +8,8 @@ expression: terminal.backend()
 "This will grant write access to /tmp for the remainder of this session.         "
 "                                                                                "
 "▌Apply changes?                                                                 "
-"▌ Yes   No, provide feedback                                                    "
+"▌> 1. Yes                                                                       "
+"▌  2. No, provide feedback                                                      "
+"▌                                                                               "
 "▌ Approve and apply the changes                                                 "
 "                                                                                "

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_widget_and_approval_modal.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_widget_and_approval_modal.snap
@@ -1,12 +1,14 @@
 ---
 source: tui/src/chatwidget/tests.rs
-assertion_line: 921
 expression: terminal.backend()
 ---
 "                                                                                "
 "this is a test reason such as one that would be produced by the model           "
 "                                                                                "
 "▌Allow command?                                                                 "
-"▌ Yes   Always   No, provide feedback                                           "
+"▌> 1. Yes                                                                       "
+"▌  2. Always                                                                    "
+"▌  3. No, provide feedback                                                      "
+"▌                                                                               "
 "▌ Approve and run the command                                                   "
 "                                                                                "


### PR DESCRIPTION
## Summary
- render approval modal choices as a vertical list and support up/down navigation and numeric shortcuts
- adjust desired height calculations and styles for the vertical layout
- refresh approval modal snapshots to reflect the updated presentation

## Testing
- cargo test -p codex-tui

------
https://chatgpt.com/codex/tasks/task_i_68c24734f9388321b7e6ad411ac14bc1