### PR TITLE
fix: column calculation after UnicodeDecodeError

### DIFF
--- a/scripts/asciicheck.py
+++ b/scripts/asciicheck.py
@@ -82,7 +82,7 @@ def lint_utf8_ascii(filename: Path, fix: bool) -> bool:
         # Attempt to find line/column
         partial = raw[: e.start]
         line = partial.count(b"\n") + 1
-        col = e.start - (partial.rfind(b"\n") if b"\n" in partial else -1)
+        col = e.start - (partial.rfind(b"\n") + 1 if b"\n" in partial else 0) + 1
         print(f"  location: line {line}, column {col}")
         return True
 


### PR DESCRIPTION
I adjusted the calculation of the column when a `UnicodeDecodeError` occurs:

```python
col = e.start - (partial.rfind(b"\n") + 1 if b"\n" in partial else 0) + 1
```

Previously, the column could be off by 1. Now it correctly starts at 1 after the last newline.
No other changes were made.
