### PR TITLE
Fix nix build

### DIFF
--- a/codex-rs/default.nix
+++ b/codex-rs/default.nix
@@ -16,6 +16,9 @@ rec {
       pkg-config
       openssl
     ];
+    cargoLock.outputHashes = {
+      "ratatui-0.29.0" = "sha256-HBvT5c8GsiCxMffNjJGLmHnvG77A6cqEL+1ARurBXho=";
+    };
     meta = with pkgs.lib; {
       description = "OpenAI Codex command‑line interface rust implementation";
       license = licenses.asl20;

--- a/codex-rs/default.nix
+++ b/codex-rs/default.nix
@@ -1,4 +1,4 @@
-{ pkgs, monorep-deps ? [], ... }:
+{ pkgs, ... }:
 let
   env = {
     PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig:$PKG_CONFIG_PATH";
@@ -28,7 +28,7 @@ rec {
   devShell = pkgs.mkShell {
     inherit env;
     name = "codex-rs-dev";
-    packages = monorep-deps ++ [
+    packages = [
       pkgs.cargo
       package
     ];

--- a/codex-rs/default.nix
+++ b/codex-rs/default.nix
@@ -38,8 +38,4 @@ rec {
       ${pkgs.rustPlatform.cargoSetupHook}
     '';
   };
-  app = {
-    type = "app";
-    program = "${package}/bin/codex";
-  };
 }

--- a/codex-rs/default.nix
+++ b/codex-rs/default.nix
@@ -1,41 +1,31 @@
-{ pkgs, ... }:
-let
+{
+  openssl,
+  rustPlatform,
+  pkg-config,
+  lib,
+  ...
+}:
+rustPlatform.buildRustPackage (finalAttrs: {
   env = {
-    PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig:$PKG_CONFIG_PATH";
+    PKG_CONFIG_PATH = "${openssl.dev}/lib/pkgconfig:$PKG_CONFIG_PATH";
   };
-in
-rec {
-  package = pkgs.rustPlatform.buildRustPackage {
-    inherit env;
-    pname = "codex-rs";
-    version = "0.1.0";
-    cargoLock.lockFile = ./Cargo.lock;
-    doCheck = false;
-    src = ./.;
-    nativeBuildInputs = with pkgs; [
-      pkg-config
-      openssl
-    ];
-    cargoLock.outputHashes = {
-      "ratatui-0.29.0" = "sha256-HBvT5c8GsiCxMffNjJGLmHnvG77A6cqEL+1ARurBXho=";
-    };
-    meta = with pkgs.lib; {
-      description = "OpenAI Codex command‑line interface rust implementation";
-      license = licenses.asl20;
-      homepage = "https://github.com/openai/codex";
-    };
+  pname = "codex-rs";
+  version = "0.1.0";
+  cargoLock.lockFile = ./Cargo.lock;
+  doCheck = false;
+  src = ./.;
+  nativeBuildInputs = [
+    pkg-config
+    openssl
+  ];
+
+  cargoLock.outputHashes = {
+    "ratatui-0.29.0" = "sha256-HBvT5c8GsiCxMffNjJGLmHnvG77A6cqEL+1ARurBXho=";
   };
-  devShell = pkgs.mkShell {
-    inherit env;
-    name = "codex-rs-dev";
-    packages = [
-      pkgs.cargo
-      package
-    ];
-    shellHook = ''
-      echo "Entering development shell for codex-rs"
-      alias codex="cd ${package.src}/tui; cargo run; cd -"
-      ${pkgs.rustPlatform.cargoSetupHook}
-    '';
+
+  meta = with lib; {
+    description = "OpenAI Codex command‑line interface rust implementation";
+    license = licenses.asl20;
+    homepage = "https://github.com/openai/codex";
   };
-}
+})

--- a/flake.lock
+++ b/flake.lock
@@ -1,30 +1,12 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758277210,
-        "narHash": "sha256-iCGWf/LTy+aY0zFu8q12lK8KuZp7yvdhStehhyX1v8w=",
+        "lastModified": 1758427187,
+        "narHash": "sha256-pHpxZ/IyCwoTQPtFIAG2QaxuSm8jWzrzBGjwQZIttJc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "8eaee110344796db060382e15d3af0a9fc396e0e",
+        "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
         "type": "github"
       },
       "original": {
@@ -36,24 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs",
-        "rust-overlay": "rust-overlay"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
+        "nixpkgs": "nixpkgs"
       }
     }
   },

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1744463964,
-        "narHash": "sha256-LWqduOgLHCFxiTNYi3Uj5Lgz0SR+Xhw3kr/3Xd0GPTM=",
+        "lastModified": 1758277210,
+        "narHash": "sha256-iCGWf/LTy+aY0zFu8q12lK8KuZp7yvdhStehhyX1v8w=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2631b0b7abcea6e640ce31cd78ea58910d31e650",
+        "rev": "8eaee110344796db060382e15d3af0a9fc396e0e",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746844454,
-        "narHash": "sha256-GcUWDQUDRYrD34ol90KGUpjbVcOfUNbv0s955jPecko=",
+        "lastModified": 1758508617,
+        "narHash": "sha256-kx2uELmVnAbiekj/YFfWR26OXqXedImkhe2ocnbumTA=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "be092436d4c0c303b654e4007453b69c0e33009e",
+        "rev": "d2bac276ac7e669a1f09c48614538a37e3eb6d0f",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -41,26 +41,6 @@
         "rust-overlay": "rust-overlay"
       }
     },
-    "rust-overlay": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1758508617,
-        "narHash": "sha256-kx2uELmVnAbiekj/YFfWR26OXqXedImkhe2ocnbumTA=",
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "rev": "d2bac276ac7e669a1f09c48614538a37e3eb6d0f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "oxalica",
-        "repo": "rust-overlay",
-        "type": "github"
-      }
-    },
     "systems": {
       "locked": {
         "lastModified": 1681028828,

--- a/flake.nix
+++ b/flake.nix
@@ -20,19 +20,8 @@
           codex-rs = pkgs.callPackage ./codex-rs { };
         in
         {
-          codex-rs = codex-rs.package;
-          default = codex-rs.package;
-        }
-      );
-
-      devShells = forAllSystems (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          codex-rs = pkgs.callPackage ./codex-rs { };
-        in
-        {
-          codex-rs = codex-rs.devShell;
-          default = codex-rs.devShell;
+          codex-rs = codex-rs;
+          default = codex-rs;
         }
       );
     };

