### PR TITLE
Let codex exec resume runs by session UUID

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -598,6 +598,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
 ]
 
 [[package]]
@@ -689,6 +690,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "wiremock",
 ]
 

--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -35,9 +35,21 @@ npx @modelcontextprotocol/inspector codex mcp
 
 You can enable notifications by configuring a script that is run whenever the agent finishes a turn. The [notify documentation](../docs/config.md#notify) includes a detailed example that explains how to get desktop notifications via [terminal-notifier](https://github.com/julienXX/terminal-notifier) on macOS.
 
-### `codex exec` to run Codex programmatially/non-interactively
+### `codex exec` to run Codex programmatically/non-interactively
 
-To run Codex non-interactively, run `codex exec PROMPT` (you can also pass the prompt via `stdin`) and Codex will work on your task until it decides that it is done and exits. Output is printed to the terminal directly. You can set the `RUST_LOG` environment variable to see more about what's going on.
+Run `codex exec PROMPT` (you can also pipe the prompt via `stdin`) to let Codex work unattended until it decides it is done. Output is streamed directly to stdout/stderr; set `RUST_LOG=debug` if you want additional trace output.
+
+Each run prints a session banner with the conversation UUID and the rollout file path. You can resume that state later via:
+
+```shell
+# Resume by the UUID from the banner
+codex exec --session 7f7116f0-a04f-4a8b-b994-a4ce80ac2875 "continue deployment"
+
+# Resume from an explicit rollout JSONL path
+codex exec --resume-rollout ~/.codex/sessions/2025/09/27/rollout-2025-09-27T15-20-33-7f7116f0-a04f-4a8b-b994-a4ce80ac2875.jsonl "pick up the last turn"
+```
+
+Both flags populate the `experimental_resume` override automatically—setting it by hand should now be the exception rather than the norm.
 
 ### Use `@` for file search
 

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -37,4 +37,5 @@ tokio = { version = "1", features = [
 ] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
+uuid = { version = "1", features = ["v4"] }
 codex-protocol-ts = { path = "../protocol-ts" }

--- a/codex-rs/cli/src/proto.rs
+++ b/codex-rs/cli/src/proto.rs
@@ -1,5 +1,7 @@
 use std::io::IsTerminal;
+use std::path::PathBuf;
 
+use anyhow::Context;
 use clap::Parser;
 use codex_common::CliConfigOverrides;
 use codex_core::AuthManager;
@@ -7,18 +9,39 @@ use codex_core::ConversationManager;
 use codex_core::NewConversation;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
+use codex_core::config::find_codex_home;
+use codex_core::find_rollout_by_conversation_id;
 use codex_core::protocol::Event;
 use codex_core::protocol::EventMsg;
 use codex_core::protocol::Submission;
+use codex_protocol::mcp_protocol::ConversationId;
 use tokio::io::AsyncBufReadExt;
 use tokio::io::BufReader;
 use tracing::error;
 use tracing::info;
+use uuid::Uuid;
 
 #[derive(Debug, Parser)]
 pub struct ProtoCli {
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,
+
+    /// Resume a previous session by conversation UUID.
+    #[arg(
+        long = "session",
+        value_name = "UUID",
+        conflicts_with = "resume_rollout",
+        help = "Resume a saved Codex session by its conversation UUID (printed in exec/tui banners)."
+    )]
+    pub session: Option<String>,
+
+    /// Resume a previous session from a rollout file on disk.
+    #[arg(
+        long = "resume-rollout",
+        value_name = "FILE",
+        help = "Resume from an explicit rollout file, e.g. ~/.codex/sessions/.../rollout-2025-09-27T11-22-33-<uuid>.jsonl"
+    )]
+    pub resume_rollout: Option<PathBuf>,
 }
 
 pub async fn run_main(opts: ProtoCli) -> anyhow::Result<()> {
@@ -30,10 +53,58 @@ pub async fn run_main(opts: ProtoCli) -> anyhow::Result<()> {
         .with_writer(std::io::stderr)
         .init();
 
-    let ProtoCli { config_overrides } = opts;
-    let overrides_vec = config_overrides
-        .parse_overrides()
-        .map_err(anyhow::Error::msg)?;
+    let ProtoCli {
+        mut config_overrides,
+        session,
+        resume_rollout,
+    } = opts;
+
+    let parse_cli_overrides =
+        |overrides: &CliConfigOverrides| overrides.parse_overrides().map_err(anyhow::Error::msg);
+
+    let cli_overrides_before_resume = parse_cli_overrides(&config_overrides)?;
+    if (session.is_some() || resume_rollout.is_some())
+        && cli_overrides_before_resume
+            .iter()
+            .any(|(key, _)| key == "experimental_resume")
+    {
+        anyhow::bail!(
+            "--session/--resume-rollout cannot be combined with -c experimental_resume overrides"
+        );
+    }
+
+    let resume_path_override = if let Some(path) = resume_rollout {
+        Some(path)
+    } else if let Some(session_id) = session {
+        let trimmed = session_id.trim();
+        let session_uuid =
+            Uuid::parse_str(trimmed).with_context(|| format!("Invalid session UUID: {trimmed}"))?;
+        let codex_home = find_codex_home().context("Failed to locate Codex home directory")?;
+        let conversation_id = ConversationId(session_uuid);
+        let found_path = find_rollout_by_conversation_id(&codex_home, &conversation_id)
+            .await
+            .with_context(|| format!("Failed to search sessions under {}", codex_home.display()))?;
+        let path =
+            found_path.ok_or_else(|| anyhow::anyhow!("No rollout found for session {trimmed}"))?;
+        Some(path)
+    } else {
+        None
+    };
+
+    if let Some(path) = resume_path_override {
+        let canonical = std::fs::canonicalize(&path)
+            .with_context(|| format!("Failed to resolve rollout path {}", path.display()))?;
+        let normalized = if cfg!(windows) {
+            canonical.to_string_lossy().replace('\\', "/")
+        } else {
+            canonical.to_string_lossy().into_owned()
+        };
+        config_overrides
+            .raw_overrides
+            .push(format!("experimental_resume=\"{normalized}\""));
+    }
+
+    let overrides_vec = parse_cli_overrides(&config_overrides)?;
 
     let config = Config::load_with_cli_overrides(overrides_vec, ConfigOverrides::default())?;
     // Use conversation_manager API to start a conversation

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -66,6 +66,7 @@ pub use rollout::ARCHIVED_SESSIONS_SUBDIR;
 pub use rollout::RolloutRecorder;
 pub use rollout::SESSIONS_SUBDIR;
 pub use rollout::SessionMeta;
+pub use rollout::find_rollout_by_conversation_id;
 pub use rollout::list::ConversationItem;
 pub use rollout::list::ConversationsPage;
 pub use rollout::list::Cursor;

--- a/codex-rs/core/src/rollout/list.rs
+++ b/codex-rs/core/src/rollout/list.rs
@@ -1,4 +1,5 @@
 use std::cmp::Reverse;
+use std::collections::VecDeque;
 use std::io::{self};
 use std::path::Path;
 use std::path::PathBuf;
@@ -13,6 +14,7 @@ use super::SESSIONS_SUBDIR;
 use super::recorder::RolloutItem;
 use super::recorder::RolloutLine;
 use crate::protocol::EventMsg;
+use codex_protocol::mcp_protocol::ConversationId;
 
 /// Returned page of conversation summaries.
 #[derive(Debug, Default, PartialEq)]
@@ -192,6 +194,68 @@ async fn traverse_directories_for_paths(
         num_scanned_files: scanned_files,
         reached_scan_cap: scanned_files >= MAX_SCAN_FILES,
     })
+}
+
+pub async fn find_rollout_by_conversation_id(
+    codex_home: &Path,
+    conversation_id: &ConversationId,
+) -> io::Result<Option<PathBuf>> {
+    let root = codex_home.join(SESSIONS_SUBDIR);
+    if !root.exists() {
+        return Ok(None);
+    }
+
+    let mut to_visit = VecDeque::new();
+    to_visit.push_back(root);
+    let mut matches = Vec::new();
+    let suffix = format!("-{conversation_id}.jsonl");
+
+    while let Some(dir) = to_visit.pop_front() {
+        let mut entries = tokio::fs::read_dir(&dir).await?;
+        while let Some(entry) = entries.next_entry().await? {
+            let file_type = entry.file_type().await?;
+            let path = entry.path();
+            if file_type.is_dir() {
+                to_visit.push_back(path);
+            } else if file_type.is_file()
+                && entry
+                    .file_name()
+                    .to_str()
+                    .map(|name| name.starts_with("rollout-") && name.ends_with(&suffix))
+                    .unwrap_or(false)
+            {
+                matches.push(path);
+            }
+        }
+    }
+
+    match matches.len() {
+        0 => Ok(None),
+        1 => Ok(matches.pop()),
+        _ => {
+            let preview: Vec<String> = matches
+                .iter()
+                .take(3)
+                .map(|p| p.display().to_string())
+                .collect();
+            let preview_joined = preview.join(", ");
+            let suggestion = if matches.len() > preview.len() {
+                format!(
+                    "{} (showing {} of {} matches)",
+                    preview_joined,
+                    preview.len(),
+                    matches.len()
+                )
+            } else {
+                preview_joined
+            };
+            Err(io::Error::other(format!(
+                "found {} rollout files for conversation {conversation_id}; re-run with --resume-rollout <path> to choose one (examples: {})",
+                matches.len(),
+                suggestion
+            )))
+        }
+    }
 }
 
 /// Pagination cursor token format: "<file_ts>|<uuid>" where `file_ts` matches the

