### PR TITLE
Update Codex Web reference to Codex Cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <p align="center"><strong>Codex CLI</strong> is a coding agent from OpenAI that runs locally on your computer.
 </br>
 </br>If you want Codex in your code editor (VS Code, Cursor, Windsurf), <a href="https://developers.openai.com/codex/ide">install in your IDE</a>
-</br>If you are looking for the <em>cloud-based agent</em> from OpenAI, <strong>Codex Web</strong>, go to <a href="https://chatgpt.com/codex">chatgpt.com/codex</a></p>
+</br>If you are looking for the <em>cloud-based agent</em> from OpenAI, <strong>Codex Cloud</strong>, go to <a href="https://chatgpt.com/codex">chatgpt.com/codex</a></p>
 
 <p align="center">
   <img src="./.github/codex-cli-splash.png" alt="Codex CLI splash" width="80%" />


### PR DESCRIPTION
It's called Codex Cloud in this news post: https://openai.com/index/introducing-upgrades-to-codex/

That's a better name than Codex Web since you can also access Codex cloud via the native ChatGPT iPhone app, no web involved.