### PR TITLE
Feature/plan step notify

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3603,6 +3603,7 @@ mod tests {
             session_manager: ExecSessionManager::default(),
             unified_exec_manager: UnifiedExecSessionManager::default(),
             notify: None,
+            plan_step_notifications: false,
             rollout: Mutex::new(None),
             state: Mutex::new(State {
                 history: ConversationHistory::new(),

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -95,6 +95,13 @@ pub struct Tui {
     /// Enable desktop notifications from the TUI when the terminal is unfocused.
     /// Defaults to `false`.
     pub notifications: Notifications,
+    /// When true, emit notifications as plan steps are completed. Defaults to `true`.
+    #[serde(default = "true_bool")]
+    pub plan_step_notifications: bool,
+}
+
+const fn true_bool() -> bool {
+    true
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -373,6 +373,12 @@ impl BottomPane {
         self.request_redraw();
     }
 
+    pub(crate) fn set_plan_progress(&mut self, step: Option<String>) {
+        if self.composer.set_current_plan_step(step) {
+            self.request_redraw();
+        }
+    }
+
     /// Called when the agent requests user approval.
     pub fn push_approval_request(&mut self, request: ApprovalRequest) {
         let request = if let Some(view) = self.active_view.as_mut() {

--- a/docs/config.md
+++ b/docs/config.md
@@ -510,7 +510,7 @@ notify = ["python3", "/Users/mbolin/.codex/notify.py"]
 ```
 
 > [!NOTE]
-> Use `notify` for automation and integrations: Codex invokes your external program with a single JSON argument for each event, independent of the TUI. If you only want lightweight desktop notifications while using the TUI, prefer `tui.notifications`, which uses terminal escape codes and requires no external program. You can enable both; `tui.notifications` covers in‑TUI alerts (e.g., approval prompts), while `notify` is best for system‑level hooks or custom notifiers. Currently, `notify` emits only `agent-turn-complete`, whereas `tui.notifications` supports `agent-turn-complete` and `approval-requested` with optional filtering.
+> Use `notify` for automation and integrations: Codex invokes your external program with a single JSON argument for each event, independent of the TUI. If you only want lightweight desktop notifications while using the TUI, prefer `tui.notifications`, which uses terminal escape codes and requires no external program. You can enable both; `tui.notifications` covers in‑TUI alerts (e.g., approval prompts), while `notify` is best for system-level hooks or custom notifiers. Currently, `notify` emits only `agent-turn-complete`, whereas `tui.notifications` supports `agent-turn-complete`, `approval-requested`, and `plan-step-complete` with optional filtering.
 
 ## history
 
@@ -589,8 +589,12 @@ Options that are specific to the TUI.
 notifications = true
 
 # You can optionally filter to specific notification types.
-# Available types are "agent-turn-complete" and "approval-requested".
+# Available types are "agent-turn-complete", "approval-requested", and "plan-step-complete".
 notifications = [ "agent-turn-complete", "approval-requested" ]
+
+# Emit notifications when a plan step transitions to completed.
+# Defaults to true; set to false to silence plan updates.
+plan_step_notifications = true
 ```
 
 > [!NOTE]
@@ -615,6 +619,7 @@ notifications = [ "agent-turn-complete", "approval-requested" ]
 | `sandbox_workspace_write.exclude_slash_tmp` | boolean | Exclude `/tmp` from writable roots (default: false). |
 | `disable_response_storage` | boolean | Required for ZDR orgs. |
 | `notify` | array<string> | External program for notifications. |
+| `tui.plan_step_notifications` | boolean | Notify when plan steps complete (default: true). |
 | `instructions` | string | Currently ignored; use `experimental_instructions_file` or `AGENTS.md`. |
 | `mcp_servers.<id>.command` | string | MCP server launcher command. |
 | `mcp_servers.<id>.args` | array<string> | MCP server args. |


### PR DESCRIPTION
## Summary
  - surface the current plan step in the footer and keep the UI state in sync with plan updates
  - add a TUI-only “plan step complete” toast, defaulting it on while leaving the external `notify` hook unchanged
  - document the new toggle and add config/tests to ensure `plan_step_notifications` defaults to true

Screenshot (iterm2):

<img width="371" height="145" alt="Screenshot 2025-09-17 at 15 50 48" src="https://github.com/user-attachments/assets/666a4c70-c505-408d-b8f0-c6191ac59f15" />
