### PR TITLE
Gate model upgrade prompt behind ChatGPT auth

### DIFF
--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -537,6 +537,7 @@ mod tests {
     use codex_core::auth::get_auth_file;
     use codex_core::auth::login_with_api_key;
     use codex_core::auth::write_auth_json;
+    use codex_core::token_data::IdTokenInfo;
     use codex_core::token_data::TokenData;
     use std::sync::Once;
 
@@ -583,10 +584,14 @@ mod tests {
                 login_with_api_key(codex_home, "sk-test-key").expect("write api key auth.json");
             }
             AuthMode::ChatGPT => {
+                // Minimal valid JWT payload: header.payload.signature (all base64url, no padding)
+                const FAKE_JWT: &str = "eyJhbGciOiJub25lIiwidHlwIjoiSldUIn0.e30.c2ln"; // {"alg":"none","typ":"JWT"}.{}."sig"
+                let mut id_info = IdTokenInfo::default();
+                id_info.raw_jwt = FAKE_JWT.to_string();
                 let auth = AuthDotJson {
                     openai_api_key: None,
                     tokens: Some(TokenData {
-                        id_token: Default::default(),
+                        id_token: id_info,
                         access_token: "access-token".to_string(),
                         refresh_token: "refresh-token".to_string(),
                         account_id: None,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -569,52 +569,28 @@ mod tests {
     fn shows_model_rollout_prompt_for_default_model() {
         let cli = Cli::parse_from(["codex"]);
         let cfg = make_config();
-        assert!(should_show_model_rollout_prompt(
-            &cli,
-            &cfg,
-            LoginStatus::AuthMode(AuthMode::ChatGPT),
-            None,
-            false,
-        ));
+        assert!(should_show_model_rollout_prompt(&cli, &cfg, None, false,));
     }
 
     #[test]
     fn hides_model_rollout_prompt_when_api_auth_mode() {
         let cli = Cli::parse_from(["codex"]);
         let cfg = make_config();
-        assert!(!should_show_model_rollout_prompt(
-            &cli,
-            &cfg,
-            LoginStatus::AuthMode(AuthMode::ApiKey),
-            None,
-            false,
-        ));
+        assert!(!should_show_model_rollout_prompt(&cli, &cfg, None, false,));
     }
 
     #[test]
     fn hides_model_rollout_prompt_when_marked_seen() {
         let cli = Cli::parse_from(["codex"]);
         let cfg = make_config();
-        assert!(!should_show_model_rollout_prompt(
-            &cli,
-            &cfg,
-            LoginStatus::AuthMode(AuthMode::ChatGPT),
-            None,
-            true,
-        ));
+        assert!(!should_show_model_rollout_prompt(&cli, &cfg, None, true,));
     }
 
     #[test]
     fn hides_model_rollout_prompt_when_cli_overrides_model() {
         let cli = Cli::parse_from(["codex", "--model", "gpt-4.1"]);
         let cfg = make_config();
-        assert!(!should_show_model_rollout_prompt(
-            &cli,
-            &cfg,
-            LoginStatus::AuthMode(AuthMode::ChatGPT),
-            None,
-            false,
-        ));
+        assert!(!should_show_model_rollout_prompt(&cli, &cfg, None, false,));
     }
 
     #[test]
@@ -624,7 +600,6 @@ mod tests {
         assert!(!should_show_model_rollout_prompt(
             &cli,
             &cfg,
-            LoginStatus::AuthMode(AuthMode::ChatGPT),
             Some("gpt5"),
             false,
         ));

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -321,7 +321,7 @@ async fn run_ratatui_app(
     session_log::maybe_init(&config);
 
     let auth_manager = AuthManager::shared(config.codex_home.clone());
-    let mut login_status = get_login_status(&config);
+    let login_status = get_login_status(&config);
     let should_show_onboarding =
         should_show_onboarding(login_status, &config, should_show_trust_screen);
     if should_show_onboarding {
@@ -341,8 +341,6 @@ async fn run_ratatui_app(
             config.sandbox_policy = SandboxPolicy::new_workspace_write_policy();
         }
     }
-
-    login_status = get_login_status(&config);
 
     let resume_selection = if cli.r#continue {
         match RolloutRecorder::list_conversations(&config.codex_home, 1, None).await {
@@ -369,7 +367,6 @@ async fn run_ratatui_app(
     if should_show_model_rollout_prompt(
         &cli,
         &config,
-        login_status,
         active_profile.as_deref(),
         internal_storage.swiftfox_model_prompt_seen,
     ) {
@@ -514,10 +511,10 @@ fn should_show_login_screen(login_status: LoginStatus, config: &Config) -> bool 
 fn should_show_model_rollout_prompt(
     cli: &Cli,
     config: &Config,
-    login_status: LoginStatus,
     active_profile: Option<&str>,
     swiftfox_model_prompt_seen: bool,
 ) -> bool {
+    let login_status = get_login_status(config);
     // TODO(jif) drop.
     let debug_high_enabled = std::env::var("DEBUG_HIGH")
         .map(|v| v.eq_ignore_ascii_case("1"))


### PR DESCRIPTION
- refresh the login_state after onboarding.
- should be on chatgpt for upgrade