### PR TITLE
core: expand default sandbox

### DIFF
--- a/codex-rs/core/src/seatbelt_base_policy.sbpl
+++ b/codex-rs/core/src/seatbelt_base_policy.sbpl
@@ -2,6 +2,7 @@
 
 ; inspired by Chrome's sandbox policy:
 ; https://source.chromium.org/chromium/chromium/src/+/main:sandbox/policy/mac/common.sb;l=273-319;drc=7b3962fe2e5fc9e2ee58000dc8fbf3429d84d3bd
+; https://source.chromium.org/chromium/chromium/src/+/main:sandbox/policy/mac/renderer.sb;l=64;drc=7b3962fe2e5fc9e2ee58000dc8fbf3429d84d3bd
 
 ; start with closed-by-default
 (deny default)
@@ -9,7 +10,13 @@
 ; child processes inherit the policy of their parent
 (allow process-exec)
 (allow process-fork)
-(allow signal (target self))
+(allow signal (target same-sandbox))
+
+; Allow cf prefs to work.
+(allow user-preference-read)
+
+; process-info
+(allow process-info* (target same-sandbox))
 
 (allow file-write-data
   (require-all
@@ -32,28 +39,22 @@
   (sysctl-name "hw.l3cachesize_compat")
   (sysctl-name "hw.logicalcpu_max")
   (sysctl-name "hw.machine")
+  (sysctl-name "hw.memsize")
   (sysctl-name "hw.ncpu")
   (sysctl-name "hw.nperflevels")
-  (sysctl-name "hw.optional.arm.FEAT_BF16")
-  (sysctl-name "hw.optional.arm.FEAT_DotProd")
-  (sysctl-name "hw.optional.arm.FEAT_FCMA")
-  (sysctl-name "hw.optional.arm.FEAT_FHM")
-  (sysctl-name "hw.optional.arm.FEAT_FP16")
-  (sysctl-name "hw.optional.arm.FEAT_I8MM")
-  (sysctl-name "hw.optional.arm.FEAT_JSCVT")
-  (sysctl-name "hw.optional.arm.FEAT_LSE")
-  (sysctl-name "hw.optional.arm.FEAT_RDM")
-  (sysctl-name "hw.optional.arm.FEAT_SHA512")
-  (sysctl-name "hw.optional.armv8_2_sha512")
-  (sysctl-name "hw.memsize")
-  (sysctl-name "hw.pagesize")
+  ; Chrome locks these CPU feature detection down a bit more tightly,
+  ; but mostly for fingerprinting concerns which isn't an issue for codex.
+  (sysctl-name-prefix "hw.optional.arm.")
+  (sysctl-name-prefix "hw.optional.armv8_")
   (sysctl-name "hw.packages")
   (sysctl-name "hw.pagesize_compat")
+  (sysctl-name "hw.pagesize")
   (sysctl-name "hw.physicalcpu_max")
   (sysctl-name "hw.tbfrequency_compat")
   (sysctl-name "hw.vectorunit")
   (sysctl-name "kern.hostname")
   (sysctl-name "kern.maxfilesperproc")
+  (sysctl-name "kern.maxproc")
   (sysctl-name "kern.osproductversion")
   (sysctl-name "kern.osrelease")
   (sysctl-name "kern.ostype")
@@ -63,14 +64,27 @@
   (sysctl-name "kern.usrstack64")
   (sysctl-name "kern.version")
   (sysctl-name "sysctl.proc_cputype")
+  (sysctl-name "vm.loadavg")
   (sysctl-name-prefix "hw.perflevel")
+  (sysctl-name-prefix "kern.proc.pgrp.")
+  (sysctl-name-prefix "kern.proc.pid.")
+  (sysctl-name-prefix "net.routetable.")
+)
+
+; IOKit
+(allow iokit-open
+  (iokit-registry-entry-class "RootDomainUserClient")
+)
+
+; needed to look up user info, see https://crbug.com/792228
+(allow mach-lookup
+  (global-name "com.apple.system.opendirectoryd.libinfo")
 )
 
 ; Added on top of Chrome profile
 ; Needed for python multiprocessing on MacOS for the SemLock
 (allow ipc-posix-sem)
 
-; needed to look up user info, see https://crbug.com/792228
 (allow mach-lookup
-  (global-name "com.apple.system.opendirectoryd.libinfo")
+  (global-name "com.apple.PowerManagement.control")
 )


### PR DESCRIPTION
this adds some more capabilities to the default sandbox which I feel are safe. Most are in the [renderer.sb](https://source.chromium.org/chromium/chromium/src/+/main:sandbox/policy/mac/renderer.sb) sandbox for chrome renderers, which i feel is fair game for codex commands.

Specific changes:

1. Allow processes in the sandbox to send signals to any other process in the same sandbox (e.g. child processes or daemonized processes), instead of just themselves.
2. Allow user-preference-read
3. Allow process-info* to anything in the same sandbox. This is a bit wider than Chromium allows, but it seems OK to me to allow anything in the sandbox to get details about other processes in the same sandbox. Bazel uses these to e.g. wait for another process to exit.
4. Allow all CPU feature detection, this seems harmless to me. It's wider than Chromium, but Chromium is concerned about fingerprinting, and tightly controls what CPU features they actually care about, and we don't have either that restriction or that advantage.
5. Allow new sysctl-reads:
   ```
     (sysctl-name "vm.loadavg")
     (sysctl-name-prefix "kern.proc.pgrp.")
     (sysctl-name-prefix "kern.proc.pid.")
     (sysctl-name-prefix "net.routetable.")
   ```
   bazel needs these for waiting on child processes and for communicating with its local build server, i believe. I wonder if we should just allow all (sysctl-read), as reading any arbitrary info about the system seems fine to me.
6. Allow iokit-open on RootDomainUserClient. This has to do with power management I believe, and Chromium allows renderers to do this, so okay. Bazel needs it to boot successfully, possibly for sleep/wake callbacks?
7. Mach lookup to `com.apple.system.opendirectoryd.libinfo`, which has to do with user data, and which Chrome allows.
8. Mach lookup to `com.apple.PowerManagement.control`. Chromium allows its GPU process to do this, but not its renderers. Bazel needs this to boot, probably relatedly to sleep/wake stuff.