### PR TITLE
experimental model selector config

### DIFF
--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -13,6 +13,8 @@ use serde::Deserializer;
 use serde::Serialize;
 use serde::de::Error as SerdeError;
 
+use codex_protocol::config_types::ReasoningEffort;
+
 #[derive(Serialize, Debug, Clone, PartialEq)]
 pub struct McpServerConfig {
     pub command: String,
@@ -175,6 +177,16 @@ pub struct Tui {
     /// Defaults to `false`.
     #[serde(default)]
     pub notifications: Notifications,
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct CustomSelectorModel {
+    pub label: String,
+    pub model: String,
+    #[serde(default)]
+    pub effort: Option<ReasoningEffort>,
+    #[serde(default)]
+    pub description: Option<String>,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -67,6 +67,9 @@ pub(crate) struct BottomPane {
     status: Option<StatusIndicatorWidget>,
     /// Queued user messages to show under the status indicator.
     queued_user_messages: Vec<String>,
+
+    #[cfg(test)]
+    pub(crate) debug_last_selection_items: Option<Vec<String>>,
 }
 
 pub(crate) struct BottomPaneParams {
@@ -99,6 +102,8 @@ impl BottomPane {
             status: None,
             queued_user_messages: Vec::new(),
             esc_backtrack_hint: false,
+            #[cfg(test)]
+            debug_last_selection_items: None,
         }
     }
 
@@ -337,8 +342,18 @@ impl BottomPane {
 
     /// Show a generic list selection view with the provided items.
     pub(crate) fn show_selection_view(&mut self, params: list_selection_view::SelectionViewParams) {
+        #[cfg(test)]
+        let debug_names = params
+            .items
+            .iter()
+            .map(|item| item.name.clone())
+            .collect::<Vec<_>>();
         let view = list_selection_view::ListSelectionView::new(params, self.app_event_tx.clone());
         self.push_view(Box::new(view));
+        #[cfg(test)]
+        {
+            self.debug_last_selection_items = Some(debug_names);
+        }
     }
 
     /// Update the queued messages shown under the status header.
@@ -354,6 +369,11 @@ impl BottomPane {
     pub(crate) fn set_custom_prompts(&mut self, prompts: Vec<CustomPrompt>) {
         self.composer.set_custom_prompts(prompts);
         self.request_redraw();
+    }
+
+    #[cfg(test)]
+    pub(crate) fn last_selection_item_names(&self) -> Option<&[String]> {
+        self.debug_last_selection_items.as_deref()
     }
 
     pub(crate) fn composer_is_empty(&self) -> bool {

--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,34 @@ The model that Codex should use.
 model = "o3"  # overrides the default of "gpt-5-codex"
 ```
 
+## experimental_custom_selector_models
+
+Define additional presets that appear in the TUI `/model` selector. Each entry
+includes the model slug plus optional reasoning effort and description. When you
+pick a preset from the popup, Codex persists only the model and effort; the
+label and description stay in your config.
+
+```toml
+[[experimental_custom_selector_models]]
+label = "o4-mini medium"
+model = "o4-mini"
+effort = "medium"
+description = "balanced latency"
+
+[[experimental_custom_selector_models]]
+label = "Local llama high"
+model = "llama-3.1-70b-instruct"
+effort = "high"
+```
+
+Custom presets are appended after the built-in entries. If an entry references
+an unavailable model or effort, selecting it will surface the same error you
+would see after changing `model` manually.
+
+When a custom preset shares the same label or `(model, effort)` pair as a
+built-in preset, the built-in entry wins and the conflicting custom entry is
+ignored.
+
 ## model_providers
 
 This option lets you override and amend the default set of model providers bundled with Codex. This value is a map where the key is the value to use with `model_provider` to select the corresponding provider.
@@ -607,6 +635,7 @@ notifications = [ "agent-turn-complete", "approval-requested" ]
 | Key | Type / Values | Notes |
 | --- | --- | --- |
 | `model` | string | Model to use (e.g., `gpt-5-codex`). |
+| `experimental_custom_selector_models` | array<table> | Extra presets for the `/model` TUI selector. |
 | `model_provider` | string | Provider id from `model_providers` (default: `openai`). |
 | `model_context_window` | number | Context window tokens. |
 | `model_max_output_tokens` | number | Max output tokens. |


### PR DESCRIPTION
Adds an experimental config option for adding model slugs to the selector in the TUI


https://github.com/user-attachments/assets/4d4df7c8-d084-4fcf-85c5-48e7ff582200

