### PR TITLE
feat: support arguments in Custom Prompts

### DIFF
--- a/codex-rs/core/src/custom_prompts.rs
+++ b/codex-rs/core/src/custom_prompts.rs
@@ -63,14 +63,75 @@ pub async fn discover_prompts_in_excluding(
             Ok(s) => s,
             Err(_) => continue,
         };
+        // Extract optional description from simple front matter and strip it from the body.
+        // We support a minimal subset:
+        // ---\n
+        // description: <single line>\n
+        // ---\n
+        let (description, body) = parse_front_matter_description_and_body(&content);
         out.push(CustomPrompt {
             name,
             path,
-            content,
+            content: body,
+            description,
         });
     }
     out.sort_by(|a, b| a.name.cmp(&b.name));
     out
+}
+
+/// Parse a minimal YAML-like front matter from the beginning of `content` and
+/// return `(description, body_without_front_matter)`.
+///
+/// Front matter is recognized only when the very first line is exactly `---` (ignoring
+/// surrounding whitespace), and it ends at the next line that is exactly `---`.
+/// Within the block, if a line with `description:` is present, its value is captured
+/// (with surrounding quotes stripped) and returned.
+/// If front matter is malformed (no closing `---`), returns `(None, content.to_string())`.
+fn parse_front_matter_description_and_body(content: &str) -> (Option<String>, String) {
+    let mut lines_iter = content.lines();
+    match lines_iter.next() {
+        Some(first) if first.trim() == "---" => {}
+        _ => return (None, content.to_string()),
+    }
+
+    let mut desc: Option<String> = None;
+    let mut in_front = true;
+    let mut body_lines: Vec<&str> = Vec::new();
+
+    for line in content.lines().skip(1) {
+        let trimmed = line.trim();
+        if in_front {
+            if trimmed == "---" {
+                in_front = false;
+                continue;
+            }
+            if let Some(rest) = trimmed.strip_prefix("description:") {
+                let mut val = rest.trim().to_string();
+                if (val.starts_with('"') && val.ends_with('"'))
+                    || (val.starts_with('\'') && val.ends_with('\''))
+                {
+                    val = val[1..val.len().saturating_sub(1)].to_string();
+                }
+                if !val.is_empty() {
+                    desc = Some(val);
+                }
+            }
+        } else {
+            body_lines.push(line);
+        }
+    }
+
+    if in_front {
+        // No closing '---'
+        return (None, content.to_string());
+    }
+
+    let mut body = body_lines.join("\n");
+    if content.ends_with('\n') && (!body.is_empty()) {
+        body.push('\n');
+    }
+    (desc, body)
 }
 
 #[cfg(test)]
@@ -123,5 +184,18 @@ mod tests {
         let found = discover_prompts_in(dir).await;
         let names: Vec<String> = found.into_iter().map(|e| e.name).collect();
         assert_eq!(names, vec!["good"]);
+    }
+
+    #[tokio::test]
+    async fn parses_front_matter_description() {
+        let tmp = tempdir().expect("create TempDir");
+        let dir = tmp.path();
+        let content = b"---\ndescription: Hello world\n---\nBody text";
+        fs::write(dir.join("desc.md"), content).unwrap();
+        let found = discover_prompts_in(dir).await;
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].name, "desc");
+        assert_eq!(found[0].description.as_deref(), Some("Hello world"));
+        assert_eq!(found[0].content.as_str(), "Body text");
     }
 }

--- a/codex-rs/protocol/src/custom_prompts.rs
+++ b/codex-rs/protocol/src/custom_prompts.rs
@@ -8,4 +8,6 @@ pub struct CustomPrompt {
     pub name: String,
     pub path: PathBuf,
     pub content: String,
+    /// Optional short description (from front matter) to show in the UI popup.
+    pub description: Option<String>,
 }

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -2410,6 +2410,7 @@ mod tests {
             name: "my-prompt".to_string(),
             path: "/tmp/my-prompt.md".to_string().into(),
             content: prompt_text.to_string(),
+            description: None,
         }]);
 
         type_chars_humanlike(
@@ -2544,6 +2545,7 @@ mod tests {
             name: "test".to_string(),
             path: "/tmp/test.md".to_string().into(),
             content: template.to_string(),
+            description: None,
         }]);
 
         type_chars_humanlike(
@@ -2578,6 +2580,7 @@ mod tests {
             name: "test1".to_string(),
             path: "/tmp/test1.md".to_string().into(),
             content: template.to_string(),
+            description: None,
         }]);
         type_chars_humanlike(
             &mut composer,
@@ -2614,6 +2617,7 @@ mod tests {
             name: "test2".to_string(),
             path: "/tmp/test2.md".to_string().into(),
             content: template.to_string(),
+            description: None,
         }]);
 
         // Provide only one positional argument; $2 and $9 should remain verbatim.

