### PR TITLE
fix: set gpt-5-codex medium preset reasoning

### DIFF
--- a/codex-rs/common/src/model_presets.rs
+++ b/codex-rs/common/src/model_presets.rs
@@ -29,7 +29,7 @@ const PRESETS: &[ModelPreset] = &[
         label: "gpt-5-codex medium",
         description: "",
         model: "gpt-5-codex",
-        effort: None,
+        effort: Some(ReasoningEffort::Medium),
     },
     ModelPreset {
         id: "gpt-5-codex-high",


### PR DESCRIPTION
Otherwise it shows up as none, see https://github.com/openai/codex/issues/4321
