### PR TITLE
TUI: optional mid‑turn approval/sandbox changes via 'c' in approval modal (config‑gated)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,6 +78,10 @@ package.json-e
 session.ts-e
 CHANGELOG.ignore.md
 
+# local Rust toolchain caches (do not commit)
+codex-rs/.cargo/
+codex-rs/.rustup/
+
 # nix related
 .direnv
 .envrc

--- a/codex-rs/core/src/apply_patch.rs
+++ b/codex-rs/core/src/apply_patch.rs
@@ -40,10 +40,13 @@ pub(crate) async fn apply_patch(
     call_id: &str,
     action: ApplyPatchAction,
 ) -> InternalApplyPatchInvocation {
+    let (effective_approval, effective_sandbox) = sess
+        .effective_policies(turn_context.approval_policy, &turn_context.sandbox_policy)
+        .await;
     match assess_patch_safety(
         &action,
-        turn_context.approval_policy,
-        &turn_context.sandbox_policy,
+        effective_approval,
+        &effective_sandbox,
         &turn_context.cwd,
     ) {
         SafetyCheck::AutoApprove {

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -137,6 +137,9 @@ pub struct Config {
     /// and turn completions when not focused.
     pub tui_notifications: Notifications,
 
+    /// Allow the TUI to change approval/sandbox policy mid-turn.
+    pub tui_midturn_approval_mode_enabled: bool,
+
     /// The directory that should be treated as the current working directory
     /// for the session. All relative paths inside the business-logic layer are
     /// resolved against this path.
@@ -1185,6 +1188,11 @@ impl Config {
                 .as_ref()
                 .map(|t| t.notifications.clone())
                 .unwrap_or_default(),
+            tui_midturn_approval_mode_enabled: cfg
+                .tui
+                .as_ref()
+                .map(|t| t.midturn_approval_mode_enabled)
+                .unwrap_or(false),
             otel: {
                 let t: OtelConfigToml = cfg.otel.unwrap_or_default();
                 let log_user_prompt = t.log_user_prompt.unwrap_or(false);
@@ -2124,6 +2132,7 @@ model_verbosity = "high"
                 windows_wsl_setup_acknowledged: false,
                 disable_paste_burst: false,
                 tui_notifications: Default::default(),
+                tui_midturn_approval_mode_enabled: false,
                 otel: OtelConfig::default(),
             },
             o3_profile_config
@@ -2187,6 +2196,7 @@ model_verbosity = "high"
             windows_wsl_setup_acknowledged: false,
             disable_paste_burst: false,
             tui_notifications: Default::default(),
+            tui_midturn_approval_mode_enabled: false,
             otel: OtelConfig::default(),
         };
 
@@ -2265,6 +2275,7 @@ model_verbosity = "high"
             windows_wsl_setup_acknowledged: false,
             disable_paste_burst: false,
             tui_notifications: Default::default(),
+            tui_midturn_approval_mode_enabled: false,
             otel: OtelConfig::default(),
         };
 
@@ -2329,6 +2340,7 @@ model_verbosity = "high"
             windows_wsl_setup_acknowledged: false,
             disable_paste_burst: false,
             tui_notifications: Default::default(),
+            tui_midturn_approval_mode_enabled: false,
             otel: OtelConfig::default(),
         };
 

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -320,6 +320,11 @@ pub struct Tui {
     /// Defaults to `false`.
     #[serde(default)]
     pub notifications: Notifications,
+
+    /// Allow changing approval and sandbox modes while a task is in progress.
+    /// Defaults to `false`.
+    #[serde(default)]
+    pub midturn_approval_mode_enabled: bool,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]

--- a/codex-rs/core/src/git_info.rs
+++ b/codex-rs/core/src/git_info.rs
@@ -816,9 +816,13 @@ mod tests {
             .expect("Should collect git info from repo");
 
         // Should have repository URL
-        assert_eq!(
-            git_info.repository_url,
-            Some("https://github.com/example/repo.git".to_string())
+        let url = git_info
+            .repository_url
+            .expect("expected repository URL to be present");
+        assert!(
+            url == "https://github.com/example/repo.git"
+                || url == "git@github.com:example/repo.git",
+            "unexpected remote URL: {url}"
         );
     }
 

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -71,6 +71,7 @@ pub(crate) struct App {
 
     // Esc-backtracking state grouped
     pub(crate) backtrack: crate::app_backtrack::BacktrackState,
+    pub(crate) midturn_approval_mode_enabled: bool,
 }
 
 impl App {
@@ -94,6 +95,8 @@ impl App {
 
         let enhanced_keys_supported = tui.enhanced_keys_supported();
 
+        let midturn_approval_mode_enabled = config.tui_midturn_approval_mode_enabled;
+
         let chat_widget = match resume_selection {
             ResumeSelection::StartFresh | ResumeSelection::Exit => {
                 let init = crate::chatwidget::ChatWidgetInit {
@@ -104,6 +107,7 @@ impl App {
                     initial_images: initial_images.clone(),
                     enhanced_keys_supported,
                     auth_manager: auth_manager.clone(),
+                    midturn_approval_mode_enabled,
                 };
                 ChatWidget::new(init, conversation_manager.clone())
             }
@@ -126,6 +130,7 @@ impl App {
                     initial_images: initial_images.clone(),
                     enhanced_keys_supported,
                     auth_manager: auth_manager.clone(),
+                    midturn_approval_mode_enabled,
                 };
                 ChatWidget::new_from_existing(
                     init,
@@ -152,6 +157,7 @@ impl App {
             has_emitted_history_lines: false,
             commit_anim_running: Arc::new(AtomicBool::new(false)),
             backtrack: BacktrackState::default(),
+            midturn_approval_mode_enabled,
         };
 
         let tui_events = tui.event_stream();
@@ -228,6 +234,7 @@ impl App {
                     initial_images: Vec::new(),
                     enhanced_keys_supported: self.enhanced_keys_supported,
                     auth_manager: self.auth_manager.clone(),
+                    midturn_approval_mode_enabled: self.midturn_approval_mode_enabled,
                 };
                 self.chat_widget = ChatWidget::new(init, self.server.clone());
                 tui.frame_requester().schedule_frame();
@@ -371,6 +378,9 @@ impl App {
             }
             AppEvent::UpdateSandboxPolicy(policy) => {
                 self.chat_widget.set_sandbox_policy(policy);
+            }
+            AppEvent::OpenApprovalsPopup => {
+                self.chat_widget.open_approvals_popup();
             }
             AppEvent::OpenReviewBranchPicker(cwd) => {
                 self.chat_widget.show_review_branch_picker(&cwd).await;
@@ -520,6 +530,7 @@ mod tests {
             enhanced_keys_supported: false,
             commit_anim_running: Arc::new(AtomicBool::new(false)),
             backtrack: BacktrackState::default(),
+            midturn_approval_mode_enabled: false,
         }
     }
 

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -338,6 +338,7 @@ impl App {
             initial_images: Vec::new(),
             enhanced_keys_supported: self.enhanced_keys_supported,
             auth_manager: self.auth_manager.clone(),
+            midturn_approval_mode_enabled: self.midturn_approval_mode_enabled,
         };
         self.chat_widget =
             crate::chatwidget::ChatWidget::new_from_existing(init, conv, session_configured);

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -87,4 +87,7 @@ pub(crate) enum AppEvent {
 
     /// Open the approval popup.
     FullScreenApprovalRequest(ApprovalRequest),
+
+    /// Show the approval mode selection popup.
+    OpenApprovalsPopup,
 }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -69,6 +69,7 @@ pub(crate) struct BottomPane {
     /// Queued user messages to show under the status indicator.
     queued_user_messages: Vec<String>,
     context_window_percent: Option<u8>,
+    midturn_approval_mode_enabled: bool,
 }
 
 pub(crate) struct BottomPaneParams {
@@ -78,6 +79,7 @@ pub(crate) struct BottomPaneParams {
     pub(crate) enhanced_keys_supported: bool,
     pub(crate) placeholder_text: String,
     pub(crate) disable_paste_burst: bool,
+    pub(crate) midturn_approval_mode_enabled: bool,
 }
 
 impl BottomPane {
@@ -102,6 +104,7 @@ impl BottomPane {
             queued_user_messages: Vec::new(),
             esc_backtrack_hint: false,
             context_window_percent: None,
+            midturn_approval_mode_enabled: params.midturn_approval_mode_enabled,
         }
     }
 
@@ -415,7 +418,11 @@ impl BottomPane {
         };
 
         // Otherwise create a new approval modal overlay.
-        let modal = ApprovalOverlay::new(request, self.app_event_tx.clone());
+        let modal = ApprovalOverlay::new(
+            request,
+            self.app_event_tx.clone(),
+            self.midturn_approval_mode_enabled,
+        );
         self.pause_status_timer_for_modal();
         self.push_view(Box::new(modal));
     }
@@ -564,6 +571,7 @@ mod tests {
             enhanced_keys_supported: false,
             placeholder_text: "Ask Codex to do anything".to_string(),
             disable_paste_burst: false,
+            midturn_approval_mode_enabled: false,
         });
         pane.push_approval_request(exec_request());
         assert_eq!(CancellationEvent::Handled, pane.on_ctrl_c());
@@ -584,6 +592,7 @@ mod tests {
             enhanced_keys_supported: false,
             placeholder_text: "Ask Codex to do anything".to_string(),
             disable_paste_burst: false,
+            midturn_approval_mode_enabled: false,
         });
 
         // Create an approval modal (active view).
@@ -615,6 +624,7 @@ mod tests {
             enhanced_keys_supported: false,
             placeholder_text: "Ask Codex to do anything".to_string(),
             disable_paste_burst: false,
+            midturn_approval_mode_enabled: false,
         });
 
         // Start a running task so the status indicator is active above the composer.
@@ -683,6 +693,7 @@ mod tests {
             enhanced_keys_supported: false,
             placeholder_text: "Ask Codex to do anything".to_string(),
             disable_paste_burst: false,
+            midturn_approval_mode_enabled: false,
         });
 
         // Begin a task: show initial status.
@@ -714,6 +725,7 @@ mod tests {
             enhanced_keys_supported: false,
             placeholder_text: "Ask Codex to do anything".to_string(),
             disable_paste_burst: false,
+            midturn_approval_mode_enabled: false,
         });
 
         // Activate spinner (status view replaces composer) with no live ring.
@@ -743,6 +755,7 @@ mod tests {
             enhanced_keys_supported: false,
             placeholder_text: "Ask Codex to do anything".to_string(),
             disable_paste_burst: false,
+            midturn_approval_mode_enabled: false,
         });
 
         pane.set_task_running(true);

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -233,6 +233,7 @@ async fn helpers_are_available_and_do_not_panic() {
         initial_images: Vec::new(),
         enhanced_keys_supported: false,
         auth_manager,
+        midturn_approval_mode_enabled: false,
     };
     let mut w = ChatWidget::new(init, conversation_manager);
     // Basic construction sanity.
@@ -256,6 +257,7 @@ fn make_chatwidget_manual() -> (
         enhanced_keys_supported: false,
         placeholder_text: "Ask Codex to do anything".to_string(),
         disable_paste_burst: false,
+        midturn_approval_mode_enabled: false,
     });
     let auth_manager = AuthManager::from_auth_for_testing(CodexAuth::from_api_key("test"));
     let widget = ChatWidget {
@@ -289,6 +291,8 @@ fn make_chatwidget_manual() -> (
         ghost_snapshots_disabled: false,
         needs_final_message_separator: false,
         last_rendered_width: std::cell::Cell::new(None),
+        midturn_approval_mode_enabled: false,
+        mode_change_banner_pending: false,
     };
     (widget, rx, op_rx)
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -764,6 +764,10 @@ notifications = true
 # You can optionally filter to specific notification types.
 # Available types are "agent-turn-complete" and "approval-requested".
 notifications = [ "agent-turn-complete", "approval-requested" ]
+
+# Allow changing approval and sandbox policy while a task is running.
+# Defaults to false; set to true when you understand the security trade-offs.
+midturn_approval_mode_enabled = true
 ```
 
 > [!NOTE]
@@ -798,6 +802,7 @@ notifications = [ "agent-turn-complete", "approval-requested" ]
 | `mcp_servers.<id>.tool_timeout_sec`              | number                                                            | Per-tool timeout in seconds (default: 60). Accepts fractional values; omit to use the default.                             |
 | `model_providers.<id>.name`                      | string                                                            | Display name.                                                                                                              |
 | `model_providers.<id>.base_url`                  | string                                                            | API base URL.                                                                                                              |
+| `tui.midturn_approval_mode_enabled`              | boolean                                                           | Enable mid-turn approval mode changes in the TUI (defaults to false; see [live-midturn-approvals-security](./live-midturn-approvals-security.md)). |
 | `model_providers.<id>.env_key`                   | string                                                            | Env var for API key.                                                                                                       |
 | `model_providers.<id>.wire_api`                  | `chat` \| `responses`                                             | Protocol used (default: `chat`).                                                                                           |
 | `model_providers.<id>.query_params`              | map<string,string>                                                | Extra query params (e.g., Azure `api-version`).                                                                            |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -16,7 +16,7 @@ It's possible that your [API account needs to be verified](https://help.openai.c
 
 ### How do I stop Codex from editing my files?
 
-By default, Codex can modify files in your current working directory (Auto mode). To prevent edits, run `codex` in read-only mode with the CLI flag `--sandbox read-only`. Alternatively, you can change the approval level mid-conversation with `/approvals`.
+By default, Codex can modify files in your current working directory (Auto mode). To prevent edits, run `codex` in read-only mode with the CLI flag `--sandbox read-only`. You can change the approval level mid-conversation with `/approvals`; to adjust the mode during an active task, set `[tui].midturn_approval_mode_enabled = true` in `config.toml`.
 
 ### Does it work on Windows?
 

--- a/docs/live-midturn-approvals-security.md
+++ b/docs/live-midturn-approvals-security.md
@@ -1,0 +1,24 @@
+Title: Security implications of live mid‑turn approval changes
+
+Summary
+- Changing approval and sandbox policy mid‑turn alters safety decisions for commands and file edits that have not yet been executed in the current turn. This feature is powerful but increases blast radius if a user elevates to broader permissions while an agent is actively proposing or executing actions.
+
+Key risks
+- Trust expansion mid‑execution: switching to Auto or Full Access can immediately convert pending or subsequent tool invocations within the same turn from “ask” to “auto‑approve”.
+- Patch scope: apply_patch diffs are often large; elevating mid‑turn can approve edits not fully reviewed yet.
+- Sandbox coverage: Full Access disables sandboxing; accidental elevation can allow network and non‑workspace writes.
+- Social engineering: a malicious diff or tool output could encourage elevation mid‑turn.
+
+Mitigations in this PR
+- Changes apply only to subsequent approval decisions; already‑displayed approval modals are not auto‑resolved.
+- Workspace boundaries enforced: “Auto” uses WorkspaceWrite sandbox; writes outside workspace still require approval.
+- No tool list reshaping mid‑turn: only safety decisions are updated; tool exposure remains consistent until next turn.
+
+Operational guidance
+- Prefer raising to “Auto” (WorkspaceWrite) rather than “Full Access” when possible.
+- Use `/diff` and patch previews to review changes before switching modes.
+- If elevation is made by mistake, immediately switch back to a more restrictive preset; new decisions will honor the tighter policy.
+
+PR review gate
+- This change MUST receive a dedicated security review before merge. Reviewers should verify that all approval and patch execution paths consult the effective mid‑turn policies and that sandbox policies are still enforced as documented.
+

--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -35,6 +35,9 @@ Yes, you can disable all approval prompts with `--ask-for-approval never`. This 
 
 > Note: In `workspace-write`, network is disabled by default unless enabled in config (`[sandbox_workspace_write].network_access = true`).
 
+> [!WARNING]
+> You can enable live approval-mode changes during a running task by setting `[tui].midturn_approval_mode_enabled = true` in `config.toml`. Changes take effect immediately for subsequent commands and patches—review [live-midturn-approvals-security](./live-midturn-approvals-security.md) before turning it on.
+
 #### Fine-tuning in `config.toml`
 
 ```toml


### PR DESCRIPTION
Title: Mid‑Turn Approval Mode Changes — Implementation & PR Plan

This is for those of us that sometimes flip between modes and hate it when we forget we had approvals on and a turn ends up needing dozens of approvals (like me..).

Summary
- Add optional, config‑gated hotkey ‘c’ to change approval/sandbox presets from within approval prompts.
- Keep behavior aligned with global /approvals: selecting a preset applies both approval policy and sandbox mode.
- Changes take effect after the current prompt (if one is in progress).
- Provide immediate transcript notice and a post‑turn banner.

Config
- Key: [tui].midturn_approval_mode_enabled (boolean; default: false)
- Examples:
  [tui]
  midturn_approval_mode_enabled = true

  [profiles.gpt5.tui]
  midturn_approval_mode_enabled = true

- Per‑run override:
  codex -c tui.midturn_approval_mode_enabled=true

User Experience
- While an approval prompt is visible, press ‘c’ to open an inline selector (Read Only / Auto / Full Access).
- Immediate info line: “Approval mode changed to ‘<label>’. Changes take effect after the current prompt, if one is in progress.”
- Post‑turn banner (after final response, only if changed mid‑turn):
  “Approval mode was updated during this turn. Current: approval=<policy>, sandbox=<sandbox>.”
- Approval prompt remains active; user still chooses Yes/No (or other) for the current request.
- Visible hint (when enabled): “Press ‘c’ to change approval mode” at the bottom of the approval modal.

Files Changed (clean main → patch)
1) codex-rs/core/src/config_types.rs
   - Add field to TUI config schema:
     pub struct Tui {
         #[serde(default)]
         pub midturn_approval_mode_enabled: Option<bool>,
     }

2) codex-rs/tui/src/lib.rs
   - Read [tui].midturn_approval_mode_enabled from config.toml during bootstrap.
   - Pass boolean gate into App::run(..., midturn_enabled_for_call).

