### PR TITLE
Log cf-ray header in client traces

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -239,10 +239,10 @@ impl ModelClient {
             let res = req_builder.send().await;
             if let Ok(resp) = &res {
                 trace!(
-                    "Response status: {}, request-id: {}",
+                    "Response status: {}, cf-ray: {}",
                     resp.status(),
                     resp.headers()
-                        .get("x-request-id")
+                        .get("cf-ray")
                         .map(|v| v.to_str().unwrap_or_default())
                         .unwrap_or_default()
                 );


### PR DESCRIPTION
## Summary
- log the `cf-ray` header when tracing HTTP responses in the Codex client
- keep existing response status logging unchanged

## Testing
- just fmt
- just fix -p codex-core
- cargo test -p codex-core *(fails: suite::client::azure_overrides_assign_properties_used_for_responses_url, suite::client::env_var_overrides_loaded_auth)*

------
https://chatgpt.com/codex/tasks/task_i_68c31640dacc83209be131baf91611cd