### PR TITLE
fix: clarify read-only preset

### DIFF
--- a/codex-rs/common/src/approval_presets.rs
+++ b/codex-rs/common/src/approval_presets.rs
@@ -25,7 +25,7 @@ pub fn builtin_approval_presets() -> Vec<ApprovalPreset> {
             id: "read-only",
             label: "Read Only",
             description: "Codex can read files and answer questions. Codex requires approval to make edits, run commands, or access network",
-            approval: AskForApproval::OnRequest,
+            approval: AskForApproval::Never,
             sandbox: SandboxPolicy::ReadOnly,
         },
         ApprovalPreset {


### PR DESCRIPTION
## Summary
We are planning to fix read-only sandbox modes in #2694, but until these fixes land, we should ensure the read-only mode is consistent.

## Testing
- [x] Tested locally