### PR TITLE
chore: simplify dep so serde=1 in Cargo.toml

### DIFF
--- a/codex-rs/execpolicy/Cargo.toml
+++ b/codex-rs/execpolicy/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
+edition = "2024"
 name = "codex-execpolicy"
 version = { workspace = true }
-edition = "2024"
 
 [[bin]]
 name = "codex-execpolicy"
@@ -15,9 +15,8 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-anyhow = "1"
-starlark = "0.13.0"
 allocative = "0.3.3"
+anyhow = "1"
 clap = { version = "4", features = ["derive"] }
 derive_more = { version = "2", features = ["display"] }
 env_logger = "0.11.5"
@@ -25,9 +24,10 @@ log = "0.4"
 multimap = "0.10.0"
 path-absolutize = "3.1.1"
 regex-lite = "0.1"
-serde = { version = "1.0.194", features = ["derive"] }
-serde_json = "1.0.145"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
 serde_with = { version = "3", features = ["macros"] }
+starlark = "0.13.0"
 
 [dev-dependencies]
 tempfile = "3.13.0"

--- a/codex-rs/file-search/Cargo.toml
+++ b/codex-rs/file-search/Cargo.toml
@@ -17,5 +17,5 @@ clap = { version = "4", features = ["derive"] }
 ignore = "0.4.23"
 nucleo-matcher = "0.3.1"
 serde = { version = "1", features = ["derive"] }
-serde_json = "1.0.145"
+serde_json = "1"
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
With this change, dependabot should just have to update `Cargo.lock` for `serde`, e.g.:

- https://github.com/openai/codex/pull/3617
- https://github.com/openai/codex/pull/3618