### PR TITLE
Fix codex resume so flags (cd, model, search, etc.) still work

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -289,13 +289,6 @@ fn prepend_config_flags(
 }
 
 /// Build the final `TuiCli` for a `codex resume` invocation.
-///
-/// This function encapsulates the business logic for combining:
-/// - the base interactive CLI parsed at the root level,
-/// - the resume-specific flags and overrides,
-/// - and any root-level config overrides (lower precedence).
-///
-/// The resulting `TuiCli` is ready to be passed to `codex_tui::run_main`.
 fn finalize_resume_interactive(
     mut interactive: TuiCli,
     root_config_overrides: CliConfigOverrides,

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -7,10 +7,18 @@ use std::path::PathBuf;
 #[command(version)]
 pub struct Cli {
     /// Optional user prompt to start the session.
+    #[arg(value_name = "PROMPT", global = true)]
     pub prompt: Option<String>,
 
     /// Optional image(s) to attach to the initial prompt.
-    #[arg(long = "image", short = 'i', value_name = "FILE", value_delimiter = ',', num_args = 1..)]
+    #[arg(
+        long = "image",
+        short = 'i',
+        value_name = "FILE",
+        value_delimiter = ',',
+        num_args = 1..,
+        global = true
+    )]
     pub images: Vec<PathBuf>,
 
     // Internal controls set by the top-level `codex resume` subcommand.
@@ -27,30 +35,30 @@ pub struct Cli {
     pub resume_session_id: Option<String>,
 
     /// Model the agent should use.
-    #[arg(long, short = 'm')]
+    #[arg(long, short = 'm', global = true)]
     pub model: Option<String>,
 
     /// Convenience flag to select the local open source model provider.
     /// Equivalent to -c model_provider=oss; verifies a local Ollama server is
     /// running.
-    #[arg(long = "oss", default_value_t = false)]
+    #[arg(long = "oss", default_value_t = false, global = true)]
     pub oss: bool,
 
     /// Configuration profile from config.toml to specify default options.
-    #[arg(long = "profile", short = 'p')]
+    #[arg(long = "profile", short = 'p', global = true)]
     pub config_profile: Option<String>,
 
     /// Select the sandbox policy to use when executing model-generated shell
     /// commands.
-    #[arg(long = "sandbox", short = 's')]
+    #[arg(long = "sandbox", short = 's', global = true)]
     pub sandbox_mode: Option<codex_common::SandboxModeCliArg>,
 
     /// Configure when the model requires human approval before executing a command.
-    #[arg(long = "ask-for-approval", short = 'a')]
+    #[arg(long = "ask-for-approval", short = 'a', global = true)]
     pub approval_policy: Option<ApprovalModeCliArg>,
 
     /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, --sandbox workspace-write).
-    #[arg(long = "full-auto", default_value_t = false)]
+    #[arg(long = "full-auto", default_value_t = false, global = true)]
     pub full_auto: bool,
 
     /// Skip all confirmation prompts and execute commands without sandboxing.
@@ -59,16 +67,17 @@ pub struct Cli {
         long = "dangerously-bypass-approvals-and-sandbox",
         alias = "yolo",
         default_value_t = false,
-        conflicts_with_all = ["approval_policy", "full_auto"]
+        conflicts_with_all = ["approval_policy", "full_auto"],
+        global = true
     )]
     pub dangerously_bypass_approvals_and_sandbox: bool,
 
     /// Tell the agent to use the specified directory as its working root.
-    #[clap(long = "cd", short = 'C', value_name = "DIR")]
+    #[clap(long = "cd", short = 'C', value_name = "DIR", global = true)]
     pub cwd: Option<PathBuf>,
 
     /// Enable web search (off by default). When enabled, the native Responses `web_search` tool is available to the model (no per‑call approval).
