### PR TITLE
fix: update try_parse_word_only_commands_sequence() to return commands in order

### DIFF
--- a/codex-rs/core/src/bash.rs
+++ b/codex-rs/core/src/bash.rs
@@ -73,6 +73,9 @@ pub fn try_parse_word_only_commands_sequence(tree: &Tree, src: &str) -> Option<V
         }
     }
 
+    // Walk uses a stack (LIFO), so re-sort by position to restore source order.
+    command_nodes.sort_by_key(|node| node.start_byte());
+
     let mut commands = Vec::new();
     for node in command_nodes {
         if let Some(words) = parse_plain_command_from_node(node, src) {
@@ -150,10 +153,10 @@ mod tests {
         let src = "ls && pwd; echo 'hi there' | wc -l";
         let cmds = parse_seq(src).unwrap();
         let expected: Vec<Vec<String>> = vec![
-            vec!["wc".to_string(), "-l".to_string()],
-            vec!["echo".to_string(), "hi there".to_string()],
-            vec!["pwd".to_string()],
             vec!["ls".to_string()],
+            vec!["pwd".to_string()],
+            vec!["echo".to_string(), "hi there".to_string()],
+            vec!["wc".to_string(), "-l".to_string()],
         ];
         assert_eq!(cmds, expected);
     }

--- a/codex-rs/core/src/parse_command.rs
+++ b/codex-rs/core/src/parse_command.rs
@@ -1156,10 +1156,8 @@ fn parse_bash_lc_commands(original: &[String]) -> Option<Vec<ParsedCommand>> {
         // bias toward the primary command when pipelines are present.
         // First, drop obvious small formatting helpers (e.g., wc/awk/etc).
         let had_multiple_commands = all_commands.len() > 1;
-        // The bash AST walker yields commands in right-to-left order for
-        // connector/pipeline sequences. Reverse to reflect actual execution order.
-        let mut filtered_commands = drop_small_formatting_commands(all_commands);
-        filtered_commands.reverse();
+        // Commands arrive in source order; drop formatting helpers while preserving it.
+        let filtered_commands = drop_small_formatting_commands(all_commands);
         if filtered_commands.is_empty() {
             return Some(vec![ParsedCommand::Unknown {
                 cmd: script.clone(),


### PR DESCRIPTION
Incidentally, we had a test for this in `accepts_multiple_commands_with_allowed_operators()`, but it was verifying the bad behavior. Oops!