### PR TITLE
timeouts for mcp tool calls

### DIFF
--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -148,7 +148,7 @@ fn run_add(config_overrides: &CliConfigOverrides, add_args: AddArgs) -> Result<(
         command: command_bin,
         args: command_args,
         env: env_map,
-        startup_timeout_ms: None,
+        startup_timeout_sec: None,
         tool_timeout_sec: None,
     };
 
@@ -211,7 +211,9 @@ fn run_list(config_overrides: &CliConfigOverrides, list_args: ListArgs) -> Resul
                     "command": cfg.command,
                     "args": cfg.args,
                     "env": env,
-                    "startup_timeout_ms": cfg.startup_timeout_ms,
+                    "startup_timeout_sec": cfg
+                        .startup_timeout_sec
+                        .map(|timeout| timeout.as_secs_f64()),
                     "tool_timeout_sec": cfg
                         .tool_timeout_sec
                         .map(|timeout| timeout.as_secs_f64()),
@@ -309,7 +311,9 @@ fn run_get(config_overrides: &CliConfigOverrides, get_args: GetArgs) -> Result<(
             "command": server.command,
             "args": server.args,
             "env": env,
-            "startup_timeout_ms": server.startup_timeout_ms,
+            "startup_timeout_sec": server
+                .startup_timeout_sec
+                .map(|timeout| timeout.as_secs_f64()),
             "tool_timeout_sec": server
                 .tool_timeout_sec
                 .map(|timeout| timeout.as_secs_f64()),
@@ -340,8 +344,8 @@ fn run_get(config_overrides: &CliConfigOverrides, get_args: GetArgs) -> Result<(
         }
     };
     println!("  env: {env_display}");
-    if let Some(timeout) = server.startup_timeout_ms {
-        println!("  startup_timeout_ms: {timeout}");
+    if let Some(timeout) = server.startup_timeout_sec {
+        println!("  startup_timeout_sec: {}", timeout.as_secs_f64());
     }
     if let Some(timeout) = server.tool_timeout_sec {
         println!("  tool_timeout_sec: {}", timeout.as_secs_f64());

--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -149,6 +149,7 @@ fn run_add(config_overrides: &CliConfigOverrides, add_args: AddArgs) -> Result<(
         args: command_args,
         env: env_map,
         startup_timeout_ms: None,
+        tool_timeout_sec: None,
     };
 
     servers.insert(name.clone(), new_entry);
@@ -211,6 +212,9 @@ fn run_list(config_overrides: &CliConfigOverrides, list_args: ListArgs) -> Resul
                     "args": cfg.args,
                     "env": env,
                     "startup_timeout_ms": cfg.startup_timeout_ms,
+                    "tool_timeout_sec": cfg
+                        .tool_timeout_sec
+                        .map(|timeout| timeout.as_secs_f64()),
                 })
             })
             .collect();
@@ -306,6 +310,9 @@ fn run_get(config_overrides: &CliConfigOverrides, get_args: GetArgs) -> Result<(
             "args": server.args,
             "env": env,
             "startup_timeout_ms": server.startup_timeout_ms,
+            "tool_timeout_sec": server
+                .tool_timeout_sec
+                .map(|timeout| timeout.as_secs_f64()),
         }))?;
         println!("{output}");
         return Ok(());
