### PR TITLE
fix: Don't collect pending input in review mode

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -85,7 +85,7 @@ jobs:
 
   # --- CI to validate on different os/targets --------------------------------
   lint_build_test:
-    name: ${{ matrix.runner }} - ${{ matrix.target }} [run ${{ matrix.repeat }}]${{ matrix.profile == 'release' && ' (release)' || '' }}
+    name: ${{ matrix.runner }} - ${{ matrix.target }}${{ matrix.profile == 'release' && ' (release)' || '' }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     needs: changed
@@ -99,24 +99,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # - runner: macos-14
-          #   target: aarch64-apple-darwin
-          #   profile: dev
-          # - runner: macos-14
-          #   target: x86_64-apple-darwin
-          #   profile: dev
-          # - runner: ubuntu-24.04
-          #   target: x86_64-unknown-linux-musl
-          #   profile: dev
-          # - runner: ubuntu-24.04
-          #   target: x86_64-unknown-linux-gnu
-          #   profile: dev
-          # - runner: ubuntu-24.04-arm
-          #   target: aarch64-unknown-linux-musl
-          #   profile: dev
-          # - runner: ubuntu-24.04-arm
-          #   target: aarch64-unknown-linux-gnu
-          #   profile: dev
+          - runner: macos-14
+            target: aarch64-apple-darwin
+            profile: dev
+          - runner: macos-14
+            target: x86_64-apple-darwin
+            profile: dev
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+            profile: dev
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-gnu
+            profile: dev
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            profile: dev
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+            profile: dev
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
             profile: dev
@@ -128,20 +128,18 @@ jobs:
           # there could be release-only build errors we want to catch.
           # Hopefully this also pre-populates the build cache to speed up
           # releases.
-          # - runner: macos-14
-          #   target: aarch64-apple-darwin
-          #   profile: release
-          # - runner: ubuntu-24.04
-          #   target: x86_64-unknown-linux-musl
-          #   profile: release
+          - runner: macos-14
+            target: aarch64-apple-darwin
+            profile: release
+          - runner: ubuntu-24.04
+            target: x86_64-unknown-linux-musl
+            profile: release
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
             profile: release
           - runner: windows-11-arm
             target: aarch64-pc-windows-msvc
             profile: release
-
-        repeat: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -85,7 +85,7 @@ jobs:
 
   # --- CI to validate on different os/targets --------------------------------
   lint_build_test:
-    name: ${{ matrix.runner }} - ${{ matrix.target }}${{ matrix.profile == 'release' && ' (release)' || '' }}
+    name: ${{ matrix.runner }} - ${{ matrix.target }} [run ${{ matrix.repeat }}]${{ matrix.profile == 'release' && ' (release)' || '' }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
     needs: changed
@@ -99,24 +99,24 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-14
-            target: aarch64-apple-darwin
-            profile: dev
-          - runner: macos-14
-            target: x86_64-apple-darwin
-            profile: dev
-          - runner: ubuntu-24.04
-            target: x86_64-unknown-linux-musl
-            profile: dev
-          - runner: ubuntu-24.04
-            target: x86_64-unknown-linux-gnu
-            profile: dev
-          - runner: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-musl
-            profile: dev
-          - runner: ubuntu-24.04-arm
-            target: aarch64-unknown-linux-gnu
-            profile: dev
+          # - runner: macos-14
+          #   target: aarch64-apple-darwin
+          #   profile: dev
+          # - runner: macos-14
+          #   target: x86_64-apple-darwin
+          #   profile: dev
+          # - runner: ubuntu-24.04
+          #   target: x86_64-unknown-linux-musl
+          #   profile: dev
+          # - runner: ubuntu-24.04
+          #   target: x86_64-unknown-linux-gnu
+          #   profile: dev
+          # - runner: ubuntu-24.04-arm
+          #   target: aarch64-unknown-linux-musl
+          #   profile: dev
+          # - runner: ubuntu-24.04-arm
+          #   target: aarch64-unknown-linux-gnu
+          #   profile: dev
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
             profile: dev
@@ -128,18 +128,20 @@ jobs:
           # there could be release-only build errors we want to catch.
           # Hopefully this also pre-populates the build cache to speed up
           # releases.
-          - runner: macos-14
-            target: aarch64-apple-darwin
-            profile: release
-          - runner: ubuntu-24.04
-            target: x86_64-unknown-linux-musl
-            profile: release
+          # - runner: macos-14
+          #   target: aarch64-apple-darwin
+          #   profile: release
+          # - runner: ubuntu-24.04
+          #   target: x86_64-unknown-linux-musl
+          #   profile: release
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
             profile: release
           - runner: windows-11-arm
             target: aarch64-pc-windows-msvc
             profile: release
+
+        repeat: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
We previously would drain the `pending_input` even in review mode (whereas review mode should be non-interactive for now.)