### PR TITLE
feat: Save prompts with ctrl+S

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -269,6 +269,11 @@ impl ChatComposer {
         self.textarea.text().to_string()
     }
 
+    /// Get the current composer text (for runtime use).
+    pub(crate) fn text_content(&self) -> String {
+        self.textarea.text().to_string()
+    }
+
     /// Attempt to start a burst by retro-capturing recent chars before the cursor.
     pub fn attach_image(&mut self, path: PathBuf, width: u32, height: u32, format_label: &str) {
         let placeholder = format!("[image {width}x{height} {format_label}]");
@@ -1282,7 +1287,7 @@ impl WidgetRef for ChatComposer {
                     } else {
                         key_hint::ctrl('J')
                     };
-                    vec![
+                    let mut base: Vec<Span<'static>> = vec![
                         key_hint::plain('⏎'),
                         " send   ".into(),
                         newline_hint_key,
@@ -1291,7 +1296,14 @@ impl WidgetRef for ChatComposer {
                         " transcript   ".into(),
                         key_hint::ctrl('C'),
                         " quit".into(),
-                    ]
+                    ];
+                    // When there is text in the composer, show Ctrl+S to save as a custom prompt.
+                    if !self.textarea.is_empty() {
+                        base.push("   ".into());
+                        base.push(key_hint::ctrl('S'));
+                        base.push(" save prompt".into());
+                    }
+                    base
                 };
 
                 if !self.ctrl_c_quit_hint && self.esc_backtrack_hint {

--- a/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
+++ b/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
@@ -20,7 +20,7 @@ use super::textarea::TextArea;
 use super::textarea::TextAreaState;
 
 /// Callback invoked when the user submits a custom prompt.
-pub(crate) type PromptSubmitted = Box<dyn Fn(String) + Send + Sync>;
+pub(crate) type PromptSubmitted = Box<dyn Fn(String) -> bool + Send + Sync>;
 
 /// Minimal multi-line text input view to collect custom review instructions.
 pub(crate) struct CustomPromptView {
@@ -68,8 +68,7 @@ impl BottomPaneView for CustomPromptView {
                 ..
             } => {
                 let text = self.textarea.text().trim().to_string();
-                if !text.is_empty() {
-                    (self.on_submit)(text);
+                if !text.is_empty() && (self.on_submit)(text) {
                     self.complete = true;
                 }
             }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -360,6 +360,11 @@ impl BottomPane {
         self.composer.is_empty()
     }
 
+    /// Get the current composer text (without mutating state).
+    pub(crate) fn composer_text_now(&self) -> String {
+        self.composer.text_content()
+    }
+
     pub(crate) fn is_task_running(&self) -> bool {
         self.is_task_running
     }

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__backspace_after_pastes.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__backspace_after_pastes.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "                                                                                                    "
-"⏎ send   ⌃J newline   ⌃T transcript   ⌃C quit                                                       "
+"⏎ send   ⌃J newline   ⌃T transcript   ⌃C quit   ⌃S save prompt                                      "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__large.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__large.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "                                                                                                    "
-"⏎ send   ⌃J newline   ⌃T transcript   ⌃C quit                                                       "
+"⏎ send   ⌃J newline   ⌃T transcript   ⌃C quit   ⌃S save prompt                                      "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__multiple_pastes.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__multiple_pastes.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "                                                                                                    "
-"⏎ send   ⌃J newline   ⌃T transcript   ⌃C quit                                                       "
+"⏎ send   ⌃J newline   ⌃T transcript   ⌃C quit   ⌃S save prompt                                      "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "▌                                                                                                   "
 "▌                                                                                                   "
 "                                                                                                    "
-"⏎ send   ⌃J newline   ⌃T transcript   ⌃C quit                                                       "
+"⏎ send   ⌃J newline   ⌃T transcript   ⌃C quit   ⌃S save prompt                                      "

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__chatwidget_exec_and_status_layout_vt100_snapshot.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__chatwidget_exec_and_status_layout_vt100_snapshot.snap
@@ -13,4 +13,4 @@ expression: visual
 
 ▌ Summarize recent commits
 
-⏎ send   ⌃J newline   ⌃T transcript   ⌃C quit
+⏎ send   ⌃J newline   ⌃T transcript   ⌃C quit   ⌃S save prompt


### PR DESCRIPTION
Saves your chat widget's pending text as a custom prompt with Ctrl+S.

<img width="673" height="139" alt="Screenshot 2025-09-23 at 11 28 58 AM" src="https://github.com/user-attachments/assets/ce477d1f-62ce-4d4b-b627-225b1c9ff2c0" />

---

When you hit ctrl+S, you will see this prompt to set a name:

<img width="357" height="106" alt="Screenshot 2025-09-23 at 11 29 27 AM" src="https://github.com/user-attachments/assets/cb5b2970-9437-43a9-a217-2b914aa36d70" />
