### PR TITLE
fix: remove default timeout of 30s in the proxy

### DIFF
--- a/codex-rs/responses-api-proxy/src/lib.rs
+++ b/codex-rs/responses-api-proxy/src/lib.rs
@@ -6,6 +6,7 @@ use std::net::TcpListener;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use anyhow::Context;
 use anyhow::Result;
@@ -62,6 +63,8 @@ pub fn run_main(args: Args) -> Result<()> {
         .map_err(|err| anyhow!("creating HTTP server: {err}"))?;
     let client = Arc::new(
         Client::builder()
+            // Disable reqwest's 30s default so long-lived response streams keep flowing.
+            .timeout(None::<Duration>)
             .build()
             .context("building reqwest client")?,
     );


### PR DESCRIPTION
This is likely the reason that I saw some conversations "freeze up" when using the proxy.

Note the client in `core` does not specify a timeout when making requests to the Responses API, so the proxy should not, either.