### PR TITLE
feat: tighten preset filter, tame storage load logs, enable rollout prompt by default

### DIFF
--- a/codex-rs/common/src/model_presets.rs
+++ b/codex-rs/common/src/model_presets.rs
@@ -74,7 +74,7 @@ pub fn builtin_model_presets(auth_mode: Option<AuthMode>) -> Vec<ModelPreset> {
         Some(AuthMode::ApiKey) => PRESETS
             .iter()
             .copied()
-            .filter(|p| !p.model.contains(SWIFTFOX_MEDIUM_MODEL))
+            .filter(|p| p.model != SWIFTFOX_MEDIUM_MODEL)
             .collect(),
         _ => PRESETS.to_vec(),
     }

--- a/codex-rs/core/src/internal_storage.rs
+++ b/codex-rs/core/src/internal_storage.rs
@@ -1,6 +1,7 @@
 use anyhow::Context;
 use serde::Deserialize;
 use serde::Serialize;
+use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
 
@@ -31,7 +32,14 @@ impl InternalStorage {
                 }
             },
             Err(error) => {
-                tracing::warn!("failed to read internal storage: {error:?}");
+                if error.kind() == ErrorKind::NotFound {
+                    tracing::debug!(
+                        "internal storage not found at {}; initializing defaults",
+                        storage_path.display()
+                    );
+                } else {
+                    tracing::warn!("failed to read internal storage: {error:?}");
+                }
                 Self::empty(storage_path)
             }
         }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -8,8 +8,6 @@ use codex_core::AuthManager;
 use codex_core::BUILT_IN_OSS_MODEL_PROVIDER_ID;
 use codex_core::CodexAuth;
 use codex_core::RolloutRecorder;
-use codex_core::auth::get_auth_file;
-use codex_core::auth::try_read_auth_json;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
 use codex_core::config::ConfigToml;
@@ -529,19 +527,6 @@ fn should_show_model_rollout_prompt(
     swiftfox_model_prompt_seen: bool,
 ) -> bool {
     let login_status = get_login_status(config);
-    // If an API key is present in auth.json, we're in ApiKey auth mode;
-    // suppress the ChatGPT rollout prompt in that case.
-    if let Ok(auth) = try_read_auth_json(&get_auth_file(&config.codex_home)) {
-        if auth.openai_api_key.as_deref().is_some() {
-            return false;
-        }
-    }
-    // Double-check by loading current auth mode; if ApiKey, do not show prompt.
-    if let Ok(Some(auth)) = CodexAuth::from_codex_home(&config.codex_home) {
-        if matches!(auth.mode, AuthMode::ApiKey) {
-            return false;
-        }
-    }
 
     active_profile.is_none()
         && cli.model.is_none()

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -8,6 +8,8 @@ use codex_core::AuthManager;
 use codex_core::BUILT_IN_OSS_MODEL_PROVIDER_ID;
 use codex_core::CodexAuth;
 use codex_core::RolloutRecorder;
+use codex_core::auth::get_auth_file;
+use codex_core::auth::try_read_auth_json;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
 use codex_core::config::ConfigToml;
@@ -527,13 +529,21 @@ fn should_show_model_rollout_prompt(
     swiftfox_model_prompt_seen: bool,
 ) -> bool {
     let login_status = get_login_status(config);
-    // TODO(jif) drop.
-    let debug_high_enabled = std::env::var("DEBUG_HIGH")
-        .map(|v| v.eq_ignore_ascii_case("1"))
-        .unwrap_or(false);
+    // If an API key is present in auth.json, we're in ApiKey auth mode;
+    // suppress the ChatGPT rollout prompt in that case.
+    if let Ok(auth) = try_read_auth_json(&get_auth_file(&config.codex_home)) {
+        if auth.openai_api_key.as_deref().is_some() {
+            return false;
+        }
+    }
+    // Double-check by loading current auth mode; if ApiKey, do not show prompt.
+    if let Ok(Some(auth)) = CodexAuth::from_codex_home(&config.codex_home) {
+        if matches!(auth.mode, AuthMode::ApiKey) {
+            return false;
+        }
+    }
 
     active_profile.is_none()
-        && debug_high_enabled
         && cli.model.is_none()
         && !swiftfox_model_prompt_seen
         && config.model_provider.requires_openai_auth
@@ -551,21 +561,7 @@ mod tests {
     use codex_core::auth::write_auth_json;
     use codex_core::token_data::IdTokenInfo;
     use codex_core::token_data::TokenData;
-    use std::sync::Once;
-
-    fn enable_debug_high_env() {
-        static DEBUG_HIGH_ONCE: Once = Once::new();
-        DEBUG_HIGH_ONCE.call_once(|| {
-            // SAFETY: Tests run in a controlled environment and require this env variable to
-            // opt into the GPT-5 High rollout prompt gating. We only set it once.
-            unsafe {
-                std::env::set_var("DEBUG_HIGH", "1");
-            }
-        });
-    }
-
     fn make_config() -> Config {
-        enable_debug_high_env();
         // Create a unique CODEX_HOME per test to isolate auth.json writes.
         let mut codex_home = std::env::temp_dir();
         let unique_suffix = format!(


### PR DESCRIPTION
Summary
- common: use exact equality for Swiftfox exclusion to avoid hiding future slugs that merely contain the substring
- core: treat missing internal_storage.json as expected (debug), warn only on real IO/parse errors
- tui: drop DEBUG_HIGH gate; always consider showing rollout prompt, but suppress under ApiKey auth mode
