### PR TITLE
Add --timeout CLI argument for configurable command execution timeout

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3664,4 +3664,90 @@ mod tests {
 
         (rollout_items, live_history.contents())
     }
+
+    #[test]
+    fn test_to_exec_params_timeout_fallback_logic() {
+        use crate::config_types::ShellEnvironmentPolicyInherit;
+        use codex_protocol::models::ShellToolCallParams;
+
+        // Create a TurnContext with timeout in shell policy
+        let shell_policy = ShellEnvironmentPolicy {
+            inherit: ShellEnvironmentPolicyInherit::All,
+            ignore_default_excludes: false,
+            exclude: vec![],
+            r#set: HashMap::new(),
+            include_only: vec![],
+            use_profile: false,
+            exec_timeout_seconds: Some(90), // 90 seconds in shell policy
+        };
+
+        let (session, mut turn_context) = make_session_and_context();
+        turn_context.shell_environment_policy = shell_policy;
+
+        // Test case 1: Tool call params has timeout - should use that
+        let params_with_timeout = ShellToolCallParams {
+            command: vec!["echo".to_string(), "test".to_string()],
+            workdir: None,
+            timeout_ms: Some(5000), // 5 seconds - should take precedence
+            with_escalated_permissions: None,
+            justification: None,
+        };
+
+        let exec_params = to_exec_params(params_with_timeout, &turn_context);
+        assert_eq!(exec_params.timeout_ms, Some(5000)); // Should use tool param timeout
+
+        // Test case 2: Tool call params has no timeout - should fall back to shell policy
+        let params_without_timeout = ShellToolCallParams {
+            command: vec!["echo".to_string(), "test".to_string()],
+            workdir: None,
+            timeout_ms: None,
+            with_escalated_permissions: None,
+            justification: None,
+        };
+
+        let exec_params = to_exec_params(params_without_timeout, &turn_context);
+        assert_eq!(exec_params.timeout_ms, Some(90000)); // Should use shell policy timeout (90s * 1000ms)
+
+        // Test case 3: Neither tool params nor shell policy has timeout - should be None
+        turn_context.shell_environment_policy.exec_timeout_seconds = None;
+        let exec_params = to_exec_params(params_without_timeout.clone(), &turn_context);
+        assert_eq!(exec_params.timeout_ms, None); // Should be None when no fallback available
+    }
+
+    #[test]
+    fn test_to_exec_params_preserves_other_fields() {
+        use crate::config_types::ShellEnvironmentPolicyInherit;
+        use codex_protocol::models::ShellToolCallParams;
+
+        let shell_policy = ShellEnvironmentPolicy {
+            inherit: ShellEnvironmentPolicyInherit::All,
+            ignore_default_excludes: false,
+            exclude: vec![],
+            r#set: HashMap::new(),
+            include_only: vec![],
+            use_profile: false,
+            exec_timeout_seconds: Some(60),
+        };
+
+        let (session, mut turn_context) = make_session_and_context();
+        turn_context.shell_environment_policy = shell_policy;
+
+        let params = ShellToolCallParams {
+            command: vec!["ls".to_string(), "-la".to_string()],
+            workdir: Some("test_dir".to_string()),
+            timeout_ms: None,
+            with_escalated_permissions: Some(true),
+            justification: Some("Testing permissions".to_string()),
+        };
+
+        let exec_params = to_exec_params(params, &turn_context);
+
+        // Verify all fields are correctly transferred
+        assert_eq!(exec_params.command, vec!["ls", "-la"]);
+        assert_eq!(exec_params.cwd, turn_context.cwd.join("test_dir"));
+        assert_eq!(exec_params.timeout_ms, Some(60000)); // 60s from shell policy
+        assert_eq!(exec_params.with_escalated_permissions, Some(true));
+        assert_eq!(exec_params.justification, Some("Testing permissions".to_string()));
+        // env should be created from shell policy (tested elsewhere)
+    }
 }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -314,6 +314,7 @@ pub(crate) struct TurnContext {
     pub(crate) shell_environment_policy: ShellEnvironmentPolicy,
     pub(crate) tools_config: ToolsConfig,
     pub(crate) is_review_mode: bool,
+    pub(crate) exec_timeout_seconds: Option<u64>,
 }
 
 impl TurnContext {
@@ -486,6 +487,7 @@ impl Session {
             shell_environment_policy: config.shell_environment_policy.clone(),
             cwd,
             is_review_mode: false,
+            exec_timeout_seconds: config.exec_timeout_seconds,
         };
         let sess = Arc::new(Session {
             conversation_id,
@@ -1261,6 +1263,7 @@ async fn submission_loop(
                     shell_environment_policy: prev.shell_environment_policy.clone(),
                     cwd: new_cwd.clone(),
                     is_review_mode: false,
+                    exec_timeout_seconds: prev.exec_timeout_seconds,
                 };
 
                 // Install the new persistent context for subsequent tasks/turns.
@@ -1347,6 +1350,7 @@ async fn submission_loop(
                         shell_environment_policy: turn_context.shell_environment_policy.clone(),
                         cwd,
                         is_review_mode: false,
+                        exec_timeout_seconds: config.exec_timeout_seconds,
                     };
                     // TODO: record the new environment context in the conversation history
                     // no current task, spawn a new one with the per‑turn context
@@ -1581,6 +1585,7 @@ async fn spawn_review_thread(
         shell_environment_policy: parent_turn_context.shell_environment_policy.clone(),
         cwd: parent_turn_context.cwd.clone(),
         is_review_mode: true,
+        exec_timeout_seconds: parent_turn_context.exec_timeout_seconds,
     };
 
     // Seed the child task with the review prompt as the initial user message.
@@ -2631,10 +2636,14 @@ async fn handle_custom_tool_call(
 }
 
 fn to_exec_params(params: ShellToolCallParams, turn_context: &TurnContext) -> ExecParams {
+    // Use timeout from tool call params, fallback to config timeout (converted to ms), then to default
+    let timeout_ms = params.timeout_ms
+        .or_else(|| turn_context.exec_timeout_seconds.map(|s| s * 1000));
+
     ExecParams {
         command: params.command,
         cwd: turn_context.resolve_path(params.workdir.clone()),
-        timeout_ms: params.timeout_ms,
+        timeout_ms,
         env: create_env(&turn_context.shell_environment_policy),
         with_escalated_permissions: params.with_escalated_permissions,
         justification: params.justification,
@@ -3539,6 +3548,7 @@ mod tests {
             shell_environment_policy: config.shell_environment_policy.clone(),
             tools_config,
             is_review_mode: false,
+            exec_timeout_seconds: config.exec_timeout_seconds,
         };
         let session = Session {
             conversation_id,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2632,8 +2632,12 @@ async fn handle_custom_tool_call(
 
 fn to_exec_params(params: ShellToolCallParams, turn_context: &TurnContext) -> ExecParams {
     // Use timeout from tool call params, fallback to shell policy timeout (converted to ms), then to default
-    let timeout_ms = params.timeout_ms
-        .or_else(|| turn_context.shell_environment_policy.exec_timeout_seconds.map(|s| s * 1000));
+    let timeout_ms = params.timeout_ms.or_else(|| {
+        turn_context
+            .shell_environment_policy
+            .exec_timeout_seconds
+            .map(|s| s * 1000)
+    });
 
     ExecParams {
         command: params.command,
@@ -3667,7 +3671,8 @@ mod tests {
 
     #[test]
     fn test_to_exec_params_timeout_fallback() {
-        use crate::config_types::{ShellEnvironmentPolicy, ShellEnvironmentPolicyInherit};
+        use crate::config_types::ShellEnvironmentPolicy;
+        use crate::config_types::ShellEnvironmentPolicyInherit;
         use codex_protocol::models::ShellToolCallParams;
 
         // Create minimal TurnContext-like struct for testing
@@ -3678,7 +3683,8 @@ mod tests {
 
         impl MockTurnContext {
             fn resolve_path(&self, path: Option<String>) -> PathBuf {
-                path.map(|p| self.cwd.join(p)).unwrap_or_else(|| self.cwd.clone())
+                path.map(|p| self.cwd.join(p))
+                    .unwrap_or_else(|| self.cwd.clone())
             }
         }
 
@@ -3704,8 +3710,12 @@ mod tests {
             justification: None,
         };
 
-        let timeout_ms = params_with_timeout.timeout_ms
-            .or_else(|| mock_context.shell_environment_policy.exec_timeout_seconds.map(|s| s * 1000));
+        let timeout_ms = params_with_timeout.timeout_ms.or_else(|| {
+            mock_context
+                .shell_environment_policy
+                .exec_timeout_seconds
+                .map(|s| s * 1000)
+        });
         assert_eq!(timeout_ms, Some(5000));
 
         // Test fallback: shell policy timeout (90s * 1000ms) when no tool param
@@ -3717,8 +3727,12 @@ mod tests {
             justification: None,
         };
 
-        let timeout_ms = params_without_timeout.timeout_ms
-            .or_else(|| mock_context.shell_environment_policy.exec_timeout_seconds.map(|s| s * 1000));
+        let timeout_ms = params_without_timeout.timeout_ms.or_else(|| {
+            mock_context
+                .shell_environment_policy
+                .exec_timeout_seconds
+                .map(|s| s * 1000)
+        });
         assert_eq!(timeout_ms, Some(90000));
     }
 }

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1969,76 +1969,35 @@ mod notifications_tests {
         let cfg = ConfigToml::default();
         let codex_home = std::env::temp_dir();
 
-        // Test that CLI timeout override is applied to shell environment policy
         let overrides = ConfigOverrides {
-            timeout_seconds: Some(120), // 2 minutes
+            timeout_seconds: Some(120),
             cwd: Some(codex_home.clone()),
             ..Default::default()
         };
 
         let config = Config::load_from_base_config_with_overrides(cfg, overrides, codex_home)?;
-
         assert_eq!(config.shell_environment_policy.exec_timeout_seconds, Some(120));
         Ok(())
     }
 
     #[test]
-    fn test_timeout_defaults_when_not_overridden() -> std::io::Result<()> {
-        let cfg = ConfigToml::default();
-        let codex_home = std::env::temp_dir();
-
-        let overrides = ConfigOverrides {
-            cwd: Some(codex_home.clone()),
-            ..Default::default()
-        };
-
-        let config = Config::load_from_base_config_with_overrides(cfg, overrides, codex_home)?;
-
-        // Should be None when not overridden
-        assert_eq!(config.shell_environment_policy.exec_timeout_seconds, None);
-        Ok(())
-    }
-
-    #[test]
-    fn test_timeout_toml_config_with_cli_override() -> std::io::Result<()> {
+    fn test_timeout_cli_override_precedence() -> std::io::Result<()> {
         let toml_with_timeout = r#"
 [shell_environment_policy]
 exec_timeout_seconds = 60
 "#;
-        let cfg: ConfigToml = toml::from_str(toml_with_timeout).expect("parse TOML");
+        let cfg: ConfigToml = toml::from_str(toml_with_timeout).unwrap();
         let codex_home = std::env::temp_dir();
 
         // CLI override should take precedence over TOML config
         let overrides = ConfigOverrides {
-            timeout_seconds: Some(180), // 3 minutes - should override the 60s from TOML
+            timeout_seconds: Some(180),
             cwd: Some(codex_home.clone()),
             ..Default::default()
         };
 
         let config = Config::load_from_base_config_with_overrides(cfg, overrides, codex_home)?;
-
         assert_eq!(config.shell_environment_policy.exec_timeout_seconds, Some(180));
-        Ok(())
-    }
-
-    #[test]
-    fn test_timeout_toml_config_without_cli_override() -> std::io::Result<()> {
-        let toml_with_timeout = r#"
-[shell_environment_policy]
-exec_timeout_seconds = 45
-"#;
-        let cfg: ConfigToml = toml::from_str(toml_with_timeout).expect("parse TOML");
-        let codex_home = std::env::temp_dir();
-
-        // No CLI override - should use TOML value
-        let overrides = ConfigOverrides {
-            cwd: Some(codex_home.clone()),
-            ..Default::default()
-        };
-
-        let config = Config::load_from_base_config_with_overrides(cfg, overrides, codex_home)?;
-
-        assert_eq!(config.shell_environment_policy.exec_timeout_seconds, Some(45));
         Ok(())
     }
 }

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1965,39 +1965,33 @@ mod notifications_tests {
     }
 
     #[test]
-    fn test_timeout_cli_override_applied_to_shell_policy() -> std::io::Result<()> {
+    fn test_timeout_cli_override_applied_to_shell_policy() {
         let cfg = ConfigToml::default();
-        let codex_home = std::env::temp_dir();
-
         let overrides = ConfigOverrides {
             timeout_seconds: Some(120),
-            cwd: Some(codex_home.clone()),
             ..Default::default()
         };
 
-        let config = Config::load_from_base_config_with_overrides(cfg, overrides, codex_home)?;
+        let config = Config::load_from_base_config_with_overrides(cfg, overrides, PathBuf::from("/tmp")).unwrap();
         assert_eq!(config.shell_environment_policy.exec_timeout_seconds, Some(120));
-        Ok(())
     }
 
     #[test]
-    fn test_timeout_cli_override_precedence() -> std::io::Result<()> {
-        let toml_with_timeout = r#"
-[shell_environment_policy]
-exec_timeout_seconds = 60
-"#;
-        let cfg: ConfigToml = toml::from_str(toml_with_timeout).unwrap();
-        let codex_home = std::env::temp_dir();
-
-        // CLI override should take precedence over TOML config
-        let overrides = ConfigOverrides {
-            timeout_seconds: Some(180),
-            cwd: Some(codex_home.clone()),
+    fn test_timeout_cli_override_precedence() {
+        let cfg = ConfigToml {
+            shell_environment_policy: ShellEnvironmentPolicyToml {
+                exec_timeout_seconds: Some(60),
+                ..Default::default()
+            },
             ..Default::default()
         };
 
-        let config = Config::load_from_base_config_with_overrides(cfg, overrides, codex_home)?;
+        let overrides = ConfigOverrides {
+            timeout_seconds: Some(180),
+            ..Default::default()
+        };
+
+        let config = Config::load_from_base_config_with_overrides(cfg, overrides, PathBuf::from("/tmp")).unwrap();
         assert_eq!(config.shell_environment_policy.exec_timeout_seconds, Some(180));
-        Ok(())
     }
 }

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -194,9 +194,6 @@ pub struct Config {
     /// All characters are inserted as they are received, and no buffering
     /// or placeholder replacement will occur for fast keypress bursts.
     pub disable_paste_burst: bool,
-
-    /// Timeout for individual command execution in seconds. Defaults to 10 seconds.
-    pub exec_timeout_seconds: Option<u64>,
 }
 
 impl Config {
@@ -848,6 +845,7 @@ pub struct ConfigOverrides {
     pub include_view_image_tool: Option<bool>,
     pub show_raw_agent_reasoning: Option<bool>,
     pub tools_web_search_request: Option<bool>,
+    pub timeout_seconds: Option<u64>,
 }
 
 impl Config {
@@ -876,6 +874,7 @@ impl Config {
             include_view_image_tool,
             show_raw_agent_reasoning,
             tools_web_search_request: override_tools_web_search_request,
+            timeout_seconds,
         } = overrides;
 
         let active_profile_name = config_profile_key
@@ -918,7 +917,16 @@ impl Config {
             })?
             .clone();
 
-        let shell_environment_policy = cfg.shell_environment_policy.into();
+        let shell_environment_policy = {
+            let mut policy_toml = cfg.shell_environment_policy;
+
+            // Override timeout from CLI if provided
+            if let Some(timeout) = timeout_seconds {
+                policy_toml.exec_timeout_seconds = Some(timeout);
+            }
+
+            policy_toml.into()
+        };
 
         let resolved_cwd = {
             use std::env;
@@ -1051,7 +1059,6 @@ impl Config {
             include_view_image_tool,
             active_profile: active_profile_name,
             disable_paste_burst: cfg.disable_paste_burst.unwrap_or(false),
-            exec_timeout_seconds: None, // Will be set from CLI args later
             tui_notifications: cfg
                 .tui
                 .as_ref()
@@ -1620,7 +1627,6 @@ model_verbosity = "high"
                 include_view_image_tool: true,
                 active_profile: Some("o3".to_string()),
                 disable_paste_burst: false,
-                exec_timeout_seconds: None,
                 tui_notifications: Default::default(),
             },
             o3_profile_config
@@ -1679,7 +1685,6 @@ model_verbosity = "high"
             include_view_image_tool: true,
             active_profile: Some("gpt3".to_string()),
             disable_paste_burst: false,
-            exec_timeout_seconds: None,
             tui_notifications: Default::default(),
         };
 
@@ -1753,7 +1758,6 @@ model_verbosity = "high"
             include_view_image_tool: true,
             active_profile: Some("zdr".to_string()),
             disable_paste_burst: false,
-            exec_timeout_seconds: None,
             tui_notifications: Default::default(),
         };
 
@@ -1813,7 +1817,6 @@ model_verbosity = "high"
             include_view_image_tool: true,
             active_profile: Some("gpt5".to_string()),
             disable_paste_burst: false,
-            exec_timeout_seconds: None,
             tui_notifications: Default::default(),
         };
 

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1924,8 +1924,10 @@ trust_level = "trusted"
 
 #[cfg(test)]
 mod notifications_tests {
-    use crate::config_types::Notifications;
+    use super::{Config, ConfigOverrides, ConfigToml};
+    use crate::config_types::{Notifications, ShellEnvironmentPolicyToml};
     use serde::Deserialize;
+    use std::path::PathBuf;
 
     #[derive(Deserialize, Debug, PartialEq)]
     struct TuiTomlTest {
@@ -1972,8 +1974,13 @@ mod notifications_tests {
             ..Default::default()
         };
 
-        let config = Config::load_from_base_config_with_overrides(cfg, overrides, PathBuf::from("/tmp")).unwrap();
-        assert_eq!(config.shell_environment_policy.exec_timeout_seconds, Some(120));
+        let config =
+            Config::load_from_base_config_with_overrides(cfg, overrides, PathBuf::from("/tmp"))
+                .unwrap();
+        assert_eq!(
+            config.shell_environment_policy.exec_timeout_seconds,
+            Some(120)
+        );
     }
 
     #[test]
@@ -1991,7 +1998,12 @@ mod notifications_tests {
             ..Default::default()
         };
 
-        let config = Config::load_from_base_config_with_overrides(cfg, overrides, PathBuf::from("/tmp")).unwrap();
-        assert_eq!(config.shell_environment_policy.exec_timeout_seconds, Some(180));
+        let config =
+            Config::load_from_base_config_with_overrides(cfg, overrides, PathBuf::from("/tmp"))
+                .unwrap();
+        assert_eq!(
+            config.shell_environment_policy.exec_timeout_seconds,
+            Some(180)
+        );
     }
 }

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -194,6 +194,9 @@ pub struct Config {
     /// All characters are inserted as they are received, and no buffering
     /// or placeholder replacement will occur for fast keypress bursts.
     pub disable_paste_burst: bool,
+
+    /// Timeout for individual command execution in seconds. Defaults to 10 seconds.
+    pub exec_timeout_seconds: Option<u64>,
 }
 
 impl Config {
@@ -1048,6 +1051,7 @@ impl Config {
             include_view_image_tool,
             active_profile: active_profile_name,
             disable_paste_burst: cfg.disable_paste_burst.unwrap_or(false),
+            exec_timeout_seconds: None, // Will be set from CLI args later
             tui_notifications: cfg
                 .tui
                 .as_ref()
@@ -1616,6 +1620,7 @@ model_verbosity = "high"
                 include_view_image_tool: true,
                 active_profile: Some("o3".to_string()),
                 disable_paste_burst: false,
+                exec_timeout_seconds: None,
                 tui_notifications: Default::default(),
             },
             o3_profile_config
@@ -1674,6 +1679,7 @@ model_verbosity = "high"
             include_view_image_tool: true,
             active_profile: Some("gpt3".to_string()),
             disable_paste_burst: false,
+            exec_timeout_seconds: None,
             tui_notifications: Default::default(),
         };
 
@@ -1747,6 +1753,7 @@ model_verbosity = "high"
             include_view_image_tool: true,
             active_profile: Some("zdr".to_string()),
             disable_paste_burst: false,
+            exec_timeout_seconds: None,
             tui_notifications: Default::default(),
         };
 
@@ -1806,6 +1813,7 @@ model_verbosity = "high"
             include_view_image_tool: true,
             active_profile: Some("gpt5".to_string()),
             disable_paste_burst: false,
+            exec_timeout_seconds: None,
             tui_notifications: Default::default(),
         };
 

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1963,4 +1963,82 @@ mod notifications_tests {
             Notifications::Custom(ref v) if v == &vec!["foo".to_string()]
         ));
     }
+
+    #[test]
+    fn test_timeout_cli_override_applied_to_shell_policy() -> std::io::Result<()> {
+        let cfg = ConfigToml::default();
+        let codex_home = std::env::temp_dir();
+
+        // Test that CLI timeout override is applied to shell environment policy
+        let overrides = ConfigOverrides {
+            timeout_seconds: Some(120), // 2 minutes
+            cwd: Some(codex_home.clone()),
+            ..Default::default()
+        };
+
+        let config = Config::load_from_base_config_with_overrides(cfg, overrides, codex_home)?;
+
+        assert_eq!(config.shell_environment_policy.exec_timeout_seconds, Some(120));
+        Ok(())
+    }
+
+    #[test]
+    fn test_timeout_defaults_when_not_overridden() -> std::io::Result<()> {
+        let cfg = ConfigToml::default();
+        let codex_home = std::env::temp_dir();
+
+        let overrides = ConfigOverrides {
+            cwd: Some(codex_home.clone()),
+            ..Default::default()
+        };
+
+        let config = Config::load_from_base_config_with_overrides(cfg, overrides, codex_home)?;
+
+        // Should be None when not overridden
+        assert_eq!(config.shell_environment_policy.exec_timeout_seconds, None);
+        Ok(())
+    }
+
+    #[test]
+    fn test_timeout_toml_config_with_cli_override() -> std::io::Result<()> {
+        let toml_with_timeout = r#"
+[shell_environment_policy]
+exec_timeout_seconds = 60
+"#;
+        let cfg: ConfigToml = toml::from_str(toml_with_timeout).expect("parse TOML");
+        let codex_home = std::env::temp_dir();
+
+        // CLI override should take precedence over TOML config
+        let overrides = ConfigOverrides {
+            timeout_seconds: Some(180), // 3 minutes - should override the 60s from TOML
+            cwd: Some(codex_home.clone()),
+            ..Default::default()
+        };
+
+        let config = Config::load_from_base_config_with_overrides(cfg, overrides, codex_home)?;
+
+        assert_eq!(config.shell_environment_policy.exec_timeout_seconds, Some(180));
+        Ok(())
+    }
+
+    #[test]
+    fn test_timeout_toml_config_without_cli_override() -> std::io::Result<()> {
+        let toml_with_timeout = r#"
+[shell_environment_policy]
+exec_timeout_seconds = 45
+"#;
+        let cfg: ConfigToml = toml::from_str(toml_with_timeout).expect("parse TOML");
+        let codex_home = std::env::temp_dir();
+
+        // No CLI override - should use TOML value
+        let overrides = ConfigOverrides {
+            cwd: Some(codex_home.clone()),
+            ..Default::default()
+        };
+
+        let config = Config::load_from_base_config_with_overrides(cfg, overrides, codex_home)?;
+
+        assert_eq!(config.shell_environment_policy.exec_timeout_seconds, Some(45));
+        Ok(())
+    }
 }

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -238,46 +238,11 @@ mod tests {
     #[test]
     fn test_shell_environment_policy_timeout_conversion() {
         let toml_policy = ShellEnvironmentPolicyToml {
-            inherit: Some(ShellEnvironmentPolicyInherit::Core),
-            ignore_default_excludes: Some(true),
-            exclude: Some(vec!["TEST_*".to_string()]),
-            r#set: Some([("VAR".to_string(), "value".to_string())].into()),
-            include_only: Some(vec!["HOME".to_string()]),
-            experimental_use_profile: Some(true),
-            exec_timeout_seconds: Some(120), // 2 minutes
+            exec_timeout_seconds: Some(120),
+            ..Default::default()
         };
 
         let policy: ShellEnvironmentPolicy = toml_policy.into();
-
-        assert_eq!(policy.inherit, ShellEnvironmentPolicyInherit::Core);
-        assert_eq!(policy.ignore_default_excludes, true);
-        assert_eq!(policy.exclude.len(), 1);
-        assert_eq!(policy.r#set.get("VAR"), Some(&"value".to_string()));
-        assert_eq!(policy.include_only.len(), 1);
-        assert_eq!(policy.use_profile, true);
         assert_eq!(policy.exec_timeout_seconds, Some(120));
-    }
-
-    #[test]
-    fn test_shell_environment_policy_timeout_defaults() {
-        let toml_policy = ShellEnvironmentPolicyToml {
-            inherit: None,
-            ignore_default_excludes: None,
-            exclude: None,
-            r#set: None,
-            include_only: None,
-            experimental_use_profile: None,
-            exec_timeout_seconds: None,
-        };
-
-        let policy: ShellEnvironmentPolicy = toml_policy.into();
-
-        assert_eq!(policy.inherit, ShellEnvironmentPolicyInherit::All); // default
-        assert_eq!(policy.ignore_default_excludes, false); // default
-        assert!(policy.exclude.is_empty());
-        assert!(policy.r#set.is_empty());
-        assert!(policy.include_only.is_empty());
-        assert_eq!(policy.use_profile, false); // default
-        assert_eq!(policy.exec_timeout_seconds, None); // default
     }
 }

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -230,3 +230,54 @@ pub enum ReasoningSummaryFormat {
     None,
     Experimental,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_shell_environment_policy_timeout_conversion() {
+        let toml_policy = ShellEnvironmentPolicyToml {
+            inherit: Some(ShellEnvironmentPolicyInherit::Core),
+            ignore_default_excludes: Some(true),
+            exclude: Some(vec!["TEST_*".to_string()]),
+            r#set: Some([("VAR".to_string(), "value".to_string())].into()),
+            include_only: Some(vec!["HOME".to_string()]),
+            experimental_use_profile: Some(true),
+            exec_timeout_seconds: Some(120), // 2 minutes
+        };
+
+        let policy: ShellEnvironmentPolicy = toml_policy.into();
+
+        assert_eq!(policy.inherit, ShellEnvironmentPolicyInherit::Core);
+        assert_eq!(policy.ignore_default_excludes, true);
+        assert_eq!(policy.exclude.len(), 1);
+        assert_eq!(policy.r#set.get("VAR"), Some(&"value".to_string()));
+        assert_eq!(policy.include_only.len(), 1);
+        assert_eq!(policy.use_profile, true);
+        assert_eq!(policy.exec_timeout_seconds, Some(120));
+    }
+
+    #[test]
+    fn test_shell_environment_policy_timeout_defaults() {
+        let toml_policy = ShellEnvironmentPolicyToml {
+            inherit: None,
+            ignore_default_excludes: None,
+            exclude: None,
+            r#set: None,
+            include_only: None,
+            experimental_use_profile: None,
+            exec_timeout_seconds: None,
+        };
+
+        let policy: ShellEnvironmentPolicy = toml_policy.into();
+
+        assert_eq!(policy.inherit, ShellEnvironmentPolicyInherit::All); // default
+        assert_eq!(policy.ignore_default_excludes, false); // default
+        assert!(policy.exclude.is_empty());
+        assert!(policy.r#set.is_empty());
+        assert!(policy.include_only.is_empty());
+        assert_eq!(policy.use_profile, false); // default
+        assert_eq!(policy.exec_timeout_seconds, None); // default
+    }
+}

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -152,6 +152,9 @@ pub struct ShellEnvironmentPolicyToml {
     pub include_only: Option<Vec<String>>,
 
     pub experimental_use_profile: Option<bool>,
+
+    /// Timeout for individual command execution in seconds.
+    pub exec_timeout_seconds: Option<u64>,
 }
 
 pub type EnvironmentVariablePattern = WildMatchPattern<'*', '?'>;
@@ -183,6 +186,9 @@ pub struct ShellEnvironmentPolicy {
 
     /// If true, the shell profile will be used to run the command.
     pub use_profile: bool,
+
+    /// Timeout for individual command execution in seconds. Defaults to 10 seconds.
+    pub exec_timeout_seconds: Option<u64>,
 }
 
 impl From<ShellEnvironmentPolicyToml> for ShellEnvironmentPolicy {
@@ -212,6 +218,7 @@ impl From<ShellEnvironmentPolicyToml> for ShellEnvironmentPolicy {
             r#set,
             include_only,
             use_profile,
+            exec_timeout_seconds: toml.exec_timeout_seconds,
         }
     }
 }

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -15,3 +15,4 @@ mod rollout_list_find;
 mod seatbelt;
 mod stream_error_allows_next_turn;
 mod stream_no_completed;
+mod timeout_config;

--- a/codex-rs/core/tests/suite/timeout_config.rs
+++ b/codex-rs/core/tests/suite/timeout_config.rs
@@ -1,0 +1,32 @@
+use codex_core::CodexAuth;
+use codex_core::ConversationManager;
+use codex_core::protocol::EventMsg;
+use codex_core::protocol::Op;
+use core_test_support::load_default_config_for_test;
+use core_test_support::wait_for_event;
+use tempfile::TempDir;
+
+/// Test that timeout configuration flows correctly from CLI to execution
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn timeout_config_integration() {
+    let codex_home = TempDir::new().unwrap();
+    let mut config = load_default_config_for_test(&codex_home);
+
+    // Simulate CLI timeout override (this would normally come from TUI via ConfigOverrides)
+    config.shell_environment_policy.exec_timeout_seconds = Some(30);
+
+    let conversation_manager =
+        ConversationManager::with_auth(CodexAuth::from_api_key("Test API Key"));
+    let codex = conversation_manager
+        .new_conversation(config)
+        .await
+        .expect("create conversation")
+        .conversation;
+
+    // Verify timeout is configured - would be used in actual shell execution
+    // Note: We can't easily test actual timeout execution in this integration test
+    // without mocking or very complex setup, but the unit tests cover that logic
+
+    codex.submit(Op::Shutdown).await.expect("request shutdown");
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::ShutdownComplete)).await;
+}

--- a/codex-rs/core/tests/suite/timeout_config.rs
+++ b/codex-rs/core/tests/suite/timeout_config.rs
@@ -6,7 +6,8 @@ use core_test_support::load_default_config_for_test;
 use core_test_support::wait_for_event;
 use tempfile::TempDir;
 
-/// Test that timeout configuration flows correctly from CLI to execution
+/// Test that timeout configuration flows correctly from overrides into the
+/// session initialization path.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn timeout_config_integration() {
     let codex_home = TempDir::new().unwrap();

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -72,6 +72,10 @@ pub struct Cli {
     #[arg(long = "search", default_value_t = false)]
     pub web_search: bool,
 
+    /// Set the timeout for individual command execution in seconds (default: 10).
+    #[arg(long = "timeout", value_name = "SECONDS")]
+    pub timeout_seconds: Option<u64>,
+
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,
 }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -164,10 +164,8 @@ pub async fn run_main(
         }
     };
 
-    // Override timeout from CLI argument if provided
-    if let Some(timeout_seconds) = cli.timeout_seconds {
-        config.exec_timeout_seconds = Some(timeout_seconds);
-    }
+    // Timeout override is already applied via ConfigOverrides in
+    // Config::load_with_cli_overrides; no additional mutation needed here.
 
     // we load config.toml here to determine project state.
     #[allow(clippy::print_stderr)]

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -163,6 +163,11 @@ pub async fn run_main(
         }
     };
 
+    // Override timeout from CLI argument if provided
+    if let Some(timeout_seconds) = cli.timeout_seconds {
+        config.exec_timeout_seconds = Some(timeout_seconds);
+    }
+
     // we load config.toml here to determine project state.
     #[allow(clippy::print_stderr)]
     let config_toml = {

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -138,6 +138,7 @@ pub async fn run_main(
         include_view_image_tool: None,
         show_raw_agent_reasoning: cli.oss.then_some(true),
         tools_web_search_request: cli.web_search.then_some(true),
+        timeout_seconds: cli.timeout_seconds,
     };
     let raw_overrides = cli.config_overrides.raw_overrides.clone();
     let overrides_cli = codex_common::CliConfigOverrides { raw_overrides };


### PR DESCRIPTION
## Summary
We are using Codex for a large migration, and each step has additional instructions to run several checks (build, test, etc) after each set of code changes and the steps often take several minutes. This results in a timeout the first couple times they are run before the Bazel network cache is filled with build artifacts. 

Ideally, we would like to pass a `--timeout` parameter in our automated tooling to something > 10 seconds (likely closer to 5-10 minutes) to let our migration continue unattended.



- Add `--timeout <seconds>` CLI flag to allow users to configure how long individual command executions can run
- Extend the configuration system to pass timeout through to command execution 
- Maintain backward compatibility with existing 10-second default timeout

## Changes
- **CLI**: Added `--timeout <seconds>` argument to TUI CLI with help text and validation
- **Config**: Extended `Config` struct with optional `exec_timeout_seconds` field
- **Context**: Added `exec_timeout_seconds` to `TurnContext` and updated all construction sites
- **Execution**: Modified `to_exec_params` to use config timeout as fallback when model doesn't specify timeout
- **Flow**: Timeout now flows from CLI → Config → TurnContext → ExecParams → execution system

## Implementation Details
The timeout value flows through the system as follows:
1. User specifies `--timeout 30` on command line
2. CLI parses and stores in `timeout_seconds` field
3. TUI `run_main` updates `config.exec_timeout_seconds` 
4. Config is passed to `TurnContext` construction
5. `TurnContext.exec_timeout_seconds` is used in `to_exec_params`
6. Converted to milliseconds and set in `ExecParams.timeout_ms`
7. Used by execution system for actual command timeout

## Test plan
- [x] CLI help displays new timeout option correctly
- [x] All Rust struct constructions updated with new field
- [x] Timeout flows through configuration system properly
- [x] Backward compatibility maintained (no timeout specified = 10s default)

This addresses the issue where commands were timing out too quickly by allowing users to adjust the timeout duration as needed.