### PR TITLE
fix typo in sandbox doc

### DIFF
--- a/docs/sandbox.md
+++ b/docs/sandbox.md
@@ -21,7 +21,7 @@ If you need Codex to read files, make edits, and run commands with network acces
 
 ### Can I run without ANY approvals?
 
-Yes, you can disable all approval prompts with `--ask-for-approval never`. This option works with all `--sandbox` modes, so you still have full control over Codex's level of autonomy. It will make its best attempt with whatever contrainsts you provide.
+Yes, you can disable all approval prompts with `--ask-for-approval never`. This option works with all `--sandbox` modes, so you still have full control over Codex's level of autonomy. It will make its best attempt with whatever constraints you provide.
 
 ### Common sandbox + approvals combinations
 


### PR DESCRIPTION
just fixes a simple typo I noticed.
