### PR TITLE
Fix output schema handling for Codex models

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -183,13 +183,13 @@ impl ModelClient {
 
         let input_with_instructions = prompt.get_formatted_input();
 
-        // Only include `text.verbosity` for GPT-5 family models
-        let text = if self.config.model_family.family == "gpt-5" {
+        // Only include text controls for model families that support them
+        let text = if self.config.model_family.supports_text_controls() {
             create_text_param_for_request(self.config.model_verbosity, &prompt.output_schema)
         } else {
             if self.config.model_verbosity.is_some() {
                 warn!(
-                    "model_verbosity is set but ignored for non-gpt-5 model family: {}",
+                    "model_verbosity is set but ignored for model family without text controls: {}",
                     self.config.model_family.family
                 );
             }

--- a/codex-rs/core/src/model_family.rs
+++ b/codex-rs/core/src/model_family.rs
@@ -43,6 +43,13 @@ pub struct ModelFamily {
     pub base_instructions: String,
 }
 
+impl ModelFamily {
+    /// Returns true when the model family supports Responses API text controls.
+    pub fn supports_text_controls(&self) -> bool {
+        self.family.starts_with("gpt-5") || self.family.starts_with("codex-")
+    }
+}
+
 macro_rules! model_family {
     (
         $slug:expr, $family:expr $(, $key:ident : $value:expr )* $(,)?

--- a/codex-rs/core/tests/suite/json_result.rs
+++ b/codex-rs/core/tests/suite/json_result.rs
@@ -29,10 +29,7 @@ const SCHEMA: &str = r#"
 }
 "#;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn codex_returns_json_result() -> anyhow::Result<()> {
-    non_sandbox_test!(result);
-
+async fn run_json_result_test(model: &str) -> anyhow::Result<()> {
     let server = start_mock_server().await;
 
     let sse1 = sse(vec![
@@ -62,7 +59,6 @@ async fn codex_returns_json_result() -> anyhow::Result<()> {
 
     let TestCodex { codex, cwd, .. } = test_codex().build(&server).await?;
 
-    // 1) Normal user input – should hit server once.
     codex
         .submit(Op::UserTurn {
             items: vec![InputItem::Text {
@@ -72,7 +68,7 @@ async fn codex_returns_json_result() -> anyhow::Result<()> {
             cwd: cwd.path().to_path_buf(),
             approval_policy: AskForApproval::Never,
             sandbox_policy: SandboxPolicy::DangerFullAccess,
-            model: "gpt-5".to_string(),
+            model: model.to_string(),
             effort: None,
             summary: ReasoningSummary::Auto,
         })
@@ -94,4 +90,16 @@ async fn codex_returns_json_result() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn codex_returns_json_result() -> anyhow::Result<()> {
+    non_sandbox_test!(result);
+    run_json_result_test("gpt-5").await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn codex_returns_json_result_for_codex_family() -> anyhow::Result<()> {
+    non_sandbox_test!(result);
+    run_json_result_test("gpt-5-codex").await
 }

--- a/codex-rs/exec/tests/suite/output_schema.rs
+++ b/codex-rs/exec/tests/suite/output_schema.rs
@@ -8,8 +8,7 @@ use std::process::Command;
 use tempfile::TempDir;
 use wiremock::matchers::any;
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn exec_includes_output_schema_in_request() -> anyhow::Result<()> {
+async fn run_output_schema_in_request_test(model: &str) -> anyhow::Result<()> {
     let home = TempDir::new()?;
     let workspace = TempDir::new()?;
 
@@ -47,7 +46,7 @@ async fn exec_includes_output_schema_in_request() -> anyhow::Result<()> {
         .arg("--output-schema")
         .arg(&schema_path)
         .arg("-m")
-        .arg("gpt-5")
+        .arg(model)
         .arg("tell me a joke")
         .assert()
         .success();
@@ -73,4 +72,14 @@ async fn exec_includes_output_schema_in_request() -> anyhow::Result<()> {
     );
 
     Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exec_includes_output_schema_in_request() -> anyhow::Result<()> {
+    run_output_schema_in_request_test("gpt-5").await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exec_includes_output_schema_for_codex_family() -> anyhow::Result<()> {
+    run_output_schema_in_request_test("gpt-5-codex").await
 }


### PR DESCRIPTION
## Summary
- allow Codex model families to emit Responses text controls for output schemas
- add regression coverage ensuring exec and core honor the schema for Codex slugs

## Testing
- just fmt
- just fix -p codex-exec
- just fix -p codex-core
- cargo test -p codex-exec
- cargo test -p codex-core

Resolves #4181