### PR TITLE
[codex exec] Add item.started and support it for command execution

### DIFF
--- a/codex-rs/exec/src/exec_events.rs
+++ b/codex-rs/exec/src/exec_events.rs
@@ -93,6 +93,7 @@ pub enum CommandExecutionStatus {
 pub struct CommandExecutionItem {
     pub command: String,
     pub aggregated_output: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub exit_code: Option<i32>,
     pub status: CommandExecutionStatus,
 }

--- a/codex-rs/exec/src/exec_events.rs
+++ b/codex-rs/exec/src/exec_events.rs
@@ -8,6 +8,8 @@ use ts_rs::TS;
 pub enum ConversationEvent {
     #[serde(rename = "session.created")]
     SessionCreated(SessionCreatedEvent),
+    #[serde(rename = "item.started")]
+    ItemStarted(ItemStartedEvent),
     #[serde(rename = "item.completed")]
     ItemCompleted(ItemCompletedEvent),
     #[serde(rename = "error")]
@@ -18,6 +20,12 @@ pub enum ConversationEvent {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS)]
 pub struct SessionCreatedEvent {
     pub session_id: String,
+}
+
+/// Payload describing the start of an existing conversation item.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS)]
+pub struct ItemStartedEvent {
+    pub item: ConversationItem,
 }
 
 /// Payload describing the completion of an existing conversation item.

--- a/codex-rs/exec/src/exec_events.rs
+++ b/codex-rs/exec/src/exec_events.rs
@@ -93,7 +93,7 @@ pub enum CommandExecutionStatus {
 pub struct CommandExecutionItem {
     pub command: String,
     pub aggregated_output: String,
-    pub exit_code: i32,
+    pub exit_code: Option<i32>,
     pub status: CommandExecutionStatus,
 }
 

--- a/codex-rs/exec/src/experimental_event_processor_with_json_output.rs
+++ b/codex-rs/exec/src/experimental_event_processor_with_json_output.rs
@@ -202,7 +202,6 @@ impl ExperimentalEventProcessorWithJsonOutput {
             );
             return Vec::new();
         };
-        let command = command;
         let status = if ev.exit_code == 0 {
             CommandExecutionStatus::Completed
         } else {

--- a/codex-rs/exec/tests/event_processor_with_json_output.rs
+++ b/codex-rs/exec/tests/event_processor_with_json_output.rs
@@ -163,7 +163,7 @@ fn exec_command_end_success_produces_completed_command_item() {
             item: ConversationItem {
                 id: "item_0".to_string(),
                 details: ConversationItemDetails::CommandExecution(CommandExecutionItem {
-                    command: "bash -lc echo hi".to_string(),
+                    command: "bash -lc 'echo hi'".to_string(),
                     aggregated_output: String::new(),
                     exit_code: None,
                     status: CommandExecutionStatus::InProgress,
@@ -192,7 +192,7 @@ fn exec_command_end_success_produces_completed_command_item() {
             item: ConversationItem {
                 id: "item_0".to_string(),
                 details: ConversationItemDetails::CommandExecution(CommandExecutionItem {
-                    command: "bash -lc echo hi".to_string(),
+                    command: "bash -lc 'echo hi'".to_string(),
                     aggregated_output: "hi\n".to_string(),
                     exit_code: Some(0),
                     status: CommandExecutionStatus::Completed,

--- a/codex-rs/exec/tests/event_processor_with_json_output.rs
+++ b/codex-rs/exec/tests/event_processor_with_json_output.rs
@@ -16,6 +16,7 @@ use codex_exec::exec_events::ConversationEvent;
 use codex_exec::exec_events::ConversationItem;
 use codex_exec::exec_events::ConversationItemDetails;
 use codex_exec::exec_events::ItemCompletedEvent;
+use codex_exec::exec_events::ItemStartedEvent;
 use codex_exec::exec_events::PatchApplyStatus;
 use codex_exec::exec_events::PatchChangeKind;
 use codex_exec::exec_events::ReasoningItem;
@@ -156,7 +157,20 @@ fn exec_command_end_success_produces_completed_command_item() {
         }),
     );
     let out_begin = ep.collect_conversation_events(&begin);
-    assert!(out_begin.is_empty());
+    assert_eq!(
+        out_begin,
+        vec![ConversationEvent::ItemStarted(ItemStartedEvent {
+            item: ConversationItem {
+                id: "item_0".to_string(),
+                details: ConversationItemDetails::CommandExecution(CommandExecutionItem {
+                    command: "bash -lc echo hi".to_string(),
+                    aggregated_output: String::new(),
+                    exit_code: 0,
+                    status: CommandExecutionStatus::InProgress,
+                }),
+            },
+        })]
+    );
 
     // End (success) -> item.completed (item_0)
     let end_ok = event(
@@ -202,7 +216,20 @@ fn exec_command_end_failure_produces_failed_command_item() {
             parsed_cmd: Vec::new(),
         }),
     );
-    assert!(ep.collect_conversation_events(&begin).is_empty());
+    assert_eq!(
+        ep.collect_conversation_events(&begin),
+        vec![ConversationEvent::ItemStarted(ItemStartedEvent {
+            item: ConversationItem {
+                id: "item_0".to_string(),
+                details: ConversationItemDetails::CommandExecution(CommandExecutionItem {
+                    command: "sh -c exit 1".to_string(),
+                    aggregated_output: String::new(),
+                    exit_code: 0,
+                    status: CommandExecutionStatus::InProgress,
+                }),
+            },
+        })]
+    );
 
     // End (failure) -> item.completed (item_0)
     let end_fail = event(

--- a/codex-rs/exec/tests/event_processor_with_json_output.rs
+++ b/codex-rs/exec/tests/event_processor_with_json_output.rs
@@ -222,7 +222,7 @@ fn exec_command_end_failure_produces_failed_command_item() {
             item: ConversationItem {
                 id: "item_0".to_string(),
                 details: ConversationItemDetails::CommandExecution(CommandExecutionItem {
-                    command: "sh -c exit 1".to_string(),
+                    command: "sh -c 'exit 1'".to_string(),
                     aggregated_output: String::new(),
                     exit_code: None,
                     status: CommandExecutionStatus::InProgress,
@@ -251,7 +251,7 @@ fn exec_command_end_failure_produces_failed_command_item() {
             item: ConversationItem {
                 id: "item_0".to_string(),
                 details: ConversationItemDetails::CommandExecution(CommandExecutionItem {
-                    command: "sh -c exit 1".to_string(),
+                    command: "sh -c 'exit 1'".to_string(),
                     aggregated_output: String::new(),
                     exit_code: Some(1),
                     status: CommandExecutionStatus::Failed,


### PR DESCRIPTION
Adds a new `item.started` event to `codex exec` and implements it for command_execution item type.

```jsonl
{"type":"session.created","session_id":"019982d1-75f0-7920-b051-e0d3731a5ed8"}
{"type":"item.completed","item":{"id":"item_0","item_type":"reasoning","text":"**Executing commands securely**\n\nI'm thinking about how the default harness typically uses \"bash -lc,\" while historically \"bash\" is what we've been using. The command should be executed as a string in our CLI, so using \"bash -lc 'echo hello'\" is optimal but calling \"echo hello\" directly feels safer. The sandbox makes sure environment variables like CODEX_SANDBOX_NETWORK_DISABLED=1 are set, so I won't ask for approval. I just need to run \"echo hello\" and correctly present the output."}}
{"type":"item.completed","item":{"id":"item_1","item_type":"reasoning","text":"**Preparing for tool calls**\n\nI realize that I need to include a preamble before making any tool calls. So, I'll first state the preamble in the commentary channel, then proceed with the tool call. After that, I need to present the final message along with the output. It's possible that the CLI will show the output inline, but I must ensure that I present the result clearly regardless. Let's move forward and get this organized!"}}
{"type":"item.completed","item":{"id":"item_2","item_type":"assistant_message","text":"Running `echo` to confirm shell access and print output."}}
{"type":"item.started","item":{"id":"item_3","item_type":"command_execution","command":"bash -lc echo hello","aggregated_output":"","exit_code":null,"status":"in_progress"}}
{"type":"item.completed","item":{"id":"item_3","item_type":"command_execution","command":"bash -lc echo hello","aggregated_output":"hello\n","exit_code":0,"status":"completed"}}
{"type":"item.completed","item":{"id":"item_4","item_type":"assistant_message","text":"hello"}}
```