@@ -335,6 +342,9 @@ fn run_get(config_overrides: &CliConfigOverrides, get_args: GetArgs) -> Result<(
     println!("  env: {env_display}");
     if let Some(timeout) = server.startup_timeout_ms {
         println!("  startup_timeout_ms: {timeout}");
+    }
+    if let Some(timeout) = server.tool_timeout_sec {
+        println!("  tool_timeout_sec: {}", timeout.as_secs_f64());
     }
     println!("  remove: codex mcp remove {}", get_args.name);
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -991,10 +991,9 @@ impl Session {
         server: &str,
         tool: &str,
         arguments: Option<serde_json::Value>,
-        timeout: Option<Duration>,
     ) -> anyhow::Result<CallToolResult> {
         self.mcp_connection_manager
-            .call_tool(server, tool, arguments, timeout)
+            .call_tool(server, tool, arguments)
             .await
     }
 
@@ -2574,12 +2573,7 @@ async fn handle_function_call(
         _ => {
             match sess.mcp_connection_manager.parse_tool_name(&name) {
                 Some((server, tool_name)) => {
-                    // TODO(mbolin): Determine appropriate timeout for tool call.
-                    let timeout = None;
-                    handle_mcp_tool_call(
-                        sess, &sub_id, call_id, server, tool_name, arguments, timeout,
-                    )
-                    .await
+                    handle_mcp_tool_call(sess, &sub_id, call_id, server, tool_name, arguments).await
                 }
                 None => {
                     // Unknown function: reply with structured failure so the model can adapt.

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -333,14 +333,8 @@ pub fn write_global_mcp_servers(
                 entry["env"] = TomlItem::Table(env_table);
             }
 
-            if let Some(timeout) = config.startup_timeout_ms {
-                let timeout = i64::try_from(timeout).map_err(|_| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::InvalidData,
-                        "startup_timeout_ms exceeds supported range",
-                    )
-                })?;
-                entry["startup_timeout_ms"] = toml_edit::value(timeout);
+            if let Some(timeout) = config.startup_timeout_sec {
+                entry["startup_timeout_sec"] = toml_edit::value(timeout.as_secs_f64());
             }
 
             if let Some(timeout) = config.tool_timeout_sec {
@@ -1297,7 +1291,7 @@ exclude_slash_tmp = true
                 command: "echo".to_string(),
                 args: vec!["hello".to_string()],
                 env: None,
-                startup_timeout_ms: None,
+                startup_timeout_sec: Some(Duration::from_secs(3)),
                 tool_timeout_sec: Some(Duration::from_secs(5)),
             },
         );
@@ -1309,12 +1303,35 @@ exclude_slash_tmp = true
         let docs = loaded.get("docs").expect("docs entry");
         assert_eq!(docs.command, "echo");
         assert_eq!(docs.args, vec!["hello".to_string()]);
+        assert_eq!(docs.startup_timeout_sec, Some(Duration::from_secs(3)));
         assert_eq!(docs.tool_timeout_sec, Some(Duration::from_secs(5)));
 
         let empty = BTreeMap::new();
         write_global_mcp_servers(codex_home.path(), &empty)?;
         let loaded = load_global_mcp_servers(codex_home.path())?;
         assert!(loaded.is_empty());
+
+        Ok(())
+    }
+
+    #[test]
+    fn load_global_mcp_servers_accepts_legacy_ms_field() -> anyhow::Result<()> {
+        let codex_home = TempDir::new()?;
+        let config_path = codex_home.path().join(CONFIG_TOML_FILE);
+
+        std::fs::write(
+            &config_path,
+            r#"
+[mcp_servers]
+[mcp_servers.docs]
+command = "echo"
+startup_timeout_ms = 2500
+"#,
+        )?;
+
+        let servers = load_global_mcp_servers(codex_home.path())?;
+        let docs = servers.get("docs").expect("docs entry");
+        assert_eq!(docs.startup_timeout_sec, Some(Duration::from_millis(2500)));
 
         Ok(())
     }

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -343,6 +343,10 @@ pub fn write_global_mcp_servers(
                 entry["startup_timeout_ms"] = toml_edit::value(timeout);
             }
 
+            if let Some(timeout) = config.tool_timeout_sec {
+                entry["tool_timeout_sec"] = toml_edit::value(timeout.as_secs_f64());
+            }
+
             doc["mcp_servers"][name.as_str()] = TomlItem::Table(entry);
         }
     }
@@ -1168,6 +1172,7 @@ mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
 
+    use std::time::Duration;
     use tempfile::TempDir;
 
     #[test]
@@ -1293,6 +1298,7 @@ exclude_slash_tmp = true
                 args: vec!["hello".to_string()],
                 env: None,
                 startup_timeout_ms: None,
+                tool_timeout_sec: Some(Duration::from_secs(5)),
             },
         );
 
@@ -1303,6 +1309,7 @@ exclude_slash_tmp = true
         let docs = loaded.get("docs").expect("docs entry");
         assert_eq!(docs.command, "echo");
         assert_eq!(docs.args, vec!["hello".to_string()]);
+        assert_eq!(docs.tool_timeout_sec, Some(Duration::from_secs(5)));
 
         let empty = BTreeMap::new();
         write_global_mcp_servers(codex_home.path(), &empty)?;

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -9,9 +9,11 @@ use std::time::Duration;
 use wildmatch::WildMatchPattern;
 
 use serde::Deserialize;
+use serde::Deserializer;
 use serde::Serialize;
