### PR TITLE
feat: update default

### DIFF
--- a/codex-rs/common/src/model_presets.rs
+++ b/codex-rs/common/src/model_presets.rs
@@ -1,4 +1,3 @@
-use codex_core::config::GPT_5_CODEX_MEDIUM_MODEL;
 use codex_core::protocol_config_types::ReasoningEffort;
 use codex_protocol::mcp_protocol::AuthMode;
 
@@ -69,13 +68,6 @@ const PRESETS: &[ModelPreset] = &[
     },
 ];
 
-pub fn builtin_model_presets(auth_mode: Option<AuthMode>) -> Vec<ModelPreset> {
-    match auth_mode {
-        Some(AuthMode::ApiKey) => PRESETS
-            .iter()
-            .copied()
-            .filter(|p| p.model != GPT_5_CODEX_MEDIUM_MODEL)
-            .collect(),
-        _ => PRESETS.to_vec(),
-    }
+pub fn builtin_model_presets(_auth_mode: Option<AuthMode>) -> Vec<ModelPreset> {
+    PRESETS.to_vec()
 }

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -37,7 +37,7 @@ use toml_edit::DocumentMut;
 use toml_edit::Item as TomlItem;
 use toml_edit::Table as TomlTable;
 
-const OPENAI_DEFAULT_MODEL: &str = "gpt-5";
+const OPENAI_DEFAULT_MODEL: &str = "gpt-5-codex";
 const OPENAI_DEFAULT_REVIEW_MODEL: &str = "gpt-5-codex";
 pub const GPT_5_CODEX_MEDIUM_MODEL: &str = "gpt-5-codex";
 
@@ -54,7 +54,7 @@ pub struct Config {
     /// Optional override of model selection.
     pub model: String,
 
-    /// Model used specifically for review sessions. Defaults to "gpt-5".
+    /// Model used specifically for review sessions. Defaults to "gpt-5-codex".
     pub review_model: String,
 
     pub model_family: ModelFamily,
@@ -1366,7 +1366,7 @@ startup_timeout_ms = 2500
         tokio::fs::write(
             &config_path,
             r#"
-model = "gpt-5"
+model = "gpt-5-codex"
 model_reasoning_effort = "medium"
 
 [profiles.dev]
@@ -1441,7 +1441,7 @@ model = "gpt-4"
 model_reasoning_effort = "medium"
 
 [profiles.prod]
-model = "gpt-5"
+model = "gpt-5-codex"
 "#,
         )
         .await?;
@@ -1472,7 +1472,7 @@ model = "gpt-5"
                 .profiles
                 .get("prod")
                 .and_then(|profile| profile.model.as_deref()),
-            Some("gpt-5"),
+            Some("gpt-5-codex"),
         );
 
         Ok(())
@@ -1532,7 +1532,7 @@ model_provider = "openai"
 approval_policy = "on-failure"
 
 [profiles.gpt5]
-model = "gpt-5"
+model = "gpt-5-codex"
 model_provider = "openai"
 approval_policy = "on-failure"
 model_reasoning_effort = "high"
@@ -1808,9 +1808,9 @@ model_verbosity = "high"
             fixture.codex_home(),
         )?;
         let expected_gpt5_profile_config = Config {
-            model: "gpt-5".to_string(),
+            model: "gpt-5-codex".to_string(),
             review_model: OPENAI_DEFAULT_REVIEW_MODEL.to_string(),
-            model_family: find_family_for_model("gpt-5").expect("known model slug"),
+            model_family: find_family_for_model("gpt-5-codex").expect("known model slug"),
             model_context_window: Some(272_000),
             model_max_output_tokens: Some(128_000),
             model_auto_compact_token_limit: None,

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1531,8 +1531,8 @@ model = "o3"
 model_provider = "openai"
 approval_policy = "on-failure"
 
-[profiles.gpt5_codex]
-model = "gpt-5-codex"
+[profiles.gpt5]
+model = "gpt-5"
 model_provider = "openai"
 approval_policy = "on-failure"
 model_reasoning_effort = "high"
@@ -1808,9 +1808,9 @@ model_verbosity = "high"
             fixture.codex_home(),
         )?;
         let expected_gpt5_profile_config = Config {
-            model: "gpt-5-codex".to_string(),
+            model: "gpt-5".to_string(),
             review_model: OPENAI_DEFAULT_REVIEW_MODEL.to_string(),
-            model_family: find_family_for_model("gpt-5-codex").expect("known model slug"),
+            model_family: find_family_for_model("gpt-5").expect("known model slug"),
             model_context_window: Some(272_000),
             model_max_output_tokens: Some(128_000),
             model_auto_compact_token_limit: None,

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1531,7 +1531,7 @@ model = "o3"
 model_provider = "openai"
 approval_policy = "on-failure"
 
-[profiles.gpt5]
+[profiles.gpt5_codex]
 model = "gpt-5-codex"
 model_provider = "openai"
 approval_policy = "on-failure"

--- a/codex-rs/core/src/config_edit.rs
+++ b/codex-rs/core/src/config_edit.rs
@@ -228,7 +228,7 @@ mod tests {
             codex_home,
             None,
             &[
-                (&[CONFIG_KEY_MODEL], "gpt-5"),
+                (&[CONFIG_KEY_MODEL], "gpt-5-codex"),
                 (&[CONFIG_KEY_EFFORT], "high"),
             ],
         )
@@ -236,7 +236,7 @@ mod tests {
         .expect("persist");
 
         let contents = read_config(codex_home).await;
-        let expected = r#"model = "gpt-5"
+        let expected = r#"model = "gpt-5-codex"
 model_reasoning_effort = "high"
 "#;
         assert_eq!(contents, expected);
@@ -348,7 +348,7 @@ model_reasoning_effort = "high"
             &[
                 (&["a", "b", "c"], "v"),
                 (&["x"], "y"),
-                (&["profiles", "p1", CONFIG_KEY_MODEL], "gpt-5"),
+                (&["profiles", "p1", CONFIG_KEY_MODEL], "gpt-5-codex"),
             ],
         )
         .await
@@ -361,7 +361,7 @@ model_reasoning_effort = "high"
 c = "v"
 
 [profiles.p1]
-model = "gpt-5"
+model = "gpt-5-codex"
 "#;
         assert_eq!(contents, expected);
     }
