### PR TITLE
core: add potentially dangerous command check

### DIFF
--- a/codex-rs/core/src/bash.rs
+++ b/codex-rs/core/src/bash.rs
@@ -88,6 +88,21 @@ pub fn try_parse_word_only_commands_sequence(tree: &Tree, src: &str) -> Option<V
     Some(commands)
 }
 
+/// Returns the sequence of plain commands within a `bash -lc "..."` invocation
+/// when the script only contains word-only commands joined by safe operators.
+pub fn parse_bash_lc_plain_commands(command: &[String]) -> Option<Vec<Vec<String>>> {
+    let [bash, flag, script] = command else {
+        return None;
+    };
+
+    if bash != "bash" || flag != "-lc" {
+        return None;
+    }
+
+    let tree = try_parse_bash(script)?;
+    try_parse_word_only_commands_sequence(&tree, script)
+}
+
 fn parse_plain_command_from_node(cmd: tree_sitter::Node, src: &str) -> Option<Vec<String>> {
     if cmd.kind() != "command" {
         return None;

--- a/codex-rs/core/src/command_safety/is_dangerous_command.rs
+++ b/codex-rs/core/src/command_safety/is_dangerous_command.rs
@@ -12,8 +12,7 @@ pub fn command_might_be_dangerous(command: &[String]) -> bool {
     if let [bash, flag, script] = command
         && bash == "bash"
         && flag == "-lc"
-    {
-        if let Some(tree) = try_parse_bash(script)
+        && let Some(tree) = try_parse_bash(script)
             && let Some(all_commands) = try_parse_word_only_commands_sequence(&tree, script)
             && all_commands
                 .iter()
@@ -21,7 +20,6 @@ pub fn command_might_be_dangerous(command: &[String]) -> bool {
         {
             return true;
         }
-    }
 
     false
 }

--- a/codex-rs/core/src/command_safety/is_dangerous_command.rs
+++ b/codex-rs/core/src/command_safety/is_dangerous_command.rs
@@ -1,0 +1,96 @@
+use crate::bash::try_parse_bash;
+use crate::bash::try_parse_word_only_commands_sequence;
+
+const DANGEROUS_COMMAND_PREFIXES: &[&str] = &["git reset"];
+
+pub fn command_might_be_dangerous(command: &[String]) -> bool {
+    if starts_with_dangerous_prefix(command) {
+        return true;
+    }
+
+    // Support `bash -lc "<script>"` where the any part of the script might start with a dangerous prefix.
+    if let [bash, flag, script] = command
+        && bash == "bash"
+        && flag == "-lc"
+    {
+        if let Some(tree) = try_parse_bash(script)
+            && let Some(all_commands) = try_parse_word_only_commands_sequence(&tree, script)
+            && all_commands
+                .iter()
+                .any(|cmd| starts_with_dangerous_prefix(cmd))
+        {
+            return true;
+        }
+    }
+
+    false
+}
+
+fn starts_with_dangerous_prefix(command: &[String]) -> bool {
+    if command.is_empty() {
+        return false;
+    }
+
+    let command_string = command.join(" ");
+
+    DANGEROUS_COMMAND_PREFIXES
+        .iter()
+        .any(|dangerous| command_string.trim().starts_with(dangerous))
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vec_str(items: &[&str]) -> Vec<String> {
+        items.iter().map(std::string::ToString::to_string).collect()
+    }
+
+    #[test]
+    fn git_reset_is_dangerous() {
+        assert!(command_might_be_dangerous(&vec_str(&[
+            "git", "reset"
+        ])));
+    }
+
+    #[test]
+    fn git_reset_with_leading_space_is_dangerous() {
+        assert!(command_might_be_dangerous(&vec_str(&[
+            "  git",
+            "reset"
+        ])));
+    }
+
+    #[test]
+    fn bash_git_reset_is_dangerous() {
+        assert!(command_might_be_dangerous(&vec_str(&[
+            "bash",
+            "-lc",
+            "git reset --hard"
+        ])));
+    }
+
+    #[test]
+    fn bash_git_reset_with_leading_space_is_dangerous() {
+        assert!(command_might_be_dangerous(&vec_str(&[
+            "bash",
+            "-lc",
+            "   git reset --hard"
+        ])));
+    }
+
+    #[test]
+    fn git_status_is_not_dangerous() {
+        assert!(!command_might_be_dangerous(&vec_str(&["git", "status"])));
+    }
+
+    #[test]
+    fn bash_git_status_is_not_dangerous() {
+        assert!(!command_might_be_dangerous(&vec_str(&[
+            "bash",
+            "-lc",
+            "git status"
+        ])));
+    }
+}

--- a/codex-rs/core/src/command_safety/is_dangerous_command.rs
+++ b/codex-rs/core/src/command_safety/is_dangerous_command.rs
@@ -13,13 +13,13 @@ pub fn command_might_be_dangerous(command: &[String]) -> bool {
         && bash == "bash"
         && flag == "-lc"
         && let Some(tree) = try_parse_bash(script)
-            && let Some(all_commands) = try_parse_word_only_commands_sequence(&tree, script)
-            && all_commands
-                .iter()
-                .any(|cmd| starts_with_dangerous_prefix(cmd))
-        {
-            return true;
-        }
+        && let Some(all_commands) = try_parse_word_only_commands_sequence(&tree, script)
+        && all_commands
+            .iter()
+            .any(|cmd| starts_with_dangerous_prefix(cmd))
+    {
+        return true;
+    }
 
     false
 }
@@ -36,7 +36,6 @@ fn starts_with_dangerous_prefix(command: &[String]) -> bool {
         .any(|dangerous| command_string.trim().starts_with(dangerous))
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -47,17 +46,12 @@ mod tests {
 
     #[test]
     fn git_reset_is_dangerous() {
-        assert!(command_might_be_dangerous(&vec_str(&[
-            "git", "reset"
-        ])));
+        assert!(command_might_be_dangerous(&vec_str(&["git", "reset"])));
     }
 
     #[test]
     fn git_reset_with_leading_space_is_dangerous() {
-        assert!(command_might_be_dangerous(&vec_str(&[
-            "  git",
-            "reset"
-        ])));
+        assert!(command_might_be_dangerous(&vec_str(&["  git", "reset"])));
     }
 
     #[test]

--- a/codex-rs/core/src/command_safety/is_dangerous_command.rs
+++ b/codex-rs/core/src/command_safety/is_dangerous_command.rs
@@ -89,10 +89,7 @@ mod tests {
     #[test]
     fn sudo_git_reset_is_dangerous() {
         assert!(command_might_be_dangerous(&vec_str(&[
-            "sudo",
-            "git",
-            "reset",
-            "--hard"
+            "sudo", "git", "reset", "--hard"
         ])));
     }
 

--- a/codex-rs/core/src/command_safety/is_safe_command.rs
+++ b/codex-rs/core/src/command_safety/is_safe_command.rs
@@ -1,5 +1,4 @@
-use crate::bash::try_parse_bash;
-use crate::bash::try_parse_word_only_commands_sequence;
+use crate::bash::parse_bash_lc_plain_commands;
 
 pub fn is_known_safe_command(command: &[String]) -> bool {
     #[cfg(target_os = "windows")]
@@ -20,11 +19,7 @@ pub fn is_known_safe_command(command: &[String]) -> bool {
     // introduce side effects ( "&&", "||", ";", and "|" ). If every
     // individual command in the script is itself a known‑safe command, then
     // the composite expression is considered safe.
-    if let [bash, flag, script] = command
-        && bash == "bash"
-        && flag == "-lc"
-        && let Some(tree) = try_parse_bash(script)
-        && let Some(all_commands) = try_parse_word_only_commands_sequence(&tree, script)
+    if let Some(all_commands) = parse_bash_lc_plain_commands(command)
         && !all_commands.is_empty()
         && all_commands
             .iter()

--- a/codex-rs/core/src/command_safety/mod.rs
+++ b/codex-rs/core/src/command_safety/mod.rs
@@ -1,5 +1,4 @@
-
+pub mod is_dangerous_command;
 pub mod is_safe_command;
 #[cfg(target_os = "windows")]
 pub mod windows_safe_commands;
-pub mod is_dangerous_command;

--- a/codex-rs/core/src/command_safety/mod.rs
+++ b/codex-rs/core/src/command_safety/mod.rs
@@ -1,3 +1,5 @@
+
 pub mod is_safe_command;
 #[cfg(target_os = "windows")]
 pub mod windows_safe_commands;
+pub mod is_dangerous_command;

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -7,7 +7,9 @@ use codex_apply_patch::ApplyPatchAction;
 use codex_apply_patch::ApplyPatchFileChange;
 
 use crate::exec::SandboxType;
-use crate::is_safe_command::is_known_safe_command;
+
+use crate::command_safety::is_dangerous_command::command_might_be_dangerous;
+use crate::command_safety::is_safe_command::is_known_safe_command;
 use crate::protocol::AskForApproval;
 use crate::protocol::SandboxPolicy;
 
@@ -85,6 +87,14 @@ pub fn assess_command_safety(
     approved: &HashSet<Vec<String>>,
     with_escalated_permissions: bool,
 ) -> SafetyCheck {
+
+    // Some commands look dangerous. Even if they are run inside a sandbox,
+    // unless the user has explicitly approved them, we should ask,
+    // regardless of the approval policy and sandbox policy.
+    if command_might_be_dangerous(command) && !approved.contains(command) {
+        return SafetyCheck::AskUser;
+    }
+
     // A command is "trusted" because either:
     // - it belongs to a set of commands we consider "safe" by default, or
     // - the user has explicitly approved the command for this session
@@ -98,6 +108,7 @@ pub fn assess_command_safety(
     // would probably be fine to run the command in a sandbox, but when
     // `approved.contains(command)` is `true`, the user may have approved it for
     // the session _because_ they know it needs to run outside a sandbox.
+
     if is_known_safe_command(command) || approved.contains(command) {
         return SafetyCheck::AutoApprove {
             sandbox_type: SandboxType::None,
@@ -313,6 +324,44 @@ mod tests {
         let sandbox_policy = SandboxPolicy::ReadOnly;
         let approved: HashSet<Vec<String>> = HashSet::new();
         let request_escalated_privileges = true;
+
+        let safety_check = assess_command_safety(
+            &command,
+            approval_policy,
+            &sandbox_policy,
+            &approved,
+            request_escalated_privileges,
+        );
+
+        assert_eq!(safety_check, SafetyCheck::AskUser);
+    }
+
+    #[test]
+    fn dangerous_command_allowed_if_explicitly_approved() {
+        let command = vec!["git".to_string(), "reset".to_string(), "--hard".to_string()];
+        let approval_policy = AskForApproval::OnRequest;
+        let sandbox_policy = SandboxPolicy::ReadOnly;
+        let mut approved: HashSet<Vec<String>> = HashSet::new();
+        approved.insert(command.clone());
+        let request_escalated_privileges = false;
+
+        let safety_check = assess_command_safety(
+            &command,
+            approval_policy,
+            &sandbox_policy,
+            &approved,
+            request_escalated_privileges,
+        );
+
+        assert_eq!(safety_check, SafetyCheck::AutoApprove { sandbox_type: SandboxType::None });
+    }
+
+    fn dangerous_command_not_allowed_if_not_explicitly_approved() {
+        let command = vec!["git".to_string(), "reset".to_string(), "--hard".to_string()];
+        let approval_policy = AskForApproval::Never;
+        let sandbox_policy = SandboxPolicy::ReadOnly;
+        let approved: HashSet<Vec<String>> = HashSet::new();
+        let request_escalated_privileges = false;
 
         let safety_check = assess_command_safety(
             &command,

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -360,6 +360,7 @@ mod tests {
         );
     }
 
+    #[test]
     fn dangerous_command_not_allowed_if_not_explicitly_approved() {
         let command = vec!["git".to_string(), "reset".to_string(), "--hard".to_string()];
         let approval_policy = AskForApproval::Never;

--- a/codex-rs/core/src/safety.rs
+++ b/codex-rs/core/src/safety.rs
@@ -87,7 +87,6 @@ pub fn assess_command_safety(
     approved: &HashSet<Vec<String>>,
     with_escalated_permissions: bool,
 ) -> SafetyCheck {
-
     // Some commands look dangerous. Even if they are run inside a sandbox,
     // unless the user has explicitly approved them, we should ask,
     // regardless of the approval policy and sandbox policy.
@@ -353,7 +352,12 @@ mod tests {
             request_escalated_privileges,
         );
 
-        assert_eq!(safety_check, SafetyCheck::AutoApprove { sandbox_type: SandboxType::None });
+        assert_eq!(
+            safety_check,
+            SafetyCheck::AutoApprove {
+                sandbox_type: SandboxType::None
+            }
+        );
     }
 
     fn dangerous_command_not_allowed_if_not_explicitly_approved() {


### PR DESCRIPTION
Certain shell commands are potentially dangerous, and we want to check for them.
Unless the user has explicitly approved a command, we will *always* ask them for approval
when one of these commands is encountered, regardless of whether they are in a sandbox, or what their approval policy is.

The first (of probably many) such examples is `git reset --hard`. We will be conservative and check for any `git reset`