--- a/codex-rs/core/src/rollout/mod.rs
+++ b/codex-rs/core/src/rollout/mod.rs
@@ -7,6 +7,7 @@ pub mod list;
 pub(crate) mod policy;
 pub mod recorder;
 
+pub use list::find_rollout_by_conversation_id;
 pub use recorder::RolloutRecorder;
 pub use recorder::RolloutRecorderParams;
 pub use recorder::SessionMeta;

--- a/codex-rs/exec/Cargo.toml
+++ b/codex-rs/exec/Cargo.toml
@@ -39,11 +39,13 @@ tokio = { version = "1", features = [
 ] }
 tracing = { version = "0.1.41", features = ["log"] }
 tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
+uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]
 assert_cmd = "2"
 core_test_support = { path = "../core/tests/common" }
 libc = "0.2"
 predicates = "3"
+serde_json = "1"
 tempfile = "3.13.0"
 wiremock = "0.6"

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -63,6 +63,23 @@ pub struct Cli {
     #[arg(long = "output-last-message")]
     pub last_message_file: Option<PathBuf>,
 
+    /// Resume a previous session by conversation UUID.
+    #[arg(
+        long = "session",
+        value_name = "UUID",
+        conflicts_with = "resume_rollout",
+        help = "Resume a saved Codex session by its conversation UUID (shown in the session banner)."
+    )]
+    pub session: Option<String>,
+
+    /// Resume a previous session from a rollout file on disk.
+    #[arg(
+        long = "resume-rollout",
+        value_name = "FILE",
+        help = "Resume from an explicit rollout file, e.g. ~/.codex/sessions/.../rollout-2025-09-27T11-22-33-<uuid>.jsonl"
+    )]
+    pub resume_rollout: Option<PathBuf>,
+
     /// Initial instructions for the agent. If not provided as an argument (or
     /// if `-` is used), instructions are read from stdin.
     #[arg(value_name = "PROMPT")]

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -523,7 +523,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                     history_log_id: _,
                     history_entry_count: _,
                     initial_messages: _,
