### PR TITLE
feat: allow mcp resume by conversation id

### DIFF
--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -71,6 +71,7 @@ pub use rollout::RolloutRecorder;
 pub use rollout::SESSIONS_SUBDIR;
 pub use rollout::SessionMeta;
 pub use rollout::find_conversation_path_by_id_str;
+pub use rollout::find_rollout_by_conversation_id;
 pub use rollout::list::ConversationItem;
 pub use rollout::list::ConversationsPage;
 pub use rollout::list::Cursor;

--- a/codex-rs/core/src/rollout/mod.rs
+++ b/codex-rs/core/src/rollout/mod.rs
@@ -9,6 +9,7 @@ pub mod recorder;
 
 pub use codex_protocol::protocol::SessionMeta;
 pub use list::find_conversation_path_by_id_str;
+pub use list::find_rollout_by_conversation_id;
 pub use recorder::RolloutRecorder;
 pub use recorder::RolloutRecorderParams;
 

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -225,6 +225,16 @@ async fn run_codex_tool_session_inner(
                             Some(msg) => msg,
                             None => "".to_string(),
                         };
+                        let conversation_id = running_requests_id_to_codex_uuid
+                            .lock()
+                            .await
+                            .get(&request_id)
+                            .copied();
+                        let structured_content = conversation_id.map(|id| {
+                            json!({
+                                "conversationId": id.to_string()
+                            })
+                        });
                         let result = CallToolResult {
                             content: vec![ContentBlock::TextContent(TextContent {
                                 r#type: "text".to_string(),
@@ -232,7 +242,7 @@ async fn run_codex_tool_session_inner(
                                 annotations: None,
                             })],
                             is_error: None,
-                            structured_content: None,
+                            structured_content,
                         };
                         outgoing.send_response(request_id.clone(), result).await;
                         // unregister the id so we don't keep it in the map

--- a/codex-rs/protocol/src/mcp_protocol.rs
+++ b/codex-rs/protocol/src/mcp_protocol.rs
@@ -343,7 +343,11 @@ pub struct ListConversationsResponse {
 #[serde(rename_all = "camelCase")]
 pub struct ResumeConversationParams {
     /// Absolute path to the rollout JSONL file.
-    pub path: PathBuf,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+    /// Conversation identifier previously returned via SessionConfigured.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_id: Option<ConversationId>,
     /// Optional overrides to apply when spawning the resumed session.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub overrides: Option<NewConversationParams>,


### PR DESCRIPTION
I’ve been hitting the wall described in #3712: once an MCP client calls codex-reply, the server needs a stable conversationId to locate the rollout JSONL, but today that only works if the client hand-passes an absolute path. 

This PR means the MCP server can now accept either the existing rollout path or the conversation UUID that was emitted in the earlier SessionConfigured event. Under the hood that’s powered by a new `find_rollout_by_conversation_id` helper in codex-core, so both paths share the same lookup logic.

What's inside:

- Core exposes `find_rollout_by_conversation_id` so we can map a UUID back to ~/.codex/sessions/.../rollout-*.jsonl.
- `ResumeConversationParams` now takes path or `conversation_id` (both optional, at least one required) to stay compatible with existing clients.
- `resumeConversation` in the MCP server resolves the rollout path automatically when only the UUID is supplied, and returns clear JSON-RPC errors when
  neither argument is present or the UUID can’t be found.
- The resume integration test exercises both flows: resume by explicit path and resume by conversation ID only.

This should close #3712 and replaces #4374. 

I have read the CLA Document and I hereby sign the CLA