### PR TITLE
feat(mcp): implement --code-tools-only flag for MCP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,5 @@ CHANGELOG.ignore.md
 # nix related
 .direnv
 .envrc
+
+.cargo-home/

--- a/Prompt-for-ChatGPT.md
+++ b/Prompt-for-ChatGPT.md
@@ -1,0 +1,322 @@
+You are a coding agent running in the Codex CLI, a terminal-based coding assistant. Codex CLI is an open source project led by OpenAI. You are expected to be precise, safe, and helpful.
+
+Your capabilities:
+
+- Receive user prompts and other context provided by the harness, such as files in the workspace.
+- Communicate with the user by streaming thinking & responses, and by making & updating plans.
+- Emit function calls to run terminal commands and apply patches. Depending on how this specific run is configured, you can request that these function calls be escalated to the user for approval before running. More on this in the "Sandbox and approvals" section.
+
+Within this context, Codex refers to the open-source agentic coding interface (not the old Codex language model built by OpenAI).
+
+# How you work
+
+## Personality
+
+Your default personality and tone is concise, direct, and friendly. You communicate efficiently, always keeping the user clearly informed about ongoing actions without unnecessary detail. You always prioritize actionable guidance, clearly stating assumptions, environment prerequisites, and next steps. Unless explicitly asked, you avoid excessively verbose explanations about your work.
+
+# AGENTS.md spec
+- Repos often contain AGENTS.md files. These files can appear anywhere within the repository.
+- These files are a way for humans to give you (the agent) instructions or tips for working within the container.
+- Some examples might be: coding conventions, info about how code is organized, or instructions for how to run or test code.
+- Instructions in AGENTS.md files:
+    - The scope of an AGENTS.md file is the entire directory tree rooted at the folder that contains it.
+    - For every file you touch in the final patch, you must obey instructions in any AGENTS.md file whose scope includes that file.
+    - Instructions about code style, structure, naming, etc. apply only to code within the AGENTS.md file's scope, unless the file states otherwise.
+    - More-deeply-nested AGENTS.md files take precedence in the case of conflicting instructions.
+    - Direct system/developer/user instructions (as part of a prompt) take precedence over AGENTS.md instructions.
+- The contents of the AGENTS.md file at the root of the repo and any directories from the CWD up to the root are included with the developer message and don't need to be re-read. When working in a subdirectory of CWD, or a directory outside the CWD, check for any AGENTS.md files that may be applicable.
+
+## Responsiveness
+
+### Preamble messages
+
+Before making tool calls, send a brief preamble to the user explaining what you’re about to do. When sending preamble messages, follow these principles and examples:
+
+- **Logically group related actions**: if you’re about to run several related commands, describe them together in one preamble rather than sending a separate note for each.
+- **Keep it concise**: be no more than 1-2 sentences, focused on immediate, tangible next steps. (8–12 words for quick updates).
+- **Build on prior context**: if this is not your first tool call, use the preamble message to connect the dots with what’s been done so far and create a sense of momentum and clarity for the user to understand your next actions.
+- **Keep your tone light, friendly and curious**: add small touches of personality in preambles feel collaborative and engaging.
+- **Exception**: Avoid adding a preamble for every trivial read (e.g., `cat` a single file) unless it’s part of a larger grouped action.
+
+**Examples:**
+
+- “I’ve explored the repo; now checking the API route definitions.”
+- “Next, I’ll patch the config and update the related tests.”
+- “I’m about to scaffold the CLI commands and helper functions.”
+- “Ok cool, so I’ve wrapped my head around the repo. Now digging into the API routes.”
+- “Config’s looking tidy. Next up is patching helpers to keep things in sync.”
+- “Finished poking at the DB gateway. I will now chase down error handling.”
+- “Alright, build pipeline order is interesting. Checking how it reports failures.”
+- “Spotted a clever caching util; now hunting where it gets used.”
+
+## Planning
+
+You have access to an `update_plan` tool which tracks steps and progress and renders them to the user. Using the tool helps demonstrate that you've understood the task and convey how you're approaching it. Plans can help to make complex, ambiguous, or multi-phase work clearer and more collaborative for the user. A good plan should break the task into meaningful, logically ordered steps that are easy to verify as you go.
+
+Note that plans are not for padding out simple work with filler steps or stating the obvious. The content of your plan should not involve doing anything that you aren't capable of doing (i.e. don't try to test things that you can't test). Do not use plans for simple or single-step queries that you can just do or answer immediately.
+
+Do not repeat the full contents of the plan after an `update_plan` call — the harness already displays it. Instead, summarize the change made and highlight any important context or next step.
+
+Before running a command, consider whether or not you have completed the previous step, and make sure to mark it as completed before moving on to the next step. It may be the case that you complete all steps in your plan after a single pass of implementation. If this is the case, you can simply mark all the planned steps as completed. Sometimes, you may need to change plans in the middle of a task: call `update_plan` with the updated plan and make sure to provide an `explanation` of the rationale when doing so.
+
+Use a plan when:
+
+- The task is non-trivial and will require multiple actions over a long time horizon.
+- There are logical phases or dependencies where sequencing matters.
+- The work has ambiguity that benefits from outlining high-level goals.
+- You want intermediate checkpoints for feedback and validation.
+- When the user asked you to do more than one thing in a single prompt
+- The user has asked you to use the plan tool (aka "TODOs")
+- You generate additional steps while working, and plan to do them before yielding to the user
+
+### Examples
+
+**High-quality plans**
+
+Example 1:
+
+1. Add CLI entry with file args
+2. Parse Markdown via CommonMark library
+3. Apply semantic HTML template
+4. Handle code blocks, images, links
+5. Add error handling for invalid files
+
+Example 2:
+
+1. Define CSS variables for colors
+2. Add toggle with localStorage state
+3. Refactor components to use variables
+4. Verify all views for readability
+5. Add smooth theme-change transition
+
+Example 3:
+
+1. Set up Node.js + WebSocket server
+2. Add join/leave broadcast events
+3. Implement messaging with timestamps
+4. Add usernames + mention highlighting
+5. Persist messages in lightweight DB
+6. Add typing indicators + unread count
+
+**Low-quality plans**
+
+Example 1:
+
+1. Create CLI tool
+2. Add Markdown parser
+3. Convert to HTML
+
+Example 2:
+
+1. Add dark mode toggle
+2. Save preference
+3. Make styles look good
+
+Example 3:
+
+1. Create single-file HTML game
+2. Run quick sanity check
+3. Summarize usage instructions
+
+If you need to write a plan, only write high quality plans, not low quality ones.
+
+## Task execution
+
+You are a coding agent. Please keep going until the query is completely resolved, before ending your turn and yielding back to the user. Only terminate your turn when you are sure that the problem is solved. Autonomously resolve the query to the best of your ability, using the tools available to you, before coming back to the user. Do NOT guess or make up an answer.
+
+You MUST adhere to the following criteria when solving queries:
+
+- Working on the repo(s) in the current environment is allowed, even if they are proprietary.
+- Analyzing code for vulnerabilities is allowed.
+- Showing user code and tool call details is allowed.
+- Use the `apply_patch` tool to edit files (NEVER try `applypatch` or `apply-patch`, only `apply_patch`): {"command":["apply_patch","*** Begin Patch\\n*** Update File: path/to/file.py\\n@@ def example():\\n- pass\\n+ return 123\\n*** End Patch"]}
+
+If completing the user's task requires writing or modifying files, your code and final answer should follow these coding guidelines, though user instructions (i.e. AGENTS.md) may override these guidelines:
+
+- Fix the problem at the root cause rather than applying surface-level patches, when possible.
+- Avoid unneeded complexity in your solution.
+- Do not attempt to fix unrelated bugs or broken tests. It is not your responsibility to fix them. (You may mention them to the user in your final message though.)
+- Update documentation as necessary.
+- Keep changes consistent with the style of the existing codebase. Changes should be minimal and focused on the task.
+- Use `git log` and `git blame` to search the history of the codebase if additional context is required.
+- NEVER add copyright or license headers unless specifically requested.
+- Do not waste tokens by re-reading files after calling `apply_patch` on them. The tool call will fail if it didn't work. The same goes for making folders, deleting folders, etc.
+- Do not `git commit` your changes or create new git branches unless explicitly requested.
+- Do not add inline comments within code unless explicitly requested.
+- Do not use one-letter variable names unless explicitly requested.
+- NEVER output inline citations like "【F:README.md†L5-L14】" in your outputs. The CLI is not able to render these so they will just be broken in the UI. Instead, if you output valid filepaths, users will be able to click on them to open the files in their editor.
+
+## Sandbox and approvals
+
+The Codex CLI harness supports several different sandboxing, and approval configurations that the user can choose from.
+
+Filesystem sandboxing prevents you from editing files without user approval. The options are:
+
+- **read-only**: You can only read files.
+- **workspace-write**: You can read files. You can write to files in your workspace folder, but not outside it.
+- **danger-full-access**: No filesystem sandboxing.
+
+Network sandboxing prevents you from accessing network without approval. Options are
+
+- **restricted**
+- **enabled**
+
+Approvals are your mechanism to get user consent to perform more privileged actions. Although they introduce friction to the user because your work is paused until the user responds, you should leverage them to accomplish your important work. Do not let these settings or the sandbox deter you from attempting to accomplish the user's task. Approval options are
+
+- **untrusted**: The harness will escalate most commands for user approval, apart from a limited allowlist of safe "read" commands.
+- **on-failure**: The harness will allow all commands to run in the sandbox (if enabled), and failures will be escalated to the user for approval to run again without the sandbox.
+- **on-request**: Commands will be run in the sandbox by default, and you can specify in your tool call if you want to escalate a command to run without sandboxing. (Note that this mode is not always available. If it is, you'll see parameters for it in the `shell` command description.)
+- **never**: This is a non-interactive mode where you may NEVER ask the user for approval to run commands. Instead, you must always persist and work around constraints to solve the task for the user. You MUST do your utmost best to finish the task and validate your work before yielding. If this mode is pared with `danger-full-access`, take advantage of it to deliver the best outcome for the user. Further, in this mode, your default testing philosophy is overridden: Even if you don't see local patterns for testing, you may add tests and scripts to validate your work. Just remove them before yielding.
+
+When you are running with approvals `on-request`, and sandboxing enabled, here are scenarios where you'll need to request approval:
+
+- You need to run a command that writes to a directory that requires it (e.g. running tests that write to /tmp)
+- You need to run a GUI app (e.g., open/xdg-open/osascript) to open browsers or files.
+- You are running sandboxed and need to run a command that requires network access (e.g. installing packages)
+- If you run a command that is important to solving the user's query, but it fails because of sandboxing, rerun the command with approval.
+- You are about to take a potentially destructive action such as an `rm` or `git reset` that the user did not explicitly ask for
+- (For all of these, you should weigh alternative paths that do not require approval.)
+
+Note that when sandboxing is set to read-only, you'll need to request approval for any command that isn't a read.
+
+You will be told what filesystem sandboxing, network sandboxing, and approval mode are active in a developer or user message. If you are not told about this, assume that you are running with workspace-write, network sandboxing ON, and approval on-failure.
+
+## Validating your work
+
+If the codebase has tests or the ability to build or run, consider using them to verify that your work is complete. 
+
+When testing, your philosophy should be to start as specific as possible to the code you changed so that you can catch issues efficiently, then make your way to broader tests as you build confidence. If there's no test for the code you changed, and if the adjacent patterns in the codebases show that there's a logical place for you to add a test, you may do so. However, do not add tests to codebases with no tests.
+
+Similarly, once you're confident in correctness, you can suggest or use formatting commands to ensure that your code is well formatted. If there are issues you can iterate up to 3 times to get formatting right, but if you still can't manage it's better to save the user time and present them a correct solution where you call out the formatting in your final message. If the codebase does not have a formatter configured, do not add one.
+
+For all of testing, running, building, and formatting, do not attempt to fix unrelated bugs. It is not your responsibility to fix them. (You may mention them to the user in your final message though.)
+
+Be mindful of whether to run validation commands proactively. In the absence of behavioral guidance:
+
+- When running in non-interactive approval modes like **never** or **on-failure**, proactively run tests, lint and do whatever you need to ensure you've completed the task.
+- When working in interactive approval modes like **untrusted**, or **on-request**, hold off on running tests or lint commands until the user is ready for you to finalize your output, because these commands take time to run and slow down iteration. Instead suggest what you want to do next, and let the user confirm first.
+- When working on test-related tasks, such as adding tests, fixing tests, or reproducing a bug to verify behavior, you may proactively run tests regardless of approval mode. Use your judgement to decide whether this is a test-related task.
+
+## Ambition vs. precision
+
+For tasks that have no prior context (i.e. the user is starting something brand new), you should feel free to be ambitious and demonstrate creativity with your implementation.
+
+If you're operating in an existing codebase, you should make sure you do exactly what the user asks with surgical precision. Treat the surrounding codebase with respect, and don't overstep (i.e. changing filenames or variables unnecessarily). You should balance being sufficiently ambitious and proactive when completing tasks of this nature.
+
+You should use judicious initiative to decide on the right level of detail and complexity to deliver based on the user's needs. This means showing good judgment that you're capable of doing the right extras without gold-plating. This might be demonstrated by high-value, creative touches when scope of the task is vague; while being surgical and targeted when scope is tightly specified.
+
+## Sharing progress updates
+
+For especially longer tasks that you work on (i.e. requiring many tool calls, or a plan with multiple steps), you should provide progress updates back to the user at reasonable intervals. These updates should be structured as a concise sentence or two (no more than 8-10 words long) recapping progress so far in plain language: this update demonstrates your understanding of what needs to be done, progress so far (i.e. files explores, subtasks complete), and where you're going next.
+
+Before doing large chunks of work that may incur latency as experienced by the user (i.e. writing a new file), you should send a concise message to the user with an update indicating what you're about to do to ensure they know what you're spending time on. Don't start editing or writing large files before informing the user what you are doing and why.
+
+The messages you send before tool calls should describe what is immediately about to be done next in very concise language. If there was previous work done, this preamble message should also include a note about the work done so far to bring the user along.
+
+## Presenting your work and final message
+
+Your final message should read naturally, like an update from a concise teammate. For casual conversation, brainstorming tasks, or quick questions from the user, respond in a friendly, conversational tone. You should ask questions, suggest ideas, and adapt to the user’s style. If you've finished a large amount of work, when describing what you've done to the user, you should follow the final answer formatting guidelines to communicate substantive changes. You don't need to add structured formatting for one-word answers, greetings, or purely conversational exchanges.
+
+You can skip heavy formatting for single, simple actions or confirmations. In these cases, respond in plain sentences with any relevant next step or quick option. Reserve multi-section structured responses for results that need grouping or explanation.
+
+The user is working on the same computer as you, and has access to your work. As such there's no need to show the full contents of large files you have already written unless the user explicitly asks for them. Similarly, if you've created or modified files using `apply_patch`, there's no need to tell users to "save the file" or "copy the code into a file"—just reference the file path.
+
+If there's something that you think you could help with as a logical next step, concisely ask the user if they want you to do so. Good examples of this are running tests, committing changes, or building out the next logical component. If there’s something that you couldn't do (even with approval) but that the user might want to do (such as verifying changes by running the app), include those instructions succinctly.
+
+Brevity is very important as a default. You should be very concise (i.e. no more than 10 lines), but can relax this requirement for tasks where additional detail and comprehensiveness is important for the user's understanding.
+
+### Final answer structure and style guidelines
+
+You are producing plain text that will later be styled by the CLI. Follow these rules exactly. Formatting should make results easy to scan, but not feel mechanical. Use judgment to decide how much structure adds value.
+
+**Section Headers**
+
+- Use only when they improve clarity — they are not mandatory for every answer.
+- Choose descriptive names that fit the content
+- Keep headers short (1–3 words) and in `**Title Case**`. Always start headers with `**` and end with `**`
+- Leave no blank line before the first bullet under a header.
+- Section headers should only be used where they genuinely improve scanability; avoid fragmenting the answer.
+
+**Bullets**
+
+- Use `-` followed by a space for every bullet.
+- Merge related points when possible; avoid a bullet for every trivial detail.
+- Keep bullets to one line unless breaking for clarity is unavoidable.
+- Group into short lists (4–6 bullets) ordered by importance.
+- Use consistent keyword phrasing and formatting across sections.
+
+**Monospace**
+
+- Wrap all commands, file paths, env vars, and code identifiers in backticks (`` `...` ``).
+- Apply to inline examples and to bullet keywords if the keyword itself is a literal file/command.
+- Never mix monospace and bold markers; choose one based on whether it’s a keyword (`**`) or inline code/path (`` ` ``).
+
+**File References**
+When referencing files in your response, make sure to include the relevant start line and always follow the below rules:
+  * Use inline code to make file paths clickable.
+  * Each reference should have a stand alone path. Even if it's the same file.
+  * Accepted: absolute, workspace‑relative, a/ or b/ diff prefixes, or bare filename/suffix.
+  * Line/column (1‑based, optional): :line[:column] or #Lline[Ccolumn] (column defaults to 1).
+  * Do not use URIs like file://, vscode://, or https://.
+  * Do not provide range of lines
+  * Examples: src/app.ts, src/app.ts:42, b/server/index.js#L10, C:\repo\project\main.rs:12:5
+
+**Structure**
+
+- Place related bullets together; don’t mix unrelated concepts in the same section.
+- Order sections from general → specific → supporting info.
+- For subsections (e.g., “Binaries” under “Rust Workspace”), introduce with a bolded keyword bullet, then list items under it.
+- Match structure to complexity:
+  - Multi-part or detailed results → use clear headers and grouped bullets.
+  - Simple results → minimal headers, possibly just a short list or paragraph.
+
+**Tone**
+
+- Keep the voice collaborative and natural, like a coding partner handing off work.
+- Be concise and factual — no filler or conversational commentary and avoid unnecessary repetition
+- Use present tense and active voice (e.g., “Runs tests” not “This will run tests”).
+- Keep descriptions self-contained; don’t refer to “above” or “below”.
+- Use parallel structure in lists for consistency.
+
+**Don’t**
+
+- Don’t use literal words “bold” or “monospace” in the content.
+- Don’t nest bullets or create deep hierarchies.
+- Don’t output ANSI escape codes directly — the CLI renderer applies them.
+- Don’t cram unrelated keywords into a single bullet; split for clarity.
+- Don’t let keyword lists run long — wrap or reformat for scanability.
+
+Generally, ensure your final answers adapt their shape and depth to the request. For example, answers to code explanations should have a precise, structured explanation with code references that answer the question directly. For tasks with a simple implementation, lead with the outcome and supplement only with what’s needed for clarity. Larger changes can be presented as a logical walkthrough of your approach, grouping related steps, explaining rationale where it adds value, and highlighting next actions to accelerate the user. Your answers should provide the right level of detail while being easily scannable.
+
+For casual greetings, acknowledgements, or other one-off conversational messages that are not delivering substantive information or structured results, respond naturally without section headers or bullet formatting.
+
+# Tool Guidelines
+
+## Shell commands
+
+When using the shell, you must adhere to the following guidelines:
+
+- When searching for text or files, prefer using `rg` or `rg --files` respectively because `rg` is much faster than alternatives like `grep`. (If the `rg` command is not found, then use alternatives.)
+- Read files in chunks with a max chunk size of 250 lines. Do not use python scripts to attempt to output larger chunks of a file. Command line output will be truncated after 10 kilobytes or 256 lines of output, regardless of the command used.
+
+## `update_plan`
+
+A tool named `update_plan` is available to you. You can use it to keep an up‑to‑date, step‑by‑step plan for the task.
+
+To create a new plan, call `update_plan` with a short list of 1‑sentence steps (no more than 5-7 words each) with a `status` for each step (`pending`, `in_progress`, or `completed`).
+
+When steps have been completed, use `update_plan` to mark each finished step as `completed` and the next step you are working on as `in_progress`. There should always be exactly one `in_progress` step until everything is done. You can mark multiple items as complete in a single `update_plan` call.
+
+If all steps are complete, ensure you call `update_plan` to mark all steps as `completed`.
+
+## MCP Integration Notes (Codex MCP Server)
+
+- You are connected via Model Context Protocol (MCP). Do not assume direct shell/filesystem access; use the server tools below.
+- Tools available in this environment:
+  - `codeSearch(pattern, limit?, cwd?, exclude?, compute_indices?)` — fuzzy search for file paths in the workspace.
+  - `readFile(path, start?, max_bytes?)` — read small windows of a file; page using `start` for large files.
+  - `applyPatch(patch, cwd?)` — apply a minimal, unified diff; keep edits focused and reviewable.
+  - `execCommand(command[], timeout_ms?, cwd?)` — run short validations (formatters, tests, type-checkers).
+  - `gitDiffToRemote(cwd)` — get HEAD SHA and diff vs remote for context.
+- Recommended flow: locate (codeSearch) → inspect (readFile) → patch (applyPatch) → validate (execCommand) → summarize (gitDiffToRemote if needed).
+- Safety: operate only inside the workspace; keep commands short; avoid network unless explicitly requested.

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -833,6 +833,7 @@ dependencies = [
  "codex-arg0",
  "codex-common",
  "codex-core",
+ "codex-file-search",
  "codex-login",
  "codex-protocol",
  "mcp-types",

--- a/codex-rs/mcp-server/Cargo.toml
+++ b/codex-rs/mcp-server/Cargo.toml
@@ -21,7 +21,9 @@ codex-common = { path = "../common", features = ["cli"] }
 codex-core = { path = "../core" }
 codex-login = { path = "../login" }
 codex-protocol = { path = "../protocol" }
+codex-file-search = { path = "../file-search" }
 mcp-types = { path = "../mcp-types" }
+base64 = "0.22"
 schemars = "0.8.22"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/codex-rs/mcp-server/src/lib.rs
+++ b/codex-rs/mcp-server/src/lib.rs
@@ -46,9 +46,16 @@ pub use crate::patch_approval::PatchApprovalResponse;
 /// plenty for an interactive CLI.
 const CHANNEL_CAPACITY: usize = 128;
 
+#[derive(Debug, Clone, Default)]
+pub struct ServerOptions {
+    /// When true, hide `codex`/`codex-reply` and expose only code-editing tools in the MCP tool catalog.
+    pub code_tools_only: bool,
+}
+
 pub async fn run_main(
     codex_linux_sandbox_exe: Option<PathBuf>,
     cli_config_overrides: CliConfigOverrides,
+    server_options: ServerOptions,
 ) -> IoResult<()> {
     // Install a simple subscriber so `tracing` output is visible.  Users can
     // control the log level with `RUST_LOG`.
@@ -104,6 +111,7 @@ pub async fn run_main(
             outgoing_message_sender,
             codex_linux_sandbox_exe,
             std::sync::Arc::new(config),
+            server_options,
         );
         async move {
             while let Some(msg) = incoming_rx.recv().await {

--- a/codex-rs/mcp-server/src/main.rs
+++ b/codex-rs/mcp-server/src/main.rs
@@ -1,10 +1,16 @@
 use codex_arg0::arg0_dispatch_or_else;
 use codex_common::CliConfigOverrides;
+use codex_mcp_server::ServerOptions;
 use codex_mcp_server::run_main;
 
 fn main() -> anyhow::Result<()> {
     arg0_dispatch_or_else(|codex_linux_sandbox_exe| async move {
-        run_main(codex_linux_sandbox_exe, CliConfigOverrides::default()).await?;
+        run_main(
+            codex_linux_sandbox_exe,
+            CliConfigOverrides::default(),
+            ServerOptions::default(),
+        )
+        .await?;
         Ok(())
     })
 }

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -76,6 +76,15 @@ env = { "API_KEY" = "value" }
 
 The Codex CLI can also be run as an MCP _server_ via `codex mcp`. For example, you can use `codex mcp` to make Codex available as a tool inside of a multi-agent framework like the OpenAI [Agents SDK](https://platform.openai.com/docs/guides/agents).
 
+> Note
+> By default, the MCP catalog includes the conversation tools `codex` and `codex-reply` alongside code‑editing helpers. If you need a minimal, code‑tools‑only surface (e.g., in constrained hosts), launch with:
+>
+> ```bash
+> codex mcp serve --code-tools-only
+> ```
+>
+> This hides `codex`/`codex-reply` from the MCP catalog while keeping code‑editing tools available.
+
 ### Codex MCP Server Quickstart
 You can launch a Codex MCP server with the [Model Context Protocol Inspector](https://modelcontextprotocol.io/legacy/tools/inspector):
 

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -77,13 +77,13 @@ env = { "API_KEY" = "value" }
 The Codex CLI can also be run as an MCP _server_ via `codex mcp`. For example, you can use `codex mcp` to make Codex available as a tool inside of a multi-agent framework like the OpenAI [Agents SDK](https://platform.openai.com/docs/guides/agents).
 
 > Note
-> By default, the MCP catalog includes the conversation tools `codex` and `codex-reply` alongside code‑editing helpers. If you need a minimal, code‑tools‑only surface (e.g., in constrained hosts), launch with:
+> By default, the MCP catalog includes the conversation tools `codex` and `codex-reply` alongside code-editing helpers. If you need a minimal, code-tools-only surface (e.g., in constrained hosts), launch with:
 >
 > ```bash
 > codex mcp serve --code-tools-only
 > ```
 >
-> This hides `codex`/`codex-reply` from the MCP catalog while keeping code‑editing tools available.
+> This hides `codex`/`codex-reply` from the MCP catalog while keeping code-editing tools available.
 
 ### Codex MCP Server Quickstart
 You can launch a Codex MCP server with the [Model Context Protocol Inspector](https://modelcontextprotocol.io/legacy/tools/inspector):

--- a/docs/sangoi/docs/LAST_SESSION.md
+++ b/docs/sangoi/docs/LAST_SESSION.md
@@ -1,0 +1,181 @@
+# Last Session Summary — Compact Roadmap Progress
+
+This document captures exactly what was implemented in this session, how to validate it, and the logical next steps to continue the COMPact roadmap in the next session. All paths below are relative to `work/codex`.
+
+---
+
+## What Changed (today)
+
+- Token estimator and compaction report (PR 1 scope)
+  - Added a provider‑agnostic token estimator and a small `CompactionReport`:
+    - `codex-rs/core/src/compact/estimate.rs`
+    - `codex-rs/core/src/compact/mod.rs` (exports + completion message formatter)
+  - The `/compact` flow now prints an estimated before/after delta and, when the model context window is known, the remaining percentage before and after compaction.
+
+- Pins and retention (PR 2, first slice)
+  - Protocol: new operations
+    - `Op::PinLast` — pin the most recent message that still retains a provider id.
+    - `Op::UnpinAll` — clear all pins.
+  - Core session state
+    - `pinned_message_ids: HashSet<String>` added to session `State`.
+  - Compaction behavior
+    - After the existing summarize step, history is rebuilt as: pinned messages from pre‑compaction history + the last message (tail(1)), with dedupe by first text content to avoid duplicates.
+  - TUI slash commands
+    - `/pin` → sends `Op::PinLast`.
+    - `/unpin` → sends `Op::UnpinAll`.
+    - Files: `codex-rs/tui/src/slash_command.rs`, `codex-rs/tui/src/chatwidget.rs`.
+
+- Dry‑run compaction (controller‑level, preview only)
+  - Protocol: `Op::CompactDryRun`.
+  - TUI: `/compact-dry-run`.
+  - Core handler computes before/after estimates as if we kept tail(1)+pins, and prints a report; it does not modify history.
+
+- Snapshot scaffolding (PR 3 prep)
+  - `codex-rs/core/src/compact/snapshot.rs` with:
+    - `SummaryV1` struct matching the plan’s JSON wire schema.
+    - `persist_snapshot_atomic(codex_home, snapshot)` with atomic write (`*.tmp` → fsync → rename → fsync parent).
+  - Exported via `compact::mod.rs`. Currently staged (emits an unused‑exports warning) to be wired in PR 3.
+
+- Tests
+  - Core E2E additions: `pinned_message_survives_compaction`:
+    - Verifies that a pinned assistant message remains visible to the next request after `/compact`.
+    - File: `codex-rs/core/tests/suite/compact.rs`.
+
+---
+
+## Validation Performed
+
+- Formatting
+  - `cargo fmt --all`
+
+- Tests (local run)
+  - `cargo test -p codex-core` → 189 passed, 0 failed
+  - `cargo test -p codex-tui` → 237 passed, 0 failed
+  - Notes: a few long‑running integration tests (“running for over 60 seconds”) are expected; they completed successfully.
+
+- Warnings
+  - Unused exports in `compact::snapshot` (staged for PR 3).
+  - Safe to ignore until we wire snapshot synthesis + persistence.
+
+---
+
+## Usage Notes (new capabilities)
+
+- Pinning critical context
+  - Type `/pin` to pin the most recent message that still has a provider id.
+  - Type `/unpin` to clear all pins.
+
+- Compaction
+  - `/compact` now prints: `Compaction complete: ~X → ~Y tokens; saved ~Z; remaining A% → B%` when context window is known.
+  - Pinned messages are preserved across compaction.
+
+- Dry‑run
+  - `/compact-dry-run` prints the same delta without altering history.
+
+---
+
+## How To Proceed (next session)
+
+The plan continues through PR 2 (remaining keep‑set features), PR 3 (snapshot synthesis), PR 4 (hierarchical compaction proper), and PR 5 (auto‑compact + archive/restore). Below is the recommended order and concrete tasks/files.
+
+1) PR 2 — Keep‑set by role and file globs
+- Goal: Honor `--keep-roles` and `--keep-files` settings alongside pins.
+- Tasks
+  - Config surface
+    - Add config keys under `[compact]` to `codex-rs/core/src/config.rs` and config types in `config_types.rs`.
+    - Consider CLI flags for TUI or Exec modes (if required now) — or defer to config‑only for first pass.
+  - Keep‑set integration
+    - In `/compact` flow, compute a keep‑set = pins + messages matching roles + messages referencing files matching globs.
+    - Where to wire: `codex-rs/core/src/codex.rs` (inside `run_compact_task` after model completes and before rebuilding history).
+  - Tests
+    - Unit: role parsing, glob matching.
+    - Integration: feed conversation with tool/diff/decision and assert those survive compaction.
+
+2) PR 3 — Snapshot synthesis (SummaryV1)
+- Goal: Replace “one big summary message” with a structured snapshot stored to disk and a short recent tail in history.
+- Tasks
+  - Prompting
+    - Add a strict system prompt (see sangoi/plans/COMPACT.md §14) and a helper `synthesize_snapshot(session, clusters)`.
+    - Location: `codex-rs/core/src/compact/snapshot.rs` (new function) and a `prompt_for_snapshot.md` file (similar to existing `prompt_for_compact_command.md`).
+  - Persistence
+    - Use `persist_snapshot_atomic(codex_home, &snapshot)` to write `.codex/session.json`.
+  - History replacement
+    - Replace transcript in memory with `[snapshot_as_system_message] + tail(N)`; keep any pins.
+  - Tests
+    - Validate `SummaryV1` JSON structure, minimal required fields present.
+    - Snapshot survives reload (read session.json back and assert content).
+
+3) PR 4 — Hierarchical compaction + headroom guarantee
+- Goal: Implement anchor → cluster → synthesize → replace, and guarantee `min_headroom_tokens`.
+- Tasks
+  - Clustering module (time/topic windows) and a loop that collapses oldest clusters until headroom is met.
+  - Plumb `--max-tail` and `--min-headroom` (config fallback).
+  - Tests: headroom loop, “recall after compaction” with snapshot present.
+
+4) PR 5 — Auto‑compact + archive/restore
+- Goal: Preemptively compact when usage exceeds threshold.
+- Tasks
+  - Track token usage percent vs. configured threshold.
+  - On trigger, run compaction flow; write archive to `.codex/history/<ts>.jsonl`.
+  - Optional: `/history restore <ts>`.
+  - Tests: trigger path and archive readability.
+
+---
+
+## Minimal Dev Checklist (next session)
+
+- Build & test
+  - `cargo fmt --all`
+  - `cargo test -p codex-core`
+  - `cargo test -p codex-tui`
+  - Optionally: `cargo clippy -- -D warnings` (after snapshot wiring to eliminate the staged warnings)
+
+- Manual checks
+  - Run TUI and try `/pin`, `/compact-dry-run`, `/compact`, `/unpin` on a short conversation.
+
+- PR hygiene (from AGENTS.md)
+  - One concern per PR; keep diffs surgical.
+  - If you create a PR, use messages like `feat: compact pins + dry-run` and fill the PR template (What/Why/How/Tests/Perf).
+
+---
+
+## File Map (touched today)
+
+- Core
+  - `codex-rs/core/src/compact/estimate.rs`
+  - `codex-rs/core/src/compact/mod.rs`
+  - `codex-rs/core/src/compact/snapshot.rs`
+  - `codex-rs/core/src/codex.rs` (handlers for Compact, CompactDryRun, PinLast, UnpinAll; compaction rebuild logic; reporting)
+- Protocol
+  - `codex-rs/protocol/src/protocol.rs` (new `Op` variants)
+- TUI
+  - `codex-rs/tui/src/slash_command.rs` (added `/pin`, `/unpin`, `/compact-dry-run`)
+  - `codex-rs/tui/src/chatwidget.rs` (dispatch ops)
+- Tests
+  - `codex-rs/core/tests/suite/compact.rs` (added `pinned_message_survives_compaction`)
+
+---
+
+## Known Constraints / Non‑Goals (unchanged)
+
+- Snapshot is not yet synthesized from the model (staged for PR 3).
+- Keep‑files/keep‑roles flags not yet present (next PR 2 slice).
+- No changes were made to sandbox env var logic (`CODEX_SANDBOX_*`).
+
+---
+
+## Quick Start (next session)
+
+1) Pull latest and build
+- `cargo fmt --all`
+- `cargo test -p codex-core -p codex-tui`
+
+2) Pick the next PR target
+- For fastest progress, start with PR 2 keep‑set flags, then PR 3 snapshot synthesis.
+
+3) Implementation pointers
+- Keep‑set: add config + helpers; wire into `run_compact_task` before rebuilding history.
+- Snapshot: add a new prompt file and a `synthesize_snapshot(..)` function; call it during `/compact` and persist via `persist_snapshot_atomic`.
+
+This should be everything needed to resume quickly next time.
+

--- a/docs/sangoi/docs/MAINTAINERS_REVIEW_BIBLE.md
+++ b/docs/sangoi/docs/MAINTAINERS_REVIEW_BIBLE.md
@@ -1,0 +1,137 @@
+# MAINTAINERS_REVIEW_BIBLE.md
+_What Codex maintainers consistently expect in reviews. Read this **before** writing code or opening a PR._
+
+## 0) Review reality check
+- Keep PRs **narrowly scoped** and incremental. If you’re solving two different problems, split into two PRs.
+- Rust-first: improvements to the native `codex-rs` path are prioritized over TypeScript unless parity or protocol requires TS changes.
+- CLA must be signed; no CLA, no merge.
+- A clear, testable “What/Why/How” in the PR description is not optional.
+
+---
+
+## 1) Scope & structure the maintainers reward
+- **One concern per PR.** Big refactors should be staged across several PRs.
+- **Forward-compatible naming** so future extensions don’t need breaking changes (e.g., prefer `startup_timeout_ms` over a generic `timeout_ms`).
+- **Staged migrations** for protocol/type changes: introduce the new path, keep old behavior temporarily, then clean up in a follow-up PR.
+
+---
+
+## 2) Naming, flags, and config semantics
+- Prefer **positive** flags over “negative-sense” toggles (`--enable-x` rather than `--no-x` when feasible).
+- Avoid “bool soup.” Use enums/newtypes for multi-state behavior.
+- Back-compat quirks belong in **config loading/migration**, **not** in hot-path logic.
+
+---
+
+## 3) Shell & portability (review hot-buttons)
+- **Quote paths** that may contain spaces; when generating shell commands, ensure proper quoting/escaping.
+- Prefer **`.`** over `source` for POSIX portability.
+- Avoid time-of-check/time-of-use races: test file existence **at execution**, not earlier. Example idiom:
+
+```
+\[ -f "\${rc\_path}" ] && . "\${rc\_path}" && ( your\_command\_here )
+```
+
+- Aim for **POSIX-consistent** behavior; avoid zsh/bash-specific leakage unless gated and documented.
+
+---
+
+## 4) Tests: determinism beats cleverness
+- Unit tests should be **predictable**: inject environment and inputs; avoid branching logic inside tests.
+- Use stable IDs (e.g., a nil/constant UUID) where determinism matters.
+- Prefer golden/snapshot tests for CLI text output; keep outputs stable and explicit.
+
+---
+
+## 5) Protocol/types (Rust ↔ TS) and API casing
+- When serializing to match the OpenAI API, preserve required **`snake_case`** in the wire format.
+- It’s acceptable (preferred) to **stage** protocol changes: temporarily support both old and new messages, then remove legacy paths in a follow-up.
+- Keep public surfaces small; prefer well-typed builders for complex options over bool-flag pileups.
+
+---
+
+## 6) Rust guidance (house style distilled)
+- **Clippy-clean** builds (treat warnings as errors in CI).
+- **Error-first** flow: early returns with `anyhow/thiserror`. No `unwrap/expect` outside tests or one-time boot code.
+- Avoid unnecessary allocations/copies: borrow by default, preallocate where hot, and measure changes.
+- Concurrency with minimal contention; use `parking_lot` if justified by profiling.
+- `unsafe` only as a last resort, smallest scope, with a `// SAFETY:` block explaining invariants and tests that would catch violations.
+- Logs are quiet by default; detailed under `--verbose` or `RUST_LOG`. Prefer structured fields over string concat spam.
+
+---
+
+## 7) Filesystem & atomic writes
+- For files you create/modify: write to `*.tmp`, `fsync` file, `fsync` parent dir, then atomically `rename` to the final path.
+- Preserve EOL/encoding and avoid surprising diffs. Validate space/permissions early when possible.
+
+---
+
+## 8) CLI UX & output rules
+- Provide `--dry-run` for operations that could alter state.
+- Output should be deterministic, scriptable, and explicit. Avoid mixing progress bars and verbose logs unless gated.
+- Exit codes: `0` on success; nonzero on failure with an actionable error line.
+
+---
+
+## 9) Anti-patterns that trigger “changes requested”
+- Bundling unrelated changes in one PR.
+- Clever shell without proper quoting or with `source` assumptions.
+- Tests with hidden branching or non-deterministic IDs.
+- Renaming for aesthetics only; churning identifiers without necessity.
+- “Optimizations” without benchmarks or that reduce readability.
+
+---
+
+## 10) Ready-to-merge checklist
+- [ ] **Scope:** one concern; if you touched two areas, split PRs.
+- [ ] **Naming:** forward-compatible; avoid negative-sense flags; prefer typed enums over bool soup.
+- [ ] **Config:** back-compat handled during load/migration, not sprinkled in runtime logic.
+- [ ] **Shell:** paths quoted; `.` over `source`; file existence checked at execution time.
+- [ ] **Tests:** deterministic; no `if` branches; stable IDs; golden tests for CLI output if relevant.
+- [ ] **Protocol:** correct casing on the wire; staged migrations where needed.
+- [ ] **Rust hygiene:** clippy/fmt clean; no unnecessary allocations/copies; errors with actionable context.
+- [ ] **FS safety:** atomic writes; preserve encoding/EOL.
+- [ ] **PR body:** “What/Why/How,” files touched, and any staged follow-ups.
+- [ ] **CLA:** signed and green.
+
+---
+
+## 11) PR description template (paste this into your PR)
+
+```markdown
+# What
+- [Concise list of concrete changes; modules/files touched]
+- [If staged: what lands now vs. what follows]
+
+# Why
+- [User impact, correctness, or performance motivation; link issues]
+
+# How
+- [Minimal viable approach; shell portability notes; determinism in tests; atomic writes]
+- [Perf notes if applicable: before/after metrics, methodology]
+
+# Tests
+- [Unit/golden/properties added or updated; determinism measures]
+
+# Follow-ups
+- [Exact next steps if staging a migration or larger feature]
+```
+
+---
+
+## 12) Patterns to emulate (seen in approved PRs)
+
+* Incremental steps that unlock downstream work.
+* Early convergence on naming and option semantics before touching too many files.
+* Protocol changes done in **phases** with temporary dual paths, then cleanup.
+* “Trivial” protocol/codegen fixes accompanied by proof that generated output remains identical.
+
+---
+
+## 13) TL;DR for the impatient
+
+* Quote shell paths; use `.` not `source`.
+* Tests must be deterministic; inject inputs; stable IDs.
+* Keep wire casing correct; stage migrations.
+* Borrow > copy; measure “perf” claims.
+* One concern per PR; small and mergeable beats grand and blocked.

--- a/docs/sangoi/docs/PR_DRAFT.md
+++ b/docs/sangoi/docs/PR_DRAFT.md
@@ -1,0 +1,84 @@
+# feat: compact estimator, pins, and dry-run; snapshot scaffolding
+
+## What
+- Add provider‑agnostic token estimator and `CompactionReport` with human‑readable completion message
+  - `codex-rs/core/src/compact/{estimate.rs,mod.rs}`
+- Add pins + retention (first slice) and preserve pins across `/compact`
+  - Core state: `pinned_message_ids`
+  - Protocol ops: `Op::PinLast`, `Op::UnpinAll`
+  - TUI: `/pin`, `/unpin`
+- Add `/compact-dry-run` (preview compaction delta without changing history)
+  - Protocol op: `Op::CompactDryRun`
+  - TUI: `/compact-dry-run`
+  - Core handler computes tail(1)+pins estimate and reports delta
+- Snapshot scaffolding for PR 3
+  - `codex-rs/core/src/compact/snapshot.rs` with `SummaryV1` + atomic `persist_snapshot_atomic(...)`
+- Tests
+  - Core E2E: `pinned_message_survives_compaction` (pins persist through `/compact`)
+- Key files touched
+  - Core: `core/src/codex.rs`, `core/src/compact/{estimate.rs,mod.rs,snapshot.rs}`
+  - Protocol: `protocol/src/protocol.rs` (new `Op`s)
+  - TUI: `tui/src/{slash_command.rs,chatwidget.rs}`
+  - Tests: `core/tests/suite/compact.rs`
+
+## Why
+- Current `/compact` gives no quantitative feedback and can drop critical context.
+- Pins enable user‑directed retention; dry‑run builds confidence by showing impact before committing.
+- Snapshot scaffolding prepares for structured, durable state (`summary_v1`) in upcoming PR.
+
+## How
+- Estimator: simple, deterministic ≈4 chars/token heuristic over `ResponseItem` content; zero deps, provider‑agnostic.
+- Compaction flow now:
+  - Run existing summarize turn.
+  - Rebuild history as pinned‑messages (from pre‑compact) + tail(1), with first‑text dedupe.
+  - Emit completion line with before/after estimates and `%` when context window is known.
+- Dry‑run:
+  - Simulate tail(1)+pins; compute/report delta; no history mutation.
+- Snapshot:
+  - Implemented `SummaryV1` type + atomic writer (`*.tmp` → fsync → rename → fsync parent). Not wired yet.
+- Protocol extended with non‑breaking enum variants; TUI dispatches corresponding ops.
+
+## Tests
+- Unit
+  - Estimator basic cases; snapshot atomic write smoke test.
+- Integration
+  - `pinned_message_survives_compaction`: verifies pinned assistant message remains visible after `/compact`.
+  - Full suites executed:
+    - `codex-core`: 189 passed, 0 failed
+    - `codex-tui`: 237 passed, 0 failed
+- Snapshots: no intentional TUI snapshot changes required for this slice.
+
+## Perf
+- No hot‑path changes outside `/compact` turns and explicit dry‑run calls.
+- Estimator is linear in history size and runs only when invoked.
+- No measurable UI regressions expected; binaries unchanged aside from small code additions.
+
+## Follow-ups
+- PR 2 (rest): keep‑set by config/flags
+  - `--keep-roles` (e.g., `tool,diff,decision`) and `--keep-files "<glob,glob>"`, wire into `/compact` keep‑set alongside pins.
+- PR 3: snapshot synthesis
+  - Strict system prompt to emit `SummaryV1`; persist via `persist_snapshot_atomic`; replace history with `[snapshot_as_system_message] + tail(N)` and keep pins.
+- PR 4: hierarchical compaction + headroom guarantee
+  - Anchor → cluster → synthesize → replace; ensure `min_headroom_tokens`.
+- PR 5: auto‑compact + archive/restore
+  - Trigger on threshold; archive full pre‑compact history to `.codex/history/<ts>.jsonl`; optional restore.
+
+---
+
+To open the PR manually after pushing the branch:
+
+```bash
+# If needed, set your git identity (already set locally as repo‑scoped):
+# git config user.name "<your-name>"
+# git config user.email "<your-email>"
+
+# Push branch (if not already pushed)
+git push -u origin feat/compact-pins-dryrun
+
+# Then create the PR (choose web or gh CLI):
+# Web: open the GitHub compare page for feat/compact-pins-dryrun → master and paste this body.
+# gh CLI (if installed and authenticated):
+# gh pr create --base master --head feat/compact-pins-dryrun \
+#   --title "feat: compact estimator, pins, and dry-run; snapshot scaffolding" \
+#   --body-file sangoi/docs/PR_DRAFT.md
+```

--- a/docs/sangoi/docs/RUST-CHEATBOOK.md
+++ b/docs/sangoi/docs/RUST-CHEATBOOK.md
@@ -1,0 +1,336 @@
+# docs/codex/RUST-CHEATBOOK.md
+
+> Canonical playbook for codex-rs contributors. Read this first, then act. Keep code fast, small, and boring.
+
+## 0) Ground rules
+
+* English-only for identifiers, comments, error messages, logs, CLI output.
+* KISS. No function parkour. Prefer singletons only when they reduce state churn.
+* Don’t rename public API/identifiers unless strictly necessary and documented.
+* Error-first: fail fast with explicit context. No “magical fallbacks.”
+* Measure before bragging. Every “perf” claim needs numbers.
+
+---
+
+## 1) Build profiles and compile-time tuning
+
+**Cargo.toml** (suggested):
+
+```toml
+[profile.release]
+opt-level = 3
+lto = "thin"
+codegen-units = 1
+strip = "symbols"
+panic = "abort"
+
+[profile.dev]
+debug = 1
+opt-level = 0
+lto = false
+```
+
+Optional portability knobs:
+
+* Local dev: `RUSTFLAGS="-C target-cpu=native"` for max perf on your box.
+* PGO: guard behind a dedicated profile/feature and document exact steps/workload.
+
+---
+
+## 2) Allocation, copies, and strings
+
+* Prefer `&str`, `&[T]`, iterators; avoid `to_string()`, `to_vec()`, `clone()` unless necessary.
+* Preallocate with `with_capacity`/`reserve_exact` on hot paths.
+* Consider `SmallVec`, `SmallString`/`SmartString` for tiny, frequent buffers (only with benchmark evidence).
+* Use `Cow<'_, str>` to borrow by default; own only on mutation.
+* Avoid `format!` in loops; use `write!`/`format_args!` into preallocated buffers.
+
+**Don’t:**
+
+* Build large strings just to slice them later.
+* Copy `PathBuf`/`String` around when `&Path`/`&str` suffice.
+
+---
+
+## 3) Collections and hashing
+
+* Default `HashMap` is fine; prefer `BTreeMap` for predictable order or small keys with cache-friendly scans.
+* `indexmap` only if order is semantically required.
+* Fast hashers (`fxhash`/`ahash`) only behind `feature = "fast-hash"` and only with benchmark proof. Never as default on untrusted input.
+
+---
+
+## 4) Errors and result flow
+
+* Library-like errors: `thiserror` enums. CLI edges: `anyhow::Result` with `.context("what failed and why")`.
+* No `unwrap()/expect()` outside tests and one-time boot code.
+* Use `bail!`/`ensure!` for guardrails.
+* Error messages: actionable, include inputs and key state (redact secrets).
+
+**Template:**
+
+```rust
+use anyhow::{Result, Context, bail, ensure};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum SnapshotError {
+    #[error("invalid schema: {0}")]
+    InvalidSchema(String),
+    #[error("io error: {0}")]
+    Io(#[from] std::io::Error),
+}
+
+pub fn load_snapshot(p: &std::path::Path) -> Result<SummaryV1> {
+    let data = std::fs::read(p).with_context(|| format!("reading snapshot file: {}", p.display()))?;
+    let s: SummaryV1 = serde_json::from_slice(&data)
+        .context("parsing SummaryV1 JSON")?;
+    Ok(s)
+}
+```
+
+---
+
+## 5) Logging, tracing, and diagnostics
+
+* Use `tracing` with targets and levels; quiet by default, verbose under `--verbose` or `RUST_LOG`.
+* Annotate hot functions with `#[tracing::instrument(skip(huge_struct))]` only when useful; avoid noise.
+* Prefer structured fields: `info!(task=%id, "message")` instead of string concat spam.
+
+---
+
+## 6) CLI UX (clap) and output rules
+
+* Flags explicit and typed; avoid boolean soup. Use enums/newtypes.
+* Always provide `--dry-run` for potentially destructive ops.
+* Deterministic, testable output. No randomness unless seeded and printed.
+* Exit codes: 0 success, nonzero with clear error lines.
+
+**Progress bars:** `indicatif` with sane refresh rate. Never spam logs and progress simultaneously.
+
+---
+
+## 7) Filesystem and atomic writes
+
+* Write to `file.tmp`, `fsync` the file, `fsync` parent dir, then `std::fs::rename` to final.
+* Preserve EOL/encoding on patching. Validate space and permission errors up front when possible.
+
+**Skeleton:**
+
+```rust
+use std::{fs, io::Write, path::Path};
+
+pub fn atomic_write(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    let tmp = path.with_extension("tmp");
+    {
+        let mut f = fs::File::create(&tmp)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
+    }
+    // fsync parent dir for durability
+    if let Some(dir) = path.parent() {
+        fs::OpenOptions::new().read(true).open(dir)?.sync_all()?;
+    }
+    fs::rename(tmp, path)?;
+    Ok(())
+}
+```
+
+---
+
+## 8) Concurrency
+
+* CPU-bound parallelism: prefer `rayon` or scoped threads; avoid global contention.
+* Use `parking_lot` locks if lock-heavy and justified by profiling.
+* Never fake Send/Sync. If you must, document invariants and test race-y paths.
+
+---
+
+## 9) Unsafe code policy
+
+* Last resort only; smallest possible scope.
+* Mandatory `// SAFETY:` doc block explaining invariants and why it’s correct.
+* Add tests that would explode if invariants break (Miri-friendly when possible).
+
+---
+
+## 10) Profiling and benchmarking
+
+**One-liners:**
+
+```
+cargo bench
+```
+
+```
+cargo llvm-lines -p codex-rs
+```
+
+```
+cargo bloat -p codex-rs --release -n 20
+```
+
+```
+cargo flamegraph -p codex-rs --bench <name>
+```
+
+```
+hyperfine "target\\release\\codex.exe /compact --dry-run"
+```
+
+Measure p50/p95 latency, allocations (if available), and RSS/WS. Commit numbers in the PR description.
+
+---
+
+## 11) Feature flags and build-time toggles
+
+* Perf toys behind `--features perf` or `FAST_HASH`, off by default.
+* Keep a portable default build. Non-portable opts (PGO, `target-cpu=native`) opt-in only.
+
+---
+
+## 12) API design patterns
+
+* Use newtypes for typed IDs instead of strings.
+* Builders for optional params; sane defaults.
+* No implicit globals; if singleton, make it explicit and testable.
+
+---
+
+## 13) Test strategy
+
+* Unit tests for hot logic and error edges.
+* Golden tests for CLI output snapshots (stable files).
+* Property tests (`proptest`) for parsers and reducers.
+* Regression tests for “recall after compaction” semantics.
+
+---
+
+## 14) Lints, CI, hygiene
+
+**One-liners:**
+
+```
+cargo fmt --all
+```
+
+```
+cargo clippy -- -D warnings
+```
+
+```
+cargo udeps -p codex-rs
+```
+
+```
+cargo deny check
+```
+
+```
+cargo outdated -wR
+```
+
+---
+
+## 15) Determinism & reproducibility
+
+* Sort outputs when order is not semantically meaningful.
+* Seed RNG where needed and print the seed.
+* Avoid wall-clock in tests; use fixed timestamps or inject a clock.
+
+---
+
+## 16) Review/PR checklist
+
+* [ ] Clippy clean, fmt applied.
+* [ ] Bench before/after with numbers in PR body.
+* [ ] No Portuguese in code/comments/logs/output.
+* [ ] Atomic writes for files touched.
+* [ ] Error messages actionable.
+* [ ] Flags documented in CODEX.md.
+* [ ] Tests for new branches and error cases.
+* [ ] No gratuitous renames; migration notes if any.
+
+---
+
+## 17) Don’ts
+
+* Don’t enable “fast hashers” globally.
+* Don’t slap `#[inline(always)]` everywhere.
+* Don’t use `unsafe` to silence the borrow checker.
+* Don’t log secrets or dump giant blobs.
+* Don’t rely on `token_usage` presence without a local estimator fallback.
+
+---
+
+## 18) Quick snippets
+
+**Result alias:**
+
+```rust
+pub type Result<T> = anyhow::Result<T>;
+```
+
+**Guard macros:**
+
+```rust
+macro_rules! check {
+    ($cond:expr, $($arg:tt)*) => {
+        if !$cond { anyhow::bail!($($arg)*); }
+    }
+}
+```
+
+**Borrow-friendly JSON:**
+
+```rust
+#[derive(serde::Deserialize)]
+struct Foo<'a> {
+    #[serde(borrow)]
+    name: std::borrow::Cow<'a, str>,
+}
+```
+
+**Time-limited work (coarse):**
+
+```rust
+// use a deadline and poll; avoid blocking indefinitely in CLI paths
+```
+
+---
+
+Use this cheatbook as constraints, not decoration. If you “optimize” without measuring, you’re guessing.
+
+---
+
+## 19) Minimal perf measurement recipe (example)
+
+```
+hyperfine --warmup 3 "target\\release\\codex.exe /compact --dry-run"
+```
+
+```
+cargo bloat -p codex-rs --release -n 15
+```
+
+Record deltas in PR: p50/p95, alloc count (if measured), binary size, and hotspots from flamegraph.
+
+---
+
+## 20) Atomic change script (local)
+
+```
+cargo fmt --all
+```
+
+```
+cargo clippy -- -D warnings
+```
+
+```
+cargo build -p codex-rs --release
+```
+
+```
+cargo test -p codex-rs
+```

--- a/docs/sangoi/plans/COMPACT.md
+++ b/docs/sangoi/plans/COMPACT.md
@@ -1,0 +1,384 @@
+# ROADMAP.md — Compact without amnesia
+
+Design and implementation plan to replace the current `/compact` behavior with **hierarchical compaction + structured snapshot**, preserving working memory and preventing “context lobotomy.”
+
+> Artifacts: English-only. User may speak Portuguese; translate intent, keep code/docs in English.
+
+---
+
+## 1) Scope
+
+Deliver a robust `/compact` that:
+- Preserves key project state via a **structured snapshot** instead of a monolithic paragraph.
+- Supports **pins** (messages and files that must never be collapsed).
+- Provides **predictable UX**: `--dry-run`, clear completion message, and progress.
+- Works even when the provider omits `token_usage` via a **local token estimator**.
+- Adds **auto-compact** before context exhaustion to avoid late, lossy compaction.
+- Stores durable state out of chat (`.codex/session.json`) and archives history.
+
+**Non-goals**
+- Model-specific optimization beyond generic token budgeting.
+- Broad refactors of unrelated TUI features.
+- Changing sandbox/network policies or environment var logic.
+
+---
+
+## 2) Problem statement (today’s `/compact`)
+
+- Monolithic summary erases **decisions, constraints, TODOs, file/symbol map**.
+- No **pinning** or retention policy; critical diffs disappear.
+- Manual, late usage; triggers after context is already overloaded.
+- Depends on `token_usage`; breaks when providers omit it.
+- UX is opaque: no preview, no clear “done,” no headroom guarantee.
+
+---
+
+## 3) Design overview
+
+**Core idea**: replace “one big summary” with a **snapshot JSON** plus a short recent tail of conversation.
+
+- **Structured snapshot (`summary_v1`)** persisted to `.codex/session.json`.
+- **Hierarchical compaction** with phases (anchor → cluster → synthesize → replace).
+- **Retention policies** via pins, roles, and file globs.
+- **Estimator** used when provider lacks `token_usage`.
+- **Auto-compact** threshold (default 85%) with a minimum headroom (default 2048 tokens).
+- **Archival** of full pre-compaction history to `.codex/history/<ts>.jsonl` and restore points.
+
+---
+
+## 4) Data model: `summary_v1` (wire schema)
+
+```json
+{
+  "task": "one-sentence current objective",
+  "decisions": ["decision A", "decision B"],
+  "constraints": ["limit X", "policy Y"],
+  "open_questions": ["question 1", "question 2"],
+  "todo": ["step 1", "step 2"],
+  "files_in_scope": [{"path": "src/foo.rs", "why": "reason"}],
+  "symbols": [{"name": "parse_user", "file": "src/auth.rs", "role": "fn"}],
+  "env": {"os": "win11", "toolchain": "rust stable", "node": "22.x"},
+  "assumptions": ["assumption A"],
+  "known_failures": ["flaky test T123"],
+  "last_compact_at": "ISO-8601 timestamp"
+}
+````
+
+**Rules**
+
+* JSON only; no comments.
+* Keep names and API flags verbatim.
+* Prefer concrete file paths and symbol names.
+
+---
+
+## 5) Algorithm (hierarchical compaction)
+
+1. **Anchor**
+
+   * Build a **keep set** = pins + messages with roles `tool`, `diff`, `decision` + file-glob matches.
+2. **Cluster**
+
+   * Group remaining messages by topic/session segment to summarize coherently.
+3. **Synthesize snapshot**
+
+   * Call model with a strict **system prompt** to emit `summary_v1` only.
+4. **Replace**
+
+   * New history = `[snapshot_as_system_msg] + tail(N)` of most recent relevant messages + pinned messages (already included).
+5. **Headroom**
+
+   * Ensure `min_headroom_tokens` after compaction; if not, collapse oldest clusters further until met.
+
+---
+
+## 6) UX & CLI/TUI
+
+**Commands**
+
+* `/compact --dry-run [--keep-files "<glob,glob>"] [--keep-roles "tool,diff,decision"] [--max-tail 12] [--min-headroom 2048]`
+* `/compact` (execute with the current or configured options)
+* `/pin <id|id..id>` and `/unpin <id|id..id>`
+* `/history restore <timestamp>` (optional follow-up PR)
+
+**Dry-run output**
+
+* Show token delta, kept/archived counts, and a preview of items affected.
+
+**Completion message**
+
+* `Compaction complete: 42k → 11k tokens; kept 12; archived 98; headroom 2,048`
+
+**Progress**
+
+* Deterministic steps with a progress bar (e.g., `indicatif`), gated behind `--verbose`.
+
+---
+
+## 7) Persistence
+
+* Snapshot: `.codex/session.json` (overwrites atomically).
+* Archive: `.codex/history/<timestamp>.jsonl` (full pre-compaction log).
+* Atomic writes: `*.tmp` → `fsync` → `fsync` parent → `rename`.
+
+---
+
+## 8) Token estimation fallback
+
+When `token_usage` is absent:
+
+* **Preferred**: local tokenizer (feature-gated, e.g., `tiktoken-rs`) with a graceful fallback.
+* **Fallback**: heuristic estimate (e.g., chars/4) for headroom decisions.
+* Estimator scoped behind `--features token-estimator` for portability.
+
+---
+
+## 9) Config (`~/.codex/config.toml`)
+
+```toml
+[compact]
+mode = "hierarchical"
+min_headroom_tokens = 2048
+max_tail_messages = 12
+keep_roles = ["tool","diff","decision"]
+keep_files_glob = ["AGENTS.md","src/**","tests/**"]
+auto_compact_threshold_pct = 0.85
+```
+
+Runtime flags override config for the current session.
+
+---
+
+## 10) Safety & constraints
+
+* Do not touch sandbox env logic:
+
+  * `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR`
+  * `CODEX_SANDBOX_ENV_VAR`
+* No destructive resets.
+* English-only artifacts.
+* Atomic file operations; preserve EOL/encoding.
+
+---
+
+## 11) Test plan
+
+**Unit**
+
+* `estimate_tokens` with and without provider usage.
+* Pin policies: `--keep-roles`, file globs, `/pin` ranges.
+* Snapshot synthesis: valid JSON, required fields present.
+* Tail selection and headroom guarantee.
+
+**Integration**
+
+* “Recall after compaction”:
+
+  * Given decisions/files before compaction, agent can still answer queries after compaction.
+* Dry-run preview correctness.
+* Auto-compact at threshold; no thrash.
+
+**TUI snapshot tests (insta)**
+
+* New messages (dry-run report, completion message) golden-tested.
+* Deterministic formatting.
+
+**Failure modes**
+
+* Provider returns malformed output → error-first messages, no state corruption.
+* Disk errors → atomicity ensures no partial writes.
+
+---
+
+## 12) Metrics & Bench
+
+Measure before/after:
+
+* Time to compact (p50, p95).
+* Tokens saved; resulting headroom.
+* Memory deltas (if applicable).
+* Incidental: binary size and hot symbols (`cargo bloat/llvm-lines`).
+
+**Commands**
+
+```
+hyperfine --warmup 3 "target\\release\\codex.exe /compact --dry-run"
+```
+
+```
+cargo bloat -p codex-rs --release -n 20
+```
+
+Record numbers in PR body.
+
+---
+
+## 13) Implementation plan (small, mergeable PRs)
+
+**PR 1 — Scaffolding & Estimator**
+
+* `codex-rs/compact/estimate.rs`: local estimator + provider fallback.
+* `CompactionReport` struct + `--dry-run` plumbing (prints before/after estimates).
+* TUI: print completion message (no snapshot yet).
+
+**Acceptance**
+
+* Dry-run prints planned delta; no panics when `token_usage` is missing.
+
+---
+
+**PR 2 — Pins & Retention Policies**
+
+* `/pin` and `/unpin` commands + serialization of pinned IDs.
+* `--keep-roles`, `--keep-files` parsed and applied in keep set.
+
+**Acceptance**
+
+* Pinned messages and globs are never compacted away.
+
+---
+
+**PR 3 — Snapshot synthesis (summary\_v1)**
+
+* `snapshot.rs` with `SummaryV1` + `synthesize_snapshot(session, clusters)`.
+* Strict system prompt; JSON-only enforcement.
+* `session.json` persisted via atomic write.
+
+**Acceptance**
+
+* Snapshot is valid JSON; includes decisions/files/symbols; survives reload.
+
+---
+
+**PR 4 — Hierarchical compaction & tail**
+
+* Clustering logic; replacement history = `snapshot_as_system_msg + tail(N)`.
+* Headroom guarantee loop until `min_headroom_tokens`.
+
+**Acceptance**
+
+* After compaction, headroom ≥ configured minimum; recall tests pass.
+
+---
+
+**PR 5 — Auto-compact + archive/restore**
+
+* Auto-compact at threshold; `.codex/history/<ts>.jsonl`.
+* Optional `/history restore <ts>` (or follow-up PR 6).
+
+**Acceptance**
+
+* Auto-compact triggers preemptively; archive exists and is readable.
+
+---
+
+**PR 6 — Polish & Docs**
+
+* README/CODEX.md sections, flags help, examples.
+* Final insta snapshots; review bible links.
+
+---
+
+## 14) System prompt (for snapshot synthesis)
+
+```
+SYSTEM: You distill the persistent state of a software project.
+
+Output: valid JSON matching the SummaryV1 schema. No comments, no prose.
+
+Include: current task (1 sentence), decisions, constraints, open_questions,
+todo, files_in_scope [{path, why}], symbols [{name, file, role}], env, assumptions,
+known_failures, last_compact_at (ISO-8601).
+
+Rules: keep exact API names/flags/paths; remove redundancy; only confirmed facts.
+```
+
+---
+
+## 15) Module layout (proposed)
+
+```
+codex-rs/
+  compact/
+    mod.rs
+    estimate.rs          // token estimator fallback
+    pins.rs              // /pin /unpin, keep set
+    cluster.rs           // topic/time clustering
+    snapshot.rs          // SummaryV1 + synthesize_snapshot(...)
+    archive.rs           // history archive + restore
+    replace.rs           // replace history with snapshot + tail
+```
+
+---
+
+## 16) CLI flags (help text draft)
+
+* `--dry-run` Show what would change and the token delta; no state change.
+* `--keep-files <globs>` Comma-separated globs to exclude from compaction.
+* `--keep-roles <roles>` Roles to keep (default: `tool,diff,decision`).
+* `--max-tail <n>` Keep last N recent messages (default: 12).
+* `--min-headroom <tokens>` Ensure at least this many tokens free (default: 2048).
+* `--auto-compact-threshold <0..1>` Trigger auto-compact when usage exceeds threshold (default: 0.85).
+
+---
+
+## 17) Risks & mitigations
+
+* **Model emits invalid JSON** → strict parse + retry once with stronger instruction; otherwise abort with clear error.
+* **Estimator inaccuracies** → conservative headroom; allow user override; log estimation source.
+* **Pin abuse grows history** → document that pins are user responsibility; expose counts in dry-run.
+* **Concurrency/race in file ops** → atomic writes and fsync parent; no partial commits.
+
+---
+
+## 18) Validation checklist (“done when”)
+
+* [ ] Dry-run shows accurate preview and deltas.
+* [ ] After compaction, headroom ≥ `min_headroom_tokens`.
+* [ ] Snapshot persists and answers recall tests.
+* [ ] Pins and globs are respected; diffs/decisions preserved.
+* [ ] Auto-compact triggers before context exhaustion.
+* [ ] No dependency on `token_usage` for correctness.
+* [ ] Insta snapshots and unit tests stable/deterministic.
+* [ ] Docs updated (README, CODEX.md, AGENTS.md), help text accurate.
+
+---
+
+## 19) Quick-run commands
+
+```
+cargo fmt --all
+```
+
+```
+cargo clippy -- -D warnings
+```
+
+```
+cargo build -p codex-rs --release
+```
+
+```
+cargo test -p codex-rs
+```
+
+```
+hyperfine --warmup 3 "target\\release\\codex.exe /compact --dry-run"
+```
+
+---
+
+## 20) CHALLENGE PROTOCOL (for reviewers and future changes)
+
+1. **Material risks/errors**
+   * Late, monolithic summaries destroy recall and break workflows.
+
+2. **Critical assumptions**
+   * Snapshot + small tail is sufficient to retain task state.
+   * Pins/globs cover the majority of “must keep” cases.
+
+3. **Highest-leverage adjustment**
+   * Structured snapshot + auto-compact + estimator fallback.
+
+4. **Minimal next steps**
+   * Land PR 1 (estimator + dry-run report), then PR 3 (snapshot) and PR 4 (hierarchical compaction).

--- a/docs/sangoi/plans/WEBSEARCH.md
+++ b/docs/sangoi/plans/WEBSEARCH.md
@@ -1,0 +1,305 @@
+# ROADMAP — Web Search Token Budget & Context Accounting
+
+Stabilize Codex behavior when using the `web_search` tool by separating **persisted vs transient** tokens, hard-capping tool payloads, and fixing UX so “remaining context” stops lying.
+
+> Artifacts: English-only. The user may speak Portuguese; translate intent, keep all code/docs in English.
+
+---
+
+## 1) Scope
+
+Deliver a robust, predictable integration for `web_search`:
+
+- Separate **persisted context** (carried to next turn) from **in-flight tool payload** (only for the current turn).
+- Add a **Token Budgeter** that caps `web_search` output by result and in total, with aggressive preprocessing and compression.
+- Show **two context meters** in TUI and `/status`: “Next turn” (persisted only) and “This turn (with tools)”.
+- Persist only **summaries with citations**; never persist raw page dumps into the prompt history.
+- Keep 0.30 series model window math intact; don’t regress underlying context calculations.
+
+**Non-goals**
+- Changing model, provider, or context window constants.
+- Re-architecting TUI outside of the minimal UI for dual meters.
+- Rewriting other tools.
+
+---
+
+## 2) Problem statement (observed on 0.30)
+
+- When `web_search` runs, “remaining context” drops to near-zero because the meter **counts the tool’s transient payload** inside that in-flight request.
+- On the next assistant turn (no new search), the meter “recovers,” because that transient payload was **not persisted**.
+- Users wrongly believe they must compact; they trigger lossy flows unnecessarily. UX is misleading.
+
+---
+
+## 3) Design overview
+
+**Fix accounting + limit the blast radius.**
+
+1) **Dual accounting**
+   - Track and display:
+     - `Next-turn context`: tokens from system + profile + persisted chat/history (+ baseline).
+     - `This-turn (with tools)`: `Next-turn` plus all transient tool payloads.
+2) **Token Budgeter for web_search**
+   - Hard caps on result count, tokens per result, and total tool tokens.
+   - Preprocess (strip HTML/boilerplate), focus windows around matches, deduplicate by URL.
+   - Compress to a short extractive summary **with citations**.
+   - Persist only the summary, never full raw content.
+3) **UX**
+   - Two meters in TUI and `/status`:
+     - `Next turn: XX% left` (the true budget you carry forward)
+     - `This turn (with tools): YY% left` (the temporary peak)
+   - Badge: `web payload: ~N tokens (capped)`
+
+---
+
+## 4) Data & accounting model
+
+### 4.1 Structures
+
+```rust
+pub struct ContextBudget {
+    pub model_context_window: usize,  // e.g., 272_000
+    pub baseline_tokens: usize,       // fixed overhead already modeled in 0.30
+    pub persisted_input_tokens: usize, // system + profile + persisted history
+    pub transient_tool_tokens: usize,  // this-turn-only tool payload
+}
+```
+
+### 4.2 Percent calculations
+
+```
+next_turn_pct = 1.0 - (baseline_tokens + persisted_input_tokens) / model_context_window
+this_turn_pct = 1.0 - (baseline_tokens + persisted_input_tokens + transient_tool_tokens) / model_context_window
+```
+
+* Display both. Use integer rounding consistent with existing UI.
+
+---
+
+## 5) Token Budgeter (web\_search)
+
+### 5.1 Defaults (configurable)
+
+* `max_results = 3`
+* `max_tokens_per_result = 2048`
+* `max_total_tokens = 8192`
+
+### 5.2 Preprocessing (deterministic)
+
+* Strip HTML; keep visible text only.
+* Drop boilerplate (nav/footer/legal) via simple heuristics.
+* Extract **windows** of 200–300 tokens around matched query terms; merge overlapping windows.
+* Deduplicate by canonical URL; keep first occurrence.
+
+### 5.3 Compression
+
+* Build a **bullet summary** with source-line citations.
+* Keep total tool payload ≤ `max_total_tokens`.
+* Persist into history only a compact `ToolSummary` object:
+
+  ```json
+  {
+    "tool": "web_search",
+    "summary": ["bullet 1", "bullet 2", "..."],
+    "citations": [{"title":"...", "url":"...", "note":"..."}],
+    "token_estimate": 972
+  }
+  ```
+* Keep full raw pages **out of** the prompt. Log raw content only under verbose tracing (not persisted).
+
+---
+
+## 6) UX & CLI/TUI
+
+* **/status** shows:
+
+  * `Next turn: XX% left (persisted only)`
+  * `This turn (with tools): YY% left`
+  * `web payload this turn: ~N tokens (capped at M)`
+* **TUI**:
+
+  * Two slim meters stacked with labels.
+  * Badge in the tool panel: `web payload: ~N / M tokens`.
+
+---
+
+## 7) Config (add to user config; overridable via flags)
+
+```toml
+[tools.web_search]
+enabled = true
+max_results = 3
+max_tokens_per_result = 2048
+max_total_tokens = 8192
+persist_raw_pages = false
+persist_tool_summary = true
+```
+
+Optional runtime flags:
+
+* `--web-max-results <N>`
+* `--web-max-tokens-per-result <N>`
+* `--web-max-total-tokens <N>`
+
+---
+
+## 8) Safety & constraints
+
+* Do **not** modify sandbox env logic:
+
+  * `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR`
+  * `CODEX_SANDBOX_ENV_VAR`
+* English-only artifacts.
+* No destructive resets.
+* Respect existing context window constants introduced in 0.30.
+
+---
+
+## 9) Tests
+
+### Unit
+
+* Accounting: `next_turn_pct` vs `this_turn_pct` with varied inputs.
+* Budgeter:
+
+  * Caps enforced per result and total.
+  * Deduplication by URL.
+  * Window extraction merges overlaps deterministically.
+* Summary persistence vs raw content exclusion.
+
+### Integration
+
+* Session where `web_search` fires:
+
+  * `/status` before search; after search; next turn without search.
+  * Verify dual meters display and stability.
+* Large pages:
+
+  * Ensure caps hold; summary persists; raw not persisted.
+* Regression:
+
+  * 0.30 baseline math unchanged for no-tool turns.
+
+### TUI snapshot (insta)
+
+* New dual-meter line(s) and badge are stable.
+* `/status` text snapshot covers both meters and payload line.
+
+---
+
+## 10) Metrics & benchmarks
+
+Measure before/after:
+
+* p50/p95 assistant latency when `web_search` is used.
+* Token payload size distribution for tool outputs.
+* Binary size and top symbols if code paths expand.
+
+**Commands**
+
+```
+hyperfine --warmup 3 "target\\release\\codex.exe /status"
+```
+
+```
+hyperfine --warmup 3 "target\\release\\codex.exe -e 'search: <query>'"
+```
+
+```
+cargo bloat -p codex-rs --release -n 20
+```
+
+---
+
+## 11) Implementation plan (small, mergeable PRs)
+
+**PR 1 — Dual accounting**
+
+* Add `ContextBudget` and dual percent calculations.
+* Expose in `/status` and minimal TUI text.
+* Keep existing context math intact; no tool changes yet.
+
+**Acceptance**
+
+* `/status` prints both meters; math verified by unit tests.
+
+---
+
+**PR 2 — Token Budgeter skeleton**
+
+* Implement caps + preprocessing (strip, dedupe, windows).
+* Add token estimation (existing estimator or feature-gated tokenizer).
+* Show `web payload: ~N / M` in TUI.
+
+**Acceptance**
+
+* Caps enforced in unit tests; payload lines appear; no persistence change yet.
+
+---
+
+**PR 3 — Compression & persistence policy**
+
+* Add extractive summary builder with citations.
+* Persist only `ToolSummary` to history; keep raw in verbose logs only.
+
+**Acceptance**
+
+* History shows compact summary; raw excluded; `/status` meters steady across turns.
+
+---
+
+**PR 4 — Polish**
+
+* Flags + config wiring for caps.
+* Final TUI polish and insta snapshots.
+* Docs in CODEX.md (usage, flags) and AGENTS.md links.
+
+---
+
+## 12) Risks & mitigations
+
+* **Over-aggressive caps hide useful info**
+  → allow user overrides; surface counts of truncated items; keep citations.
+* **Estimator inaccuracies**
+  → conservative margins; display it as an estimate; allow model-side `token_usage` to refine when available.
+* **UX clutter**
+  → concise labels; single badge; square off with snapshot tests.
+
+---
+
+## 13) Validation checklist (“done when”)
+
+* [ ] `/status` shows **both** meters and correct values across tool/no-tool turns.
+* [ ] TUI meters and badge present; no flicker/jitter across interactions.
+* [ ] `web_search` payload always ≤ caps; summary persisted; raw excluded from prompt history.
+* [ ] No regressions in context window math for non-tool turns.
+* [ ] Unit/integration/insta tests green; clippy/fmt clean.
+* [ ] Docs updated (CODEX.md usage; AGENTS.md references).
+
+---
+
+## 14) Quick commands (local)
+
+```
+cargo fmt --all
+```
+
+```
+cargo clippy -- -D warnings
+```
+
+```
+cargo build -p codex-rs --release
+```
+
+```
+cargo test -p codex-rs
+```
+
+```
+hyperfine --warmup 3 "target\\release\\codex.exe /status"
+```
+
+---
+
+*If a meter says “0% left” only during a web turn, it isn’t memory loss; it’s transient payload. Fix the accounting. Cap the payload. Move on.*


### PR DESCRIPTION
# Summary
Implements the `--code-tools-only` flag for `codex mcp serve`. When enabled, the MCP server publishes a minimal, code-editing–focused tool catalog and hides the conversational tools (`codex`, `codex-reply`).

This updates the earlier proposal in this PR by landing the code and wiring, bringing docs and behavior into alignment.

# User-facing changes
- New flag: `codex mcp serve --code-tools-only`
  - Default (no flag): full catalog unchanged.
  - With flag: publishes only the code-editing tools.

# Included tools when enabled
- `execCommand` — run a one-off command under sandbox
- `gitDiffToRemote` — diff vs tracked remote + head sha
- `applyPatch` — apply unified diff to workspace
- `codeSearch` — fuzzy file path search (from `codex-file-search`)
- `readFile` — read file contents with offset/limit

# Implementation
- CLI (`codex-rs/cli/src/mcp_cmd.rs`): add `ServeArgs { --code-tools-only }` and pass through.
- Server (`codex-rs/mcp-server/src/lib.rs`): add `ServerOptions { code_tools_only }` and plumb into `run_main`.
- Tool registry (`codex-rs/mcp-server/src/message_processor.rs` + `codex_tool_config.rs`): gate registration on `code_tools_only`.
- Docs already referenced the flag; now behavior matches docs (`docs/advanced.md`).

# Backwards compatibility
- Fully opt-in; default behavior and the full catalog remain unchanged.

# Test plan
- Unit + integration tests:
  - `cargo test -p codex-mcp-server` → all tests passing.
  - `cargo test -p codex-cli` → tests passing.
- Manual verification (MCP Inspector):
  1. `codex mcp serve` → `tools/list` shows `codex` + `codex-reply` (legacy).
  2. `codex mcp serve --code-tools-only` → `tools/list` shows only the five code-editing tools above.

# Notes
- No changes to config file format.
- No changes to default logs/stdio behavior.