-                    rollout_path: _,
+                    rollout_path,
                 } = session_configured_event;
 
                 ts_println!(
@@ -534,6 +534,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                 );
 
                 ts_println!(self, "model: {}", model);
+                ts_println!(self, "rollout: {}", rollout_path.display());
                 println!();
             }
             EventMsg::PlanUpdate(plan_update_event) => {

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -14,6 +14,7 @@ use codex_core::ConversationManager;
 use codex_core::NewConversation;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
+use codex_core::config::find_codex_home;
 use codex_core::git_info::get_git_repo_root;
 use codex_core::protocol::AskForApproval;
 use codex_core::protocol::Event;
@@ -23,12 +24,17 @@ use codex_core::protocol::Op;
 use codex_core::protocol::TaskCompleteEvent;
 use codex_ollama::DEFAULT_OSS_MODEL;
 use codex_protocol::config_types::SandboxMode;
+use codex_protocol::mcp_protocol::ConversationId;
 use event_processor_with_human_output::EventProcessorWithHumanOutput;
 use event_processor_with_json_output::EventProcessorWithJsonOutput;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
 use tracing_subscriber::EnvFilter;
+
+use anyhow::Context;
+use codex_core::find_rollout_by_conversation_id;
+use uuid::Uuid;
 
 use crate::event_processor::CodexStatus;
 use crate::event_processor::EventProcessor;
@@ -45,11 +51,15 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         skip_git_repo_check,
         color,
         last_message_file,
+        session,
+        resume_rollout,
         json: json_mode,
         sandbox_mode: sandbox_mode_cli_arg,
         prompt,
         config_overrides,
     } = cli;
