### PR TITLE
fix: change MIN_ANIMATION_HEIGHT so show_animation is calculated correctly

### DIFF
--- a/codex-rs/tui/src/onboarding/welcome.rs
+++ b/codex-rs/tui/src/onboarding/welcome.rs
@@ -17,7 +17,7 @@ use std::time::Duration;
 use std::time::Instant;
 
 const FRAME_TICK: Duration = FRAME_TICK_DEFAULT;
-const MIN_ANIMATION_HEIGHT: u16 = 21;
+const MIN_ANIMATION_HEIGHT: u16 = 20;
 const MIN_ANIMATION_WIDTH: u16 = 60;
 
 pub(crate) struct WelcomeWidget {


### PR DESCRIPTION
Reported height was `20` instead of `21`, so `area.height >= MIN_ANIMATION_HEIGHT` was `false` and therefore `show_animation` was `false`, so the animation never displayed.