### PR TITLE
feat: configure auto compact feature

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1351,6 +1351,8 @@ async fn derive_config_from_params(
         include_view_image_tool: None,
         show_raw_agent_reasoning: None,
         tools_web_search_request: None,
+        auto_compact_mode: None,
+        auto_compact_threshold_tokens: None,
     };
 
     let cli_overrides = cli_overrides

--- a/codex-rs/common/src/config_summary.rs
+++ b/codex-rs/common/src/config_summary.rs
@@ -12,12 +12,7 @@ pub fn create_config_summary_entries(config: &Config) -> Vec<(&'static str, Stri
         ("approval", config.approval_policy.to_string()),
         ("sandbox", summarize_sandbox_policy(&config.sandbox_policy)),
     ];
-    let auto_compact = if config.auto_compact_enabled {
-        "on"
-    } else {
-        "off"
-    };
-    entries.push(("auto-compact", auto_compact.to_string()));
+    entries.push(("auto-compact", config.auto_compact_mode.to_string()));
     if config.model_provider.wire_api == WireApi::Responses
         && config.model_family.supports_reasoning_summaries
     {

--- a/codex-rs/common/src/config_summary.rs
+++ b/codex-rs/common/src/config_summary.rs
@@ -12,6 +12,12 @@ pub fn create_config_summary_entries(config: &Config) -> Vec<(&'static str, Stri
         ("approval", config.approval_policy.to_string()),
         ("sandbox", summarize_sandbox_policy(&config.sandbox_policy)),
     ];
+    let auto_compact = if config.auto_compact_enabled {
+        "on"
+    } else {
+        "off"
+    };
+    entries.push(("auto-compact", auto_compact.to_string()));
     if config.model_provider.wire_api == WireApi::Responses
         && config.model_family.supports_reasoning_summaries
     {

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -116,7 +116,7 @@ impl ModelClient {
 
     pub fn get_auto_compact_token_limit(&self) -> Option<i64> {
         self.config.model_auto_compact_token_limit.or_else(|| {
-            get_model_info(&self.config.model_family).and_then(|info| info.auto_compact_token_limit)
+            get_model_info(&self.config.model_family).map(|info| info.auto_compact_token_limit)
         })
     }
 

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -114,6 +114,9 @@ impl ModelClient {
     }
 
     pub fn get_auto_compact_token_limit(&self) -> Option<i64> {
+        if !self.config.auto_compact_enabled {
+            return None;
+        }
         self.config.model_auto_compact_token_limit.or_else(|| {
             get_model_info(&self.config.model_family).and_then(|info| info.auto_compact_token_limit)
         })

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -50,6 +50,7 @@ use crate::protocol::TokenUsage;
 use crate::token_data::PlanType;
 use crate::util::backoff;
 use codex_otel::otel_event_manager::OtelEventManager;
+use codex_protocol::config_types::AutoCompactMode;
 use codex_protocol::config_types::ReasoningEffort as ReasoningEffortConfig;
 use codex_protocol::config_types::ReasoningSummary as ReasoningSummaryConfig;
 use codex_protocol::models::ResponseItem;
@@ -114,12 +115,13 @@ impl ModelClient {
     }
 
     pub fn get_auto_compact_token_limit(&self) -> Option<i64> {
-        if !self.config.auto_compact_enabled {
-            return None;
-        }
         self.config.model_auto_compact_token_limit.or_else(|| {
             get_model_info(&self.config.model_family).and_then(|info| info.auto_compact_token_limit)
         })
+    }
+
+    pub fn get_auto_compact_mode(&self) -> AutoCompactMode {
+        self.config.auto_compact_mode
     }
 
     /// Dispatches to either the Responses or Chat implementation depending on

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1864,24 +1864,7 @@ pub(crate) async fn run_task(
                     }
                 }
 
-                if context_window_reached {
-                    let limit_str = model_context_window
-                        .map(|limit| limit.to_string())
-                        .unwrap_or_else(|| "unknown".to_string());
-                    let current_tokens = total_usage_tokens
-                        .map(|tokens| tokens.to_string())
-                        .unwrap_or_else(|| "unknown".to_string());
-                    let event = Event {
-                        id: sub_id.clone(),
-                        msg: EventMsg::Error(ErrorEvent {
-                            message: format!(
-                                "Conversation reached the model context window (limit {limit_str}, current {current_tokens}). Lower your auto-compaction threshold under /auto-compact or start a new session."
-                            ),
-                        }),
-                    };
-                    sess.send_event(event).await;
-                    break;
-                } else if auto_compact_threshold_reached {
+                if auto_compact_threshold_reached {
                     let limit_str = auto_compact_threshold
                         .map(|limit| limit.to_string())
                         .unwrap_or_else(|| "unknown".to_string());
@@ -1923,6 +1906,23 @@ pub(crate) async fn run_task(
                             break;
                         }
                     }
+                } else if context_window_reached {
+                    let limit_str = model_context_window
+                        .map(|limit| limit.to_string())
+                        .unwrap_or_else(|| "unknown".to_string());
+                    let current_tokens = total_usage_tokens
+                        .map(|tokens| tokens.to_string())
+                        .unwrap_or_else(|| "unknown".to_string());
+                    let event = Event {
+                        id: sub_id.clone(),
+                        msg: EventMsg::Error(ErrorEvent {
+                            message: format!(
+                                "Conversation reached the model context window (limit {limit_str}, current {current_tokens}). Lower your auto-compaction threshold under /auto-compact or start a new session."
+                            ),
+                        }),
+                    };
+                    sess.send_event(event).await;
+                    break;
                 }
 
                 auto_retry_in_progress = false;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -63,7 +63,6 @@ use crate::openai_model_info::get_model_info;
 use crate::openai_tools::ToolsConfig;
 use crate::openai_tools::ToolsConfigParams;
 use crate::parse_command::parse_command;
-use crate::plan_tool::handle_update_plan;
 use crate::project_doc::get_user_instructions;
 use crate::protocol::AgentMessageDeltaEvent;
 use crate::protocol::AgentReasoningDeltaEvent;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1124,7 +1124,7 @@ impl Drop for Session {
 async fn submission_loop(
     sess: Arc<Session>,
     turn_context: TurnContext,
-    config: Arc<Config>,
+    mut config: Arc<Config>,
     rx_sub: Receiver<Submission>,
 ) {
     // Wrap once to avoid cloning TurnContext for each task.
@@ -1143,6 +1143,7 @@ async fn submission_loop(
                 model,
                 effort,
                 summary,
+                auto_compact,
             } => {
                 // Recalculate the persistent turn context with provided overrides.
                 let prev = Arc::clone(&turn_context);
@@ -1165,6 +1166,10 @@ async fn submission_loop(
 
                 // Build updated config for the client
                 let mut updated_config = (*config).clone();
+                if let Some(auto_compact_enabled) = auto_compact {
+                    updated_config.auto_compact_enabled = auto_compact_enabled;
+                    Arc::make_mut(&mut config).auto_compact_enabled = auto_compact_enabled;
+                }
                 updated_config.model = effective_model.clone();
                 updated_config.model_family = effective_family.clone();
                 if let Some(model_info) = get_model_info(&effective_family) {

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1195,7 +1195,7 @@ impl Config {
             .or_else(|| {
                 openai_model_info
                     .as_ref()
-                    .and_then(|info| info.auto_compact_token_limit)
+                    .map(|info| info.auto_compact_token_limit)
             });
 
         // Load base instructions override from a file if specified. If the

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -83,6 +83,9 @@ pub struct Config {
     /// Token usage threshold triggering auto-compaction of conversation history.
     pub model_auto_compact_token_limit: Option<i64>,
 
+    /// When `false`, automatic compaction is disabled even if a token limit is set.
+    pub auto_compact_enabled: bool,
+
     /// Key into the model_providers map that specifies which provider to use.
     pub model_provider_id: String,
 
@@ -709,6 +712,9 @@ pub struct ConfigToml {
     /// Token usage threshold triggering auto-compaction of conversation history.
     pub model_auto_compact_token_limit: Option<i64>,
 
+    /// Enable or disable automatic conversation compaction.
+    pub auto_compact: Option<bool>,
+
     /// Default approval policy for executing commands.
     pub approval_policy: Option<AskForApproval>,
 
@@ -1083,6 +1089,10 @@ impl Config {
                 .as_ref()
                 .and_then(|info| info.auto_compact_token_limit)
         });
+        let auto_compact_enabled = config_profile
+            .auto_compact
+            .or(cfg.auto_compact)
+            .unwrap_or(true);
 
         // Load base instructions override from a file if specified. If the
         // path is relative, resolve it against the effective cwd so the
@@ -1107,6 +1117,7 @@ impl Config {
             model_context_window,
             model_max_output_tokens,
             model_auto_compact_token_limit,
+            auto_compact_enabled,
             model_provider_id,
             model_provider,
             cwd: resolved_cwd,
@@ -2046,6 +2057,7 @@ model_verbosity = "high"
                 model_context_window: Some(200_000),
                 model_max_output_tokens: Some(100_000),
                 model_auto_compact_token_limit: None,
+                auto_compact_enabled: true,
                 model_provider_id: "openai".to_string(),
                 model_provider: fixture.openai_provider.clone(),
                 approval_policy: AskForApproval::Never,
@@ -2109,6 +2121,7 @@ model_verbosity = "high"
             model_context_window: Some(16_385),
             model_max_output_tokens: Some(4_096),
             model_auto_compact_token_limit: None,
+            auto_compact_enabled: true,
             model_provider_id: "openai-chat-completions".to_string(),
             model_provider: fixture.openai_chat_completions_provider.clone(),
             approval_policy: AskForApproval::UnlessTrusted,
@@ -2187,6 +2200,7 @@ model_verbosity = "high"
             model_context_window: Some(200_000),
             model_max_output_tokens: Some(100_000),
             model_auto_compact_token_limit: None,
+            auto_compact_enabled: true,
             model_provider_id: "openai".to_string(),
             model_provider: fixture.openai_provider.clone(),
             approval_policy: AskForApproval::OnFailure,
@@ -2251,6 +2265,7 @@ model_verbosity = "high"
             model_context_window: Some(272_000),
             model_max_output_tokens: Some(128_000),
             model_auto_compact_token_limit: None,
+            auto_compact_enabled: true,
             model_provider_id: "openai".to_string(),
             model_provider: fixture.openai_provider.clone(),
             approval_policy: AskForApproval::OnFailure,

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -2293,7 +2293,7 @@ model_verbosity = "high"
             .expect("model info for gpt-3.5-turbo");
 
         assert_eq!(gpt3_profile_config.model, "gpt-3.5-turbo");
-        assert_eq!(gpt3_profile_config.model_family, gpt3_family.clone());
+        assert_eq!(gpt3_profile_config.model_family, gpt3_family);
         assert_eq!(gpt3_profile_config.model_context_window, Some(16_385));
         assert_eq!(gpt3_profile_config.model_max_output_tokens, Some(4_096));
         assert_eq!(
@@ -2307,7 +2307,7 @@ model_verbosity = "high"
         );
         assert_eq!(
             gpt3_profile_config.model_provider,
-            fixture.openai_chat_completions_provider.clone()
+            fixture.openai_chat_completions_provider
         );
         assert_eq!(
             gpt3_profile_config.approval_policy,

--- a/codex-rs/core/src/config_profile.rs
+++ b/codex-rs/core/src/config_profile.rs
@@ -15,6 +15,8 @@ pub struct ConfigProfile {
     /// [`ModelProviderInfo`] to use.
     pub model_provider: Option<String>,
     pub approval_policy: Option<AskForApproval>,
+    /// Override for automatic conversation compaction.
+    pub auto_compact: Option<bool>,
     pub model_reasoning_effort: Option<ReasoningEffort>,
     pub model_reasoning_summary: Option<ReasoningSummary>,
     pub model_verbosity: Option<Verbosity>,

--- a/codex-rs/core/src/config_profile.rs
+++ b/codex-rs/core/src/config_profile.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 use std::path::PathBuf;
 
+use crate::config::AutoCompactToml;
 use crate::protocol::AskForApproval;
 use codex_protocol::config_types::ReasoningEffort;
 use codex_protocol::config_types::ReasoningSummary;
@@ -16,7 +17,8 @@ pub struct ConfigProfile {
     pub model_provider: Option<String>,
     pub approval_policy: Option<AskForApproval>,
     /// Override for automatic conversation compaction.
-    pub auto_compact: Option<bool>,
+    #[serde(default)]
+    pub auto_compact: Option<AutoCompactToml>,
     pub model_reasoning_effort: Option<ReasoningEffort>,
     pub model_reasoning_summary: Option<ReasoningSummary>,
     pub model_verbosity: Option<Verbosity>,

--- a/codex-rs/core/src/git_info.rs
+++ b/codex-rs/core/src/git_info.rs
@@ -816,9 +816,13 @@ mod tests {
             .expect("Should collect git info from repo");
 
         // Should have repository URL
-        assert_eq!(
-            git_info.repository_url,
-            Some("https://github.com/example/repo.git".to_string())
+        let repository_url = git_info
+            .repository_url
+            .expect("repository URL should be present");
+        assert!(
+            repository_url == "https://github.com/example/repo.git"
+                || repository_url == "git@github.com:example/repo.git",
+            "unexpected repository URL: {repository_url}"
         );
     }
 

--- a/codex-rs/core/src/openai_model_info.rs
+++ b/codex-rs/core/src/openai_model_info.rs
@@ -20,12 +20,12 @@ pub(crate) struct ModelInfo {
 
 impl ModelInfo {
     fn new(context_window: u64, max_output_tokens: u64) -> Self {
-        let auto_compact_limit = ((context_window as u128 * 9) / 10).min(i64::MAX as u128) as i64;
+        let auto_compact_token_limit = (context_window as f64 * 0.8) as i64;
 
         Self {
             context_window,
             max_output_tokens,
-            auto_compact_token_limit: auto_compact_limit,
+            auto_compact_token_limit,
         }
     }
 }

--- a/codex-rs/core/tests/suite/cli_stream.rs
+++ b/codex-rs/core/tests/suite/cli_stream.rs
@@ -576,8 +576,9 @@ async fn integration_git_info_unit_test() {
         "Git info should contain repository_url"
     );
     let repo_url = git_info.repository_url.as_ref().unwrap();
-    assert_eq!(
-        repo_url, "https://github.com/example/integration-test.git",
+    assert!(
+        repo_url == "https://github.com/example/integration-test.git"
+            || repo_url == "git@github.com:example/integration-test.git",
         "Repository URL should match what we configured"
     );
 

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -12,6 +12,7 @@ use codex_core::protocol::RolloutLine;
 use codex_protocol::config_types::AutoCompactMode;
 use core_test_support::load_default_config_for_test;
 use core_test_support::skip_if_no_network;
+use core_test_support::skip_if_sandbox;
 use core_test_support::wait_for_event;
 use tempfile::TempDir;
 
@@ -413,7 +414,7 @@ async fn auto_compact_runs_after_token_limit_hit() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn auto_compact_respects_config_toggle() {
-    non_sandbox_test!();
+    skip_if_sandbox!();
 
     let server = start_mock_server().await;
 
@@ -460,7 +461,7 @@ async fn auto_compact_respects_config_toggle() {
     let mut config = load_default_config_for_test(&home);
     config.model_provider = model_provider;
     config.model_auto_compact_token_limit = Some(200_000);
-    config.auto_compact_mode = AutoCompactMode::Off;
+    config.auto_compact_mode = AutoCompactMode::Manual;
     let conversation_manager = ConversationManager::with_auth(CodexAuth::from_api_key("dummy"));
     let codex = conversation_manager
         .new_conversation(config)
@@ -507,7 +508,7 @@ async fn auto_compact_respects_config_toggle() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn auto_compact_override_disables_inline_compaction() {
-    non_sandbox_test!();
+    skip_if_sandbox!();
 
     let server = start_mock_server().await;
 
@@ -580,7 +581,7 @@ async fn auto_compact_override_disables_inline_compaction() {
             model: None,
             effort: None,
             summary: None,
-            auto_compact: Some(AutoCompactMode::Off),
+            auto_compact: Some(AutoCompactMode::Manual),
             auto_compact_limit: None,
         })
         .await
@@ -614,7 +615,7 @@ async fn auto_compact_override_disables_inline_compaction() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn auto_compact_manual_mode_emits_warning_without_compaction() {
-    non_sandbox_test!();
+    skip_if_sandbox!();
 
     let server = start_mock_server().await;
 

--- a/codex-rs/core/tests/suite/model_overrides.rs
+++ b/codex-rs/core/tests/suite/model_overrides.rs
@@ -38,6 +38,7 @@ async fn override_turn_context_does_not_persist_when_config_exists() {
             model: Some("o3".to_string()),
             effort: Some(Some(ReasoningEffort::High)),
             summary: None,
+            auto_compact: None,
         })
         .await
         .expect("submit override");
@@ -78,6 +79,7 @@ async fn override_turn_context_does_not_create_config_file() {
             model: Some("o3".to_string()),
             effort: Some(Some(ReasoningEffort::Medium)),
             summary: None,
+            auto_compact: None,
         })
         .await
         .expect("submit override");

--- a/codex-rs/core/tests/suite/model_overrides.rs
+++ b/codex-rs/core/tests/suite/model_overrides.rs
@@ -39,6 +39,7 @@ async fn override_turn_context_does_not_persist_when_config_exists() {
             effort: Some(Some(ReasoningEffort::High)),
             summary: None,
             auto_compact: None,
+            auto_compact_limit: None,
         })
         .await
         .expect("submit override");
@@ -80,6 +81,7 @@ async fn override_turn_context_does_not_create_config_file() {
             effort: Some(Some(ReasoningEffort::Medium)),
             summary: None,
             auto_compact: None,
+            auto_compact_limit: None,
         })
         .await
         .expect("submit override");

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -442,6 +442,7 @@ async fn overrides_turn_context_but_keeps_cached_prefix_and_key_constant() {
             model: Some("o3".to_string()),
             effort: Some(Some(ReasoningEffort::High)),
             summary: Some(ReasoningSummary::Detailed),
+            auto_compact: None,
         })
         .await
         .unwrap();

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -443,6 +443,7 @@ async fn overrides_turn_context_but_keeps_cached_prefix_and_key_constant() {
             effort: Some(Some(ReasoningEffort::High)),
             summary: Some(ReasoningSummary::Detailed),
             auto_compact: None,
+            auto_compact_limit: None,
         })
         .await
         .unwrap();

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -18,6 +18,10 @@ pub struct Cli {
     #[arg(long, short = 'm')]
     pub model: Option<String>,
 
+    /// Token usage threshold that triggers auto-compaction.
+    #[arg(long = "auto-compact-limit", value_name = "TOKENS")]
+    pub auto_compact_limit: Option<i64>,
+
     #[arg(long = "oss", default_value_t = false)]
     pub oss: bool,
 

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -181,6 +181,8 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         include_view_image_tool: None,
         show_raw_agent_reasoning: oss.then_some(true),
         tools_web_search_request: None,
+        auto_compact_mode: None,
+        auto_compact_threshold_tokens: None,
     };
     // Parse `-c` overrides.
     let cli_kv_overrides = match config_overrides.parse_overrides() {

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -56,6 +56,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         command,
         images,
         model: model_cli_arg,
+        auto_compact_limit,
         oss,
         config_profile,
         full_auto,
@@ -182,7 +183,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         show_raw_agent_reasoning: oss.then_some(true),
         tools_web_search_request: None,
         auto_compact_mode: None,
-        auto_compact_threshold_tokens: None,
+        auto_compact_threshold_tokens: auto_compact_limit,
     };
     // Parse `-c` overrides.
     let cli_kv_overrides = match config_overrides.parse_overrides() {

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -164,6 +164,8 @@ impl CodexToolCallParam {
             include_view_image_tool: None,
             show_raw_agent_reasoning: None,
             tools_web_search_request: None,
+            auto_compact_mode: None,
+            auto_compact_threshold_tokens: None,
         };
 
         let cli_overrides = cli_overrides

--- a/codex-rs/protocol/src/config_types.rs
+++ b/codex-rs/protocol/src/config_types.rs
@@ -45,6 +45,20 @@ pub enum Verbosity {
     High,
 }
 
+#[derive(
+    Debug, Serialize, Deserialize, Default, Clone, Copy, PartialEq, Eq, Display, TS, EnumIter,
+)]
+#[serde(rename_all = "kebab-case")]
+#[strum(serialize_all = "kebab-case")]
+pub enum AutoCompactMode {
+    #[default]
+    Auto,
+    Off,
+    Manual,
+    #[serde(rename = "smart-auto")]
+    SmartAuto,
+}
+
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq, Default, Serialize, Display, TS)]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]

--- a/codex-rs/protocol/src/config_types.rs
+++ b/codex-rs/protocol/src/config_types.rs
@@ -53,10 +53,7 @@ pub enum Verbosity {
 pub enum AutoCompactMode {
     #[default]
     Auto,
-    Off,
     Manual,
-    #[serde(rename = "smart-auto")]
-    SmartAuto,
 }
 
 #[derive(Deserialize, Debug, Clone, Copy, PartialEq, Default, Serialize, Display, TS)]

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -130,6 +130,11 @@ pub enum Op {
         /// Updated auto-compaction mode.
         #[serde(skip_serializing_if = "Option::is_none")]
         auto_compact: Option<AutoCompactMode>,
+
+        /// Updated limit (in tokens) used to trigger auto-compaction. Use `None`
+        /// to revert to the model's default limit.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        auto_compact_limit: Option<Option<i64>>,
     },
 
     /// Approve a command execution

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -125,6 +125,10 @@ pub enum Op {
         /// Updated reasoning summary preference (honored only for reasoning-capable models).
         #[serde(skip_serializing_if = "Option::is_none")]
         summary: Option<ReasoningSummaryConfig>,
+
+        /// Enable or disable automatic conversation compaction.
+        #[serde(skip_serializing_if = "Option::is_none")]
+        auto_compact: Option<bool>,
     },
 
     /// Approve a command execution

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -11,6 +11,7 @@ use std::str::FromStr;
 use std::time::Duration;
 
 use crate::ConversationId;
+use crate::config_types::AutoCompactMode;
 use crate::config_types::ReasoningEffort as ReasoningEffortConfig;
 use crate::config_types::ReasoningSummary as ReasoningSummaryConfig;
 use crate::custom_prompts::CustomPrompt;
@@ -126,9 +127,9 @@ pub enum Op {
         #[serde(skip_serializing_if = "Option::is_none")]
         summary: Option<ReasoningSummaryConfig>,
 
-        /// Enable or disable automatic conversation compaction.
+        /// Updated auto-compaction mode.
         #[serde(skip_serializing_if = "Option::is_none")]
-        auto_compact: Option<bool>,
+        auto_compact: Option<AutoCompactMode>,
     },
 
     /// Approve a command execution

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -678,11 +678,11 @@ impl TokenUsage {
         self.non_cached_input() + self.output_tokens
     }
 
-    /// Returns the tokens currently occupying the model context window. Providers
-    /// report this via the input token count, which already accounts for any
-    /// cached segments and excludes generated output.
+    /// Returns the tokens currently occupying the model context window. This includes
+    /// all prompt tokens (even if cached) plus the assistant's output tokens because
+    /// both must be present for the next turn.
     pub fn tokens_in_context_window(&self) -> u64 {
-        self.input_tokens
+        self.input_tokens.saturating_add(self.output_tokens)
     }
 
     /// Estimate the remaining user-controllable percentage of the model's context window.

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -678,13 +678,11 @@ impl TokenUsage {
         self.non_cached_input() + self.output_tokens
     }
 
-    /// For estimating what % of the model's context window is used, we need to account
-    /// for reasoning output tokens from prior turns being dropped from the context window.
-    /// We approximate this here by subtracting reasoning output tokens from the total.
-    /// This will be off for the current turn and pending function calls.
+    /// Returns the tokens currently occupying the model context window. Providers
+    /// report this via the input token count, which already accounts for any
+    /// cached segments and excludes generated output.
     pub fn tokens_in_context_window(&self) -> u64 {
-        self.total_tokens
-            .saturating_sub(self.reasoning_output_tokens)
+        self.input_tokens
     }
 
     /// Estimate the remaining user-controllable percentage of the model's context window.

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -372,17 +372,13 @@ impl App {
             AppEvent::UpdateSandboxPolicy(policy) => {
                 self.chat_widget.set_sandbox_policy(policy);
             }
-            AppEvent::UpdateAutoCompactEnabled(enabled) => {
-                let changed = self.config.auto_compact_enabled != enabled;
-                self.chat_widget.set_auto_compact_enabled(enabled);
-                self.config.auto_compact_enabled = enabled;
+            AppEvent::UpdateAutoCompactMode(mode) => {
+                let changed = self.config.auto_compact_mode != mode;
+                self.chat_widget.set_auto_compact_mode(mode);
+                self.config.auto_compact_mode = mode;
                 if changed {
-                    let message = if enabled {
-                        "Auto-compact enabled"
-                    } else {
-                        "Auto-compact disabled"
-                    };
-                    self.chat_widget.add_info_message(message.to_string(), None);
+                    let message = format!("Auto-compact mode set to {}", mode);
+                    self.chat_widget.add_info_message(message, None);
                 }
             }
             AppEvent::OpenReviewBranchPicker(cwd) => {

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -372,6 +372,19 @@ impl App {
             AppEvent::UpdateSandboxPolicy(policy) => {
                 self.chat_widget.set_sandbox_policy(policy);
             }
+            AppEvent::UpdateAutoCompactEnabled(enabled) => {
+                let changed = self.config.auto_compact_enabled != enabled;
+                self.chat_widget.set_auto_compact_enabled(enabled);
+                self.config.auto_compact_enabled = enabled;
+                if changed {
+                    let message = if enabled {
+                        "Auto-compact enabled"
+                    } else {
+                        "Auto-compact disabled"
+                    };
+                    self.chat_widget.add_info_message(message.to_string(), None);
+                }
+            }
             AppEvent::OpenReviewBranchPicker(cwd) => {
                 self.chat_widget.show_review_branch_picker(&cwd).await;
             }

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -22,6 +22,7 @@ use codex_core::protocol::SessionSource;
 use codex_core::protocol::TokenUsage;
 use codex_core::protocol_config_types::ReasoningEffort as ReasoningEffortConfig;
 use codex_protocol::ConversationId;
+use codex_protocol::num_format::format_with_separators;
 use color_eyre::eyre::Result;
 use color_eyre::eyre::WrapErr;
 use crossterm::event::KeyCode;
@@ -380,6 +381,24 @@ impl App {
                     let message = format!("Auto-compact mode set to {}", mode);
                     self.chat_widget.add_info_message(message, None);
                 }
+            }
+            AppEvent::UpdateAutoCompactLimit(limit) => {
+                let changed = self.config.model_auto_compact_token_limit != limit;
+                self.chat_widget.set_auto_compact_limit(limit);
+                self.config.model_auto_compact_token_limit = limit;
+                if changed {
+                    let message = match limit {
+                        Some(tokens) => {
+                            let formatted = format_with_separators(tokens.max(0) as u64);
+                            format!("Auto-compact limit set to {formatted} tokens")
+                        }
+                        None => "Auto-compact limit reset to the model default".to_string(),
+                    };
+                    self.chat_widget.add_info_message(message, None);
+                }
+            }
+            AppEvent::OpenAutoCompactLimitEditor => {
+                self.chat_widget.show_auto_compact_limit_editor();
             }
             AppEvent::OpenReviewBranchPicker(cwd) => {
                 self.chat_widget.show_review_branch_picker(&cwd).await;

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -77,6 +77,12 @@ pub(crate) enum AppEvent {
     /// Update the auto-compaction mode for the session.
     UpdateAutoCompactMode(AutoCompactMode),
 
+    /// Update (or clear) the token limit that triggers auto-compaction.
+    UpdateAutoCompactLimit(Option<i64>),
+
+    /// Open the editor that lets the user set a custom auto-compaction limit.
+    OpenAutoCompactLimitEditor,
+
     /// Forwarded conversation history snapshot from the current conversation.
     ConversationHistory(ConversationPathResponseEvent),
 

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -73,6 +73,9 @@ pub(crate) enum AppEvent {
     /// Update the current sandbox policy in the running app and widget.
     UpdateSandboxPolicy(SandboxPolicy),
 
+    /// Update whether automatic compaction is enabled for the session.
+    UpdateAutoCompactEnabled(bool),
+
     /// Forwarded conversation history snapshot from the current conversation.
     ConversationHistory(ConversationPathResponseEvent),
 

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -4,6 +4,7 @@ use codex_common::model_presets::ModelPreset;
 use codex_core::protocol::ConversationPathResponseEvent;
 use codex_core::protocol::Event;
 use codex_file_search::FileMatch;
+use codex_protocol::config_types::AutoCompactMode;
 
 use crate::bottom_pane::ApprovalRequest;
 use crate::history_cell::HistoryCell;
@@ -73,8 +74,8 @@ pub(crate) enum AppEvent {
     /// Update the current sandbox policy in the running app and widget.
     UpdateSandboxPolicy(SandboxPolicy),
 
-    /// Update whether automatic compaction is enabled for the session.
-    UpdateAutoCompactEnabled(bool),
+    /// Update the auto-compaction mode for the session.
+    UpdateAutoCompactMode(AutoCompactMode),
 
     /// Forwarded conversation history snapshot from the current conversation.
     ConversationHistory(ConversationPathResponseEvent),

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1846,6 +1846,7 @@ impl ChatWidget {
         // Allow editing the custom limit
         items.push(SelectionItem {
             name: "Use custom token limit…".to_string(),
+            display_shortcut: None,
             description: Some(custom_description),
             is_current: has_custom_limit,
             actions: vec![Box::new(|tx| {
@@ -1858,6 +1859,7 @@ impl ChatWidget {
         // Allow clearing the custom limit
         items.push(SelectionItem {
             name: "Use model default limit".to_string(),
+            display_shortcut: None,
             description: Some(
                 "Clear the custom threshold and rely on the model's default.".to_string(),
             ),
@@ -1909,6 +1911,7 @@ impl ChatWidget {
             })];
             items.push(SelectionItem {
                 name: (*label).to_string(),
+                display_shortcut: None,
                 description: Some((*description).to_string()),
                 is_current,
                 actions,
@@ -1918,12 +1921,12 @@ impl ChatWidget {
         }
 
         self.bottom_pane.show_selection_view(SelectionViewParams {
-            title: "Auto-compact".to_string(),
+            title: Some("Auto-compact".to_string()),
             subtitle: Some(format!(
                 "{} Select a mode or adjust the limit to fit your workflow.",
                 limit_caption
             )),
-            footer_hint: Some(STANDARD_POPUP_HINT_LINE.to_string()),
+            footer_hint: Some(standard_popup_hint_line()),
             items,
             ..Default::default()
         });

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1890,16 +1890,6 @@ impl ChatWidget {
                 "Manual",
                 "Warn when the limit is reached but wait for you to run /compact.",
             ),
-            (
-                AutoCompactMode::Off,
-                "Off",
-                "Never summarize automatically; rely on /compact or new sessions.",
-            ),
-            (
-                AutoCompactMode::SmartAuto,
-                "Smart auto",
-                "Reserved for future adaptive compaction behaviour (acts like auto).",
-            ),
         ];
 
         for (mode, label, description) in options {

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -31,6 +31,10 @@ pub struct Cli {
     #[arg(long, short = 'm')]
     pub model: Option<String>,
 
+    /// Token usage threshold that triggers auto-compaction.
+    #[arg(long = "auto-compact-limit", value_name = "TOKENS")]
+    pub auto_compact_limit: Option<i64>,
+
     /// Convenience flag to select the local open source model provider.
     /// Equivalent to -c model_provider=oss; verifies a local Ollama server is
     /// running.

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -149,7 +149,7 @@ pub async fn run_main(
         show_raw_agent_reasoning: cli.oss.then_some(true),
         tools_web_search_request: cli.web_search.then_some(true),
         auto_compact_mode: None,
-        auto_compact_threshold_tokens: None,
+        auto_compact_threshold_tokens: cli.auto_compact_limit,
     };
     let raw_overrides = cli.config_overrides.raw_overrides.clone();
     let overrides_cli = codex_common::CliConfigOverrides { raw_overrides };

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -148,6 +148,8 @@ pub async fn run_main(
         include_view_image_tool: None,
         show_raw_agent_reasoning: cli.oss.then_some(true),
         tools_web_search_request: cli.web_search.then_some(true),
+        auto_compact_mode: None,
+        auto_compact_threshold_tokens: None,
     };
     let raw_overrides = cli.config_overrides.raw_overrides.clone();
     let overrides_cli = codex_common::CliConfigOverrides { raw_overrides };

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -45,7 +45,7 @@ impl SlashCommand {
             SlashCommand::Status => "show current session configuration and token usage",
             SlashCommand::Model => "choose what model and reasoning effort to use",
             SlashCommand::Approvals => "choose what Codex can do without approval",
-            SlashCommand::AutoCompact => "toggle automatic conversation summarization",
+            SlashCommand::AutoCompact => "configure automatic conversation summarization",
             SlashCommand::Mcp => "list configured MCP tools",
             SlashCommand::Logout => "log out of Codex",
             #[cfg(debug_assertions)]

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -14,6 +14,7 @@ pub enum SlashCommand {
     // more frequently used commands should be listed first.
     Model,
     Approvals,
+    AutoCompact,
     Review,
     New,
     Init,
@@ -44,6 +45,7 @@ impl SlashCommand {
             SlashCommand::Status => "show current session configuration and token usage",
             SlashCommand::Model => "choose what model and reasoning effort to use",
             SlashCommand::Approvals => "choose what Codex can do without approval",
+            SlashCommand::AutoCompact => "toggle automatic conversation summarization",
             SlashCommand::Mcp => "list configured MCP tools",
             SlashCommand::Logout => "log out of Codex",
             #[cfg(debug_assertions)]
@@ -66,6 +68,7 @@ impl SlashCommand {
             | SlashCommand::Undo
             | SlashCommand::Model
             | SlashCommand::Approvals
+            | SlashCommand::AutoCompact
             | SlashCommand::Review
             | SlashCommand::Logout => false,
             SlashCommand::Diff

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -15,6 +15,7 @@ pub enum SlashCommand {
     Model,
     Approvals,
     AutoCompact,
+    AutoCompactLimit,
     Review,
     New,
     Init,
@@ -46,6 +47,9 @@ impl SlashCommand {
             SlashCommand::Model => "choose what model and reasoning effort to use",
             SlashCommand::Approvals => "choose what Codex can do without approval",
             SlashCommand::AutoCompact => "configure automatic conversation summarization",
+            SlashCommand::AutoCompactLimit => {
+                "set a custom token limit for automatic summarization"
+            }
             SlashCommand::Mcp => "list configured MCP tools",
             SlashCommand::Logout => "log out of Codex",
             #[cfg(debug_assertions)]
@@ -69,6 +73,7 @@ impl SlashCommand {
             | SlashCommand::Model
             | SlashCommand::Approvals
             | SlashCommand::AutoCompact
+            | SlashCommand::AutoCompactLimit
             | SlashCommand::Review
             | SlashCommand::Logout => false,
             SlashCommand::Diff

--- a/docs/config.md
+++ b/docs/config.md
@@ -736,6 +736,23 @@ In general, Codex knows the context window for the most common OpenAI models, bu
 
 This is analogous to `model_context_window`, but for the maximum number of output tokens for the model.
 
+## auto_compact
+
+Codex can automatically summarize the current conversation when token usage crosses a safety threshold. By default the threshold is derived from the selected model family, but you can override it with `model_auto_compact_token_limit`.
+
+- `model_auto_compact_token_limit` sets a custom token threshold. When omitted, Codex uses the provider's recommended limit.
+- `auto_compact` controls whether automatic summarization runs when the threshold is exceeded. It defaults to `true`.
+
+```toml
+# Disable automatic summarization; `/compact` remains available.
+auto_compact = false
+
+# Optional custom threshold (tokens in the model's context window)
+model_auto_compact_token_limit = 200_000
+```
+
+You can also toggle this behaviour at runtime from the TUI with the `/auto-compact` slash command.
+
 ## project_doc_max_bytes
 
 Maximum number of bytes to read from an `AGENTS.md` file to include in the instructions sent with the first turn of a session. Defaults to 32 KiB.
@@ -778,6 +795,8 @@ notifications = [ "agent-turn-complete", "approval-requested" ]
 | `model_provider`                                 | string                                                            | Provider id from `model_providers` (default: `openai`).                                                                    |
 | `model_context_window`                           | number                                                            | Context window tokens.                                                                                                     |
 | `model_max_output_tokens`                        | number                                                            | Max output tokens.                                                                                                         |
+| `model_auto_compact_token_limit` | number | Token threshold for automatic summarization. |
+| `auto_compact` | boolean | Enable/disable automatic summarization (default: true). |
 | `approval_policy`                                | `untrusted` \| `on-failure` \| `on-request` \| `never`            | When to prompt for approval.                                                                                               |
 | `sandbox_mode`                                   | `read-only` \| `workspace-write` \| `danger-full-access`          | OS sandbox policy.                                                                                                         |
 | `sandbox_workspace_write.writable_roots`         | array<string>                                                     | Extra writable roots in workspace‑write.                                                                                   |

--- a/docs/config.md
+++ b/docs/config.md
@@ -740,16 +740,16 @@ This is analogous to `model_context_window`, but for the maximum number of outpu
 
 Codex can automatically summarize the current conversation when token usage crosses a safety threshold. By default the threshold is derived from the selected model family, but you can override both the mode and the token trigger.
 
-- `[autocompact].mode` accepts `"auto"`, `"manual"`, `"off"`, or `"smart-auto"` (currently behaves like `auto`). The default is `auto`.
+- `[autocompact].mode` accepts `"auto"` or `"manual"` (default: `auto`). Legacy values `"smart-auto"` and `"off"` continue to work and are interpreted as `auto` and `manual` respectively.
 - `[autocompact].threshold_tokens` lets you set a custom token limit for triggering compaction. When omitted, Codex uses the provider's recommended limit (you can also continue to use the legacy `model_auto_compact_token_limit` key).
 
 ```toml
 [autocompact]
-mode = "manual"           # auto | manual | off | smart-auto
+mode = "manual"           # auto | manual
 threshold_tokens = 240_000 # optional per-model override
 ```
 
-When `mode = "manual"`, Codex emits a warning once the limit is reached but waits for you to run `/compact`. `mode = "off"` prevents automatic summarization entirely. You can adjust the active mode at runtime from the TUI with the `/auto-compact` slash command.
+When `mode = "manual"`, Codex emits a warning once the limit is reached but waits for you to run `/compact`. You can adjust the active mode at runtime from the TUI with the `/auto-compact` slash command.
 
 ## project_doc_max_bytes
 
@@ -794,7 +794,7 @@ notifications = [ "agent-turn-complete", "approval-requested" ]
 | `model_context_window`                           | number                                                            | Context window tokens.                                                                                                     |
 | `model_max_output_tokens`                        | number                                                            | Max output tokens.                                                                                                         |
 | `model_auto_compact_token_limit` | number | Token threshold for automatic summarization (legacy alias). |
-| `autocompact.mode` | `auto` \| `manual` \| `off` \| `smart-auto` | Control when Codex summarizes automatically. |
+| `autocompact.mode` | `auto` \| `manual` | Control when Codex summarizes automatically. |
 | `autocompact.threshold_tokens` | number | Custom token threshold before auto-compaction triggers. |
 | `approval_policy`                                | `untrusted` \| `on-failure` \| `on-request` \| `never`            | When to prompt for approval.                                                                                               |
 | `sandbox_mode`                                   | `read-only` \| `workspace-write` \| `danger-full-access`          | OS sandbox policy.                                                                                                         |

--- a/docs/config.md
+++ b/docs/config.md
@@ -738,20 +738,18 @@ This is analogous to `model_context_window`, but for the maximum number of outpu
 
 ## auto_compact
 
-Codex can automatically summarize the current conversation when token usage crosses a safety threshold. By default the threshold is derived from the selected model family, but you can override it with `model_auto_compact_token_limit`.
+Codex can automatically summarize the current conversation when token usage crosses a safety threshold. By default the threshold is derived from the selected model family, but you can override both the mode and the token trigger.
 
-- `model_auto_compact_token_limit` sets a custom token threshold. When omitted, Codex uses the provider's recommended limit.
-- `auto_compact` controls whether automatic summarization runs when the threshold is exceeded. It defaults to `true`.
+- `[autocompact].mode` accepts `"auto"`, `"manual"`, `"off"`, or `"smart-auto"` (currently behaves like `auto`). The default is `auto`.
+- `[autocompact].threshold_tokens` lets you set a custom token limit for triggering compaction. When omitted, Codex uses the provider's recommended limit (you can also continue to use the legacy `model_auto_compact_token_limit` key).
 
 ```toml
-# Disable automatic summarization; `/compact` remains available.
-auto_compact = false
-
-# Optional custom threshold (tokens in the model's context window)
-model_auto_compact_token_limit = 200_000
+[autocompact]
+mode = "manual"           # auto | manual | off | smart-auto
+threshold_tokens = 240_000 # optional per-model override
 ```
 
-You can also toggle this behaviour at runtime from the TUI with the `/auto-compact` slash command.
+When `mode = "manual"`, Codex emits a warning once the limit is reached but waits for you to run `/compact`. `mode = "off"` prevents automatic summarization entirely. You can adjust the active mode at runtime from the TUI with the `/auto-compact` slash command.
 
 ## project_doc_max_bytes
 
@@ -795,8 +793,9 @@ notifications = [ "agent-turn-complete", "approval-requested" ]
 | `model_provider`                                 | string                                                            | Provider id from `model_providers` (default: `openai`).                                                                    |
 | `model_context_window`                           | number                                                            | Context window tokens.                                                                                                     |
 | `model_max_output_tokens`                        | number                                                            | Max output tokens.                                                                                                         |
-| `model_auto_compact_token_limit` | number | Token threshold for automatic summarization. |
-| `auto_compact` | boolean | Enable/disable automatic summarization (default: true). |
+| `model_auto_compact_token_limit` | number | Token threshold for automatic summarization (legacy alias). |
+| `autocompact.mode` | `auto` \| `manual` \| `off` \| `smart-auto` | Control when Codex summarizes automatically. |
+| `autocompact.threshold_tokens` | number | Custom token threshold before auto-compaction triggers. |
 | `approval_policy`                                | `untrusted` \| `on-failure` \| `on-request` \| `never`            | When to prompt for approval.                                                                                               |
 | `sandbox_mode`                                   | `read-only` \| `workspace-write` \| `danger-full-access`          | OS sandbox policy.                                                                                                         |
 | `sandbox_workspace_write.writable_roots`         | array<string>                                                     | Extra writable roots in workspace‑write.                                                                                   |


### PR DESCRIPTION
Hopefully, this can resolve #4106 but it  needs some proper testing from PR reviewers

  - Add configurable auto-compaction mode and limit overrides (CLI flag, slash command, TUI picker) with persistence to config.toml.
  - Teach the runtime to retry turns after inline summarization and surface clearer limit/context-window errors.
  - Update core/tests to cover manual mode, retry flows, and rollout persistence; document the new config options.


Also supersedes #4546