### PR TITLE
feat(compact): refresh token usage after summarizing context

### DIFF
--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -612,7 +612,7 @@ pub struct RateLimitWindow {
 }
 
 // Includes prompts, tools and space to call compact.
-const BASELINE_TOKENS: u64 = 12000;
+pub const BASELINE_TOKENS: u64 = 12_000;
 
 impl TokenUsage {
     pub fn is_zero(&self) -> bool {


### PR DESCRIPTION
I have read the CLA Document and I hereby sign the CLA.


This fixes that we still see prev `n% context left` after running compaction and it's unclear, if compaction really worked.