### PR TITLE
Revert "refactor transcript view to handle HistoryCells"

### DIFF
--- a/codex-rs/core/src/conversation_manager.rs
+++ b/codex-rs/core/src/conversation_manager.rs
@@ -134,19 +134,19 @@ impl ConversationManager {
         self.conversations.write().await.remove(conversation_id)
     }
 
-    /// Fork an existing conversation by taking messages up to the given position
-    /// (not including the message at the given position) and starting a new
+    /// Fork an existing conversation by dropping the last `drop_last_messages`
+    /// user/assistant messages from its transcript and starting a new
     /// conversation with identical configuration (unless overridden by the
     /// caller's `config`). The new conversation will have a fresh id.
     pub async fn fork_conversation(
         &self,
-        nth_user_message: usize,
+        num_messages_to_drop: usize,
         config: Config,
         path: PathBuf,
     ) -> CodexResult<NewConversation> {
         // Compute the prefix up to the cut point.
         let history = RolloutRecorder::get_rollout_history(&path).await?;
-        let history = truncate_after_nth_user_message(history, nth_user_message);
+        let history = truncate_after_dropping_last_messages(history, num_messages_to_drop);
 
         // Spawn a new conversation with the computed initial history.
         let auth_manager = self.auth_manager.clone();
@@ -159,10 +159,14 @@ impl ConversationManager {
     }
 }
 
-/// Return a prefix of `items` obtained by cutting strictly before the nth user message
-/// (0-based) and all items that follow it.
-fn truncate_after_nth_user_message(history: InitialHistory, n: usize) -> InitialHistory {
-    // Work directly on rollout items, and cut the vector at the nth user message input.
+/// Return a prefix of `items` obtained by dropping the last `n` user messages
+/// and all items that follow them.
+fn truncate_after_dropping_last_messages(history: InitialHistory, n: usize) -> InitialHistory {
+    if n == 0 {
+        return InitialHistory::Forked(history.get_rollout_items());
+    }
+
+    // Work directly on rollout items, and cut the vector at the nth-from-last user message input.
     let items: Vec<RolloutItem> = history.get_rollout_items();
 
     // Find indices of user message inputs in rollout order.
@@ -175,13 +179,13 @@ fn truncate_after_nth_user_message(history: InitialHistory, n: usize) -> Initial
         }
     }
 
