### PR TITLE
Added resume session as a command (/resume)

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -18,6 +18,9 @@ pub(crate) enum AppEvent {
     /// Start a new session.
     NewSession,
 
+    /// Open the resume picker and optionally resume a previous session.
+    ResumeSession,
+
     /// Request to exit the application gracefully.
     ExitRequest,
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -952,6 +952,9 @@ impl ChatWidget {
             SlashCommand::New => {
                 self.app_event_tx.send(AppEvent::NewSession);
             }
+            SlashCommand::Resume => {
+                self.app_event_tx.send(AppEvent::ResumeSession);
+            }
             SlashCommand::Init => {
                 const INIT_PROMPT: &str = include_str!("../prompt_for_init_command.md");
                 self.submit_text_message(INIT_PROMPT.to_string());

--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -44,6 +44,7 @@ pub async fn run_resume_picker(tui: &mut Tui, codex_home: &Path) -> Result<Resum
     let mut state = PickerState::new(codex_home.to_path_buf(), alt.tui.frame_requester());
     state.load_page(None).await?;
     state.request_frame();
+    draw_picker(alt.tui, &state)?;
 
     let mut events = alt.tui.event_stream();
     while let Some(ev) = events.next().await {

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -16,6 +16,7 @@ pub enum SlashCommand {
     Approvals,
     Review,
     New,
+    Resume,
     Init,
     Compact,
     Diff,
@@ -44,6 +45,7 @@ impl SlashCommand {
             SlashCommand::Approvals => "choose what Codex can do without approval",
             SlashCommand::Mcp => "list configured MCP tools",
             SlashCommand::Logout => "log out of Codex",
+            SlashCommand::Resume => "open the session picker to resume a past chat",
             #[cfg(debug_assertions)]
             SlashCommand::TestApproval => "test approval request",
         }
@@ -60,6 +62,7 @@ impl SlashCommand {
         match self {
             SlashCommand::New
             | SlashCommand::Init
+            | SlashCommand::Resume
             | SlashCommand::Compact
             | SlashCommand::Model
             | SlashCommand::Approvals


### PR DESCRIPTION
Currently, the only way to resume a previous Codex session is by running codex resume on startup. This works, but it’s inconsistent with many other AI CLIs that support a /resume command directly within the session, and may be confusing to new users.