### PR TITLE
fix(tui): shift+tab to display shortcuts

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -1209,7 +1209,6 @@ impl ChatComposer {
         }
 
         let toggles = match key_event.code {
-            KeyCode::Char('?') if key_event.modifiers.is_empty() => true,
             KeyCode::BackTab => true,
             KeyCode::Tab if key_event.modifiers.contains(KeyModifiers::SHIFT) => true,
             _ => false,
@@ -1448,7 +1447,7 @@ mod tests {
         let mut hint_row: Option<(u16, String)> = None;
         for y in 0..area.height {
             let row = row_to_string(y);
-            if row.contains("? for shortcuts") {
+            if row.contains("shift+tab for shortcuts") {
                 hint_row = Some((y, row));
                 break;
             }
@@ -1510,8 +1509,7 @@ mod tests {
 
         snapshot_composer_state("footer_mode_shortcut_overlay", true, |composer| {
             composer.set_esc_backtrack_hint(true);
-            let _ =
-                composer.handle_key_event(KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE));
+            let _ = composer.handle_key_event(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT));
         });
 
         snapshot_composer_state("footer_mode_ctrl_c_quit", true, |composer| {
@@ -1529,8 +1527,7 @@ mod tests {
         });
 
         snapshot_composer_state("footer_mode_esc_hint_from_overlay", true, |composer| {
-            let _ =
-                composer.handle_key_event(KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE));
+            let _ = composer.handle_key_event(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT));
             let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
         });
 
@@ -1543,8 +1540,8 @@ mod tests {
             "footer_mode_overlay_then_external_esc_hint",
             true,
             |composer| {
-                let _ = composer
-                    .handle_key_event(KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE));
+                let _ =
+                    composer.handle_key_event(KeyEvent::new(KeyCode::BackTab, KeyModifiers::SHIFT));
                 composer.set_esc_backtrack_hint(true);
             },
         );

--- a/codex-rs/tui/src/bottom_pane/footer.rs
+++ b/codex-rs/tui/src/bottom_pane/footer.rs
@@ -75,7 +75,7 @@ fn footer_lines(props: FooterProps) -> Vec<Line<'static>> {
                 is_task_running: props.is_task_running,
             })]
         }
-        FooterMode::ShortcutPrompt => vec![Line::from(vec!["? for shortcuts".dim()])],
+        FooterMode::ShortcutPrompt => vec![Line::from(vec!["shift+tab for shortcuts".dim()])],
         FooterMode::ShortcutOverlay => shortcut_overlay_lines(ShortcutsState {
             use_shift_enter_hint: props.use_shift_enter_hint,
             esc_backtrack_hint: props.esc_backtrack_hint,

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__backspace_after_pastes.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__backspace_after_pastes.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  ? for shortcuts                                                                                   "
+"  shift+tab for shortcuts                                                                           "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__empty.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__empty.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  ? for shortcuts                                                                                   "
+"  shift+tab for shortcuts                                                                           "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__large.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__large.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  ? for shortcuts                                                                                   "
+"  shift+tab for shortcuts                                                                           "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__multiple_pastes.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__multiple_pastes.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  ? for shortcuts                                                                                   "
+"  shift+tab for shortcuts                                                                           "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__small.snap
@@ -11,4 +11,4 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  ? for shortcuts                                                                                   "
+"  shift+tab for shortcuts                                                                           "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_default.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_default.snap
@@ -2,4 +2,4 @@
 source: tui/src/bottom_pane/footer.rs
 expression: terminal.backend()
 ---
-"? for shortcuts                                                                 "
+"shift+tab for shortcuts                                                         "

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__chatwidget_exec_and_status_layout_vt100_snapshot.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__chatwidget_exec_and_status_layout_vt100_snapshot.snap
@@ -15,4 +15,4 @@ expression: term.backend().vt100().screen().contents()
 › Summarize recent commits
 
 
-  ? for shortcuts
+  shift+tab for shortcuts

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_widget_active.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_widget_active.snap
@@ -9,5 +9,5 @@ expression: terminal.backend()
 "› Ask Codex to do anything                                                      "
 "                                                                                "
 "                                                                                "
-"  ? for shortcuts                                                               "
+"  shift+tab for shortcuts                                                       "
 "                                                                                "


### PR DESCRIPTION
## Summary
- remove the `?` shortcut binding in the chat composer so the overlay is toggled with Shift+Tab instead
- update the footer hint text to "shift+tab for shortcuts" and adjust related tests
- refresh TUI snapshots to match the new shortcut hint

## Testing
- `just fmt`
- `cargo test -p codex-tui`


------
https://chatgpt.com/codex/tasks/task_i_68d822300470832d94d90cf4179c3060