### PR TITLE
docs: add missing config keys for tools.view_image and disable_paste_burst

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,10 @@ In the codex-rs folder where the rust code lives:
   - Similarly, when you spawn a process using Seatbelt (`/usr/bin/sandbox-exec`), `CODEX_SANDBOX=seatbelt` will be set on the child process. Integration tests that want to run Seatbelt themselves cannot be run under Seatbelt, so checks for `CODEX_SANDBOX=seatbelt` are also often used to early exit out of tests, as appropriate.
 
 Run `just fmt` (in `codex-rs` directory) automatically after making Rust code changes; do not ask for approval to run it. Before finalizing a change to `codex-rs`, run `just fix -p <project>` (in `codex-rs` directory) to fix any linter issues in the code. Prefer scoping with `-p` to avoid slow workspace‑wide Clippy builds; only run `just fix` without `-p` if you changed shared crates. Additionally, run the tests:
+
 1. Run the test for the specific project that was changed. For example, if changes were made in `codex-rs/tui`, run `cargo test -p codex-tui`.
 2. Once those pass, if any changes were made in common, core, or protocol, run the complete test suite with `cargo test --all-features`.
-When running interactively, ask the user before running `just fix` to finalize. `just fmt` does not require approval. project-specific or individual tests can be run without asking the user, but do ask the user before running the complete test suite.
+   When running interactively, ask the user before running `just fix` to finalize. `just fmt` does not require approval. project-specific or individual tests can be run without asking the user, but do ask the user before running the complete test suite.
 
 ## TUI style conventions
 
@@ -28,6 +29,7 @@ See `codex-rs/tui/styles.md`.
     - Desired: vec!["  └ ".into(), "M".red(), " ".dim(), "tui/src/app.rs".dim()]
 
 ### TUI Styling (ratatui)
+
 - Prefer Stylize helpers: use "text".dim(), .bold(), .cyan(), .italic(), .underlined() instead of manual Style where possible.
 - Prefer simple conversions: use "text".into() for spans and vec![…].into() for lines; when inference is ambiguous (e.g., Paragraph::new/Cell::from), use Line::from(spans) or Span::from(text).
 - Computed styles: if the Style is computed at runtime, using `Span::styled` is OK (`Span::from(text).set_style(style)` is also acceptable).
@@ -39,6 +41,7 @@ See `codex-rs/tui/styles.md`.
 - Compactness: prefer the form that stays on one line after rustfmt; if only one of Line::from(vec![…]) or vec![…].into() avoids wrapping, choose that. If both wrap, pick the one with fewer wrapped lines.
 
 ### Text wrapping
+
 - Always use textwrap::wrap to wrap plain strings.
 - If you have a ratatui Line and you want to wrap it, use the helpers in tui/src/wrapping.rs, e.g. word_wrap_lines / word_wrap_line.
 - If you need to indent wrapped lines, use the initial_indent / subsequent_indent options from RtOptions if you can, rather than writing custom logic.
@@ -60,6 +63,7 @@ This repo uses snapshot tests (via `insta`), especially in `codex-rs/tui`, to va
   - `cargo insta accept -p codex-tui`
 
 If you don’t have the tool:
+
 - `cargo install cargo-insta`
 
 ### Test assertions

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 <p align="center"><code>npm i -g @openai/codex</code><br />or <code>brew install codex</code></p>
 
 <p align="center"><strong>Codex CLI</strong> is a coding agent from OpenAI that runs locally on your computer.
@@ -63,7 +62,6 @@ You can also use Codex with an API key, but this requires [additional setup](./d
 ### Model Context Protocol (MCP)
 
 Codex CLI supports [MCP servers](./docs/advanced.md#model-context-protocol-mcp). Enable by adding an `mcp_servers` section to your `~/.codex/config.toml`.
-
 
 ### Configuration
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -692,6 +692,34 @@ This is analogous to `model_context_window`, but for the maximum number of outpu
 
 Maximum number of bytes to read from an `AGENTS.md` file to include in the instructions sent with the first turn of a session. Defaults to 32 KiB.
 
+## tools
+
+Configure which agent tools are enabled.
+
+```toml
+[tools]
+web_search = true  # default: false
+view_image = true  # default: false
+```
+
+### tools.web_search
+
+Enable the web search tool (also aliased as `web_search_request`). When enabled, the agent can search the web for information. Defaults to `false`.
+
+### tools.view_image
+
+Enable the `view_image` tool that lets the agent attach local image paths to provide extra visual context. When enabled, the agent can reference images from your filesystem. Defaults to `false`.
+
+## disable_paste_burst
+
+When set to `true`, disables burst-paste detection for typed input entirely in the TUI. All characters are inserted as they are received, and no buffering or placeholder replacement will occur for fast keypress bursts. Defaults to `false`.
+
+```toml
+disable_paste_burst = true  # default: false
+```
+
+This setting is useful if you experience issues with pasted content being modified or if you want to disable the paste detection feature.
+
 ## tui
 
 Options that are specific to the TUI.
@@ -767,3 +795,5 @@ notifications = [ "agent-turn-complete", "approval-requested" ]
 | `responses_originator_header_internal_override` | string | Override `originator` header value. |
 | `projects.<path>.trust_level` | string | Mark project/worktree as trusted (only `"trusted"` is recognized). |
 | `tools.web_search` | boolean | Enable web search tool (alias: `web_search_request`) (default: false). |
+| `tools.view_image` | boolean | Enable view_image tool for attaching local images (default: false). |
+| `disable_paste_burst` | boolean | Disable burst-paste detection in TUI (default: false). |


### PR DESCRIPTION
Fixes #3101

## Summary

Added documentation for two config keys that were missing from `docs/config.md`:

- `tools.view_image`: Enable the view_image tool for attaching local images
- `disable_paste_burst`: Disable burst-paste detection in TUI input

## Changes

### New Sections Added

1. **tools section** (before `tui` section)
   - Documents both `tools.web_search` and `tools.view_image` together
   - Includes example TOML configuration
   - Explains each tool's purpose and default values

2. **disable_paste_burst section** (before `tui` section)
   - Explains the paste burst detection feature
   - Shows TOML configuration example
   - Notes the default value (false)

### Config Reference Table Updates

Added entries to the configuration reference table at the end of the document:
- `tools.view_image | boolean | Enable view_image tool for attaching local images (default: false).`
- `disable_paste_burst | boolean | Disable burst-paste detection in TUI (default: false).`

## Note

The commit also includes formatting fixes for `AGENTS.md` and `README.md` from prettier, which were needed due to upstream changes.

## Verification

Config key definitions verified in source code:
- `tools.view_image`: `codex-rs/core/src/config.rs:512-519`
- `disable_paste_burst`: `codex-rs/core/src/config.rs:813-815`

Note: `model_reasoning_summary` mentioned in #3101 is already documented, so it was not included in this PR.