@@ -454,7 +454,7 @@ existing = "keep"
             codex_home,
             None,
             &[
-                (&[CONFIG_KEY_MODEL], "gpt-5"),
+                (&[CONFIG_KEY_MODEL], "gpt-5-codex"),
                 (&[CONFIG_KEY_EFFORT], "minimal"),
             ],
         )
@@ -466,7 +466,7 @@ existing = "keep"
 # should be preserved
 
 existing = "keep"
-model = "gpt-5"
+model = "gpt-5-codex"
 model_reasoning_effort = "minimal"
 "#;
         assert_eq!(contents, expected);
@@ -524,7 +524,7 @@ model = "o3"
         let codex_home = tmpdir.path();
 
         // Seed with a model value only
-        let seed = "model = \"gpt-5\"\n";
+        let seed = "model = \"gpt-5-codex\"\n";
         tokio::fs::write(codex_home.join(CONFIG_TOML_FILE), seed)
             .await
             .expect("seed write");
@@ -535,7 +535,7 @@ model = "o3"
             .expect("persist");
 
         let contents = read_config(codex_home).await;
-        let expected = r#"model = "gpt-5"
+        let expected = r#"model = "gpt-5-codex"
 model_reasoning_effort = "high"
 "#;
         assert_eq!(contents, expected);
@@ -579,7 +579,7 @@ model = "o4-mini"
 
         // No active profile key; we'll target an explicit override
         let seed = r#"[profiles.team]
-model = "gpt-5"
+model = "gpt-5-codex"
 "#;
         tokio::fs::write(codex_home.join(CONFIG_TOML_FILE), seed)
             .await
@@ -595,7 +595,7 @@ model = "gpt-5"
 
         let contents = read_config(codex_home).await;
         let expected = r#"[profiles.team]
-model = "gpt-5"
+model = "gpt-5-codex"
 model_reasoning_effort = "minimal"
 "#;
         assert_eq!(contents, expected);
