### PR TITLE
Fix status usage ratio

### DIFF
--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -152,7 +152,7 @@ impl StatusHistoryCell {
             Span::from(format!("{percent}% left")),
             Span::from(" (").dim(),
             Span::from(used_fmt).dim(),
-            Span::from(" / ").dim(),
+            Span::from(" used / ").dim(),
             Span::from(window_fmt).dim(),
             Span::from(")").dim(),
         ])

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -302,8 +302,8 @@ impl HistoryCell for StatusHistoryCell {
         }
 
         lines.push(Line::from(Vec::<Span<'static>>::new()));
-        // Only show token usage when using an API key
-        if matches!(self.account, Some(StatusAccountDisplay::ApiKey)) {
+        // Hide token usage only for ChatGPT subscribers
+        if !matches!(self.account, Some(StatusAccountDisplay::ChatGpt { .. })) {
             lines.push(formatter.line("Token usage", self.token_usage_spans()));
         }
 

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -302,7 +302,10 @@ impl HistoryCell for StatusHistoryCell {
         }
 
         lines.push(Line::from(Vec::<Span<'static>>::new()));
-        lines.push(formatter.line("Token usage", self.token_usage_spans()));
+        // Only show token usage when using an API key
+        if matches!(self.account, Some(StatusAccountDisplay::ApiKey)) {
+            lines.push(formatter.line("Token usage", self.token_usage_spans()));
+        }
 
         if let Some(spans) = self.context_window_spans() {
             lines.push(formatter.line("Context window", spans));

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
@@ -13,6 +13,7 @@ expression: sanitized
 │  Sandbox:          read-only                                               │
 │  Agents.md:        <none>                                                  │
 │                                                                            │
+│  Token usage:      1.2K total  (800 input + 400 output)                    │
 │  Context window:   100% left (1.2K used / 272K)                            │
 │  Monthly limit:    [██░░░░░░░░░░░░░░░░░░] 12% used (resets 07:08 on 7 May) │
 ╰────────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
@@ -13,7 +13,6 @@ expression: sanitized
 │  Sandbox:          read-only                                               │
 │  Agents.md:        <none>                                                  │
 │                                                                            │
-│  Token usage:      1.2K total  (800 input + 400 output)                    │
-│  Context window:   100% left (1.2K / 272K)                                 │
+│  Context window:   100% left (1.2K used / 272K)                            │
 │  Monthly limit:    [██░░░░░░░░░░░░░░░░░░] 12% used (resets 07:08 on 7 May) │
 ╰────────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
@@ -13,6 +13,7 @@ expression: sanitized
 │  Sandbox:          workspace-write                                  │
 │  Agents.md:        <none>                                           │
 │                                                                     │
+│  Token usage:      1.9K total  (1K input + 900 output)              │
 │  Context window:   100% left (2.1K used / 272K)                     │
 │  5h limit:         [███████████████░░░░░] 72% used (resets 03:14)   │
 │  Weekly limit:     [█████████░░░░░░░░░░░] 45% used (resets 03:24)   │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
@@ -13,8 +13,7 @@ expression: sanitized
 │  Sandbox:          workspace-write                                  │
 │  Agents.md:        <none>                                           │
 │                                                                     │
-│  Token usage:      1.9K total  (1K input + 900 output)              │
-│  Context window:   100% left (2.1K / 272K)                          │
+│  Context window:   100% left (2.1K used / 272K)                     │
 │  5h limit:         [███████████████░░░░░] 72% used (resets 03:14)   │
 │  Weekly limit:     [█████████░░░░░░░░░░░] 45% used (resets 03:24)   │
 ╰─────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_empty_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_empty_limits_message.snap
@@ -13,7 +13,6 @@ expression: sanitized
 │  Sandbox:          read-only                                    │
 │  Agents.md:        <none>                                       │
 │                                                                 │
-│  Token usage:      750 total  (500 input + 250 output)          │
-│  Context window:   100% left (750 / 272K)                       │
+│  Context window:   100% left (750 used / 272K)                  │
 │  Limits:           data not available yet                       │
 ╰─────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_empty_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_empty_limits_message.snap
@@ -13,6 +13,7 @@ expression: sanitized
 │  Sandbox:          read-only                                    │
 │  Agents.md:        <none>                                       │
 │                                                                 │
+│  Token usage:      750 total  (500 input + 250 output)          │
 │  Context window:   100% left (750 used / 272K)                  │
 │  Limits:           data not available yet                       │
 ╰─────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
@@ -13,6 +13,7 @@ expression: sanitized
 │  Sandbox:          read-only                                    │
 │  Agents.md:        <none>                                       │
 │                                                                 │
+│  Token usage:      750 total  (500 input + 250 output)          │
 │  Context window:   100% left (750 used / 272K)                  │
 │  Limits:           send a message to load usage data            │
 ╰─────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
@@ -13,7 +13,6 @@ expression: sanitized
 │  Sandbox:          read-only                                    │
 │  Agents.md:        <none>                                       │
 │                                                                 │
-│  Token usage:      750 total  (500 input + 250 output)          │
-│  Context window:   100% left (750 / 272K)                       │
+│  Context window:   100% left (750 used / 272K)                  │
 │  Limits:           send a message to load usage data            │
 ╰─────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
@@ -13,8 +13,7 @@ expression: sanitized
 │  Sandbox:          read-only               │
 │  Agents.md:        <none>                  │
 │                                            │
-│  Token usage:      1.9K total  (1K input + │
-│  Context window:   100% left (2.1K / 272K) │
+│  Context window:   100% left (2.1K used /  │
 │  5h limit:         [███████████████░░░░░]  │
 │                    (resets 03:14)          │
 ╰────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
@@ -13,6 +13,7 @@ expression: sanitized
 │  Sandbox:          read-only               │
 │  Agents.md:        <none>                  │
 │                                            │
+│  Token usage:      1.9K total  (1K input + │
 │  Context window:   100% left (2.1K used /  │
 │  5h limit:         [███████████████░░░░░]  │
 │                    (resets 03:14)          │

--- a/codex-rs/tui/src/status/tests.rs
+++ b/codex-rs/tui/src/status/tests.rs
@@ -314,7 +314,7 @@ fn status_context_window_uses_last_usage() {
         .expect("context line");
 
     assert!(
-        context_line.contains("13.7K / 272K"),
+        context_line.contains("13.7K used / 272K"),
         "expected context line to reflect last usage tokens, got: {context_line}"
     );
     assert!(


### PR DESCRIPTION
1. Removes "Token usage" line for chatgpt sub users
2. Adds the word "used" to the context window line