### PR TITLE
fix: clean up some minor issues with .github/workflows/ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: ci
 
 on:
-  pull_request: { branches: [main] }
+  pull_request: {}
   push: { branches: [main] }
 
 jobs:
@@ -31,6 +31,7 @@ jobs:
       - uses: facebook/install-dotslash@v2
 
       - name: Stage npm package
+        id: stage_npm_package
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -40,13 +41,13 @@ jobs:
           python3 ./codex-cli/scripts/build_npm_package.py \
             --release-version "$CODEX_VERSION" \
             --pack-output "$PACK_OUTPUT"
-          echo "PACK_OUTPUT=$PACK_OUTPUT" >> "$GITHUB_ENV"
+          echo "pack_output=$PACK_OUTPUT" >> "$GITHUB_OUTPUT"
 
       - name: Upload staged npm package artifact
         uses: actions/upload-artifact@v4
         with:
           name: codex-npm-staging
-          path: ${{ env.PACK_OUTPUT }}
+          path: ${{ steps.stage_npm_package.outputs.pack_output }}
 
       - name: Ensure root README.md contains only ASCII and certain Unicode code points
         run: ./scripts/asciicheck.py README.md


### PR DESCRIPTION
Two fixes:

- changes the trigger from `pull_request: { branches: [main] }` to `pull_request: {}` (which is what we do in `rust-ci.yml`, for example) because if you require the base branch to be `main` and you use stacked PRs, the CI job only gets run for the PR on the bottom of the stack
- prefer step outputs to env vars to pass information along

I started looking at the second issue because I thought the step wasn't working (though it is). The issue is that the PR UI here on GitHub will link you to the job:

https://github.com/openai/codex/actions/runs/18078793569/job/51439094961?pr=4408

and if you dig through the logs, you can get a download URL for the artifact, but the easier thing is to cut off the end of the URL and view this instead:

https://github.com/openai/codex/actions/runs/18078793569/

where the download link is prominent:

<img width="1250" height="239" alt="Screenshot 2025-09-28 at 12 35 51 PM" src="https://github.com/user-attachments/assets/3607953c-0fe0-427e-8dcd-eb041e8e8557" />

