### PR TITLE
Parse out frontmatter for custom prompts

### DIFF
--- a/codex-rs/protocol/src/custom_prompts.rs
+++ b/codex-rs/protocol/src/custom_prompts.rs
@@ -8,4 +8,10 @@ pub struct CustomPrompt {
     pub name: String,
     pub path: PathBuf,
     pub content: String,
+    // Optional short description shown in the slash popup, typically provided
+    // via frontmatter in the prompt file.
+    pub description: Option<String>,
+    // Optional argument hint (e.g., "[file] [flags]") shown alongside the
+    // description in the popup when available.
+    pub argument_hint: Option<String>,
 }

--- a/codex-rs/protocol/src/custom_prompts.rs
+++ b/codex-rs/protocol/src/custom_prompts.rs
@@ -8,10 +8,6 @@ pub struct CustomPrompt {
     pub name: String,
     pub path: PathBuf,
     pub content: String,
-    // Optional short description shown in the slash popup, typically provided
-    // via frontmatter in the prompt file.
     pub description: Option<String>,
-    // Optional argument hint (e.g., "[file] [flags]") shown alongside the
-    // description in the popup when available.
     pub argument_hint: Option<String>,
 }

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -2258,6 +2258,8 @@ mod tests {
             name: "my-prompt".to_string(),
             path: "/tmp/my-prompt.md".to_string().into(),
             content: prompt_text.to_string(),
+            description: None,
+            argument_hint: None,
         }]);
 
         type_chars_humanlike(

--- a/codex-rs/tui/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/command_popup.rs
@@ -276,11 +276,15 @@ mod tests {
                 name: "foo".to_string(),
                 path: "/tmp/foo.md".to_string().into(),
                 content: "hello from foo".to_string(),
+                description: None,
+                argument_hint: None,
             },
             CustomPrompt {
                 name: "bar".to_string(),
                 path: "/tmp/bar.md".to_string().into(),
                 content: "hello from bar".to_string(),
+                description: None,
+                argument_hint: None,
             },
         ];
         let popup = CommandPopup::new(prompts);
@@ -303,6 +307,8 @@ mod tests {
             name: "init".to_string(),
             path: "/tmp/init.md".to_string().into(),
             content: "should be ignored".to_string(),
+            description: None,
+            argument_hint: None,
         }]);
         let items = popup.filtered_items();
         let has_collision_prompt = items.into_iter().any(|it| match it {


### PR DESCRIPTION
[Cherry picked from https://github.com/openai/codex/pull/3565]

Removes the frontmatter description/args from custom prompt files and only includes body.