### PR TITLE
include session ID on non-interactive surfaces

### DIFF
--- a/codex-rs/exec/src/event_processor.rs
+++ b/codex-rs/exec/src/event_processor.rs
@@ -2,6 +2,7 @@ use std::path::Path;
 
 use codex_core::config::Config;
 use codex_core::protocol::Event;
+use codex_core::protocol::SessionConfiguredEvent;
 
 pub(crate) enum CodexStatus {
     Running,
@@ -11,7 +12,12 @@ pub(crate) enum CodexStatus {
 
 pub(crate) trait EventProcessor {
     /// Print summary of effective configuration and user prompt.
-    fn print_config_summary(&mut self, config: &Config, prompt: &str);
+    fn print_config_summary(
+        &mut self,
+        config: &Config,
+        prompt: &str,
+        session_configured: &SessionConfiguredEvent,
+    );
 
     /// Handle a single event emitted by the agent.
     fn process_event(&mut self, event: Event) -> CodexStatus;

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -141,7 +141,12 @@ impl EventProcessor for EventProcessorWithHumanOutput {
     /// Print a concise summary of the effective configuration that will be used
     /// for the session. This mirrors the information shown in the TUI welcome
     /// screen.
-    fn print_config_summary(&mut self, config: &Config, prompt: &str) {
+    fn print_config_summary(
+        &mut self,
+        config: &Config,
+        prompt: &str,
+        session_configured: &SessionConfiguredEvent,
+    ) {
         const VERSION: &str = env!("CARGO_PKG_VERSION");
         ts_println!(
             self,
@@ -149,7 +154,8 @@ impl EventProcessor for EventProcessorWithHumanOutput {
             VERSION
         );
 
-        let entries = create_config_summary_entries(config);
+        let mut entries = create_config_summary_entries(config);
+        entries.insert(0, ("session id", session_configured.session_id.to_string()));
 
         for (key, value) in entries {
             println!("{} {}", format!("{key}:").style(self.bold), value);

--- a/codex-rs/exec/src/event_processor_with_json_output.rs
+++ b/codex-rs/exec/src/event_processor_with_json_output.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use codex_core::config::Config;
 use codex_core::protocol::Event;
 use codex_core::protocol::EventMsg;
+use codex_core::protocol::SessionConfiguredEvent;
 use codex_core::protocol::TaskCompleteEvent;
 use serde_json::json;
 
@@ -23,11 +24,20 @@ impl EventProcessorWithJsonOutput {
 }
 
 impl EventProcessor for EventProcessorWithJsonOutput {
-    fn print_config_summary(&mut self, config: &Config, prompt: &str) {
-        let entries = create_config_summary_entries(config)
+    fn print_config_summary(
+        &mut self,
+        config: &Config,
+        prompt: &str,
+        session_configured: &SessionConfiguredEvent,
+    ) {
+        let mut entries = create_config_summary_entries(config)
             .into_iter()
             .map(|(key, value)| (key.to_string(), value))
             .collect::<HashMap<String, String>>();
+        entries.insert(
+            "session_id".to_string(),
+            session_configured.session_id.to_string(),
+        );
         #[expect(clippy::expect_used)]
         let config_json =
             serde_json::to_string(&entries).expect("Failed to serialize config summary to JSON");


### PR DESCRIPTION
 - on the JSON mode, include it on the initial JSON config summary
 - on non-interactive mode, include it alongside human-readable info

This unblocks more easily building sophisticated tooling around `codex exec`, where a session can be tracked for the purposes of monitoring the session outputs (outside of the subprocess `stdout`) and later used via `resume`

## Tests

```sh
$ cargo run --bin codex -- exec "hello"

--------
session id: 01995d63-c8ce-7050-bb72-a0bb1a71e836
workdir: ...
...
--------
```

```sh

$ cargo run --bin codex -- exec "hello" --json

{"approval":"never","session_id":"01995d67-f645-7843-b5c4-36b062746557",...}
```