### PR TITLE
fix: use -F instead of -f for force=true in gh call

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -237,4 +237,4 @@ jobs:
             repos/${GITHUB_REPOSITORY}/git/refs/heads/latest-alpha-cli \
             -X PATCH \
             -f sha="${GITHUB_SHA}" \
-            -f force=true
+            -F force=true


### PR DESCRIPTION
Apparently `-F` is the correct thing to use. From the code sample on 

https://docs.github.com/en/rest/git/refs?apiVersion=2022-11-28#update-a-reference

```shell
gh api \
  --method PATCH \
  -H "Accept: application/vnd.github+json" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  /repos/OWNER/REPO/git/refs/REF \
   -f 'sha=aa218f56b14c9653891f9e74264a383fa43fefbd' -F "force=true"
```

Also, I ran the following locally and verified it worked:

```shell
export GITHUB_REPOSITORY=openai/codex
export GITHUB_SHA=305252b2fb2d57bb40a9e4bad269db9a761f7099
gh api \
  repos/${GITHUB_REPOSITORY}/git/refs/heads/latest-alpha-cli \
  -X PATCH \
  -f sha="${GITHUB_SHA}" \
  -F force=true
```

`$GITHUB_REPOSITORY` and `$GITHUB_SHA` should already be available as environment variables for the `run` step without having to be redeclared in the `env` section.