### PR TITLE
Fix: Script Uses Unsafe Text Processing That Could Be Exploited in codex-cli/scripts/init_firewall.sh

### DIFF
--- a/codex-cli/scripts/init_firewall.sh
+++ b/codex-cli/scripts/init_firewall.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -euo pipefail  # Exit on error, undefined vars, and pipeline failures
-IFS=$'\n\t'       # Stricter word splitting
 
 # Read allowed domains from file
 ALLOWED_DOMAINS_FILE="/etc/codex/allowed_domains.txt"


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** The special variable IFS affects how splitting takes place when expanding unquoted variables. Don't set it globally. Prefer a dedicated utility such as 'cut' or 'awk' if you need to split input data. If you must use 'read', set IFS locally using e.g. 'IFS="," read -a my_array'.
- **Rule ID:** bash.lang.security.ifs-tampering.ifs-tampering
- **Severity:** LOW
- **File:** codex-cli/scripts/init_firewall.sh
- **Lines Affected:** 3 - 3

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `codex-cli/scripts/init_firewall.sh` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.