### PR TITLE
Add ExecFlow supervisor with controllable exec sessions

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -701,6 +701,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha1",
+ "sha2",
  "shlex",
  "similar",
  "strum_macros 0.27.2",

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -36,6 +36,7 @@ reqwest = { workspace = true, features = ["json", "stream"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha1 = { workspace = true }
+sha2 = { workspace = true }
 shlex = { workspace = true }
 similar = { workspace = true }
 strum_macros = { workspace = true }

--- a/codex-rs/core/src/exec_command/control.rs
+++ b/codex-rs/core/src/exec_command/control.rs
@@ -1,0 +1,64 @@
+use serde::Deserialize;
+use serde::Serialize;
+use std::fmt;
+
+use super::session_id::SessionId;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct ExecControlParams {
+    pub(crate) session_id: SessionId,
+    pub(crate) action: ExecControlAction,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ExecControlAction {
+    Keepalive {
+        #[serde(default)]
+        extend_timeout_ms: Option<u64>,
+    },
+    SendCtrlC,
+    Terminate,
+    ForceKill,
+    SetIdleTimeout {
+        timeout_ms: u64,
+    },
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ExecControlResponse {
+    pub session_id: SessionId,
+    pub status: ExecControlStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub note: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ExecControlStatus {
+    Ack,
+    NoSuchSession,
+    AlreadyTerminated,
+    Reject(String),
+}
+
+impl ExecControlStatus {
+    pub(crate) fn ack() -> Self {
+        Self::Ack
+    }
+
+    pub(crate) fn reject(msg: impl Into<String>) -> Self {
+        Self::Reject(msg.into())
+    }
+}
+
+impl fmt::Display for ExecControlStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Ack => write!(f, "ack"),
+            Self::NoSuchSession => write!(f, "no_such_session"),
+            Self::AlreadyTerminated => write!(f, "already_terminated"),
+            Self::Reject(msg) => write!(f, "reject({msg})"),
+        }
+    }
+}

--- a/codex-rs/core/src/exec_command/exec_command_params.rs
+++ b/codex-rs/core/src/exec_command/exec_command_params.rs
@@ -18,6 +18,18 @@ pub struct ExecCommandParams {
 
     #[serde(default = "default_login")]
     pub(crate) login: bool,
+
+    #[serde(default)]
+    pub(crate) idle_timeout_ms: Option<u64>,
+
+    #[serde(default)]
+    pub(crate) hard_timeout_ms: Option<u64>,
+
+    #[serde(default = "default_grace_period_ms")]
+    pub(crate) grace_period_ms: u64,
+
+    #[serde(default = "default_log_threshold_bytes")]
+    pub(crate) log_threshold_bytes: u64,
 }
 
 fn default_yield_time() -> u64 {
@@ -34,6 +46,14 @@ fn default_login() -> bool {
 
 fn default_shell() -> String {
     "/bin/bash".to_string()
+}
+
+fn default_grace_period_ms() -> u64 {
+    5_000
+}
+
+fn default_log_threshold_bytes() -> u64 {
+    4 * 1024
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/codex-rs/core/src/exec_command/exec_command_session.rs
+++ b/codex-rs/core/src/exec_command/exec_command_session.rs
@@ -65,6 +65,15 @@ impl ExecCommandSession {
     pub(crate) fn has_exited(&self) -> bool {
         self.exit_status.load(std::sync::atomic::Ordering::SeqCst)
     }
+
+    pub(crate) fn force_kill(&self) -> Result<(), String> {
+        if let Ok(mut killer_opt) = self.killer.lock()
+            && let Some(killer) = killer_opt.as_mut()
+        {
+            killer.kill().map_err(|err| err.to_string())?;
+        }
+        Ok(())
+    }
 }
 
 impl Drop for ExecCommandSession {

--- a/codex-rs/core/src/exec_command/mod.rs
+++ b/codex-rs/core/src/exec_command/mod.rs
@@ -1,14 +1,25 @@
+mod control;
 mod exec_command_params;
 mod exec_command_session;
 mod responses_api;
 mod session_id;
 mod session_manager;
 
+#[allow(unused_imports)]
+pub use control::ExecControlAction;
+#[allow(unused_imports)]
+pub use control::ExecControlParams;
+#[allow(unused_imports)]
+pub use control::ExecControlStatus;
 pub use exec_command_params::ExecCommandParams;
 pub use exec_command_params::WriteStdinParams;
 pub(crate) use exec_command_session::ExecCommandSession;
 pub use responses_api::EXEC_COMMAND_TOOL_NAME;
+pub use responses_api::EXEC_CONTROL_TOOL_NAME;
+pub use responses_api::LIST_EXEC_SESSIONS_TOOL_NAME;
 pub use responses_api::WRITE_STDIN_TOOL_NAME;
 pub use responses_api::create_exec_command_tool_for_responses_api;
+pub use responses_api::create_exec_control_tool_for_responses_api;
+pub use responses_api::create_list_exec_sessions_tool_for_responses_api;
 pub use responses_api::create_write_stdin_tool_for_responses_api;
 pub use session_manager::SessionManager as ExecSessionManager;

--- a/codex-rs/core/src/exec_command/responses_api.rs
+++ b/codex-rs/core/src/exec_command/responses_api.rs
@@ -5,6 +5,8 @@ use crate::openai_tools::ResponsesApiTool;
 
 pub const EXEC_COMMAND_TOOL_NAME: &str = "exec_command";
 pub const WRITE_STDIN_TOOL_NAME: &str = "write_stdin";
+pub const EXEC_CONTROL_TOOL_NAME: &str = "exec_control";
+pub const LIST_EXEC_SESSIONS_TOOL_NAME: &str = "list_exec_sessions";
 
 pub fn create_exec_command_tool_for_responses_api() -> ResponsesApiTool {
     let mut properties = BTreeMap::<String, JsonSchema>::new();
@@ -92,6 +94,79 @@ Can write control characters (\u0003 for Ctrl-C), or an empty string to just pol
         parameters: JsonSchema::Object {
             properties,
             required: Some(vec!["session_id".to_string(), "chars".to_string()]),
+            additional_properties: Some(false),
+        },
+    }
+}
+
+pub fn create_exec_control_tool_for_responses_api() -> ResponsesApiTool {
+    let mut action_properties = BTreeMap::<String, JsonSchema>::new();
+    action_properties.insert(
+        "type".to_string(),
+        JsonSchema::String {
+            description: Some(
+                "Action to perform. Allowed values: keepalive, send_ctrl_c, terminate, force_kill, set_idle_timeout.".to_string(),
+            ),
+        },
+    );
+    action_properties.insert(
+        "extend_timeout_ms".to_string(),
+        JsonSchema::Number {
+            description: Some(
+                "Optional: when type=keepalive, reset idle timer to now and optionally extend the idle timeout.".to_string(),
+            ),
+        },
+    );
+    action_properties.insert(
+        "timeout_ms".to_string(),
+        JsonSchema::Number {
+            description: Some(
+                "Optional: when type=set_idle_timeout, new idle timeout in milliseconds."
+                    .to_string(),
+            ),
+        },
+    );
+
+    let mut properties = BTreeMap::<String, JsonSchema>::new();
+    properties.insert(
+        "session_id".to_string(),
+        JsonSchema::Number {
+            description: Some("The target exec session identifier.".to_string()),
+        },
+    );
+    properties.insert(
+        "action".to_string(),
+        JsonSchema::Object {
+            properties: action_properties,
+            required: Some(vec!["type".to_string()]),
+            additional_properties: Some(false),
+        },
+    );
+
+    ResponsesApiTool {
+        name: EXEC_CONTROL_TOOL_NAME.to_owned(),
+        description:
+            "Send control signals to a running exec session (keepalive, interrupt, terminate)."
+                .to_string(),
+        strict: false,
+        parameters: JsonSchema::Object {
+            properties,
+            required: Some(vec!["session_id".to_string(), "action".to_string()]),
+            additional_properties: Some(false),
+        },
+    }
+}
+
+pub fn create_list_exec_sessions_tool_for_responses_api() -> ResponsesApiTool {
+    ResponsesApiTool {
+        name: LIST_EXEC_SESSIONS_TOOL_NAME.to_owned(),
+        description:
+            "Summarize currently known exec sessions (running, graceful, or recently terminated)."
+                .to_string(),
+        strict: false,
+        parameters: JsonSchema::Object {
+            properties: BTreeMap::new(),
+            required: Some(Vec::new()),
             additional_properties: Some(false),
         },
     }

--- a/codex-rs/core/src/exec_command/session_manager.rs
+++ b/codex-rs/core/src/exec_command/session_manager.rs
@@ -1,19 +1,33 @@
 use std::collections::HashMap;
+use std::fmt;
 use std::io::ErrorKind;
 use std::io::Read;
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::Mutex as StdMutex;
 use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU8;
 use std::sync::atomic::AtomicU32;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
 
+use chrono::Utc;
+use dirs::cache_dir;
 use portable_pty::CommandBuilder;
 use portable_pty::PtySize;
 use portable_pty::native_pty_system;
+use sha2::Digest;
+use sha2::Sha256;
+use tokio::fs::File as TokioFile;
+use tokio::fs::{self};
+use tokio::io::AsyncWriteExt;
 use tokio::sync::Mutex;
 use tokio::sync::mpsc;
 use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
 use tokio::time::Duration;
 use tokio::time::Instant;
+use tokio::time::sleep;
 use tokio::time::timeout;
 
 use crate::exec_command::exec_command_params::ExecCommandParams;
@@ -22,62 +36,44 @@ use crate::exec_command::exec_command_session::ExecCommandSession;
 use crate::exec_command::session_id::SessionId;
 use crate::truncate::truncate_middle;
 
-#[derive(Debug, Default)]
+use super::control::ExecControlAction;
+use super::control::ExecControlParams;
+use super::control::ExecControlResponse;
+use super::control::ExecControlStatus;
+
+const DEFAULT_IDLE_TIMEOUT_MS: u64 = 300_000;
+const MIN_IDLE_TIMEOUT_MS: u64 = 1_000;
+const MAX_IDLE_TIMEOUT_MS: u64 = 86_400_000; // 24h
+const DEFAULT_HARD_TIMEOUT_MS: Option<u64> = Some(7_200_000); // 2h
+const MIN_GRACE_MS: u64 = 500;
+const MAX_GRACE_MS: u64 = 60_000;
+const IDLE_WATCH_INTERVAL: Duration = Duration::from_secs(1);
+const PRUNE_AFTER_MS: u64 = 600_000;
+
+#[derive(Debug, Clone)]
 pub struct SessionManager {
-    next_session_id: AtomicU32,
-    sessions: Mutex<HashMap<SessionId, ExecCommandSession>>,
+    inner: Arc<SessionRegistry>,
 }
 
-#[derive(Debug)]
-pub struct ExecCommandOutput {
-    wall_time: Duration,
-    exit_status: ExitStatus,
-    original_token_count: Option<u64>,
-    output: String,
-}
-
-impl ExecCommandOutput {
-    pub(crate) fn to_text_output(&self) -> String {
-        let wall_time_secs = self.wall_time.as_secs_f32();
-        let termination_status = match self.exit_status {
-            ExitStatus::Exited(code) => format!("Process exited with code {code}"),
-            ExitStatus::Ongoing(session_id) => {
-                format!("Process running with session ID {}", session_id.0)
-            }
-        };
-        let truncation_status = match self.original_token_count {
-            Some(tokens) => {
-                format!("\nWarning: truncated output (original token count: {tokens})")
-            }
-            None => "".to_string(),
-        };
-        format!(
-            r#"Wall time: {wall_time_secs:.3} seconds
-{termination_status}{truncation_status}
-Output:
-{output}"#,
-            output = self.output
-        )
+impl Default for SessionManager {
+    fn default() -> Self {
+        Self {
+            inner: Arc::new(SessionRegistry {
+                next_session_id: AtomicU32::new(0),
+                sessions: Mutex::new(HashMap::new()),
+            }),
+        }
     }
 }
 
-#[derive(Debug)]
-pub enum ExitStatus {
-    Exited(i32),
-    Ongoing(SessionId),
-}
-
 impl SessionManager {
-    /// Processes the request and is required to send a response via `outgoing`.
     pub async fn handle_exec_command_request(
         &self,
         params: ExecCommandParams,
     ) -> Result<ExecCommandOutput, String> {
-        // Allocate a session id.
-        let session_id = SessionId(
-            self.next_session_id
-                .fetch_add(1, std::sync::atomic::Ordering::SeqCst),
-        );
+        self.inner.prune_finished().await;
+
+        let session_id = SessionId(self.inner.next_session_id.fetch_add(1, Ordering::SeqCst));
 
         let (session, mut output_rx, mut exit_rx) = create_exec_command_session(params.clone())
             .await
@@ -88,12 +84,39 @@ impl SessionManager {
                 )
             })?;
 
-        // Insert into session map.
-        self.sessions.lock().await.insert(session_id, session);
+        let idle_timeout = params
+            .idle_timeout_ms
+            .map(|ms| clamp(ms, MIN_IDLE_TIMEOUT_MS, MAX_IDLE_TIMEOUT_MS))
+            .unwrap_or(DEFAULT_IDLE_TIMEOUT_MS);
+        let hard_timeout = params
+            .hard_timeout_ms
+            .or(DEFAULT_HARD_TIMEOUT_MS)
+            .map(Duration::from_millis);
+        let grace_period =
+            Duration::from_millis(clamp(params.grace_period_ms, MIN_GRACE_MS, MAX_GRACE_MS));
+        let log_threshold = params.log_threshold_bytes.clamp(1_024, 4 * 1024 * 1024) as usize;
 
-        // Collect output until either timeout expires or process exits.
-        // Do not cap during collection; truncate at the end if needed.
-        // Use a modest initial capacity to avoid large preallocation.
+        let managed_session = ManagedSession::new(
+            session_id,
+            params.cmd.clone(),
+            session,
+            Duration::from_millis(idle_timeout),
+            hard_timeout,
+            grace_period,
+            log_threshold,
+        );
+
+        let managed_session = Arc::new(managed_session);
+        self.inner
+            .sessions
+            .lock()
+            .await
+            .insert(session_id, Arc::clone(&managed_session));
+        managed_session
+            .start_watchdogs(Arc::clone(&self.inner))
+            .await;
+
+        // Collect output
         let cap_bytes_u64 = params.max_output_tokens.saturating_mul(4);
         let cap_bytes: usize = cap_bytes_u64.min(usize::MAX as u64) as usize;
         let mut collected: Vec<u8> = Vec::with_capacity(4096);
@@ -111,15 +134,17 @@ impl SessionManager {
                 biased;
                 exit = &mut exit_rx => {
                     exit_code = exit.ok();
-                    // Small grace period to pull remaining buffered output
                     let grace_deadline = Instant::now() + Duration::from_millis(25);
                     while Instant::now() < grace_deadline {
                         match timeout(Duration::from_millis(1), output_rx.recv()).await {
                             Ok(Ok(chunk)) => {
+                                managed_session.record_activity().await;
+                                if let Err(err) = managed_session.append_log(&chunk).await {
+                                    tracing::error!("failed to append log: {err}");
+                                }
                                 collected.extend_from_slice(&chunk);
                             }
                             Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {
-                                // Skip missed messages; keep trying within grace period.
                                 continue;
                             }
                             Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => break,
@@ -131,41 +156,64 @@ impl SessionManager {
                 chunk = timeout(remaining, output_rx.recv()) => {
                     match chunk {
                         Ok(Ok(chunk)) => {
+                            managed_session.record_activity().await;
+                            if let Err(err) = managed_session.append_log(&chunk).await {
+                                tracing::error!("failed to append log: {err}");
+                            }
                             collected.extend_from_slice(&chunk);
                         }
-                        Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {
-                            // Skip missed messages; continue collecting fresh output.
+                        Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
+                        Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => {
+                            break;
                         }
-                        Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => { break; }
-                        Err(_) => { break; }
+                        Err(_) => break,
                     }
                 }
             }
         }
 
         let output = String::from_utf8_lossy(&collected).to_string();
+        let (output, original_token_count) = truncate_middle(&output, cap_bytes);
+        let wall_time = Instant::now().duration_since(start_time);
+        managed_session.increment_output_bytes(collected.len() as u64);
+
+        let snapshot = managed_session.log_snapshot().await;
 
         let exit_status = if let Some(code) = exit_code {
+            managed_session
+                .mark_terminated(TerminationReason::Completed { exit_code: code })
+                .await;
+            self.inner.remove_session(session_id).await;
             ExitStatus::Exited(code)
         } else {
             ExitStatus::Ongoing(session_id)
         };
 
-        // If output exceeds cap, truncate the middle and record original token estimate.
-        let (output, original_token_count) = truncate_middle(&output, cap_bytes);
         Ok(ExecCommandOutput {
-            wall_time: Instant::now().duration_since(start_time),
+            wall_time,
             exit_status,
             original_token_count,
             output,
+            log_path: snapshot.log_path,
+            log_sha256: snapshot.log_sha256,
+            total_output_bytes: snapshot.total_bytes,
         })
     }
 
-    /// Write characters to a session's stdin and collect combined output for up to `yield_time_ms`.
     pub async fn handle_write_stdin_request(
         &self,
         params: WriteStdinParams,
     ) -> Result<ExecCommandOutput, String> {
+        self.inner.prune_finished().await;
+        let session = {
+            let sessions = self.inner.sessions.lock().await;
+            sessions.get(&params.session_id).cloned()
+        };
+
+        let Some(session) = session else {
+            return Err(format!("unknown session id {}", params.session_id.0));
+        };
+
         let WriteStdinParams {
             session_id,
             chars,
@@ -173,26 +221,17 @@ impl SessionManager {
             max_output_tokens,
         } = params;
 
-        // Grab handles without holding the sessions lock across await points.
-        let (writer_tx, mut output_rx) = {
-            let sessions = self.sessions.lock().await;
-            match sessions.get(&session_id) {
-                Some(session) => (session.writer_sender(), session.output_receiver()),
-                None => {
-                    return Err(format!("unknown session id {}", session_id.0));
-                }
-            }
-        };
-
-        // Write stdin if provided.
-        if !chars.is_empty() && writer_tx.send(chars.into_bytes()).await.is_err() {
+        if !chars.is_empty() && session.write_to_stdin(chars.into_bytes()).await.is_err() {
             return Err("failed to write to stdin".to_string());
         }
 
-        // Collect output up to yield_time_ms, truncating to max_output_tokens bytes.
+        let cap_bytes_u64 = max_output_tokens.saturating_mul(4);
+        let cap_bytes: usize = cap_bytes_u64.min(usize::MAX as u64) as usize;
         let mut collected: Vec<u8> = Vec::with_capacity(4096);
         let start_time = Instant::now();
         let deadline = start_time + Duration::from_millis(yield_time_ms);
+        let mut output_rx = session.output_receiver();
+
         loop {
             let now = Instant::now();
             if now >= deadline {
@@ -201,32 +240,604 @@ impl SessionManager {
             let remaining = deadline - now;
             match timeout(remaining, output_rx.recv()).await {
                 Ok(Ok(chunk)) => {
-                    // Collect all output within the time budget; truncate at the end.
+                    session.record_activity().await;
+                    if let Err(err) = session.append_log(&chunk).await {
+                        tracing::error!("failed to append log: {err}");
+                    }
                     collected.extend_from_slice(&chunk);
                 }
-                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {
-                    // Skip missed messages; continue collecting fresh output.
-                }
+                Ok(Err(tokio::sync::broadcast::error::RecvError::Lagged(_))) => {}
                 Ok(Err(tokio::sync::broadcast::error::RecvError::Closed)) => break,
-                Err(_) => break, // timeout
+                Err(_) => break,
             }
         }
 
-        // Return structured output, truncating middle if over cap.
+        session.increment_output_bytes(collected.len() as u64);
+
         let output = String::from_utf8_lossy(&collected).to_string();
-        let cap_bytes_u64 = max_output_tokens.saturating_mul(4);
-        let cap_bytes: usize = cap_bytes_u64.min(usize::MAX as u64) as usize;
         let (output, original_token_count) = truncate_middle(&output, cap_bytes);
+        let wall_time = Instant::now().duration_since(start_time);
+        let snapshot = session.log_snapshot().await;
+
+        let exit_status = if session.session.has_exited() {
+            session
+                .mark_terminated(TerminationReason::Completed { exit_code: 0 })
+                .await;
+            self.inner.remove_session(session_id).await;
+            ExitStatus::Exited(0)
+        } else {
+            ExitStatus::Ongoing(session_id)
+        };
+
         Ok(ExecCommandOutput {
-            wall_time: Instant::now().duration_since(start_time),
-            exit_status: ExitStatus::Ongoing(session_id),
+            wall_time,
+            exit_status,
             original_token_count,
             output,
+            log_path: snapshot.log_path,
+            log_sha256: snapshot.log_sha256,
+            total_output_bytes: snapshot.total_bytes,
         })
+    }
+
+    pub async fn handle_exec_control_request(
+        &self,
+        params: ExecControlParams,
+    ) -> ExecControlResponse {
+        self.inner.prune_finished().await;
+
+        let session = {
+            let sessions = self.inner.sessions.lock().await;
+            sessions.get(&params.session_id).cloned()
+        };
+
+        let Some(session) = session else {
+            return ExecControlResponse {
+                session_id: params.session_id,
+                status: ExecControlStatus::NoSuchSession,
+                note: None,
+            };
+        };
+
+        if session.is_terminated() {
+            return ExecControlResponse {
+                session_id: params.session_id,
+                status: ExecControlStatus::AlreadyTerminated,
+                note: session.termination_note().await,
+            };
+        }
+
+        let status = match params.action {
+            ExecControlAction::Keepalive { extend_timeout_ms } => {
+                session.keepalive(extend_timeout_ms).await;
+                ExecControlStatus::ack()
+            }
+            ExecControlAction::SendCtrlC => {
+                if session.send_ctrl_c().await {
+                    ExecControlStatus::ack()
+                } else {
+                    ExecControlStatus::reject("failed to send ctrl-c")
+                }
+            }
+            ExecControlAction::Terminate => {
+                session.mark_grace(TerminationReason::UserRequested).await;
+                if session.send_ctrl_c().await {
+                    ExecControlStatus::ack()
+                } else {
+                    ExecControlStatus::reject("failed to signal process")
+                }
+            }
+            ExecControlAction::ForceKill => session
+                .force_kill(TerminationReason::ForceKilled)
+                .await
+                .map_or_else(ExecControlStatus::reject, |_| ExecControlStatus::ack()),
+            ExecControlAction::SetIdleTimeout { timeout_ms } => {
+                session.set_idle_timeout(timeout_ms).await;
+                ExecControlStatus::ack()
+            }
+        };
+
+        ExecControlResponse {
+            session_id: params.session_id,
+            status,
+            note: session.termination_note().await,
+        }
+    }
+
+    pub async fn list_sessions(&self) -> Vec<ExecSessionSummary> {
+        self.inner.prune_finished().await;
+        let sessions = self.inner.sessions.lock().await;
+        let mut summaries: Vec<_> = sessions.values().map(|session| session.summary()).collect();
+        summaries.sort_by(|a, b| a.session_id.0.cmp(&b.session_id.0));
+        summaries
     }
 }
 
-/// Spawn PTY and child process per spawn_exec_command_session logic.
+#[derive(Debug)]
+pub struct ExecCommandOutput {
+    wall_time: Duration,
+    exit_status: ExitStatus,
+    original_token_count: Option<u64>,
+    output: String,
+    log_path: Option<PathBuf>,
+    log_sha256: Option<String>,
+    total_output_bytes: u64,
+}
+
+impl ExecCommandOutput {
+    pub(crate) fn to_text_output(&self) -> String {
+        let wall_time_secs = self.wall_time.as_secs_f32();
+        let termination_status = match self.exit_status {
+            ExitStatus::Exited(code) => format!("Process exited with code {code}"),
+            ExitStatus::Ongoing(session_id) => {
+                format!("Process running with session ID {}", session_id.0)
+            }
+        };
+        let truncation_status = match self.original_token_count {
+            Some(tokens) => {
+                format!("\nWarning: truncated output (original token count: {tokens})")
+            }
+            None => "".to_string(),
+        };
+        let log_status = match (&self.log_path, &self.log_sha256) {
+            (Some(path), Some(hash)) => format!(
+                "\nLog: {path:?} (sha256:{hash}, total_bytes:{})",
+                self.total_output_bytes
+            ),
+            _ => String::new(),
+        };
+        format!(
+            r#"Wall time: {wall_time_secs:.3} seconds
+{termination_status}{truncation_status}{log_status}
+Output:
+{output}"#,
+            output = self.output
+        )
+    }
+}
+
+#[derive(Debug)]
+pub enum ExitStatus {
+    Exited(i32),
+    Ongoing(SessionId),
+}
+
+#[derive(Debug)]
+struct SessionRegistry {
+    next_session_id: AtomicU32,
+    sessions: Mutex<HashMap<SessionId, Arc<ManagedSession>>>,
+}
+
+impl SessionRegistry {
+    async fn remove_session(&self, session_id: SessionId) {
+        self.sessions.lock().await.remove(&session_id);
+    }
+
+    async fn prune_finished(&self) {
+        let mut sessions = self.sessions.lock().await;
+        let now = Instant::now();
+        sessions.retain(|_, session| !session.prunable(now));
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SessionLifecycle {
+    Running,
+    Grace,
+    Terminated,
+}
+
+impl fmt::Display for SessionLifecycle {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SessionLifecycle::Running => write!(f, "running"),
+            SessionLifecycle::Grace => write!(f, "grace"),
+            SessionLifecycle::Terminated => write!(f, "terminated"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ExecSessionSummary {
+    pub session_id: SessionId,
+    pub command_preview: String,
+    pub state: SessionLifecycle,
+    pub uptime_ms: u128,
+    pub idle_remaining_ms: Option<u128>,
+    pub total_output_bytes: u64,
+    pub log_path: Option<PathBuf>,
+}
+
+#[derive(Debug)]
+struct ManagedSession {
+    session_id: SessionId,
+    command: String,
+    session: ExecCommandSession,
+    writer_tx: mpsc::Sender<Vec<u8>>,
+    created_at: Instant,
+    last_activity: Mutex<Instant>,
+    idle_timeout: Mutex<Duration>,
+    hard_deadline: Mutex<Option<Instant>>,
+    grace_period: Duration,
+    state: AtomicU8,
+    termination: Mutex<Option<TerminationRecord>>,
+    log: Mutex<LogDescriptor>,
+    output_bytes: AtomicU64,
+    watchers: Mutex<Vec<JoinHandle<()>>>,
+}
+
+impl ManagedSession {
+    fn new(
+        session_id: SessionId,
+        command: String,
+        session: ExecCommandSession,
+        idle_timeout: Duration,
+        hard_deadline: Option<Duration>,
+        grace_period: Duration,
+        log_threshold: usize,
+    ) -> Self {
+        let now = Instant::now();
+        let writer_tx = session.writer_sender();
+        let hard_deadline_instant = hard_deadline.map(|d| now + d);
+        Self {
+            session_id,
+            command,
+            session,
+            writer_tx,
+            created_at: now,
+            last_activity: Mutex::new(now),
+            idle_timeout: Mutex::new(idle_timeout),
+            hard_deadline: Mutex::new(hard_deadline_instant),
+            grace_period,
+            state: AtomicU8::new(SessionState::RUNNING),
+            termination: Mutex::new(None),
+            log: Mutex::new(LogDescriptor::new(log_threshold, session_id)),
+            output_bytes: AtomicU64::new(0),
+            watchers: Mutex::new(Vec::new()),
+        }
+    }
+
+    async fn start_watchdogs(self: &Arc<Self>, registry: Arc<SessionRegistry>) {
+        let idle_session = Arc::clone(self);
+        let idle_registry = Arc::clone(&registry);
+        let idle_handle = tokio::spawn(async move {
+            loop {
+                if idle_session.is_terminated() {
+                    break;
+                }
+                let idle_timeout = idle_session.current_idle_timeout().await;
+                let since_activity = idle_session.since_last_activity().await;
+                if since_activity >= idle_timeout {
+                    idle_session
+                        .mark_grace(TerminationReason::IdleTimeout { idle_timeout })
+                        .await;
+                    let _ = idle_session.send_ctrl_c().await;
+                    sleep(idle_session.grace_period).await;
+                    if !idle_session.is_terminated() {
+                        let _ = idle_session
+                            .force_kill(TerminationReason::IdleTimeout { idle_timeout })
+                            .await;
+                    }
+                    idle_registry.prune_finished().await;
+                    break;
+                }
+                sleep(IDLE_WATCH_INTERVAL).await;
+            }
+        });
+
+        let mut handles = self.watchers.lock().await;
+        handles.push(idle_handle);
+
+        if let Some(deadline) = *self.hard_deadline.lock().await {
+            let hard_session = Arc::clone(self);
+            let hard_registry = Arc::clone(&registry);
+            handles.push(tokio::spawn(async move {
+                let now = Instant::now();
+                if deadline > now {
+                    sleep(deadline - now).await;
+                }
+                if hard_session.is_terminated() {
+                    return;
+                }
+                hard_session
+                    .mark_grace(TerminationReason::HardTimeout)
+                    .await;
+                let _ = hard_session.send_ctrl_c().await;
+                sleep(hard_session.grace_period).await;
+                if !hard_session.is_terminated() {
+                    let _ = hard_session
+                        .force_kill(TerminationReason::HardTimeout)
+                        .await;
+                }
+                hard_registry.prune_finished().await;
+            }));
+        }
+    }
+
+    async fn record_activity(&self) {
+        let mut guard = self.last_activity.lock().await;
+        *guard = Instant::now();
+    }
+
+    async fn since_last_activity(&self) -> Duration {
+        let guard = self.last_activity.lock().await;
+        Instant::now().saturating_duration_since(*guard)
+    }
+
+    async fn current_idle_timeout(&self) -> Duration {
+        *self.idle_timeout.lock().await
+    }
+
+    async fn log_snapshot(&self) -> LogSnapshot {
+        self.log.lock().await.snapshot()
+    }
+
+    async fn append_log(&self, chunk: &[u8]) -> std::io::Result<()> {
+        self.log.lock().await.append(chunk).await
+    }
+
+    fn increment_output_bytes(&self, delta: u64) {
+        self.output_bytes.fetch_add(delta, Ordering::SeqCst);
+    }
+
+    async fn mark_terminated(&self, reason: TerminationReason) {
+        self.state.store(SessionState::TERMINATED, Ordering::SeqCst);
+        let mut guard = self.termination.lock().await;
+        *guard = Some(TerminationRecord {
+            reason,
+            at: Instant::now(),
+        });
+    }
+
+    async fn mark_grace(&self, reason: TerminationReason) {
+        let _ = self.state.compare_exchange(
+            SessionState::RUNNING,
+            SessionState::GRACE,
+            Ordering::SeqCst,
+            Ordering::SeqCst,
+        );
+        let mut guard = self.termination.lock().await;
+        *guard = Some(TerminationRecord {
+            reason,
+            at: Instant::now(),
+        });
+    }
+
+    async fn write_to_stdin(&self, bytes: Vec<u8>) -> Result<(), ()> {
+        self.writer_tx.send(bytes).await.map_err(|_| ())
+    }
+
+    fn output_receiver(&self) -> tokio::sync::broadcast::Receiver<Vec<u8>> {
+        self.session.output_receiver()
+    }
+
+    async fn keepalive(&self, extend_timeout_ms: Option<u64>) {
+        self.record_activity().await;
+        if let Some(ms) = extend_timeout_ms {
+            let ms = clamp(ms, MIN_IDLE_TIMEOUT_MS, MAX_IDLE_TIMEOUT_MS);
+            let mut guard = self.idle_timeout.lock().await;
+            *guard = Duration::from_millis(ms);
+        }
+    }
+
+    async fn set_idle_timeout(&self, timeout_ms: u64) {
+        let ms = clamp(timeout_ms, MIN_IDLE_TIMEOUT_MS, MAX_IDLE_TIMEOUT_MS);
+        let mut guard = self.idle_timeout.lock().await;
+        *guard = Duration::from_millis(ms);
+    }
+
+    async fn send_ctrl_c(&self) -> bool {
+        self.writer_tx.send(vec![0x03]).await.is_ok()
+    }
+
+    async fn force_kill(&self, reason: TerminationReason) -> Result<(), String> {
+        self.session.force_kill()?;
+        self.mark_terminated(reason).await;
+        Ok(())
+    }
+
+    fn is_terminated(&self) -> bool {
+        self.state.load(Ordering::SeqCst) == SessionState::TERMINATED
+    }
+
+    fn summary(&self) -> ExecSessionSummary {
+        let state = self.state();
+        let uptime = Instant::now().saturating_duration_since(self.created_at);
+        let idle_remaining = self.idle_timeout.try_lock().ok().and_then(|timeout| {
+            self.last_activity
+                .try_lock()
+                .ok()
+                .map(|last| timeout.saturating_sub(Instant::now().saturating_duration_since(*last)))
+        });
+        ExecSessionSummary {
+            session_id: self.session_id,
+            command_preview: preview_command(&self.command, 80),
+            state,
+            uptime_ms: uptime.as_millis(),
+            idle_remaining_ms: idle_remaining.map(|d| d.as_millis()),
+            total_output_bytes: self.output_bytes.load(Ordering::SeqCst),
+            log_path: self
+                .log
+                .try_lock()
+                .ok()
+                .and_then(|log| log.snapshot().log_path),
+        }
+    }
+
+    fn state(&self) -> SessionLifecycle {
+        match self.state.load(Ordering::SeqCst) {
+            SessionState::RUNNING => SessionLifecycle::Running,
+            SessionState::GRACE => SessionLifecycle::Grace,
+            _ => SessionLifecycle::Terminated,
+        }
+    }
+
+    async fn termination_note(&self) -> Option<String> {
+        let record = self.termination.lock().await;
+        record.as_ref().map(|r| r.reason.to_string())
+    }
+
+    fn prunable(&self, now: Instant) -> bool {
+        if let Ok(record) = self.termination.try_lock()
+            && let Some(record) = &*record
+        {
+            return now
+                .checked_duration_since(record.at)
+                .map(|dur| dur.as_millis() as u64 > PRUNE_AFTER_MS)
+                .unwrap_or(false);
+        }
+        false
+    }
+}
+
+#[derive(Debug, Clone)]
+struct TerminationRecord {
+    reason: TerminationReason,
+    at: Instant,
+}
+
+#[derive(Debug, Clone)]
+enum TerminationReason {
+    Completed { exit_code: i32 },
+    IdleTimeout { idle_timeout: Duration },
+    HardTimeout,
+    UserRequested,
+    ForceKilled,
+}
+
+impl std::fmt::Display for TerminationReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TerminationReason::Completed { exit_code } => {
+                write!(f, "completed (exit_code={exit_code})")
+            }
+            TerminationReason::IdleTimeout { idle_timeout } => {
+                write!(f, "idle_timeout (timeout={}s)", idle_timeout.as_secs())
+            }
+            TerminationReason::HardTimeout => write!(f, "hard_timeout"),
+            TerminationReason::UserRequested => write!(f, "user_requested"),
+            TerminationReason::ForceKilled => write!(f, "force_killed"),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+struct LogSnapshot {
+    log_path: Option<PathBuf>,
+    log_sha256: Option<String>,
+    total_bytes: u64,
+}
+
+#[derive(Debug)]
+struct LogDescriptor {
+    threshold: usize,
+    buffer: Vec<u8>,
+    file: Option<LogFile>,
+    hasher: Sha256,
+    total_bytes: u64,
+    session_label: String,
+}
+
+impl LogDescriptor {
+    fn new(threshold: usize, session_id: SessionId) -> Self {
+        Self {
+            threshold,
+            buffer: Vec::with_capacity(threshold),
+            file: None,
+            hasher: Sha256::new(),
+            total_bytes: 0,
+            session_label: format!("session-{:08}", session_id.0),
+        }
+    }
+
+    async fn append(&mut self, chunk: &[u8]) -> std::io::Result<()> {
+        self.total_bytes = self.total_bytes.saturating_add(chunk.len() as u64);
+        self.hasher.update(chunk);
+        if let Some(file) = &mut self.file {
+            file.write(chunk).await?;
+            return Ok(());
+        }
+
+        if self.buffer.len() + chunk.len() <= self.threshold {
+            self.buffer.extend_from_slice(chunk);
+            return Ok(());
+        }
+
+        let mut file = LogFile::create(&self.session_label).await?;
+        file.write(&self.buffer).await?;
+        file.write(chunk).await?;
+        self.file = Some(file);
+        self.buffer.clear();
+        Ok(())
+    }
+
+    fn snapshot(&self) -> LogSnapshot {
+        let hasher = self.hasher.clone();
+        let digest = hasher.finalize();
+        let mut hash_hex = String::with_capacity(digest.len() * 2);
+        for byte in digest {
+            use std::fmt::Write;
+            let _ = write!(&mut hash_hex, "{byte:02x}");
+        }
+        LogSnapshot {
+            log_path: self.file.as_ref().map(|file| file.path.clone()),
+            log_sha256: if self.total_bytes > 0 {
+                Some(hash_hex)
+            } else {
+                None
+            },
+            total_bytes: self.total_bytes,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct LogFile {
+    path: PathBuf,
+    file: TokioFile,
+}
+
+impl LogFile {
+    async fn create(label: &str) -> std::io::Result<Self> {
+        let base = log_base_dir().await?;
+        let filename = format!("{label}-{}.ansi", Utc::now().format("%Y%m%dT%H%M%S%.3fZ"));
+        let path = base.join(filename);
+        let file = TokioFile::create(&path).await?;
+        Ok(Self { path, file })
+    }
+
+    async fn write(&mut self, bytes: &[u8]) -> std::io::Result<()> {
+        self.file.write_all(bytes).await
+    }
+}
+
+async fn log_base_dir() -> std::io::Result<PathBuf> {
+    let dir = cache_dir()
+        .map(|p| p.join("codex").join("exec_logs"))
+        .unwrap_or_else(|| std::env::temp_dir().join("codex-exec-logs"));
+    fs::create_dir_all(&dir).await?;
+    Ok(dir)
+}
+
+fn preview_command(cmd: &str, max: usize) -> String {
+    if cmd.len() <= max {
+        return cmd.to_string();
+    }
+    let keep = max / 2;
+    format!("{}…{}", &cmd[..keep], &cmd[cmd.len() - keep..])
+}
+
+fn clamp(value: u64, min: u64, max: u64) -> u64 {
+    value.min(max).max(min)
+}
+
+struct SessionState;
+impl SessionState {
+    const RUNNING: u8 = 0;
+    const GRACE: u8 = 1;
+    const TERMINATED: u8 = 2;
+}
+
 async fn create_exec_command_session(
     params: ExecCommandParams,
 ) -> anyhow::Result<(
@@ -240,12 +851,13 @@ async fn create_exec_command_session(
         max_output_tokens: _,
         shell,
         login,
+        idle_timeout_ms: _,
+        hard_timeout_ms: _,
+        grace_period_ms: _,
+        log_threshold_bytes: _,
     } = params;
 
-    // Use the native pty implementation for the system
     let pty_system = native_pty_system();
-
-    // Create a new pty
     let pair = pty_system.openpty(PtySize {
         rows: 24,
         cols: 80,
@@ -253,38 +865,29 @@ async fn create_exec_command_session(
         pixel_height: 0,
     })?;
 
-    // Spawn a shell into the pty
     let mut command_builder = CommandBuilder::new(shell);
     let shell_mode_opt = if login { "-lc" } else { "-c" };
     command_builder.arg(shell_mode_opt);
     command_builder.arg(cmd);
 
     let mut child = pair.slave.spawn_command(command_builder)?;
-    // Obtain a killer that can signal the process independently of `.wait()`.
     let killer = child.clone_killer();
 
-    // Channel to forward write requests to the PTY writer.
     let (writer_tx, mut writer_rx) = mpsc::channel::<Vec<u8>>(128);
-    // Broadcast for streaming PTY output to readers: subscribers receive from subscription time.
     let (output_tx, _) = tokio::sync::broadcast::channel::<Vec<u8>>(256);
-    // Reader task: drain PTY and forward chunks to output channel.
+
     let mut reader = pair.master.try_clone_reader()?;
     let output_tx_clone = output_tx.clone();
     let reader_handle = tokio::task::spawn_blocking(move || {
         let mut buf = [0u8; 8192];
         loop {
             match reader.read(&mut buf) {
-                Ok(0) => break, // EOF
+                Ok(0) => break,
                 Ok(n) => {
-                    // Forward to broadcast; best-effort if there are subscribers.
                     let _ = output_tx_clone.send(buf[..n].to_vec());
                 }
-                Err(ref e) if e.kind() == ErrorKind::Interrupted => {
-                    // Retry on EINTR
-                    continue;
-                }
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => continue,
                 Err(ref e) if e.kind() == ErrorKind::WouldBlock => {
-                    // We're in a blocking thread; back off briefly and retry.
                     std::thread::sleep(Duration::from_millis(5));
                     continue;
                 }
@@ -293,7 +896,6 @@ async fn create_exec_command_session(
         }
     });
 
-    // Writer task: apply stdin writes to the PTY writer.
     let writer = pair.master.take_writer()?;
     let writer = Arc::new(StdMutex::new(writer));
     let writer_handle = tokio::spawn({
@@ -301,7 +903,6 @@ async fn create_exec_command_session(
         async move {
             while let Some(bytes) = writer_rx.recv().await {
                 let writer = writer.clone();
-                // Perform blocking write on a blocking thread.
                 let _ = tokio::task::spawn_blocking(move || {
                     if let Ok(mut guard) = writer.lock() {
                         use std::io::Write;
@@ -314,7 +915,6 @@ async fn create_exec_command_session(
         }
     });
 
-    // Keep the child alive until it exits, then signal exit code.
     let (exit_tx, exit_rx) = oneshot::channel::<i32>();
     let exit_status = Arc::new(AtomicBool::new(false));
     let wait_exit_status = exit_status.clone();
@@ -323,11 +923,10 @@ async fn create_exec_command_session(
             Ok(status) => status.exit_code() as i32,
             Err(_) => -1,
         };
-        wait_exit_status.store(true, std::sync::atomic::Ordering::SeqCst);
+        wait_exit_status.store(true, Ordering::SeqCst);
         let _ = exit_tx.send(code);
     });
 
-    // Create and store the session with channels.
     let (session, initial_output_rx) = ExecCommandSession::new(
         writer_tx,
         output_tx,
@@ -343,164 +942,95 @@ async fn create_exec_command_session(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::exec_command::session_id::SessionId;
+    use crate::exec_command::ExecControlAction;
+    use crate::exec_command::ExecControlParams;
+    use crate::exec_command::ExecControlStatus;
 
-    /// Test that verifies that [`SessionManager::handle_exec_command_request()`]
-    /// and [`SessionManager::handle_write_stdin_request()`] work as expected
-    /// in the presence of a process that never terminates (but produces
-    /// output continuously).
-    #[cfg(unix)]
-    #[allow(clippy::print_stderr)]
-    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
-    async fn session_manager_streams_and_truncates_from_now() {
-        use crate::exec_command::exec_command_params::ExecCommandParams;
-        use crate::exec_command::exec_command_params::WriteStdinParams;
-        use tokio::time::sleep;
+    const TEST_SHELL: &str = "/bin/bash";
 
-        let session_manager = SessionManager::default();
-        // Long-running loop that prints an increasing counter every ~100ms.
-        // Use Python for a portable, reliable sleep across shells/PTYs.
-        let cmd = r#"python3 - <<'PY'
-import sys, time
-count = 0
-while True:
-    print(count)
-    sys.stdout.flush()
-    count += 100
-    time.sleep(0.1)
-PY"#
-        .to_string();
-
-        // Start the session and collect ~3s of output.
-        let params = ExecCommandParams {
-            cmd,
-            yield_time_ms: 3_000,
-            max_output_tokens: 1_000, // large enough to avoid truncation here
-            shell: "/bin/bash".to_string(),
+    fn base_params(cmd: &str) -> ExecCommandParams {
+        ExecCommandParams {
+            cmd: cmd.to_string(),
+            yield_time_ms: 250,
+            max_output_tokens: 1024,
+            shell: TEST_SHELL.to_string(),
             login: false,
-        };
-        let initial_output = match session_manager
-            .handle_exec_command_request(params.clone())
-            .await
-        {
-            Ok(v) => v,
-            Err(e) => {
-                // PTY may be restricted in some sandboxes; skip in that case.
-                if e.contains("openpty") || e.contains("Operation not permitted") {
-                    eprintln!("skipping test due to restricted PTY: {e}");
-                    return;
-                }
-                panic!("exec request failed unexpectedly: {e}");
-            }
-        };
-        eprintln!("initial output: {initial_output:?}");
+            idle_timeout_ms: Some(1_000),
+            hard_timeout_ms: Some(2_000),
+            grace_period_ms: 200,
+            log_threshold_bytes: 1_024,
+        }
+    }
 
-        // Should be ongoing (we launched a never-ending loop).
-        let session_id = match initial_output.exit_status {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn idle_timeout_terminates_session() {
+        let manager = SessionManager::default();
+        let params = base_params("sleep 5");
+        let output = match manager.handle_exec_command_request(params).await {
+            Ok(output) => output,
+            Err(err) => panic!("exec start failed: {err}"),
+        };
+        let session_id = match output.exit_status {
             ExitStatus::Ongoing(id) => id,
-            _ => panic!("expected ongoing session"),
+            ExitStatus::Exited(code) => panic!("session exited early {code}"),
         };
 
-        // Parse the numeric lines and get the max observed value in the first window.
-        let first_nums = extract_monotonic_numbers(&initial_output.output);
-        assert!(
-            !first_nums.is_empty(),
-            "expected some output from first window"
-        );
-        let first_max = *first_nums.iter().max().unwrap();
+        tokio::time::sleep(Duration::from_millis(1_600)).await;
 
-        // Wait ~4s so counters progress while we're not reading.
-        sleep(Duration::from_millis(4_000)).await;
+        let list = manager.list_sessions().await;
+        let summary = match list.into_iter().find(|s| s.session_id == session_id) {
+            Some(summary) => summary,
+            None => panic!("session summary not found"),
+        };
+        assert!(matches!(
+            summary.state,
+            SessionLifecycle::Grace | SessionLifecycle::Terminated
+        ));
+    }
 
-        // Now read ~3s of output "from now" only.
-        // Use a small token cap so truncation occurs and we test middle truncation.
-        let write_params = WriteStdinParams {
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn keepalive_extends_session() {
+        let manager = SessionManager::default();
+        let params = ExecCommandParams {
+            idle_timeout_ms: Some(1_000),
+            hard_timeout_ms: Some(4_000),
+            grace_period_ms: 200,
+            ..base_params("sleep 6")
+        };
+        let output = match manager.handle_exec_command_request(params).await {
+            Ok(output) => output,
+            Err(err) => panic!("exec start failed: {err}"),
+        };
+        let session_id = match output.exit_status {
+            ExitStatus::Ongoing(id) => id,
+            ExitStatus::Exited(code) => panic!("session exited early {code}"),
+        };
+
+        tokio::time::sleep(Duration::from_millis(700)).await;
+        let control = ExecControlParams {
             session_id,
-            chars: String::new(),
-            yield_time_ms: 3_000,
-            max_output_tokens: 16, // 16 tokens ~= 64 bytes -> likely truncation
+            action: ExecControlAction::Keepalive {
+                extend_timeout_ms: Some(2_000),
+            },
         };
-        let second = session_manager
-            .handle_write_stdin_request(write_params)
-            .await
-            .expect("write stdin should succeed");
+        let resp = manager.handle_exec_control_request(control).await;
+        assert!(matches!(resp.status, ExecControlStatus::Ack));
 
-        // Verify truncation metadata and size bound (cap is tokens*4 bytes).
-        assert!(second.original_token_count.is_some());
-        let cap_bytes = (16u64 * 4) as usize;
-        assert!(second.output.len() <= cap_bytes);
-        // New middle marker should be present.
-        assert!(
-            second.output.contains("tokens truncated") && second.output.contains('…'),
-            "expected truncation marker in output, got: {}",
-            second.output
-        );
+        tokio::time::sleep(Duration::from_millis(1_500)).await;
 
-        // Minimal freshness check: the earliest number we see in the second window
-        // should be significantly larger than the last from the first window.
-        let second_nums = extract_monotonic_numbers(&second.output);
-        assert!(
-            !second_nums.is_empty(),
-            "expected some numeric output from second window"
-        );
-        let second_min = *second_nums.iter().min().unwrap();
+        let list = manager.list_sessions().await;
+        let summary = match list.into_iter().find(|s| s.session_id == session_id) {
+            Some(summary) => summary,
+            None => panic!("session summary not found"),
+        };
+        assert_eq!(summary.state, SessionLifecycle::Running);
 
-        // We slept 4 seconds (~40 ticks at 100ms/tick, each +100), so expect
-        // an increase of roughly 4000 or more. Allow a generous margin.
-        assert!(
-            second_min >= first_max + 2000,
-            "second_min={second_min} first_max={first_max}",
-        );
-    }
-
-    #[cfg(unix)]
-    fn extract_monotonic_numbers(s: &str) -> Vec<i64> {
-        s.lines()
-            .filter_map(|line| {
-                if !line.is_empty()
-                    && line.chars().all(|c| c.is_ascii_digit())
-                    && let Ok(n) = line.parse::<i64>()
-                {
-                    // Our generator increments by 100; ignore spurious fragments.
-                    if n % 100 == 0 {
-                        return Some(n);
-                    }
-                }
-                None
+        // Clean up to avoid lingering processes.
+        let _ = manager
+            .handle_exec_control_request(ExecControlParams {
+                session_id,
+                action: ExecControlAction::ForceKill,
             })
-            .collect()
-    }
-
-    #[test]
-    fn to_text_output_exited_no_truncation() {
-        let out = ExecCommandOutput {
-            wall_time: Duration::from_millis(1234),
-            exit_status: ExitStatus::Exited(0),
-            original_token_count: None,
-            output: "hello".to_string(),
-        };
-        let text = out.to_text_output();
-        let expected = r#"Wall time: 1.234 seconds
-Process exited with code 0
-Output:
-hello"#;
-        assert_eq!(expected, text);
-    }
-
-    #[test]
-    fn to_text_output_ongoing_with_truncation() {
-        let out = ExecCommandOutput {
-            wall_time: Duration::from_millis(500),
-            exit_status: ExitStatus::Ongoing(SessionId(42)),
-            original_token_count: Some(1000),
-            output: "abc".to_string(),
-        };
-        let text = out.to_text_output();
-        let expected = r#"Wall time: 0.500 seconds
-Process running with session ID 42
-Warning: truncated output (original token count: 1000)
-Output:
-abc"#;
-        assert_eq!(expected, text);
+            .await;
     }
 }

--- a/codex-rs/core/src/openai_tools.rs
+++ b/codex-rs/core/src/openai_tools.rs
@@ -499,6 +499,12 @@ pub(crate) fn get_openai_tools(
                 tools.push(OpenAiTool::Function(
                     crate::exec_command::create_write_stdin_tool_for_responses_api(),
                 ));
+                tools.push(OpenAiTool::Function(
+                    crate::exec_command::create_exec_control_tool_for_responses_api(),
+                ));
+                tools.push(OpenAiTool::Function(
+                    crate::exec_command::create_list_exec_sessions_tool_for_responses_api(),
+                ));
             }
         }
     }

--- a/docs/exec_flow.md
+++ b/docs/exec_flow.md
@@ -1,0 +1,138 @@
+# ExecFlow Supervisor
+
+ExecFlow is the supervisory layer that now wraps every `exec_command`
+invocation. It turns long‑running shell commands into managed sessions with
+explicit lifetimes, logging, and control signals. The goal is to guarantee that
+agents never leave “runaway” processes behind while still supporting legitimate
+long builds or interactive flows.
+
+## Motivation
+
+Previously, commands launched by the agent were effectively fire‑and‑forget:
+
+- a background `npm start` or `sleep` could run forever unless a human
+  intervened;
+- idle terminals consumed sandbox resources and blocked subsequent commands;
+- truncating large stdout streams relied on ad hoc token budgets, making UX
+  inconsistent across clients.
+
+ExecFlow consolidates the guardrails for these issues: every session now has an
+explicit idle watchdog, a hard deadline, predictable logging, and a bidirectional
+control channel. This keeps contributions reviewable and protects shared compute
+while preserving the ability to run legitimate long tasks.
+
+## Default Behaviour
+
+- **Idle watchdog.** Each session receives an `idle_timeout_ms` (default 5 minutes).
+  If no stdout/stderr chunks *and* no keepalive signals arrive within that
+  window, ExecFlow issues `Ctrl-C`, waits for `grace_period_ms` (default 5 s) and
+  escalates to `SIGKILL` if the process is still running.
+- **Hard deadline.** A second guardrail, `hard_timeout_ms` (default 2 hours),
+  terminates the process even if it is still producing output. The same
+  Ctrl-C/kill ladder is used.
+- **Log redirection.** Once combined stdout/stderr exceeds `log_threshold_bytes`
+  (default 4 KiB), the remainder is streamed to a dedicated log file
+  `~/.cache/codex/exec_logs/session-<id>-<timestamp>.ansi`. The initial chunk is
+  still returned inline so the model can show context without exhausting tokens.
+- **Session registry.** ExecFlow keeps an in-memory registry of sessions
+  (`Running`, `Grace`, `Terminated`). The new `list_exec_sessions` tool provides a
+  compact textual snapshot suitable for UI surfaces and agents.
+
+## Tools Exposed to the Model
+
+| Tool name              | Purpose                                                       |
+|------------------------|---------------------------------------------------------------|
+| `exec_command`         | start a PTY-backed command (unchanged API)                    |
+| `write_stdin`          | send stdin to an existing session                             |
+| `exec_control`         | manage a session: keepalive, interrupt, terminate, force kill |
+| `list_exec_sessions`   | dump a concise overview of active/recent sessions             |
+
+### `exec_control`
+
+```json
+{
+  "session_id": 3,
+  "action": { "type": "keepalive", "extend_timeout_ms": 120000 }
+}
+```
+
+Allowed `action.type` values:
+
+| Type             | Effect                                                                 |
+|-----------------|-------------------------------------------------------------------------|
+| `keepalive`      | Record activity; optional `extend_timeout_ms` overwrites idle timeout.  |
+| `send_ctrl_c`    | Inject ASCII `0x03` through the PTY.                                    |
+| `terminate`      | Enter grace mode and send `Ctrl-C`.                                     |
+| `force_kill`     | Immediately kill the process (via `ChildKiller`).                      |
+| `set_idle_timeout` | Update idle timeout for future watchdog checks without keepalive.    |
+
+Responses contain `status` (`ack`, `no_such_session`, `already_terminated`,
+`reject(...)`) and an optional explanatory `note`.
+
+### `list_exec_sessions`
+
+Returns human-readable lines of the form:
+
+```
+#03 running uptime=47.2s idle_left=212.8s bytes=8192 log=/…/session-00000003-….ansi cmd=npm run build
+```
+
+This allows the UI or the model to detect hanging commands without fetching
+large logs.
+
+## SessionManager API Additions
+
+`SessionManager` now exposes two new entry points:
+
+- `handle_exec_control_request(ExecControlParams)` – executes the `exec_control` actions.
+- `list_sessions() -> Vec<ExecSessionSummary>` – returns snapshots for
+  `list_exec_sessions`.
+
+`ExecSessionSummary` captures the session id, preview of the original command,
+`SessionLifecycle` (`Running`/`Grace`/`Terminated`), uptime, time left before the
+idle watchdog fires, total bytes emitted, and the optional log path.
+
+## Log Storage
+
+- Location: `~/.cache/codex/exec_logs/` (Linux/macOS) or `%TEMP%\codex-exec-logs`
+  (Windows). The directory is created on-demand.
+- Format: raw ANSI stream with the file name `session-<id>-<timestamp>.ansi`.
+- Integrity: SHA-256 is reported with the inline response so downstream tooling
+  can verify the log file if needed.
+
+## Configuration Surface
+
+`ExecCommandParams` understands four new knobs:
+
+| Field                 | Default   | Notes                                                 |
+|-----------------------|-----------|-------------------------------------------------------|
+| `idle_timeout_ms`     | 300_000   | Minimum 1 000 ms, maximum 24 h                        |
+| `hard_timeout_ms`     | 7_200_000 | Optional; disables hard deadline if set to `None`     |
+| `grace_period_ms`     | 5_000     | Pause between `Ctrl-C` and escalation                 |
+| `log_threshold_bytes` | 4 * 1024  | Switch-over point from inline output to log file      |
+
+All fields are optional in JSON inputs; safe defaults are applied automatically.
+
+## Testing
+
+Two targeted async tests cover the critical flows:
+
+- `idle_timeout_terminates_session` – ensures a silent `sleep` is cleaned up.
+- `keepalive_extends_session` – validates that keepalive signals keep a long job
+  alive and reachable.
+
+Full regression coverage is reachable via:
+
+```bash
+cargo test -p codex-core session_manager
+cargo test -p codex-core --all-features
+```
+
+## Operational Notes
+
+- The watcher loops run inside the Tokio runtime and prune finished sessions
+  automatically; logs older than 10 minutes after termination are dropped.
+- `force_kill` uses `portable_pty::ChildKiller` directly, so behaviour is
+  uniform across Unix platforms and Windows.
+- The registry is in-memory today; if CLI restarts are a requirement, future
+  work can persist the session metadata and reattach after launch.


### PR DESCRIPTION
## Summary
- add ExecFlow supervisor to `SessionManager` with idle/hard watchdogs, log streaming, and control surface
- expose `exec_control` and `list_exec_sessions` tools plus the supporting control structs
- document ExecFlow behaviour for contributors in `docs/exec_flow.md`

## Testing
- just fmt
- just fix -p codex-core
- cargo test -p codex-core
- cargo test -p codex-core --all-features
