### PR TITLE
chore: move pre_main_hardening() utility into its own crate

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -692,12 +692,12 @@ dependencies = [
  "codex-exec",
  "codex-login",
  "codex-mcp-server",
+ "codex-process-hardening",
  "codex-protocol",
  "codex-protocol-ts",
  "codex-responses-api-proxy",
  "codex-tui",
  "ctor 0.5.0",
- "libc",
  "owo-colors",
  "predicates",
  "pretty_assertions",
@@ -947,6 +947,13 @@ dependencies = [
  "tokio",
  "tracing",
  "wiremock",
+]
+
+[[package]]
+name = "codex-process-hardening"
+version = "0.0.0"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "mcp-server",
     "mcp-types",
     "ollama",
+    "process-hardening",
     "protocol",
     "protocol-ts",
     "rmcp-client",
@@ -49,10 +50,11 @@ codex-login = { path = "login" }
 codex-mcp-client = { path = "mcp-client" }
 codex-mcp-server = { path = "mcp-server" }
 codex-ollama = { path = "ollama" }
+codex-process-hardening = { path = "process-hardening" }
 codex-protocol = { path = "protocol" }
-codex-rmcp-client = { path = "rmcp-client" }
 codex-protocol-ts = { path = "protocol-ts" }
 codex-responses-api-proxy = { path = "responses-api-proxy" }
+codex-rmcp-client = { path = "rmcp-client" }
 codex-tui = { path = "tui" }
 codex-utils-readiness = { path = "utils/readiness" }
 core_test_support = { path = "core/tests/common" }
@@ -83,8 +85,8 @@ dirs = "6"
 dotenvy = "0.15.7"
 env-flags = "0.1.1"
 env_logger = "0.11.5"
-eventsource-stream = "0.2.3"
 escargot = "0.5"
+eventsource-stream = "0.2.3"
 futures = "0.3"
 icu_decimal = "2.0.0"
 icu_locale_core = "2.0.0"

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -25,6 +25,7 @@ codex-core = { workspace = true }
 codex-exec = { workspace = true }
 codex-login = { workspace = true }
 codex-mcp-server = { workspace = true }
+codex-process-hardening = { workspace = true }
 codex-protocol = { workspace = true }
 codex-protocol-ts = { workspace = true }
 codex-responses-api-proxy = { workspace = true }
@@ -42,15 +43,6 @@ tokio = { workspace = true, features = [
 ] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
-
-[target.'cfg(target_os = "linux")'.dependencies]
-libc = { workspace = true }
-
-[target.'cfg(target_os = "android")'.dependencies]
-libc = { workspace = true }
-
-[target.'cfg(target_os = "macos")'.dependencies]
-libc = { workspace = true }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -23,7 +23,6 @@ use std::path::PathBuf;
 use supports_color::Stream;
 
 mod mcp_cmd;
-mod pre_main_hardening;
 
 use crate::mcp_cmd::McpCli;
 use crate::proto::ProtoCli;
@@ -213,14 +212,7 @@ fn pre_main_hardening() {
     };
 
     if secure_mode == "1" {
-        #[cfg(any(target_os = "linux", target_os = "android"))]
-        crate::pre_main_hardening::pre_main_hardening_linux();
-
-        #[cfg(target_os = "macos")]
-        crate::pre_main_hardening::pre_main_hardening_macos();
-
-        #[cfg(windows)]
-        crate::pre_main_hardening::pre_main_hardening_windows();
+        codex_process_hardening::pre_main_hardening();
     }
 
     // Always clear this env var so child processes don't inherit it.

--- a/codex-rs/process-hardening/Cargo.toml
+++ b/codex-rs/process-hardening/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+edition = "2024"
+name = "codex-process-hardening"
+version = { workspace = true }
+
+[lib]
+name = "codex_process_hardening"
+path = "src/lib.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(target_os = "android")'.dependencies]
+libc = { workspace = true }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+libc = { workspace = true }

--- a/codex-rs/process-hardening/src/lib.rs
+++ b/codex-rs/process-hardening/src/lib.rs
@@ -1,3 +1,19 @@
+/// This is designed to be called pre-main() (using `#[ctor::ctor]`) to perform
+/// various process hardening steps, such as
+/// - disabling core dumps
+/// - disabling ptrace attach on Linux and macOS.
+/// - removing dangerous environment variables such as LD_PRELOAD and DYLD_*
+pub fn pre_main_hardening() {
+    #[cfg(any(target_os = "linux", target_os = "android"))]
+    pre_main_hardening_linux();
+
+    #[cfg(target_os = "macos")]
+    pre_main_hardening_macos();
+
+    #[cfg(windows)]
+    pre_main_hardening_windows();
+}
+
 #[cfg(any(target_os = "linux", target_os = "android"))]
 const PRCTL_FAILED_EXIT_CODE: i32 = 5;
 


### PR DESCRIPTION
Move this function so it can be reused in the standalone version of `codex-responses-api-proxy` in https://github.com/openai/codex/pull/4404.






---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/4403).
* #4406
* #4404
* __->__ #4403