### PR TITLE
feat: build codex-responses-api-proxy for all platforms as part of the GitHub Release

### DIFF
--- a/.github/dotslash-config.json
+++ b/.github/dotslash-config.json
@@ -27,6 +27,34 @@
           "path": "codex.exe"
         }
       }
+    },
+    "codex-responses-api-proxy": {
+      "platforms": {
+        "macos-aarch64": {
+          "regex": "^codex-responses-api-proxy-aarch64-apple-darwin\\.zst$",
+          "path": "codex-responses-api-proxy"
+        },
+        "macos-x86_64": {
+          "regex": "^codex-responses-api-proxy-x86_64-apple-darwin\\.zst$",
+          "path": "codex-responses-api-proxy"
+        },
+        "linux-x86_64": {
+          "regex": "^codex-responses-api-proxy-x86_64-unknown-linux-musl\\.zst$",
+          "path": "codex-responses-api-proxy"
+        },
+        "linux-aarch64": {
+          "regex": "^codex-responses-api-proxy-aarch64-unknown-linux-musl\\.zst$",
+          "path": "codex-responses-api-proxy"
+        },
+        "windows-x86_64": {
+          "regex": "^codex-responses-api-proxy-x86_64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex-responses-api-proxy.exe"
+        },
+        "windows-aarch64": {
+          "regex": "^codex-responses-api-proxy-aarch64-pc-windows-msvc\\.exe\\.zst$",
+          "path": "codex-responses-api-proxy.exe"
+        }
+      }
     }
   }
 }

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -97,7 +97,7 @@ jobs:
           sudo apt install -y musl-tools pkg-config
 
       - name: Cargo build
-        run: cargo build --target ${{ matrix.target }} --release --bin codex
+        run: cargo build --target ${{ matrix.target }} --release --bin codex --bin codex-responses-api-proxy
 
       - name: Stage artifacts
         shell: bash
@@ -107,8 +107,10 @@ jobs:
 
           if [[ "${{ matrix.runner }}" == windows* ]]; then
             cp target/${{ matrix.target }}/release/codex.exe "$dest/codex-${{ matrix.target }}.exe"
+            cp target/${{ matrix.target }}/release/codex-responses-api-proxy.exe "$dest/codex-responses-api-proxy-${{ matrix.target }}.exe"
           else
             cp target/${{ matrix.target }}/release/codex "$dest/codex-${{ matrix.target }}"
+            cp target/${{ matrix.target }}/release/codex-responses-api-proxy "$dest/codex-responses-api-proxy-${{ matrix.target }}"
           fi
 
       - if: ${{ matrix.runner == 'windows-11-arm' }}

--- a/codex-cli/scripts/build_npm_package.py
+++ b/codex-cli/scripts/build_npm_package.py
@@ -158,11 +158,8 @@ def stage_sources(staging_dir: Path, version: str) -> None:
         out.write("\n")
 
 
-def install_native_binaries(staging_dir: Path, workflow_url: str | None) -> None:
-    cmd = ["./scripts/install_native_deps.py"]
-    if workflow_url:
-        cmd.extend(["--workflow-url", workflow_url])
-    cmd.append(str(staging_dir))
+def install_native_binaries(staging_dir: Path, workflow_url: str) -> None:
+    cmd = ["./scripts/install_native_deps.py", "--workflow-url", workflow_url, str(staging_dir)]
     subprocess.check_call(cmd, cwd=CODEX_CLI_ROOT)
 
 


### PR DESCRIPTION
This should make the `codex-responses-api-proxy` binaries available for all platforms in a GitHub Release as well as a corresponding DotSlash file.

Making `codex-responses-api-proxy` available as an `npm` module will be done in a follow-up PR.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/4404).
* __->__ #4406
* #4404
* #4403