### PR TITLE
Resize local images before upload

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -874,6 +874,7 @@ dependencies = [
  "base64",
  "icu_decimal",
  "icu_locale_core",
+ "image",
  "mcp-types",
  "mime_guess",
  "pretty_assertions",

--- a/codex-rs/protocol/Cargo.toml
+++ b/codex-rs/protocol/Cargo.toml
@@ -16,6 +16,10 @@ icu_decimal = "2.0.0"
 icu_locale_core = "2.0.0"
 mcp-types = { path = "../mcp-types" }
 mime_guess = "2.0.5"
+image = { version = "^0.25.8", default-features = false, features = [
+    "jpeg",
+    "png",
+] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_with = { version = "3.14.0", features = ["macros", "base64"] }


### PR DESCRIPTION
## Summary
- resize local images before attaching them to requests so that they fit within a 2048×768 box
- reuse the image crate to downscale oversized files, preserve MIME types when possible, and add unit tests for the helper

## Testing
- just fmt
- just fix -p codex-protocol
- cargo test -p codex-protocol
- cargo test --all-features *(fails at `exec_command::session_manager::tests::session_manager_streams_and_truncates_from_now`; passes when rerun in isolation)*

------
https://chatgpt.com/codex/tasks/task_i_68cdd1afd0bc8325b33320d732151922