+use serde::de::Error as SerdeError;
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Debug, Clone, PartialEq)]
 pub struct McpServerConfig {
     pub command: String,
 
@@ -21,13 +23,58 @@ pub struct McpServerConfig {
     #[serde(default)]
     pub env: Option<HashMap<String, String>>,
 
-    /// Startup timeout in milliseconds for initializing MCP server & initially listing tools.
-    #[serde(default)]
-    pub startup_timeout_ms: Option<u64>,
+    /// Startup timeout in seconds for initializing MCP server & initially listing tools.
+    #[serde(
+        default,
+        with = "option_duration_secs",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub startup_timeout_sec: Option<Duration>,
 
     /// Default timeout for MCP tool calls initiated via this server.
     #[serde(default, with = "option_duration_secs")]
     pub tool_timeout_sec: Option<Duration>,
+}
+
+impl<'de> Deserialize<'de> for McpServerConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        struct RawMcpServerConfig {
+            command: String,
+            #[serde(default)]
+            args: Vec<String>,
+            #[serde(default)]
+            env: Option<HashMap<String, String>>,
+            #[serde(default)]
+            startup_timeout_sec: Option<f64>,
+            #[serde(default)]
+            startup_timeout_ms: Option<u64>,
+            #[serde(default, with = "option_duration_secs")]
+            tool_timeout_sec: Option<Duration>,
+        }
+
+        let raw = RawMcpServerConfig::deserialize(deserializer)?;
+
+        let startup_timeout_sec = match (raw.startup_timeout_sec, raw.startup_timeout_ms) {
+            (Some(sec), _) => {
+                let duration = Duration::try_from_secs_f64(sec).map_err(SerdeError::custom)?;
+                Some(duration)
+            }
+            (None, Some(ms)) => Some(Duration::from_millis(ms)),
+            (None, None) => None,
+        };
+
+        Ok(Self {
+            command: raw.command,
+            args: raw.args,
+            env: raw.env,
+            startup_timeout_sec,
+            tool_timeout_sec: raw.tool_timeout_sec,
+        })
+    }
 }
 
 mod option_duration_secs {

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -44,7 +44,7 @@ const DEFAULT_STARTUP_TIMEOUT: Duration = Duration::from_secs(10);
 /// Default timeout for individual tool calls (can be overridden per server or via env var).
 const DEFAULT_TOOL_TIMEOUT: Duration = Duration::from_secs(60);
 
-/// Environment variable that overrides the MCP tool timeout (in seconds). Use `0` to disable.
+/// Environment variable that overrides the MCP tool timeout (in seconds).
 const MCP_TOOL_TIMEOUT_ENV: &str = "MCP_TOOL_TIMEOUT";
 
 /// Map that holds a startup error for every MCP server that could **not** be

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -151,10 +151,7 @@ impl McpConnectionManager {
                 continue;
             }
 
-            let startup_timeout = cfg
-                .startup_timeout_ms
-                .map(Duration::from_millis)
-                .unwrap_or(DEFAULT_STARTUP_TIMEOUT);
+            let startup_timeout = cfg.startup_timeout_sec.unwrap_or(DEFAULT_STARTUP_TIMEOUT);
 
             let tool_timeout =
                 env_tool_timeout.unwrap_or(cfg.tool_timeout_sec.unwrap_or(DEFAULT_TOOL_TIMEOUT));

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -1,4 +1,3 @@
-use std::time::Duration;
 use std::time::Instant;
 
 use tracing::error;
@@ -21,7 +20,6 @@ pub(crate) async fn handle_mcp_tool_call(
     server: String,
     tool_name: String,
     arguments: String,
-    timeout: Option<Duration>,
 ) -> ResponseInputItem {
     // Parse the `arguments` as JSON. An empty string is OK, but invalid JSON
     // is not.
@@ -58,7 +56,7 @@ pub(crate) async fn handle_mcp_tool_call(
     let start = Instant::now();
     // Perform the tool call.
     let result = sess
-        .call_tool(&server, &tool_name, arguments_value.clone(), timeout)
+        .call_tool(&server, &tool_name, arguments_value.clone())
         .await
         .map_err(|e| format!("tool call error: {e}"));
     let tool_call_end_event = EventMsg::McpToolCallEnd(McpToolCallEndEvent {

--- a/docs/config.md
+++ b/docs/config.md
@@ -343,6 +343,7 @@ Defines the list of MCP servers that Codex can consult for tool use. Currently, 
 **Note:** Codex may cache the list of tools and resources from an MCP server so that Codex can include this information in context at startup without spawning all the servers. This is designed to save resources by loading MCP servers lazily.
 
 Each server may set `startup_timeout_ms` to adjust how long Codex waits for it to start and respond to a tools listing. The default is `10_000` (10 seconds).
+Similarly, `tool_timeout_sec` limits how long individual tool calls may run (default: `60` seconds). Fractional seconds are allowed (`4.5`, `120.0`, etc.), and Codex will fall back to the default when this value is omitted. You can also override the timeout globally with the `MCP_TOOL_TIMEOUT` environment variable (interpreted as seconds) when launching Codex; leave it unset to use the default.
 
 This config option is comparable to how Claude and Cursor define `mcpServers` in their respective JSON config files, though because Codex uses TOML for its config language, the format is slightly different. For example, the following config in JSON:
 
@@ -370,6 +371,8 @@ args = ["-y", "mcp-server"]
 env = { "API_KEY" = "value" }
 # Optional: override the default 10s startup timeout
 startup_timeout_ms = 20_000
+# Optional: override the default 60s per-tool timeout
+tool_timeout_sec = 30
 ```
 
 You can also manage these entries from the CLI [experimental]:
@@ -620,6 +623,7 @@ notifications = [ "agent-turn-complete", "approval-requested" ]
 | `mcp_servers.<id>.args` | array<string> | MCP server args. |
 | `mcp_servers.<id>.env` | map<string,string> | MCP server env vars. |
 | `mcp_servers.<id>.startup_timeout_ms` | number | Startup timeout in milliseconds (default: 10_000). Timeout is applied both for initializing MCP server and initially listing tools. |
+| `mcp_servers.<id>.tool_timeout_sec` | number | Per-tool timeout in seconds (default: 60). Accepts fractional values; omit to use the default. |
 | `model_providers.<id>.name` | string | Display name. |
 | `model_providers.<id>.base_url` | string | API base URL. |
 | `model_providers.<id>.env_key` | string | Env var for API key. |

--- a/docs/config.md
+++ b/docs/config.md
@@ -343,7 +343,7 @@ Defines the list of MCP servers that Codex can consult for tool use. Currently, 
 **Note:** Codex may cache the list of tools and resources from an MCP server so that Codex can include this information in context at startup without spawning all the servers. This is designed to save resources by loading MCP servers lazily.
 
 Each server may set `startup_timeout_sec` to adjust how long Codex waits for it to start and respond to a tools listing. The default is `10` seconds.
-Similarly, `tool_timeout_sec` limits how long individual tool calls may run (default: `60` seconds). Fractional seconds are allowed (`4.5`, `120.0`, etc.), and Codex will fall back to the default when this value is omitted. You can also override the timeout globally with the `MCP_TOOL_TIMEOUT` environment variable (interpreted as seconds) when launching Codex; leave it unset to use the default.
+Similarly, `tool_timeout_sec` limits how long individual tool calls may run (default: `60` seconds), and Codex will fall back to the default when this value is omitted.
 
 This config option is comparable to how Claude and Cursor define `mcpServers` in their respective JSON config files, though because Codex uses TOML for its config language, the format is slightly different. For example, the following config in JSON:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -342,7 +342,7 @@ Defines the list of MCP servers that Codex can consult for tool use. Currently, 
 
 **Note:** Codex may cache the list of tools and resources from an MCP server so that Codex can include this information in context at startup without spawning all the servers. This is designed to save resources by loading MCP servers lazily.
 
-Each server may set `startup_timeout_ms` to adjust how long Codex waits for it to start and respond to a tools listing. The default is `10_000` (10 seconds).
+Each server may set `startup_timeout_sec` to adjust how long Codex waits for it to start and respond to a tools listing. The default is `10` seconds.
 Similarly, `tool_timeout_sec` limits how long individual tool calls may run (default: `60` seconds). Fractional seconds are allowed (`4.5`, `120.0`, etc.), and Codex will fall back to the default when this value is omitted. You can also override the timeout globally with the `MCP_TOOL_TIMEOUT` environment variable (interpreted as seconds) when launching Codex; leave it unset to use the default.
 
 This config option is comparable to how Claude and Cursor define `mcpServers` in their respective JSON config files, though because Codex uses TOML for its config language, the format is slightly different. For example, the following config in JSON:
@@ -370,7 +370,7 @@ command = "npx"
 args = ["-y", "mcp-server"]
 env = { "API_KEY" = "value" }
 # Optional: override the default 10s startup timeout
-startup_timeout_ms = 20_000
+startup_timeout_sec = 20
 # Optional: override the default 60s per-tool timeout
 tool_timeout_sec = 30
 ```
@@ -622,7 +622,7 @@ notifications = [ "agent-turn-complete", "approval-requested" ]
 | `mcp_servers.<id>.command` | string | MCP server launcher command. |
 | `mcp_servers.<id>.args` | array<string> | MCP server args. |
 | `mcp_servers.<id>.env` | map<string,string> | MCP server env vars. |
-| `mcp_servers.<id>.startup_timeout_ms` | number | Startup timeout in milliseconds (default: 10_000). Timeout is applied both for initializing MCP server and initially listing tools. |
+| `mcp_servers.<id>.startup_timeout_sec` | number | Startup timeout in seconds (default: 10). Timeout is applied both for initializing MCP server and initially listing tools. |
 | `mcp_servers.<id>.tool_timeout_sec` | number | Per-tool timeout in seconds (default: 60). Accepts fractional values; omit to use the default. |
 | `model_providers.<id>.name` | string | Display name. |
 | `model_providers.<id>.base_url` | string | API base URL. |


### PR DESCRIPTION
defaults to 60sec, overridable with MCP_TOOL_TIMEOUT or on a per-server basis in the config.