### PR TITLE
exec: add `--search` flag to enable `web_search` in `codex exec`

### DIFF
--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -44,6 +44,10 @@ pub struct Cli {
     #[clap(long = "cd", short = 'C', value_name = "DIR")]
     pub cwd: Option<PathBuf>,
 
+    /// Enable web search (off by default). When enabled, the native Responses `web_search` tool is available to the model (no per‑call approval).
+    #[arg(long = "search", default_value_t = false)]
+    pub web_search: bool,
+
     /// Allow running Codex outside a Git repository.
     #[arg(long = "skip-git-repo-check", default_value_t = false)]
     pub skip_git_repo_check: bool,

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -42,6 +42,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         full_auto,
         dangerously_bypass_approvals_and_sandbox,
         cwd,
+        web_search,
         skip_git_repo_check,
         color,
         last_message_file,
@@ -150,7 +151,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         include_apply_patch_tool: None,
         include_view_image_tool: None,
         show_raw_agent_reasoning: oss.then_some(true),
-        tools_web_search_request: None,
+        tools_web_search_request: web_search.then_some(true),
     };
     // Parse `-c` overrides.
     let cli_kv_overrides = match config_overrides.parse_overrides() {


### PR DESCRIPTION
## exec: add `--search` flag to enable `web_search`

Closes #3496

### Summary
Adds a `--search` flag to the `codex exec` CLI to enable the native Responses `web_search` tool, mirroring the existing behavior in the TUI CLI.

### Motivation
The TUI CLI (`codex-rs/tui/src/cli.rs`) already exposes `--search` to allow the model to use the native `web_search` tool when requested. The exec CLI (`codex-rs/exec/src/cli.rs`) lacked this flag, so `codex exec` sessions could not opt into web search. This change brings feature parity between the two CLIs.

### Changes
- codex-rs/exec/src/cli.rs
  - Added `--search` (`pub web_search: bool`) with identical help text and default value as in TUI.
- codex-rs/exec/src/lib.rs
  - Threaded the new CLI flag through to configuration by setting `ConfigOverrides { tools_web_search_request: web_search.then_some(true), .. }`.

### Behavior
- Default remains unchanged: web search is disabled unless `--search` is passed.
- When `--search` is provided, the `web_search` tool becomes available to the model without per-call approval (matching TUI semantics).
- No changes to approval policy: exec remains headless and sets `AskForApproval::Never`.
