### PR TITLE
tui: Reserve Alt+V for clipboard images so Ctrl+V stays text-only on Windows

### DIFF
--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -14,6 +14,7 @@ use ratatui::layout::Layout;
 use ratatui::layout::Rect;
 use ratatui::widgets::WidgetRef;
 use std::time::Duration;
+use std::time::Instant;
 
 mod approval_modal_view;
 mod bottom_pane_view;
@@ -182,6 +183,15 @@ impl BottomPane {
             let (input_result, needs_redraw) = self.composer.handle_key_event(key_event);
             if needs_redraw {
                 self.request_redraw();
+            }
+            if let Some(deadline) = self.composer.alt_paste_feedback_deadline() {
+                if let Some(delay) = deadline.checked_duration_since(Instant::now()) {
+                    if delay.is_zero() {
+                        self.request_redraw();
+                    } else {
+                        self.request_redraw_in(delay);
+                    }
+                }
             }
             if self.composer.is_in_paste_burst() {
                 self.request_redraw_in(ChatComposer::recommended_paste_flush_delay());


### PR DESCRIPTION
### Summary

Windows Terminal consumes Ctrl+V before it ever reaches our TUI, so we never received a KeyEvent to trigger image pastes. Users could copy a file path and paste it, but screenshots on the clipboard were silently ignored. This PR reserves Alt+V as an image-only paste chord while keeping Ctrl+V dedicated to text.

### Changes

- Added a Windows hook for Alt+V in the chat composer: when an image is available we attach it immediately; otherwise we dimly notify the user (“No image found on clipboard”) in the footer for ~2 seconds.
- Leave Ctrl+V untouched so the terminal’s text paste keeps working out of the box.