### PR TITLE
docs: update Inspector link

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -77,7 +77,7 @@ env = { "API_KEY" = "value" }
 The Codex CLI can also be run as an MCP _server_ via `codex mcp`. For example, you can use `codex mcp` to make Codex available as a tool inside of a multi-agent framework like the OpenAI [Agents SDK](https://platform.openai.com/docs/guides/agents).
 
 ### Codex MCP Server Quickstart
-You can launch a Codex MCP server with the [Model Context Protocol Inspector](https://modelcontextprotocol.io/legacy/tools/inspector):
+You can launch a Codex MCP server with the [Model Context Protocol Inspector](https://modelcontextprotocol.io/docs/tools/inspector):
 
 ``` bash
 npx @modelcontextprotocol/inspector codex mcp


### PR DESCRIPTION
the old Inspector link was broken.
switched it to the new docs URL so it points to the right place.