-    // If fewer than or equal to n user messages exist, treat as empty (out of range).
-    if user_positions.len() <= n {
+    // If fewer than n user messages exist, treat as empty.
+    if user_positions.len() < n {
         return InitialHistory::New;
     }
 
-    // Cut strictly before the nth user message (do not keep the nth itself).
-    let cut_idx = user_positions[n];
+    // Cut strictly before the nth-from-last user message (do not keep the nth itself).
+    let cut_idx = user_positions[user_positions.len() - n];
     let rolled: Vec<RolloutItem> = items.into_iter().take(cut_idx).collect();
 
     if rolled.is_empty() {
@@ -248,7 +252,7 @@ mod tests {
             .cloned()
             .map(RolloutItem::ResponseItem)
             .collect();
-        let truncated = truncate_after_nth_user_message(InitialHistory::Forked(initial), 1);
+        let truncated = truncate_after_dropping_last_messages(InitialHistory::Forked(initial), 1);
         let got_items = truncated.get_rollout_items();
         let expected_items = vec![
             RolloutItem::ResponseItem(items[0].clone()),
@@ -265,7 +269,7 @@ mod tests {
             .cloned()
             .map(RolloutItem::ResponseItem)
             .collect();
-        let truncated2 = truncate_after_nth_user_message(InitialHistory::Forked(initial2), 2);
+        let truncated2 = truncate_after_dropping_last_messages(InitialHistory::Forked(initial2), 2);
         assert!(matches!(truncated2, InitialHistory::New));
     }
 }

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -74,7 +74,7 @@ async fn compact_resume_and_fork_preserve_model_history_view() {
         "compact+resume test expects resumed path {resumed_path:?} to exist",
     );
 
-    let forked = fork_conversation(&manager, &config, resumed_path, 4).await;
+    let forked = fork_conversation(&manager, &config, resumed_path, 1).await;
     user_turn(&forked, "AFTER_FORK").await;
 
     // 3. Capture the requests to the model and validate the history slices.
@@ -535,7 +535,7 @@ async fn compact_resume_after_second_compaction_preserves_history() {
         "second compact test expects resumed path {resumed_path:?} to exist",
     );
 
-    let forked = fork_conversation(&manager, &config, resumed_path, 1).await;
+    let forked = fork_conversation(&manager, &config, resumed_path, 3).await;
     user_turn(&forked, "AFTER_FORK").await;
 
     compact_conversation(&forked).await;

--- a/codex-rs/core/tests/suite/fork_conversation.rs
+++ b/codex-rs/core/tests/suite/fork_conversation.rs
@@ -104,8 +104,7 @@ async fn fork_conversation_twice_drops_to_first_message() {
         items
     };
 
-    // Compute expected prefixes after each fork by truncating base rollout
-    // strictly before the nth user input (0-based).
+    // Compute expected prefixes after each fork by truncating base rollout at nth-from-last user input.
     let base_items = read_items(&base_path);
     let find_user_input_positions = |items: &[RolloutItem]| -> Vec<usize> {
         let mut pos = Vec::new();
@@ -127,8 +126,11 @@ async fn fork_conversation_twice_drops_to_first_message() {
     };
     let user_inputs = find_user_input_positions(&base_items);
 
-    // After cutting at nth user input (n=1 → second user message), cut strictly before that input.
-    let cut1 = user_inputs.get(1).copied().unwrap_or(0);
+    // After dropping last user input (n=1), cut strictly before that input if present, else empty.
+    let cut1 = user_inputs
+        .get(user_inputs.len().saturating_sub(1))
+        .copied()
+        .unwrap_or(0);
     let expected_after_first: Vec<RolloutItem> = base_items[..cut1].to_vec();
 
     // After dropping again (n=1 on fork1), compute expected relative to fork1's rollout.
@@ -159,12 +161,12 @@ async fn fork_conversation_twice_drops_to_first_message() {
         serde_json::to_value(&expected_after_first).unwrap()
     );
 
-    // Fork again with n=0 → drops the (new) last user message, leaving only the first.
+    // Fork again with n=1 → drops the (new) last user message, leaving only the first.
     let NewConversation {
         conversation: codex_fork2,
         ..
     } = conversation_manager
-        .fork_conversation(0, config_for_fork.clone(), fork1_path.clone())
+        .fork_conversation(1, config_for_fork.clone(), fork1_path.clone())
         .await
         .expect("fork 2");
 

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use crate::app::App;
-use crate::history_cell::UserHistoryCell;
+use crate::backtrack_helpers;
 use crate::pager_overlay::Overlay;
 use crate::tui;
 use crate::tui::TuiEvent;
@@ -19,11 +19,11 @@ pub(crate) struct BacktrackState {
     pub(crate) primed: bool,
     /// Session id of the base conversation to fork from.
     pub(crate) base_id: Option<ConversationId>,
-    /// Index in the transcript of the last user message.
-    pub(crate) nth_user_message: usize,
+    /// Current step count (Nth last user message).
+    pub(crate) count: usize,
     /// True when the transcript overlay is showing a backtrack preview.
     pub(crate) overlay_preview_active: bool,
-    /// Pending fork request: (base_id, nth_user_message, prefill).
+    /// Pending fork request: (base_id, drop_count, prefill).
     pub(crate) pending: Option<(ConversationId, usize, String)>,
 }
 
@@ -96,9 +96,9 @@ impl App {
         &mut self,
         prefill: String,
         base_id: ConversationId,
-        nth_user_message: usize,
+        drop_last_messages: usize,
     ) {
-        self.backtrack.pending = Some((base_id, nth_user_message, prefill));
+        self.backtrack.pending = Some((base_id, drop_last_messages, prefill));
         self.app_event_tx.send(crate::app_event::AppEvent::CodexOp(
             codex_core::protocol::Op::GetPath,
         ));
@@ -107,7 +107,7 @@ impl App {
     /// Open transcript overlay (enters alternate screen and shows full transcript).
     pub(crate) fn open_transcript_overlay(&mut self, tui: &mut tui::Tui) {
         let _ = tui.enter_alt_screen();
-        self.overlay = Some(Overlay::new_transcript(self.transcript_cells.clone()));
+        self.overlay = Some(Overlay::new_transcript(self.transcript_lines.clone()));
         tui.frame_requester().schedule_frame();
     }
 
@@ -130,17 +130,15 @@ impl App {
     /// Re-render the full transcript into the terminal scrollback in one call.
     /// Useful when switching sessions to ensure prior history remains visible.
     pub(crate) fn render_transcript_once(&mut self, tui: &mut tui::Tui) {
-        if !self.transcript_cells.is_empty() {
-            for cell in &self.transcript_cells {
-                tui.insert_history_lines(cell.transcript_lines());
-            }
+        if !self.transcript_lines.is_empty() {
+            tui.insert_history_lines(self.transcript_lines.clone());
         }
     }
 
     /// Initialize backtrack state and show composer hint.
     fn prime_backtrack(&mut self) {
         self.backtrack.primed = true;
-        self.backtrack.nth_user_message = usize::MAX;
+        self.backtrack.count = 0;
         self.backtrack.base_id = self.chat_widget.conversation_id();
         self.chat_widget.show_esc_backtrack_hint();
     }
@@ -159,44 +157,51 @@ impl App {
         self.backtrack.primed = true;
         self.backtrack.base_id = self.chat_widget.conversation_id();
         self.backtrack.overlay_preview_active = true;
-        let last_user_cell_position = self
-            .transcript_cells
-            .iter()
-            .filter_map(|c| c.as_any().downcast_ref::<UserHistoryCell>())
-            .count() as i64
-            - 1;
-        if last_user_cell_position >= 0 {
-            self.apply_backtrack_selection(last_user_cell_position as usize);
-        }
+        let sel = self.compute_backtrack_selection(tui, 1);
+        self.apply_backtrack_selection(sel);
         tui.frame_requester().schedule_frame();
     }
 
     /// Step selection to the next older user message and update overlay.
     fn step_backtrack_and_highlight(&mut self, tui: &mut tui::Tui) {
-        let last_user_cell_position = self
-            .transcript_cells
-            .iter()
-            .filter(|c| c.as_any().is::<UserHistoryCell>())
-            .take(self.backtrack.nth_user_message)
-            .count()
-            .saturating_sub(1);
-        self.apply_backtrack_selection(last_user_cell_position);
+        let next = self.backtrack.count.saturating_add(1);
+        let sel = self.compute_backtrack_selection(tui, next);
+        self.apply_backtrack_selection(sel);
         tui.frame_requester().schedule_frame();
     }
 
+    /// Compute normalized target, scroll offset, and highlight for requested step.
+    fn compute_backtrack_selection(
+        &self,
+        tui: &tui::Tui,
+        requested_n: usize,
+    ) -> (usize, Option<usize>, Option<(usize, usize)>) {
+        let nth = backtrack_helpers::normalize_backtrack_n(&self.transcript_lines, requested_n);
+        let header_idx =
+            backtrack_helpers::find_nth_last_user_header_index(&self.transcript_lines, nth);
+        let offset = header_idx.map(|idx| {
+            backtrack_helpers::wrapped_offset_before(
+                &self.transcript_lines,
+                idx,
+                tui.terminal.viewport_area.width,
+            )
+        });
+        let hl = backtrack_helpers::highlight_range_for_nth_last_user(&self.transcript_lines, nth);
+        (nth, offset, hl)
+    }
+
     /// Apply a computed backtrack selection to the overlay and internal counter.
-    fn apply_backtrack_selection(&mut self, nth_user_message: usize) {
-        self.backtrack.nth_user_message = nth_user_message;
+    fn apply_backtrack_selection(
+        &mut self,
+        selection: (usize, Option<usize>, Option<(usize, usize)>),
+    ) {
+        let (nth, offset, hl) = selection;
+        self.backtrack.count = nth;
         if let Some(Overlay::Transcript(t)) = &mut self.overlay {
-            let cell = self
-                .transcript_cells
-                .iter()
-                .enumerate()
-                .filter(|(_, c)| c.as_any().is::<UserHistoryCell>())
-                .nth(nth_user_message);
-            if let Some((idx, _)) = cell {
-                t.set_highlight_cell(Some(idx));
+            if let Some(off) = offset {
+                t.set_scroll_offset(off);
             }
+            t.set_highlight_range(hl);
         }
     }
 
@@ -214,19 +219,13 @@ impl App {
 
     /// Handle Enter in overlay backtrack preview: confirm selection and reset state.
     fn overlay_confirm_backtrack(&mut self, tui: &mut tui::Tui) {
-        let nth_user_message = self.backtrack.nth_user_message;
         if let Some(base_id) = self.backtrack.base_id {
-            let user_cells = self
-                .transcript_cells
-                .iter()
-                .filter_map(|c| c.as_any().downcast_ref::<UserHistoryCell>())
-                .collect::<Vec<_>>();
-            let prefill = user_cells
-                .get(nth_user_message)
-                .map(|c| c.message.clone())
-                .unwrap_or_default();
+            let drop_last_messages = self.backtrack.count;
+            let prefill =
+                backtrack_helpers::nth_last_user_text(&self.transcript_lines, drop_last_messages)
+                    .unwrap_or_default();
             self.close_transcript_overlay(tui);
-            self.request_backtrack(prefill, base_id, nth_user_message);
+            self.request_backtrack(prefill, base_id, drop_last_messages);
         }
         self.reset_backtrack_state();
     }
@@ -245,15 +244,11 @@ impl App {
     /// Computes the prefill from the selected user message and requests history.
     pub(crate) fn confirm_backtrack_from_main(&mut self) {
         if let Some(base_id) = self.backtrack.base_id {
-            let prefill = self
-                .transcript_cells
-                .iter()
-                .filter(|c| c.as_any().is::<UserHistoryCell>())
-                .nth(self.backtrack.nth_user_message)
-                .and_then(|c| c.as_any().downcast_ref::<UserHistoryCell>())
-                .map(|c| c.message.clone())
-                .unwrap_or_default();
-            self.request_backtrack(prefill, base_id, self.backtrack.nth_user_message);
+            let drop_last_messages = self.backtrack.count;
+            let prefill =
+                backtrack_helpers::nth_last_user_text(&self.transcript_lines, drop_last_messages)
+                    .unwrap_or_default();
+            self.request_backtrack(prefill, base_id, drop_last_messages);
         }
         self.reset_backtrack_state();
     }
@@ -262,7 +257,7 @@ impl App {
     pub(crate) fn reset_backtrack_state(&mut self) {
         self.backtrack.primed = false;
         self.backtrack.base_id = None;
-        self.backtrack.nth_user_message = usize::MAX;
+        self.backtrack.count = 0;
         // In case a hint is somehow still visible (e.g., race with overlay open/close).
         self.chat_widget.clear_esc_backtrack_hint();
     }
@@ -276,9 +271,9 @@ impl App {
     ) -> Result<()> {
         if let Some((base_id, _, _)) = self.backtrack.pending.as_ref()
             && ev.conversation_id == *base_id
-            && let Some((_, nth_user_message, prefill)) = self.backtrack.pending.take()
+            && let Some((_, drop_count, prefill)) = self.backtrack.pending.take()
         {
-            self.fork_and_switch_to_new_conversation(tui, ev, nth_user_message, prefill)
+            self.fork_and_switch_to_new_conversation(tui, ev, drop_count, prefill)
                 .await;
         }
         Ok(())
@@ -289,17 +284,17 @@ impl App {
         &mut self,
         tui: &mut tui::Tui,
         ev: ConversationPathResponseEvent,
-        nth_user_message: usize,
+        drop_count: usize,
         prefill: String,
     ) {
         let cfg = self.chat_widget.config_ref().clone();
         // Perform the fork via a thin wrapper for clarity/testability.
         let result = self
-            .perform_fork(ev.path.clone(), nth_user_message, cfg.clone())
+            .perform_fork(ev.path.clone(), drop_count, cfg.clone())
             .await;
         match result {
             Ok(new_conv) => {
-                self.install_forked_conversation(tui, cfg, new_conv, nth_user_message, &prefill)
+                self.install_forked_conversation(tui, cfg, new_conv, drop_count, &prefill)
             }
             Err(e) => tracing::error!("error forking conversation: {e:#}"),
         }
@@ -309,12 +304,10 @@ impl App {
     async fn perform_fork(
         &self,
         path: PathBuf,
-        nth_user_message: usize,
+        drop_count: usize,
         cfg: codex_core::config::Config,
     ) -> codex_core::error::Result<codex_core::NewConversation> {
-        self.server
-            .fork_conversation(nth_user_message, cfg, path)
-            .await
+        self.server.fork_conversation(drop_count, cfg, path).await
     }
 
     /// Install a forked conversation into the ChatWidget and update UI to reflect selection.
@@ -323,7 +316,7 @@ impl App {
         tui: &mut tui::Tui,
         cfg: codex_core::config::Config,
         new_conv: codex_core::NewConversation,
-        nth_user_message: usize,
+        drop_count: usize,
         prefill: &str,
     ) {
         let conv = new_conv.conversation;
@@ -340,7 +333,7 @@ impl App {
         self.chat_widget =
             crate::chatwidget::ChatWidget::new_from_existing(init, conv, session_configured);
         // Trim transcript up to the selected user message and re-render it.
-        self.trim_transcript_for_backtrack(nth_user_message);
+        self.trim_transcript_for_backtrack(drop_count);
         self.render_transcript_once(tui);
         if !prefill.is_empty() {
             self.chat_widget.set_composer_text(prefill.to_string());
@@ -348,21 +341,14 @@ impl App {
         tui.frame_requester().schedule_frame();
     }
 
-    /// Trim transcript_cells to preserve only content up to the selected user message.
-    fn trim_transcript_for_backtrack(&mut self, nth_user_message: usize) {
-        let cut_idx = self
-            .transcript_cells
-            .iter()
-            .enumerate()
-            .filter_map(|(idx, cell)| {
-                if cell.as_any().is::<UserHistoryCell>() {
-                    Some(idx)
-                } else {
-                    None
-                }
-            })
-            .nth(nth_user_message - 1)
-            .unwrap_or(self.transcript_cells.len());
-        self.transcript_cells.truncate(cut_idx);
+    /// Trim transcript_lines to preserve only content up to the selected user message.
+    fn trim_transcript_for_backtrack(&mut self, drop_count: usize) {
+        if let Some(cut_idx) =
+            backtrack_helpers::find_nth_last_user_header_index(&self.transcript_lines, drop_count)
+        {
+            self.transcript_lines.truncate(cut_idx);
+        } else {
+            self.transcript_lines.clear();
+        }
     }
 }

--- a/codex-rs/tui/src/backtrack_helpers.rs
+++ b/codex-rs/tui/src/backtrack_helpers.rs
@@ -1,0 +1,153 @@
+use ratatui::text::Line;
+
+/// Convenience: compute the highlight range for the Nth last user message.
+pub(crate) fn highlight_range_for_nth_last_user(
+    lines: &[Line<'_>],
+    n: usize,
+) -> Option<(usize, usize)> {
+    let header = find_nth_last_user_header_index(lines, n)?;
+    Some(highlight_range_from_header(lines, header))
+}
+
+/// Compute the wrapped display-line offset before `header_idx`, for a given width.
+pub(crate) fn wrapped_offset_before(lines: &[Line<'_>], header_idx: usize, width: u16) -> usize {
+    let before = &lines[0..header_idx];
+    crate::wrapping::word_wrap_lines(before, width as usize).len()
+}
+
+/// Find the header index for the Nth last user message in the transcript.
+/// Returns `None` if `n == 0` or there are fewer than `n` user messages.
+pub(crate) fn find_nth_last_user_header_index(lines: &[Line<'_>], n: usize) -> Option<usize> {
+    if n == 0 {
+        return None;
+    }
+    let mut found = 0usize;
+    for (idx, line) in lines.iter().enumerate().rev() {
+        let content: String = line
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect::<Vec<_>>()
+            .join("");
+        if content.trim() == "user" {
+            found += 1;
+            if found == n {
+                return Some(idx);
+            }
+        }
+    }
+    None
+}
+
+/// Normalize a requested backtrack step `n` against the available user messages.
+/// - Returns `0` if there are no user messages.
+/// - Returns `n` if the Nth last user message exists.
+/// - Otherwise wraps to `1` (the most recent user message).
+pub(crate) fn normalize_backtrack_n(lines: &[Line<'_>], n: usize) -> usize {
+    if n == 0 {
+        return 0;
+    }
+    if find_nth_last_user_header_index(lines, n).is_some() {
+        return n;
+    }
+    if find_nth_last_user_header_index(lines, 1).is_some() {
+        1
+    } else {
+        0
+    }
+}
+
+/// Extract the text content of the Nth last user message.
+/// The message body is considered to be the lines following the "user" header
+/// until the first blank line.
+pub(crate) fn nth_last_user_text(lines: &[Line<'_>], n: usize) -> Option<String> {
+    let header_idx = find_nth_last_user_header_index(lines, n)?;
+    extract_message_text_after_header(lines, header_idx)
+}
+
+/// Extract message text starting after `header_idx` until the first blank line.
+fn extract_message_text_after_header(lines: &[Line<'_>], header_idx: usize) -> Option<String> {
+    let start = header_idx + 1;
+    let mut out: Vec<String> = Vec::new();
+    for line in lines.iter().skip(start) {
+        let is_blank = line
+            .spans
+            .iter()
+            .all(|s| s.content.as_ref().trim().is_empty());
+        if is_blank {
+            break;
+        }
+        let text: String = line
+            .spans
+            .iter()
+            .map(|s| s.content.as_ref())
+            .collect::<Vec<_>>()
+            .join("");
+        out.push(text);
+    }
+    if out.is_empty() {
+        None
+    } else {
+        Some(out.join("\n"))
+    }
+}
+
+/// Given a header index, return the inclusive range for the message block
+/// [header_idx, end) where end is the first blank line after the header or the
+/// end of the transcript.
+fn highlight_range_from_header(lines: &[Line<'_>], header_idx: usize) -> (usize, usize) {
+    let mut end = header_idx + 1;
+    while end < lines.len() {
+        let is_blank = lines[end]
+            .spans
+            .iter()
+            .all(|s| s.content.as_ref().trim().is_empty());
+        if is_blank {
+            break;
+        }
+        end += 1;
+    }
+    (header_idx, end)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn line(s: &str) -> Line<'static> {
+        s.to_string().into()
+    }
+
+    fn transcript_with_users(count: usize) -> Vec<Line<'static>> {
+        // Build a transcript with `count` user messages, each followed by one body line and a blank line.
+        let mut v = Vec::new();
+        for i in 0..count {
+            v.push(line("user"));
+            v.push(line(&format!("message {i}")));
+            v.push(line(""));
+        }
+        v
+    }
+
+    #[test]
+    fn normalize_wraps_to_one_when_past_oldest() {
+        let lines = transcript_with_users(2);
+        assert_eq!(normalize_backtrack_n(&lines, 1), 1);
+        assert_eq!(normalize_backtrack_n(&lines, 2), 2);
+        // Requesting 3rd when only 2 exist wraps to 1
+        assert_eq!(normalize_backtrack_n(&lines, 3), 1);
+    }
+
+    #[test]
+    fn normalize_returns_zero_when_no_user_messages() {
+        let lines = transcript_with_users(0);
+        assert_eq!(normalize_backtrack_n(&lines, 1), 0);
+        assert_eq!(normalize_backtrack_n(&lines, 5), 0);
+    }
+
+    #[test]
+    fn normalize_keeps_valid_n() {
+        let lines = transcript_with_users(3);
+        assert_eq!(normalize_backtrack_n(&lines, 2), 2);
+    }
+}

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -43,7 +43,6 @@ use ratatui::style::Stylize;
 use ratatui::widgets::Paragraph;
 use ratatui::widgets::WidgetRef;
 use ratatui::widgets::Wrap;
-use std::any::Any;
 use std::collections::HashMap;
 use std::io::Cursor;
 use std::path::Path;
@@ -70,7 +69,7 @@ pub(crate) enum PatchEventType {
 /// Represents an event to display in the conversation history. Returns its
 /// `Vec<Line<'static>>` representation to make it easier to display in a
 /// scrollable list.
-pub(crate) trait HistoryCell: std::fmt::Debug + Send + Sync + Any {
+pub(crate) trait HistoryCell: std::fmt::Debug + Send + Sync {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>>;
 
     fn transcript_lines(&self) -> Vec<Line<'static>> {
@@ -90,15 +89,9 @@ pub(crate) trait HistoryCell: std::fmt::Debug + Send + Sync + Any {
     }
 }
 
-impl dyn HistoryCell {
-    pub(crate) fn as_any(&self) -> &dyn Any {
-        self
-    }
-}
-
 #[derive(Debug)]
 pub(crate) struct UserHistoryCell {
-    pub message: String,
+    message: String,
 }
 
 impl HistoryCell for UserHistoryCell {

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -32,6 +32,7 @@ mod app;
 mod app_backtrack;
 mod app_event;
 mod app_event_sender;
+mod backtrack_helpers;
 mod bottom_pane;
 mod chatwidget;
 mod citation_regex;

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_snapshot_basic.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_snapshot_basic.snap
@@ -4,10 +4,10 @@ expression: term.backend()
 ---
 "/ T R A N S C R I P T / / / / / / / / / "
 "alpha                                   "
-"                                        "
 "beta                                    "
-"                                        "
 "gamma                                   "
+"~                                       "
+"~                                       "
 "───────────────────────────────── 100% ─"
 " ↑/↓ scroll   PgUp/PgDn page   Home/End "
 " q quit   Esc edit prev                 "


### PR DESCRIPTION
Reverts openai/codex#3538
It panics on forking first message. It also calculates the index in a wrong way.