### PR TITLE
core: support nested additionalProperties in tool schemas

### DIFF
--- a/codex-rs/core/src/exec_command/responses_api.rs
+++ b/codex-rs/core/src/exec_command/responses_api.rs
@@ -1,5 +1,6 @@
 use std::collections::BTreeMap;
 
+use crate::openai_tools::AdditionalProperties;
 use crate::openai_tools::JsonSchema;
 use crate::openai_tools::ResponsesApiTool;
 
@@ -49,7 +50,7 @@ pub fn create_exec_command_tool_for_responses_api() -> ResponsesApiTool {
         parameters: JsonSchema::Object {
             properties,
             required: Some(vec!["cmd".to_string()]),
-            additional_properties: Some(false),
+            additional_properties: Some(AdditionalProperties::Bool(false)),
         },
     }
 }
@@ -92,7 +93,7 @@ Can write control characters (\u0003 for Ctrl-C), or an empty string to just pol
         parameters: JsonSchema::Object {
             properties,
             required: Some(vec!["session_id".to_string(), "chars".to_string()]),
-            additional_properties: Some(false),
+            additional_properties: Some(AdditionalProperties::Bool(false)),
         },
     }
 }

--- a/codex-rs/core/src/plan_tool.rs
+++ b/codex-rs/core/src/plan_tool.rs
@@ -3,6 +3,7 @@ use std::sync::LazyLock;
 
 use crate::codex::Session;
 use crate::function_tool::FunctionCallError;
+use crate::openai_tools::AdditionalProperties;
 use crate::openai_tools::JsonSchema;
 use crate::openai_tools::OpenAiTool;
 use crate::openai_tools::ResponsesApiTool;
@@ -32,7 +33,7 @@ pub(crate) static PLAN_TOOL: LazyLock<OpenAiTool> = LazyLock::new(|| {
         items: Box::new(JsonSchema::Object {
             properties: plan_item_props,
             required: Some(vec!["step".to_string(), "status".to_string()]),
-            additional_properties: Some(false),
+            additional_properties: Some(AdditionalProperties::Bool(false)),
         }),
     };
 
@@ -54,7 +55,7 @@ At most one step can be in_progress at a time.
         parameters: JsonSchema::Object {
             properties,
             required: Some(vec!["plan".to_string()]),
-            additional_properties: Some(false),
+            additional_properties: Some(AdditionalProperties::Bool(false)),
         },
     })
 });

--- a/codex-rs/core/src/tool_apply_patch.rs
+++ b/codex-rs/core/src/tool_apply_patch.rs
@@ -2,6 +2,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::collections::BTreeMap;
 
+use crate::openai_tools::AdditionalProperties;
 use crate::openai_tools::FreeformTool;
 use crate::openai_tools::FreeformToolFormat;
 use crate::openai_tools::JsonSchema;
@@ -116,7 +117,7 @@ It is important to remember:
         parameters: JsonSchema::Object {
             properties,
             required: Some(vec!["input".to_string()]),
-            additional_properties: Some(false),
+            additional_properties: Some(AdditionalProperties::Bool(false)),
         },
     })
 }


### PR DESCRIPTION
## Summary
- model `additionalProperties` as either a boolean or nested schema so we can deserialize MCP tool schemas like Firecrawl's
- recurse through `AdditionalProperties` when sanitizing and serializing tool schemas used by exec, plan, and apply_patch
- add coverage to ensure nested schema-valued `additionalProperties` round-trips, preventing regressions like openai/codex#4300

Fixes #4300.

## Testing
- just fmt
- just fix -p codex-core
- cargo test -p codex-core
