### PR TITLE
fix: ensure pnpm is installed before running `npm install`

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -193,6 +193,14 @@ jobs:
       # Publish to npm using OIDC authentication.
       # July 31, 2025: https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
       # npm docs: https://docs.npmjs.com/trusted-publishers
+
+      # package.json has `packageManager: "pnpm@`, so we must get pnpm on the
+      # PATH before setting up Node.js.
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v5
         with:


### PR DESCRIPTION
Note we do the same thing in `ci.yml`:

https://github.com/openai/codex/blob/791d7b125f4166ef576531075688aac339350011/.github/workflows/ci.yml#L17-L25