### PR TITLE
fix: specify --repo when calling gh

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -260,6 +260,7 @@ jobs:
           tag="${{ needs.release.outputs.tag }}"
           mkdir -p dist/npm
           gh release download "$tag" \
+            --repo "${GITHUB_REPOSITORY}" \
             --pattern "codex-npm-${version}.tgz" \
             --dir dist/npm
 


### PR DESCRIPTION
Often, `gh` infers `--repo` when it is run from a Git clone, but our `publish-npm` step is designed to avoid the overhead of cloning the repo, so add the `--repo` option explicitly to fix things.