### PR TITLE
fix(tui): format cached tokens with separators

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1225,7 +1225,7 @@ pub(crate) fn new_status_output(
     ];
     if usage.cached_input_tokens > 0 {
         let cached = usage.cached_input_tokens;
-        input_line_spans.push(format!(" (+ {cached} cached)").into());
+        input_line_spans.push(format!(" (+ {} cached)", format_with_separators(cached)).into());
     }
     lines.push(Line::from(input_line_spans));
     // Output: <output>


### PR DESCRIPTION
Use format_with_separators() when rendering the cached token usage number.

| Before | After |
|--------|--------|
| <img width="332" height="77" alt="image" src="https://github.com/user-attachments/assets/dd877c8c-2860-4ad5-8419-913c07f9836f" /> | <img width="359" height="84" alt="image" src="https://github.com/user-attachments/assets/0db8e018-57c7-4227-999e-eb50f1f0b5e4" /> |