### PR TITLE
fixing broken links in protocol_v1.md

### DIFF
--- a/codex-rs/docs/protocol_v1.md
+++ b/codex-rs/docs/protocol_v1.md
@@ -1,4 +1,4 @@
-Overview of Protocol Defined in [protocol.rs](../core/src/protocol.rs) and [agent.rs](../core/src/agent.rs).
+Overview of Protocol Defined in [protocol.rs](../protocol/src/protocol.rs) and [codex.rs](../core/src/codex.rs).
 
 The goal of this document is to define terminology used in the system and explain the expected behavior of the system.
 
@@ -62,7 +62,7 @@ Since only 1 `Task` can be run at a time, for parallel tasks it is recommended t
     - This enum is `non_exhaustive`; variants can be added at future dates
     - It should be expected that new `EventMsg` variants will be added over time to expose more detailed information about the model's actions.
 
-For complete documentation of the `Op` and `EventMsg` variants, refer to [protocol.rs](../core/src/protocol.rs). Some example payload types:
+For complete documentation of the `Op` and `EventMsg` variants, refer to [protocol.rs](../protocol/src/protocol.rs). Some example payload types:
 
 - `Op`
   - `Op::UserInput` – Any input from the user to kick off a `Task`


### PR DESCRIPTION
Fixes #4202 

## Why These Changes Were Necessary:

- The codebase structure had evolved since the documentation was written:
- Protocol definitions moved
- The Op and EventMsg enums, along with all protocol-related types, were moved from protocol.rs to their own dedicated crate at protocol.rs
- Agent implementation consolidated
- The agent logic referenced as agent.rs no longer exists as a separate file.
- Instead, the session management, task execution, and turn handling are now implemented in codex.rs

## File references were broken:
- The old links resulted in 404 errors for anyone trying to find the actual protocol definitions mentioned

## Result After Changes:
The documentation now correctly points readers to where they can find:
- The complete protocol definitions (protocol.rs)
- The core implementation logic (codex.rs)

This ensures developers can actually locate and reference the current, authoritative source code when working with the Codex protocol.
