### PR TITLE
feat(cli): optional notification sounds (opt-in, system sounds)

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -649,14 +649,17 @@ dependencies = [
  "codex-responses-api-proxy",
  "codex-tui",
  "ctor 0.5.0",
+ "dirs 5.0.1",
  "libc",
  "owo-colors",
  "predicates",
  "pretty_assertions",
+ "serde",
  "serde_json",
  "supports-color",
  "tempfile",
  "tokio",
+ "toml 0.8.23",
  "tracing",
  "tracing-subscriber",
 ]
@@ -669,7 +672,7 @@ dependencies = [
  "codex-core",
  "codex-protocol",
  "serde",
- "toml",
+ "toml 0.9.5",
 ]
 
 [[package]]
@@ -690,7 +693,7 @@ dependencies = [
  "codex-protocol",
  "codex-rmcp-client",
  "core_test_support",
- "dirs",
+ "dirs 6.0.0",
  "env-flags",
  "escargot",
  "eventsource-stream",
@@ -721,8 +724,8 @@ dependencies = [
  "tokio",
  "tokio-test",
  "tokio-util",
- "toml",
- "toml_edit",
+ "toml 0.9.5",
+ "toml_edit 0.23.4",
  "tracing",
  "tree-sitter",
  "tree-sitter-bash",
@@ -879,7 +882,7 @@ dependencies = [
  "shlex",
  "tempfile",
  "tokio",
- "toml",
+ "toml 0.9.5",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -987,7 +990,7 @@ dependencies = [
  "color-eyre",
  "crossterm",
  "diffy",
- "dirs",
+ "dirs 6.0.0",
  "image",
  "insta",
  "itertools 0.14.0",
@@ -1472,11 +1475,20 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
+name = "dirs"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -1487,6 +1499,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3669,7 +3693,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4267,6 +4291,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5028,17 +5061,38 @@ dependencies = [
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
+]
+
+[[package]]
+name = "toml"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
 dependencies = [
  "indexmap 2.10.0",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
  "toml_parser",
  "toml_writer",
  "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -5052,12 +5106,26 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.10.0",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7211ff1b8f0d3adae1663b7da9ffe396eabe1ca25f0b0bee42b0da29a9ddce93"
 dependencies = [
  "indexmap 2.10.0",
- "toml_datetime",
+ "toml_datetime 0.7.0",
  "toml_parser",
  "toml_writer",
  "winnow",
@@ -5071,6 +5139,12 @@ checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
 dependencies = [
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "toml_writer"
@@ -5766,6 +5840,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
 ]
 
 [[package]]

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -42,6 +42,9 @@ tokio = { workspace = true, features = [
 ] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.8"
+dirs = "5"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = { workspace = true }

--- a/codex-rs/cli/src/notifications.rs
+++ b/codex-rs/cli/src/notifications.rs
@@ -1,0 +1,87 @@
+use std::io::Write;
+use std::{fs, path::PathBuf, process::Command, time::Instant};
+use serde::Deserialize;
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct NotificationsConfig {
+    #[serde(default)]
+    pub sound: bool,
+    #[serde(default)]
+    pub only_on_long_runs_ms: u64,
+    #[serde(default = "default_true")]
+    pub respect_focus: bool,
+    #[serde(default = "default_str_default")]
+    pub success_tone: String,
+    #[serde(default = "default_str_default")]
+    pub error_tone: String,
+}
+
+fn default_true() -> bool { true }
+fn default_str_default() -> String { "default".to_string() }
+
+pub fn load_notifications_config() -> NotificationsConfig {
+    let mut p = home_dir();
+    p.push(".codex");
+    p.push("config.toml");
+    let Ok(raw) = fs::read_to_string(p) else { return NotificationsConfig::default() };
+    let Ok(toml_val) = raw.parse::<toml::Value>() else { return NotificationsConfig::default() };
+    let Some(notifs) = toml_val.get("notifications") else { return NotificationsConfig::default() };
+    let Ok(cfg) = notifs.clone().try_into() else { return NotificationsConfig::default() };
+    cfg
+}
+
+fn home_dir() -> PathBuf {
+    std::env::var_os("HOME")
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir())
+        .unwrap_or_else(|| PathBuf::from("."))
+}
+
+pub fn should_notify(start: Instant, cfg: &NotificationsConfig) -> bool {
+    if !cfg.sound { return false; }
+    let min = cfg.only_on_long_runs_ms;
+    if min == 0 { return true; }
+    let elapsed = Instant::now().saturating_duration_since(start).as_millis() as u64;
+    elapsed >= min
+}
+
+pub fn play_completion_sound(ok: bool, cfg: &NotificationsConfig) {
+    if !cfg.sound { return; }
+
+    #[cfg(target_os = "macos")]
+    {
+        let tone = if ok { &cfg.success_tone } else { &cfg.error_tone };
+        let default_path = if ok { "/System/Library/Sounds/Hero.aiff" } else { "/System/Library/Sounds/Basso.aiff" };
+        let path = if tone == "default" { default_path } else { tone };
+        if Command::new("afplay").arg(path).spawn().is_err() { bell(); }
+        return;
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let tone = if ok { &cfg.success_tone } else { &cfg.error_tone };
+        let name = if tone == "default" { if ok { "Asterisk" } else { "Hand" } } else { tone };
+        let ps = format!(r#"Add-Type -AssemblyName System.Windows.Forms; [System.Media.SystemSounds]::{name}.Play()"#);
+        if Command::new("powershell").args(["-NoProfile", "-Command", &ps]).spawn().is_err() { bell(); }
+        return;
+    }
+
+    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+    {
+        let tone = if ok { &cfg.success_tone } else { &cfg.error_tone };
+        let id = if tone == "default" { if ok { "complete" } else { "dialog-error" } } else { tone.as_str() };
+        if Command::new("canberra-gtk-play").args(["--id", id]).spawn().is_ok() { return; }
+        let path = if ok {
+            "/usr/share/sounds/freedesktop/stereo/complete.oga"
+        } else {
+            "/usr/share/sounds/freedesktop/stereo/dialog-error.oga"
+        };
+        if Command::new("paplay").arg(path).spawn().is_ok() { return; }
+        bell();
+    }
+}
+
+fn bell() {
+    let _ = std::io::Write::write_all(&mut std::io::stdout(), b"\x07");
+    let _ = std::io::stdout().flush();
+}


### PR DESCRIPTION
Adds an opt-in completion sound in the CLI.

### Why
Long-running turns (often minutes to tens of minutes) benefit from audible completion cues so users can context-switch without polling the terminal.

### What’s in this PR
- **Config (opt-in)** via `~/.codex/config.toml`:
  ~~~toml
  [notifications]
  sound = true
  only_on_long_runs_ms = 10000
  success_tone = "default"
  error_tone = "default"
  ~~~
- Cross-platform system sounds with safe defaults:
  - macOS → **Hero** (success), **Basso** (error)
  - Windows → `SystemSounds.Asterisk` / `SystemSounds.Hand`
  - Linux → canberra `complete` / `dialog-error`
- Fallback to terminal **BEL** if no backend is available
- No bundled assets; zero footprint by default

### Behavior
- Fires only on **final** CLI exit (not clap parse errors)
- Respects `only_on_long_runs_ms` threshold
- Minimal changes: a short wrapper in `cli_main` + `notifications.rs` helper

### Notes
- Feature is **off by default**
- Happy to follow up with support for custom sound file paths

Closes #3962
