### PR TITLE
fix: pnpm/action-setup@v4 should run before actions/setup-node@v5

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -216,15 +216,18 @@ jobs:
             echo "npm_tag=" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Setup Node.js for npm packaging
         uses: actions/setup-node@v5
         with:
           node-version: 22
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v3
-        with:
-          version: 9
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       # stage_npm_packages.py requires DotSlash when staging releases.
       - uses: facebook/install-dotslash@v2


### PR DESCRIPTION
`rust-release.yml` just failed:

https://github.com/openai/codex/actions/runs/18167317356/job/51714366768

The error is:

> Error: Unable to locate executable file: pnpm. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable. Also check the file mode to verify the file is executable.

We need to install `pnpm` first like we do in `ci.yml`:

https://github.com/openai/codex/blob/f815157dd9d02377f827c0b6cd1cd1d0386461f8/.github/workflows/ci.yml#L17-L25