+
+    let mut config_overrides = config_overrides;
 
     // Determine the prompt based on CLI arg and/or stdin.
     let prompt = match prompt {
@@ -134,6 +144,57 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         None // No specific model provider override.
     };
 
+    let parse_cli_overrides =
+        |overrides: &codex_common::CliConfigOverrides| match overrides.parse_overrides() {
+            Ok(v) => v,
+            Err(e) => {
+                eprintln!("Error parsing -c overrides: {e}");
+                std::process::exit(1);
+            }
+        };
+
+    let cli_overrides_before_resume = parse_cli_overrides(&config_overrides);
+    if (session.is_some() || resume_rollout.is_some())
+        && cli_overrides_before_resume
+            .iter()
+            .any(|(key, _)| key == "experimental_resume")
+    {
+        anyhow::bail!(
+            "--session/--resume-rollout cannot be combined with -c experimental_resume overrides"
+        );
+    }
+
+    let resume_path_override = if let Some(path) = resume_rollout {
+        Some(path)
+    } else if let Some(session_id) = session {
+        let trimmed = session_id.trim();
+        let session_uuid =
+            Uuid::parse_str(trimmed).with_context(|| format!("Invalid session UUID: {trimmed}"))?;
+        let codex_home = find_codex_home().context("Failed to locate Codex home directory")?;
+        let conversation_id = ConversationId(session_uuid);
+        let found_path = find_rollout_by_conversation_id(&codex_home, &conversation_id)
+            .await
+            .with_context(|| format!("Failed to search sessions under {}", codex_home.display()))?;
+        let path =
+            found_path.ok_or_else(|| anyhow::anyhow!("No rollout found for session {trimmed}"))?;
+        Some(path)
+    } else {
+        None
+    };
+
+    if let Some(path) = resume_path_override {
+        let canonical = std::fs::canonicalize(&path)
+            .with_context(|| format!("Failed to resolve rollout path {}", path.display()))?;
+        let normalized = if cfg!(windows) {
+            canonical.to_string_lossy().replace('\\', "/")
+        } else {
+            canonical.to_string_lossy().into_owned()
+        };
+        config_overrides
+            .raw_overrides
+            .push(format!("experimental_resume=\"{normalized}\""));
+    }
+
     // Load configuration and determine approval policy
     let overrides = ConfigOverrides {
         model,
@@ -153,13 +214,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         tools_web_search_request: None,
     };
     // Parse `-c` overrides.
