### PR TITLE
MCP management overhaul: registry, CLI wizard, and TUI manager (experimental flag)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ CHANGELOG.ignore.md
 # nix related
 .direnv
 .envrc
+
+# codex CLI artifacts
+.codex/

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -638,6 +638,7 @@ dependencies = [
  "codex-protocol",
  "codex-protocol-ts",
  "codex-tui",
+ "inquire",
  "predicates",
  "pretty_assertions",
  "serde_json",
@@ -919,7 +920,7 @@ dependencies = [
  "codex-ollama",
  "codex-protocol",
  "color-eyre",
- "crossterm",
+ "crossterm 0.28.1",
  "diffy",
  "dirs",
  "image",
@@ -929,7 +930,6 @@ dependencies = [
  "libc",
  "mcp-types",
  "once_cell",
- "owo-colors",
  "path-clean",
  "pathdiff",
  "pretty_assertions",
@@ -1077,7 +1077,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "tokio",
- "wiremock",
 ]
 
 [[package]]
@@ -1134,6 +1133,22 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
+dependencies = [
+ "bitflags 1.3.2",
+ "crossterm_winapi",
+ "libc",
+ "mio 0.8.11",
+ "parking_lot",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm"
 version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
@@ -1141,7 +1156,7 @@ dependencies = [
  "bitflags 2.9.1",
  "crossterm_winapi",
  "futures-core",
- "mio",
+ "mio 1.0.4",
  "parking_lot",
  "rustix 0.38.44",
  "signal-hook",
@@ -1837,6 +1852,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fuzzy-matcher"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54614a3312934d066701a80f20f15fa3b56d67ac7722b39eea5b4c9dd1d66c94"
+dependencies = [
+ "thread_local",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2384,6 +2408,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
+name = "inquire"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fddf93031af70e75410a2511ec04d49e758ed2f26dad3404a934e0fb45cc12a"
+dependencies = [
+ "bitflags 2.9.1",
+ "crossterm 0.25.0",
+ "dyn-clone",
+ "fuzzy-matcher",
+ "fxhash",
+ "newline-converter",
+ "once_cell",
+ "unicode-segmentation",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "insta"
 version = "1.43.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2795,6 +2836,18 @@ dependencies = [
 
 [[package]]
 name = "mio"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a650543ca06a924e8b371db273b2756685faae30f8487da1b56505a8f78b0c"
+dependencies = [
+ "libc",
+ "log",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "mio"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
@@ -2852,6 +2905,15 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "newline-converter"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b6b097ecb1cbfed438542d16e84fd7ad9b0c76c8a65b7f9039212a3d14dc7f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "nibble_vec"
@@ -3519,7 +3581,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cassowary",
  "compact_str",
- "crossterm",
+ "crossterm 0.28.1",
  "indoc",
  "instability",
  "itertools 0.13.0",
@@ -4126,7 +4188,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
 dependencies = [
  "libc",
- "mio",
+ "mio 0.8.11",
+ "mio 1.0.4",
  "signal-hook",
 ]
 
@@ -4656,7 +4719,7 @@ dependencies = [
  "bytes",
  "io-uring",
  "libc",
- "mio",
+ "mio 1.0.4",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
@@ -5406,6 +5469,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -27,6 +27,7 @@ codex-login = { path = "../login" }
 codex-mcp-server = { path = "../mcp-server" }
 codex-protocol = { path = "../protocol" }
 codex-tui = { path = "../tui" }
+inquire = "0.7"
 serde_json = "1"
 tokio = { version = "1", features = [
     "io-std",

--- a/codex-rs/cli/src/lib.rs
+++ b/codex-rs/cli/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod debug_sandbox;
 mod exit_status;
 pub mod login;
+pub mod mcp;
 pub mod proto;
 
 use clap::Parser;

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -47,6 +47,7 @@ struct MultitoolCli {
     subcommand: Option<Subcommand>,
 }
 
+#[allow(clippy::large_enum_variant)]
 #[derive(Debug, clap::Subcommand)]
 enum Subcommand {
     /// Run Codex non-interactively.
@@ -177,11 +178,8 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
                 root_config_overrides.clone(),
             );
             let usage = codex_tui::run_main(interactive, codex_linux_sandbox_exe).await?;
-            if !usage.token_usage.is_zero() {
-                println!(
-                    "{}",
-                    codex_core::protocol::FinalOutput::from(usage.token_usage)
-                );
+            if !usage.is_zero() {
+                println!("{}", codex_core::protocol::FinalOutput::from(usage));
             }
         }
         Some(Subcommand::Exec(mut exec_cli)) => {

--- a/codex-rs/cli/src/mcp/cli.rs
+++ b/codex-rs/cli/src/mcp/cli.rs
@@ -1,0 +1,100 @@
+use clap::Parser;
+
+/// [experimental] Arguments for the MCP wizard.
+#[derive(Debug, Parser, Clone, Default)]
+pub struct WizardArgs {
+    /// Optional template to preselect when starting the wizard.
+    #[arg(long)]
+    pub template: Option<String>,
+
+    /// Server name (non-interactive mode).
+    #[arg(long)]
+    pub name: Option<String>,
+
+    /// Command to launch the MCP server.
+    #[arg(long)]
+    pub command: Option<String>,
+
+    /// Command arguments (repeatable).
+    #[arg(long = "arg", value_name = "ARG")]
+    pub args: Vec<String>,
+
+    /// Environment variables KEY=VALUE (repeatable).
+    #[arg(long = "env", value_parser = parse_env_pair, value_name = "KEY=VALUE")]
+    pub env: Vec<(String, String)>,
+
+    /// Startup timeout in milliseconds.
+    #[arg(long = "startup-timeout-ms")]
+    pub startup_timeout_ms: Option<u64>,
+
+    /// Optional description for the server.
+    #[arg(long)]
+    pub description: Option<String>,
+
+    /// Tags to associate with the server (repeatable).
+    #[arg(long = "tag", value_name = "TAG")]
+    pub tags: Vec<String>,
+
+    /// Authentication type (e.g. none, env, apikey).
+    #[arg(long = "auth-type")]
+    pub auth_type: Option<String>,
+
+    /// Authentication secret reference.
+    #[arg(long = "auth-secret-ref")]
+    pub auth_secret_ref: Option<String>,
+
+    /// Authentication environment variables KEY=VALUE (repeatable).
+    #[arg(long = "auth-env", value_parser = parse_env_pair, value_name = "KEY=VALUE")]
+    pub auth_env: Vec<(String, String)>,
+
+    /// Healthcheck type (e.g. none, stdio, http).
+    #[arg(long = "health-type")]
+    pub health_type: Option<String>,
+
+    /// Healthcheck command (for stdio type).
+    #[arg(long = "health-command")]
+    pub health_command: Option<String>,
+
+    /// Healthcheck arguments (repeatable).
+    #[arg(long = "health-arg", value_name = "ARG")]
+    pub health_args: Vec<String>,
+
+    /// Healthcheck timeout in milliseconds.
+    #[arg(long = "health-timeout-ms")]
+    pub health_timeout_ms: Option<u64>,
+
+    /// Healthcheck interval in seconds.
+    #[arg(long = "health-interval-seconds")]
+    pub health_interval_seconds: Option<u64>,
+
+    /// Healthcheck endpoint (for network types).
+    #[arg(long = "health-endpoint")]
+    pub health_endpoint: Option<String>,
+
+    /// Healthcheck protocol (for network types).
+    #[arg(long = "health-protocol")]
+    pub health_protocol: Option<String>,
+
+    /// Apply configuration without prompting.
+    #[arg(long, default_value_t = false)]
+    pub apply: bool,
+
+    /// Output summary as JSON instead of launching interactive flow.
+    #[arg(long, default_value_t = false)]
+    pub json: bool,
+}
+
+fn parse_env_pair(raw: &str) -> Result<(String, String), String> {
+    let mut parts = raw.splitn(2, '=');
+    let key = parts
+        .next()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| "environment entries must be in KEY=VALUE form".to_string())?;
+    let value = parts
+        .next()
+        .map(str::to_string)
+        .ok_or_else(|| "environment entries must be in KEY=VALUE form".to_string())?;
+
+    Ok((key.to_string(), value))
+}

--- a/codex-rs/cli/src/mcp/mod.rs
+++ b/codex-rs/cli/src/mcp/mod.rs
@@ -1,0 +1,2 @@
+pub mod cli;
+pub mod wizard;

--- a/codex-rs/cli/src/mcp/wizard.rs
+++ b/codex-rs/cli/src/mcp/wizard.rs
@@ -1,0 +1,522 @@
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::time::SystemTime;
+
+use anyhow::Context;
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
+use inquire::Confirm;
+use inquire::Select;
+use inquire::Text;
+use inquire::validator::ErrorMessage;
+use inquire::validator::Validation;
+
+use codex_core::config_types::McpAuthConfig;
+use codex_core::config_types::McpHealthcheckConfig;
+use codex_core::config_types::McpServerConfig;
+use codex_core::mcp::registry::McpRegistry;
+use codex_core::mcp::registry::validate_server_name;
+
+use crate::mcp::cli::WizardArgs;
+
+const AUTH_TYPES: &[&str] = &["none", "env", "apikey", "oauth"];
+const HEALTH_TYPES: &[&str] = &["none", "stdio", "http"];
+
+#[derive(Debug, Clone)]
+pub struct WizardOutcome {
+    pub name: String,
+    pub server: McpServerConfig,
+    pub template_id: Option<String>,
+    pub generated_at: SystemTime,
+}
+
+impl WizardOutcome {
+    pub fn summary(&self) -> BTreeMap<String, String> {
+        let mut map = BTreeMap::new();
+        map.insert("name".into(), self.name.clone());
+        map.insert("command".into(), self.server.command.clone());
+        if !self.server.args.is_empty() {
+            map.insert("args".into(), self.server.args.join(", "));
+        }
+        if let Some(env) = self.server.env.as_ref()
+            && !env.is_empty()
+        {
+            map.insert(
+                "env".into(),
+                env.iter()
+                    .map(|(k, v)| format!("{k}={v}"))
+                    .collect::<Vec<_>>()
+                    .join(", "),
+            );
+        }
+        if let Some(timeout) = self.server.startup_timeout_ms {
+            map.insert("startup_timeout_ms".into(), timeout.to_string());
+        }
+        if let Some(template_id) = self.template_id.as_ref() {
+            map.insert("template_id".into(), template_id.clone());
+        }
+        if let Some(description) = self.server.description.as_ref() {
+            map.insert("description".into(), description.clone());
+        }
+        if !self.server.tags.is_empty() {
+            map.insert("tags".into(), self.server.tags.join(", "));
+        }
+        map
+    }
+}
+
+pub fn build_non_interactive(registry: &McpRegistry, args: &WizardArgs) -> Result<WizardOutcome> {
+    let template_result = if let Some(template_id) = args.template.as_ref() {
+        let cfg = registry
+            .instantiate_template(template_id)
+            .with_context(|| format!("Template '{template_id}' not found"))?;
+        Some((cfg, Some(template_id.clone())))
+    } else {
+        None
+    };
+
+    let mut server = template_result
+        .as_ref()
+        .map(|(cfg, _)| cfg.clone())
+        .unwrap_or_default();
+
+    if let Some(description) = args.description.as_ref() {
+        server.description = Some(description.clone());
+    }
+    if let Some(command) = args.command.as_ref() {
+        server.command = command.clone();
+    }
+    if !args.args.is_empty() {
+        server.args = args.args.clone();
+    }
+    merge_env(&mut server.env, &args.env);
+
+    if let Some(timeout) = args.startup_timeout_ms {
+        server.startup_timeout_ms = Some(timeout);
+    }
+    if !args.tags.is_empty() {
+        server.tags = args.tags.clone();
+    }
+
+    if args.auth_type.is_some() || args.auth_secret_ref.is_some() || !args.auth_env.is_empty() {
+        let mut auth = server.auth.unwrap_or_default();
+        if let Some(kind) = args.auth_type.as_ref() {
+            auth.kind = Some(kind.clone());
+        }
+        if let Some(secret_ref) = args.auth_secret_ref.as_ref() {
+            auth.secret_ref = Some(secret_ref.clone());
+        }
+        merge_env(&mut auth.env, &args.auth_env);
+        server.auth = Some(auth);
+    }
+
+    if args.health_type.is_some()
+        || args.health_command.is_some()
+        || !args.health_args.is_empty()
+        || args.health_timeout_ms.is_some()
+        || args.health_interval_seconds.is_some()
+        || args.health_endpoint.is_some()
+        || args.health_protocol.is_some()
+    {
+        let mut health = server.healthcheck.unwrap_or_default();
+        if let Some(kind) = args.health_type.as_ref() {
+            health.kind = Some(kind.clone());
+        }
+        if let Some(cmd) = args.health_command.as_ref() {
+            health.command = Some(cmd.clone());
+        }
+        if !args.health_args.is_empty() {
+            health.args = args.health_args.clone();
+        }
+        if let Some(timeout) = args.health_timeout_ms {
+            health.timeout_ms = Some(timeout);
+        }
+        if let Some(interval) = args.health_interval_seconds {
+            health.interval_seconds = Some(interval);
+        }
+        if let Some(endpoint) = args.health_endpoint.as_ref() {
+            health.endpoint = Some(endpoint.clone());
+        }
+        if let Some(protocol) = args.health_protocol.as_ref() {
+            health.protocol = Some(protocol.clone());
+        }
+        server.healthcheck = Some(health);
+    }
+
+    if server.command.trim().is_empty() {
+        bail!("Missing required --command for MCP server launch");
+    }
+
+    let name = args
+        .name
+        .clone()
+        .ok_or_else(|| anyhow!("Non-interactive mode requires --name"))?;
+    validate_server_name(&name)?;
+
+    let template_id_for_outcome = template_result.as_ref().and_then(|(_, id)| id.clone());
+
+    Ok(WizardOutcome {
+        name,
+        server,
+        template_id: template_id_for_outcome,
+        generated_at: SystemTime::now(),
+    })
+}
+
+pub fn run_interactive(
+    registry: &McpRegistry,
+    template_hint: Option<&str>,
+) -> Result<WizardOutcome> {
+    let mut server = template_hint
+        .and_then(|id| registry.instantiate_template(id))
+        .unwrap_or_default();
+
+    let template_ids = registry.templates().keys().cloned().collect::<Vec<_>>();
+
+    let chosen_template = if !template_ids.is_empty() {
+        let mut options = template_ids;
+        options.sort();
+        let default_index = template_hint
+            .and_then(|hint| options.iter().position(|id| id == hint))
+            .unwrap_or(0);
+        Select::new("Select template", options)
+            .with_starting_cursor(default_index)
+            .prompt()
+            .ok()
+    } else {
+        None
+    };
+
+    if let Some(template_id) = chosen_template.as_deref()
+        && let Some(cfg) = registry.instantiate_template(template_id)
+    {
+        server = cfg;
+    }
+
+    let default_name = template_hint
+        .map(sanitize_name)
+        .or_else(|| chosen_template.as_deref().map(sanitize_name))
+        .unwrap_or_default();
+
+    let name = Text::new("MCP server name")
+        .with_initial_value(&default_name)
+        .with_validator(
+            |input: &str| -> Result<Validation, Box<dyn std::error::Error + Send + Sync>> {
+                match validate_server_name(input) {
+                    Ok(()) => Ok(Validation::Valid),
+                    Err(err) => Ok(Validation::Invalid(ErrorMessage::Custom(err.to_string()))),
+                }
+            },
+        )
+        .prompt()
+        .map_err(|err| anyhow!("Wizard cancelled: {err}"))?;
+
+    loop {
+        let command = Text::new("Launch command (e.g. /usr/bin/node)")
+            .with_initial_value(&server.command)
+            .prompt()
+            .map_err(|err| anyhow!("Wizard cancelled: {err}"))?;
+        if command.trim().is_empty() {
+            println!("Command must not be empty.");
+            continue;
+        }
+        server.command = command;
+        break;
+    }
+
+    server.args = parse_list(
+        Text::new("Arguments (comma separated, Enter to skip)")
+            .with_initial_value(&server.args.join(","))
+            .prompt()
+            .map_err(|err| anyhow!("Wizard cancelled: {err}"))?,
+    );
+
+    server.env = collect_env(server.env.take())?;
+
+    server.startup_timeout_ms = parse_optional_u64(
+        Text::new("Startup timeout (ms, Enter to skip)")
+            .with_initial_value(
+                &server
+                    .startup_timeout_ms
+                    .map(|v| v.to_string())
+                    .unwrap_or_default(),
+            )
+            .prompt()
+            .map_err(|err| anyhow!("Wizard cancelled: {err}"))?,
+    )?;
+
+    server.description = Some(
+        Text::new("Description (Enter to leave blank)")
+            .with_initial_value(server.description.as_deref().unwrap_or(""))
+            .prompt()
+            .map_err(|err| anyhow!("Wizard cancelled: {err}"))?,
+    )
+    .filter(|s| !s.is_empty());
+
+    server.tags = parse_list(
+        Text::new("Tags (comma separated, Enter to skip)")
+            .with_initial_value(&server.tags.join(","))
+            .prompt()
+            .map_err(|err| anyhow!("Wizard cancelled: {err}"))?,
+    );
+
+    server.auth = collect_auth(server.auth.take())?;
+    server.healthcheck = collect_health(server.healthcheck.take())?;
+
+    Ok(WizardOutcome {
+        name,
+        server,
+        template_id: chosen_template.or(template_hint.map(|s| s.to_string())),
+        generated_at: SystemTime::now(),
+    })
+}
+
+pub fn confirm_apply(outcome: &WizardOutcome) -> Result<bool> {
+    println!("Configuration summary:");
+    for (key, value) in outcome.summary() {
+        println!("  {key}: {value}");
+    }
+    Confirm::new("Persist changes?")
+        .with_default(true)
+        .prompt()
+        .map_err(|err| anyhow!("Wizard cancelled: {err}"))
+}
+
+pub fn render_json_summary(outcome: &WizardOutcome) -> Result<String> {
+    let json = serde_json::json!({
+        "name": outcome.name,
+        "command": outcome.server.command,
+        "args": outcome.server.args,
+        "env": outcome.server.env,
+        "startup_timeout_ms": outcome.server.startup_timeout_ms,
+        "description": outcome.server.description,
+        "tags": outcome.server.tags,
+        "template_id": outcome.template_id,
+        "auth": outcome.server.auth,
+        "healthcheck": outcome.server.healthcheck,
+    });
+    Ok(serde_json::to_string_pretty(&json)?)
+}
+
+fn collect_env(
+    existing: Option<HashMap<String, String>>,
+) -> Result<Option<HashMap<String, String>>> {
+    let mut env = existing.unwrap_or_default();
+    while Confirm::new("Add environment variable?")
+        .with_default(false)
+        .prompt()
+        .map_err(|err| anyhow!("Wizard cancelled: {err}"))?
+    {
+        let pair = Text::new("Enter KEY=VALUE")
+            .prompt()
+            .map_err(|err| anyhow!("Wizard cancelled: {err}"))?;
+        let (key, value) = parse_env_pair(&pair)?;
+        env.insert(key, value);
+    }
+    if env.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(env))
+    }
+}
+
+fn collect_auth(existing: Option<McpAuthConfig>) -> Result<Option<McpAuthConfig>> {
+    let mut auth = existing.unwrap_or_default();
+    let selection = Select::new("Authentication type", AUTH_TYPES.to_vec())
+        .with_starting_cursor(match auth.kind.as_deref() {
+            Some("env") => 1,
+            Some("apikey") => 2,
+            Some("oauth") => 3,
+            _ => 0,
+        })
+        .prompt()
+        .map_err(|err| anyhow!("Wizard cancelled: {err}"))?;
+
+    if selection == "none" {
+        return Ok(None);
+    }
+    auth.kind = Some(selection.to_string());
+
+    auth.secret_ref = Text::new("Secret ref (Enter to skip)")
+        .with_initial_value(auth.secret_ref.as_deref().unwrap_or(""))
+        .prompt()
+        .map_err(|err| anyhow!("Wizard cancelled: {err}"))?
+        .trim()
+        .to_owned()
+        .into();
+
+    auth.env = collect_env(auth.env)?;
+    Ok(Some(auth))
+}
+
+fn collect_health(existing: Option<McpHealthcheckConfig>) -> Result<Option<McpHealthcheckConfig>> {
+    let mut health = existing.unwrap_or_default();
+    let selection = Select::new("Health-check type", HEALTH_TYPES.to_vec())
+        .with_starting_cursor(match health.kind.as_deref() {
+            Some("stdio") => 1,
+            Some("http") => 2,
+            _ => 0,
+        })
+        .prompt()
+        .map_err(|err| anyhow!("Wizard cancelled: {err}"))?;
+
+    if selection == "none" {
+        return Ok(None);
+    }
+    health.kind = Some(selection.to_string());
+
+    if selection == "stdio" {
+        health.command = Some(
+            Text::new("Health command")
+                .with_initial_value(health.command.as_deref().unwrap_or(""))
+                .prompt()
+                .map_err(|err| anyhow!("Wizard cancelled: {err}"))?,
+        );
+        health.args = parse_list(
+            Text::new("Health args (comma separated)")
+                .with_initial_value(&health.args.join(","))
+                .prompt()
+                .map_err(|err| anyhow!("Wizard cancelled: {err}"))?,
+        );
+        health.endpoint = None;
+        health.protocol = None;
+    } else {
+        health.endpoint = Some(
+            Text::new("Health endpoint")
+                .with_initial_value(health.endpoint.as_deref().unwrap_or(""))
+                .prompt()
+                .map_err(|err| anyhow!("Wizard cancelled: {err}"))?,
+        )
+        .filter(|s| !s.is_empty());
+        health.protocol = Some("http".into());
+        health.command = None;
+        health.args.clear();
+    }
+
+    health.timeout_ms = parse_optional_u64(
+        Text::new("Health timeout (ms, Enter to skip)")
+            .with_initial_value(&health.timeout_ms.map(|v| v.to_string()).unwrap_or_default())
+            .prompt()
+            .map_err(|err| anyhow!("Wizard cancelled: {err}"))?,
+    )?;
+    health.interval_seconds = parse_optional_u64(
+        Text::new("Health interval (s, Enter to skip)")
+            .with_initial_value(
+                &health
+                    .interval_seconds
+                    .map(|v| v.to_string())
+                    .unwrap_or_default(),
+            )
+            .prompt()
+            .map_err(|err| anyhow!("Wizard cancelled: {err}"))?,
+    )?;
+
+    Ok(Some(health))
+}
+
+fn merge_env(target: &mut Option<HashMap<String, String>>, updates: &[(String, String)]) {
+    if updates.is_empty() {
+        return;
+    }
+    let mut map = target.take().unwrap_or_default();
+    for (k, v) in updates {
+        map.insert(k.clone(), v.clone());
+    }
+    if map.is_empty() {
+        *target = None;
+    } else {
+        *target = Some(map);
+    }
+}
+
+fn parse_list(input: String) -> Vec<String> {
+    input
+        .split([',', ';'])
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(String::from)
+        .collect()
+}
+
+fn parse_optional_u64(raw: String) -> Result<Option<u64>> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    let value = trimmed.parse::<u64>()?;
+    Ok(Some(value))
+}
+
+fn parse_env_pair(raw: &str) -> Result<(String, String)> {
+    let mut parts = raw.splitn(2, '=');
+    let key = parts
+        .next()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .ok_or_else(|| anyhow!("Entry must be KEY=VALUE"))?;
+    let value = parts
+        .next()
+        .map(|s| s.to_string())
+        .ok_or_else(|| anyhow!("Entry must be KEY=VALUE"))?;
+    Ok((key.to_string(), value))
+}
+
+fn sanitize_name(template_id: &str) -> String {
+    template_id
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '-' || c == '_' {
+                c
+            } else {
+                '-'
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_core::config::Config;
+    use codex_core::config::ConfigOverrides;
+    use codex_core::config::ConfigToml;
+    use codex_core::mcp::templates::TemplateCatalog;
+    use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    #[test]
+    fn build_non_interactive_applies_fields() {
+        let tmp = TempDir::new().expect("tempdir");
+        let config = Config::load_from_base_config_with_overrides(
+            ConfigToml::default(),
+            ConfigOverrides::default(),
+            tmp.path().to_path_buf(),
+        )
+        .expect("load config");
+        let registry = McpRegistry::new(&config, TemplateCatalog::empty());
+
+        let args = WizardArgs {
+            name: Some("demo".to_string()),
+            command: Some("/bin/echo".to_string()),
+            args: vec!["hello".into(), "world".into()],
+            env: vec![("FOO".into(), "BAR".into())],
+            startup_timeout_ms: Some(1500),
+            description: Some("Example".to_string()),
+            tags: vec!["fast".into()],
+            ..Default::default()
+        };
+
+        let outcome = build_non_interactive(&registry, &args).expect("build outcome");
+
+        assert_eq!("demo", outcome.name);
+        assert_eq!("/bin/echo", outcome.server.command);
+        assert_eq!(vec!["hello", "world"], outcome.server.args);
+        assert_eq!(Some(1500), outcome.server.startup_timeout_ms);
+        assert_eq!(Some("Example".to_string()), outcome.server.description);
+        assert_eq!(vec!["fast".to_string()], outcome.server.tags);
+
+        let env = outcome.server.env.expect("env");
+        assert_eq!(Some(&"BAR".to_string()), env.get("FOO"));
+    }
+}

--- a/codex-rs/core/src/config/migrations/mcp.rs
+++ b/codex-rs/core/src/config/migrations/mcp.rs
@@ -1,0 +1,272 @@
+use std::fs;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+
+use tempfile::NamedTempFile;
+use toml::Value as TomlValue;
+use toml_edit::DocumentMut;
+
+use super::super::CONFIG_TOML_FILE;
+use super::super::load_config_as_toml;
+
+/// Number of historical config backups retained during migration.
+pub const BACKUP_RETENTION: usize = 3;
+
+/// Options controlling MCP schema migration behaviour.
+#[derive(Debug, Clone, Copy)]
+pub struct MigrationOptions {
+    pub dry_run: bool,
+    pub force: bool,
+}
+
+impl Default for MigrationOptions {
+    fn default() -> Self {
+        Self {
+            dry_run: true,
+            force: false,
+        }
+    }
+}
+
+/// Outcome of a migration attempt.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MigrationReport {
+    pub backed_up: bool,
+    pub changes_detected: bool,
+    pub from_version: u32,
+    pub to_version: u32,
+    pub notes: Vec<String>,
+}
+
+impl MigrationReport {
+    fn unchanged(version: u32, note: impl Into<String>) -> Self {
+        Self {
+            backed_up: false,
+            changes_detected: false,
+            from_version: version,
+            to_version: version,
+            notes: vec![note.into()],
+        }
+    }
+}
+
+/// Result of creating/rotating configuration backups.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct BackupOutcome {
+    pub created: bool,
+    pub rotated: bool,
+    pub backup_path: Option<PathBuf>,
+}
+
+/// Performs a best-effort migration of MCP-related configuration to schema version 2.
+///
+/// Behaviour:
+/// * Inspects current `mcp_schema_version` (default = 1 when absent).
+/// * If already at or above the target version and `force` is false, returns early.
+/// * For dry-run, reports whether a change would occur without touching disk.
+/// * For apply (`dry_run = false`), rotates backups and writes an updated config
+///   with `mcp_schema_version = 2` (placeholder transformation for now).
+pub fn migrate_to_v2(
+    codex_home: &Path,
+    options: &MigrationOptions,
+) -> std::io::Result<MigrationReport> {
+    let config_path = codex_home.join(CONFIG_TOML_FILE);
+    if !config_path.exists() {
+        return Ok(MigrationReport::unchanged(
+            1,
+            "config.toml not found; nothing to migrate",
+        ));
+    }
+
+    let root_value = load_config_as_toml(codex_home)?;
+    let current_version = root_value
+        .get("mcp_schema_version")
+        .and_then(TomlValue::as_integer)
+        .map(|v| v.max(0) as u32)
+        .unwrap_or(1);
+
+    if current_version >= 2 && !options.force {
+        return Ok(MigrationReport::unchanged(
+            current_version,
+            "mcp_schema_version already at or above 2",
+        ));
+    }
+
+    if options.dry_run {
+        return Ok(MigrationReport {
+            backed_up: false,
+            changes_detected: current_version < 2 || options.force,
+            from_version: current_version,
+            to_version: 2,
+            notes: vec!["dry-run: no changes applied".into()],
+        });
+    }
+
+    let backup = create_backup_with_rotation(codex_home)?;
+    let mut doc = load_config_as_document(&config_path)?;
+
+    doc["mcp_schema_version"] = toml_edit::value(2);
+
+    write_document_atomic(codex_home, &config_path, doc)?;
+
+    Ok(MigrationReport {
+        backed_up: backup.created,
+        changes_detected: true,
+        from_version: current_version,
+        to_version: 2,
+        notes: vec![format!(
+            "mcp_schema_version updated from {} to 2",
+            current_version
+        )],
+    })
+}
+
+/// Creates `config.toml.bak{N}` backups, rotating existing snapshots up to [`BACKUP_RETENTION`].
+pub fn create_backup_with_rotation(codex_home: &Path) -> std::io::Result<BackupOutcome> {
+    let config_path = codex_home.join(CONFIG_TOML_FILE);
+    if !config_path.exists() {
+        return Ok(BackupOutcome::default());
+    }
+
+    fs::create_dir_all(codex_home)?;
+
+    let mut rotated = false;
+    for idx in (1..=BACKUP_RETENTION).rev() {
+        let src = backup_path(codex_home, idx);
+        if !src.exists() {
+            continue;
+        }
+        if idx == BACKUP_RETENTION {
+            fs::remove_file(&src)?;
+        } else {
+            let dst = backup_path(codex_home, idx + 1);
+            if dst.exists() {
+                fs::remove_file(&dst)?;
+            }
+            fs::rename(&src, &dst)?;
+        }
+        rotated = true;
+    }
+
+    let bak1 = backup_path(codex_home, 1);
+    fs::copy(&config_path, &bak1)?;
+
+    Ok(BackupOutcome {
+        created: true,
+        rotated,
+        backup_path: Some(bak1),
+    })
+}
+
+fn backup_path(codex_home: &Path, index: usize) -> PathBuf {
+    codex_home.join(format!("config.toml.bak{index}"))
+}
+
+fn load_config_as_document(path: &Path) -> std::io::Result<DocumentMut> {
+    let contents = fs::read_to_string(path)?;
+    contents
+        .parse::<DocumentMut>()
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+fn write_document_atomic(
+    codex_home: &Path,
+    config_path: &Path,
+    doc: DocumentMut,
+) -> std::io::Result<()> {
+    fs::create_dir_all(codex_home)?;
+    let tmp = NamedTempFile::new_in(codex_home)?;
+    tmp.as_file().write_all(doc.to_string().as_bytes())?;
+    tmp.persist(config_path).map_err(|e| e.error)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn backup_rotation_creates_and_rotates() -> std::io::Result<()> {
+        let tmp = TempDir::new()?;
+        let codex_home = tmp.path();
+        let config_path = codex_home.join(CONFIG_TOML_FILE);
+        fs::create_dir_all(codex_home)?;
+        fs::write(&config_path, "model = \"gpt-5\"\n")?;
+
+        // First backup
+        let outcome1 = create_backup_with_rotation(codex_home)?;
+        assert!(outcome1.created);
+        assert!(outcome1.backup_path.unwrap().exists());
+
+        // Modify config and create additional backups to trigger rotation.
+        fs::write(&config_path, "model = \"o3\"\n")?;
+        let _ = create_backup_with_rotation(codex_home)?;
+        fs::write(&config_path, "model = \"gpt-4\"\n")?;
+        let _ = create_backup_with_rotation(codex_home)?;
+        fs::write(&config_path, "model = \"gpt-4.1\"\n")?;
+        let outcome4 = create_backup_with_rotation(codex_home)?;
+        assert!(outcome4.created);
+
+        let bak1 = backup_path(codex_home, 1);
+        let bak2 = backup_path(codex_home, 2);
+        let bak3 = backup_path(codex_home, 3);
+        assert!(bak1.exists());
+        assert!(bak2.exists());
+        assert!(bak3.exists());
+
+        Ok(())
+    }
+
+    #[test]
+    fn dry_run_reports_without_changes() -> std::io::Result<()> {
+        let tmp = TempDir::new()?;
+        let codex_home = tmp.path();
+        let config_path = codex_home.join(CONFIG_TOML_FILE);
+        fs::create_dir_all(codex_home)?;
+        fs::write(&config_path, "model = \"gpt-5\"\n")?;
+
+        let report = migrate_to_v2(codex_home, &MigrationOptions::default())?;
+        assert!(report.changes_detected);
+        assert!(report.notes.iter().any(|n| n.contains("dry-run")));
+        assert_eq!(report.from_version, 1);
+        assert_eq!(report.to_version, 2);
+
+        // Dry run should not create backup or modify file.
+        assert!(!backup_path(codex_home, 1).exists());
+        let contents = fs::read_to_string(&config_path)?;
+        assert!(!contents.contains("mcp_schema_version"));
+
+        Ok(())
+    }
+
+    #[test]
+    fn migrate_applies_version_and_creates_backup() -> std::io::Result<()> {
+        let tmp = TempDir::new()?;
+        let codex_home = tmp.path();
+        let config_path = codex_home.join(CONFIG_TOML_FILE);
+        fs::create_dir_all(codex_home)?;
+        fs::write(&config_path, "model = \"gpt-5\"\n")?;
+
+        let options = MigrationOptions {
+            dry_run: false,
+            force: false,
+        };
+        let report = migrate_to_v2(codex_home, &options)?;
+        assert!(report.changes_detected);
+        assert!(report.backed_up);
+        assert_eq!(report.to_version, 2);
+        assert!(backup_path(codex_home, 1).exists());
+
+        let parsed = load_config_as_toml(codex_home)?;
+        assert_eq!(
+            parsed
+                .get("mcp_schema_version")
+                .and_then(TomlValue::as_integer),
+            Some(2)
+        );
+
+        Ok(())
+    }
+}

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -8,9 +8,22 @@ use std::path::PathBuf;
 use wildmatch::WildMatchPattern;
 
 use serde::Deserialize;
+use serde::Serialize;
 
-#[derive(Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct McpServerConfig {
+    #[serde(default)]
+    pub display_name: Option<String>,
+
+    #[serde(default)]
+    pub category: Option<String>,
+
+    #[serde(default)]
+    pub template_id: Option<String>,
+
+    #[serde(default)]
+    pub description: Option<String>,
+
     pub command: String,
 
     #[serde(default)]
@@ -22,6 +35,108 @@ pub struct McpServerConfig {
     /// Startup timeout in milliseconds for initializing MCP server & initially listing tools.
     #[serde(default)]
     pub startup_timeout_ms: Option<u64>,
+
+    #[serde(default)]
+    pub auth: Option<McpAuthConfig>,
+
+    #[serde(default)]
+    pub healthcheck: Option<McpHealthcheckConfig>,
+
+    #[serde(default)]
+    pub tags: Vec<String>,
+
+    #[serde(default)]
+    pub created_at: Option<String>,
+
+    #[serde(default)]
+    pub last_verified_at: Option<String>,
+
+    #[serde(default)]
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct McpAuthConfig {
+    #[serde(rename = "type")]
+    pub kind: Option<String>,
+
+    #[serde(default)]
+    pub secret_ref: Option<String>,
+
+    #[serde(default)]
+    pub env: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct McpHealthcheckConfig {
+    #[serde(rename = "type")]
+    pub kind: Option<String>,
+
+    #[serde(default)]
+    pub command: Option<String>,
+
+    #[serde(default)]
+    pub args: Vec<String>,
+
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+
+    #[serde(default)]
+    pub interval_seconds: Option<u64>,
+
+    #[serde(default)]
+    pub endpoint: Option<String>,
+
+    #[serde(default)]
+    pub protocol: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct McpTemplate {
+    #[serde(default)]
+    pub version: Option<String>,
+
+    #[serde(default)]
+    pub summary: Option<String>,
+
+    #[serde(default)]
+    pub category: Option<String>,
+
+    #[serde(default)]
+    pub defaults: Option<McpTemplateDefaults>,
+
+    #[serde(default)]
+    pub metadata: Option<HashMap<String, String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct McpTemplateDefaults {
+    #[serde(default)]
+    pub command: Option<String>,
+
+    #[serde(default)]
+    pub args: Vec<String>,
+
+    #[serde(default)]
+    pub env: Option<HashMap<String, String>>,
+
+    #[serde(default)]
+    pub auth: Option<McpAuthConfig>,
+
+    #[serde(default)]
+    pub healthcheck: Option<McpHealthcheckConfig>,
+
+    #[serde(default)]
+    pub tags: Vec<String>,
+
+    #[serde(default)]
+    pub startup_timeout_ms: Option<u64>,
+
+    #[serde(default)]
+    pub description: Option<String>,
+
+    #[serde(default)]
+    pub metadata: Option<HashMap<String, String>>,
 }
 
 #[derive(Deserialize, Debug, Copy, Clone, PartialEq)]
@@ -94,7 +209,6 @@ impl Default for Notifications {
 pub struct Tui {
     /// Enable desktop notifications from the TUI when the terminal is unfocused.
     /// Defaults to `false`.
-    #[serde(default)]
     pub notifications: Notifications,
 }
 

--- a/codex-rs/core/src/mcp/health.rs
+++ b/codex-rs/core/src/mcp/health.rs
@@ -1,0 +1,34 @@
+use std::time::SystemTime;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HealthStatus {
+    Unknown,
+    Passing,
+    Failing,
+}
+
+#[derive(Debug, Clone)]
+pub struct HealthReport {
+    pub status: HealthStatus,
+    pub last_checked_at: Option<SystemTime>,
+    pub notes: Option<String>,
+}
+
+impl HealthReport {
+    pub fn new(status: HealthStatus) -> Self {
+        Self {
+            status,
+            last_checked_at: None,
+            notes: None,
+        }
+    }
+
+    pub fn with_notes(mut self, notes: impl Into<String>) -> Self {
+        self.notes = Some(notes.into());
+        self
+    }
+
+    pub fn unknown() -> Self {
+        Self::new(HealthStatus::Unknown).with_notes("health checks not implemented yet")
+    }
+}

--- a/codex-rs/core/src/mcp/mod.rs
+++ b/codex-rs/core/src/mcp/mod.rs
@@ -1,0 +1,5 @@
+//! MCP management utilities (experimental).
+
+pub mod health;
+pub mod registry;
+pub mod templates;

--- a/codex-rs/core/src/mcp/registry.rs
+++ b/codex-rs/core/src/mcp/registry.rs
@@ -1,0 +1,202 @@
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::path::Path;
+
+use anyhow::Result;
+
+use crate::config::Config;
+use crate::config::load_global_mcp_servers;
+use crate::config::write_global_mcp_servers;
+use crate::config_types::McpServerConfig;
+use crate::config_types::McpTemplate;
+use crate::mcp::health::HealthReport;
+use crate::mcp::templates::TemplateCatalog;
+
+/// Lightweight view into MCP configuration state (experimental).
+pub struct McpRegistry<'a> {
+    config: &'a Config,
+    templates: TemplateCatalog,
+}
+
+impl<'a> McpRegistry<'a> {
+    /// Construct a registry backed by the given config and template catalog.
+    pub fn new(config: &'a Config, templates: TemplateCatalog) -> Self {
+        Self { config, templates }
+    }
+
+    /// Whether overhaul features are enabled.
+    pub fn experimental_enabled(&self) -> bool {
+        self.config.experimental_mcp_overhaul
+    }
+
+    /// Iterate configured MCP servers.
+    pub fn servers(&self) -> impl Iterator<Item = (&String, &McpServerConfig)> {
+        self.config.mcp_servers.iter()
+    }
+
+    /// Retrieve a single server by name.
+    pub fn server(&self, name: &str) -> Option<&McpServerConfig> {
+        self.config.mcp_servers.get(name)
+    }
+
+    /// Return template metadata by id, if available.
+    pub fn template(&self, template_id: &str) -> Option<&McpTemplate> {
+        self.templates.templates().get(template_id)
+    }
+
+    /// All known templates.
+    pub fn templates(&self) -> &HashMap<String, McpTemplate> {
+        self.templates.templates()
+    }
+
+    /// Resolve template defaults into a server configuration skeleton.
+    pub fn instantiate_template(&self, template_id: &str) -> Option<McpServerConfig> {
+        self.templates.instantiate(template_id)
+    }
+
+    /// Persist the provided server configuration under the given name.
+    pub fn upsert_server(&self, name: &str, config: McpServerConfig) -> Result<()> {
+        self.upsert_server_with_existing(None, name, config)
+    }
+
+    /// Persist a server configuration, optionally replacing an existing entry.
+    /// When `existing_name` is provided and differs from `name`, the old entry is removed
+    /// after the new one is written, ensuring we never drop the original configuration
+    /// before a successful write of the replacement.
+    pub fn upsert_server_with_existing(
+        &self,
+        existing_name: Option<&str>,
+        name: &str,
+        config: McpServerConfig,
+    ) -> Result<()> {
+        validate_server_name(name)?;
+        let mut servers = load_global_mcp_servers(self.codex_home())?;
+        servers.insert(name.to_string(), config);
+
+        if let Some(old_name) = existing_name
+            && old_name != name
+        {
+            servers.remove(old_name);
+        }
+
+        write_global_mcp_servers(self.codex_home(), &servers)?;
+        Ok(())
+    }
+
+    /// Remove a server entry. Returns true if removed.
+    pub fn remove_server(&self, name: &str) -> Result<bool> {
+        let mut servers = load_global_mcp_servers(self.codex_home())?;
+        let removed = servers.remove(name).is_some();
+        if removed {
+            write_global_mcp_servers(self.codex_home(), &servers)?;
+        }
+        Ok(removed)
+    }
+
+    /// Health status placeholder for UI surfaces.
+    pub fn health_report(&self, _name: &str) -> HealthReport {
+        HealthReport::unknown()
+    }
+
+    pub fn codex_home(&self) -> &Path {
+        &self.config.codex_home
+    }
+
+    pub fn reload_servers(&self) -> Result<BTreeMap<String, McpServerConfig>> {
+        Ok(load_global_mcp_servers(self.codex_home())?)
+    }
+}
+
+pub fn validate_server_name(name: &str) -> Result<()> {
+    let is_valid = !name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_');
+
+    if is_valid {
+        Ok(())
+    } else {
+        anyhow::bail!("invalid server name '{name}' (use letters, numbers, '-', '_')")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::Config;
+    use crate::config::ConfigOverrides;
+    use crate::config::ConfigToml;
+    use crate::config_types::McpServerConfig;
+    use crate::mcp::templates::TemplateCatalog;
+    use tempfile::TempDir;
+
+    fn make_config(temp: &TempDir) -> Config {
+        Config::load_from_base_config_with_overrides(
+            ConfigToml::default(),
+            ConfigOverrides::default(),
+            temp.path().to_path_buf(),
+        )
+        .expect("load config")
+    }
+
+    #[test]
+    fn upsert_with_existing_renames_without_losing_original() {
+        let tmp = TempDir::new().expect("tempdir");
+        let config = make_config(&tmp);
+        let registry = McpRegistry::new(&config, TemplateCatalog::empty());
+
+        let mut initial = BTreeMap::new();
+        initial.insert(
+            "old".to_string(),
+            McpServerConfig {
+                command: "run-old".into(),
+                ..Default::default()
+            },
+        );
+        write_global_mcp_servers(registry.codex_home(), &initial).expect("seed config");
+
+        let replacement = McpServerConfig {
+            command: "run-new".into(),
+            ..Default::default()
+        };
+
+        registry
+            .upsert_server_with_existing(Some("old"), "new", replacement)
+            .expect("rename server");
+
+        let updated = load_global_mcp_servers(registry.codex_home()).expect("load config");
+        assert!(updated.contains_key("new"));
+        assert!(!updated.contains_key("old"));
+        assert_eq!(updated["new"].command, "run-new".to_string());
+    }
+
+    #[test]
+    fn upsert_with_existing_updates_in_place_when_name_unchanged() {
+        let tmp = TempDir::new().expect("tempdir");
+        let config = make_config(&tmp);
+        let registry = McpRegistry::new(&config, TemplateCatalog::empty());
+
+        let mut initial = BTreeMap::new();
+        initial.insert(
+            "service".to_string(),
+            McpServerConfig {
+                command: "original".into(),
+                ..Default::default()
+            },
+        );
+        write_global_mcp_servers(registry.codex_home(), &initial).expect("seed config");
+
+        let replacement = McpServerConfig {
+            command: "updated".into(),
+            ..Default::default()
+        };
+
+        registry
+            .upsert_server_with_existing(Some("service"), "service", replacement)
+            .expect("update server");
+
+        let updated = load_global_mcp_servers(registry.codex_home()).expect("load config");
+        assert_eq!(updated.len(), 1);
+        assert_eq!(updated["service"].command, "updated".to_string());
+    }
+}

--- a/codex-rs/core/src/mcp/templates.rs
+++ b/codex-rs/core/src/mcp/templates.rs
@@ -1,0 +1,133 @@
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use anyhow::Result;
+use serde_json::Value as JsonValue;
+
+use crate::config_types::McpServerConfig;
+use crate::config_types::McpTemplate;
+use crate::config_types::McpTemplateDefaults;
+
+/// Container for built-in and dynamically loaded MCP templates.
+#[derive(Default, Clone)]
+pub struct TemplateCatalog {
+    templates: HashMap<String, McpTemplate>,
+}
+
+impl TemplateCatalog {
+    /// Create an empty catalog.
+    pub fn empty() -> Self {
+        Self {
+            templates: HashMap::new(),
+        }
+    }
+
+    /// Load templates from the default resources directory.
+    pub fn load_default() -> Result<Self> {
+        let root = Self::default_template_dir();
+        if !root.exists() {
+            return Ok(Self::empty());
+        }
+
+        Self::load_from_dir(&root)
+    }
+
+    /// Load templates from a specific directory.
+    pub fn load_from_dir(dir: &Path) -> Result<Self> {
+        let mut catalog = HashMap::new();
+        if !dir.is_dir() {
+            return Ok(Self { templates: catalog });
+        }
+
+        for entry in
+            fs::read_dir(dir).with_context(|| format!("failed to read {}", dir.display()))?
+        {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("json") {
+                continue;
+            }
+
+            let contents = fs::read_to_string(&path)
+                .with_context(|| format!("failed to read template {}", path.display()))?;
+            match serde_json::from_str::<HashMap<String, McpTemplate>>(&contents) {
+                Ok(map) => catalog.extend(map),
+                Err(err) => {
+                    tracing::warn!("Failed to parse MCP template {}: {err}", path.display());
+                }
+            }
+        }
+
+        Ok(Self { templates: catalog })
+    }
+
+    pub fn templates(&self) -> &HashMap<String, McpTemplate> {
+        &self.templates
+    }
+
+    pub fn instantiate(&self, template_id: &str) -> Option<McpServerConfig> {
+        let template = self.templates.get(template_id)?;
+        let mut config = McpServerConfig {
+            template_id: Some(template_id.to_string()),
+            display_name: template.summary.clone(),
+            category: template.category.clone(),
+            metadata: template.metadata.clone(),
+            ..McpServerConfig::default()
+        };
+
+        if let Some(defaults) = template.defaults.as_ref() {
+            defaults.apply_to(&mut config);
+        }
+
+        Some(config)
+    }
+
+    fn default_template_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../resources/mcp_templates")
+    }
+}
+
+/// Utility to validate that a JSON blob can be deserialized as `McpTemplate`.
+pub fn validate_template_json(json: &JsonValue) -> Result<McpTemplate> {
+    let template: McpTemplate = serde_json::from_value(json.clone())?;
+    Ok(template)
+}
+
+impl McpTemplateDefaults {
+    pub fn apply_to(&self, config: &mut McpServerConfig) {
+        if let Some(command) = &self.command {
+            config.command = command.clone();
+        }
+        if !self.args.is_empty() {
+            config.args = self.args.clone();
+        }
+        if let Some(env) = &self.env {
+            if env.is_empty() {
+                config.env = None;
+            } else {
+                config.env = Some(env.clone());
+            }
+        }
+        if let Some(auth) = &self.auth {
+            config.auth = Some(auth.clone());
+        }
+        if let Some(health) = &self.healthcheck {
+            config.healthcheck = Some(health.clone());
+        }
+        if !self.tags.is_empty() {
+            config.tags = self.tags.clone();
+        }
+        if let Some(timeout) = self.startup_timeout_ms {
+            config.startup_timeout_ms = Some(timeout);
+        }
+        if let Some(description) = &self.description {
+            config.description = Some(description.clone());
+        }
+        if let Some(metadata) = &self.metadata {
+            config.metadata = Some(metadata.clone());
+        }
+    }
+}

--- a/codex-rs/todo.machine.md
+++ b/codex-rs/todo.machine.md
@@ -1,0 +1,55 @@
+# MCP Management Overhaul – Phase 3 (Wizard & UX)
+
+## Objective
+Ship a feature-flagged MCP wizard and dashboard that meet these success criteria:
+- ≥95% of guided CLI/TUI sessions reach a valid config within 5 minutes (measured via telemetry or manual timing).
+- Health check command returns a structured result for every configured server.
+- CLI/TUI/JSON outputs stay in sync (no divergence bugs in manual QA).
+- No plaintext secrets written to disk during wizard flows.
+
+## Preconditions
+- Schema extensions, migrations, and CLI migrate command ✅
+- `experimental.mcp_overhaul` flag wired into config ✅
+
+## Deliverables
+1. **Templates & Registry (Success when…)**
+   - `resources/mcp_templates/*.json` exist with schema validation.
+   - `codex_core::mcp::registry` supports create/update/delete/list using templates.
+   - Policy hooks (command allowlist stub + env warning) execute during registry ops.
+
+2. **CLI Wizard (Success when…)**
+   - `codex mcp wizard` (flagged) walks through template selection, validation, preview, final apply.
+   - `codex mcp add --template … --set …` works headless and writes identical config.
+   - `codex mcp list/get` show health summary when flag on.
+   - Non-interactive wizard: `codex mcp wizard --name foo --command bar --apply` persists entry via registry.
+   - Interactive wizard after confirmation writes entry and re-runs summary on success.
+   - `--json` path returns machine summary without side effects.
+
+3. **TUI Panel (Success when…)**
+   - New panel lists servers + status.
+   - Wizard modal mirrors CLI flow; snapshot tests updated.
+
+4. **Health Probe Stub (Success when…)**
+   - `codex mcp test <name> [--json]` returns cached/placeholder status without panic.
+
+5. **Automation Hooks (Success when…)**
+   - `codex mcp plan --json` emits validation summary suitable for CI.
+
+6. **Documentation & Guardrails (Success when…)**
+   - `docs/config.md` updated with flag instructions + wizard quickstart.
+   - CLI help (`--help`) references experimental gate.
+   - Running wizard/test without flag yields explicit guidance.
+
+## Validation Checklist
+- Unit tests: template parsing, registry validation, wizard step transitions.
+- CLI integration tests: `codex mcp wizard --json`, apply path writes config.
+- TUI snapshot: panel, wizard flows.
+- Manual QA: CLI happy path + failure, TUI flow, automation commands.
+- Telemetry/mock timing: confirm ≤5 min setup goal (manual timing if telemetry absent).
+- Secrets audit: ensure wizard never leaves secrets in plain config.
+
+## Progress — 2025-09-17
+- TUI manager modal + wizard flow implemented (`codex-rs/tui/src/mcp/*`).
+- App events for open/apply/reload/remove integrated with `McpRegistry` in `tui/src/app.rs`.
+- Snapshot test scaffolding for manager & wizard views added (pending `cargo insta accept`).
+- Health status stub exposed via `codex_core::mcp::health` and surfaced in manager list.

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -3,6 +3,7 @@ use codex_core::protocol::Event;
 use codex_file_search::FileMatch;
 
 use crate::history_cell::HistoryCell;
+use crate::mcp::McpWizardDraft;
 
 use codex_core::protocol::AskForApproval;
 use codex_core::protocol::SandboxPolicy;
@@ -65,4 +66,28 @@ pub(crate) enum AppEvent {
 
     /// Forwarded conversation history snapshot from the current conversation.
     ConversationHistory(ConversationPathResponseEvent),
+
+    /// Open MCP manager panel when experimental overhaul is enabled.
+    OpenMcpManager,
+
+    /// Open the MCP wizard with optional template hint and pre-filled draft.
+    OpenMcpWizard {
+        template_id: Option<String>,
+        draft: Option<McpWizardDraft>,
+        existing_name: Option<String>,
+    },
+
+    /// Apply wizard changes (persist configuration, refresh views).
+    ApplyMcpWizard {
+        draft: McpWizardDraft,
+        existing_name: Option<String>,
+    },
+
+    /// Reload MCP servers from disk and refresh the manager view.
+    ReloadMcpServers,
+
+    /// Remove a configured MCP server.
+    RemoveMcpServer {
+        name: String,
+    },
 }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 use crate::app_event_sender::AppEventSender;
 use crate::tui::FrameRequester;
 use crate::user_approval_widget::ApprovalRequest;
-use bottom_pane_view::BottomPaneView;
+pub(crate) use bottom_pane_view::BottomPaneView;
 use codex_core::protocol::TokenUsageInfo;
 use codex_file_search::FileMatch;
 use crossterm::event::KeyEvent;
@@ -27,6 +27,8 @@ mod popup_consts;
 mod scroll_state;
 mod selection_popup_common;
 mod textarea;
+
+pub(crate) use scroll_state::ScrollState;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CancellationEvent {
@@ -333,6 +335,11 @@ impl BottomPane {
             self.app_event_tx.clone(),
         );
         self.active_view = Some(Box::new(view));
+        self.request_redraw();
+    }
+
+    pub(crate) fn show_custom_view(&mut self, view: Box<dyn BottomPaneView>) {
+        self.active_view = Some(view);
         self.request_redraw();
     }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -4,7 +4,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use codex_core::config::Config;
+use codex_core::config_types::McpServerConfig;
 use codex_core::config_types::Notifications;
+use codex_core::mcp::templates::TemplateCatalog;
 use codex_core::protocol::AgentMessageDeltaEvent;
 use codex_core::protocol::AgentMessageEvent;
 use codex_core::protocol::AgentReasoningDeltaEvent;
@@ -19,7 +21,6 @@ use codex_core::protocol::EventMsg;
 use codex_core::protocol::ExecApprovalRequestEvent;
 use codex_core::protocol::ExecCommandBeginEvent;
 use codex_core::protocol::ExecCommandEndEvent;
-use codex_core::protocol::ExitedReviewModeEvent;
 use codex_core::protocol::InputItem;
 use codex_core::protocol::InputMessageKind;
 use codex_core::protocol::ListCustomPromptsResponseEvent;
@@ -28,7 +29,6 @@ use codex_core::protocol::McpToolCallBeginEvent;
 use codex_core::protocol::McpToolCallEndEvent;
 use codex_core::protocol::Op;
 use codex_core::protocol::PatchApplyBeginEvent;
-use codex_core::protocol::ReviewRequest;
 use codex_core::protocol::StreamErrorEvent;
 use codex_core::protocol::TaskCompleteEvent;
 use codex_core::protocol::TokenUsage;
@@ -38,7 +38,6 @@ use codex_core::protocol::TurnDiffEvent;
 use codex_core::protocol::UserMessageEvent;
 use codex_core::protocol::WebSearchBeginEvent;
 use codex_core::protocol::WebSearchEndEvent;
-use codex_protocol::mcp_protocol::ConversationId;
 use codex_protocol::parse_command::ParsedCommand;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
@@ -66,12 +65,16 @@ use crate::clipboard_paste::paste_image_to_temp_png;
 use crate::diff_render::display_path_for;
 use crate::get_git_diff::get_git_diff;
 use crate::history_cell;
-use crate::history_cell::AgentMessageCell;
 use crate::history_cell::CommandOutput;
 use crate::history_cell::ExecCell;
 use crate::history_cell::HistoryCell;
 use crate::history_cell::PatchEventType;
-use crate::markdown::append_markdown;
+use crate::mcp::McpManagerEntry;
+use crate::mcp::McpManagerInit;
+use crate::mcp::McpManagerView;
+use crate::mcp::McpWizardDraft;
+use crate::mcp::McpWizardInit;
+use crate::mcp::McpWizardView;
 use crate::slash_command::SlashCommand;
 use crate::text_formatting::truncate_text;
 use crate::tui::FrameRequester;
@@ -96,6 +99,7 @@ use codex_core::protocol::AskForApproval;
 use codex_core::protocol::SandboxPolicy;
 use codex_core::protocol_config_types::ReasoningEffort as ReasoningEffortConfig;
 use codex_file_search::FileMatch;
+use codex_protocol::mcp_protocol::ConversationId;
 
 // Track information about an in-flight exec command.
 struct RunningCommand {
@@ -145,8 +149,6 @@ pub(crate) struct ChatWidget {
     queued_user_messages: VecDeque<UserMessage>,
     // Pending notification to show when unfocused on next Draw
     pending_notification: Option<Notification>,
-    // Simple review mode flag; used to adjust layout and banners.
-    is_review_mode: bool,
 }
 
 struct UserMessage {
@@ -261,7 +263,7 @@ impl ChatWidget {
         self.request_redraw();
     }
 
-    fn on_task_complete(&mut self, last_agent_message: Option<String>) {
+    fn on_task_complete(&mut self) {
         // If a stream is currently active, finalize only that stream to flush any tail
         // without emitting stray headers for other streams.
         if self.stream.is_write_cycle_active() {
@@ -276,19 +278,20 @@ impl ChatWidget {
         // If there is a queued user message, send exactly one now to begin the next turn.
         self.maybe_send_next_queued_input();
         // Emit a notification when the turn completes (suppressed if focused).
-        self.notify(Notification::AgentTurnComplete {
-            response: last_agent_message.unwrap_or_default(),
-        });
+        self.notify(Notification::AgentTurnComplete);
     }
 
     pub(crate) fn set_token_info(&mut self, info: Option<TokenUsageInfo>) {
         self.bottom_pane.set_token_usage(info.clone());
         self.token_info = info;
     }
-    /// Finalize any active exec as failed and stop/clear running UI state.
-    fn finalize_turn(&mut self) {
+    /// Finalize any active exec as failed, push an error message into history,
+    /// and stop/clear running UI state.
+    fn finalize_turn_with_error_message(&mut self, message: String) {
         // Ensure any spinner is replaced by a red ✗ and flushed into history.
         self.finalize_active_exec_cell_as_failed();
+        // Emit the provided error message/history cell.
+        self.add_to_history(history_cell::new_error_event(message));
         // Reset running state and clear streaming buffers.
         self.bottom_pane.set_task_running(false);
         self.running_commands.clear();
@@ -296,8 +299,7 @@ impl ChatWidget {
     }
 
     fn on_error(&mut self, message: String) {
-        self.finalize_turn();
-        self.add_to_history(history_cell::new_error_event(message));
+        self.finalize_turn_with_error_message(message);
         self.request_redraw();
 
         // After an error ends the turn, try sending the next queued input.
@@ -307,15 +309,11 @@ impl ChatWidget {
     /// Handle a turn aborted due to user interrupt (Esc).
     /// When there are queued user messages, restore them into the composer
     /// separated by newlines rather than auto‑submitting the next one.
-    fn on_interrupted_turn(&mut self, reason: TurnAbortReason) {
+    fn on_interrupted_turn(&mut self) {
         // Finalize, log a gentle prompt, and clear running state.
-        self.finalize_turn();
-
-        if reason != TurnAbortReason::ReviewEnded {
-            self.add_to_history(history_cell::new_error_event(
-                "Conversation interrupted - tell the model what to do differently".to_owned(),
-            ));
-        }
+        self.finalize_turn_with_error_message(
+            "Conversation interrupted - tell the model what to do differently".to_owned(),
+        );
 
         // If any messages were queued during the task, restore them into the composer.
         if !self.queued_user_messages.is_empty() {
@@ -710,7 +708,6 @@ impl ChatWidget {
             show_welcome_banner: true,
             suppress_session_configured_redraw: false,
             pending_notification: None,
-            is_review_mode: false,
         }
     }
 
@@ -767,7 +764,6 @@ impl ChatWidget {
             show_welcome_banner: true,
             suppress_session_configured_redraw: true,
             pending_notification: None,
-            is_review_mode: false,
         }
     }
 
@@ -881,15 +877,6 @@ impl ChatWidget {
             SlashCommand::Compact => {
                 self.clear_token_usage();
                 self.app_event_tx.send(AppEvent::CodexOp(Op::Compact));
-            }
-            SlashCommand::Review => {
-                // Simplified flow: directly send a review op for current changes.
-                self.submit_op(Op::Review {
-                    review_request: ReviewRequest {
-                        prompt: "review current changes".to_string(),
-                        user_facing_hint: "current changes".to_string(),
-                    },
-                });
             }
             SlashCommand::Model => {
                 self.open_model_popup();
@@ -1103,20 +1090,15 @@ impl ChatWidget {
             }
             EventMsg::AgentReasoningSectionBreak(_) => self.on_reasoning_section_break(),
             EventMsg::TaskStarted(_) => self.on_task_started(),
-            EventMsg::TaskComplete(TaskCompleteEvent { last_agent_message }) => {
-                self.on_task_complete(last_agent_message)
-            }
+            EventMsg::TaskComplete(TaskCompleteEvent { .. }) => self.on_task_complete(),
             EventMsg::TokenCount(ev) => self.set_token_info(ev.info),
             EventMsg::Error(ErrorEvent { message }) => self.on_error(message),
             EventMsg::TurnAborted(ev) => match ev.reason {
                 TurnAbortReason::Interrupted => {
-                    self.on_interrupted_turn(ev.reason);
+                    self.on_interrupted_turn();
                 }
                 TurnAbortReason::Replaced => {
                     self.on_error("Turn aborted: replaced by a new task".to_owned())
-                }
-                TurnAbortReason::ReviewEnded => {
-                    self.on_interrupted_turn(ev.reason);
                 }
             },
             EventMsg::PlanUpdate(update) => self.on_plan_update(update),
@@ -1154,60 +1136,9 @@ impl ChatWidget {
                 self.app_event_tx
                     .send(crate::app_event::AppEvent::ConversationHistory(ev));
             }
-            EventMsg::EnteredReviewMode(review_request) => {
-                self.on_entered_review_mode(review_request)
-            }
-            EventMsg::ExitedReviewMode(review) => self.on_exited_review_mode(review),
+            EventMsg::EnteredReviewMode(_) => {}
+            EventMsg::ExitedReviewMode(_) => {}
         }
-    }
-
-    fn on_entered_review_mode(&mut self, review: ReviewRequest) {
-        // Enter review mode and emit a concise banner
-        self.is_review_mode = true;
-        let banner = format!(">> Code review started: {} <<", review.user_facing_hint);
-        self.add_to_history(history_cell::new_review_status_line(banner));
-        self.request_redraw();
-    }
-
-    fn on_exited_review_mode(&mut self, review: ExitedReviewModeEvent) {
-        // Leave review mode; if output is present, flush pending stream + show results.
-        if let Some(output) = review.review_output {
-            self.flush_answer_stream_with_separator();
-            self.flush_interrupt_queue();
-            self.flush_active_exec_cell();
-
-            if output.findings.is_empty() {
-                let explanation = output.overall_explanation.trim().to_string();
-                if explanation.is_empty() {
-                    tracing::error!("Reviewer failed to output a response.");
-                    self.add_to_history(history_cell::new_error_event(
-                        "Reviewer failed to output a response.".to_owned(),
-                    ));
-                } else {
-                    // Show explanation when there are no structured findings.
-                    let mut rendered: Vec<ratatui::text::Line<'static>> = vec!["".into()];
-                    append_markdown(&explanation, &mut rendered, &self.config);
-                    let body_cell = AgentMessageCell::new(rendered, false);
-                    self.app_event_tx
-                        .send(AppEvent::InsertHistoryCell(Box::new(body_cell)));
-                }
-            } else {
-                let message_text =
-                    codex_core::review_format::format_review_findings_block(&output.findings, None);
-                let mut message_lines: Vec<ratatui::text::Line<'static>> = Vec::new();
-                append_markdown(&message_text, &mut message_lines, &self.config);
-                let body_cell = AgentMessageCell::new(message_lines, true);
-                self.app_event_tx
-                    .send(AppEvent::InsertHistoryCell(Box::new(body_cell)));
-            }
-        }
-
-        self.is_review_mode = false;
-        // Append a finishing banner at the end of this turn.
-        self.add_to_history(history_cell::new_review_status_line(
-            "<< Code review finished >>".to_string(),
-        ));
-        self.request_redraw();
     }
 
     fn on_user_message_event(&mut self, event: UserMessageEvent) {
@@ -1428,6 +1359,52 @@ impl ChatWidget {
     }
 
     pub(crate) fn add_mcp_output(&mut self) {
+        if self.config.experimental_mcp_overhaul {
+            self.app_event_tx.send(AppEvent::OpenMcpManager);
+            return;
+        }
+
+        self.show_mcp_history_summary();
+    }
+
+    pub(crate) fn show_mcp_manager(
+        &mut self,
+        entries: Vec<McpManagerEntry>,
+        template_count: usize,
+    ) {
+        let init = McpManagerInit {
+            app_event_tx: self.app_event_tx.clone(),
+            entries,
+            template_count,
+        };
+        self.bottom_pane
+            .show_custom_view(Box::new(McpManagerView::new(init)));
+    }
+
+    pub(crate) fn show_mcp_wizard(
+        &mut self,
+        catalog: TemplateCatalog,
+        draft: Option<McpWizardDraft>,
+        existing_name: Option<String>,
+    ) {
+        let init = McpWizardInit {
+            app_event_tx: self.app_event_tx.clone(),
+            catalog,
+            draft,
+            existing_name,
+        };
+        self.bottom_pane
+            .show_custom_view(Box::new(McpWizardView::new(init)));
+    }
+
+    pub(crate) fn set_mcp_servers(
+        &mut self,
+        servers: std::collections::BTreeMap<String, McpServerConfig>,
+    ) {
+        self.config.mcp_servers = servers.into_iter().collect();
+    }
+
+    pub(crate) fn show_mcp_history_summary(&mut self) {
         if self.config.mcp_servers.is_empty() {
             self.add_to_history(history_cell::empty_mcp_output());
         } else {
@@ -1556,7 +1533,7 @@ impl WidgetRef for &ChatWidget {
 }
 
 enum Notification {
-    AgentTurnComplete { response: String },
+    AgentTurnComplete,
     ExecApprovalRequested { command: String },
     EditApprovalRequested { cwd: PathBuf, changes: Vec<PathBuf> },
 }
@@ -1564,10 +1541,7 @@ enum Notification {
 impl Notification {
     fn display(&self) -> String {
         match self {
-            Notification::AgentTurnComplete { response } => {
-                Notification::agent_turn_preview(response)
-                    .unwrap_or_else(|| "Agent turn complete".to_string())
-            }
+            Notification::AgentTurnComplete => "Agent turn complete".to_string(),
             Notification::ExecApprovalRequested { command } => {
                 format!("Approval requested: {}", truncate_text(command, 30))
             }
@@ -1587,7 +1561,7 @@ impl Notification {
 
     fn type_name(&self) -> &str {
         match self {
-            Notification::AgentTurnComplete { .. } => "agent-turn-complete",
+            Notification::AgentTurnComplete => "agent-turn-complete",
             Notification::ExecApprovalRequested { .. }
             | Notification::EditApprovalRequested { .. } => "approval-requested",
         }
@@ -1599,25 +1573,7 @@ impl Notification {
             Notifications::Custom(allowed) => allowed.iter().any(|a| a == self.type_name()),
         }
     }
-
-    fn agent_turn_preview(response: &str) -> Option<String> {
-        let mut normalized = String::new();
-        for part in response.split_whitespace() {
-            if !normalized.is_empty() {
-                normalized.push(' ');
-            }
-            normalized.push_str(part);
-        }
-        let trimmed = normalized.trim();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(truncate_text(trimmed, AGENT_NOTIFICATION_PREVIEW_GRAPHEMES))
-        }
-    }
 }
-
-const AGENT_NOTIFICATION_PREVIEW_GRAPHEMES: usize = 200;
 
 const EXAMPLE_PROMPTS: [&str; 6] = [
     "Explain this codebase",

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -4,7 +4,6 @@
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 #![deny(clippy::disallowed_methods)]
 use app::App;
-pub use app::AppExitInfo;
 use codex_core::AuthManager;
 use codex_core::BUILT_IN_OSS_MODEL_PROVIDER_ID;
 use codex_core::CodexAuth;
@@ -33,7 +32,7 @@ mod app;
 mod app_backtrack;
 mod app_event;
 mod app_event_sender;
-mod ascii_animation;
+mod backtrack_helpers;
 mod bottom_pane;
 mod chatwidget;
 mod citation_regex;
@@ -52,6 +51,7 @@ pub mod live_wrap;
 mod markdown;
 mod markdown_render;
 mod markdown_stream;
+pub mod mcp;
 mod new_model_popup;
 pub mod onboarding;
 mod pager_overlay;
@@ -86,7 +86,7 @@ use codex_core::internal_storage::InternalStorage;
 pub async fn run_main(
     cli: Cli,
     codex_linux_sandbox_exe: Option<PathBuf>,
-) -> std::io::Result<AppExitInfo> {
+) -> std::io::Result<codex_core::protocol::TokenUsage> {
     let (sandbox_mode, approval_policy) = if cli.full_auto {
         (
             Some(SandboxMode::WorkspaceWrite),
@@ -258,7 +258,7 @@ async fn run_ratatui_app(
     mut internal_storage: InternalStorage,
     active_profile: Option<String>,
     should_show_trust_screen: bool,
-) -> color_eyre::Result<AppExitInfo> {
+) -> color_eyre::Result<codex_core::protocol::TokenUsage> {
     let mut config = config;
     color_eyre::install()?;
 
@@ -370,10 +370,7 @@ async fn run_ratatui_app(
             resume_picker::ResumeSelection::Exit => {
                 restore();
                 session_log::log_session_end();
-                return Ok(AppExitInfo {
-                    token_usage: codex_core::protocol::TokenUsage::default(),
-                    conversation_id: None,
-                });
+                return Ok(codex_core::protocol::TokenUsage::default());
             }
             other => other,
         }

--- a/codex-rs/tui/src/mcp/manager_view.rs
+++ b/codex-rs/tui/src/mcp/manager_view.rs
@@ -1,0 +1,549 @@
+use std::cell::Cell;
+
+use codex_core::mcp::health::HealthReport;
+use codex_core::mcp::health::HealthStatus;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Constraint;
+use ratatui::layout::Layout;
+use ratatui::layout::Rect;
+use ratatui::style::Modifier;
+use ratatui::style::Style;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::text::Span;
+use ratatui::widgets::Block;
+use ratatui::widgets::Borders;
+use ratatui::widgets::Paragraph;
+use ratatui::widgets::Row;
+use ratatui::widgets::StatefulWidget;
+use ratatui::widgets::Table;
+use ratatui::widgets::TableState;
+use ratatui::widgets::Widget;
+use ratatui::widgets::Wrap;
+
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+use crate::bottom_pane::BottomPane;
+use crate::bottom_pane::BottomPaneView;
+use crate::bottom_pane::CancellationEvent;
+use crate::bottom_pane::ScrollState;
+use crate::mcp::types::McpServerSnapshot;
+use crate::mcp::types::McpWizardDraft;
+
+#[derive(Clone)]
+pub(crate) struct McpManagerEntry {
+    pub snapshot: McpServerSnapshot,
+    pub health: HealthReport,
+}
+
+pub(crate) struct McpManagerInit {
+    pub app_event_tx: AppEventSender,
+    pub entries: Vec<McpManagerEntry>,
+    pub template_count: usize,
+}
+
+pub(crate) struct McpManagerView {
+    app_event_tx: AppEventSender,
+    entries: Vec<McpManagerEntry>,
+    template_count: usize,
+    scroll: ScrollState,
+    list_visible_rows: Cell<usize>,
+    close_requested: bool,
+    confirm_delete: bool,
+}
+
+impl McpManagerView {
+    pub(crate) fn new(init: McpManagerInit) -> Self {
+        let mut scroll = ScrollState::new();
+        scroll.clamp_selection(init.entries.len());
+        Self {
+            app_event_tx: init.app_event_tx,
+            entries: init.entries,
+            template_count: init.template_count,
+            scroll,
+            list_visible_rows: Cell::new(1),
+            close_requested: false,
+            confirm_delete: false,
+        }
+    }
+
+    fn selected_entry(&self) -> Option<&McpManagerEntry> {
+        self.scroll
+            .selected_idx
+            .and_then(|idx| self.entries.get(idx))
+    }
+
+    fn visible_rows(&self) -> usize {
+        self.list_visible_rows.get().max(1)
+    }
+
+    fn move_selection_up(&mut self) {
+        self.scroll.move_up_wrap(self.entries.len());
+        self.scroll
+            .ensure_visible(self.entries.len(), self.visible_rows());
+        self.confirm_delete = false;
+    }
+
+    fn move_selection_down(&mut self) {
+        self.scroll.move_down_wrap(self.entries.len());
+        self.scroll
+            .ensure_visible(self.entries.len(), self.visible_rows());
+        self.confirm_delete = false;
+    }
+
+    fn page_up(&mut self) {
+        let steps = self.visible_rows().saturating_sub(1);
+        for _ in 0..steps {
+            self.scroll.move_up_wrap(self.entries.len());
+        }
+        self.scroll
+            .ensure_visible(self.entries.len(), self.visible_rows());
+        self.confirm_delete = false;
+    }
+
+    fn page_down(&mut self) {
+        let steps = self.visible_rows().saturating_sub(1);
+        for _ in 0..steps {
+            self.scroll.move_down_wrap(self.entries.len());
+        }
+        self.scroll
+            .ensure_visible(self.entries.len(), self.visible_rows());
+        self.confirm_delete = false;
+    }
+
+    fn open_new_wizard(&self) {
+        self.app_event_tx.send(AppEvent::OpenMcpWizard {
+            template_id: None,
+            draft: None,
+            existing_name: None,
+        });
+    }
+
+    fn open_edit_wizard(&self) {
+        if let Some(entry) = self.selected_entry() {
+            let config = entry.snapshot.to_config();
+            let draft = McpWizardDraft::from_existing(entry.snapshot.name.clone(), &config);
+            self.app_event_tx.send(AppEvent::OpenMcpWizard {
+                template_id: entry.snapshot.template_id.clone(),
+                draft: Some(draft),
+                existing_name: Some(entry.snapshot.name.clone()),
+            });
+        }
+    }
+
+    fn request_remove_selected(&mut self) {
+        if self.selected_entry().is_none() {
+            return;
+        }
+        if self.confirm_delete {
+            if let Some(entry) = self.selected_entry() {
+                self.app_event_tx.send(AppEvent::RemoveMcpServer {
+                    name: entry.snapshot.name.clone(),
+                });
+            }
+            self.confirm_delete = false;
+        } else {
+            self.confirm_delete = true;
+        }
+    }
+
+    fn refresh(&self) {
+        self.app_event_tx.send(AppEvent::ReloadMcpServers);
+    }
+
+    fn render_list(&self, area: Rect, buf: &mut Buffer) {
+        let header = Row::new(vec!["Name".bold(), "Status".bold(), "Command".bold()]);
+
+        let rows: Vec<Row> = self
+            .entries
+            .iter()
+            .map(|entry| {
+                Row::new(vec![
+                    Span::raw(entry.snapshot.name.clone()),
+                    health_span(&entry.health.status),
+                    Span::raw(entry.snapshot.command.clone()),
+                ])
+            })
+            .collect();
+
+        let mut state = TableState::default();
+        state.select(self.scroll.selected_idx);
+        *state.offset_mut() = self.scroll.scroll_top;
+
+        let table = Table::new(
+            rows,
+            [
+                Constraint::Percentage(28),
+                Constraint::Length(10),
+                Constraint::Percentage(62),
+            ],
+        )
+        .header(header)
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Configured MCP Servers"),
+        )
+        .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+
+        StatefulWidget::render(table, area, buf, &mut state);
+
+        let visible_rows = area.height.saturating_sub(3) as usize; // header + borders
+        self.list_visible_rows.set(visible_rows.max(1));
+    }
+
+    fn render_detail(&self, area: Rect, buf: &mut Buffer) {
+        let mut lines: Vec<Line> = Vec::new();
+        if let Some(entry) = self.selected_entry() {
+            lines.extend(detail_lines(&entry.snapshot));
+            lines.push(Line::from(vec![
+                "Status: ".dim(),
+                health_span(&entry.health.status),
+            ]));
+            if let Some(notes) = entry.health.notes.as_ref() {
+                lines.push(Line::from(vec!["  • ".into(), notes.clone().dim()]));
+            }
+            if self.confirm_delete {
+                lines.push(Line::from(""));
+                lines.push("Press 'd' again to confirm deletion".red().into());
+            }
+        } else if self.entries.is_empty() {
+            lines.push("No MCP servers configured.".into());
+            if self.template_count > 0 {
+                lines.push(
+                    format!(
+                        "Press 'n' to create one using {} available template(s).",
+                        self.template_count
+                    )
+                    .dim()
+                    .into(),
+                );
+            }
+        }
+
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            "Keys: ".dim(),
+            "↑/↓".cyan(),
+            " move  ".dim(),
+            "n".cyan(),
+            " new  ".dim(),
+            "Enter".cyan(),
+            " edit  ".dim(),
+            "r".cyan(),
+            " reload  ".dim(),
+            "d".cyan(),
+            " delete  ".dim(),
+            "Esc".cyan(),
+            " close".dim(),
+        ]));
+
+        let paragraph = Paragraph::new(lines)
+            .block(Block::default().borders(Borders::ALL).title("Details"))
+            .wrap(Wrap { trim: true });
+        Widget::render(paragraph, area, buf);
+    }
+}
+
+impl BottomPaneView for McpManagerView {
+    fn handle_key_event(&mut self, _pane: &mut BottomPane, key_event: crossterm::event::KeyEvent) {
+        use crossterm::event::KeyCode;
+        self.confirm_delete &= matches!(key_event.code, KeyCode::Char('d'));
+
+        match key_event.code {
+            KeyCode::Esc | KeyCode::Char('q') => {
+                self.close_requested = true;
+            }
+            KeyCode::Char('n') => self.open_new_wizard(),
+            KeyCode::Enter | KeyCode::Char('e') => self.open_edit_wizard(),
+            KeyCode::Char('r') => self.refresh(),
+            KeyCode::Char('d') => self.request_remove_selected(),
+            KeyCode::Up => self.move_selection_up(),
+            KeyCode::Down => self.move_selection_down(),
+            KeyCode::PageUp => self.page_up(),
+            KeyCode::PageDown => self.page_down(),
+            _ => {
+                if !matches!(key_event.code, KeyCode::Char('d')) {
+                    self.confirm_delete = false;
+                }
+            }
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        self.close_requested
+    }
+
+    fn on_ctrl_c(&mut self, _pane: &mut BottomPane) -> CancellationEvent {
+        self.close_requested = true;
+        CancellationEvent::Handled
+    }
+
+    fn desired_height(&self, _width: u16) -> u16 {
+        16
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let layout =
+            Layout::vertical([Constraint::Percentage(60), Constraint::Percentage(40)]).split(area);
+        self.render_list(layout[0], buf);
+        self.render_detail(layout[1], buf);
+    }
+}
+
+fn health_span(status: &HealthStatus) -> Span<'static> {
+    match status {
+        HealthStatus::Unknown => "unknown".dim(),
+        HealthStatus::Passing => "passing".green(),
+        HealthStatus::Failing => "failing".red(),
+    }
+}
+
+fn detail_lines(snapshot: &McpServerSnapshot) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    lines.push(Line::from(vec![
+        "Name: ".dim(),
+        snapshot.name.clone().into(),
+        "  Command: ".dim(),
+        snapshot.command.clone().into(),
+    ]));
+
+    if !snapshot.args.is_empty() {
+        lines.push(Line::from(vec![
+            "Args: ".dim(),
+            snapshot.args.join(" ").into(),
+        ]));
+    }
+
+    if let Some(desc) = snapshot.description.as_ref() {
+        lines.push(Line::from(vec!["Description: ".dim(), desc.clone().into()]));
+    }
+
+    if !snapshot.tags.is_empty() {
+        lines.push(Line::from(vec![
+            "Tags: ".dim(),
+            snapshot.tags.join(", ").into(),
+        ]));
+    }
+
+    if let Some(template_id) = snapshot.template_id.as_ref() {
+        lines.push(Line::from(vec![
+            "Template: ".dim(),
+            template_id.clone().into(),
+        ]));
+    }
+
+    if let Some(timeout) = snapshot.startup_timeout_ms {
+        lines.push(Line::from(vec![
+            "Startup timeout (ms): ".dim(),
+            timeout.to_string().into(),
+        ]));
+    }
+
+    if !snapshot.env.is_empty() {
+        lines.push("Env:".dim().into());
+        for (idx, (k, v)) in snapshot.env.iter().enumerate() {
+            if idx >= 6 {
+                lines.push(
+                    format!("  … {} more", snapshot.env.len() - idx)
+                        .dim()
+                        .into(),
+                );
+                break;
+            }
+            lines.push(Line::from(vec!["  • ".into(), format!("{k}={v}").into()]));
+        }
+    }
+
+    if let Some(auth) = snapshot.auth.as_ref() {
+        lines.extend(auth_lines(auth));
+    }
+
+    if let Some(health) = snapshot.health.as_ref() {
+        lines.extend(health_lines(health));
+    }
+
+    lines
+}
+
+fn auth_lines(auth: &crate::mcp::types::AuthDraft) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    lines.push("Auth:".dim().into());
+    if let Some(kind) = auth.kind.as_ref() {
+        lines.push(Line::from(vec!["  • Type: ".into(), kind.clone().into()]));
+    }
+    if let Some(secret) = auth.secret_ref.as_ref() {
+        lines.push(Line::from(vec![
+            "  • Secret: ".into(),
+            secret.clone().into(),
+        ]));
+    }
+    if !auth.env.is_empty() {
+        for (idx, (k, v)) in auth.env.iter().enumerate() {
+            if idx >= 4 {
+                lines.push(format!("  … {} more", auth.env.len() - idx).dim().into());
+                break;
+            }
+            lines.push(Line::from(vec![
+                "     - ".into(),
+                format!("{k}={v}").into(),
+            ]));
+        }
+    }
+    lines
+}
+
+fn health_lines(health: &crate::mcp::types::HealthDraft) -> Vec<Line<'static>> {
+    let mut lines = Vec::new();
+    lines.push("Health:".dim().into());
+    if let Some(kind) = health.kind.as_ref() {
+        lines.push(Line::from(vec!["  • Type: ".into(), kind.clone().into()]));
+    }
+    if let Some(cmd) = health.command.as_ref() {
+        lines.push(Line::from(vec!["  • Command: ".into(), cmd.clone().into()]));
+    }
+    if !health.args.is_empty() {
+        lines.push(Line::from(vec![
+            "  • Args: ".into(),
+            health.args.join(" ").into(),
+        ]));
+    }
+    if let Some(endpoint) = health.endpoint.as_ref() {
+        lines.push(Line::from(vec![
+            "  • Endpoint: ".into(),
+            endpoint.clone().into(),
+        ]));
+    }
+    if let Some(timeout) = health.timeout_ms {
+        lines.push(Line::from(vec![
+            "  • Timeout (ms): ".into(),
+            timeout.to_string().into(),
+        ]));
+    }
+    if let Some(interval) = health.interval_seconds {
+        lines.push(Line::from(vec![
+            "  • Interval (s): ".into(),
+            interval.to_string().into(),
+        ]));
+    }
+    lines
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::types::AuthDraft;
+    use crate::mcp::types::HealthDraft;
+    use insta::assert_snapshot;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use std::collections::BTreeMap;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    fn render_view(view: &McpManagerView) -> String {
+        let width = 72;
+        let height = BottomPaneView::desired_height(view, width);
+        let area = Rect::new(0, 0, width, height);
+        let mut buf = Buffer::empty(area);
+        BottomPaneView::render(view, area, &mut buf);
+
+        (0..area.height)
+            .map(|row| {
+                let mut line = String::new();
+                for col in 0..area.width {
+                    let symbol = buf[(area.x + col, area.y + row)].symbol();
+                    if symbol.is_empty() {
+                        line.push(' ');
+                    } else {
+                        line.push_str(symbol);
+                    }
+                }
+                line.trim_end().to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn sample_entry(name: &str, command: &str, status: HealthStatus) -> McpManagerEntry {
+        let mut env = BTreeMap::new();
+        env.insert("TOKEN".to_string(), "***".to_string());
+
+        let snapshot = McpServerSnapshot {
+            name: name.to_string(),
+            command: command.to_string(),
+            args: vec!["--serve".to_string()],
+            env,
+            description: Some("Sample server".to_string()),
+            tags: vec!["beta".to_string(), "internal".to_string()],
+            template_id: Some("sample-template".to_string()),
+            auth: Some(AuthDraft {
+                kind: Some("env".to_string()),
+                secret_ref: Some("vault:secret".to_string()),
+                env: BTreeMap::from([("AUTH_TOKEN".to_string(), "secret".to_string())]),
+            }),
+            health: Some(HealthDraft {
+                kind: Some("stdio".to_string()),
+                command: Some("health-check".to_string()),
+                args: vec!["--ping".to_string()],
+                timeout_ms: Some(5_000),
+                interval_seconds: Some(60),
+                endpoint: None,
+                protocol: None,
+            }),
+            display_name: Some(format!("{name} MCP")),
+            category: Some("general".to_string()),
+            metadata: None,
+            startup_timeout_ms: Some(15_000),
+        };
+
+        McpManagerEntry {
+            snapshot,
+            health: HealthReport::new(status).with_notes("synthetic status for test rendering"),
+        }
+    }
+
+    fn make_view(entries: Vec<McpManagerEntry>, template_count: usize) -> McpManagerView {
+        let (tx, _rx) = unbounded_channel();
+        McpManagerView::new(McpManagerInit {
+            app_event_tx: AppEventSender::new(tx),
+            entries,
+            template_count,
+        })
+    }
+
+    #[test]
+    fn renders_manager_with_entries() {
+        let view = make_view(
+            vec![
+                sample_entry("anthropic", "anthropic-mcp", HealthStatus::Unknown),
+                sample_entry("openai", "openai-mcp", HealthStatus::Passing),
+            ],
+            3,
+        );
+
+        assert_snapshot!("mcp_manager_with_entries", render_view(&view));
+    }
+
+    #[test]
+    fn renders_delete_confirmation() {
+        let mut view = make_view(
+            vec![sample_entry(
+                "perplexity",
+                "perplexity-mcp",
+                HealthStatus::Failing,
+            )],
+            1,
+        );
+        view.scroll.selected_idx = Some(0);
+        view.confirm_delete = true;
+
+        assert_snapshot!("mcp_manager_delete_confirm", render_view(&view));
+    }
+
+    #[test]
+    fn renders_empty_state_with_template_hint() {
+        let view = make_view(Vec::new(), 5);
+
+        assert_snapshot!("mcp_manager_empty", render_view(&view));
+    }
+}

--- a/codex-rs/tui/src/mcp/mod.rs
+++ b/codex-rs/tui/src/mcp/mod.rs
@@ -1,0 +1,11 @@
+mod manager_view;
+mod types;
+mod wizard_view;
+
+pub(crate) use manager_view::McpManagerEntry;
+pub(crate) use manager_view::McpManagerInit;
+pub(crate) use manager_view::McpManagerView;
+pub(crate) use types::McpManagerState;
+pub(crate) use types::McpWizardDraft;
+pub(crate) use wizard_view::McpWizardInit;
+pub(crate) use wizard_view::McpWizardView;

--- a/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__manager_view__tests__mcp_manager_delete_confirm.snap
+++ b/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__manager_view__tests__mcp_manager_delete_confirm.snap
@@ -1,0 +1,20 @@
+---
+source: tui/src/mcp/manager_view.rs
+expression: render_view(&view)
+---
+┌Configured MCP Servers────────────────────────────────────────────────┐
+│Name            Status     Command                                    │
+│perplexity      failing    perplexity-mcp                             │
+│                                                                      │
+│                                                                      │
+│                                                                      │
+│                                                                      │
+│                                                                      │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+┌Details───────────────────────────────────────────────────────────────┐
+│Name: perplexity  Command: perplexity-mcp                             │
+│Args: --serve                                                         │
+│Description: Sample server                                            │
+│Tags: beta, internal                                                  │
+└──────────────────────────────────────────────────────────────────────┘

--- a/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__manager_view__tests__mcp_manager_empty.snap
+++ b/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__manager_view__tests__mcp_manager_empty.snap
@@ -1,0 +1,20 @@
+---
+source: tui/src/mcp/manager_view.rs
+expression: render_view(&view)
+---
+┌Configured MCP Servers────────────────────────────────────────────────┐
+│Name            Status     Command                                    │
+│                                                                      │
+│                                                                      │
+│                                                                      │
+│                                                                      │
+│                                                                      │
+│                                                                      │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+┌Details───────────────────────────────────────────────────────────────┐
+│No MCP servers configured.                                            │
+│Press 'n' to create one using 5 available template(s).                │
+│                                                                      │
+│Keys: ↑/↓ move  n new  Enter edit  r reload  d delete  Esc close      │
+└──────────────────────────────────────────────────────────────────────┘

--- a/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__manager_view__tests__mcp_manager_with_entries.snap
+++ b/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__manager_view__tests__mcp_manager_with_entries.snap
@@ -1,0 +1,20 @@
+---
+source: tui/src/mcp/manager_view.rs
+expression: render_view(&view)
+---
+┌Configured MCP Servers────────────────────────────────────────────────┐
+│Name            Status     Command                                    │
+│anthropic       unknown    anthropic-mcp                              │
+│openai          passing    openai-mcp                                 │
+│                                                                      │
+│                                                                      │
+│                                                                      │
+│                                                                      │
+│                                                                      │
+└──────────────────────────────────────────────────────────────────────┘
+┌Details───────────────────────────────────────────────────────────────┐
+│Name: anthropic  Command: anthropic-mcp                               │
+│Args: --serve                                                         │
+│Description: Sample server                                            │
+│Tags: beta, internal                                                  │
+└──────────────────────────────────────────────────────────────────────┘

--- a/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__wizard_view__tests__mcp_wizard_form_error.snap
+++ b/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__wizard_view__tests__mcp_wizard_form_error.snap
@@ -1,0 +1,22 @@
+---
+source: tui/src/mcp/wizard_view.rs
+expression: render(&view)
+---
+┌MCP Wizard──────────────────────────────────────────────────────────────────┐
+│Field                       Value                                           │
+│Template                    anthropic/cli                                   │
+│Name                        anthropic-mcp                                   │
+│Command                     anthropic-mcp                                   │
+│Args                        --serve --port 8080                             │
+│Env                         1 entry                                         │
+│Description                 Anthropic MCP bridge                            │
+│Tags                        anthropic, beta                                 │
+│Startup timeout (ms)        15000                                           │
+│Auth type                   env                                             │
+│Auth secret                 vault:anthropic                                 │
+└────────────────────────────────────────────────────────────────────────────┘
+┌Help────────────────────────────────────────────────────────────────────────┐
+│Command must not be empty                                                   │
+│Keys: ↑/↓ move  Enter edit/select  s summary  Esc close                     │
+│                                                                            │
+└────────────────────────────────────────────────────────────────────────────┘

--- a/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__wizard_view__tests__mcp_wizard_summary.snap
+++ b/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__wizard_view__tests__mcp_wizard_summary.snap
@@ -1,0 +1,22 @@
+---
+source: tui/src/mcp/wizard_view.rs
+expression: render(&view)
+---
+┌Review──────────────────────────────────────────────────────────────────────┐
+│MCP Wizard Summary                                                          │
+│                                                                            │
+│Name: anthropic-mcp                                                         │
+│Template: anthropic/cli                                                     │
+│Command: anthropic-mcp                                                      │
+│Args: --serve --port 8080                                                   │
+│Env:                                                                        │
+│• API_KEY=${SECRET}                                                         │
+│Startup timeout (ms): 15000                                                 │
+│Description: Anthropic MCP bridge                                           │
+│Tags: anthropic, beta                                                       │
+│Auth:                                                                       │
+│• Type: env                                                                 │
+│• Secret: vault:anthropic                                                   │
+│- TOKEN=${TOKEN}                                                            │
+│Health:                                                                     │
+└────────────────────────────────────────────────────────────────────────────┘

--- a/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__wizard_view__tests__mcp_wizard_template_select.snap
+++ b/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__wizard_view__tests__mcp_wizard_template_select.snap
@@ -1,0 +1,22 @@
+---
+source: tui/src/mcp/wizard_view.rs
+expression: render(&view)
+---
+┌Select MCP Template─────────────────────────────────────────────────────────┐
+│Template                Summary                                             │
+│anthropic/cli           Anthropic CLI bridge (llm)                          │
+│openai/web              OpenAI Browser agent (llm)                          │
+│manual                  Start from scratch                                  │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+Enter to select • Esc to cancel──────────────────────────────────────────────┘

--- a/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__wizard_view__tests__mcp_wizard_text_edit.snap
+++ b/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__wizard_view__tests__mcp_wizard_text_edit.snap
@@ -1,0 +1,22 @@
+---
+source: tui/src/mcp/wizard_view.rs
+expression: render(&view)
+---
+┌Edit────────────────────────────────────────────────────────────────────────┐
+│Env                                                                         │
+│Expected KEY=VALUE pairs                                                    │
+│Enter to save • Esc to cancel                                               │
+│                                                                            │
+│API_KEY=ORG_ID=1234                                                         │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+└────────────────────────────────────────────────────────────────────────────┘

--- a/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__wizard_view__tests__mcp_wizard_variant_select.snap
+++ b/codex-rs/tui/src/mcp/snapshots/codex_tui__mcp__wizard_view__tests__mcp_wizard_variant_select.snap
@@ -1,0 +1,22 @@
+---
+source: tui/src/mcp/wizard_view.rs
+expression: render(&view)
+---
+┌Select authentication───────────────────────────────────────────────────────┐
+│none                                                                        │
+│env                                                                         │
+│oauth                                                                       │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+│                                                                            │
+Enter to confirm • Esc to cancel─────────────────────────────────────────────┘

--- a/codex-rs/tui/src/mcp/types.rs
+++ b/codex-rs/tui/src/mcp/types.rs
@@ -1,0 +1,452 @@
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+
+use anyhow::Result;
+use anyhow::anyhow;
+use anyhow::bail;
+use codex_core::config_types::McpAuthConfig;
+use codex_core::config_types::McpHealthcheckConfig;
+use codex_core::config_types::McpServerConfig;
+use codex_core::config_types::McpTemplate;
+use codex_core::mcp::registry::McpRegistry;
+use codex_core::mcp::registry::validate_server_name;
+use codex_core::mcp::templates::TemplateCatalog;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct McpWizardDraft {
+    pub name: String,
+    pub template_id: Option<String>,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: BTreeMap<String, String>,
+    pub startup_timeout_ms: Option<u64>,
+    pub description: Option<String>,
+    pub tags: Vec<String>,
+    pub auth: Option<AuthDraft>,
+    pub health: Option<HealthDraft>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct AuthDraft {
+    pub kind: Option<String>,
+    pub secret_ref: Option<String>,
+    pub env: BTreeMap<String, String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct HealthDraft {
+    pub kind: Option<String>,
+    pub command: Option<String>,
+    pub args: Vec<String>,
+    pub timeout_ms: Option<u64>,
+    pub interval_seconds: Option<u64>,
+    pub endpoint: Option<String>,
+    pub protocol: Option<String>,
+}
+
+impl McpWizardDraft {
+    pub(crate) fn from_existing(name: String, cfg: &McpServerConfig) -> Self {
+        let env_map = cfg
+            .env
+            .as_ref()
+            .map(|env| env.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+            .unwrap_or_default();
+
+        let auth = cfg.auth.as_ref().map(|auth| AuthDraft {
+            kind: auth.kind.clone(),
+            secret_ref: auth.secret_ref.clone(),
+            env: auth
+                .env
+                .as_ref()
+                .map(|env| env.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+                .unwrap_or_default(),
+        });
+
+        let health = cfg.healthcheck.as_ref().map(|health| HealthDraft {
+            kind: health.kind.clone(),
+            command: health.command.clone(),
+            args: health.args.clone(),
+            timeout_ms: health.timeout_ms,
+            interval_seconds: health.interval_seconds,
+            endpoint: health.endpoint.clone(),
+            protocol: health.protocol.clone(),
+        });
+
+        Self {
+            name,
+            template_id: cfg.template_id.clone(),
+            command: cfg.command.clone(),
+            args: cfg.args.clone(),
+            env: env_map,
+            startup_timeout_ms: cfg.startup_timeout_ms,
+            description: cfg.description.clone(),
+            tags: cfg.tags.clone(),
+            auth,
+            health,
+        }
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        validate_server_name(&self.name)?;
+        if self.command.trim().is_empty() {
+            bail!("Command must not be empty");
+        }
+        for k in self.env.keys() {
+            if k.trim().is_empty() {
+                bail!("Environment variable keys must not be empty");
+            }
+        }
+        if let Some(auth) = &self.auth {
+            if let Some(kind) = &auth.kind
+                && kind.trim().is_empty()
+            {
+                bail!("Authentication type must not be blank");
+            }
+            for k in auth.env.keys() {
+                if k.trim().is_empty() {
+                    bail!("Authentication environment keys must not be empty");
+                }
+            }
+        }
+        if let Some(health) = &self.health
+            && let Some(kind) = &health.kind
+            && kind.trim().is_empty()
+        {
+            bail!("Health check type must not be blank");
+        }
+        Ok(())
+    }
+
+    pub(crate) fn build_server_config(
+        &self,
+        templates: &TemplateCatalog,
+    ) -> Result<McpServerConfig> {
+        self.validate()?;
+
+        let mut server = if let Some(template_id) = self.template_id.as_ref() {
+            instantiate_template(templates, template_id)?
+        } else {
+            McpServerConfig::default()
+        };
+
+        if self.template_id.is_some() {
+            server.template_id = self.template_id.clone();
+        }
+
+        server.command = self.command.clone();
+        server.args = self.args.clone();
+        server.env = map_opt(&self.env);
+        server.startup_timeout_ms = self.startup_timeout_ms;
+        server.description = self.description.clone();
+        server.tags = self.tags.clone();
+
+        server.auth = self.auth.as_ref().map(|auth| McpAuthConfig {
+            kind: auth.kind.clone(),
+            secret_ref: auth.secret_ref.clone(),
+            env: map_opt(&auth.env),
+        });
+
+        server.healthcheck = self.health.as_ref().map(|health| McpHealthcheckConfig {
+            kind: health.kind.clone(),
+            command: health.command.clone(),
+            args: health.args.clone(),
+            timeout_ms: health.timeout_ms,
+            interval_seconds: health.interval_seconds,
+            endpoint: health.endpoint.clone(),
+            protocol: health.protocol.clone(),
+        });
+
+        if server.command.trim().is_empty() {
+            bail!("Command must not be empty");
+        }
+
+        Ok(server)
+    }
+
+    pub(crate) fn apply_template_config(&mut self, cfg: &McpServerConfig) {
+        self.template_id = cfg.template_id.clone();
+        self.command = cfg.command.clone();
+        self.args = cfg.args.clone();
+        self.env = cfg
+            .env
+            .as_ref()
+            .map(|env| env.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+            .unwrap_or_default();
+        self.startup_timeout_ms = cfg.startup_timeout_ms;
+        self.description = cfg.description.clone();
+        self.tags = cfg.tags.clone();
+        self.auth = cfg.auth.as_ref().map(|auth| AuthDraft {
+            kind: auth.kind.clone(),
+            secret_ref: auth.secret_ref.clone(),
+            env: auth
+                .env
+                .as_ref()
+                .map(|env| env.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+                .unwrap_or_default(),
+        });
+        self.health = cfg.healthcheck.as_ref().map(|health| HealthDraft {
+            kind: health.kind.clone(),
+            command: health.command.clone(),
+            args: health.args.clone(),
+            timeout_ms: health.timeout_ms,
+            interval_seconds: health.interval_seconds,
+            endpoint: health.endpoint.clone(),
+            protocol: health.protocol.clone(),
+        });
+    }
+
+    pub(crate) fn summary_lines(&self) -> Vec<Line<'static>> {
+        let mut lines: Vec<Line> = Vec::new();
+        lines.push("MCP Wizard Summary".bold().into());
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec!["Name: ".dim(), self.name.clone().into()]));
+        if let Some(template) = self.template_id.as_ref() {
+            lines.push(Line::from(vec![
+                "Template: ".dim(),
+                template.clone().into(),
+            ]));
+        } else {
+            lines.push(Line::from(vec!["Template: ".dim(), "manual".into()]));
+        }
+        lines.push(Line::from(vec![
+            "Command: ".dim(),
+            self.command.clone().into(),
+        ]));
+        if !self.args.is_empty() {
+            lines.push(Line::from(vec!["Args: ".dim(), self.args.join(" ").into()]));
+        }
+        if !self.env.is_empty() {
+            lines.push("Env:".dim().into());
+            for (k, v) in &self.env {
+                lines.push(Line::from(vec!["  • ".into(), format!("{k}={v}").into()]));
+            }
+        }
+        if let Some(timeout) = self.startup_timeout_ms {
+            lines.push(Line::from(vec![
+                "Startup timeout (ms): ".dim(),
+                timeout.to_string().into(),
+            ]));
+        }
+        if let Some(desc) = self.description.as_ref() {
+            lines.push(Line::from(vec!["Description: ".dim(), desc.clone().into()]));
+        }
+        if !self.tags.is_empty() {
+            lines.push(Line::from(vec![
+                "Tags: ".dim(),
+                self.tags.join(", ").into(),
+            ]));
+        }
+        if let Some(auth) = &self.auth {
+            lines.push("Auth:".dim().into());
+            if let Some(kind) = auth.kind.as_ref() {
+                lines.push(Line::from(vec!["  • Type: ".into(), kind.clone().into()]));
+            }
+            if let Some(secret) = auth.secret_ref.as_ref() {
+                lines.push(Line::from(vec![
+                    "  • Secret: ".into(),
+                    secret.clone().into(),
+                ]));
+            }
+            if !auth.env.is_empty() {
+                for (k, v) in &auth.env {
+                    lines.push(Line::from(vec![
+                        "     - ".into(),
+                        format!("{k}={v}").into(),
+                    ]));
+                }
+            }
+        }
+        if let Some(health) = &self.health {
+            lines.push("Health:".dim().into());
+            if let Some(kind) = health.kind.as_ref() {
+                lines.push(Line::from(vec!["  • Type: ".into(), kind.clone().into()]));
+            }
+            if let Some(cmd) = health.command.as_ref() {
+                lines.push(Line::from(vec!["  • Command: ".into(), cmd.clone().into()]));
+            }
+            if !health.args.is_empty() {
+                lines.push(Line::from(vec![
+                    "  • Args: ".into(),
+                    health.args.join(" ").into(),
+                ]));
+            }
+            if let Some(endpoint) = health.endpoint.as_ref() {
+                lines.push(Line::from(vec![
+                    "  • Endpoint: ".into(),
+                    endpoint.clone().into(),
+                ]));
+            }
+            if let Some(timeout) = health.timeout_ms {
+                lines.push(Line::from(vec![
+                    "  • Timeout (ms): ".into(),
+                    timeout.to_string().into(),
+                ]));
+            }
+            if let Some(interval) = health.interval_seconds {
+                lines.push(Line::from(vec![
+                    "  • Interval (s): ".into(),
+                    interval.to_string().into(),
+                ]));
+            }
+        }
+        lines
+    }
+}
+
+fn map_opt(source: &BTreeMap<String, String>) -> Option<HashMap<String, String>> {
+    if source.is_empty() {
+        None
+    } else {
+        Some(source.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+    }
+}
+
+fn instantiate_template(templates: &TemplateCatalog, id: &str) -> Result<McpServerConfig> {
+    match templates.instantiate(id) {
+        Some(cfg) => Ok(cfg),
+        None => Err(anyhow!("Template '{id}' not found")),
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct TemplateSummary {
+    pub id: String,
+    pub summary: Option<String>,
+    pub category: Option<String>,
+}
+
+impl TemplateSummary {
+    pub(crate) fn from_template(id: &str, tpl: &McpTemplate) -> Self {
+        Self {
+            id: id.to_string(),
+            summary: tpl.summary.clone(),
+            category: tpl.category.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct McpServerSnapshot {
+    pub name: String,
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: BTreeMap<String, String>,
+    pub description: Option<String>,
+    pub tags: Vec<String>,
+    pub template_id: Option<String>,
+    pub auth: Option<AuthDraft>,
+    pub health: Option<HealthDraft>,
+    pub display_name: Option<String>,
+    pub category: Option<String>,
+    pub metadata: Option<HashMap<String, String>>,
+    pub startup_timeout_ms: Option<u64>,
+}
+
+impl McpServerSnapshot {
+    pub(crate) fn from_config(name: &str, cfg: &McpServerConfig) -> Self {
+        let env = cfg
+            .env
+            .as_ref()
+            .map(|env| env.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+            .unwrap_or_default();
+        let auth = cfg.auth.as_ref().map(|auth| AuthDraft {
+            kind: auth.kind.clone(),
+            secret_ref: auth.secret_ref.clone(),
+            env: auth
+                .env
+                .as_ref()
+                .map(|env| env.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+                .unwrap_or_default(),
+        });
+        let health = cfg.healthcheck.as_ref().map(|health| HealthDraft {
+            kind: health.kind.clone(),
+            command: health.command.clone(),
+            args: health.args.clone(),
+            timeout_ms: health.timeout_ms,
+            interval_seconds: health.interval_seconds,
+            endpoint: health.endpoint.clone(),
+            protocol: health.protocol.clone(),
+        });
+
+        Self {
+            name: name.to_string(),
+            command: cfg.command.clone(),
+            args: cfg.args.clone(),
+            env,
+            description: cfg.description.clone(),
+            tags: cfg.tags.clone(),
+            template_id: cfg.template_id.clone(),
+            auth,
+            health,
+            display_name: cfg.display_name.clone(),
+            category: cfg.category.clone(),
+            metadata: cfg.metadata.clone(),
+            startup_timeout_ms: cfg.startup_timeout_ms,
+        }
+    }
+
+    pub(crate) fn to_config(&self) -> McpServerConfig {
+        McpServerConfig {
+            display_name: self.display_name.clone(),
+            category: self.category.clone(),
+            template_id: self.template_id.clone(),
+            description: self.description.clone(),
+            command: self.command.clone(),
+            args: self.args.clone(),
+            env: map_opt(&self.env),
+            startup_timeout_ms: self.startup_timeout_ms,
+            auth: self.auth.as_ref().map(|auth| McpAuthConfig {
+                kind: auth.kind.clone(),
+                secret_ref: auth.secret_ref.clone(),
+                env: map_opt(&auth.env),
+            }),
+            healthcheck: self.health.as_ref().map(|health| McpHealthcheckConfig {
+                kind: health.kind.clone(),
+                command: health.command.clone(),
+                args: health.args.clone(),
+                timeout_ms: health.timeout_ms,
+                interval_seconds: health.interval_seconds,
+                endpoint: health.endpoint.clone(),
+                protocol: health.protocol.clone(),
+            }),
+            tags: self.tags.clone(),
+            created_at: None,
+            last_verified_at: None,
+            metadata: self.metadata.clone(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct McpManagerState {
+    pub servers: Vec<McpServerSnapshot>,
+    pub template_count: usize,
+}
+
+impl McpManagerState {
+    pub(crate) fn from_registry(registry: &McpRegistry) -> Self {
+        let mut servers: Vec<McpServerSnapshot> = registry
+            .servers()
+            .map(|(name, cfg)| McpServerSnapshot::from_config(name, cfg))
+            .collect();
+        servers.sort_by(|a, b| a.name.cmp(&b.name));
+
+        let template_count = registry.templates().len();
+        Self {
+            servers,
+            template_count,
+        }
+    }
+}
+
+pub(crate) fn template_summaries(catalog: &TemplateCatalog) -> Vec<TemplateSummary> {
+    let mut summaries: Vec<TemplateSummary> = catalog
+        .templates()
+        .iter()
+        .map(|(id, tpl)| TemplateSummary::from_template(id, tpl))
+        .collect();
+    summaries.sort_by(|a, b| a.id.cmp(&b.id));
+    summaries
+}

--- a/codex-rs/tui/src/mcp/wizard_view.rs
+++ b/codex-rs/tui/src/mcp/wizard_view.rs
@@ -1,0 +1,1424 @@
+use std::cell::Cell;
+use std::collections::BTreeMap;
+
+use anyhow::Context;
+use anyhow::anyhow;
+use codex_core::mcp::templates::TemplateCatalog;
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use crossterm::event::KeyModifiers;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Constraint;
+use ratatui::layout::Layout;
+use ratatui::layout::Rect;
+use ratatui::style::Modifier;
+use ratatui::style::Style;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::text::Span;
+use ratatui::widgets::Block;
+use ratatui::widgets::Borders;
+use ratatui::widgets::Paragraph;
+use ratatui::widgets::Row;
+use ratatui::widgets::StatefulWidget;
+use ratatui::widgets::Table;
+use ratatui::widgets::TableState;
+use ratatui::widgets::Widget;
+use ratatui::widgets::Wrap;
+use unicode_segmentation::UnicodeSegmentation;
+
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+use crate::bottom_pane::BottomPane;
+use crate::bottom_pane::BottomPaneView;
+use crate::bottom_pane::CancellationEvent;
+use crate::bottom_pane::ScrollState;
+use crate::mcp::types::AuthDraft;
+use crate::mcp::types::HealthDraft;
+use crate::mcp::types::McpWizardDraft;
+use crate::mcp::types::TemplateSummary;
+use crate::mcp::types::template_summaries;
+
+const AUTH_TYPES: &[&str] = &["none", "env", "apikey", "oauth"];
+const HEALTH_TYPES: &[&str] = &["none", "stdio", "http"];
+
+pub(crate) struct McpWizardInit {
+    pub app_event_tx: AppEventSender,
+    pub catalog: TemplateCatalog,
+    pub draft: Option<McpWizardDraft>,
+    pub existing_name: Option<String>,
+}
+
+pub(crate) struct McpWizardView {
+    app_event_tx: AppEventSender,
+    catalog: TemplateCatalog,
+    templates: Vec<TemplateSummary>,
+    draft: McpWizardDraft,
+    existing_name: Option<String>,
+    screen: WizardScreen,
+    field_scroll: ScrollState,
+    field_visible_rows: Cell<usize>,
+    template_scroll: ScrollState,
+    variant_scroll: ScrollState,
+    text_input: Option<TextInput>,
+    variant_options: Vec<String>,
+    variant_target: Option<FieldKind>,
+    error_message: Option<String>,
+    close_requested: bool,
+}
+
+impl McpWizardView {
+    pub(crate) fn new(init: McpWizardInit) -> Self {
+        let templates = template_summaries(&init.catalog);
+        let draft = init.draft.unwrap_or_default();
+        let needs_template = draft.template_id.is_none() && !templates.is_empty();
+        let screen = if needs_template {
+            WizardScreen::TemplateSelect
+        } else {
+            WizardScreen::Form
+        };
+
+        let mut field_scroll = ScrollState::new();
+        if matches!(screen, WizardScreen::Form) {
+            let entries = field_entries(&draft);
+            field_scroll.clamp_selection(entries.iter().filter(|e| e.enabled).count());
+            ensure_selection(&entries, &mut field_scroll);
+        }
+
+        let mut template_scroll = ScrollState::new();
+        if !templates.is_empty() {
+            template_scroll.clamp_selection(templates.len() + 1);
+            if let Some(id) = draft.template_id.as_ref() {
+                if let Some(idx) = templates.iter().position(|tpl| tpl.id == *id) {
+                    template_scroll.selected_idx = Some(idx);
+                } else {
+                    template_scroll.selected_idx = Some(templates.len());
+                }
+            } else {
+                template_scroll.selected_idx = Some(templates.len());
+            }
+        }
+
+        Self {
+            app_event_tx: init.app_event_tx,
+            catalog: init.catalog,
+            templates,
+            draft,
+            existing_name: init.existing_name,
+            screen,
+            field_scroll,
+            field_visible_rows: Cell::new(1),
+            template_scroll,
+            variant_scroll: ScrollState::new(),
+            text_input: None,
+            variant_options: Vec::new(),
+            variant_target: None,
+            error_message: None,
+            close_requested: false,
+        }
+    }
+
+    fn submit(&mut self) {
+        if let Err(err) = self.draft.validate() {
+            self.error_message = Some(err.to_string());
+            self.screen = WizardScreen::Form;
+            return;
+        }
+        self.app_event_tx.send(AppEvent::ApplyMcpWizard {
+            draft: self.draft.clone(),
+            existing_name: self.existing_name.clone(),
+        });
+        self.close_requested = true;
+    }
+
+    fn start_text_edit(&mut self, field: FieldKind) {
+        let current = field_value(&self.draft, field);
+        self.text_input = Some(TextInput::new(current));
+        self.screen = WizardScreen::TextEdit(field);
+        self.error_message = None;
+    }
+
+    fn commit_text_edit(&mut self, field: FieldKind) {
+        let input = match self.text_input.take() {
+            Some(input) => input.content,
+            None => return,
+        };
+        if let Err(err) = self.apply_text(field, &input) {
+            self.error_message = Some(err.to_string());
+            self.text_input = Some(TextInput::new(input));
+            return;
+        }
+        self.screen = WizardScreen::Form;
+        self.error_message = None;
+        ensure_selection(&field_entries(&self.draft), &mut self.field_scroll);
+    }
+
+    fn apply_text(&mut self, field: FieldKind, value: &str) -> anyhow::Result<()> {
+        match field {
+            FieldKind::Name => {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    return Err(anyhow!("Name cannot be empty"));
+                }
+                self.draft.name = trimmed.to_string();
+            }
+            FieldKind::Command => {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    return Err(anyhow!("Command cannot be empty"));
+                }
+                self.draft.command = trimmed.to_string();
+            }
+            FieldKind::Args => {
+                self.draft.args = split_items(value);
+            }
+            FieldKind::Env => {
+                self.draft.env = parse_key_values(value)?;
+            }
+            FieldKind::Description => {
+                let trimmed = value.trim();
+                self.draft.description = if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed.to_string())
+                };
+            }
+            FieldKind::Tags => {
+                self.draft.tags = split_items(value);
+            }
+            FieldKind::StartupTimeout => {
+                let trimmed = value.trim();
+                if trimmed.is_empty() {
+                    self.draft.startup_timeout_ms = None;
+                } else {
+                    let timeout = trimmed.parse::<u64>().context("Expected a number")?;
+                    self.draft.startup_timeout_ms = Some(timeout);
+                }
+            }
+            FieldKind::AuthSecret => {
+                if let Some(auth) = self.ensure_auth_slot() {
+                    let trimmed = value.trim();
+                    auth.secret_ref = if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed.to_string())
+                    };
+                }
+            }
+            FieldKind::AuthEnv => {
+                if let Some(auth) = self.ensure_auth_slot() {
+                    auth.env = parse_key_values(value)?;
+                }
+            }
+            FieldKind::HealthCommand => {
+                let trimmed = value.trim();
+                if let Some(health) = self.ensure_health_slot() {
+                    health.command = if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed.to_string())
+                    };
+                }
+            }
+            FieldKind::HealthArgs => {
+                if let Some(health) = self.ensure_health_slot() {
+                    health.args = split_items(value);
+                }
+            }
+            FieldKind::HealthEndpoint => {
+                if let Some(health) = self.ensure_health_slot() {
+                    let trimmed = value.trim();
+                    health.endpoint = if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed.to_string())
+                    };
+                }
+            }
+            FieldKind::HealthTimeout => {
+                if let Some(health) = self.ensure_health_slot() {
+                    let trimmed = value.trim();
+                    health.timeout_ms = if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed.parse::<u64>().context("Expected a number")?)
+                    };
+                }
+            }
+            FieldKind::HealthInterval => {
+                if let Some(health) = self.ensure_health_slot() {
+                    let trimmed = value.trim();
+                    health.interval_seconds = if trimmed.is_empty() {
+                        None
+                    } else {
+                        Some(trimmed.parse::<u64>().context("Expected a number")?)
+                    };
+                }
+            }
+            FieldKind::Summary => {}
+            FieldKind::Template => {}
+            FieldKind::AuthType | FieldKind::HealthType => {}
+        }
+        Ok(())
+    }
+
+    fn ensure_auth_slot(&mut self) -> Option<&mut AuthDraft> {
+        if self.draft.auth.is_none() {
+            self.draft.auth = Some(AuthDraft::default());
+        }
+        self.draft.auth.as_mut()
+    }
+
+    fn ensure_health_slot(&mut self) -> Option<&mut HealthDraft> {
+        if self.draft.health.is_none() {
+            self.draft.health = Some(HealthDraft::default());
+        }
+        self.draft.health.as_mut()
+    }
+
+    fn start_variant_select(&mut self, field: FieldKind, options: Vec<String>) {
+        self.variant_options = options;
+        self.variant_target = Some(field);
+        self.variant_scroll = ScrollState::new();
+        let len = self.variant_options.len();
+        self.variant_scroll.clamp_selection(len);
+        let current = match field {
+            FieldKind::AuthType => self
+                .draft
+                .auth
+                .as_ref()
+                .and_then(|auth| auth.kind.clone())
+                .unwrap_or_else(|| "none".to_string()),
+            FieldKind::HealthType => self
+                .draft
+                .health
+                .as_ref()
+                .and_then(|health| health.kind.clone())
+                .unwrap_or_else(|| "none".to_string()),
+            _ => String::new(),
+        };
+        if let Some(pos) = self.variant_options.iter().position(|opt| opt == &current) {
+            self.variant_scroll.selected_idx = Some(pos);
+        }
+        self.screen = WizardScreen::VariantSelect;
+    }
+
+    fn commit_variant_select(&mut self) {
+        let field = match self.variant_target.take() {
+            Some(field) => field,
+            None => {
+                self.screen = WizardScreen::Form;
+                return;
+            }
+        };
+        let idx = self.variant_scroll.selected_idx.unwrap_or(0);
+        if let Some(value) = self.variant_options.get(idx).cloned() {
+            match field {
+                FieldKind::AuthType => {
+                    if value == "none" {
+                        self.draft.auth = None;
+                    } else if let Some(auth) = self.ensure_auth_slot() {
+                        auth.kind = Some(value);
+                    } else {
+                        self.error_message = Some("Failed to prepare auth settings".to_string());
+                    }
+                }
+                FieldKind::HealthType => {
+                    if value == "none" {
+                        self.draft.health = None;
+                    } else if let Some(health) = self.ensure_health_slot() {
+                        health.kind = Some(value.clone());
+                        if value == "http" {
+                            health.protocol = Some("http".to_string());
+                            health.command = None;
+                            health.args.clear();
+                        } else {
+                            health.endpoint = None;
+                            health.protocol = None;
+                        }
+                    } else {
+                        self.error_message = Some("Failed to prepare health settings".to_string());
+                    }
+                }
+                FieldKind::Template => {}
+                _ => {}
+            }
+        }
+        self.screen = WizardScreen::Form;
+        ensure_selection(&field_entries(&self.draft), &mut self.field_scroll);
+    }
+
+    fn activate_field(&mut self, field: FieldKind) {
+        match field {
+            FieldKind::Template => {
+                if self.templates.is_empty() {
+                    self.error_message = Some("No templates available".to_string());
+                    return;
+                }
+                let total = self.templates.len() + 1;
+                self.template_scroll.clamp_selection(total);
+                if let Some(id) = self.draft.template_id.as_ref() {
+                    if let Some(pos) = self.templates.iter().position(|tpl| tpl.id == *id) {
+                        self.template_scroll.selected_idx = Some(pos);
+                    } else {
+                        self.template_scroll.selected_idx = Some(self.templates.len());
+                    }
+                } else {
+                    self.template_scroll.selected_idx = Some(self.templates.len());
+                }
+                self.screen = WizardScreen::TemplateSelect;
+            }
+            FieldKind::AuthType => {
+                self.start_variant_select(
+                    FieldKind::AuthType,
+                    AUTH_TYPES.iter().map(|s| s.to_string()).collect(),
+                );
+            }
+            FieldKind::HealthType => {
+                self.start_variant_select(
+                    FieldKind::HealthType,
+                    HEALTH_TYPES.iter().map(|s| s.to_string()).collect(),
+                );
+            }
+            FieldKind::Summary => {
+                self.screen = WizardScreen::Summary;
+            }
+            _ => self.start_text_edit(field),
+        }
+    }
+
+    fn apply_template_choice(&mut self) {
+        let idx = self.template_scroll.selected_idx.unwrap_or(0);
+        if idx >= self.templates.len() {
+            self.draft.template_id = None;
+            self.screen = WizardScreen::Form;
+            return;
+        }
+        let template_id = self.templates[idx].id.clone();
+        if let Some(cfg) = self.catalog.instantiate(&template_id) {
+            self.draft.apply_template_config(&cfg);
+            self.draft.template_id = Some(template_id);
+            if self.draft.command.trim().is_empty() {
+                self.draft.command = cfg.command;
+            }
+            self.screen = WizardScreen::Form;
+            ensure_selection(&field_entries(&self.draft), &mut self.field_scroll);
+        } else {
+            self.error_message = Some(format!("Template '{template_id}' not found"));
+            self.screen = WizardScreen::Form;
+        }
+    }
+
+    fn render_template_select(&self, area: Rect, buf: &mut Buffer) {
+        let mut rows: Vec<Row> = self
+            .templates
+            .iter()
+            .map(|tpl| {
+                let summary = match (&tpl.summary, &tpl.category) {
+                    (Some(summary), Some(category)) if !category.is_empty() => {
+                        format!("{summary} ({category})")
+                    }
+                    (Some(summary), _) => summary.clone(),
+                    (None, Some(category)) if !category.is_empty() => {
+                        format!("({category})")
+                    }
+                    _ => String::new(),
+                };
+                Row::new(vec![tpl.id.clone(), summary])
+            })
+            .collect();
+        rows.push(Row::new(vec![
+            "manual".to_string(),
+            "Start from scratch".to_string(),
+        ]));
+
+        let mut state = TableState::default();
+        state.select(self.template_scroll.selected_idx);
+        *state.offset_mut() = self.template_scroll.scroll_top;
+
+        let table = Table::new(
+            rows,
+            [Constraint::Percentage(30), Constraint::Percentage(70)],
+        )
+        .header(Row::new(vec!["Template".bold(), "Summary".bold()]))
+        .block(
+            Block::default()
+                .borders(Borders::ALL)
+                .title("Select MCP Template"),
+        )
+        .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+
+        StatefulWidget::render(table, area, buf, &mut state);
+
+        let footer = Paragraph::new("Enter to select • Esc to cancel".dim())
+            .block(Block::default().borders(Borders::NONE));
+        Widget::render(
+            footer,
+            Rect {
+                x: area.x,
+                y: area.bottom().saturating_sub(1),
+                width: area.width,
+                height: 1,
+            },
+            buf,
+        );
+    }
+
+    fn render_form(&self, area: Rect, buf: &mut Buffer) {
+        let chunks = Layout::vertical([
+            Constraint::Min(area.height.saturating_sub(5)),
+            Constraint::Length(5),
+        ])
+        .split(area);
+
+        let entries = field_entries(&self.draft);
+        let rows: Vec<Row> = entries
+            .iter()
+            .map(|entry| {
+                let style = if !entry.enabled {
+                    Style::default().add_modifier(Modifier::DIM)
+                } else {
+                    Style::default()
+                };
+                Row::new(vec![
+                    Span::styled(entry.label.to_string(), style),
+                    Span::styled(entry.value.clone(), style),
+                ])
+            })
+            .collect();
+        let mut state = TableState::default();
+        state.select(self.field_scroll.selected_idx);
+        *state.offset_mut() = self.field_scroll.scroll_top;
+
+        let table = Table::new(
+            rows,
+            [Constraint::Percentage(35), Constraint::Percentage(65)],
+        )
+        .header(Row::new(vec!["Field".bold(), "Value".bold()]))
+        .block(Block::default().borders(Borders::ALL).title("MCP Wizard"))
+        .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+        let table_area = chunks[0];
+        StatefulWidget::render(table, table_area, buf, &mut state);
+
+        let visible_rows = table_area.height.saturating_sub(3) as usize;
+        self.field_visible_rows.set(visible_rows.max(1));
+
+        let mut footer_lines: Vec<Line> = Vec::new();
+        if let Some(err) = self.error_message.as_ref() {
+            footer_lines.push(err.as_str().red().into());
+        }
+        footer_lines.push(Line::from(vec![
+            "Keys: ".dim(),
+            "↑/↓".cyan(),
+            " move  ".dim(),
+            "Enter".cyan(),
+            " edit/select  ".dim(),
+            "s".cyan(),
+            " summary  ".dim(),
+            "Esc".cyan(),
+            " close".dim(),
+        ]));
+
+        let footer = Paragraph::new(footer_lines)
+            .block(Block::default().borders(Borders::ALL).title("Help"))
+            .wrap(Wrap { trim: true });
+        Widget::render(footer, chunks[1], buf);
+    }
+
+    fn render_variant_select(&self, area: Rect, buf: &mut Buffer) {
+        let rows: Vec<Row> = self
+            .variant_options
+            .iter()
+            .map(|opt| Row::new(vec![opt.clone()]))
+            .collect();
+        let mut state = TableState::default();
+        state.select(self.variant_scroll.selected_idx);
+        *state.offset_mut() = self.variant_scroll.scroll_top;
+        let title = match self.variant_target {
+            Some(FieldKind::AuthType) => "Select authentication",
+            Some(FieldKind::HealthType) => "Select health check",
+            _ => "Select option",
+        };
+        let table = Table::new(rows, [Constraint::Percentage(100)])
+            .block(Block::default().borders(Borders::ALL).title(title))
+            .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED));
+        StatefulWidget::render(table, area, buf, &mut state);
+
+        let footer =
+            Paragraph::new("Enter to confirm • Esc to cancel".dim()).block(Block::default());
+        Widget::render(
+            footer,
+            Rect {
+                x: area.x,
+                y: area.bottom().saturating_sub(1),
+                width: area.width,
+                height: 1,
+            },
+            buf,
+        );
+    }
+
+    fn render_text_edit(&self, field: FieldKind, area: Rect, buf: &mut Buffer) {
+        let input = self
+            .text_input
+            .as_ref()
+            .map(|i| i.content.clone())
+            .unwrap_or_default();
+        let mut lines = vec![Line::from(vec![field_label(field).bold()])];
+        if let Some(err) = self.error_message.as_ref() {
+            lines.push(err.as_str().red().into());
+        }
+        lines.push("Enter to save • Esc to cancel".dim().into());
+        lines.push(Line::from(""));
+        lines.push(Line::from(input));
+        let paragraph = Paragraph::new(lines)
+            .block(Block::default().borders(Borders::ALL).title("Edit"))
+            .wrap(Wrap { trim: false });
+        Widget::render(paragraph, area, buf);
+    }
+
+    fn render_summary(&self, area: Rect, buf: &mut Buffer) {
+        let mut lines = self.draft.summary_lines();
+        lines.push(Line::from(""));
+        lines.push(Line::from(vec![
+            "Enter".cyan(),
+            " apply  ".dim(),
+            "b".cyan(),
+            " back  ".dim(),
+            "Esc".cyan(),
+            " cancel".dim(),
+        ]));
+        let paragraph = Paragraph::new(lines)
+            .block(Block::default().borders(Borders::ALL).title("Review"))
+            .wrap(Wrap { trim: true });
+        Widget::render(paragraph, area, buf);
+    }
+}
+
+impl BottomPaneView for McpWizardView {
+    fn handle_key_event(&mut self, _pane: &mut BottomPane, key_event: KeyEvent) {
+        match self.screen {
+            WizardScreen::TemplateSelect => match key_event.code {
+                KeyCode::Esc => {
+                    self.close_requested = true;
+                }
+                KeyCode::Up => {
+                    let total = self.templates.len() + 1;
+                    self.template_scroll.move_up_wrap(total);
+                    self.template_scroll.ensure_visible(total, 8);
+                }
+                KeyCode::Down => {
+                    let total = self.templates.len() + 1;
+                    self.template_scroll.move_down_wrap(total);
+                    self.template_scroll.ensure_visible(total, 8);
+                }
+                KeyCode::Enter => {
+                    self.apply_template_choice();
+                }
+                _ => {}
+            },
+            WizardScreen::Form => match key_event.code {
+                KeyCode::Esc => {
+                    self.close_requested = true;
+                }
+                KeyCode::Char('s') => {
+                    self.screen = WizardScreen::Summary;
+                }
+                KeyCode::Enter => {
+                    if let Some(entry) = current_enabled_entry(&self.draft, &self.field_scroll) {
+                        self.activate_field(entry.kind);
+                    }
+                }
+                KeyCode::Up => {
+                    move_selection(
+                        &self.draft,
+                        &mut self.field_scroll,
+                        Direction::Up,
+                        self.field_visible_rows.get(),
+                    );
+                    self.error_message = None;
+                }
+                KeyCode::Down => {
+                    move_selection(
+                        &self.draft,
+                        &mut self.field_scroll,
+                        Direction::Down,
+                        self.field_visible_rows.get(),
+                    );
+                    self.error_message = None;
+                }
+                KeyCode::PageUp => {
+                    for _ in 0..self.field_visible_rows.get().saturating_sub(1) {
+                        move_selection(
+                            &self.draft,
+                            &mut self.field_scroll,
+                            Direction::Up,
+                            self.field_visible_rows.get(),
+                        );
+                    }
+                }
+                KeyCode::PageDown => {
+                    for _ in 0..self.field_visible_rows.get().saturating_sub(1) {
+                        move_selection(
+                            &self.draft,
+                            &mut self.field_scroll,
+                            Direction::Down,
+                            self.field_visible_rows.get(),
+                        );
+                    }
+                }
+                _ => {}
+            },
+            WizardScreen::VariantSelect => match key_event.code {
+                KeyCode::Esc => {
+                    self.screen = WizardScreen::Form;
+                }
+                KeyCode::Up => {
+                    let len = self.variant_options.len();
+                    self.variant_scroll.move_up_wrap(len);
+                    self.variant_scroll.ensure_visible(len, 8);
+                }
+                KeyCode::Down => {
+                    let len = self.variant_options.len();
+                    self.variant_scroll.move_down_wrap(len);
+                    self.variant_scroll.ensure_visible(len, 8);
+                }
+                KeyCode::Enter => {
+                    self.commit_variant_select();
+                }
+                _ => {}
+            },
+            WizardScreen::TextEdit(field) => match key_event.code {
+                KeyCode::Esc => {
+                    self.text_input = None;
+                    self.screen = WizardScreen::Form;
+                }
+                KeyCode::Enter => {
+                    self.commit_text_edit(field);
+                }
+                _ => {
+                    if let Some(input) = self.text_input.as_mut() {
+                        input.handle_key(key_event);
+                    }
+                }
+            },
+            WizardScreen::Summary => match key_event.code {
+                KeyCode::Enter => self.submit(),
+                KeyCode::Char('b') => {
+                    self.screen = WizardScreen::Form;
+                }
+                KeyCode::Esc => {
+                    self.close_requested = true;
+                }
+                _ => {}
+            },
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        self.close_requested
+    }
+
+    fn on_ctrl_c(&mut self, _pane: &mut BottomPane) -> CancellationEvent {
+        self.close_requested = true;
+        CancellationEvent::Handled
+    }
+
+    fn desired_height(&self, _width: u16) -> u16 {
+        18
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        match self.screen {
+            WizardScreen::TemplateSelect => self.render_template_select(area, buf),
+            WizardScreen::Form => self.render_form(area, buf),
+            WizardScreen::VariantSelect => self.render_variant_select(area, buf),
+            WizardScreen::TextEdit(field) => self.render_text_edit(field, area, buf),
+            WizardScreen::Summary => self.render_summary(area, buf),
+        }
+    }
+}
+
+#[derive(Copy, Clone)]
+enum WizardScreen {
+    TemplateSelect,
+    Form,
+    VariantSelect,
+    TextEdit(FieldKind),
+    Summary,
+}
+
+#[derive(Copy, Clone, Debug)]
+enum FieldKind {
+    Template,
+    Name,
+    Command,
+    Args,
+    Env,
+    Description,
+    Tags,
+    StartupTimeout,
+    AuthType,
+    AuthSecret,
+    AuthEnv,
+    HealthType,
+    HealthCommand,
+    HealthArgs,
+    HealthEndpoint,
+    HealthTimeout,
+    HealthInterval,
+    Summary,
+}
+
+#[derive(Clone)]
+struct FieldEntry {
+    kind: FieldKind,
+    label: &'static str,
+    value: String,
+    enabled: bool,
+}
+
+fn field_entries(draft: &McpWizardDraft) -> Vec<FieldEntry> {
+    let mut entries = Vec::new();
+    entries.push(FieldEntry {
+        kind: FieldKind::Template,
+        label: "Template",
+        value: draft
+            .template_id
+            .clone()
+            .unwrap_or_else(|| "manual".to_string()),
+        enabled: true,
+    });
+    entries.push(FieldEntry {
+        kind: FieldKind::Name,
+        label: "Name",
+        value: draft.name.clone(),
+        enabled: true,
+    });
+    entries.push(FieldEntry {
+        kind: FieldKind::Command,
+        label: "Command",
+        value: draft.command.clone(),
+        enabled: true,
+    });
+    entries.push(FieldEntry {
+        kind: FieldKind::Args,
+        label: "Args",
+        value: if draft.args.is_empty() {
+            "-".to_string()
+        } else {
+            draft.args.join(" ")
+        },
+        enabled: true,
+    });
+    let env_count = draft.env.len();
+    entries.push(FieldEntry {
+        kind: FieldKind::Env,
+        label: "Env",
+        value: if env_count == 0 {
+            "0 entries".to_string()
+        } else {
+            format!(
+                "{env_count} entr{}",
+                if env_count == 1 { "y" } else { "ies" }
+            )
+        },
+        enabled: true,
+    });
+    entries.push(FieldEntry {
+        kind: FieldKind::Description,
+        label: "Description",
+        value: draft.description.clone().unwrap_or_else(|| "-".to_string()),
+        enabled: true,
+    });
+    entries.push(FieldEntry {
+        kind: FieldKind::Tags,
+        label: "Tags",
+        value: if draft.tags.is_empty() {
+            "-".to_string()
+        } else {
+            draft.tags.join(", ")
+        },
+        enabled: true,
+    });
+    entries.push(FieldEntry {
+        kind: FieldKind::StartupTimeout,
+        label: "Startup timeout (ms)",
+        value: draft
+            .startup_timeout_ms
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        enabled: true,
+    });
+
+    let auth_kind = draft
+        .auth
+        .as_ref()
+        .and_then(|auth| auth.kind.clone())
+        .unwrap_or_else(|| "none".to_string());
+    let auth_enabled = auth_kind != "none";
+    entries.push(FieldEntry {
+        kind: FieldKind::AuthType,
+        label: "Auth type",
+        value: auth_kind,
+        enabled: true,
+    });
+    entries.push(FieldEntry {
+        kind: FieldKind::AuthSecret,
+        label: "Auth secret",
+        value: draft
+            .auth
+            .as_ref()
+            .and_then(|auth| auth.secret_ref.clone())
+            .unwrap_or_else(|| "-".to_string()),
+        enabled: auth_enabled,
+    });
+    entries.push(FieldEntry {
+        kind: FieldKind::AuthEnv,
+        label: "Auth env",
+        value: draft
+            .auth
+            .as_ref()
+            .map(|auth| {
+                let count = auth.env.len();
+                if count == 0 {
+                    "0 entries".to_string()
+                } else {
+                    format!("{count} entr{}", if count == 1 { "y" } else { "ies" })
+                }
+            })
+            .unwrap_or_else(|| "0 entries".to_string()),
+        enabled: auth_enabled,
+    });
+
+    let health_kind = draft
+        .health
+        .as_ref()
+        .and_then(|health| health.kind.clone())
+        .unwrap_or_else(|| "none".to_string());
+    let health_stdio = health_kind == "stdio";
+    let health_http = health_kind == "http";
+    let health_enabled = health_kind != "none";
+
+    entries.push(FieldEntry {
+        kind: FieldKind::HealthType,
+        label: "Health type",
+        value: health_kind,
+        enabled: true,
+    });
+    entries.push(FieldEntry {
+        kind: FieldKind::HealthCommand,
+        label: "Health command",
+        value: draft
+            .health
+            .as_ref()
+            .and_then(|health| health.command.clone())
+            .unwrap_or_else(|| "-".to_string()),
+        enabled: health_stdio,
+    });
+    entries.push(FieldEntry {
+        kind: FieldKind::HealthArgs,
+        label: "Health args",
+        value: draft
+            .health
+            .as_ref()
+            .map(|health| {
+                if health.args.is_empty() {
+                    "-".to_string()
+                } else {
+                    health.args.join(" ")
+                }
+            })
+            .unwrap_or_else(|| "-".to_string()),
+        enabled: health_stdio,
+    });
+    entries.push(FieldEntry {
+        kind: FieldKind::HealthEndpoint,
+        label: "Health endpoint",
+        value: draft
+            .health
+            .as_ref()
+            .and_then(|health| health.endpoint.clone())
+            .unwrap_or_else(|| "-".to_string()),
+        enabled: health_http,
+    });
+    entries.push(FieldEntry {
+        kind: FieldKind::HealthTimeout,
+        label: "Health timeout (ms)",
+        value: draft
+            .health
+            .as_ref()
+            .and_then(|health| health.timeout_ms)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        enabled: health_enabled,
+    });
+    entries.push(FieldEntry {
+        kind: FieldKind::HealthInterval,
+        label: "Health interval (s)",
+        value: draft
+            .health
+            .as_ref()
+            .and_then(|health| health.interval_seconds)
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "-".to_string()),
+        enabled: health_enabled,
+    });
+    entries.push(FieldEntry {
+        kind: FieldKind::Summary,
+        label: "Review & apply",
+        value: "→".to_string(),
+        enabled: true,
+    });
+    entries
+}
+
+fn ensure_selection(entries: &[FieldEntry], scroll: &mut ScrollState) {
+    if entries.is_empty() {
+        scroll.selected_idx = None;
+        scroll.scroll_top = 0;
+        return;
+    }
+    let enabled_indices: Vec<usize> = entries
+        .iter()
+        .enumerate()
+        .filter(|(_, entry)| entry.enabled)
+        .map(|(idx, _)| idx)
+        .collect();
+    if enabled_indices.is_empty() {
+        scroll.selected_idx = None;
+        scroll.scroll_top = 0;
+        return;
+    }
+    let current = scroll.selected_idx.unwrap_or(0);
+    if !enabled_indices.contains(&current) {
+        scroll.selected_idx = Some(enabled_indices[0]);
+        scroll.scroll_top = 0;
+    }
+}
+
+fn current_enabled_entry(draft: &McpWizardDraft, scroll: &ScrollState) -> Option<FieldEntry> {
+    let entries = field_entries(draft);
+    scroll
+        .selected_idx
+        .and_then(|idx| entries.get(idx).cloned())
+        .filter(|entry| entry.enabled)
+}
+
+#[derive(Copy, Clone)]
+enum Direction {
+    Up,
+    Down,
+}
+
+fn move_selection(
+    draft: &McpWizardDraft,
+    scroll: &mut ScrollState,
+    direction: Direction,
+    visible_rows: usize,
+) {
+    let entries = field_entries(draft);
+    if entries.is_empty() {
+        scroll.selected_idx = None;
+        return;
+    }
+    let mut idx = scroll.selected_idx.unwrap_or(0);
+    let len = entries.len();
+    loop {
+        idx = match direction {
+            Direction::Up => idx.checked_sub(1).unwrap_or(len - 1),
+            Direction::Down => {
+                if idx + 1 >= len {
+                    0
+                } else {
+                    idx + 1
+                }
+            }
+        };
+        if entries[idx].enabled {
+            scroll.selected_idx = Some(idx);
+            break;
+        }
+        if idx == scroll.selected_idx.unwrap_or(0) {
+            break;
+        }
+    }
+    scroll.ensure_visible(len, visible_rows.max(1));
+}
+
+fn field_label(kind: FieldKind) -> &'static str {
+    match kind {
+        FieldKind::Template => "Template",
+        FieldKind::Name => "Name",
+        FieldKind::Command => "Command",
+        FieldKind::Args => "Args",
+        FieldKind::Env => "Env",
+        FieldKind::Description => "Description",
+        FieldKind::Tags => "Tags",
+        FieldKind::StartupTimeout => "Startup timeout (ms)",
+        FieldKind::AuthType => "Auth type",
+        FieldKind::AuthSecret => "Auth secret",
+        FieldKind::AuthEnv => "Auth env",
+        FieldKind::HealthType => "Health type",
+        FieldKind::HealthCommand => "Health command",
+        FieldKind::HealthArgs => "Health args",
+        FieldKind::HealthEndpoint => "Health endpoint",
+        FieldKind::HealthTimeout => "Health timeout (ms)",
+        FieldKind::HealthInterval => "Health interval (s)",
+        FieldKind::Summary => "Review & apply",
+    }
+}
+
+fn field_value(draft: &McpWizardDraft, field: FieldKind) -> String {
+    match field {
+        FieldKind::Template => draft
+            .template_id
+            .clone()
+            .unwrap_or_else(|| "manual".to_string()),
+        FieldKind::Name => draft.name.clone(),
+        FieldKind::Command => draft.command.clone(),
+        FieldKind::Args => draft.args.join(" "),
+        FieldKind::Env => format_key_values(&draft.env),
+        FieldKind::Description => draft.description.clone().unwrap_or_default(),
+        FieldKind::Tags => draft.tags.join(", "),
+        FieldKind::StartupTimeout => draft
+            .startup_timeout_ms
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+        FieldKind::AuthType => draft
+            .auth
+            .as_ref()
+            .and_then(|auth| auth.kind.clone())
+            .unwrap_or_else(|| "none".to_string()),
+        FieldKind::AuthSecret => draft
+            .auth
+            .as_ref()
+            .and_then(|auth| auth.secret_ref.clone())
+            .unwrap_or_default(),
+        FieldKind::AuthEnv => draft
+            .auth
+            .as_ref()
+            .map(|auth| format_key_values(&auth.env))
+            .unwrap_or_default(),
+        FieldKind::HealthType => draft
+            .health
+            .as_ref()
+            .and_then(|health| health.kind.clone())
+            .unwrap_or_else(|| "none".to_string()),
+        FieldKind::HealthCommand => draft
+            .health
+            .as_ref()
+            .and_then(|health| health.command.clone())
+            .unwrap_or_default(),
+        FieldKind::HealthArgs => draft
+            .health
+            .as_ref()
+            .map(|health| health.args.join(" "))
+            .unwrap_or_default(),
+        FieldKind::HealthEndpoint => draft
+            .health
+            .as_ref()
+            .and_then(|health| health.endpoint.clone())
+            .unwrap_or_default(),
+        FieldKind::HealthTimeout => draft
+            .health
+            .as_ref()
+            .and_then(|health| health.timeout_ms)
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+        FieldKind::HealthInterval => draft
+            .health
+            .as_ref()
+            .and_then(|health| health.interval_seconds)
+            .map(|v| v.to_string())
+            .unwrap_or_default(),
+        FieldKind::Summary => String::new(),
+    }
+}
+
+fn split_items(input: &str) -> Vec<String> {
+    input
+        .split(|c: char| c == ',' || c.is_whitespace())
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(|s| s.to_string())
+        .collect()
+}
+
+fn parse_key_values(input: &str) -> anyhow::Result<BTreeMap<String, String>> {
+    let mut map = BTreeMap::new();
+    for raw in input
+        .split(['\n', ','])
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+    {
+        let mut parts = raw.splitn(2, '=');
+        let key = parts
+            .next()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| anyhow!("Entries must be KEY=VALUE"))?;
+        let value = parts
+            .next()
+            .map(|s| s.to_string())
+            .ok_or_else(|| anyhow!("Entries must be KEY=VALUE"))?;
+        map.insert(key.to_string(), value);
+    }
+    Ok(map)
+}
+
+fn format_key_values(map: &BTreeMap<String, String>) -> String {
+    map.iter()
+        .map(|(k, v)| format!("{k}={v}"))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+struct TextInput {
+    content: String,
+    cursor: usize,
+}
+
+impl TextInput {
+    fn new(initial: String) -> Self {
+        Self {
+            cursor: initial.len(),
+            content: initial,
+        }
+    }
+
+    fn handle_key(&mut self, event: KeyEvent) {
+        match event.code {
+            KeyCode::Left => self.move_left(),
+            KeyCode::Right => self.move_right(),
+            KeyCode::Home => self.cursor = 0,
+            KeyCode::End => self.cursor = self.content.len(),
+            KeyCode::Backspace => self.backspace(),
+            KeyCode::Delete => self.delete(),
+            KeyCode::Char(c) if !event.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.insert_char(c)
+            }
+            _ => {}
+        }
+    }
+
+    fn insert_char(&mut self, ch: char) {
+        let mut buf = [0; 4];
+        let s = ch.encode_utf8(&mut buf);
+        self.content.insert_str(self.cursor, s);
+        self.cursor += s.len();
+    }
+
+    fn backspace(&mut self) {
+        if self.cursor == 0 {
+            return;
+        }
+        let prev = prev_grapheme_boundary(&self.content, self.cursor);
+        self.content.drain(prev..self.cursor);
+        self.cursor = prev;
+    }
+
+    fn delete(&mut self) {
+        if self.cursor >= self.content.len() {
+            return;
+        }
+        let next = next_grapheme_boundary(&self.content, self.cursor);
+        self.content.drain(self.cursor..next);
+    }
+
+    fn move_left(&mut self) {
+        self.cursor = prev_grapheme_boundary(&self.content, self.cursor);
+    }
+
+    fn move_right(&mut self) {
+        self.cursor = next_grapheme_boundary(&self.content, self.cursor);
+    }
+}
+
+fn prev_grapheme_boundary(s: &str, idx: usize) -> usize {
+    let mut boundary = 0;
+    for (i, _) in s[..idx].grapheme_indices(true) {
+        boundary = i;
+    }
+    boundary
+}
+
+fn next_grapheme_boundary(s: &str, idx: usize) -> usize {
+    if idx >= s.len() {
+        return s.len();
+    }
+    if let Some((i, _)) = s[idx..].grapheme_indices(true).next() {
+        return idx + i;
+    }
+    s.len()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use insta::assert_snapshot;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use std::collections::BTreeMap;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    fn render(view: &McpWizardView) -> String {
+        let width = 78;
+        let height = BottomPaneView::desired_height(view, width);
+        let area = Rect::new(0, 0, width, height);
+        let mut buf = Buffer::empty(area);
+        BottomPaneView::render(view, area, &mut buf);
+
+        (0..area.height)
+            .map(|row| {
+                let mut line = String::new();
+                for col in 0..area.width {
+                    let symbol = buf[(area.x + col, area.y + row)].symbol();
+                    if symbol.is_empty() {
+                        line.push(' ');
+                    } else {
+                        line.push_str(symbol);
+                    }
+                }
+                line.trim_end().to_string()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn make_sender() -> AppEventSender {
+        let (tx, _rx) = unbounded_channel();
+        AppEventSender::new(tx)
+    }
+
+    fn sample_draft() -> McpWizardDraft {
+        let mut env = BTreeMap::new();
+        env.insert("API_KEY".to_string(), "${SECRET}".to_string());
+
+        let mut auth_env = BTreeMap::new();
+        auth_env.insert("TOKEN".to_string(), "${TOKEN}".to_string());
+
+        McpWizardDraft {
+            name: "anthropic-mcp".to_string(),
+            template_id: Some("anthropic/cli".to_string()),
+            command: "anthropic-mcp".to_string(),
+            args: vec![
+                "--serve".to_string(),
+                "--port".to_string(),
+                "8080".to_string(),
+            ],
+            env,
+            startup_timeout_ms: Some(15_000),
+            description: Some("Anthropic MCP bridge".to_string()),
+            tags: vec!["anthropic".to_string(), "beta".to_string()],
+            auth: Some(AuthDraft {
+                kind: Some("env".to_string()),
+                secret_ref: Some("vault:anthropic".to_string()),
+                env: auth_env,
+            }),
+            health: Some(HealthDraft {
+                kind: Some("http".to_string()),
+                command: None,
+                args: vec![],
+                timeout_ms: Some(5_000),
+                interval_seconds: Some(60),
+                endpoint: Some("http://127.0.0.1:9000/health".to_string()),
+                protocol: Some("http/1.1".to_string()),
+            }),
+        }
+    }
+
+    fn empty_view() -> McpWizardView {
+        McpWizardView::new(McpWizardInit {
+            app_event_tx: make_sender(),
+            catalog: TemplateCatalog::empty(),
+            draft: None,
+            existing_name: None,
+        })
+    }
+
+    #[test]
+    fn template_select_screen() {
+        let mut view = empty_view();
+        view.templates = vec![
+            TemplateSummary {
+                id: "anthropic/cli".to_string(),
+                summary: Some("Anthropic CLI bridge".to_string()),
+                category: Some("llm".to_string()),
+            },
+            TemplateSummary {
+                id: "openai/web".to_string(),
+                summary: Some("OpenAI Browser agent".to_string()),
+                category: Some("llm".to_string()),
+            },
+        ];
+        view.template_scroll
+            .clamp_selection(view.templates.len() + 1);
+        view.template_scroll.selected_idx = Some(0);
+        view.screen = WizardScreen::TemplateSelect;
+
+        assert_snapshot!("mcp_wizard_template_select", render(&view));
+    }
+
+    #[test]
+    fn form_screen_with_error() {
+        let mut view = McpWizardView::new(McpWizardInit {
+            app_event_tx: make_sender(),
+            catalog: TemplateCatalog::empty(),
+            draft: Some(sample_draft()),
+            existing_name: None,
+        });
+        view.screen = WizardScreen::Form;
+        view.error_message = Some("Command must not be empty".to_string());
+        ensure_selection(&field_entries(&view.draft), &mut view.field_scroll);
+        view.field_scroll.selected_idx = Some(2);
+
+        assert_snapshot!("mcp_wizard_form_error", render(&view));
+    }
+
+    #[test]
+    fn variant_select_screen() {
+        let mut view = McpWizardView::new(McpWizardInit {
+            app_event_tx: make_sender(),
+            catalog: TemplateCatalog::empty(),
+            draft: Some(sample_draft()),
+            existing_name: None,
+        });
+        view.screen = WizardScreen::VariantSelect;
+        view.variant_target = Some(FieldKind::AuthType);
+        view.variant_options = vec!["none".to_string(), "env".to_string(), "oauth".to_string()];
+        view.variant_scroll
+            .clamp_selection(view.variant_options.len());
+        view.variant_scroll.selected_idx = Some(1);
+
+        assert_snapshot!("mcp_wizard_variant_select", render(&view));
+    }
+
+    #[test]
+    fn text_edit_screen() {
+        let mut view = McpWizardView::new(McpWizardInit {
+            app_event_tx: make_sender(),
+            catalog: TemplateCatalog::empty(),
+            draft: Some(sample_draft()),
+            existing_name: None,
+        });
+        view.screen = WizardScreen::TextEdit(FieldKind::Env);
+        view.error_message = Some("Expected KEY=VALUE pairs".to_string());
+        view.text_input = Some(TextInput::new("API_KEY=\nORG_ID=1234".to_string()));
+
+        assert_snapshot!("mcp_wizard_text_edit", render(&view));
+    }
+
+    #[test]
+    fn summary_screen() {
+        let mut view = McpWizardView::new(McpWizardInit {
+            app_event_tx: make_sender(),
+            catalog: TemplateCatalog::empty(),
+            draft: Some(sample_draft()),
+            existing_name: Some("existing".to_string()),
+        });
+        view.screen = WizardScreen::Summary;
+
+        assert_snapshot!("mcp_wizard_summary", render(&view));
+    }
+}


### PR DESCRIPTION
## Summary
  - add core MCP registry, template catalog, and schema migrations behind
  `experimental_mcp_overhaul`
  - expose CLI entry point (`codex mcp wizard`) with interactive + JSON flows
  - ship TUI overlay: vertical manager layout, contextual wizard footer, Esc-as-back navigation
  - document the workflow (docs/rfcs/0001…, docs/mcp/manager_ux.md); add seatbelt symlink handling +
  apply_patch CRLF guard rails

  ## Testing
  - just fmt
  - cargo test -p codex-tui
  - cargo test -p codex-core --lib -- mcp
  - cargo test -p codex-cli
  - cargo insta review (tui)