### PR TITLE
fix: make publish-npm its own job with specific permissions

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -11,9 +11,6 @@ on:
     tags:
       - "rust-v*.*.*"
 
-permissions:
-  id-token: write  # Required for OIDC
-
 concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
@@ -170,6 +167,12 @@ jobs:
     needs: build
     name: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      actions: read
+    outputs:
+      version: ${{ steps.release_name.outputs.name }}
+      tag: ${{ github.ref_name }}
 
     steps:
       - name: Checkout repository
@@ -189,28 +192,6 @@ jobs:
           # "rust-v0.1.0".
           version="${GITHUB_REF_NAME#rust-v}"
           echo "name=${version}" >> $GITHUB_OUTPUT
-
-      # Publish to npm using OIDC authentication.
-      # July 31, 2025: https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
-      # npm docs: https://docs.npmjs.com/trusted-publishers
-
-      # package.json has `packageManager: "pnpm@`, so we must get pnpm on the
-      # PATH before setting up Node.js.
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          registry-url: "https://registry.npmjs.org"
-          scope: "@openai"
-
-      # Trusted publishing requires npm CLI version 11.5.1 or later.
-      - name: Update npm
-        run: npm install -g npm@latest
 
       - name: Stage npm package
         env:
@@ -245,11 +226,46 @@ jobs:
           tag: ${{ github.ref_name }}
           config: .github/dotslash-config.json
 
+  # Publish to npm using OIDC authentication.
+  # July 31, 2025: https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
+  # npm docs: https://docs.npmjs.com/trusted-publishers
+  publish-npm:
+    # Skip this step for pre-releases (alpha/beta).
+    if: ${{ !contains(needs.release.outputs.version, '-') }}
+    name: publish-npm
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Required for OIDC
+      contents: read
+
+    steps:
+      - name: Setup Node.js
+        uses: actions/setup-node@v5
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+          scope: "@openai"
+
+      # Trusted publishing requires npm CLI version 11.5.1 or later.
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      - name: Download npm tarball from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          version="${{ needs.release.outputs.version }}"
+          tag="${{ needs.release.outputs.tag }}"
+          mkdir -p dist/npm
+          gh release download "$tag" \
+            --pattern "codex-npm-${version}.tgz" \
+            --dir dist/npm
+
       # No NODE_AUTH_TOKEN needed because we use OIDC.
       - name: Publish to npm
-        # Do not publish alphas to npm.
-        if: ${{ !contains(steps.release_name.outputs.name, '-') }}
-        run: npm publish "${GITHUB_WORKSPACE}/dist/npm/codex-npm-${{ steps.release_name.outputs.name }}.tgz"
+        run: npm publish "${GITHUB_WORKSPACE}/dist/npm/codex-npm-${{ needs.release.outputs.version }}.tgz"
 
   update-branch:
     name: Update latest-alpha-cli branch


### PR DESCRIPTION
The build for `v0.37.0-alpha.3` failed on the `Create GitHub Release` step:

https://github.com/openai/codex/actions/runs/17786866086/job/50556513221

with:

```
⚠️ GitHub release failed with status: 403
{"message":"Resource not accessible by integration","documentation_url":"https://docs.github.com/rest/releases/releases#create-a-release","status":"403"}
Skip retry — your GitHub token/PAT does not have the required permission to create a release
```

I believe I should have not introduced a top-level `permissions` for the workflow in https://github.com/openai/codex/pull/3431 because that affected the `permissions` for each job in the workflow.

This PR introduces `publish-npm` as its own job, which allows us to:

- consolidate all the Node.js-related steps required for publishing
- limit the reach of the `id-token: write` permission
- skip it altogether if is an alpha build

With this PR, each of `release`, `publish-npm`, and `update-branch` has an explicit `permissions` block.

