### PR TITLE
Revert "fix(core): flaky test `completed_commands_do_not_persist_sessions`"

### DIFF
--- a/codex-rs/core/src/exec_command/exec_command_session.rs
+++ b/codex-rs/core/src/exec_command/exec_command_session.rs
@@ -11,9 +11,6 @@ pub(crate) struct ExecCommandSession {
     /// Broadcast stream of output chunks read from the PTY. New subscribers
     /// receive only chunks emitted after they subscribe.
     output_tx: broadcast::Sender<Vec<u8>>,
-    /// Receiver subscribed before the child process starts emitting output so
-    /// the first caller can consume any early data without races.
-    initial_output_rx: StdMutex<Option<broadcast::Receiver<Vec<u8>>>>,
 
     /// Child killer handle for termination on drop (can signal independently
     /// of a thread blocked in `.wait()`).
@@ -45,7 +42,6 @@ impl ExecCommandSession {
         Self {
             writer_tx,
             output_tx,
-            initial_output_rx: StdMutex::new(None),
             killer: StdMutex::new(Some(killer)),
             reader_handle: StdMutex::new(Some(reader_handle)),
             writer_handle: StdMutex::new(Some(writer_handle)),
@@ -54,26 +50,12 @@ impl ExecCommandSession {
         }
     }
 
-    pub(crate) fn set_initial_output_receiver(&self, receiver: broadcast::Receiver<Vec<u8>>) {
-        if let Ok(mut guard) = self.initial_output_rx.lock()
-            && guard.is_none()
-        {
-            *guard = Some(receiver);
-        }
-    }
-
     pub(crate) fn writer_sender(&self) -> mpsc::Sender<Vec<u8>> {
         self.writer_tx.clone()
     }
 
     pub(crate) fn output_receiver(&self) -> broadcast::Receiver<Vec<u8>> {
-        if let Ok(mut guard) = self.initial_output_rx.lock()
-            && let Some(receiver) = guard.take()
-        {
-            receiver
-        } else {
-            self.output_tx.subscribe()
-        }
+        self.output_tx.subscribe()
     }
 
     pub(crate) fn has_exited(&self) -> bool {

--- a/codex-rs/core/src/exec_command/session_manager.rs
+++ b/codex-rs/core/src/exec_command/session_manager.rs
@@ -279,7 +279,6 @@ async fn create_exec_command_session(
     let (writer_tx, mut writer_rx) = mpsc::channel::<Vec<u8>>(128);
     // Broadcast for streaming PTY output to readers: subscribers receive from subscription time.
     let (output_tx, _) = tokio::sync::broadcast::channel::<Vec<u8>>(256);
-    let initial_output_rx = output_tx.subscribe();
 
     // Reader task: drain PTY and forward chunks to output channel.
     let mut reader = pair.master.try_clone_reader()?;
@@ -351,7 +350,6 @@ async fn create_exec_command_session(
         wait_handle,
         exit_status,
     );
-    session.set_initial_output_receiver(initial_output_rx);
     Ok((session, exit_rx))
 }
 

--- a/codex-rs/core/src/unified_exec/mod.rs
+++ b/codex-rs/core/src/unified_exec/mod.rs
@@ -327,7 +327,6 @@ async fn create_unified_exec_session(
 
     let (writer_tx, mut writer_rx) = mpsc::channel::<Vec<u8>>(128);
     let (output_tx, _) = tokio::sync::broadcast::channel::<Vec<u8>>(256);
-    let initial_output_rx = output_tx.subscribe();
 
     let mut reader = pair
         .master
@@ -381,7 +380,7 @@ async fn create_unified_exec_session(
         wait_exit_status.store(true, Ordering::SeqCst);
     });
 
-    let session = ExecCommandSession::new(
+    Ok(ExecCommandSession::new(
         writer_tx,
         output_tx,
         killer,
@@ -389,10 +388,7 @@ async fn create_unified_exec_session(
         writer_handle,
         wait_handle,
         exit_status,
-    );
-    session.set_initial_output_receiver(initial_output_rx);
-
-    Ok(session)
+    ))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Reverts openai/codex#3596 (it was a temp fix for flaky test)