### PR TITLE
Include command output when sending timeout to model

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -889,7 +889,8 @@ impl Session {
 
         let output_stderr;
         let borrowed: &ExecToolCallOutput = match &result {
-            Ok(output) | Err(CodexErr::Sandbox(SandboxErr::Timeout { output })) => output,
+            Ok(output) => output,
+            Err(CodexErr::Sandbox(SandboxErr::Timeout { output })) => output,
             Err(e) => {
                 output_stderr = ExecToolCallOutput {
                     exit_code: -1,

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -1,3 +1,4 @@
+use crate::exec::ExecToolCallOutput;
 use crate::token_data::KnownPlan;
 use crate::token_data::PlanType;
 use codex_protocol::mcp_protocol::ConversationId;
@@ -28,7 +29,7 @@ pub enum SandboxErr {
 
     /// Command timed out
     #[error("command timed out")]
-    Timeout,
+    Timeout { output: ExecToolCallOutput },
 
     /// Command was killed by a signal
     #[error("command was killed by a signal")]
@@ -247,7 +248,10 @@ pub fn get_error_message_ui(e: &CodexErr) -> String {
     match e {
         CodexErr::Sandbox(SandboxErr::Denied(_, _, stderr)) => stderr.to_string(),
         // Timeouts are not sandbox errors from a UX perspective; present them plainly
-        CodexErr::Sandbox(SandboxErr::Timeout) => "error: command timed out".to_string(),
+        CodexErr::Sandbox(SandboxErr::Timeout { output }) => format!(
+            "error: command timed out after {} ms",
+            output.duration.as_millis()
+        ),
         _ => e.to_string(),
     }
 }

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -158,6 +158,7 @@ pub async fn process_exec_tool_call(
                 stderr,
                 aggregated_output,
                 duration,
+                timed_out,
             };
 
             if timed_out {
@@ -245,6 +246,7 @@ pub struct ExecToolCallOutput {
     pub stderr: StreamOutput<String>,
     pub aggregated_output: StreamOutput<String>,
     pub duration: Duration,
+    pub timed_out: bool,
 }
 
 async fn exec(

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -130,6 +130,7 @@ pub async fn process_exec_tool_call(
     let duration = start.elapsed();
     match raw_output_result {
         Ok(raw_output) => {
+            #[allow(unused_mut)]
             let mut timed_out = raw_output.timed_out;
 
             #[cfg(target_family = "unix")]

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -34,6 +34,7 @@ const DEFAULT_TIMEOUT_MS: u64 = 10_000;
 const SIGKILL_CODE: i32 = 9;
 const TIMEOUT_CODE: i32 = 64;
 const EXIT_CODE_SIGNAL_BASE: i32 = 128; // conventional shell: 128 + signal
+const EXEC_TIMEOUT_EXIT_CODE: i32 = 124; // conventional timeout exit code
 
 // I/O buffer sizing
 const READ_CHUNK_SIZE: usize = 8192; // bytes per read
@@ -86,11 +87,12 @@ pub async fn process_exec_tool_call(
 ) -> Result<ExecToolCallOutput> {
     let start = Instant::now();
 
+    let timeout_duration = params.timeout_duration();
+
     let raw_output_result: std::result::Result<RawExecToolCallOutput, CodexErr> = match sandbox_type
     {
         SandboxType::None => exec(params, sandbox_policy, stdout_stream.clone()).await,
         SandboxType::MacosSeatbelt => {
-            let timeout = params.timeout_duration();
             let ExecParams {
                 command, cwd, env, ..
             } = params;
@@ -102,10 +104,9 @@ pub async fn process_exec_tool_call(
                 env,
             )
             .await?;
-            consume_truncated_output(child, timeout, stdout_stream.clone()).await
+            consume_truncated_output(child, timeout_duration, stdout_stream.clone()).await
         }
         SandboxType::LinuxSeccomp => {
-            let timeout = params.timeout_duration();
             let ExecParams {
                 command, cwd, env, ..
             } = params;
@@ -123,31 +124,51 @@ pub async fn process_exec_tool_call(
             )
             .await?;
 
-            consume_truncated_output(child, timeout, stdout_stream).await
+            consume_truncated_output(child, timeout_duration, stdout_stream).await
         }
     };
     let duration = start.elapsed();
     match raw_output_result {
         Ok(raw_output) => {
-            let stdout = raw_output.stdout.from_utf8_lossy();
-            let stderr = raw_output.stderr.from_utf8_lossy();
+            let mut timed_out = raw_output.timed_out;
 
             #[cfg(target_family = "unix")]
-            match raw_output.exit_status.signal() {
-                Some(TIMEOUT_CODE) => return Err(CodexErr::Sandbox(SandboxErr::Timeout)),
-                Some(signal) => {
-                    return Err(CodexErr::Sandbox(SandboxErr::Signal(signal)));
+            {
+                if let Some(signal) = raw_output.exit_status.signal() {
+                    if signal == TIMEOUT_CODE {
+                        timed_out = true;
+                    } else {
+                        return Err(CodexErr::Sandbox(SandboxErr::Signal(signal)));
+                    }
                 }
-                None => {}
             }
 
-            let exit_code = raw_output.exit_status.code().unwrap_or(-1);
+            let mut exit_code = raw_output.exit_status.code().unwrap_or(-1);
+            if timed_out {
+                exit_code = EXEC_TIMEOUT_EXIT_CODE;
+            }
+
+            let stdout = raw_output.stdout.from_utf8_lossy();
+            let stderr = raw_output.stderr.from_utf8_lossy();
+            let aggregated_output = raw_output.aggregated_output.from_utf8_lossy();
+            if timed_out {
+                let exec_output = ExecToolCallOutput {
+                    exit_code,
+                    stdout,
+                    stderr,
+                    aggregated_output,
+                    duration,
+                };
+                return Err(CodexErr::Sandbox(SandboxErr::Timeout {
+                    output: exec_output,
+                }));
+            }
 
             if exit_code != 0 && is_likely_sandbox_denied(sandbox_type, exit_code) {
                 return Err(CodexErr::Sandbox(SandboxErr::Denied(
                     exit_code,
-                    stdout.text,
-                    stderr.text,
+                    stdout.text.clone(),
+                    stderr.text.clone(),
                 )));
             }
 
@@ -155,7 +176,7 @@ pub async fn process_exec_tool_call(
                 exit_code,
                 stdout,
                 stderr,
-                aggregated_output: raw_output.aggregated_output.from_utf8_lossy(),
+                aggregated_output,
                 duration,
             })
         }
@@ -197,6 +218,7 @@ struct RawExecToolCallOutput {
     pub stdout: StreamOutput<Vec<u8>>,
     pub stderr: StreamOutput<Vec<u8>>,
     pub aggregated_output: StreamOutput<Vec<u8>>,
+    pub timed_out: bool,
 }
 
 impl StreamOutput<String> {
@@ -298,22 +320,24 @@ async fn consume_truncated_output(
         Some(agg_tx.clone()),
     ));
 
-    let exit_status = tokio::select! {
+    let (exit_status, timed_out) = tokio::select! {
         result = tokio::time::timeout(timeout, child.wait()) => {
             match result {
-                Ok(Ok(exit_status)) => exit_status,
-                Ok(e) => e?,
+                Ok(status_result) => {
+                    let exit_status = status_result?;
+                    (exit_status, false)
+                }
                 Err(_) => {
                     // timeout
                     child.start_kill()?;
                     // Debatable whether `child.wait().await` should be called here.
-                    synthetic_exit_status(EXIT_CODE_SIGNAL_BASE + TIMEOUT_CODE)
+                    (synthetic_exit_status(EXIT_CODE_SIGNAL_BASE + TIMEOUT_CODE), true)
                 }
             }
         }
         _ = tokio::signal::ctrl_c() => {
             child.start_kill()?;
-            synthetic_exit_status(EXIT_CODE_SIGNAL_BASE + SIGKILL_CODE)
+            (synthetic_exit_status(EXIT_CODE_SIGNAL_BASE + SIGKILL_CODE), false)
         }
     };
 
@@ -336,6 +360,7 @@ async fn consume_truncated_output(
         stdout,
         stderr,
         aggregated_output,
+        timed_out,
     })
 }
 

--- a/codex-rs/core/tests/suite/exec_stream_events.rs
+++ b/codex-rs/core/tests/suite/exec_stream_events.rs
@@ -2,8 +2,11 @@
 
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use async_channel::Receiver;
+use codex_core::error::CodexErr;
+use codex_core::error::SandboxErr;
 use codex_core::exec::ExecParams;
 use codex_core::exec::SandboxType;
 use codex_core::exec::StdoutStream;
@@ -169,4 +172,36 @@ async fn test_aggregated_output_interleaves_in_order() {
     assert_eq!(result.stderr.text, "E1\nE2\n");
     assert_eq!(result.aggregated_output.text, "O1\nE1\nO2\nE2\n");
     assert_eq!(result.aggregated_output.truncated_after_lines, None);
+}
+
+#[tokio::test]
+async fn test_exec_timeout_returns_partial_output() {
+    let cmd = vec![
+        "/bin/sh".to_string(),
+        "-c".to_string(),
+        "printf 'before\\n'; sleep 2; printf 'after\\n'".to_string(),
+    ];
+
+    let params = ExecParams {
+        command: cmd,
+        cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+        timeout_ms: Some(200),
+        env: HashMap::new(),
+        with_escalated_permissions: None,
+        justification: None,
+    };
+
+    let policy = SandboxPolicy::new_read_only_policy();
+
+    let result = process_exec_tool_call(params, SandboxType::None, &policy, &None, None).await;
+
+    let Err(CodexErr::Sandbox(SandboxErr::Timeout { output })) = result else {
+        panic!("expected timeout error");
+    };
+
+    assert_eq!(output.exit_code, 124);
+    assert_eq!(output.stdout.text, "before\n");
+    assert!(output.stderr.text.is_empty());
+    assert_eq!(output.aggregated_output.text, "before\n");
+    assert!(output.duration >= Duration::from_millis(200));
 }

--- a/codex-rs/core/tests/suite/exec_stream_events.rs
+++ b/codex-rs/core/tests/suite/exec_stream_events.rs
@@ -204,4 +204,5 @@ async fn test_exec_timeout_returns_partial_output() {
     assert!(output.stderr.text.is_empty());
     assert_eq!(output.aggregated_output.text, "before\n");
     assert!(output.duration >= Duration::from_millis(200));
+    assert!(output.timed_out);
 }

--- a/codex-rs/linux-sandbox/tests/suite/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/suite/landlock.rs
@@ -158,8 +158,8 @@ async fn assert_network_blocked(cmd: &[&str]) {
 
     let (exit_code, stdout, stderr) = match result {
         Ok(output) => (output.exit_code, output.stdout.text, output.stderr.text),
-        Err(CodexErr::Sandbox(SandboxErr::Denied(exit_code, stdout, stderr))) => {
-            (exit_code, stdout, stderr)
+        Err(CodexErr::Sandbox(SandboxErr::Denied { output })) => {
+            (output.exit_code, output.stdout.text, output.stderr.text)
         }
         _ => {
             panic!("expected sandbox denied error, got: {result:?}");

--- a/codex-rs/linux-sandbox/tests/suite/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/suite/landlock.rs
@@ -121,7 +121,7 @@ async fn test_writable_root() {
 }
 
 #[tokio::test]
-#[should_panic(expected = "Sandbox(Timeout)")]
+#[should_panic(expected = "Sandbox(Timeout")]
 async fn test_timeout() {
     run_cmd(&["sleep", "2"], &[], 50).await;
 }

--- a/codex-rs/linux-sandbox/tests/suite/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/suite/landlock.rs
@@ -158,7 +158,7 @@ async fn assert_network_blocked(cmd: &[&str]) {
 
     let output = match result {
         Ok(output) => output,
-        Err(CodexErr::Sandbox(SandboxErr::Denied { output })) => output,
+        Err(CodexErr::Sandbox(SandboxErr::Denied { output })) => *output,
         _ => {
             panic!("expected sandbox denied error, got: {result:?}");
         }

--- a/codex-rs/linux-sandbox/tests/suite/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/suite/landlock.rs
@@ -172,7 +172,7 @@ async fn assert_network_blocked(cmd: &[&str]) {
     // be non‑zero (EPERM from seccomp will usually bubble up as 1, 2, 13…)
     // If—*and only if*—the command exits 0 we consider the sandbox breached.
 
-    if exit_code == 0 {
+    if output.exit_code == 0 {
         panic!(
             "Network sandbox FAILED - {cmd:?} exited 0\nstdout:\n{}\nstderr:\n{}",
             output.stdout.text, output.stderr.text

--- a/codex-rs/linux-sandbox/tests/suite/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/suite/landlock.rs
@@ -173,7 +173,10 @@ async fn assert_network_blocked(cmd: &[&str]) {
     // If—*and only if*—the command exits 0 we consider the sandbox breached.
 
     if exit_code == 0 {
-        panic!("Network sandbox FAILED - {cmd:?} exited 0\nstdout:\n{stdout}\nstderr:\n{stderr}",);
+        panic!(
+            "Network sandbox FAILED - {cmd:?} exited 0\nstdout:\n{}\nstderr:\n{}",
+            output.stdout.text, output.stderr.text
+        );
     }
 }
 

--- a/codex-rs/linux-sandbox/tests/suite/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/suite/landlock.rs
@@ -156,19 +156,17 @@ async fn assert_network_blocked(cmd: &[&str]) {
     )
     .await;
 
-    let (exit_code, stdout, stderr) = match result {
-        Ok(output) => (output.exit_code, output.stdout.text, output.stderr.text),
-        Err(CodexErr::Sandbox(SandboxErr::Denied { output })) => {
-            (output.exit_code, output.stdout.text, output.stderr.text)
-        }
+    let output = match result {
+        Ok(output) => output,
+        Err(CodexErr::Sandbox(SandboxErr::Denied { output })) => output,
         _ => {
             panic!("expected sandbox denied error, got: {result:?}");
         }
     };
 
-    dbg!(&stderr);
-    dbg!(&stdout);
-    dbg!(&exit_code);
+    dbg!(&output.stderr.text);
+    dbg!(&output.stdout.text);
+    dbg!(&output.exit_code);
 
     // A completely missing binary exits with 127.  Anything else should also
     // be non‑zero (EPERM from seccomp will usually bubble up as 1, 2, 13…)


### PR DESCRIPTION
Being able to see the output helps the model decide how to handle the timeout.