### PR TITLE
fix(tui): add missing space in history cell

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1613,7 +1613,7 @@ fn format_mcp_invocation<'a>(invocation: McpInvocation) -> Line<'a> {
 
 fn build_status_limit_lines(snapshot: Option<&RateLimitSnapshot>) -> Vec<Line<'static>> {
     let mut lines: Vec<Line<'static>> =
-        vec![vec![padded_emoji("⏱️").into(), "Usage Limits".bold()].into()];
+        vec![vec![padded_emoji("⏱️").into(), " Usage Limits".bold()].into()];
 
     match snapshot {
         Some(snapshot) => {


### PR DESCRIPTION
**Summary of Changes**

  This pull request addresses a minor formatting issue in the TUI's history_cell component to improve code readability.

**Detailed Description**

  A missing space has been added to the codex-rs/tui/src/history_cell.rs file. This is a cosmetic change that has no impact on functionality and serves only to improve code style and readability.