### PR TITLE
core: Match review test runtime threads on windows

### DIFF
--- a/codex-rs/core/tests/suite/review.rs
+++ b/codex-rs/core/tests/suite/review.rs
@@ -39,7 +39,8 @@ use wiremock::matchers::path;
 /// Verify that submitting `Op::Review` spawns a child task and emits
 /// EnteredReviewMode -> ExitedReviewMode(None) -> TaskComplete
 /// in that order when the model returns a structured review JSON payload.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[cfg_attr(windows, tokio::test(flavor = "multi_thread", worker_threads = 4))]
+#[cfg_attr(not(windows), tokio::test(flavor = "multi_thread", worker_threads = 2))]
 async fn review_op_emits_lifecycle_and_review_output() {
     // Skip under Codex sandbox network restrictions.
     if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() {


### PR DESCRIPTION
- The review integration tests spawn a wiremock server and the Codex conversation manager inside the same Tokio runtime; each of those launch long-lived async tasks to drive the SSE stream and event pump. 

- On Windows the slower I/O frequently starves those tasks when we only offer two worker threads, which trips the `timeout waiting for event` guard in `wait_for_event`. 

- The other review cases (`review_op_with_plain_text_emits_review_fallback`, `review_does_not_emit_agent_message_on_structured_output`, and `review_input_isolated_from_parent_history`) already bumped their Windows flavor to four worker threads after similar CI flakes. This change makes `review_op_emits_lifecycle_and_review_output` consistent so Windows runs stop intermittently hanging while Linux/macOS stay on two threads.