--- a/flake.nix
+++ b/flake.nix
@@ -35,16 +35,5 @@
           default = codex-rs.devShell;
         }
       );
-
-      apps = forAllSystems (system:
-        let
-          pkgs = nixpkgs.legacyPackages.${system};
-          codex-rs = pkgs.callPackage ./codex-rs { };
-        in
-        {
-          codex-rs = codex-rs.app;
-          default = codex-rs.app;
-        }
-      );
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -30,17 +30,20 @@
           inherit monorepo-deps;
         };
       in
-      rec {
+      {
         packages = {
           codex-rs = codex-rs.package;
+          default = codex-rs.package;
         };
 
         devShells = {
           codex-rs = codex-rs.devShell;
+          default = codex-rs.devShell;
         };
 
         apps = {
           codex-rs = codex-rs.app;
+          default = codex-rs.app;
         };
       }
     );

--- a/flake.nix
+++ b/flake.nix
@@ -13,21 +13,12 @@
   outputs = { nixpkgs, flake-utils, rust-overlay, ... }: 
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs {
-          inherit system;
-        };
         pkgsWithRust = import nixpkgs {
           inherit system;
           overlays = [ rust-overlay.overlays.default ];
         };
-        monorepo-deps = with pkgs; [
-          # for precommit hook
-          pnpm
-          husky
-        ];
         codex-rs = import ./codex-rs {
           pkgs = pkgsWithRust;
-          inherit monorepo-deps;
         };
       in
       {

--- a/flake.nix
+++ b/flake.nix
@@ -25,9 +25,6 @@
           pnpm
           husky
         ];
-        codex-cli = import ./codex-cli {
-          inherit pkgs monorepo-deps;
-        };
         codex-rs = import ./codex-rs {
           pkgs = pkgsWithRust;
           inherit monorepo-deps;
@@ -35,23 +32,16 @@
       in
       rec {
         packages = {
-          codex-cli = codex-cli.package;
           codex-rs = codex-rs.package;
         };
 
         devShells = {
-          codex-cli = codex-cli.devShell;
           codex-rs = codex-rs.devShell;
         };
 
         apps = {
-          codex-cli = codex-cli.app;
           codex-rs = codex-rs.app;
         };
-
-        defaultPackage = packages.codex-cli;
-        defaultApp = apps.codex-cli;
-        defaultDevShell = devShells.codex-cli;
       }
     );
 }

--- a/flake.nix
+++ b/flake.nix
@@ -4,22 +4,12 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
-    rust-overlay = {
-      url = "github:oxalica/rust-overlay";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
-  outputs = { nixpkgs, flake-utils, rust-overlay, ... }: 
+  outputs = { nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgsWithRust = import nixpkgs {
-          inherit system;
-          overlays = [ rust-overlay.overlays.default ];
-        };
-        codex-rs = import ./codex-rs {
-          pkgs = pkgsWithRust;
-        };
+        codex-rs = nixpkgs.legacyPackages.${system} ./codex-rs { };
       in
       {
         packages = {

--- a/flake.nix
+++ b/flake.nix
@@ -1,31 +1,50 @@
 {
   description = "Development Nix flake for OpenAI Codex CLI";
 
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-  };
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-  outputs = { nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        codex-rs = nixpkgs.legacyPackages.${system} ./codex-rs { };
-      in
-      {
-        packages = {
+  outputs = { nixpkgs, ... }:
+    let
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = f: nixpkgs.lib.genAttrs systems f;
+    in
+    {
+      packages = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          codex-rs = pkgs.callPackage ./codex-rs { };
+        in
+        {
           codex-rs = codex-rs.package;
           default = codex-rs.package;
-        };
+        }
+      );
 
-        devShells = {
+      devShells = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          codex-rs = pkgs.callPackage ./codex-rs { };
+        in
+        {
           codex-rs = codex-rs.devShell;
           default = codex-rs.devShell;
-        };
+        }
+      );
 
-        apps = {
+      apps = forAllSystems (system:
+        let
+          pkgs = nixpkgs.legacyPackages.${system};
+          codex-rs = pkgs.callPackage ./codex-rs { };
+        in
+        {
           codex-rs = codex-rs.app;
           default = codex-rs.app;
-        };
-      }
-    );
+        }
+      );
+    };
 }


### PR DESCRIPTION
I dropped the build of the old cli from the flake, where the default.nix already seemed to removed in a previous iterations. Then I updated flake.nix and codex-rs expression to be able to build again (see individual commits for details).

Tested by running the following builds:


```
$ nix build .#packages.x86_64-linux.codex-rs
$ nix build .#packages.aarch64-darwin.codex-cli
```