### PR TITLE
chore: add `just test`, which runs `cargo nextest`

### DIFF
--- a/codex-rs/justfile
+++ b/codex-rs/justfile
@@ -31,6 +31,13 @@ install:
     rustup show active-toolchain
     cargo fetch
 
+# Run `cargo nextest` since it's faster than `cargo test`, though including
+# --no-fail-fast is important to ensure all tests are run.
+#
+# Run `cargo install cargo-nextest` if you don't have it installed.
+test:
+    cargo nextest run --no-fail-fast
+
 # Run the MCP server
 mcp-server-run *args:
     cargo run -p codex-mcp-server -- "$@"


### PR DESCRIPTION
Since I can never seem to remember to add `--no-fail-fast` when running `cargo nextest run`, let's just create an alias for it.