@@ -611,7 +611,7 @@ model_reasoning_effort = "minimal"
             codex_home,
             None,
             &[
-                (&[CONFIG_KEY_MODEL], Some("gpt-5")),
+                (&[CONFIG_KEY_MODEL], Some("gpt-5-codex")),
                 (&[CONFIG_KEY_EFFORT], None),
             ],
         )
@@ -619,7 +619,7 @@ model_reasoning_effort = "minimal"
         .expect("persist");
 
         let contents = read_config(codex_home).await;
-        let expected = "model = \"gpt-5\"\n";
+        let expected = "model = \"gpt-5-codex\"\n";
         assert_eq!(contents, expected);
     }
 
@@ -670,7 +670,7 @@ model = "o3"
         let tmpdir = tempdir().expect("tmp");
         let codex_home = tmpdir.path();
 
-        let seed = r#"model = "gpt-5"
+        let seed = r#"model = "gpt-5-codex"
 model_reasoning_effort = "medium"
 "#;
         tokio::fs::write(codex_home.join(CONFIG_TOML_FILE), seed)

--- a/codex-rs/core/src/internal_storage.rs
+++ b/codex-rs/core/src/internal_storage.rs
@@ -7,12 +7,25 @@ use std::path::PathBuf;
 
 pub(crate) const INTERNAL_STORAGE_FILE: &str = "internal_storage.json";
 
-#[derive(Debug, Default, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InternalStorage {
     #[serde(skip)]
     storage_path: PathBuf,
-    #[serde(default)]
+    #[serde(default = "default_gpt_5_codex_model_prompt_seen")]
     pub gpt_5_codex_model_prompt_seen: bool,
+}
+
+const fn default_gpt_5_codex_model_prompt_seen() -> bool {
+    true
+}
+
+impl Default for InternalStorage {
+    fn default() -> Self {
+        Self {
+            storage_path: PathBuf::new(),
+            gpt_5_codex_model_prompt_seen: default_gpt_5_codex_model_prompt_seen(),
+        }
+    }
 }
 
 // TODO(jif) generalise all the file writers and build proper async channel inserters.

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -822,7 +822,7 @@ async fn token_count_includes_rate_limits_snapshot() {
                     "reasoning_output_tokens": 0,
                     "total_tokens": 123
                 },