3) codex-rs/tui/src/app.rs
   - Thread the boolean gate through App::run into ChatWidgetInit.
   - Store in App to preserve across fork/resume.

4) codex-rs/tui/src/app_backtrack.rs
   - Preserve midturn_approval_mode_enabled when installing a forked conversation.

5) codex-rs/tui/src/chatwidget.rs
   - ChatWidgetInit: add midturn_approval_mode_enabled; thread into BottomPane.
   - Add mode_change_banner_pending flag.
   - set_approval_policy / set_sandbox_policy: mark pending; on TaskComplete, insert post‑turn banner.

6) codex-rs/tui/src/bottom_pane/mod.rs
   - BottomPaneParams: add midturn_approval_mode_enabled; store in BottomPane.
   - push_approval_request: pass gate into ApprovalModalView.
   - Update tests to initialize new param.

7) codex-rs/tui/src/bottom_pane/approval_modal_view.rs
   - Add Mode::Prompt/SelectingPresets state machine.
   - Handle ‘c’ to open preset selector only when midturn_approval_mode_enabled is true.
   - Render inline selector with title, items, and footer hints.
   - On selection:
     • Send OverrideTurnContext (approval + sandbox)
     • Send UpdateAskForApprovalPolicy / UpdateSandboxPolicy
     • Insert immediate transcript info line
   - Visible hint in Prompt mode: “Press ‘c’ to change approval mode”.

