### PR TITLE
Show current plan step in TUI footer

### DIFF
--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -373,6 +373,12 @@ impl BottomPane {
         self.request_redraw();
     }
 
+    pub(crate) fn set_plan_progress(&mut self, step: Option<String>) {
+        if self.composer.set_current_plan_step(step) {
+            self.request_redraw();
+        }
+    }
+
     /// Called when the agent requests user approval.
     pub fn push_approval_request(&mut self, request: ApprovalRequest) {
         let request = if let Some(view) = self.active_view.as_mut() {


### PR DESCRIPTION
## Motivation

Once Codex drafts a plan and starts working through it, the user has no visible cue about which step is underway. Surfacing the active step in the footer fixes that, giving immediate context while the task runs.

## Summary
  - surface the active plan item in the chat footer as `Now: …` so the current task is always visible
  - keep the footer in sync with plan updates by plumbing state through `BottomPane`
  - reset the footer when sessions change and prefer `InProgress` steps, falling back to the first pending item
  
Screenshot:

<img width="970" height="316" alt="Screenshot 2025-09-17 at 14 22 41" src="https://github.com/user-attachments/assets/02bbb5de-330b-42b5-a93c-5b417d74c05e" />
