### PR TITLE
no background for /command or @file popup

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -1238,12 +1238,6 @@ impl ChatComposer {
 impl WidgetRef for ChatComposer {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
         let [composer_rect, textarea_rect, popup_rect] = self.layout_areas(area);
-        if !matches!(self.active_popup, ActivePopup::None) {
-            buf.set_style(
-                popup_rect,
-                user_message_style(terminal_palette::default_bg()),
-            );
-        }
         match &self.active_popup {
             ActivePopup::Command(popup) => {
                 popup.render_ref(popup_rect, buf);


### PR DESCRIPTION
before:

<img width="855" height="270" alt="Screenshot 2025-09-29 at 3 42 53 PM" src="https://github.com/user-attachments/assets/eb247e1f-0947-4830-93c4-d4ecb2992b32" />


after:

<img width="855" height="270" alt="Screenshot 2025-09-29 at 3 43 04 PM" src="https://github.com/user-attachments/assets/46717844-6066-47a4-a34a-1a75508ea2c3" />