-    #[arg(long = "search", default_value_t = false)]
+    #[arg(long = "search", default_value_t = false, global = true)]
     pub web_search: bool,
 
     #[clap(skip)]

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -11,13 +11,7 @@ pub struct Cli {
     pub prompt: Option<String>,
 
     /// Optional image(s) to attach to the initial prompt.
-    #[arg(
-        long = "image",
-        short = 'i',
-        value_name = "FILE",
-        value_delimiter = ',',
-        num_args = 1..,
-    )]
+    #[arg(long = "image", short = 'i', value_name = "FILE", value_delimiter = ',', num_args = 1..)]
     pub images: Vec<PathBuf>,
 
     // Internal controls set by the top-level `codex resume` subcommand.

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 #[command(version)]
 pub struct Cli {
     /// Optional user prompt to start the session.
-    #[arg(value_name = "PROMPT", global = true)]
+    #[arg(value_name = "PROMPT")]
     pub prompt: Option<String>,
 
     /// Optional image(s) to attach to the initial prompt.
@@ -17,7 +17,6 @@ pub struct Cli {
         value_name = "FILE",
         value_delimiter = ',',
         num_args = 1..,
-        global = true
     )]
     pub images: Vec<PathBuf>,
 
@@ -35,30 +34,30 @@ pub struct Cli {
     pub resume_session_id: Option<String>,
 
     /// Model the agent should use.
-    #[arg(long, short = 'm', global = true)]
+    #[arg(long, short = 'm')]
     pub model: Option<String>,
 
     /// Convenience flag to select the local open source model provider.
     /// Equivalent to -c model_provider=oss; verifies a local Ollama server is
     /// running.
-    #[arg(long = "oss", default_value_t = false, global = true)]
+    #[arg(long = "oss", default_value_t = false)]
     pub oss: bool,
 
     /// Configuration profile from config.toml to specify default options.
-    #[arg(long = "profile", short = 'p', global = true)]
+    #[arg(long = "profile", short = 'p')]
     pub config_profile: Option<String>,
 
     /// Select the sandbox policy to use when executing model-generated shell
     /// commands.
-    #[arg(long = "sandbox", short = 's', global = true)]
+    #[arg(long = "sandbox", short = 's')]
     pub sandbox_mode: Option<codex_common::SandboxModeCliArg>,
 
     /// Configure when the model requires human approval before executing a command.
-    #[arg(long = "ask-for-approval", short = 'a', global = true)]
+    #[arg(long = "ask-for-approval", short = 'a')]
     pub approval_policy: Option<ApprovalModeCliArg>,
 
     /// Convenience alias for low-friction sandboxed automatic execution (-a on-failure, --sandbox workspace-write).
-    #[arg(long = "full-auto", default_value_t = false, global = true)]
+    #[arg(long = "full-auto", default_value_t = false)]
     pub full_auto: bool,
 
     /// Skip all confirmation prompts and execute commands without sandboxing.
@@ -68,16 +67,15 @@ pub struct Cli {
         alias = "yolo",
         default_value_t = false,
         conflicts_with_all = ["approval_policy", "full_auto"],
-        global = true
     )]
     pub dangerously_bypass_approvals_and_sandbox: bool,
 
     /// Tell the agent to use the specified directory as its working root.
-    #[clap(long = "cd", short = 'C', value_name = "DIR", global = true)]
+    #[clap(long = "cd", short = 'C', value_name = "DIR")]
     pub cwd: Option<PathBuf>,
 
     /// Enable web search (off by default). When enabled, the native Responses `web_search` tool is available to the model (no per‑call approval).
-    #[arg(long = "search", default_value_t = false, global = true)]
+    #[arg(long = "search", default_value_t = false)]
     pub web_search: bool,
 
     #[clap(skip)]

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -60,7 +60,7 @@ pub struct Cli {
         long = "dangerously-bypass-approvals-and-sandbox",
         alias = "yolo",
         default_value_t = false,
-        conflicts_with_all = ["approval_policy", "full_auto"],
+        conflicts_with_all = ["approval_policy", "full_auto"]
     )]
     pub dangerously_bypass_approvals_and_sandbox: bool,
 


### PR DESCRIPTION
Bug: now we can add flags/config values only before resume. 

`codex -m gpt-5 resume` works

However, `codex resume -m gpt-5` should also work.

This PR is following this [approach](https://stackoverflow.com/questions/76408952/rust-clap-re-use-same-arguments-in-different-subcommand) in doing so.

I didn't convert those flags to global because we have `codex login` that shouldn't expect them. 