### PR TITLE
chore: remove responses-api-proxy from the multitool

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -695,7 +695,6 @@ dependencies = [
  "codex-process-hardening",
  "codex-protocol",
  "codex-protocol-ts",
- "codex-responses-api-proxy",
  "codex-tui",
  "ctor 0.5.0",
  "owo-colors",
@@ -996,13 +995,13 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
- "codex-arg0",
+ "codex-process-hardening",
+ "ctor 0.5.0",
  "libc",
  "reqwest",
  "serde",
  "serde_json",
  "tiny_http",
- "tokio",
  "zeroize",
 ]
 

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -53,7 +53,6 @@ codex-ollama = { path = "ollama" }
 codex-process-hardening = { path = "process-hardening" }
 codex-protocol = { path = "protocol" }
 codex-protocol-ts = { path = "protocol-ts" }
-codex-responses-api-proxy = { path = "responses-api-proxy" }
 codex-rmcp-client = { path = "rmcp-client" }
 codex-tui = { path = "tui" }
 codex-utils-readiness = { path = "utils/readiness" }

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -28,7 +28,6 @@ codex-mcp-server = { workspace = true }
 codex-process-hardening = { workspace = true }
 codex-protocol = { workspace = true }
 codex-protocol-ts = { workspace = true }
-codex-responses-api-proxy = { workspace = true }
 codex-tui = { workspace = true }
 ctor = { workspace = true }
 owo-colors = { workspace = true }

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -1,4 +1,3 @@
-use anyhow::Context;
 use clap::CommandFactory;
 use clap::Parser;
 use clap_complete::Shell;
@@ -15,7 +14,6 @@ use codex_cli::login::run_logout;
 use codex_cli::proto;
 use codex_common::CliConfigOverrides;
 use codex_exec::Cli as ExecCli;
-use codex_responses_api_proxy::Args as ResponsesApiProxyArgs;
 use codex_tui::AppExitInfo;
 use codex_tui::Cli as TuiCli;
 use owo_colors::OwoColorize;
@@ -87,10 +85,6 @@ enum Subcommand {
     /// Internal: generate TypeScript protocol bindings.
     #[clap(hide = true)]
     GenerateTs(GenerateTsCommand),
-
-    /// Internal: run the responses API proxy.
-    #[clap(hide = true)]
-    ResponsesApiProxy(ResponsesApiProxyArgs),
 }
 
 #[derive(Debug, Parser)]
@@ -338,11 +332,6 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
         }
         Some(Subcommand::GenerateTs(gen_cli)) => {
             codex_protocol_ts::generate_ts(&gen_cli.out_dir, gen_cli.prettier.as_deref())?;
-        }
-        Some(Subcommand::ResponsesApiProxy(args)) => {
-            tokio::task::spawn_blocking(move || codex_responses_api_proxy::run_main(args))
-                .await
-                .context("responses-api-proxy blocking task panicked")??;
         }
     }
 

--- a/codex-rs/responses-api-proxy/Cargo.toml
+++ b/codex-rs/responses-api-proxy/Cargo.toml
@@ -8,7 +8,7 @@ name = "codex_responses_api_proxy"
 path = "src/lib.rs"
 
 [[bin]]
-name = "responses-api-proxy"
+name = "codex-responses-api-proxy"
 path = "src/main.rs"
 
 [lints]
@@ -17,11 +17,11 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
-codex-arg0 = { workspace = true }
+codex-process-hardening = { workspace = true }
+ctor = { workspace = true }
 libc = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "json", "rustls-tls"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tiny_http = { workspace = true }
-tokio = { workspace = true }
 zeroize = { workspace = true }

--- a/codex-rs/responses-api-proxy/src/main.rs
+++ b/codex-rs/responses-api-proxy/src/main.rs
@@ -1,14 +1,12 @@
-use anyhow::Context;
 use clap::Parser;
-use codex_arg0::arg0_dispatch_or_else;
 use codex_responses_api_proxy::Args as ResponsesApiProxyArgs;
 
+#[ctor::ctor]
+fn pre_main() {
+    codex_process_hardening::pre_main_hardening();
+}
+
 pub fn main() -> anyhow::Result<()> {
-    arg0_dispatch_or_else(|_codex_linux_sandbox_exe| async move {
-        let args = ResponsesApiProxyArgs::parse();
-        tokio::task::spawn_blocking(move || codex_responses_api_proxy::run_main(args))
-            .await
-            .context("responses-api-proxy blocking task panicked")??;
-        Ok(())
-    })
+    let args = ResponsesApiProxyArgs::parse();
+    codex_responses_api_proxy::run_main(args)
 }


### PR DESCRIPTION
This removes the `codex responses-api-proxy` subcommand in favor of running it as a standalone CLI.

As part of this change, we:

- remove the dependency on `tokio`/`async/await` as well as `codex_arg0`
- introduce the use of `pre_main_hardening()` so `CODEX_SECURE_MODE=1` is not required

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/4404).
* #4406
* __->__ #4404
* #4403