### PR TITLE
Send text parameter for non-gpt-5 models

### DIFF
--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -179,6 +179,7 @@ pub(crate) fn create_text_param_for_request(
     verbosity: Option<VerbosityConfig>,
     output_schema: &Option<Value>,
 ) -> Option<TextControls> {
+    
     if verbosity.is_none() && output_schema.is_none() {
         return None;
     }

--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -179,7 +179,6 @@ pub(crate) fn create_text_param_for_request(
     verbosity: Option<VerbosityConfig>,
     output_schema: &Option<Value>,
 ) -> Option<TextControls> {
-    
     if verbosity.is_none() && output_schema.is_none() {
         return None;
     }

--- a/codex-rs/core/tests/suite/json_result.rs
+++ b/codex-rs/core/tests/suite/json_result.rs
@@ -30,7 +30,16 @@ const SCHEMA: &str = r#"
 "#;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn codex_returns_json_result() -> anyhow::Result<()> {
+async fn codex_returns_json_result_for_gpt5() -> anyhow::Result<()> {
+    codex_returns_json_result("gpt-5".to_string()).await
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn codex_returns_json_result_for_gpt5_codex() -> anyhow::Result<()> {
+    codex_returns_json_result("gpt-5-codex".to_string()).await
+}
+
+async fn codex_returns_json_result(model: String) -> anyhow::Result<()> {
     non_sandbox_test!(result);
 
     let server = start_mock_server().await;
@@ -72,7 +81,7 @@ async fn codex_returns_json_result() -> anyhow::Result<()> {
             cwd: cwd.path().to_path_buf(),
             approval_policy: AskForApproval::Never,
             sandbox_policy: SandboxPolicy::DangerFullAccess,
-            model: "gpt-5".to_string(),
+            model,
             effort: None,
             summary: ReasoningSummary::Auto,
         })


### PR DESCRIPTION
We had a hardcoded check for gpt-5 before.

Fixes: https://github.com/openai/codex/issues/4181