### PR TITLE
Add HTTP and SSE MCP transport support

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -815,7 +815,10 @@ name = "codex-mcp-client"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "eventsource-stream",
+ "futures",
  "mcp-types",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",

--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -13,6 +13,14 @@ use codex_core::config::find_codex_home;
 use codex_core::config::load_global_mcp_servers;
 use codex_core::config::write_global_mcp_servers;
 use codex_core::config_types::McpServerConfig;
+use codex_core::config_types::McpTransport;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
+pub enum TransportArg {
+    Stdio,
+    Sse,
+    Http,
+}
 
 /// [experimental] Launch Codex as an MCP server or manage configured MCP servers.
 ///
@@ -75,8 +83,24 @@ pub struct AddArgs {
     #[arg(long, value_parser = parse_env_pair, value_name = "KEY=VALUE")]
     pub env: Vec<(String, String)>,
 
+    /// Transport to use when connecting to the MCP server.
+    #[arg(long, default_value = "stdio", value_enum)]
+    pub transport: TransportArg,
+
+    /// Primary URL for HTTP/SSE transports.
+    #[arg(long, value_name = "URL")]
+    pub url: Option<String>,
+
+    /// Optional override for the URL used when sending JSON-RPC messages.
+    #[arg(long = "messages-url", value_name = "URL")]
+    pub messages_url: Option<String>,
+
+    /// Extra HTTP headers to include with HTTP/SSE transports.
+    #[arg(long, value_parser = parse_header_pair, value_name = "KEY=VALUE")]
+    pub header: Vec<(String, String)>,
+
     /// Command to launch the MCP server.
-    #[arg(trailing_var_arg = true, num_args = 1..)]
+    #[arg(trailing_var_arg = true, num_args = 0..)]
     pub command: Vec<String>,
 }
 
