### PR TITLE
github: update codespell action to v2.1 in workflow

### DIFF
--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Annotate locations with typos
         uses: codespell-project/codespell-problem-matcher@b80729f885d32f78a716c2f107b4db1025001c42 # v1
       - name: Codespell
-        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2
+        uses: codespell-project/actions-codespell@v2.1 # v2
         with:
           ignore_words_file: .codespellignore
           skip: frame*.txt

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Annotate locations with typos
         uses: codespell-project/codespell-problem-matcher@b80729f885d32f78a716c2f107b4db1025001c42 # v1
       - name: Codespell
-        uses: codespell-project/actions-codespell@v2.1 # v2
+        uses: codespell-project/actions-codespell@406322ec52dd7b488e48c1c4b82e2a8b3a1bf630 # v2.1
         with:
           ignore_words_file: .codespellignore
           skip: frame*.txt


### PR DESCRIPTION
Old version fails to find python 3.8 docker image