### PR TITLE
Only one branch for swiftfox

### DIFF
--- a/codex-rs/core/src/model_family.rs
+++ b/codex-rs/core/src/model_family.rs
@@ -113,7 +113,7 @@ pub fn find_family_for_model(slug: &str) -> Option<ModelFamily> {
         simple_model_family!(slug, "gpt-4o")
     } else if slug.starts_with("gpt-3.5") {
         simple_model_family!(slug, "gpt-3.5")
-    } else if slug.starts_with("codex-") || slug.starts_with("swiftfox") {
+    } else if slug.starts_with("codex-") {
         model_family!(
             slug, slug,
             supports_reasoning_summaries: true,


### PR DESCRIPTION
Make each model family have a single branch.