### PR TITLE
feat(mcp): add project-scoped MCP server configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,10 @@ You can also use Codex with an API key, but this requires [additional setup](./d
 
 ### Model Context Protocol (MCP)
 
-Codex can access MCP servers. To configure them, refer to the [config docs](./docs/config.md#mcp_servers).
+Codex CLI supports [MCP servers](./docs/advanced.md#model-context-protocol-mcp).
+Configure them globally via the `mcp_servers` section in `~/.codex/config.toml`,
+or per-project in `./.codex/config.toml` inside your project.
+See the [config docs](./docs/config.md#mcp_servers) for full details.
 
 ### Configuration
 

--- a/codex-rs/cli/tests/mcp_project.rs
+++ b/codex-rs/cli/tests/mcp_project.rs
@@ -1,0 +1,62 @@
+use std::path::Path;
+
+use anyhow::Result;
+use codex_core::config::load_project_mcp_servers;
+use predicates::str::contains;
+use tempfile::TempDir;
+
+fn codex_command(codex_home: &Path) -> Result<assert_cmd::Command> {
+    let mut cmd = assert_cmd::Command::cargo_bin("codex")?;
+    cmd.env("CODEX_HOME", codex_home);
+    Ok(cmd)
+}
+
+#[test]
+fn add_and_remove_project_scoped_server() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let project_dir = TempDir::new()?;
+
+    // Add project-scoped server (writes into <project>/.codex/config.toml)
+    let mut add_cmd = codex_command(codex_home.path())?;
+    add_cmd
+        .current_dir(project_dir.path())
+        .args(["mcp", "add", "docs", "--project", "--", "echo", "hello"])
+        .assert()
+        .success()
+        .stdout(contains("Added project MCP server 'docs'"));
+
+    // Verify the project config via helper loader
+    let servers = load_project_mcp_servers(project_dir.path())?;
+    let docs = servers.get("docs").expect("server should exist");
+    match &docs.transport {
+        codex_core::config_types::McpServerTransportConfig::Stdio {
+            command,
+            args,
+            env,
+            env_vars,
+            cwd,
+        } => {
+            assert_eq!(command, "echo");
+            assert_eq!(args, &vec!["hello".to_string()]);
+            assert!(env.is_none());
+            assert!(env_vars.is_empty());
+            assert!(cwd.is_none());
+        }
+        other => panic!("unexpected transport: {other:?}"),
+    }
+    assert!(docs.enabled);
+
+    // Remove project-scoped server
+    let mut remove_cmd = codex_command(codex_home.path())?;
+    remove_cmd
+        .current_dir(project_dir.path())
+        .args(["mcp", "remove", "docs", "--project"])
+        .assert()
+        .success()
+        .stdout(contains("Removed project MCP server 'docs'"));
+
+    let servers_after = load_project_mcp_servers(project_dir.path())?;
+    assert!(!servers_after.contains_key("docs"));
+
+    Ok(())
+}

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -262,13 +262,17 @@ impl Config {
     ) -> std::io::Result<Self> {
         let codex_home = find_codex_home()?;
 
-        let root_value = load_resolved_config(
+        let mut layers = load_config_layers_with_overrides(
             &codex_home,
-            cli_overrides,
             crate::config_loader::LoaderOverrides::default(),
         )
         .await?;
 
+        if let Some(project_value) = load_project_config_as_toml_from_overrides(&overrides)? {
+            merge_toml_values(&mut layers.base, &project_value);
+        }
+
+        let root_value = apply_overlays(layers, cli_overrides);
         let cfg: ConfigToml = root_value.try_into().map_err(|e| {
             tracing::error!("Failed to deserialize overridden config: {e}");
             std::io::Error::new(std::io::ErrorKind::InvalidData, e)
@@ -295,6 +299,56 @@ pub async fn load_config_as_toml_with_cli_overrides(
     })?;
 
     Ok(cfg)
+}
+
+/// Attempt to load a project-local `.codex/config.toml` using cwd hints from
+/// `ConfigOverrides` (if any). Returns `Ok(Some(toml))` when found and parsed,
+/// `Ok(None)` when missing.
+fn load_project_config_as_toml_from_overrides(
+    overrides: &ConfigOverrides,
+) -> std::io::Result<Option<TomlValue>> {
+    let preliminary_cwd = match overrides.cwd.as_ref() {
+        None => std::env::current_dir()?,
+        Some(p) if p.is_absolute() => p.clone(),
+        Some(p) => {
+            let mut current = std::env::current_dir()?;
+            current.push(p);
+            current
+        }
+    };
+
+    load_project_config_as_toml(&preliminary_cwd)
+}
+
+/// Try to load `.codex/config.toml` from the project directory.
+/// Search order:
+///   1. If inside a git worktree: `<git-root>/.codex/config.toml`
+///   2. Fallback: `<cwd>/.codex/config.toml`
+fn load_project_config_as_toml(cwd: &Path) -> std::io::Result<Option<TomlValue>> {
+    let mut candidates: Vec<PathBuf> = Vec::new();
+    if let Some(root) = resolve_root_git_project_for_trust(cwd) {
+        candidates.push(root.join(".codex").join(CONFIG_TOML_FILE));
+    }
+    candidates.push(cwd.join(".codex").join(CONFIG_TOML_FILE));
+
+    for path in candidates {
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => match toml::from_str::<TomlValue>(&contents) {
+                Ok(val) => return Ok(Some(val)),
+                Err(e) => {
+                    tracing::error!(
+                        "Failed to parse project .codex/config.toml at {}: {e}",
+                        path.display()
+                    );
+                    return Err(std::io::Error::new(std::io::ErrorKind::InvalidData, e));
+                }
+            },
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(None)
 }
 
 async fn load_resolved_config(
@@ -364,6 +418,116 @@ fn ensure_no_inline_bearer_tokens(value: &TomlValue) -> std::io::Result<()> {
     Ok(())
 }
 
+fn write_mcp_servers_to_document(
+    doc: &mut DocumentMut,
+    servers: &BTreeMap<String, McpServerConfig>,
+) {
+    doc.as_table_mut().remove("mcp_servers");
+
+    if servers.is_empty() {
+        return;
+    }
+
+    let mut table = TomlTable::new();
+    table.set_implicit(true);
+    doc["mcp_servers"] = TomlItem::Table(table);
+
+    for (name, config) in servers {
+        let mut entry = TomlTable::new();
+        entry.set_implicit(false);
+        match &config.transport {
+            McpServerTransportConfig::Stdio {
+                command,
+                args,
+                env,
+                env_vars,
+                cwd,
+            } => {
+                entry["command"] = toml_edit::value(command.clone());
+
+                if !args.is_empty() {
+                    let mut args_array = TomlArray::new();
+                    for arg in args {
+                        args_array.push(arg.clone());
+                    }
+                    entry["args"] = TomlItem::Value(args_array.into());
+                }
+
+                if let Some(env) = env
+                    && !env.is_empty()
+                {
+                    let mut env_table = TomlTable::new();
+                    env_table.set_implicit(false);
+                    let mut pairs: Vec<_> = env.iter().collect();
+                    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+                    for (key, value) in pairs {
+                        env_table.insert(key, toml_edit::value(value.clone()));
+                    }
+                    entry["env"] = TomlItem::Table(env_table);
+                }
+
+                if !env_vars.is_empty() {
+                    entry["env_vars"] =
+                        TomlItem::Value(env_vars.iter().collect::<TomlArray>().into());
+                }
+
+                if let Some(cwd) = cwd {
+                    entry["cwd"] = toml_edit::value(cwd.to_string_lossy().to_string());
+                }
+            }
+            McpServerTransportConfig::StreamableHttp {
+                url,
+                bearer_token_env_var,
+                http_headers,
+                env_http_headers,
+            } => {
+                entry["url"] = toml_edit::value(url.clone());
+                if let Some(env_var) = bearer_token_env_var {
+                    entry["bearer_token_env_var"] = toml_edit::value(env_var.clone());
+                }
+                if let Some(headers) = http_headers
+                    && !headers.is_empty()
+                {
+                    let mut table = TomlTable::new();
+                    table.set_implicit(false);
+                    let mut pairs: Vec<_> = headers.iter().collect();
+                    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+                    for (key, value) in pairs {
+                        table.insert(key, toml_edit::value(value.clone()));
+                    }
+                    entry["http_headers"] = TomlItem::Table(table);
+                }
+                if let Some(headers) = env_http_headers
+                    && !headers.is_empty()
+                {
+                    let mut table = TomlTable::new();
+                    table.set_implicit(false);
+                    let mut pairs: Vec<_> = headers.iter().collect();
+                    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+                    for (key, value) in pairs {
+                        table.insert(key, toml_edit::value(value.clone()));
+                    }
+                    entry["env_http_headers"] = TomlItem::Table(table);
+                }
+            }
+        }
+
+        if !config.enabled {
+            entry["enabled"] = toml_edit::value(false);
+        }
+
+        if let Some(timeout) = config.startup_timeout_sec {
+            entry["startup_timeout_sec"] = toml_edit::value(timeout.as_secs_f64());
+        }
+
+        if let Some(timeout) = config.tool_timeout_sec {
+            entry["tool_timeout_sec"] = toml_edit::value(timeout.as_secs_f64());
+        }
+
+        doc["mcp_servers"][name.as_str()] = TomlItem::Table(entry);
+    }
+}
+
 pub fn write_global_mcp_servers(
     codex_home: &Path,
     servers: &BTreeMap<String, McpServerConfig>,
@@ -377,114 +541,65 @@ pub fn write_global_mcp_servers(
         Err(e) => return Err(e),
     };
 
-    doc.as_table_mut().remove("mcp_servers");
-
-    if !servers.is_empty() {
-        let mut table = TomlTable::new();
-        table.set_implicit(true);
-        doc["mcp_servers"] = TomlItem::Table(table);
-
-        for (name, config) in servers {
-            let mut entry = TomlTable::new();
-            entry.set_implicit(false);
-            match &config.transport {
-                McpServerTransportConfig::Stdio {
-                    command,
-                    args,
-                    env,
-                    env_vars,
-                    cwd,
-                } => {
-                    entry["command"] = toml_edit::value(command.clone());
-
-                    if !args.is_empty() {
-                        let mut args_array = TomlArray::new();
-                        for arg in args {
-                            args_array.push(arg.clone());
-                        }
-                        entry["args"] = TomlItem::Value(args_array.into());
-                    }
-
-                    if let Some(env) = env
-                        && !env.is_empty()
-                    {
-                        let mut env_table = TomlTable::new();
-                        env_table.set_implicit(false);
-                        let mut pairs: Vec<_> = env.iter().collect();
-                        pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
-                        for (key, value) in pairs {
-                            env_table.insert(key, toml_edit::value(value.clone()));
-                        }
-                        entry["env"] = TomlItem::Table(env_table);
-                    }
-
-                    if !env_vars.is_empty() {
-                        entry["env_vars"] =
-                            TomlItem::Value(env_vars.iter().collect::<TomlArray>().into());
-                    }
-
-                    if let Some(cwd) = cwd {
-                        entry["cwd"] = toml_edit::value(cwd.to_string_lossy().to_string());
-                    }
-                }
-                McpServerTransportConfig::StreamableHttp {
-                    url,
-                    bearer_token_env_var,
-                    http_headers,
-                    env_http_headers,
-                } => {
-                    entry["url"] = toml_edit::value(url.clone());
-                    if let Some(env_var) = bearer_token_env_var {
-                        entry["bearer_token_env_var"] = toml_edit::value(env_var.clone());
-                    }
-                    if let Some(headers) = http_headers
-                        && !headers.is_empty()
-                    {
-                        let mut table = TomlTable::new();
-                        table.set_implicit(false);
-                        let mut pairs: Vec<_> = headers.iter().collect();
-                        pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
-                        for (key, value) in pairs {
-                            table.insert(key, toml_edit::value(value.clone()));
-                        }
-                        entry["http_headers"] = TomlItem::Table(table);
-                    }
-                    if let Some(headers) = env_http_headers
-                        && !headers.is_empty()
-                    {
-                        let mut table = TomlTable::new();
-                        table.set_implicit(false);
-                        let mut pairs: Vec<_> = headers.iter().collect();
-                        pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
-                        for (key, value) in pairs {
-                            table.insert(key, toml_edit::value(value.clone()));
-                        }
-                        entry["env_http_headers"] = TomlItem::Table(table);
-                    }
-                }
-            }
-
-            if !config.enabled {
-                entry["enabled"] = toml_edit::value(false);
-            }
-
-            if let Some(timeout) = config.startup_timeout_sec {
-                entry["startup_timeout_sec"] = toml_edit::value(timeout.as_secs_f64());
-            }
-
-            if let Some(timeout) = config.tool_timeout_sec {
-                entry["tool_timeout_sec"] = toml_edit::value(timeout.as_secs_f64());
-            }
-
-            doc["mcp_servers"][name.as_str()] = TomlItem::Table(entry);
-        }
-    }
+    write_mcp_servers_to_document(&mut doc, servers);
 
     std::fs::create_dir_all(codex_home)?;
     let tmp_file = NamedTempFile::new_in(codex_home)?;
     std::fs::write(tmp_file.path(), doc.to_string())?;
     tmp_file.persist(config_path).map_err(|err| err.error)?;
 
+    Ok(())
+}
+
+pub fn load_project_mcp_servers(
+    project_root: &Path,
+) -> std::io::Result<BTreeMap<String, McpServerConfig>> {
+    let config_path = project_root.join(".codex").join(CONFIG_TOML_FILE);
+    let contents = match std::fs::read_to_string(&config_path) {
+        Ok(contents) => contents,
+        Err(e) if e.kind() == ErrorKind::NotFound => return Ok(BTreeMap::new()),
+        Err(e) => return Err(e),
+    };
+
+    let root_value: TomlValue = if contents.trim().is_empty() {
+        TomlValue::Table(Default::default())
+    } else {
+        toml::from_str(&contents)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?
+    };
+
+    let Some(servers_value) = root_value.get("mcp_servers") else {
+        return Ok(BTreeMap::new());
+    };
+
+    ensure_no_inline_bearer_tokens(servers_value)?;
+
+    servers_value
+        .clone()
+        .try_into()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+pub fn write_project_mcp_servers(
+    project_root: &Path,
+    servers: &BTreeMap<String, McpServerConfig>,
+) -> std::io::Result<()> {
+    let codex_dir = project_root.join(".codex");
+    let config_path = codex_dir.join(CONFIG_TOML_FILE);
+    let mut doc = match std::fs::read_to_string(&config_path) {
+        Ok(contents) => contents
+            .parse::<DocumentMut>()
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => DocumentMut::new(),
+        Err(e) => return Err(e),
+    };
+
+    write_mcp_servers_to_document(&mut doc, servers);
+
+    std::fs::create_dir_all(&codex_dir)?;
+    let tmp_file = NamedTempFile::new_in(&codex_dir)?;
+    std::fs::write(tmp_file.path(), doc.to_string())?;
+    tmp_file.persist(config_path).map_err(|err| err.error)?;
     Ok(())
 }
 
@@ -1472,6 +1587,7 @@ pub fn log_dir(cfg: &Config) -> std::io::Result<PathBuf> {
 #[cfg(test)]
 mod tests {
     use crate::config_types::HistoryPersistence;
+    use crate::config_types::McpServerTransportConfig;
     use crate::config_types::Notifications;
     use crate::features::Feature;
 
@@ -3084,6 +3200,69 @@ trust_level = "trusted"
 trust_level = "trusted"
 "#;
         assert_eq!(contents, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn project_local_codex_config_overrides_globals() -> std::io::Result<()> {
+        use std::fs;
+
+        // Arrange global config value in-memory
+        let global = r#"
+[mcp_servers.shared]
+command = "echo"
+args = ["global"]
+
+[mcp_servers.only-global]
+command = "true"
+"#;
+        let mut global_val: TomlValue = toml::from_str(global).unwrap();
+
+        // Arrange project `.codex/config.toml` on disk so loader can find it
+        let project_dir = TempDir::new()?;
+        let proj_codex_dir = project_dir.path().join(".codex");
+        fs::create_dir_all(&proj_codex_dir)?;
+        let project_toml = r#"
+[mcp_servers.shared]
+command = "echo"
+args = ["project"]
+
+[mcp_servers.only-project]
+command = "false"
+"#;
+        fs::write(proj_codex_dir.join(CONFIG_TOML_FILE), project_toml)?;
+
+        // Load project-local config and merge with global
+        let project_val = load_project_config_as_toml(project_dir.path())?
+            .expect("project config should be found");
+        merge_toml_values(&mut global_val, &project_val);
+
+        // Deserialize to ConfigToml and finish loading Config
+        let config_toml: ConfigToml = global_val.try_into().unwrap();
+        let overrides = ConfigOverrides {
+            cwd: Some(project_dir.path().to_path_buf()),
+            ..Default::default()
+        };
+        let cfg = Config::load_from_base_config_with_overrides(
+            config_toml,
+            overrides,
+            TempDir::new()?.keep(),
+        )?;
+
+        // shared should be overridden by project
+        let shared_server = cfg
+            .mcp_servers
+            .get("shared")
+            .expect("shared server should exist");
+        match &shared_server.transport {
+            McpServerTransportConfig::Stdio { args, .. } => {
+                assert_eq!(args, &["project".to_string()]);
+            }
+            transport => panic!("expected stdio transport, got {transport:?}"),
+        }
+        assert!(cfg.mcp_servers.contains_key("only-project"));
+        assert!(cfg.mcp_servers.contains_key("only-global"));
 
         Ok(())
     }

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -16,7 +16,17 @@ See the Rust documentation on [`RUST_LOG`](https://docs.rs/env_logger/latest/env
 
 ## Model Context Protocol (MCP)
 
-The Codex CLI and IDE extension is a MCP client which means that it can be configured to connect to MCP servers. For more information, refer to the [`config docs`](./config.md#connecting-to-mcp-servers).
+The Codex CLI and IDE extension is an MCP client, which means it can connect to MCP servers. Refer to the [`config docs`](./config.md#connecting-to-mcp-servers) for the full set of options.
+
+The Codex CLI can be configured to leverage MCP servers by defining an [`mcp_servers`](./config.md#mcp_servers) section in `~/.codex/config.toml`. You can also define project-scoped servers in your project's `./.codex/config.toml`. It is intended to mirror how tools such as Claude and Cursor define `mcpServers` in their respective JSON config files, though the Codex format is slightly different since it uses TOML rather than JSON, e.g.:
+
+```toml
+# IMPORTANT: the top-level key is `mcp_servers` rather than `mcpServers`.
+[mcp_servers.server-name]
+command = "npx"
+args = ["-y", "mcp-server"]
+env = { "API_KEY" = "value" }
+```
 
 ## Using Codex as an MCP Server
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -411,6 +411,18 @@ experimental_use_rmcp_client = true
 …
 ```
 
+Project-scoped MCP servers can be defined in your project's `.codex/config.toml`:
+
+```toml
+# <project>/.codex/config.toml
+[mcp_servers.docs]
+command = "npx"
+args = ["-y", "docs-server"]
+env = { TOKEN = "secret" }
+```
+
+You can also manage these entries from the CLI [experimental]:
+
 ### MCP CLI commands
 
 ```shell
@@ -419,6 +431,10 @@ codex mcp --help
 
 # Add a server (env can be repeated; `--` separates the launcher command)
 codex mcp add docs -- docs-server --port 4000
+
+# Add/remove a server scoped to the current project (writes to ./.codex/config.toml)
+codex mcp add docs --project -- docs-server --port 4000
+codex mcp remove docs --project
 
 # List configured servers (pretty table or JSON)
 codex mcp list


### PR DESCRIPTION
Add support for project-scoped MCP server configuration in `.codex/config.toml`. This allows users to configure different MCP servers per project without polluting global configuration.

Changes:
- Add `--project` flag to `codex mcp add/remove` commands
- Implement config merging where project configs override globals
- Update documentation for new project-scoped configuration

This enables fine-grained MCP server management for different projects with different toolchain requirements.