### PR TITLE
fix bug when resizing to a smaller width

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -1330,9 +1330,11 @@ impl WidgetRef for ChatComposer {
                     }
                 }
 
-                Line::from(hint)
-                    .style(Style::default().dim())
-                    .render_ref(hint_rect, buf);
+                let hint = hint
+                    .into_iter()
+                    .map(|span| span.patch_style(Style::default().dim()))
+                    .collect::<Vec<_>>();
+                Line::from(hint).render_ref(hint_rect, buf);
             }
         }
         let border_style = if self.has_focus {
@@ -1356,9 +1358,8 @@ impl WidgetRef for ChatComposer {
         let mut state = self.textarea_state.borrow_mut();
         StatefulWidgetRef::render_ref(&(&self.textarea), textarea_rect, buf, &mut state);
         if self.textarea.text().is_empty() {
-            Line::from(self.placeholder_text.as_str())
-                .style(Style::default().dim())
-                .render_ref(textarea_rect.inner(Margin::new(0, 0)), buf);
+            let placeholder = Span::from(self.placeholder_text.as_str()).dim();
+            Line::from(vec![placeholder]).render_ref(textarea_rect.inner(Margin::new(0, 0)), buf);
         }
     }
 }


### PR DESCRIPTION
The composer and key hint lines were using line styles, causing ratatui to print spaces all the way to the right side of the terminal. this meant that resizing the terminal to be narrower would result in rewrapping those lines, causing the bottom area to rerender and push all content up.

Before

https://github.com/user-attachments/assets/8b14555a-1fc5-4f78-8df7-1410ee25e07a

After

https://github.com/user-attachments/assets/707645ab-89c7-4c7f-b556-02f53cef8a2f


