### PR TITLE
Add dev message upon review out

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3283,10 +3283,8 @@ async fn exit_review_mode(
             findings_str.push_str(text);
         }
         if !out.findings.is_empty() {
-            let lines = format_review_findings_block(&out.findings, false, None);
-            for line in lines {
-                findings_str.push_str(&format!("\n{line}"));
-            }
+            let block = format_review_findings_block(&out.findings, None);
+            findings_str.push_str(&format!("\n{block}"));
         }
         user_message.push_str(&format!(
             r#"<user_action>

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -46,6 +46,7 @@ pub use model_provider_info::built_in_model_providers;
 pub use model_provider_info::create_oss_provider_with_base_url;
 mod conversation_manager;
 mod event_mapping;
+pub mod review_format;
 pub use codex_protocol::protocol::InitialHistory;
 pub use conversation_manager::ConversationManager;
 pub use conversation_manager::NewConversation;

--- a/codex-rs/core/src/review_format.rs
+++ b/codex-rs/core/src/review_format.rs
@@ -1,0 +1,56 @@
+use crate::protocol::ReviewFinding;
+
+// Note: We keep this module UI-agnostic. It returns plain strings that
+// higher layers (e.g., TUI) may style as needed.
+
+fn format_location(item: &ReviewFinding) -> String {
+    let path = item.code_location.absolute_file_path.display();
+    let start = item.code_location.line_range.start;
+    let end = item.code_location.line_range.end;
+    format!("{path}:{start}-{end}")
+}
+
+/// Format a full review findings block as plain text lines.
+///
+/// - When `include_checkboxes` is true, each item line includes a checkbox
+///   marker: "[x]" for selected items and "[ ]" for unselected. If
+///   `selection` is `None`, all items are treated as selected.
+/// - When `include_checkboxes` is false, the marker is omitted and a simple
+///   bullet is rendered ("- Title — path:start-end").
+pub fn format_review_findings_block(
+    findings: &[ReviewFinding],
+    include_checkboxes: bool,
+    selection: Option<&[bool]>,
+) -> Vec<String> {
+    let mut lines: Vec<String> = Vec::new();
+
+    // Header
+    let header = if findings.len() > 1 {
+        "Full review comments:"
+    } else {
+        "Review comment:"
+    };
+    lines.push(header.to_string());
+
+    for (idx, item) in findings.iter().enumerate() {
+        lines.push(String::new());
+
+        let title = &item.title;
+        let location = format_location(item);
+
+        if include_checkboxes {
+            // Default to selected if selection flags are not provided.
+            let checked = selection.and_then(|v| v.get(idx).copied()).unwrap_or(true);
+            let marker = if checked { "[x]" } else { "[ ]" };
+            lines.push(format!("- {marker} {title} — {location}"));
+        } else {
+            lines.push(format!("- {title} — {location}"));
+        }
+
+        for body_line in item.body.lines() {
+            lines.push(format!("  {body_line}"));
+        }
+    }
+
+    lines
+}

--- a/codex-rs/core/src/review_format.rs
+++ b/codex-rs/core/src/review_format.rs
@@ -12,16 +12,15 @@ fn format_location(item: &ReviewFinding) -> String {
 
 /// Format a full review findings block as plain text lines.
 ///
-/// - When `include_checkboxes` is true, each item line includes a checkbox
-///   marker: "[x]" for selected items and "[ ]" for unselected. If
-///   `selection` is `None`, all items are treated as selected.
-/// - When `include_checkboxes` is false, the marker is omitted and a simple
-///   bullet is rendered ("- Title — path:start-end").
+/// - When `selection` is `Some`, each item line includes a checkbox marker:
+///   "[x]" for selected items and "[ ]" for unselected. Missing indices
+///   default to selected.
+/// - When `selection` is `None`, the marker is omitted and a simple bullet is
+///   rendered ("- Title — path:start-end").
 pub fn format_review_findings_block(
     findings: &[ReviewFinding],
-    include_checkboxes: bool,
     selection: Option<&[bool]>,
-) -> Vec<String> {
+) -> String {
     let mut lines: Vec<String> = Vec::new();
 
     // Header
@@ -38,9 +37,9 @@ pub fn format_review_findings_block(
         let title = &item.title;
         let location = format_location(item);
 
-        if include_checkboxes {
-            // Default to selected if selection flags are not provided.
-            let checked = selection.and_then(|v| v.get(idx).copied()).unwrap_or(true);
+        if let Some(flags) = selection {
+            // Default to selected if index is out of bounds.
+            let checked = flags.get(idx).copied().unwrap_or(true);
             let marker = if checked { "[x]" } else { "[ ]" };
             lines.push(format!("- {marker} {title} — {location}"));
         } else {
@@ -52,5 +51,5 @@ pub fn format_review_findings_block(
         }
     }
 
-    lines
+    lines.join("\n")
 }

--- a/codex-rs/core/tests/suite/review.rs
+++ b/codex-rs/core/tests/suite/review.rs
@@ -1,10 +1,13 @@
 use codex_core::CodexAuth;
 use codex_core::CodexConversation;
+use codex_core::ContentItem;
 use codex_core::ConversationManager;
 use codex_core::ModelProviderInfo;
 use codex_core::REVIEW_PROMPT;
+use codex_core::ResponseItem;
 use codex_core::built_in_model_providers;
 use codex_core::config::Config;
+use codex_core::protocol::ConversationPathResponseEvent;
 use codex_core::protocol::ENVIRONMENT_CONTEXT_OPEN_TAG;
 use codex_core::protocol::EventMsg;
 use codex_core::protocol::ExitedReviewModeEvent;
@@ -15,6 +18,8 @@ use codex_core::protocol::ReviewFinding;
 use codex_core::protocol::ReviewLineRange;
 use codex_core::protocol::ReviewOutputEvent;
 use codex_core::protocol::ReviewRequest;
+use codex_core::protocol::RolloutItem;
+use codex_core::protocol::RolloutLine;
 use codex_core::spawn::CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR;
 use core_test_support::load_default_config_for_test;
 use core_test_support::load_sse_fixture_with_id_from_str;
@@ -116,6 +121,46 @@ async fn review_op_emits_lifecycle_and_review_output() {
     };
     assert_eq!(expected, review);
     let _complete = wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
+
+    // Also verify that a developer message with the header and a formatted finding
+    // was recorded back in the parent session's rollout.
+    codex.submit(Op::GetPath).await.unwrap();
+    let history_event =
+        wait_for_event(&codex, |ev| matches!(ev, EventMsg::ConversationPath(_))).await;
+    let path = match history_event {
+        EventMsg::ConversationPath(ConversationPathResponseEvent { path, .. }) => path,
+        other => panic!("expected ConversationPath event, got {other:?}"),
+    };
+    let text = std::fs::read_to_string(&path).expect("read rollout file");
+
+    let mut saw_header = false;
+    let mut saw_finding_line = false;
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_str(line).expect("jsonl line");
+        let rl: RolloutLine = serde_json::from_value(v).expect("rollout line");
+        if let RolloutItem::ResponseItem(ResponseItem::Message { role, content, .. }) = rl.item
+            && role == "developer"
+        {
+            for c in content {
+                if let ContentItem::InputText { text } = c {
+                    if text.contains("full review output from reviewer model") {
+                        saw_header = true;
+                    }
+                    if text.contains("- Prefer Stylize helpers — /tmp/file.rs:10-20") {
+                        saw_finding_line = true;
+                    }
+                }
+            }
+        }
+    }
+    assert!(saw_header, "developer header missing from rollout");
+    assert!(
+        saw_finding_line,
+        "formatted finding line missing from rollout"
+    );
 
     server.verify().await;
 }
@@ -450,6 +495,43 @@ async fn review_input_isolated_from_parent_history() {
     assert_eq!(
         review_msg["content"][0]["text"].as_str().unwrap(),
         format!("{REVIEW_PROMPT}\n\n---\n\nNow, here's your task: Please review only this",)
+    );
+
+    // Also verify that a developer interruption note was recorded in the rollout.
+    codex.submit(Op::GetPath).await.unwrap();
+    let history_event =
+        wait_for_event(&codex, |ev| matches!(ev, EventMsg::ConversationPath(_))).await;
+    let path = match history_event {
+        EventMsg::ConversationPath(ConversationPathResponseEvent { path, .. }) => path,
+        other => panic!("expected ConversationPath event, got {other:?}"),
+    };
+    let text = std::fs::read_to_string(&path).expect("read rollout file");
+    let mut saw_interruption_message = false;
+    for line in text.lines() {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let v: serde_json::Value = serde_json::from_str(line).expect("jsonl line");
+        let rl: RolloutLine = serde_json::from_value(v).expect("rollout line");
+        if let RolloutItem::ResponseItem(ResponseItem::Message { role, content, .. }) = rl.item
+            && role == "developer"
+        {
+            for c in content {
+                if let ContentItem::InputText { text } = c {
+                    if text.contains("[User initiated a review task, but was interrupted.") {
+                        saw_interruption_message = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if saw_interruption_message {
+            break;
+        }
+    }
+    assert!(
+        saw_interruption_message,
+        "expected developer interruption message in rollout"
     );
 
     server.verify().await;

--- a/codex-rs/core/tests/suite/review.rs
+++ b/codex-rs/core/tests/suite/review.rs
@@ -517,11 +517,11 @@ async fn review_input_isolated_from_parent_history() {
             && role == "developer"
         {
             for c in content {
-                if let ContentItem::InputText { text } = c {
-                    if text.contains("[User initiated a review task, but was interrupted.") {
-                        saw_interruption_message = true;
-                        break;
-                    }
+                if let ContentItem::InputText { text } = c
+                    && text.contains("[User initiated a review task, but was interrupted.")
+                {
+                    saw_interruption_message = true;
+                    break;
                 }
             }
         }


### PR DESCRIPTION
Proposal: We want to record a dev message like so:

```
{
      "type": "message",
      "role": "user",
      "content": [
        {
          "type": "input_text",
          "text": "<user_action>
  <context>User initiated a review task. Here's the full review output from reviewer model. User may select one or more comments to resolve.</context>
  <action>review</action>
  <results>
  {findings_str}
  </results>
</user_tool>"
        }
      ]
    },
```

Without showing in the chat transcript.

Rough idea, but it fixes issue where the user finishes a review thread, and asks the parent "fix the rest of the review issues" thinking that the parent knows about it.

### Question: Why not a tool call?

Because the agent didn't make the call, it was a human. + we haven't implemented sub-agents yet, and we'll need to think about the way we represent these human-led tool calls for the agent.