-                // Default model is gpt-5 in tests → 272000 context window
+                // Default model is gpt-5-codex in tests → 272000 context window
                 "model_context_window": 272000
             },
             "rate_limits": {

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -133,7 +133,7 @@ async fn compact_resume_and_fork_preserve_model_history_view() {
         .to_string();
     let user_turn_1 = json!(
     {
-      "model": "gpt-5",
+      "model": "gpt-5-codex",
       "instructions": prompt,
       "input": [
         {
@@ -182,7 +182,7 @@ async fn compact_resume_and_fork_preserve_model_history_view() {
     });
     let compact_1 = json!(
     {
-      "model": "gpt-5",
+      "model": "gpt-5-codex",
       "instructions": "You have exceeded the maximum number of tokens, please stop coding and instead write a short memento message for the next agent. Your note should:
 - Summarize what you finished and what still needs work. If there was a recent update_plan call, repeat its steps verbatim.
 - List outstanding TODOs with file paths / line numbers so they're easy to find.
@@ -255,7 +255,7 @@ async fn compact_resume_and_fork_preserve_model_history_view() {
     });
     let user_turn_2_after_compact = json!(
     {
-      "model": "gpt-5",
+      "model": "gpt-5-codex",
       "instructions": prompt,
       "input": [
         {
@@ -320,7 +320,7 @@ SUMMARY_ONLY_CONTEXT"
     });
     let usert_turn_3_after_resume = json!(
     {
-      "model": "gpt-5",
+      "model": "gpt-5-codex",
       "instructions": prompt,
       "input": [
         {
@@ -405,7 +405,7 @@ SUMMARY_ONLY_CONTEXT"
     });
     let user_turn_3_after_fork = json!(
     {
-      "model": "gpt-5",
+      "model": "gpt-5-codex",
       "instructions": prompt,
       "input": [
         {

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -184,6 +184,7 @@ async fn prompt_tools_are_consistent_across_requests() {
 
     let conversation_manager =
         ConversationManager::with_auth(CodexAuth::from_api_key("Test API Key"));
+    let expected_instructions = config.model_family.base_instructions.clone();
     let codex = conversation_manager
         .new_conversation(config)
         .await
@@ -213,7 +214,6 @@ async fn prompt_tools_are_consistent_across_requests() {
     let requests = server.received_requests().await.unwrap();
     assert_eq!(requests.len(), 2, "expected two POST requests");
 
-    let expected_instructions: &str = include_str!("../../prompt.md");
     // our internal implementation is responsible for keeping tools in sync
     // with the OpenAI schema, so we just verify the tool presence here
     let expected_tools_names: &[&str] = &["shell", "update_plan", "apply_patch", "view_image"];

--- a/codex-rs/docs/codex_mcp_interface.md
+++ b/codex-rs/docs/codex_mcp_interface.md
@@ -51,7 +51,7 @@ Start a new session with optional overrides:
 
 Request `newConversation` params (subset):
 
-- `model`: string model id (e.g. "o3", "gpt-5-codex")
+- `model`: string model id (e.g. "o3", "gpt-5", "gpt-5-codex")
 - `profile`: optional named profile
 - `cwd`: optional working directory
 - `approvalPolicy`: `untrusted` | `on-request` | `on-failure` | `never`
@@ -100,13 +100,13 @@ For ChatGPT or API‑key based auth flows, the server exposes helpers:
 ## Example: start and send a message
 
 ```json
-{ "jsonrpc": "2.0", "id": 1, "method": "newConversation", "params": { "model": "gpt-5-codex", "approvalPolicy": "on-request" } }
+{ "jsonrpc": "2.0", "id": 1, "method": "newConversation", "params": { "model": "gpt-5", "approvalPolicy": "on-request" } }
 ```
 
 Server responds:
 
 ```json
-{ "jsonrpc": "2.0", "id": 1, "result": { "conversationId": "c7b0…", "model": "gpt-5-codex", "rolloutPath": "/path/to/rollout.jsonl" } }
+{ "jsonrpc": "2.0", "id": 1, "result": { "conversationId": "c7b0…", "model": "gpt-5", "rolloutPath": "/path/to/rollout.jsonl" } }
 ```
 
 Then send input:

--- a/codex-rs/docs/codex_mcp_interface.md
+++ b/codex-rs/docs/codex_mcp_interface.md
@@ -51,7 +51,7 @@ Start a new session with optional overrides:
 
 Request `newConversation` params (subset):
 
-- `model`: string model id (e.g. "o3", "gpt-5")
+- `model`: string model id (e.g. "o3", "gpt-5-codex")
 - `profile`: optional named profile
 - `cwd`: optional working directory
 - `approvalPolicy`: `untrusted` | `on-request` | `on-failure` | `never`
@@ -100,13 +100,13 @@ For ChatGPT or API‑key based auth flows, the server exposes helpers:
 ## Example: start and send a message
 
 ```json
-{ "jsonrpc": "2.0", "id": 1, "method": "newConversation", "params": { "model": "gpt-5", "approvalPolicy": "on-request" } }
+{ "jsonrpc": "2.0", "id": 1, "method": "newConversation", "params": { "model": "gpt-5-codex", "approvalPolicy": "on-request" } }
 ```
 
 Server responds:
 
 ```json
-{ "jsonrpc": "2.0", "id": 1, "result": { "conversationId": "c7b0…", "model": "gpt-5", "rolloutPath": "/path/to/rollout.jsonl" } }
+{ "jsonrpc": "2.0", "id": 1, "result": { "conversationId": "c7b0…", "model": "gpt-5-codex", "rolloutPath": "/path/to/rollout.jsonl" } }
 ```
 
 Then send input:
@@ -120,4 +120,3 @@ While processing, the server emits `codex/event` notifications containing agent 
 ## Compatibility and stability
 
 This interface is experimental. Method names, fields, and event shapes may evolve. For the authoritative schema, consult `protocol/src/mcp_protocol.rs` and the corresponding server wiring in `mcp-server/`.
-

--- a/codex-rs/mcp-server/tests/suite/config.rs
+++ b/codex-rs/mcp-server/tests/suite/config.rs
@@ -26,7 +26,7 @@ fn create_config_toml(codex_home: &Path) -> std::io::Result<()> {
     std::fs::write(
         config_toml,
         r#"
-model = "gpt-5"
+model = "gpt-5-codex"
 approval_policy = "on-request"
 sandbox_mode = "workspace-write"
 model_reasoning_summary = "detailed"
@@ -92,7 +92,7 @@ async fn get_config_toml_parses_all_fields() {
                 exclude_tmpdir_env_var: Some(true),
                 exclude_slash_tmp: Some(true),
             }),
-            model: Some("gpt-5".into()),
+            model: Some("gpt-5-codex".into()),
             model_reasoning_effort: Some(ReasoningEffort::High),
             model_reasoning_summary: Some(ReasoningSummary::Detailed),
             model_verbosity: Some(Verbosity::Medium),

--- a/codex-rs/mcp-server/tests/suite/set_default_model.rs
+++ b/codex-rs/mcp-server/tests/suite/set_default_model.rs
@@ -69,7 +69,7 @@ fn create_config_toml(codex_home: &Path) -> std::io::Result<()> {
     std::fs::write(
         config_toml,
         r#"
-model = "gpt-5"
+model = "gpt-5-codex"
 model_reasoning_effort = "medium"
 "#,
     )

--- a/codex-rs/protocol/src/mcp_protocol.rs
+++ b/codex-rs/protocol/src/mcp_protocol.rs
@@ -710,7 +710,7 @@ mod tests {
         let request = ClientRequest::NewConversation {
             request_id: RequestId::Integer(42),
             params: NewConversationParams {
-                model: Some("gpt-5".to_string()),
+                model: Some("gpt-5-codex".to_string()),
                 profile: None,
                 cwd: None,
                 approval_policy: Some(AskForApproval::OnRequest),
@@ -726,7 +726,7 @@ mod tests {
                 "method": "newConversation",
                 "id": 42,
                 "params": {
-                    "model": "gpt-5",
+                    "model": "gpt-5-codex",
                     "approvalPolicy": "on-request"
                 }
             }),

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__binary_size_ideal_response.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__binary_size_ideal_response.snap
@@ -1,6 +1,5 @@
 ---
 source: tui/src/chatwidget/tests.rs
-assertion_line: 648
 expression: visible_after
 ---
 > I’m going to scan the workspace and Cargo manifests to see build profiles and
@@ -10,6 +9,14 @@ expression: visible_after
   └ List ls -la
     Read Cargo.toml
 
+• I'm reviewing the workspace's release profile, which has settings like
+  lto=fat, strip=symbols, and codegen-units=1 to reduce binary size. However, it
+  seems that "strip = symbols" only removes symbols, not debug information. In
+  Rust 1.73+, both "symbols" and "debuginfo" stripping options are available. I
+  should check whether using these results in a smaller binary. I’ll also skim
+  through crates for heavy dependencies in Cargo.toml, including cli, core,
+  exec, linux-sandbox, tui, login, ollama, and mcp.
+
 • Ran
   └ for d in ansi-escape apply-patch arg0 cli common core exec execpolicy
         file-search linux-sandbox login mcp-client mcp-server mcp-types ollama
@@ -18,6 +25,79 @@ expression: visible_after
 
 • Explored
   └ Read Cargo.toml
+
+• I’m evaluating how binary size is influenced by various factors. There are
+  many binaries, such as codex and codex-exec, which include dependencies by
+  default, pulling in features like Tokio and hyper. For instance, reqwest
+  includes default features like TLS through rustls. If default features remain
+  enabled, it inflates the size with many additional components. I notice
+  that for musl targets, using vendored builds of OpenSSL could significantly
+  increase binary size. This is quite the intricate web of dependencies!
+
+  Analyzing musl and binary size
+
+  I’m considering the implications of building for musl with static linking.
+  In this case, OpenSSL might come into play through some crates, but reqwest
+  defaults to using rustls, although openssl-sys vendored could increase
+  binary size. It’s interesting to think about whether they’re targeting musl,
+  especially since it seems they might often be building for Mac and Linux with
+  dynamic linking instead.
+
+  I also realize there’s a difference between debug and release builds — release
+  should be smaller due to optimizations, but if they’re defaulting to debug
+  builds, that could lead to much larger binaries.
+
+  Assessing crate impacts on size
+
+  I need to be precise when analyzing binary sizes from various crates. Some
+  crates, like ratatui-image, include heavy features such as libjpeg decoders,
+  which can really bulk things up. Then there are the tree-sitter crates that
+  contain large static grammar tables, adding significant size. The starlark
+  crate and tracing-subscriber also contribute to size increases.
+
+  With static linking per binary being standard in Rust, it leads to multiple
+  copies of the same dependencies unless cdylibs are used. That makes the
+  compile times longer, but using LTO helps reduce bloat somewhat through
+  deduplication.
+
+  Evaluating binary size factors
+
+  Having multiple binaries indeed increases the overall size significantly.
+  I'm considering options like upgrading to "opt-level = 'z'" or using
+  "strip=debuginfo" for reducing size. It's interesting that while the profile
+  only sets symbols for stripping, not debuginfo, this could inflate sizes if
+  retained in release builds.
+
+  The distinction between "symbols" and "debuginfo" is critical; "symbols"
+  keeps debug information which may not align with the goal of minimizing
+  size. I’d like to verify with the Rust documentation, but my network access
+  is restricted.
+
+  Explaining large binary sizes
+
+  I’m analyzing why binaries in this project are so large. The primary reasons
+  include monolithic static linking, where each binary includes the full
+  dependency graph without shared libraries. Heavy dependencies such as reqwest,
+  hyper, and TLS components also contribute significantly to size, along with
+  image decoders and other libraries.
+
+  Using MUSL targets means vendored OpenSSL can drastically increase the
+  size due to static linking. Furthermore, if the release profile keeps debug
+  information due to using "strip = symbols," that can lead to larger binaries
+  as well. It’s a mix of several factors, including panic strategies and
+  platform-specific linking behavior.
+
+  Identifying binary size contributors
+
+  I’m considering why binaries are still large even without static linking. The
+  tracing-subscriber crate potentially adds weight because it includes regex,
+  though it can sometimes use a lighter version. References from files like
+  "core/Cargo.toml" show dependencies like reqwest and tokio, while the tui uses
+  the image crate.
+
+  To present this clearly, I’ll format the final answer with two main sections:
+  "Main Causes" and "Build-Mode Notes." I can also include brief suggestions for
+  reducing size, but I want to stay focused on answering the user's question.
 
 > Here’s what’s driving size in this workspace’s binaries.
 

--- a/codex-rs/tui/tests/fixtures/binary-size-log.jsonl
+++ b/codex-rs/tui/tests/fixtures/binary-size-log.jsonl
@@ -1,4 +1,4 @@
-{"ts":"2025-08-09T15:51:04.827Z","dir":"meta","kind":"session_start","cwd":"/Users/easong/code/codex/codex-rs","model":"gpt-5","reasoning_effort":"medium","model_provider_id":"openai","model_provider_name":"OpenAI"}
+{"ts":"2025-08-09T15:51:04.827Z","dir":"meta","kind":"session_start","cwd":"/Users/easong/code/codex/codex-rs","model":"gpt-5-codex","reasoning_effort":"medium","model_provider_id":"openai","model_provider_name":"OpenAI"}
 {"ts":"2025-08-09T15:51:04.827Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('c'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
 {"ts":"2025-08-09T15:51:04.827Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('o'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
 {"ts":"2025-08-09T15:51:04.827Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('m'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
@@ -34,7 +34,7 @@
 {"ts":"2025-08-09T15:51:04.829Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
 {"ts":"2025-08-09T15:51:04.829Z","dir":"to_tui","kind":"log_line","line":"[INFO codex_core::codex] resume_path: None"}
 {"ts":"2025-08-09T15:51:04.830Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
-{"ts":"2025-08-09T15:51:04.856Z","dir":"to_tui","kind":"codex_event","payload":{"id":"0","msg":{"type":"session_configured","session_id":"d126e3d0-80ed-480a-be8c-09d97ff602cf","model":"gpt-5","reasoning_effort":"medium","history_log_id":2532619,"history_entry_count":339,"rollout_path":"/tmp/codex-test-rollout.jsonl"}}}
+{"ts":"2025-08-09T15:51:04.856Z","dir":"to_tui","kind":"codex_event","payload":{"id":"0","msg":{"type":"session_configured","session_id":"d126e3d0-80ed-480a-be8c-09d97ff602cf","model":"gpt-5-codex","reasoning_effort":"medium","history_log_id":2532619,"history_entry_count":339,"rollout_path":"/tmp/codex-test-rollout.jsonl"}}}
 {"ts":"2025-08-09T15:51:04.856Z","dir":"to_tui","kind":"insert_history","lines":9}
 {"ts":"2025-08-09T15:51:04.857Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
 {"ts":"2025-08-09T15:51:04.857Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
@@ -16447,7 +16447,7 @@
 {"ts":"2025-08-09T16:06:58.083Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
 {"ts":"2025-08-09T16:06:58.085Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
 {"ts":"2025-08-09T16:06:58.085Z","dir":"to_tui","kind":"log_line","line":"[INFO codex_core::codex] resume_path: None"}
-{"ts":"2025-08-09T16:06:58.136Z","dir":"to_tui","kind":"codex_event","payload":{"id":"0","msg":{"type":"session_configured","session_id":"c7df96da-daec-4fe9-aed9-3cd19b7a6192","model":"gpt-5","reasoning_effort":"medium","history_log_id":2532619,"history_entry_count":342,"rollout_path":"/tmp/codex-test-rollout.jsonl"}}}
+{"ts":"2025-08-09T16:06:58.136Z","dir":"to_tui","kind":"codex_event","payload":{"id":"0","msg":{"type":"session_configured","session_id":"c7df96da-daec-4fe9-aed9-3cd19b7a6192","model":"gpt-5-codex","reasoning_effort":"medium","history_log_id":2532619,"history_entry_count":342,"rollout_path":"/tmp/codex-test-rollout.jsonl"}}}
 {"ts":"2025-08-09T16:06:58.136Z","dir":"to_tui","kind":"insert_history","lines":9}
 {"ts":"2025-08-09T16:06:58.136Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
 {"ts":"2025-08-09T16:06:58.136Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}

--- a/docs/config.md
+++ b/docs/config.md
@@ -21,7 +21,7 @@ Both the `--config` flag and the `config.toml` file support the following option
 The model that Codex should use.
 
 ```toml
-model = "o3"  # overrides the default of "gpt-5"
+model = "o3"  # overrides the default of "gpt-5-codex"
 ```
 
 ## model_providers
@@ -223,11 +223,11 @@ Users can specify config values at multiple levels. Order of precedence is as fo
 1. custom command-line argument, e.g., `--model o3`
 2. as part of a profile, where the `--profile` is specified via a CLI (or in the config file itself)
 3. as an entry in `config.toml`, e.g., `model = "o3"`
-4. the default value that comes with Codex CLI (i.e., Codex CLI defaults to `gpt-5`)
+4. the default value that comes with Codex CLI (i.e., Codex CLI defaults to `gpt-5-codex`)
 
 ## model_reasoning_effort
 
-If the selected model is known to support reasoning (for example: `o3`, `o4-mini`, `codex-*`, `gpt-5`), reasoning is enabled by default when using the Responses API. As explained in the [OpenAI Platform documentation](https://platform.openai.com/docs/guides/reasoning?api-mode=responses#get-started-with-reasoning), this can be set to:
+If the selected model is known to support reasoning (for example: `o3`, `o4-mini`, `codex-*`, `gpt-5`, `gpt-5-codex`), reasoning is enabled by default when using the Responses API. As explained in the [OpenAI Platform documentation](https://platform.openai.com/docs/guides/reasoning?api-mode=responses#get-started-with-reasoning), this can be set to:
 
 - `"minimal"`
 - `"low"`
@@ -606,7 +606,7 @@ notifications = [ "agent-turn-complete", "approval-requested" ]
 
 | Key | Type / Values | Notes |
 | --- | --- | --- |
-| `model` | string | Model to use (e.g., `gpt-5`). |
+| `model` | string | Model to use (e.g., `gpt-5-codex`). |
 | `model_provider` | string | Provider id from `model_providers` (default: `openai`). |
 | `model_context_window` | number | Context window tokens. |
 | `model_max_output_tokens` | number | Max output tokens. |


### PR DESCRIPTION
Changes:
- Default model and docs now use gpt-5-codex. 
- Disables the GPT-5 Codex NUX by default.
- Keeps presets available for API key users.