8) codex-rs/tui/src/chatwidget/tests.rs
   - Initialize ChatWidgetInit.midturn_approval_mode_enabled = false in tests where needed.

Docs
- docs/config.md
  • Document [tui].midturn_approval_mode_enabled
  • Add per‑run example: codex -c tui.midturn_approval_mode_enabled=true
- docs/sandbox.md
  • New “Mid‑turn changes (optional)” section
  • Explain enablement, ‘c’ usage, and transcript notices
- docs/faq.md
  • Mention optional in‑prompt preset changes via [tui].midturn_approval_mode_enabled, linking to Sandbox docs

Logging & Session JSONL
- Outbound op: from_tui op override_turn_context (approval+sandbox)
- Insertions: to_tui insert_history_cell for the immediate info line and the post‑turn banner
- App events variants: UpdateAskForApprovalPolicy / UpdateSandboxPolicy are recorded

Build/Test Commands
- Build TUI: (cd codex-upstream/codex-rs && cargo build -p codex-tui)
- Run with gate enabled:
  cargo run -p codex-tui --bin codex-tui -- -c tui.midturn_approval_mode_enabled=true --ask-for-approval on-request --sandbox read-only
- Unit tests (example): cargo test -p codex-tui approvals_allowed_while_task_running

PR Notes
- Title: TUI: optional mid‑turn approval/sandbox changes via ‘c’ in approval modal (config‑gated)
- Summary:
  • Config key: [tui].midturn_approval_mode_enabled (default off)
  • Inline preset selector: press ‘c’ in approval modal; aligned with /approvals
  • Safety: changes apply after current prompt; approval still required for current request; post‑turn banner notifies the new mode
  • Logs: override op and insert history cell events captured; no extra tracing noise
- Risk assessment:
  • Elevation mid‑turn is explicit and gated; transcript includes immediate and post‑turn notices
  • Defaults remain unchanged; users must opt in via config

