### PR TITLE
fix: --full-auto so it sets on-failure approvals

### DIFF
--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -89,7 +89,7 @@ pub async fn run_main(
     let (sandbox_mode, approval_policy) = if cli.full_auto {
         (
             Some(SandboxMode::WorkspaceWrite),
-            Some(AskForApproval::OnRequest),
+            Some(AskForApproval::OnFailure),
         )
     } else if cli.dangerously_bypass_approvals_and_sandbox {
         (


### PR DESCRIPTION
## Summary
- fix the interactive CLI `--full-auto` preset so it applies the documented approval mode
- ensure the TUI now sets `AskForApproval::OnFailure` while keeping the workspace-write sandbox override
- document the behavioral mismatch in openai/codex#3679 for traceability

## Testing
- just fmt
- just fix -p codex-tui
- cargo test -p codex-tui
