### PR TITLE
fix: use `number` instead of `bigint` for the generated TS for RequestId

### DIFF
--- a/codex-rs/app-server-protocol/src/jsonrpc_lite.rs
+++ b/codex-rs/app-server-protocol/src/jsonrpc_lite.rs
@@ -11,6 +11,7 @@ pub const JSONRPC_VERSION: &str = "2.0";
 #[serde(untagged)]
 pub enum RequestId {
     String(String),
+    #[ts(type = "number")]
     Integer(i64),
 }
 


### PR DESCRIPTION
Before this PR:

```typescript
export type RequestId = string | bigint;
```

After:

```typescript
export type RequestId = string | number;
```

`bigint` introduces headaches in TypeScript without providing any real value.