### PR TITLE
fix: read-only escalations

### DIFF
--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -273,7 +273,7 @@ fn create_shell_tool_for_sandbox(sandbox_policy: &SandboxPolicy) -> OpenAiTool {
         },
     );
 
-    if matches!(sandbox_policy, SandboxPolicy::WorkspaceWrite { .. }) {
+    if !matches!(sandbox_policy, SandboxPolicy::DangerFullAccess) {
         properties.insert(
         "with_escalated_permissions".to_string(),
         JsonSchema::Boolean {


### PR DESCRIPTION
## Summary
Splitting out this smaller fix from #2694 - fixes the sandbox permissions so Chat / read-only mode tool definition matches expectations

## Testing 
- [x] Tested locally

<img width="1271" height="629" alt="Screenshot 2025-09-15 at 2 51 19 PM" src="https://github.com/user-attachments/assets/fcb247e4-30b6-4199-80d7-a2876d79ad7d" />
