### PR TITLE
Queue MCP tool images for model input

### DIFF
--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -2,15 +2,19 @@ use std::time::Duration;
 use std::time::Instant;
 
 use tracing::error;
+use tracing::warn;
 
 use crate::codex::Session;
 use crate::protocol::Event;
 use crate::protocol::EventMsg;
+use crate::protocol::InputItem;
 use crate::protocol::McpInvocation;
 use crate::protocol::McpToolCallBeginEvent;
 use crate::protocol::McpToolCallEndEvent;
 use codex_protocol::models::FunctionCallOutputPayload;
 use codex_protocol::models::ResponseInputItem;
+use mcp_types::CallToolResult;
+use mcp_types::ContentBlock;
 
 /// Handles the specified tool call dispatches the appropriate
 /// `McpToolCallBegin` and `McpToolCallEnd` events to the `Session`.
@@ -70,6 +74,15 @@ pub(crate) async fn handle_mcp_tool_call(
 
     notify_mcp_tool_call_event(sess, sub_id, tool_call_end_event.clone()).await;
 
+    if let Ok(call_tool_result) = &result
+        && let Some(items) = build_input_items_for_call_tool_result(call_tool_result)
+            && let Err(unqueued) = sess.inject_input(items).await {
+                warn!(
+                    "failed to queue MCP tool output for model consumption ({} items)",
+                    unqueued.len()
+                );
+            }
+
     ResponseInputItem::McpToolCallOutput { call_id, result }
 }
 
@@ -79,4 +92,27 @@ async fn notify_mcp_tool_call_event(sess: &Session, sub_id: &str, event: EventMs
         msg: event,
     })
     .await;
+}
+
+fn build_input_items_for_call_tool_result(result: &CallToolResult) -> Option<Vec<InputItem>> {
+    let mut items: Vec<InputItem> = Vec::new();
+    let mut saw_image = false;
+
+    for block in &result.content {
+        match block {
+            ContentBlock::TextContent(text) if !text.text.is_empty() => {
+                items.push(InputItem::Text {
+                    text: text.text.clone(),
+                });
+            }
+            ContentBlock::ImageContent(image) => {
+                let image_url = format!("data:{};base64,{}", image.mime_type, image.data);
+                items.push(InputItem::Image { image_url });
+                saw_image = true;
+            }
+            _ => {}
+        }
+    }
+
+    if saw_image { Some(items) } else { None }
 }


### PR DESCRIPTION
## Summary
- convert MCP tool image blocks into data URIs and queue them as upcoming `InputItem::Image`
- keep accompanying text blocks from the tool result so they are replayed to the model alongside the image
- warn if queuing fails, ensuring we still answer the tool call

## Testing
- cargo test -p codex-core
- cargo test --all-features
