### PR TITLE
chore: drop unused values from env_flags

### DIFF
--- a/codex-rs/core/src/flags.rs
+++ b/codex-rs/core/src/flags.rs
@@ -1,16 +1,6 @@
-use std::time::Duration;
-
 use env_flags::env_flags;
 
 env_flags! {
-    pub OPENAI_API_BASE: &str = "https://api.openai.com/v1";
-
-    /// Fallback when the provider-specific key is not set.
-    pub OPENAI_API_KEY: Option<&str> = None;
-    pub OPENAI_TIMEOUT_MS: Duration = Duration::from_millis(300_000), |value| {
-        value.parse().map(Duration::from_millis)
-    };
-
     /// Fixture path for offline tests (see client.rs).
     pub CODEX_RS_SSE_FIXTURE: Option<&str> = None;
 }


### PR DESCRIPTION
For the most part, we try to avoid environment variables in favor of config options so the environment variables do not leak into child processes. These environment variables are no longer honored, so let's delete them to be clear.

Ultimately, I would also like to eliminate `CODEX_RS_SSE_FIXTURE` in favor of something cleaner.