### PR TITLE
Retry on plan mismatch

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -1413,7 +1413,7 @@ mod tests {
         use std::path::PathBuf;
         use std::sync::Arc;
 
-        let mut auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
+        let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
         if let Some(auth_json) = auth.auth_dot_json.lock().unwrap().as_mut()
             && let Some(tokens) = auth_json.tokens.as_mut()
         {


### PR DESCRIPTION
Currently, we store the login token with its information on disk. In case the user's plan changed, we don't know unless the token is refreshed or they logged out.

This PR attempt to refresh token when we have `ratelimit` error and plan mismatch (between disk and server). This helps the UI render up to date information when the user needs it.