### PR TITLE
fix: esc w/ queued messages overwrites draft in composer

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -264,7 +264,6 @@ impl ChatComposer {
     }
 
     /// Get the current composer text.
-    #[cfg(test)]
     pub(crate) fn current_text(&self) -> String {
         self.textarea.text().to_string()
     }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -262,7 +262,6 @@ impl BottomPane {
     }
 
     /// Get the current composer text (for tests and programmatic checks).
-    #[cfg(test)]
     pub(crate) fn composer_text(&self) -> String {
         self.composer.current_text()
     }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -427,12 +427,20 @@ impl ChatWidget {
 
         // If any messages were queued during the task, restore them into the composer.
         if !self.queued_user_messages.is_empty() {
-            let combined = self
+            let queued_text = self
                 .queued_user_messages
                 .iter()
                 .map(|m| m.text.clone())
                 .collect::<Vec<_>>()
                 .join("\n");
+            let existing_text = self.bottom_pane.composer_text();
+            let combined = if existing_text.is_empty() {
+                queued_text
+            } else if queued_text.is_empty() {
+                existing_text
+            } else {
+                format!("{queued_text}\n{existing_text}")
+            };
             self.bottom_pane.set_composer_text(combined);
             // Clear the queue and update the status indicator list.
             self.queued_user_messages.clear();


### PR DESCRIPTION
Instead of overwriting the contents of the composer when pressing <kbd>Esc</kbd> when there's a queued message, prepend the queued message(s) to the composer draft.