### PR TITLE
Add turn started/completed events and correct exit code on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<h1 align="center">OpenAI Codex CLI</h1>
 
 <p align="center"><code>npm i -g @openai/codex</code><br />or <code>brew install codex</code></p>
 
@@ -102,4 +101,3 @@ Codex CLI supports a rich set of configuration options, with preferences stored 
 ## License
 
 This repository is licensed under the [Apache-2.0 License](LICENSE).
-

--- a/codex-rs/exec/src/exec_events.rs
+++ b/codex-rs/exec/src/exec_events.rs
@@ -8,8 +8,10 @@ use ts_rs::TS;
 pub enum ConversationEvent {
     #[serde(rename = "session.created")]
     SessionCreated(SessionCreatedEvent),
-    #[serde(rename = "session.completed")]
-    SessionCompleted(SessionCompletedEvent),
+    #[serde(rename = "turn.started")]
+    TurnStarted(TurnStartedEvent),
+    #[serde(rename = "turn.completed")]
+    TurnCompleted(TurnCompletedEvent),
     #[serde(rename = "item.started")]
     ItemStarted(ItemStartedEvent),
     #[serde(rename = "item.updated")]
@@ -27,11 +29,14 @@ pub struct SessionCreatedEvent {
 
 /// Payload describing a completed session, including usage summary.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS)]
-pub struct SessionCompletedEvent {
+pub struct TurnCompletedEvent {
     pub usage: Usage,
 }
 
-/// Minimal usage summary for a session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS, Default)]
+pub struct TurnStartedEvent {}
+
+/// Minimal usage summary for a turn.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS, Default)]
 pub struct Usage {
     pub input_tokens: u64,

--- a/codex-rs/exec/src/exec_events.rs
+++ b/codex-rs/exec/src/exec_events.rs
@@ -27,14 +27,13 @@ pub struct SessionCreatedEvent {
     pub session_id: String,
 }
 
-/// Payload describing a completed session, including usage summary.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS, Default)]
+pub struct TurnStartedEvent {}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS)]
 pub struct TurnCompletedEvent {
     pub usage: Usage,
 }
-
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS, Default)]
-pub struct TurnStartedEvent {}
 
 /// Minimal usage summary for a turn.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS, Default)]

--- a/codex-rs/exec/src/exec_events.rs
+++ b/codex-rs/exec/src/exec_events.rs
@@ -8,6 +8,8 @@ use ts_rs::TS;
 pub enum ConversationEvent {
     #[serde(rename = "session.created")]
     SessionCreated(SessionCreatedEvent),
+    #[serde(rename = "session.completed")]
+    SessionCompleted(SessionCompletedEvent),
     #[serde(rename = "item.started")]
     ItemStarted(ItemStartedEvent),
     #[serde(rename = "item.completed")]
@@ -20,6 +22,20 @@ pub enum ConversationEvent {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS)]
 pub struct SessionCreatedEvent {
     pub session_id: String,
+}
+
+/// Payload describing a completed session, including usage summary.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS)]
+pub struct SessionCompletedEvent {
+    pub usage: Usage,
+}
+
+/// Minimal usage summary for a session.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, TS, Default)]
+pub struct Usage {
+    pub input_tokens: u64,
+    pub cached_input_tokens: u64,
+    pub output_tokens: u64,
 }
 
 /// Payload describing the start of an existing conversation item.

--- a/codex-rs/exec/src/experimental_event_processor_with_json_output.rs
+++ b/codex-rs/exec/src/experimental_event_processor_with_json_output.rs
@@ -20,10 +20,11 @@ use crate::exec_events::ItemUpdatedEvent;
 use crate::exec_events::PatchApplyStatus;
 use crate::exec_events::PatchChangeKind;
 use crate::exec_events::ReasoningItem;
-use crate::exec_events::SessionCompletedEvent;
 use crate::exec_events::SessionCreatedEvent;
 use crate::exec_events::TodoItem;
 use crate::exec_events::TodoListItem;
+use crate::exec_events::TurnCompletedEvent;
+use crate::exec_events::TurnStartedEvent;
 use crate::exec_events::Usage;
 use codex_core::config::Config;
 use codex_core::plan_tool::StepStatus;
@@ -39,6 +40,7 @@ use codex_core::protocol::PatchApplyBeginEvent;
 use codex_core::protocol::PatchApplyEndEvent;
 use codex_core::protocol::SessionConfiguredEvent;
 use codex_core::protocol::TaskCompleteEvent;
+use codex_core::protocol::TaskStartedEvent;
 use tracing::error;
 use tracing::warn;
 
@@ -92,6 +94,7 @@ impl ExperimentalEventProcessorWithJsonOutput {
                 }
                 Vec::new()
             }