--- a/codex-rs/tui/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/command_popup.rs
@@ -161,10 +161,15 @@ impl CommandPopup {
                     CommandItem::Builtin(cmd) => {
                         (format!("/{}", cmd.command()), cmd.description().to_string())
                     }
-                    CommandItem::UserPrompt(i) => (
-                        format!("/{}", self.prompts[i].name),
-                        "send saved prompt".to_string(),
-                    ),
+                    CommandItem::UserPrompt(i) => {
+                        let prompt = &self.prompts[i];
+                        let desc = prompt
+                            .description
+                            .as_deref()
+                            .unwrap_or("send saved prompt")
+                            .to_string();
+                        (format!("/{}", prompt.name), desc)
+                    }
                 };
                 GenericDisplayRow {
                     name,
@@ -276,11 +281,13 @@ mod tests {
                 name: "foo".to_string(),
                 path: "/tmp/foo.md".to_string().into(),
                 content: "hello from foo".to_string(),
+                description: None,
             },
             CustomPrompt {
                 name: "bar".to_string(),
                 path: "/tmp/bar.md".to_string().into(),
                 content: "hello from bar".to_string(),
+                description: None,
             },
         ];
         let popup = CommandPopup::new(prompts);
@@ -303,6 +310,7 @@ mod tests {
             name: "init".to_string(),
             path: "/tmp/init.md".to_string().into(),
             content: "should be ignored".to_string(),
+            description: None,
         }]);
         let items = popup.filtered_items();
         let has_collision_prompt = items.into_iter().any(|it| match it {

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -433,6 +433,11 @@ impl BottomPane {
         self.composer.set_history_metadata(log_id, entry_count);
     }
 
+    /// Take and clear the one-shot history override captured by the composer.
+    pub(crate) fn take_next_history_override(&mut self) -> Option<String> {
+        self.composer.take_next_history_override()
+    }
+
     pub(crate) fn flush_paste_burst_if_due(&mut self) -> bool {
         self.composer.flush_paste_burst_if_due()
     }

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -6,6 +6,9 @@ Save frequently used prompts as Markdown files and reuse them quickly from the s
 - File type: Only Markdown files with the `.md` extension are recognized.
 - Name: The filename without the `.md` extension becomes the slash entry. For a file named `my-prompt.md`, type `/my-prompt`.
 - Content: The file contents are sent as your message when you select the item in the slash popup and press Enter.
+- Argument substitution: Use `$0` (prompt name), `$1..$9` (positionals), and `$ARGUMENTS` (all args joined). Missing positionals remain literal. Works both when selecting from the popup and when typing `/name args` directly.
+- Description in popup: Add a minimal front matter block at the top (`---` + `description: ...` + `---`); the block is stripped from the submitted body.
+- History (custom prompts): Saved in history and reusable (previously not supported).
 - How to use:
   - Start a new session (Codex loads custom prompts on session start).
   - In the composer, type `/` to open the slash popup and begin typing your prompt name.
@@ -13,3 +16,5 @@ Save frequently used prompts as Markdown files and reuse them quickly from the s
 - Notes:
   - Files with names that collide with built‑in commands (e.g. `/init`) are ignored and won’t appear.
   - New or changed files are discovered on session start. If you add a new prompt while Codex is running, start a new session to pick it up.
+
+ 


### PR DESCRIPTION
# What
  - Add support for passing arguments to custom prompts executed via slash commands and custom commands.
  - Expose the raw argument string to the template as the $ARGUMENTS (and $0...$9) placeholder so it can be rendered inside the .md file.
  - Use the frontmatter YAML property named 'description' to display descriptions in the slash popup.
  - Keep behavior fully backward-compatible when no arguments are provided.

# Why
  - Users need to parameterize prompts to avoid duplicating similar .md files and to tailor executions dynamically (see #2890).

# How
  - Thread the user-provided argument string from the slash/custom command invocation through the execution pipeline and expose it to the renderer as $ARGUMENTS, $0, $1 ... $9
  - Fallbacks:
      - If the argument string is empty, nothing happens.
  - This also fixes custom prompts to work with history, making them usable (previously this was not working properly).

## Prompt with Arguments
<img width="505" height="262" alt="CleanShot 2025-09-22 at 18 50 43" src="https://github.com/user-attachments/assets/d0d13466-894b-43ea-838a-e6074a078137" />

## Description Showing in Slash Popup
<img width="519" height="301" alt="CleanShot 2025-09-22 at 19 08 01" src="https://github.com/user-attachments/assets/253dbe3b-c82c-428c-aa12-28ca34546b4e" />

## Works as Expected!
<img width="612" height="526" alt="CleanShot 2025-09-22 at 19 08 28" src="https://github.com/user-attachments/assets/b3e306f3-6d00-4035-8319-9968e5dc899b" />

## Backward Compatibility
  - No breaking changes. Existing prompts without $ARGUMENTS continue to work unchanged.

# Notes
I have read the CLA Document and I hereby sign the CLA
