### PR TITLE
feat: introduce npm module for codex-responses-api-proxy

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -218,16 +218,29 @@ jobs:
 
       # build_npm_package.py requires DotSlash when staging releases.
       - uses: facebook/install-dotslash@v2
-      - name: Stage npm package
+      - name: Stage codex CLI npm package
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
           TMP_DIR="${RUNNER_TEMP}/npm-stage"
           ./codex-cli/scripts/build_npm_package.py \
+            --package codex \
             --release-version "${{ steps.release_name.outputs.name }}" \
             --staging-dir "${TMP_DIR}" \
             --pack-output "${GITHUB_WORKSPACE}/dist/npm/codex-npm-${{ steps.release_name.outputs.name }}.tgz"
+
+      - name: Stage responses API proxy npm package
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TMP_DIR="${RUNNER_TEMP}/npm-stage-responses"
+          ./codex-cli/scripts/build_npm_package.py \
+            --package codex-responses-api-proxy \
+            --release-version "${{ steps.release_name.outputs.name }}" \
+            --staging-dir "${TMP_DIR}" \
+            --pack-output "${GITHUB_WORKSPACE}/dist/npm/codex-responses-api-proxy-npm-${{ steps.release_name.outputs.name }}.tgz"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -271,7 +284,7 @@ jobs:
       - name: Update npm
         run: npm install -g npm@latest
 
-      - name: Download npm tarball from release
+      - name: Download npm tarballs from release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -282,6 +295,10 @@ jobs:
           gh release download "$tag" \
             --repo "${GITHUB_REPOSITORY}" \
             --pattern "codex-npm-${version}.tgz" \
+            --dir dist/npm
+          gh release download "$tag" \
+            --repo "${GITHUB_REPOSITORY}" \
+            --pattern "codex-responses-api-proxy-npm-${version}.tgz" \
             --dir dist/npm
 
       # No NODE_AUTH_TOKEN needed because we use OIDC.
@@ -296,7 +313,14 @@ jobs:
             tag_args+=(--tag "${NPM_TAG}")
           fi
 
-          npm publish "${GITHUB_WORKSPACE}/dist/npm/codex-npm-${VERSION}.tgz" "${tag_args[@]}"
+          tarballs=(
+            "codex-npm-${VERSION}.tgz"
+            "codex-responses-api-proxy-npm-${VERSION}.tgz"
+          )
+
+          for tarball in "${tarballs[@]}"; do
+            npm publish "${GITHUB_WORKSPACE}/dist/npm/${tarball}" "${tag_args[@]}"
+          done
 
   update-branch:
     name: Update latest-alpha-cli branch

--- a/codex-cli/README.md
+++ b/codex-cli/README.md
@@ -208,7 +208,7 @@ The hardening mechanism Codex uses depends on your OS:
 | Requirement                 | Details                                                         |
 | --------------------------- | --------------------------------------------------------------- |
 | Operating systems           | macOS 12+, Ubuntu 20.04+/Debian 10+, or Windows 11 **via WSL2** |
-| Node.js                     | **22 or newer** (LTS recommended)                               |
+| Node.js                     | **16 or newer** (Node 20 LTS recommended)                       |
 | Git (optional, recommended) | 2.23+ for built-in PR helpers                                   |
 | RAM                         | 4-GB minimum (8-GB recommended)                                 |
 
@@ -513,7 +513,7 @@ Codex runs model-generated commands in a sandbox. If a proposed command or file 
 <details>
 <summary>Does it work on Windows?</summary>
 