@@ -120,15 +144,17 @@ fn run_add(config_overrides: &CliConfigOverrides, add_args: AddArgs) -> Result<(
     // Validate any provided overrides even though they are not currently applied.
     config_overrides.parse_overrides().map_err(|e| anyhow!(e))?;
 
-    let AddArgs { name, env, command } = add_args;
+    let AddArgs {
+        name,
+        env,
+        transport,
+        url,
+        messages_url,
+        header,
+        command,
+    } = add_args;
 
     validate_server_name(&name)?;
-
-    let mut command_parts = command.into_iter();
-    let command_bin = command_parts
-        .next()
-        .ok_or_else(|| anyhow!("command is required"))?;
-    let command_args: Vec<String> = command_parts.collect();
 
     let env_map = if env.is_empty() {
         None
@@ -140,14 +166,73 @@ fn run_add(config_overrides: &CliConfigOverrides, add_args: AddArgs) -> Result<(
         Some(map)
     };
 
+    let header_map = if header.is_empty() {
+        None
+    } else {
+        let mut map = HashMap::new();
+        for (key, value) in header {
+            map.insert(key, value);
+        }
+        Some(map)
+    };
+
+    let transport = match transport {
+        TransportArg::Stdio => McpTransport::Stdio,
+        TransportArg::Sse => McpTransport::Sse,
+        TransportArg::Http => McpTransport::Http,
+    };
+    let transport_str = transport_name(transport);
+
+    let mut command_iter = command.into_iter();
+    let (command_opt, command_args): (Option<String>, Vec<String>) = match transport {
+        McpTransport::Stdio => {
+            if url.is_some() {
+                bail!("--url is only supported for transport=sse or transport=http");
+            }
+            if messages_url.is_some() {
+                bail!("--messages-url is only supported for transport=sse or transport=http");
+            }
+            if header_map.is_some() {
+                bail!("--header is only supported for transport=sse or transport=http");
+            }
+
+            let command_bin = command_iter
+                .next()
+                .ok_or_else(|| anyhow!("command is required when transport=stdio"))?;
+            let args: Vec<String> = command_iter.collect();
+            (Some(command_bin), args)
+        }
+        McpTransport::Sse | McpTransport::Http => {
+            if command_iter.next().is_some() {
+                bail!("command arguments are not supported for transport={transport_str}");
+            }
+            if env_map.is_some() {
+                bail!("--env is only supported for transport=stdio");
+            }
+            if url.is_none() {
+                bail!("--url is required when transport={transport_str}");
+            }
+            (None, Vec::new())
+        }
+    };
+
+    let env_map = match transport {
+        McpTransport::Stdio => env_map,
+        _ => None,
+    };
+
     let codex_home = find_codex_home().context("failed to resolve CODEX_HOME")?;
     let mut servers = load_global_mcp_servers(&codex_home)
         .with_context(|| format!("failed to load MCP servers from {}", codex_home.display()))?;
 
     let new_entry = McpServerConfig {
-        command: command_bin,
+        transport,
+        command: command_opt,
         args: command_args,
         env: env_map,
+        url,
+        messages_url,
+        headers: header_map,
         startup_timeout_ms: None,
     };
 
@@ -200,16 +285,17 @@ fn run_list(config_overrides: &CliConfigOverrides, list_args: ListArgs) -> Resul
         let json_entries: Vec<_> = entries
             .into_iter()
             .map(|(name, cfg)| {
-                let env = cfg.env.as_ref().map(|env| {
-                    env.iter()
-                        .map(|(k, v)| (k.clone(), v.clone()))
-                        .collect::<BTreeMap<_, _>>()
-                });
+                let env = option_map_to_btreemap(&cfg.env);
+                let headers = option_map_to_btreemap(&cfg.headers);
                 serde_json::json!({
                     "name": name,
+                    "transport": transport_name(cfg.transport),
                     "command": cfg.command,
                     "args": cfg.args,
                     "env": env,
+                    "url": cfg.url,
+                    "messages_url": cfg.messages_url,
+                    "headers": headers,
                     "startup_timeout_ms": cfg.startup_timeout_ms,
                 })
             })
@@ -226,30 +312,57 @@ fn run_list(config_overrides: &CliConfigOverrides, list_args: ListArgs) -> Resul
 
     let mut rows: Vec<[String; 4]> = Vec::new();
     for (name, cfg) in entries {
-        let args = if cfg.args.is_empty() {
-            "-".to_string()
-        } else {
-            cfg.args.join(" ")
+        let transport = transport_name(cfg.transport).to_string();
+        let target = match cfg.transport {
+            McpTransport::Stdio => {
+                let mut parts = Vec::new();
+                if let Some(command) = &cfg.command {
+                    parts.push(command.clone());
+                }
+                parts.extend(cfg.args.clone());
+                if parts.is_empty() {
+                    "-".to_string()
+                } else {
+                    parts.join(" ")
+                }
+            }
+            _ => cfg.url.clone().unwrap_or_else(|| "-".to_string()),
         };
 
-        let env = match cfg.env.as_ref() {
-            None => "-".to_string(),
-            Some(map) if map.is_empty() => "-".to_string(),
-            Some(map) => {
-                let mut pairs: Vec<_> = map.iter().collect();
-                pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
-                pairs
-                    .into_iter()
-                    .map(|(k, v)| format!("{k}={v}"))
-                    .collect::<Vec<_>>()
-                    .join(", ")
+        let env_string = cfg.env.as_ref().filter(|m| !m.is_empty()).map(format_map);
+        let headers_string = cfg
+            .headers
+            .as_ref()
+            .filter(|m| !m.is_empty())
+            .map(format_map);
+
+        let details = match cfg.transport {
+            McpTransport::Stdio => env_string.clone().unwrap_or_else(|| "-".to_string()),
+            _ => {
+                let mut parts = Vec::new();
+                if let Some(messages_url) = &cfg.messages_url {
+                    parts.push(format!("messages={messages_url}"));
+                }
+                if let Some(headers) = headers_string.clone() {
+                    parts.push(format!("headers={headers}"));
+                }
+                if parts.is_empty() {
+                    "-".to_string()
+                } else {
+                    parts.join("; ")
+                }
             }
         };
 
-        rows.push([name.clone(), cfg.command.clone(), args, env]);
+        rows.push([name.clone(), transport, target, details]);
     }
 
-    let mut widths = ["Name".len(), "Command".len(), "Args".len(), "Env".len()];
+    let mut widths = [
+        "Name".len(),
+        "Transport".len(),
+        "Target".len(),
+        "Details".len(),
+    ];
     for row in &rows {
         for (i, cell) in row.iter().enumerate() {
             widths[i] = widths[i].max(cell.len());
@@ -257,28 +370,28 @@ fn run_list(config_overrides: &CliConfigOverrides, list_args: ListArgs) -> Resul
     }
 
     println!(
-        "{:<name_w$}  {:<cmd_w$}  {:<args_w$}  {:<env_w$}",
+        "{:<name_w$}  {:<transport_w$}  {:<target_w$}  {:<details_w$}",
         "Name",
-        "Command",
-        "Args",
-        "Env",
+        "Transport",
+        "Target",
+        "Details",
         name_w = widths[0],
-        cmd_w = widths[1],
-        args_w = widths[2],
-        env_w = widths[3],
+        transport_w = widths[1],
+        target_w = widths[2],
+        details_w = widths[3],
     );
 
     for row in rows {
         println!(
-            "{:<name_w$}  {:<cmd_w$}  {:<args_w$}  {:<env_w$}",
+            "{:<name_w$}  {:<transport_w$}  {:<target_w$}  {:<details_w$}",
             row[0],
             row[1],
             row[2],
             row[3],
             name_w = widths[0],
-            cmd_w = widths[1],
-            args_w = widths[2],
-            env_w = widths[3],
+            transport_w = widths[1],
+            target_w = widths[2],
+            details_w = widths[3],
         );
     }
 
@@ -312,27 +425,42 @@ fn run_get(config_overrides: &CliConfigOverrides, get_args: GetArgs) -> Result<(
     }
 
     println!("{}", get_args.name);
-    println!("  command: {}", server.command);
-    let args = if server.args.is_empty() {
-        "-".to_string()
-    } else {
-        server.args.join(" ")
-    };
-    println!("  args: {args}");
-    let env_display = match server.env.as_ref() {
-        None => "-".to_string(),
-        Some(map) if map.is_empty() => "-".to_string(),
-        Some(map) => {
-            let mut pairs: Vec<_> = map.iter().collect();
-            pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
-            pairs
-                .into_iter()
-                .map(|(k, v)| format!("{k}={v}"))
-                .collect::<Vec<_>>()
-                .join(", ")
+    println!("  transport: {}", transport_name(server.transport));
+
+    match server.transport {
+        McpTransport::Stdio => {
+            let command_display = server.command.as_deref().unwrap_or("-");
+            println!("  command: {command_display}");
+            let args = if server.args.is_empty() {
+                "-".to_string()
+            } else {
+                server.args.join(" ")
+            };
+            println!("  args: {args}");
+            let env_display = server
+                .env
+                .as_ref()
+                .filter(|m| !m.is_empty())
+                .map(format_map)
+                .unwrap_or_else(|| "-".to_string());
+            println!("  env: {env_display}");
         }
-    };
-    println!("  env: {env_display}");
+        McpTransport::Sse | McpTransport::Http => {
+            let url_display = server.url.as_deref().unwrap_or("-");
+            println!("  url: {url_display}");
+            if let Some(messages_url) = &server.messages_url {
+                println!("  messages_url: {messages_url}");
+            }
+            let headers_display = server
+                .headers
+                .as_ref()
+                .filter(|m| !m.is_empty())
+                .map(format_map)
+                .unwrap_or_else(|| "-".to_string());
+            println!("  headers: {headers_display}");
+        }
+    }
+
     if let Some(timeout) = server.startup_timeout_ms {
         println!("  startup_timeout_ms: {timeout}");
     }
@@ -341,19 +469,27 @@ fn run_get(config_overrides: &CliConfigOverrides, get_args: GetArgs) -> Result<(
     Ok(())
 }
 
-fn parse_env_pair(raw: &str) -> Result<(String, String), String> {
+fn parse_key_value_pair(raw: &str, kind: &str) -> Result<(String, String), String> {
     let mut parts = raw.splitn(2, '=');
     let key = parts
         .next()
         .map(str::trim)
         .filter(|s| !s.is_empty())
-        .ok_or_else(|| "environment entries must be in KEY=VALUE form".to_string())?;
+        .ok_or_else(|| format!("{kind} must be in KEY=VALUE form"))?;
     let value = parts
         .next()
         .map(str::to_string)
-        .ok_or_else(|| "environment entries must be in KEY=VALUE form".to_string())?;
+        .ok_or_else(|| format!("{kind} must be in KEY=VALUE form"))?;
 
     Ok((key.to_string(), value))
+}
+
+fn parse_env_pair(raw: &str) -> Result<(String, String), String> {
+    parse_key_value_pair(raw, "environment entries")
+}
+
+fn parse_header_pair(raw: &str) -> Result<(String, String), String> {
+    parse_key_value_pair(raw, "header entries")
 }
 
 fn validate_server_name(name: &str) -> Result<()> {
@@ -367,4 +503,32 @@ fn validate_server_name(name: &str) -> Result<()> {
     } else {
         bail!("invalid server name '{name}' (use letters, numbers, '-', '_')");
     }
+}
+
+fn transport_name(transport: McpTransport) -> &'static str {
+    match transport {
+        McpTransport::Stdio => "stdio",
+        McpTransport::Sse => "sse",
+        McpTransport::Http => "http",
+    }
+}
+
+fn option_map_to_btreemap(
+    map: &Option<HashMap<String, String>>,
+) -> Option<BTreeMap<String, String>> {
+    map.as_ref().map(|map| {
+        map.iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect::<BTreeMap<_, _>>()
+    })
+}
+
+fn format_map(map: &HashMap<String, String>) -> String {
+    let mut pairs: Vec<_> = map.iter().collect();
+    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+    pairs
+        .into_iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(", ")
 }

--- a/codex-rs/cli/tests/mcp_add_remove.rs
+++ b/codex-rs/cli/tests/mcp_add_remove.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use anyhow::Result;
 use codex_core::config::load_global_mcp_servers;
+use codex_core::config_types::McpTransport;
 use predicates::str::contains;
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
@@ -26,9 +27,12 @@ fn add_and_remove_server_updates_global_config() -> Result<()> {
     let servers = load_global_mcp_servers(codex_home.path())?;
     assert_eq!(servers.len(), 1);
     let docs = servers.get("docs").expect("server should exist");
-    assert_eq!(docs.command, "echo");
+    assert_eq!(docs.transport, McpTransport::Stdio);
+    assert_eq!(docs.command.as_deref(), Some("echo"));
     assert_eq!(docs.args, vec!["hello".to_string()]);
     assert!(docs.env.is_none());
+    assert!(docs.url.is_none());
+    assert!(docs.headers.is_none());
 
     let mut remove_cmd = codex_command(codex_home.path())?;
     remove_cmd
@@ -81,6 +85,88 @@ fn add_with_env_preserves_key_order_and_values() -> Result<()> {
     assert_eq!(env.len(), 2);
     assert_eq!(env.get("FOO"), Some(&"bar".to_string()));
     assert_eq!(env.get("ALPHA"), Some(&"beta".to_string()));
+
+    Ok(())
+}
+
+#[test]
+fn add_sse_server_records_transport_and_urls() -> Result<()> {
+    let codex_home = TempDir::new()?;
+
+    let mut add_cmd = codex_command(codex_home.path())?;
+    add_cmd
+        .args([
+            "mcp",
+            "add",
+            "sse-server",
+            "--transport",
+            "sse",
+            "--url",
+            "http://localhost:3000/sse",
+            "--messages-url",
+            "http://localhost:3000/messages",
+            "--header",
+            "Authorization=Bearer 123",
+        ])
+        .assert()
+        .success();
+
+    let servers = load_global_mcp_servers(codex_home.path())?;
+    let cfg = servers.get("sse-server").expect("server should exist");
+
+    assert_eq!(cfg.transport, McpTransport::Sse);
+    assert_eq!(cfg.url.as_deref(), Some("http://localhost:3000/sse"));
+    assert_eq!(
+        cfg.messages_url.as_deref(),
+        Some("http://localhost:3000/messages")
+    );
+    let headers = cfg.headers.as_ref().expect("headers should be present");
+    assert_eq!(
+        headers.get("Authorization"),
+        Some(&"Bearer 123".to_string())
+    );
+    assert!(cfg.command.is_none());
+
+    Ok(())
+}
+
+#[test]
+fn add_http_server_records_headers() -> Result<()> {
+    let codex_home = TempDir::new()?;
+
+    let mut add_cmd = codex_command(codex_home.path())?;
+    add_cmd
+        .args([
+            "mcp",
+            "add",
+            "http-server",
+            "--transport",
+            "http",
+            "--url",
+            "https://example.com/events",
+            "--messages-url",
+            "https://example.com/messages",
+            "--header",
+            "X-Api-Key=abc",
+            "--header",
+            "User-Agent=codex-test",
+        ])
+        .assert()
+        .success();
+
+    let servers = load_global_mcp_servers(codex_home.path())?;
+    let cfg = servers.get("http-server").expect("server should exist");
+
+    assert_eq!(cfg.transport, McpTransport::Http);
+    assert_eq!(cfg.url.as_deref(), Some("https://example.com/events"));
+    assert_eq!(
+        cfg.messages_url.as_deref(),
+        Some("https://example.com/messages")
+    );
+    let headers = cfg.headers.as_ref().expect("headers should be present");
+    assert_eq!(headers.get("X-Api-Key"), Some(&"abc".to_string()));
+    assert_eq!(headers.get("User-Agent"), Some(&"codex-test".to_string()));
+    assert!(cfg.command.is_none());
 
     Ok(())
 }

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1,6 +1,7 @@
 use crate::config_profile::ConfigProfile;
 use crate::config_types::History;
 use crate::config_types::McpServerConfig;
+use crate::config_types::McpTransport;
 use crate::config_types::Notifications;
 use crate::config_types::ReasoningSummaryFormat;
 use crate::config_types::SandboxWorkspaceWrite;
@@ -310,7 +311,17 @@ pub fn write_global_mcp_servers(
         for (name, config) in servers {
             let mut entry = TomlTable::new();
             entry.set_implicit(false);
-            entry["command"] = toml_edit::value(config.command.clone());
+            if config.transport != McpTransport::Stdio {
+                entry["transport"] = toml_edit::value(match config.transport {
+                    McpTransport::Stdio => "stdio",
+                    McpTransport::Sse => "sse",
+                    McpTransport::Http => "http",
+                });
+            }
+
+            if let Some(command) = &config.command {
+                entry["command"] = toml_edit::value(command.clone());
+            }
 
             if !config.args.is_empty() {
                 let mut args = TomlArray::new();
@@ -331,6 +342,27 @@ pub fn write_global_mcp_servers(
                     env_table.insert(key, toml_edit::value(value.clone()));
                 }
                 entry["env"] = TomlItem::Table(env_table);
+            }
+
+            if let Some(url) = &config.url {
+                entry["url"] = toml_edit::value(url.clone());
+            }
+
+            if let Some(messages_url) = &config.messages_url {
+                entry["messages_url"] = toml_edit::value(messages_url.clone());
+            }
+
+            if let Some(headers) = &config.headers
+                && !headers.is_empty()
+            {
+                let mut headers_table = TomlTable::new();
+                headers_table.set_implicit(false);
+                let mut pairs: Vec<_> = headers.iter().collect();
+                pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+                for (key, value) in pairs {
+                    headers_table.insert(key, toml_edit::value(value.clone()));
+                }
+                entry["headers"] = TomlItem::Table(headers_table);
             }
 
             if let Some(timeout) = config.startup_timeout_ms {
@@ -1275,9 +1307,13 @@ exclude_slash_tmp = true
         servers.insert(
             "docs".to_string(),
             McpServerConfig {
-                command: "echo".to_string(),
+                transport: McpTransport::Stdio,
+                command: Some("echo".to_string()),
                 args: vec!["hello".to_string()],
                 env: None,
+                url: None,
+                messages_url: None,
+                headers: None,
                 startup_timeout_ms: None,
             },
         );
@@ -1287,7 +1323,8 @@ exclude_slash_tmp = true
         let loaded = load_global_mcp_servers(codex_home.path())?;
         assert_eq!(loaded.len(), 1);
         let docs = loaded.get("docs").expect("docs entry");
-        assert_eq!(docs.command, "echo");
+        assert_eq!(docs.transport, McpTransport::Stdio);
+        assert_eq!(docs.command.as_deref(), Some("echo"));
         assert_eq!(docs.args, vec!["hello".to_string()]);
 
         let empty = BTreeMap::new();

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -9,15 +9,46 @@ use wildmatch::WildMatchPattern;
 
 use serde::Deserialize;
 
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum McpTransport {
+    Stdio,
+    Sse,
+    Http,
+}
+
+impl Default for McpTransport {
+    fn default() -> Self {
+        Self::Stdio
+    }
+}
+
 #[derive(Deserialize, Debug, Clone, PartialEq)]
 pub struct McpServerConfig {
-    pub command: String,
+    #[serde(default)]
+    pub transport: McpTransport,
+
+    /// Command to launch a stdio-based MCP server. Required when `transport = "stdio"`.
+    #[serde(default)]
+    pub command: Option<String>,
 
     #[serde(default)]
     pub args: Vec<String>,
 
     #[serde(default)]
     pub env: Option<HashMap<String, String>>,
+
+    /// Base URL for HTTP or SSE transports. Required when `transport` is `sse` or `http`.
+    #[serde(default)]
+    pub url: Option<String>,
+
+    /// Optional override for the URL used when sending JSON-RPC messages via HTTP POST.
+    #[serde(default)]
+    pub messages_url: Option<String>,
+
+    /// Extra HTTP headers to include with HTTP/SSE requests.
+    #[serde(default)]
+    pub headers: Option<HashMap<String, String>>,
 
     /// Startup timeout in milliseconds for initializing MCP server & initially listing tools.
     #[serde(default)]

--- a/codex-rs/mcp-client/Cargo.toml
+++ b/codex-rs/mcp-client/Cargo.toml
@@ -8,7 +8,10 @@ workspace = true
 
 [dependencies]
 anyhow = "1"
+eventsource-stream = "0.2.3"
+futures = "0.3"
 mcp-types = { path = "../mcp-types" }
+reqwest = { version = "0.12", features = ["json", "stream"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = { version = "0.1.41", features = ["log"] }

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -17,6 +17,7 @@ use codex_common::elapsed::format_duration;
 use codex_core::auth::get_auth_file;
 use codex_core::auth::try_read_auth_json;
 use codex_core::config::Config;
+use codex_core::config_types::McpTransport;
 use codex_core::config_types::ReasoningSummaryFormat;
 use codex_core::plan_tool::PlanItemArg;
 use codex_core::plan_tool::StepStatus;
@@ -1275,11 +1276,48 @@ pub(crate) fn new_mcp_tools_output(
         names.sort();
 
         lines.push(vec!["  • Server: ".into(), server.clone().into()].into());
+        lines.push(
+            vec![
+                "    • Transport: ".into(),
+                transport_label(cfg.transport).into(),
+            ]
+            .into(),
+        );
 
-        if !cfg.command.is_empty() {
-            let cmd_display = format!("{} {}", cfg.command, cfg.args.join(" "));
+        match cfg.transport {
+            McpTransport::Stdio => {
+                if let Some(command) = &cfg.command {
+                    let mut parts = Vec::new();
+                    parts.push(command.clone());
+                    parts.extend(cfg.args.clone());
+                    let cmd_display = parts.join(" ").trim().to_string();
+                    if !cmd_display.is_empty() {
+                        lines.push(vec!["    • Command: ".into(), cmd_display.into()].into());
+                    }
+                }
 
-            lines.push(vec!["    • Command: ".into(), cmd_display.into()].into());
+                if let Some(env) = cfg.env.as_ref()
+                    && !env.is_empty()
+                {
+                    lines.push(vec!["    • Env: ".into(), format_kv_map(env).into()].into());
+                }
+            }
+            McpTransport::Sse | McpTransport::Http => {
+                if let Some(url) = &cfg.url {
+                    lines.push(vec!["    • URL: ".into(), url.clone().into()].into());
+                }
+                if let Some(messages_url) = &cfg.messages_url {
+                    lines.push(
+                        vec!["    • Messages URL: ".into(), messages_url.clone().into()].into(),
+                    );
+                }
+                if let Some(headers) = cfg.headers.as_ref()
+                    && !headers.is_empty()
+                {
+                    lines
+                        .push(vec!["    • Headers: ".into(), format_kv_map(headers).into()].into());
+                }
+            }
         }
 
         if names.is_empty() {
@@ -1291,6 +1329,24 @@ pub(crate) fn new_mcp_tools_output(
     }
 
     PlainHistoryCell { lines }
+}
+
+fn transport_label(transport: McpTransport) -> &'static str {
+    match transport {
+        McpTransport::Stdio => "stdio",
+        McpTransport::Sse => "sse",
+        McpTransport::Http => "http",
+    }
+}
+
+fn format_kv_map(map: &HashMap<String, String>) -> String {
+    let mut pairs: Vec<_> = map.iter().collect();
+    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+    pairs
+        .into_iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(", ")
 }
 
 pub(crate) fn new_info_event(message: String, hint: Option<String>) -> PlainHistoryCell {

--- a/docs/config.md
+++ b/docs/config.md
@@ -338,7 +338,7 @@ You can further customize how Codex runs at the command line using the `--ask-fo
 
 ## mcp_servers
 
-Defines the list of MCP servers that Codex can consult for tool use. Currently, only servers that are launched by executing a program that communicate over stdio are supported. For servers that use the SSE transport, consider an adapter like [mcp-proxy](https://github.com/sparfenyuk/mcp-proxy).
+Defines the list of MCP servers that Codex can consult for tool use. Codex can talk to servers over stdio (local processes), native SSE streams, or the streamable HTTP transport described in the [MCP specification](https://modelcontextprotocol.io). Stdio remains the default; set `transport = "sse"` or `transport = "http"` and provide the appropriate URLs to connect to remote servers.
 
 **Note:** Codex may cache the list of tools and resources from an MCP server so that Codex can include this information in context at startup without spawning all the servers. This is designed to save resources by loading MCP servers lazily.
 
@@ -365,18 +365,28 @@ Should be represented as follows in `~/.codex/config.toml`:
 ```toml
 # IMPORTANT: the top-level key is `mcp_servers` rather than `mcpServers`.
 [mcp_servers.server-name]
+transport = "stdio"
 command = "npx"
 args = ["-y", "mcp-server"]
 env = { "API_KEY" = "value" }
 # Optional: override the default 10s startup timeout
 startup_timeout_ms = 20_000
+
+[mcp_servers.remote-tools]
+transport = "sse"
+url = "http://localhost:3000/stream"
+messages_url = "http://localhost:3000/messages"
+headers = { "Authorization" = "Bearer sk-..." }
 ```
 
 You can also manage these entries from the CLI [experimental]:
 
 ```shell
-# Add a server (env can be repeated; `--` separates the launcher command)
+# Add a stdio-backed server (env can be repeated; `--` separates the launcher command)
 codex mcp add docs -- docs-server --port 4000
+
+# Add a remote SSE server
+codex mcp add remote --transport sse --url http://localhost:3000/stream --messages-url http://localhost:3000/messages --header Authorization=Bearer:token
 
 # List configured servers (pretty table or JSON)
 codex mcp list
@@ -616,9 +626,13 @@ notifications = [ "agent-turn-complete", "approval-requested" ]
 | `disable_response_storage` | boolean | Required for ZDR orgs. |
 | `notify` | array<string> | External program for notifications. |
 | `instructions` | string | Currently ignored; use `experimental_instructions_file` or `AGENTS.md`. |
-| `mcp_servers.<id>.command` | string | MCP server launcher command. |
-| `mcp_servers.<id>.args` | array<string> | MCP server args. |
-| `mcp_servers.<id>.env` | map<string,string> | MCP server env vars. |
+| `mcp_servers.<id>.transport` | `stdio` \| `sse` \| `http` | `stdio` | Transport to use when contacting the MCP server. |
+| `mcp_servers.<id>.command` | string | Launch command for stdio transports. |
+| `mcp_servers.<id>.args` | array<string> | Command-line args for stdio transports. |
+| `mcp_servers.<id>.env` | map<string,string> | Environment variables for stdio transports. |
+| `mcp_servers.<id>.url` | string | Stream endpoint for `sse`/`http` transports. |
+| `mcp_servers.<id>.messages_url` | string | Optional override for the POST endpoint used to send JSON-RPC messages (defaults to `url`). |
+| `mcp_servers.<id>.headers` | map<string,string> | Extra HTTP headers for `sse`/`http` transports. |
 | `mcp_servers.<id>.startup_timeout_ms` | number | Startup timeout in milliseconds (default: 10_000). Timeout is applied both for initializing MCP server and initially listing tools. |
 | `model_providers.<id>.name` | string | Display name. |
 | `model_providers.<id>.base_url` | string | API base URL. |


### PR DESCRIPTION
## Summary
  - extend `mcp_servers` configuration to accept `transport = "stdio" | "sse" | "http"` with optional `url`, `messages_url`, and `headers`
  - teach the MCP client and connection manager to connect over SSE and the streamable HTTP transport while retaining stdio support
  - surface transport details in the TUI history view and update docs/CLI tests for the new configuration fields

  Fixes #2129.

  ## Testing
  - just fmt 
  - cargo fmt 
  - cargo test -p codex-mcp-client
  - cargo test -p codex-core