### PR TITLE
Add nushell completions

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -537,6 +537,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete_command"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da8e198c052315686d36371e8a3c5778b7852fc75cc313e4e11eeb7a644a1b62"
+dependencies = [
+ "clap",
+ "clap_complete",
+ "clap_complete_nushell",
+]
+
+[[package]]
+name = "clap_complete_nushell"
+version = "4.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a0c951694691e65bf9d421d597d68416c22de9632e884c28412cb8cd8b73dce"
+dependencies = [
+ "clap",
+ "clap_complete",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,7 +648,7 @@ dependencies = [
  "anyhow",
  "assert_cmd",
  "clap",
- "clap_complete",
+ "clap_complete_command",
  "codex-arg0",
  "codex-chatgpt",
  "codex-common",

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -17,7 +17,7 @@ workspace = true
 [dependencies]
 anyhow = "1"
 clap = { version = "4", features = ["derive"] }
-clap_complete = "4"
+clap_complete_command = "0.6"
 codex-arg0 = { path = "../arg0" }
 codex-chatgpt = { path = "../chatgpt" }
 codex-common = { path = "../common", features = ["cli"] }

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -1,7 +1,6 @@
 use clap::CommandFactory;
 use clap::Parser;
-use clap_complete::Shell;
-use clap_complete::generate;
+use clap_complete_command::Shell;
 use codex_arg0::arg0_dispatch_or_else;
 use codex_chatgpt::apply_command::ApplyCommand;
 use codex_chatgpt::apply_command::run_apply_command;
@@ -362,8 +361,7 @@ fn merge_resume_cli_flags(interactive: &mut TuiCli, resume_cli: TuiCli) {
 
 fn print_completion(cmd: CompletionCommand) {
     let mut app = MultitoolCli::command();
-    let name = "codex";
-    generate(cmd.shell, &mut app, name, &mut std::io::stdout());
+    cmd.shell.generate(&mut app, &mut std::io::stdout());
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Adds nushell to the list of shell completions. This now makes the list bash, elvish, fish, nushell, powershell and zsh.

I haven't updated the docs since they're already non-exhaustive but all options are shown with `codex completion --help`.

https://github.com/openai/codex/blob/5332f6e2156e83a2dcd654a98a72696aa455f750/codex-rs/README.md?plain=1#L60-L64

https://github.com/openai/codex/blob/5332f6e2156e83a2dcd654a98a72696aa455f750/codex-cli/README.md?plain=1#L226

https://github.com/openai/codex/blob/5332f6e2156e83a2dcd654a98a72696aa455f750/docs/getting-started.md?plain=1#L97-L101

This uses a [simple library](https://crates.io/crates/clap_complete_command) made by me to make it so we don't have to make our own `clap::ValueEnum` which includes each shell and implement `clap_complete::Generator` by wrapping each dependency's `generate()`.

I didn't make an issue to check if this would be merged first as the PR is fairly simple and if it isn't merged it can just be closed.