### PR TITLE
fix: ensure cwd for conversation and sandbox are separate concerns

### DIFF
--- a/codex-rs/cli/src/debug_sandbox.rs
+++ b/codex-rs/cli/src/debug_sandbox.rs
@@ -64,7 +64,6 @@ async fn run_command_under_sandbox(
     sandbox_type: SandboxType,
 ) -> anyhow::Result<()> {
     let sandbox_mode = create_sandbox_mode(full_auto);
-    let cwd = std::env::current_dir()?;
     let config = Config::load_with_cli_overrides(
         config_overrides
             .parse_overrides()
@@ -75,13 +74,29 @@ async fn run_command_under_sandbox(
             ..Default::default()
         },
     )?;
+
+    // In practice, this should be `std::env::current_dir()` because this CLI
+    // does not support `--cwd`, but let's use the config value for consistency.
+    let cwd = config.cwd.clone();
+    // For now, we always use the same cwd for both the command and the
+    // sandbox policy. In the future, we could add a CLI option to set them
+    // separately.
+    let sandbox_policy_cwd = cwd.clone();
+
     let stdio_policy = StdioPolicy::Inherit;
     let env = create_env(&config.shell_environment_policy);
 
     let mut child = match sandbox_type {
         SandboxType::Seatbelt => {
-            spawn_command_under_seatbelt(command, &config.sandbox_policy, cwd, stdio_policy, env)
-                .await?
+            spawn_command_under_seatbelt(
+                command,
+                cwd,
+                &config.sandbox_policy,
+                sandbox_policy_cwd.as_path(),
+                stdio_policy,
+                env,
+            )
+            .await?
         }
         SandboxType::Landlock => {
             #[expect(clippy::expect_used)]
@@ -91,8 +106,9 @@ async fn run_command_under_sandbox(
             spawn_command_under_linux_sandbox(
                 codex_linux_sandbox_exe,
                 command,
-                &config.sandbox_policy,
                 cwd,
+                &config.sandbox_policy,
+                sandbox_policy_cwd.as_path(),
                 stdio_policy,
                 env,
             )

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::collections::HashSet;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicU64;
@@ -898,6 +899,7 @@ impl Session {
             exec_args.params,
             exec_args.sandbox_type,
             exec_args.sandbox_policy,
+            exec_args.sandbox_cwd,
             exec_args.codex_linux_sandbox_exe,
             exec_args.stdout_stream,
         )
@@ -2691,6 +2693,7 @@ pub struct ExecInvokeArgs<'a> {
     pub params: ExecParams,
     pub sandbox_type: SandboxType,
     pub sandbox_policy: &'a SandboxPolicy,
+    pub sandbox_cwd: &'a Path,
     pub codex_linux_sandbox_exe: &'a Option<PathBuf>,
     pub stdout_stream: Option<StdoutStream>,
 }
@@ -2882,6 +2885,7 @@ async fn handle_container_exec_with_params(
                 params: params.clone(),
                 sandbox_type,
                 sandbox_policy: &turn_context.sandbox_policy,
+                sandbox_cwd: &turn_context.cwd,
                 codex_linux_sandbox_exe: &sess.codex_linux_sandbox_exe,
                 stdout_stream: if exec_command_context.apply_patch.is_some() {
                     None
@@ -3016,6 +3020,7 @@ async fn handle_sandbox_error(
                         params,
                         sandbox_type: SandboxType::None,
                         sandbox_policy: &turn_context.sandbox_policy,
+                        sandbox_cwd: &turn_context.cwd,
                         codex_linux_sandbox_exe: &sess.codex_linux_sandbox_exe,
                         stdout_stream: if exec_command_context.apply_patch.is_some() {
                             None

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -3,6 +3,7 @@ use std::os::unix::process::ExitStatusExt;
 
 use std::collections::HashMap;
 use std::io;
+use std::path::Path;
 use std::path::PathBuf;
 use std::process::ExitStatus;
 use std::time::Duration;
@@ -82,6 +83,7 @@ pub async fn process_exec_tool_call(
     params: ExecParams,
     sandbox_type: SandboxType,
     sandbox_policy: &SandboxPolicy,
+    sandbox_cwd: &Path,
     codex_linux_sandbox_exe: &Option<PathBuf>,
     stdout_stream: Option<StdoutStream>,
 ) -> Result<ExecToolCallOutput> {
@@ -94,12 +96,16 @@ pub async fn process_exec_tool_call(
         SandboxType::None => exec(params, sandbox_policy, stdout_stream.clone()).await,
         SandboxType::MacosSeatbelt => {
             let ExecParams {
-                command, cwd, env, ..
+                command,
+                cwd: command_cwd,
+                env,
+                ..
             } = params;
             let child = spawn_command_under_seatbelt(
                 command,
+                command_cwd,
                 sandbox_policy,
-                cwd,
+                sandbox_cwd,
                 StdioPolicy::RedirectForShellTool,
                 env,
             )
@@ -108,7 +114,10 @@ pub async fn process_exec_tool_call(
         }
         SandboxType::LinuxSeccomp => {
             let ExecParams {
-                command, cwd, env, ..
+                command,
+                cwd: command_cwd,
+                env,
+                ..
             } = params;
 
             let codex_linux_sandbox_exe = codex_linux_sandbox_exe
@@ -117,8 +126,9 @@ pub async fn process_exec_tool_call(
             let child = spawn_command_under_linux_sandbox(
                 codex_linux_sandbox_exe,
                 command,
+                command_cwd,
                 sandbox_policy,
-                cwd,
+                sandbox_cwd,
                 StdioPolicy::RedirectForShellTool,
                 env,
             )

--- a/codex-rs/core/src/landlock.rs
+++ b/codex-rs/core/src/landlock.rs
@@ -16,21 +16,22 @@ use tokio::process::Child;
 pub async fn spawn_command_under_linux_sandbox<P>(
     codex_linux_sandbox_exe: P,
     command: Vec<String>,
+    command_cwd: PathBuf,
     sandbox_policy: &SandboxPolicy,
-    cwd: PathBuf,
+    sandbox_policy_cwd: &Path,
     stdio_policy: StdioPolicy,
     env: HashMap<String, String>,
 ) -> std::io::Result<Child>
 where
     P: AsRef<Path>,
 {
-    let args = create_linux_sandbox_command_args(command, sandbox_policy, &cwd);
+    let args = create_linux_sandbox_command_args(command, sandbox_policy, sandbox_policy_cwd);
     let arg0 = Some("codex-linux-sandbox");
     spawn_child_async(
         codex_linux_sandbox_exe.as_ref().to_path_buf(),
         args,
         arg0,
-        cwd,
+        command_cwd,
         sandbox_policy,
         stdio_policy,
         env,
@@ -42,10 +43,13 @@ where
 fn create_linux_sandbox_command_args(
     command: Vec<String>,
     sandbox_policy: &SandboxPolicy,
-    cwd: &Path,
+    sandbox_policy_cwd: &Path,
 ) -> Vec<String> {
     #[expect(clippy::expect_used)]
-    let sandbox_policy_cwd = cwd.to_str().expect("cwd must be valid UTF-8").to_string();
+    let sandbox_policy_cwd = sandbox_policy_cwd
+        .to_str()
+        .expect("cwd must be valid UTF-8")
+        .to_string();
 
     #[expect(clippy::expect_used)]
     let sandbox_policy_json =

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -349,6 +349,7 @@ mod tests {
                 },
                 SandboxType::None,
                 &SandboxPolicy::DangerFullAccess,
+                temp_home.path(),
                 &None,
                 None,
             )
@@ -455,6 +456,7 @@ mod macos_tests {
                 },
                 SandboxType::None,
                 &SandboxPolicy::DangerFullAccess,
+                temp_home.path(),
                 &None,
                 None,
             )

--- a/codex-rs/core/tests/suite/exec.rs
+++ b/codex-rs/core/tests/suite/exec.rs
@@ -39,7 +39,7 @@ async fn run_test_cmd(tmp: TempDir, cmd: Vec<&str>) -> Result<ExecToolCallOutput
 
     let policy = SandboxPolicy::new_read_only_policy();
 
-    process_exec_tool_call(params, sandbox_type, &policy, &None, None).await
+    process_exec_tool_call(params, sandbox_type, &policy, tmp.path(), &None, None).await
 }
 
 /// Command succeeds with exit code 0 normally

--- a/codex-rs/core/tests/suite/seatbelt.rs
+++ b/codex-rs/core/tests/suite/seatbelt.rs
@@ -171,6 +171,8 @@ async fn python_getpwuid_works_under_seatbelt() {
 
     // ReadOnly is sufficient here since we are only exercising user lookup.
     let policy = SandboxPolicy::ReadOnly;
+    let command_cwd = std::env::current_dir().expect("getcwd");
+    let sandbox_cwd = command_cwd.clone();
 
     let mut child = spawn_command_under_seatbelt(
         vec![
@@ -179,8 +181,9 @@ async fn python_getpwuid_works_under_seatbelt() {
             // Print the passwd struct; success implies lookup worked.
             "import pwd, os; print(pwd.getpwuid(os.getuid()))".to_string(),
         ],
+        command_cwd,
         &policy,
-        std::env::current_dir().expect("should be able to get current dir"),
+        sandbox_cwd.as_path(),
         StdioPolicy::RedirectForShellTool,
         HashMap::new(),
     )
@@ -216,13 +219,16 @@ fn create_test_scenario(tmp: &TempDir) -> TestScenario {
 /// Note that `path` must be absolute.
 async fn touch(path: &Path, policy: &SandboxPolicy) -> bool {
     assert!(path.is_absolute(), "Path must be absolute: {path:?}");
+    let command_cwd = std::env::current_dir().expect("getcwd");
+    let sandbox_cwd = command_cwd.clone();
     let mut child = spawn_command_under_seatbelt(
         vec![
             "/usr/bin/touch".to_string(),
             path.to_string_lossy().to_string(),
         ],
+        command_cwd,
         policy,
-        std::env::current_dir().expect("should be able to get current dir"),
+        sandbox_cwd.as_path(),
         StdioPolicy::RedirectForShellTool,
         HashMap::new(),
     )

--- a/codex-rs/linux-sandbox/tests/suite/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/suite/landlock.rs
@@ -35,9 +35,11 @@ fn create_env_from_core_vars() -> HashMap<String, String> {
 
 #[expect(clippy::print_stdout, clippy::expect_used, clippy::unwrap_used)]
 async fn run_cmd(cmd: &[&str], writable_roots: &[PathBuf], timeout_ms: u64) {
+    let cwd = std::env::current_dir().expect("cwd should exist");
+    let sandbox_cwd = cwd.clone();
     let params = ExecParams {
         command: cmd.iter().map(|elm| elm.to_string()).collect(),
-        cwd: std::env::current_dir().expect("cwd should exist"),
+        cwd,
         timeout_ms: Some(timeout_ms),
         env: create_env_from_core_vars(),
         with_escalated_permissions: None,
@@ -59,6 +61,7 @@ async fn run_cmd(cmd: &[&str], writable_roots: &[PathBuf], timeout_ms: u64) {
         params,
         SandboxType::LinuxSeccomp,
         &sandbox_policy,
+        sandbox_cwd.as_path(),
         &codex_linux_sandbox_exe,
         None,
     )
@@ -133,6 +136,7 @@ async fn test_timeout() {
 #[expect(clippy::expect_used)]
 async fn assert_network_blocked(cmd: &[&str]) {
     let cwd = std::env::current_dir().expect("cwd should exist");
+    let sandbox_cwd = cwd.clone();
     let params = ExecParams {
         command: cmd.iter().map(|s| s.to_string()).collect(),
         cwd,
@@ -151,6 +155,7 @@ async fn assert_network_blocked(cmd: &[&str]) {
         params,
         SandboxType::LinuxSeccomp,
         &sandbox_policy,
+        sandbox_cwd.as_path(),
         &codex_linux_sandbox_exe,
         None,
     )

--- a/codex-rs/mcp-server/src/codex_message_processor.rs
+++ b/codex-rs/mcp-server/src/codex_message_processor.rs
@@ -589,12 +589,14 @@ impl CodexMessageProcessor {
         let codex_linux_sandbox_exe = self.config.codex_linux_sandbox_exe.clone();
         let outgoing = self.outgoing.clone();
         let req_id = request_id;
+        let sandbox_cwd = self.config.cwd.clone();
 
         tokio::spawn(async move {
             match codex_core::exec::process_exec_tool_call(
                 exec_params,
                 sandbox_type,
                 &effective_policy,
+                sandbox_cwd.as_path(),
                 &codex_linux_sandbox_exe,
                 None,
             )


### PR DESCRIPTION
Previous to this PR, both of these functions take a single `cwd`:

https://github.com/openai/codex/blob/71038381aa0f51aa62e1a2bcc7cbf26a05b141f3/codex-rs/core/src/seatbelt.rs#L19-L25

https://github.com/openai/codex/blob/71038381aa0f51aa62e1a2bcc7cbf26a05b141f3/codex-rs/core/src/landlock.rs#L16-L23

whereas `cwd` and `sandbox_cwd` should be set independently (fixed in this PR).

Added `sandbox_distinguishes_command_and_policy_cwds()` to `codex-rs/exec/tests/suite/sandbox.rs` to verify this.