-Not directly. It requires [Windows Subsystem for Linux (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install) - Codex has been tested on macOS and Linux with Node 22.
+Not directly. It requires [Windows Subsystem for Linux (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install) - Codex is regularly tested on macOS and Linux with Node 20+, and also supports Node 16.
 
 </details>
 

--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 // Unified entry point for the Codex CLI.
 
+import { spawn } from "node:child_process";
 import { existsSync } from "fs";
 import path from "path";
 import { fileURLToPath } from "url";
@@ -68,7 +69,6 @@ const binaryPath = path.join(archRoot, "codex", codexBinaryName);
 // executing. This allows us to forward those signals to the child process
 // and guarantees that when either the child terminates or the parent
 // receives a fatal signal, both processes exit in a predictable manner.
-const { spawn } = await import("child_process");
 
 function getUpdatedPath(newDirs) {
   const pathSep = process.platform === "win32" ? ";" : ":";

--- a/codex-cli/package-lock.json
+++ b/codex-cli/package-lock.json
@@ -11,7 +11,7 @@
         "codex": "bin/codex.js"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=16"
       }
     }
   }

--- a/codex-rs/process-hardening/README.md
+++ b/codex-rs/process-hardening/README.md
@@ -1,0 +1,7 @@
+# codex-process-hardening
+
+This crate provides `pre_main_hardening()`, which is designed to be called pre-`main()` (using `#[ctor::ctor]`) to perform various process hardening steps, such as
+
+- disabling core dumps
+- disabling ptrace attach on Linux and macOS
+- removing dangerous environment variables such as `LD_PRELOAD` and `DYLD_*`

--- a/codex-rs/responses-api-proxy/README.md
+++ b/codex-rs/responses-api-proxy/README.md
@@ -4,12 +4,12 @@ A strict HTTP proxy that only forwards `POST` requests to `/v1/responses` to the
 
 ## Expected Usage
 
-**IMPORTANT:** This is designed to be used with `CODEX_SECURE_MODE=1` so that an unprivileged user cannot inspect or tamper with this process. Though if `--http-shutdown` is specified, an unprivileged user _can_ shutdown the server.
+**IMPORTANT:** `codex-responses-api-proxy` is designed to be run by a privileged user with access to `OPENAI_API_KEY` so that an unprivileged user cannot inspect or tamper with the process. Though if `--http-shutdown` is specified, an unprivileged user _can_ make a `GET` request to `/shutdown` to shutdown the server, as an unprivileged could not send `SIGTERM` to kill the process.
 
-A privileged user (i.e., `root` or a user with `sudo`) who has access to `OPENAI_API_KEY` would run the following to start the server:
+A privileged user (i.e., `root` or a user with `sudo`) who has access to `OPENAI_API_KEY` would run the following to start the server, as `codex-responses-api-proxy` reads the auth token from `stdin`:
 
 ```shell
-printenv OPENAI_API_KEY | CODEX_SECURE_MODE=1 codex responses-api-proxy --http-shutdown --server-info /tmp/server-info.json
+printenv OPENAI_API_KEY | codex-responses-api-proxy --http-shutdown --server-info /tmp/server-info.json
 ```
 
 A non-privileged user would then run Codex as follows, specifying the `model_provider` dynamically:
@@ -22,7 +22,7 @@ codex exec -c "model_providers.openai-proxy={ name = 'OpenAI Proxy', base_url = 
     'Your prompt here'
 ```
 
-When the unprivileged user was finished, they could shutdown the server using `curl` (since `kill -9` is not an option):
+When the unprivileged user was finished, they could shutdown the server using `curl` (since `kill -SIGTERM` is not an option):
 
 ```shell
 curl --fail --silent --show-error "${PROXY_BASE_URL}/shutdown"
@@ -30,17 +30,17 @@ curl --fail --silent --show-error "${PROXY_BASE_URL}/shutdown"
 
 ## Behavior
 
-- Reads the API key from `stdin`. All callers should pipe the key in (for example, `printenv OPENAI_API_KEY | codex responses-api-proxy`).
+- Reads the API key from `stdin`. All callers should pipe the key in (for example, `printenv OPENAI_API_KEY | codex-responses-api-proxy`).
 - Formats the header value as `Bearer <key>` and attempts to `mlock(2)` the memory holding that header so it is not swapped to disk.
 - Listens on the provided port or an ephemeral port if `--port` is not specified.
 - Accepts exactly `POST /v1/responses` (no query string). The request body is forwarded to `https://api.openai.com/v1/responses` with `Authorization: Bearer <key>` set. All original request headers (except any incoming `Authorization`) are forwarded upstream. For other requests, it responds with `403`.
 - Optionally writes a single-line JSON file with server info, currently `{ "port": <u16> }`.