-    let cli_kv_overrides = match config_overrides.parse_overrides() {
-        Ok(v) => v,
-        Err(e) => {
-            eprintln!("Error parsing -c overrides: {e}");
-            std::process::exit(1);
-        }
-    };
+    let cli_kv_overrides = parse_cli_overrides(&config_overrides);
 
     let config = Config::load_with_cli_overrides(cli_kv_overrides, overrides)?;
     let mut event_processor: Box<dyn EventProcessor> = if json_mode {
@@ -197,6 +252,18 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         session_configured,
     } = conversation_manager.new_conversation(config).await?;
     info!("Codex initialized with event: {session_configured:?}");
+
+    let session_event = Event {
+        id: String::new(),
+        msg: EventMsg::SessionConfigured(session_configured),
+    };
+    if matches!(
+        event_processor.process_event(session_event),
+        CodexStatus::InitiateShutdown | CodexStatus::Shutdown
+    ) {
+        conversation.submit(Op::Shutdown).await?;
+        return Ok(());
+    }
 
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
     {

--- a/codex-rs/exec/tests/suite/mod.rs
+++ b/codex-rs/exec/tests/suite/mod.rs
@@ -2,3 +2,4 @@
 mod apply_patch;
 mod common;
 mod sandbox;
+mod session;

--- a/codex-rs/exec/tests/suite/session.rs
+++ b/codex-rs/exec/tests/suite/session.rs
@@ -1,0 +1,66 @@
+#![allow(clippy::expect_used)]
+
+use anyhow::Context;
+use assert_cmd::prelude::*;
+use codex_core::spawn::CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR;
+use serde_json::Value;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+#[test]
+fn json_mode_emits_session_configured_event() -> anyhow::Result<()> {
+    if std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok() {
+        eprintln!(
+            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
+        );
+        return Ok(());
+    }
+
+    let home = TempDir::new().context("create temp CODEX_HOME")?;
+    let fixture =
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("../core/tests/cli_responses_fixture.sse");
+    assert!(fixture.exists(), "fixture missing at {}", fixture.display());
+
+    let output = Command::cargo_bin("codex-exec")
+        .context("should find binary for codex-exec")?
+        .current_dir(home.path())
+        .env("CODEX_HOME", home.path())
+        .env("OPENAI_API_KEY", "dummy")
+        .env("CODEX_RS_SSE_FIXTURE", &fixture)
+        .env("OPENAI_BASE_URL", "http://unused.local")
+        .arg("--json")
+        .arg("--skip-git-repo-check")
+        .arg("hello from json test")
+        .output()
+        .context("failed running codex-exec")?;
+
+    assert!(
+        output.status.success(),
+        "codex-exec exited with {:?} (stderr: {})",
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8(output.stdout).context("stdout not valid UTF-8")?;
+    let session_line = stdout
+        .lines()
+        .find(|line| line.contains("\"type\":\"session_configured\""))
+        .context("session_configured line missing")?;
+    let value: Value = serde_json::from_str(session_line).context("parse session line JSON")?;
+    let session_id = value["msg"]["session_id"]
+        .as_str()
+        .context("session_id missing in event")?;
+    assert!(!session_id.is_empty(), "session_id should be non-empty");
+    let rollout_path = value["msg"]["rollout_path"]
+        .as_str()
+        .context("rollout_path missing in event")?;
+    let rollout_path = Path::new(rollout_path);
+    assert!(
+        rollout_path.exists(),
+        "rollout_path {} does not exist",
+        rollout_path.display()
+    );
+
+    Ok(())
+}

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -39,4 +39,16 @@ env = { "API_KEY" = "value" }
 ```
 
 > [!TIP]
-> It is somewhat experimental, but the Codex CLI can also be run as an MCP _server_ via `codex mcp`. If you launch it with an MCP client such as `npx @modelcontextprotocol/inspector codex mcp` and send it a `tools/list` request, you will see that there is only one tool, `codex`, that accepts a grab-bag of inputs, including a catch-all `config` map for anything you might want to override. Feel free to play around with it and provide feedback via GitHub issues. 
+> It is somewhat experimental, but the Codex CLI can also be run as an MCP _server_ via `codex mcp`. If you launch it with an MCP client such as `npx @modelcontextprotocol/inspector codex mcp` and send it a `tools/list` request, you will see that there is only one tool, `codex`, that accepts a grab-bag of inputs, including a catch-all `config` map for anything you might want to override. Feel free to play around with it and provide feedback via GitHub issues.
+
+### Resuming automation runs
+
+When a headless run finishes, `codex exec` prints a banner with the session UUID and rollout file path. Resume later with either flag:
+
+```shell
+codex exec --session <UUID> "continue deployment"
+codex exec --resume-rollout ~/.codex/sessions/.../rollout-....jsonl "review the transcript"
+```
+
+Those flags populate the `experimental_resume` config override automatically.
+

--- a/docs/config.md
+++ b/docs/config.md
@@ -607,7 +607,7 @@ Options that are specific to the TUI.
 | `model_supports_reasoning_summaries` | boolean | Force‑enable reasoning summaries. |
 | `model_reasoning_summary_format` | `none` \| `experimental` | Force reasoning summary format. |
 | `chatgpt_base_url` | string | Base URL for ChatGPT auth flow. |
-| `experimental_resume` | string (path) | Resume JSONL path (internal/experimental). |
+| `experimental_resume` | string (path) | Rollout JSONL used to resume a session. Normally set automatically by `codex exec --session/--resume-rollout`; override manually only for advanced workflows. |
 | `experimental_instructions_file` | string (path) | Replace built‑in instructions (experimental). |
 | `experimental_use_exec_command_tool` | boolean | Use experimental exec command tool. |
 | `responses_originator_header_internal_override` | string | Override `originator` header value. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,19 +10,22 @@
 
 Key flags: `--model/-m`, `--ask-for-approval/-a`.
 
-<!--
 Resume options:
 
 - `--resume`: open an interactive picker of recent sessions (shows a preview of the first real user message). Conflicts with `--continue`.
 - `--continue`: resume the most recent session without showing the picker (falls back to starting fresh if none exist). Conflicts with `--resume`.
-
-Examples:
+- `codex exec --session <UUID>`: resume a non-interactive run by its session banner UUID.
+- `codex exec --resume-rollout <FILE>`: resume from a specific rollout JSONL file (the banner prints the exact path).
 
 ```shell
+# Interactive TUI
 codex --resume
 codex --continue
+
+# Non-interactive exec
+codex exec --session 7f7116f0-a04f-4a8b-b994-a4ce80ac2875 "continue the deployment"
+codex exec --resume-rollout ~/.codex/sessions/.../rollout-...jsonl "review the last turn"
 ```
--->
 
 ### Running with a prompt as input
 


### PR DESCRIPTION
I've been bouncing between #3712 and #3187 trying to understand why automation runs kept stalling out, and it finally clicked that the real blocker is tracked in #3817: once codex exec finishes, there’s no ergonomic way to pick the session back up. 

This PR teaches both the headless CLI and the shared proto entrypoint how to resume cleanly. `--session <UUID>` now accepts the conversation identifier that we print in the banner, discovers the matching rollout on disk, and wires it through as the experimental_resume override. 

For folks who already know the rollout path, `--resume-rollout <FILE>` skips the lookup and normalizes the path for them. While I was in there I made sure the JSON-mode SessionConfigured event echoes the rollout location, and I updated the docs so the happy path is obvious.

This should fix both `codex exec` usage and `codex mcp` conversation resuming, so closes #3712 amd #3817 🎉 Exec usage looks like:

```bash
# Non-interactive exec
codex exec --session 7f7116f0-a04f-4a8b-b994-a4ce80ac2875 "continue the deployment"
codex exec --resume-rollout ~/.codex/sessions/.../rollout-...jsonl "review the last turn"
```

I did my best to follow the contributing guidelines!