### PR TITLE
fix: ensure every variant of ClientRequest has a params field

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -193,28 +193,43 @@ impl CodexMessageProcessor {
             ClientRequest::LoginApiKey { request_id, params } => {
                 self.login_api_key(request_id, params).await;
             }
-            ClientRequest::LoginChatGpt { request_id } => {
+            ClientRequest::LoginChatGpt {
+                request_id,
+                params: _,
+            } => {
                 self.login_chatgpt(request_id).await;
             }
             ClientRequest::CancelLoginChatGpt { request_id, params } => {
                 self.cancel_login_chatgpt(request_id, params.login_id).await;
             }
-            ClientRequest::LogoutChatGpt { request_id } => {
+            ClientRequest::LogoutChatGpt {
+                request_id,
+                params: _,
+            } => {
                 self.logout_chatgpt(request_id).await;
             }
             ClientRequest::GetAuthStatus { request_id, params } => {
                 self.get_auth_status(request_id, params).await;
             }
-            ClientRequest::GetUserSavedConfig { request_id } => {
+            ClientRequest::GetUserSavedConfig {
+                request_id,
+                params: _,
+            } => {
                 self.get_user_saved_config(request_id).await;
             }
             ClientRequest::SetDefaultModel { request_id, params } => {
                 self.set_default_model(request_id, params).await;
             }
-            ClientRequest::GetUserAgent { request_id } => {
+            ClientRequest::GetUserAgent {
+                request_id,
+                params: _,
+            } => {
                 self.get_user_agent(request_id).await;
             }
-            ClientRequest::UserInfo { request_id } => {
+            ClientRequest::UserInfo {
+                request_id,
+                params: _,
+            } => {
                 self.get_user_info(request_id).await;
             }
             ClientRequest::FuzzyFileSearch { request_id, params } => {

--- a/codex-rs/protocol/src/mcp_protocol.rs
+++ b/codex-rs/protocol/src/mcp_protocol.rs
@@ -158,6 +158,10 @@ pub enum ClientRequest {
     LoginChatGpt {
         #[serde(rename = "id")]
         request_id: RequestId,
+
+        #[ts(type = "undefined")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        params: Option<()>,
     },
     CancelLoginChatGpt {
         #[serde(rename = "id")]
@@ -167,6 +171,10 @@ pub enum ClientRequest {
     LogoutChatGpt {
         #[serde(rename = "id")]
         request_id: RequestId,
+
+        #[ts(type = "undefined")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        params: Option<()>,
     },
     GetAuthStatus {
         #[serde(rename = "id")]
@@ -176,6 +184,10 @@ pub enum ClientRequest {
     GetUserSavedConfig {
         #[serde(rename = "id")]
         request_id: RequestId,
+
+        #[ts(type = "undefined")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        params: Option<()>,
     },
     SetDefaultModel {
         #[serde(rename = "id")]
@@ -185,10 +197,18 @@ pub enum ClientRequest {
     GetUserAgent {
         #[serde(rename = "id")]
         request_id: RequestId,
+
+        #[ts(type = "undefined")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        params: Option<()>,
     },
     UserInfo {
         #[serde(rename = "id")]
         request_id: RequestId,
+
+        #[ts(type = "undefined")]
+        #[serde(skip_serializing_if = "Option::is_none")]
+        params: Option<()>,
     },
     FuzzyFileSearch {
         #[serde(rename = "id")]


### PR DESCRIPTION
This ensures changes the generated TypeScript type for `ClientRequest` so that instead of this:

```typescript
/**
 * Request from the client to the server.
 */
export type ClientRequest =
  | { method: "initialize"; id: RequestId; params: InitializeParams }
  | { method: "newConversation"; id: RequestId; params: NewConversationParams }
  // ...
  | { method: "getUserAgent"; id: RequestId }
  | { method: "userInfo"; id: RequestId }
  // ...
```

we have this:

```typescript
/**
 * Request from the client to the server.
 */
export type ClientRequest =
  | { method: "initialize"; id: RequestId; params: InitializeParams }
  | { method: "newConversation"; id: RequestId; params: NewConversationParams }
  // ...
  | { method: "getUserAgent"; id: RequestId; params: undefined }
  | { method: "userInfo"; id: RequestId; params: undefined }
  // ...
```

which makes TypeScript happier when it comes to destructuring instances of `ClientRequest` because it does not complain about `params` not being guaranteed to exist anymore.