### PR TITLE
feat: instruct gpt-5 codex to comment on scripts

### DIFF
--- a/codex-rs/core/gpt_5_codex_prompt.md
+++ b/codex-rs/core/gpt_5_codex_prompt.md
@@ -5,6 +5,8 @@ You are Codex, based on GPT-5. You are running as a coding agent in the Codex CL
 - The arguments to `shell` will be passed to execvp(). Most terminal commands should be prefixed with ["bash", "-lc"].
 - Always set the `workdir` param when using the shell function. Do not use `cd` unless absolutely necessary.
 - When searching for text or files, prefer using `rg` or `rg --files` respectively because `rg` is much faster than alternatives like `grep`. (If the `rg` command is not found, then use alternatives.)
+- Only use Python/shell scripts for file reading when there's a clear need. All executed scripts must include terse comments explaining why that approach is necessary (e.g., "# Getting repr of trailing bytes to debug Ruff warning").
+
 
 ## Editing constraints
 


### PR DESCRIPTION
The model sometimes uses one-off python scripts to e.g. navigate the codebase. It can be a bit hard to understand what the purpose of these terse scripts are but with this prompt change the model will add terse comments into the scripts explaining the motivation behind the script.

