### PR TITLE
Show placeholder for commands with no output

### DIFF
--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__interrupt_exec_marks_failed.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__interrupt_exec_marks_failed.snap
@@ -3,3 +3,4 @@ source: tui/src/chatwidget/tests.rs
 expression: exec_blob
 ---
 • Ran sleep 1
+  └ (no output)

--- a/codex-rs/tui/src/exec_cell/render.rs
+++ b/codex-rs/tui/src/exec_cell/render.rs
@@ -366,26 +366,35 @@ impl ExecCell {
                     include_prefix: false,
                 },
             );
-            let trimmed_output =
-                Self::truncate_lines_middle(&raw_output_lines, layout.output_max_lines);
 
-            let mut wrapped_output: Vec<Line<'static>> = Vec::new();
-            let output_wrap_width = layout.output_block.wrap_width(width);
-            let output_opts =
-                RtOptions::new(output_wrap_width).word_splitter(WordSplitter::NoHyphenation);
-            for line in trimmed_output {
-                push_owned_lines(
-                    &word_wrap_line(&line, output_opts.clone()),
-                    &mut wrapped_output,
-                );
-            }
-
-            if !wrapped_output.is_empty() {
+            if raw_output_lines.is_empty() {
                 lines.extend(prefix_lines(
-                    wrapped_output,
+                    vec![Line::from("(no output)".dim())],
                     Span::from(layout.output_block.initial_prefix).dim(),
                     Span::from(layout.output_block.subsequent_prefix),
                 ));
+            } else {
+                let trimmed_output =
+                    Self::truncate_lines_middle(&raw_output_lines, layout.output_max_lines);
+
+                let mut wrapped_output: Vec<Line<'static>> = Vec::new();
+                let output_wrap_width = layout.output_block.wrap_width(width);
+                let output_opts =
+                    RtOptions::new(output_wrap_width).word_splitter(WordSplitter::NoHyphenation);
+                for line in trimmed_output {
+                    push_owned_lines(
+                        &word_wrap_line(&line, output_opts.clone()),
+                        &mut wrapped_output,
+                    );
+                }
+
+                if !wrapped_output.is_empty() {
+                    lines.extend(prefix_lines(
+                        wrapped_output,
+                        Span::from(layout.output_block.initial_prefix).dim(),
+                        Span::from(layout.output_block.subsequent_prefix),
+                    ));
+                }
             }
         }
 

--- a/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__multiline_command_both_lines_wrap_with_correct_prefixes.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__multiline_command_both_lines_wrap_with_correct_prefixes.snap
@@ -6,3 +6,4 @@ expression: rendered
   │ ough_to_wrap
   │ second_token_is_also_lon
   │ … +1 lines
+  └ (no output)

--- a/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__multiline_command_without_wrap_uses_branch_then_eight_spaces.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__multiline_command_without_wrap_uses_branch_then_eight_spaces.snap
@@ -4,3 +4,4 @@ expression: rendered
 ---
 • Ran echo one
   │ echo two
+  └ (no output)

--- a/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__multiline_command_wraps_with_extra_indent_on_subsequent_lines.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__multiline_command_wraps_with_extra_indent_on_subsequent_lines.snap
@@ -5,3 +5,4 @@ expression: rendered
 • Ran set -o pipefail
   │ cargo test
   │ --all-features --quiet
+  └ (no output)

--- a/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__single_line_command_compact_when_fits.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__single_line_command_compact_when_fits.snap
@@ -3,3 +3,4 @@ source: tui/src/history_cell.rs
 expression: rendered
 ---
 • Ran echo ok
+  └ (no output)

--- a/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__single_line_command_wraps_with_four_space_continuation.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__single_line_command_wraps_with_four_space_continuation.snap
@@ -5,3 +5,4 @@ expression: rendered
 • Ran a_very_long_token_
   │ without_spaces_to_
   │ force_wrapping
+  └ (no output)


### PR DESCRIPTION
## Summary
- show a dim “(no output)” placeholder when an executed command produces no stdout or stderr so empty runs are visible
- update TUI snapshots to include the new placeholder in history renderings

## Testing
- cargo test -p codex-tui


------
https://chatgpt.com/codex/tasks/task_i_68dc056c1d5883218fe8d9929e9b1657