### PR TITLE
add(core): display command without `cd` prefix

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2780,7 +2780,7 @@ async fn handle_container_exec_with_params(
                     params.with_escalated_permissions.unwrap_or(false),
                 )
             };
-            let command_for_display = params.command.clone();
+            let command_for_display = shell::prettify_command_for_display(&params.command);
             (params, safety, command_for_display)
         }
     };


### PR DESCRIPTION
Rewrite commands before display to remove the `cd {path} &&` prefix