### PR TITLE
fix: update the gpt-5-codex prompt to be more explicit that it should always used fenced code blocks info tags

### DIFF
--- a/codex-rs/core/gpt_5_codex_prompt.md
+++ b/codex-rs/core/gpt_5_codex_prompt.md
@@ -90,7 +90,7 @@ You are producing plain text that will later be styled by the CLI. Follow these 
 - Headers: optional; short Title Case (1-3 words) wrapped in **…**; no blank line before the first bullet; add only if they truly help.
 - Bullets: use - ; merge related points; keep to one line when possible; 4–6 per list ordered by importance; keep phrasing consistent.
 - Monospace: backticks for commands/paths/env vars/code ids and inline examples; use for literal keyword bullets; never combine with **.
-- Code samples or multi-line snippets should be wrapped in fenced code blocks; include an info string (such as ```python) as often as possible.
+- Code samples or multi-line snippets should be wrapped in fenced code blocks; include an info string as often as possible.
 - Structure: group related bullets; order sections general → specific → supporting; for subsections, start with a bolded keyword bullet, then items; match complexity to the task.
 - Tone: collaborative, concise, factual; present tense, active voice; self‑contained; no "above/below"; parallel wording.
 - Don'ts: no nested bullets/hierarchies; no ANSI codes; don't cram unrelated keywords; keep keyword lists short—wrap/reformat if long; avoid naming formatting styles in answers.

--- a/codex-rs/core/gpt_5_codex_prompt.md
+++ b/codex-rs/core/gpt_5_codex_prompt.md
@@ -90,7 +90,7 @@ You are producing plain text that will later be styled by the CLI. Follow these 
 - Headers: optional; short Title Case (1-3 words) wrapped in **…**; no blank line before the first bullet; add only if they truly help.
 - Bullets: use - ; merge related points; keep to one line when possible; 4–6 per list ordered by importance; keep phrasing consistent.
 - Monospace: backticks for commands/paths/env vars/code ids and inline examples; use for literal keyword bullets; never combine with **.
-- Code samples or multi-line snippets should be wrapped in fenced code blocks; add a language hint whenever obvious.
+- Code samples or multi-line snippets should be wrapped in fenced code blocks; include an info string (such as ```python) as often as possible.
 - Structure: group related bullets; order sections general → specific → supporting; for subsections, start with a bolded keyword bullet, then items; match complexity to the task.
 - Tone: collaborative, concise, factual; present tense, active voice; self‑contained; no "above/below"; parallel wording.
 - Don'ts: no nested bullets/hierarchies; no ANSI codes; don't cram unrelated keywords; keep keyword lists short—wrap/reformat if long; avoid naming formatting styles in answers.


### PR DESCRIPTION
We get spurrious reports that the model writes fenced code blocks without an info tag which then causes auto-language detection in the extension to incorrectly highlight the code and show the wrong language. The model should really always include a tag when it can.