+            EventMsg::TaskStarted(ev) => self.handle_task_started(ev),
             EventMsg::TaskComplete(_) => self.handle_task_complete(),
             EventMsg::Error(ev) => vec![ConversationEvent::Error(ConversationErrorEvent {
                 message: ev.message.clone(),
@@ -293,6 +296,10 @@ impl ExperimentalEventProcessorWithJsonOutput {
         vec![ConversationEvent::ItemStarted(ItemStartedEvent { item })]
     }
 
+    fn handle_task_started(&self, _: &TaskStartedEvent) -> Vec<ConversationEvent> {
+        vec![ConversationEvent::TurnStarted(TurnStartedEvent {})]
+    }
+
     fn handle_task_complete(&mut self) -> Vec<ConversationEvent> {
         let usage = if let Some(u) = &self.last_total_token_usage {
             Usage {
@@ -318,7 +325,7 @@ impl ExperimentalEventProcessorWithJsonOutput {
             }));
         }
 
-        items.push(ConversationEvent::SessionCompleted(SessionCompletedEvent {
+        items.push(ConversationEvent::TurnCompleted(TurnCompletedEvent {
             usage,
         }));
 

--- a/codex-rs/exec/tests/event_processor_with_json_output.rs
+++ b/codex-rs/exec/tests/event_processor_with_json_output.rs
@@ -163,23 +163,28 @@ fn plan_update_emits_todo_list_started_updated_and_completed() {
     let out_complete = ep.collect_conversation_events(&complete);
     assert_eq!(
         out_complete,
-        vec![ConversationEvent::ItemCompleted(ItemCompletedEvent {
-            item: ConversationItem {
-                id: "item_0".to_string(),
-                details: ConversationItemDetails::TodoList(ExecTodoListItem {
-                    items: vec![
-                        ExecTodoItem {
-                            text: "step one".to_string(),
-                            completed: true
-                        },
-                        ExecTodoItem {
-                            text: "step two".to_string(),
-                            completed: false
-                        },
-                    ],
-                }),
-            },
-        })]
+        vec![
+            ConversationEvent::ItemCompleted(ItemCompletedEvent {
+                item: ConversationItem {
+                    id: "item_0".to_string(),
+                    details: ConversationItemDetails::TodoList(ExecTodoListItem {
+                        items: vec![
+                            ExecTodoItem {
+                                text: "step one".to_string(),
+                                completed: true
+                            },
+                            ExecTodoItem {
+                                text: "step two".to_string(),
+                                completed: false
+                            },
+                        ],
+                    }),
+                },
+            }),
+            ConversationEvent::SessionCompleted(SessionCompletedEvent {
+                usage: Usage::default(),
+            }),
+        ]
     );
 }
 

--- a/codex-rs/exec/tests/suite/mod.rs
+++ b/codex-rs/exec/tests/suite/mod.rs
@@ -3,3 +3,4 @@ mod apply_patch;
 mod output_schema;
 mod resume;
 mod sandbox;
+mod server_error_exit;

--- a/codex-rs/exec/tests/suite/server_error_exit.rs
+++ b/codex-rs/exec/tests/suite/server_error_exit.rs
@@ -23,11 +23,10 @@ async fn exits_non_zero_when_server_reports_error() -> anyhow::Result<()> {
     })]);
     responses::mount_sse_once(&server, any(), body).await;
 
-    // Run codex-exec against the mock server and ensure it fails with
-    // a non-zero exit code.
     test.cmd_with_server(&server)
         .arg("--skip-git-repo-check")
         .arg("tell me something")
+        .arg("--experimental-json")
         .assert()
         .code(1);
 

--- a/codex-rs/exec/tests/suite/server_error_exit.rs
+++ b/codex-rs/exec/tests/suite/server_error_exit.rs
@@ -1,0 +1,35 @@
+#![cfg(not(target_os = "windows"))]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use core_test_support::responses;
+use core_test_support::test_codex_exec::test_codex_exec;
+use wiremock::matchers::any;
+
+/// Verify that when the server reports an error, `codex-exec` exits with a
+/// non-zero status code so automation can detect failures.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exits_non_zero_when_server_reports_error() -> anyhow::Result<()> {
+    let test = test_codex_exec();
+
+    // Mock a simple Responses API SSE stream that immediately reports a
+    // `response.failed` event with an error message.
+    let server = responses::start_mock_server().await;
+    let body = responses::sse(vec![serde_json::json!({
+        "type": "response.failed",
+        "response": {
+            "id": "resp_err_1",
+            "error": {"code": "rate_limit_exceeded", "message": "synthetic server error"}
+        }
+    })]);
+    responses::mount_sse_once(&server, any(), body).await;
+
+    // Run codex-exec against the mock server and ensure it fails with
+    // a non-zero exit code.
+    test.cmd_with_server(&server)
+        .arg("--skip-git-repo-check")
+        .arg("tell me something")
+        .assert()
+        .code(1);
+
+    Ok(())
+}


### PR DESCRIPTION
Adds new event for session completed that includes usage. Also ensures we return 1 on failures.
```
{
  "type": "session.created",
  "session_id": "019987a7-93e7-7b20-9e05-e90060e411ea"
}
{
  "type": "turn.started"
}
...
{
  "type": "turn.completed",
  "usage": {
    "input_tokens": 78913,
    "cached_input_tokens": 65280,
    "output_tokens": 1099
  }
}
```