-- Optional `--http-shutdown` enables `GET /shutdown` to terminate the process with exit code 0. This allows one user (e.g., root) to start the proxy and another unprivileged user on the host to shut it down.
+- Optional `--http-shutdown` enables `GET /shutdown` to terminate the process with exit code 0. This allows one user (e.g., `root`) to start the proxy and another unprivileged user on the host to shut it down.
 
 ## CLI
 
 ```
-responses-api-proxy [--port <PORT>] [--server-info <FILE>] [--http-shutdown]
+codex-responses-api-proxy [--port <PORT>] [--server-info <FILE>] [--http-shutdown]
 ```
 
 - `--port <PORT>`: Port to bind on `127.0.0.1`. If omitted, an ephemeral port is chosen.
@@ -51,3 +51,19 @@ responses-api-proxy [--port <PORT>] [--server-info <FILE>] [--http-shutdown]
 
 - Only `POST /v1/responses` is permitted. No query strings are allowed.
 - All request headers are forwarded to the upstream call (aside from overriding `Authorization`). Response status and content-type are mirrored from upstream.
+
+## Hardening Details
+
+Care is taken to restrict access/copying to the value of `OPENAI_API_KEY` retained in memory:
+
+- We leverage [`codex_process_hardening`](https://github.com/openai/codex/blob/main/codex-rs/process-hardening/README.md) so `codex-responses-api-proxy` is run with standard process-hardening techniques.
+- At startup, we allocate a `1024` byte buffer on the stack and write `"Bearer "` as the first `7` bytes.
+- We then read from `stdin`, copying the contents into the buffer after `"Bearer "`.
+- After verifying the key matches `/^[a-zA-Z0-9_-]+$/` (and does not exceed the buffer), we create a `String` from that buffer (so the data is now on the heap).
+- We zero out the stack-allocated buffer using https://crates.io/crates/zeroize so it is not optimized away by the compiler.
+- We invoke `.leak()` on the `String` so we can treat its contents as a `&'static str`, as it will live for the rest of the process.
+- On UNIX, we `mlock(2)` the memory backing the `&'static str`.
+- When using the `&'static str` when building an HTTP request, we use `HeaderValue::from_static()` to avoid copying the `&str`.
+- We also invoke `.set_sensitive(true)` on the `HeaderValue`, which in theory indicates to other parts of the HTTP stack that the header should be treated with "special care" to avoid leakage:
+
+https://github.com/hyperium/http/blob/439d1c50d71e3be3204b6c4a1bf2255ed78e1f93/src/header/value.rs#L346-L376

--- a/codex-rs/responses-api-proxy/npm/README.md
+++ b/codex-rs/responses-api-proxy/npm/README.md
@@ -1,0 +1,13 @@
+# @openai/codex-responses-api-proxy
+
+<p align="center"><code>npm i -g @openai/codex-responses-api-proxy</code> to install <code>codex-responses-api-proxy</code></p>
+
+This package distributes the prebuilt [Codex Responses API proxy binary](https://github.com/openai/codex/tree/main/codex-rs/responses-api-proxy) for macOS, Linux, and Windows.
+
+To see available options, run:
+
+```
+node ./bin/codex-responses-api-proxy.js --help
+```
+
+Refer to [`codex-rs/responses-api-proxy/README.md`](https://github.com/openai/codex/blob/main/codex-rs/responses-api-proxy/README.md) for detailed documentation.

--- a/codex-rs/responses-api-proxy/npm/bin/codex-responses-api-proxy.js
+++ b/codex-rs/responses-api-proxy/npm/bin/codex-responses-api-proxy.js
@@ -1,0 +1,97 @@
+#!/usr/bin/env node
+// Entry point for the Codex responses API proxy binary.
+
+import { spawn } from "node:child_process";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function determineTargetTriple(platform, arch) {
+  switch (platform) {
+    case "linux":
+    case "android":
+      if (arch === "x64") {
+        return "x86_64-unknown-linux-musl";
+      }
+      if (arch === "arm64") {
+        return "aarch64-unknown-linux-musl";
+      }
+      break;
+    case "darwin":
+      if (arch === "x64") {
+        return "x86_64-apple-darwin";
+      }
+      if (arch === "arm64") {
+        return "aarch64-apple-darwin";
+      }
+      break;
+    case "win32":
+      if (arch === "x64") {
+        return "x86_64-pc-windows-msvc";
+      }
+      if (arch === "arm64") {
+        return "aarch64-pc-windows-msvc";
+      }
+      break;
+    default:
+      break;
+  }
+  return null;
+}
+
+const targetTriple = determineTargetTriple(process.platform, process.arch);
+if (!targetTriple) {
+  throw new Error(
+    `Unsupported platform: ${process.platform} (${process.arch})`,
+  );
+}
+
+const vendorRoot = path.join(__dirname, "..", "vendor");
+const archRoot = path.join(vendorRoot, targetTriple);
+const binaryBaseName = "codex-responses-api-proxy";
+const binaryPath = path.join(
+  archRoot,
+  binaryBaseName,
+  process.platform === "win32" ? `${binaryBaseName}.exe` : binaryBaseName,
+);
+
+const child = spawn(binaryPath, process.argv.slice(2), {
+  stdio: "inherit",
+});
+
+child.on("error", (err) => {
+  console.error(err);
+  process.exit(1);
+});
+
+const forwardSignal = (signal) => {
+  if (!child.killed) {
+    try {
+      child.kill(signal);
+    } catch {
+      /* ignore */
+    }
+  }
+};
+
+["SIGINT", "SIGTERM", "SIGHUP"].forEach((sig) => {
+  process.on(sig, () => forwardSignal(sig));
+});
+
+const childResult = await new Promise((resolve) => {
+  child.on("exit", (code, signal) => {
+    if (signal) {
+      resolve({ type: "signal", signal });
+    } else {
+      resolve({ type: "code", exitCode: code ?? 1 });
+    }
+  });
+});
+
+if (childResult.type === "signal") {
+  process.kill(process.pid, childResult.signal);
+} else {
+  process.exit(childResult.exitCode);
+}

--- a/codex-rs/responses-api-proxy/npm/package.json
+++ b/codex-rs/responses-api-proxy/npm/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@openai/codex",
+  "name": "@openai/codex-responses-api-proxy",
   "version": "0.0.0-dev",
   "license": "Apache-2.0",
   "bin": {
-    "codex": "bin/codex.js"
+    "codex-responses-api-proxy": "bin/codex-responses-api-proxy.js"
   },
   "type": "module",
   "engines": {
@@ -16,6 +16,6 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openai/codex.git",
-    "directory": "codex-cli"
+    "directory": "codex-rs/responses-api-proxy/npm"
   }
 }


### PR DESCRIPTION
This PR expands `.github/workflows/rust-release.yml` so that it also builds and publishes the `npm` module for `@openai/codex-responses-api-proxy` in addition to `@openai/codex`. Note both `npm` modules are similar, in that they each contain a single `.js` file that is a thin launcher around the appropriate native executable. (Since we have a minimal dependency on Node.js, I also lowered the minimum version from 20 to 16 and verified that works on my machine.)

As part of this change, we tighten up some of the docs around `codex-responses-api-proxy` and ensure the details regarding protecting the `OPENAI_API_KEY` in memory match the implementation.

To test the `npm` build process, I ran:

```
./codex-cli/scripts/build_npm_package.py --package codex-responses-api-proxy --version 0.43.0-alpha.3
```

which stages the `npm` module for `@openai/codex-responses-api-proxy` in a temp directory, using the binary artifacts from https://github.com/openai/codex/releases/tag/rust-v0.43.0-alpha.3.