### PR TITLE
feat: Add CLI status command (#4493)

### DIFF
--- a/codex-rs/cli/src/lib.rs
+++ b/codex-rs/cli/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod debug_sandbox;
 mod exit_status;
 pub mod login;
+pub mod status;
 
 use clap::Parser;
 use codex_common::CliConfigOverrides;

--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -132,7 +132,7 @@ pub async fn run_logout(cli_config_overrides: CliConfigOverrides) -> ! {
     }
 }
 
-fn load_config_or_exit(cli_config_overrides: CliConfigOverrides) -> Config {
+pub(crate) fn load_config_or_exit(cli_config_overrides: CliConfigOverrides) -> Config {
     let cli_overrides = match cli_config_overrides.parse_overrides() {
         Ok(v) => v,
         Err(e) => {

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -85,6 +85,9 @@ enum Subcommand {
     /// Resume a previous interactive session (picker by default; use --last to continue the most recent).
     Resume(ResumeCommand),
 
+    /// Show current configuration, account, and usage details without launching the TUI.
+    Status(StatusCommand),
+
     /// Internal: generate TypeScript protocol bindings.
     #[clap(hide = true)]
     GenerateTs(GenerateTsCommand),
@@ -168,6 +171,12 @@ enum LoginSubcommand {
 
 #[derive(Debug, Parser)]
 struct LogoutCommand {
+    #[clap(skip)]
+    config_overrides: CliConfigOverrides,
+}
+
+#[derive(Debug, Parser)]
+struct StatusCommand {
     #[clap(skip)]
     config_overrides: CliConfigOverrides,
 }
@@ -280,6 +289,13 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
                 config_overrides,
             );
             codex_tui::run_main(interactive, codex_linux_sandbox_exe).await?;
+        }
+        Some(Subcommand::Status(mut status_cli)) => {
+            prepend_config_flags(
+                &mut status_cli.config_overrides,
+                root_config_overrides.clone(),
+            );
+            codex_cli::status::run_status(status_cli.config_overrides);
         }
         Some(Subcommand::Login(mut login_cli)) => {
             prepend_config_flags(

--- a/codex-rs/cli/src/status.rs
+++ b/codex-rs/cli/src/status.rs
@@ -1,0 +1,180 @@
+use codex_common::CliConfigOverrides;
+use codex_common::create_config_summary_entries;
+use codex_core::protocol::TokenUsage;
+use codex_tui::status::StatusAccountDisplay;
+use codex_tui::status::StatusRateLimitData;
+use codex_tui::status::compose_account_display;
+use codex_tui::status::compose_agents_summary;
+use codex_tui::status::compose_model_display;
+use codex_tui::status::compose_rate_limit_data;
+use codex_tui::status::format_directory_display;
+use codex_tui::status::format_status_limit_summary;
+use codex_tui::status::format_tokens_compact;
+use codex_tui::status::render_status_limit_progress_bar;
+
+use crate::login::load_config_or_exit;
+
+const CODEX_VERSION: &str = env!("CARGO_PKG_VERSION");
+const INDENT: &str = " ";
+
+pub fn run_status(cli_config_overrides: CliConfigOverrides) -> ! {
+    let config = load_config_or_exit(cli_config_overrides);
+
+    let entries = create_config_summary_entries(&config);
+    let (model_name, model_details) = compose_model_display(&config, &entries);
+    let model_value = if model_details.is_empty() {
+        model_name
+    } else {
+        format!("{model_name} ({})", model_details.join(", "))
+    };
+
+    let approval = entries
+        .iter()
+        .find(|(k, _)| *k == "approval")
+        .map(|(_, v)| v.clone())
+        .unwrap_or_else(|| "<unknown>".to_string());
+
+    let sandbox = match &config.sandbox_policy {
+        codex_core::protocol::SandboxPolicy::DangerFullAccess => "danger-full-access".to_string(),
+        codex_core::protocol::SandboxPolicy::ReadOnly => "read-only".to_string(),
+        codex_core::protocol::SandboxPolicy::WorkspaceWrite { .. } => "workspace-write".to_string(),
+    };
+
+    let agents_summary = compose_agents_summary(&config);
+    let account_value = compose_account_display(&config).map(account_to_string);
+
+    let directory_value = format_directory_display(&config.cwd, None);
+
+    let usage = TokenUsage::default();
+    let rate_limit_data = compose_rate_limit_data(None);
+
+    let mut fields = vec![
+        DisplayField::new("Model", model_value),
+        DisplayField::new("Directory", directory_value),
+        DisplayField::new("Approval", approval),
+        DisplayField::new("Sandbox", sandbox),
+        DisplayField::new("Agents.md", agents_summary),
+    ];
+
+    if let Some(account) = account_value {
+        fields.push(DisplayField::new("Account", account));
+    }
+
+    let total_fmt = format_tokens_compact(usage.blended_total());
+    let input_fmt = format_tokens_compact(usage.non_cached_input());
+    let output_fmt = format_tokens_compact(usage.output_tokens);
+    let token_value = format!("{total_fmt} total ({input_fmt} input + {output_fmt} output)");
+    fields.push(DisplayField::new("Token usage", token_value).with_section_break());
+
+    match rate_limit_data {
+        StatusRateLimitData::Available(rows) => {
+            if rows.is_empty() {
+                fields.push(DisplayField::new("Limits", "data not available yet"));
+            } else {
+                for row in rows {
+                    let mut value = format!(
+                        "{} {}",
+                        render_status_limit_progress_bar(row.percent_used),
+                        format_status_limit_summary(row.percent_used)
+                    );
+                    if let Some(resets_at) = row.resets_at.as_ref() {
+                        value = format!("{value} (resets {resets_at})");
+                    }
+                    fields.push(DisplayField::new(row.label.clone(), value));
+                }
+            }
+        }
+        StatusRateLimitData::Missing => {
+            fields.push(DisplayField::new(
+                "Limits",
+                "send a message to load usage data",
+            ));
+        }
+    }
+
+    let mut lines = Vec::new();
+    lines.push(format!("{INDENT}>_ OpenAI Codex (v{CODEX_VERSION})"));
+    lines.push(String::new());
+    lines.extend(format_fields(&fields));
+
+    for line in lines {
+        println!("{line}");
+    }
+
+    std::process::exit(0);
+}
+
+fn account_to_string(account: StatusAccountDisplay) -> String {
+    match account {
+        StatusAccountDisplay::ChatGpt { email, plan } => match (email, plan) {
+            (Some(email), Some(plan)) => format!("{email} ({plan})"),
+            (Some(email), None) => email,
+            (None, Some(plan)) => plan,
+            (None, None) => "ChatGPT".to_string(),
+        },
+        StatusAccountDisplay::ApiKey => {
+            "API key configured (run codex login to use ChatGPT)".to_string()
+        }
+    }
+}
+
+struct DisplayField {
+    label: String,
+    value: String,
+    continuations: Vec<String>,
+    section_break_before: bool,
+}
+
+impl DisplayField {
+    fn new(label: impl Into<String>, value: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            value: value.into(),
+            continuations: Vec::new(),
+            section_break_before: false,
+        }
+    }
+
+    fn with_section_break(mut self) -> Self {
+        self.section_break_before = true;
+        self
+    }
+}
+
+fn format_fields(fields: &[DisplayField]) -> Vec<String> {
+    if fields.is_empty() {
+        return Vec::new();
+    }
+
+    let label_width = fields.iter().map(|f| f.label.len()).max().unwrap_or(0);
+    let value_offset = INDENT.len() + label_width + 1 + 3;
+    let value_prefix = " ".repeat(value_offset);
+
+    let mut lines = Vec::new();
+    for field in fields {
+        if field.section_break_before && !lines.is_empty() {
+            lines.push(String::new());
+        }
+
+        let line = if field.label.is_empty() {
+            format!("{value_prefix}{}", field.value)
+        } else {
+            let mut prefix = String::with_capacity(value_offset);
+            prefix.push_str(INDENT);
+            prefix.push_str(&field.label);
+            prefix.push(':');
+            let padding = 3 + label_width.saturating_sub(field.label.len());
+            for _ in 0..padding {
+                prefix.push(' ');
+            }
+            format!("{prefix}{}", field.value)
+        };
+        lines.push(line);
+
+        for cont in &field.continuations {
+            lines.push(format!("{value_prefix}{cont}"));
+        }
+    }
+
+    lines
+}

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -61,7 +61,7 @@ mod resume_picker;
 mod session_log;
 mod shimmer;
 mod slash_command;
-mod status;
+pub mod status;
 mod status_indicator_widget;
 mod streaming;
 mod style;

--- a/codex-rs/tui/src/status/account.rs
+++ b/codex-rs/tui/src/status/account.rs
@@ -1,5 +1,5 @@
 #[derive(Debug, Clone)]
-pub(crate) enum StatusAccountDisplay {
+pub enum StatusAccountDisplay {
     ChatGpt {
         email: Option<String>,
         plan: Option<String>,

--- a/codex-rs/tui/src/status/helpers.rs
+++ b/codex-rs/tui/src/status/helpers.rs
@@ -11,10 +11,7 @@ use unicode_width::UnicodeWidthStr;
 
 use super::account::StatusAccountDisplay;
 
-pub(crate) fn compose_model_display(
-    config: &Config,
-    entries: &[(&str, String)],
-) -> (String, Vec<String>) {
+pub fn compose_model_display(config: &Config, entries: &[(&str, String)]) -> (String, Vec<String>) {
     let mut details: Vec<String> = Vec::new();
     if let Some((_, effort)) = entries.iter().find(|(k, _)| *k == "reasoning effort") {
         details.push(format!("reasoning {}", effort.to_ascii_lowercase()));
@@ -31,7 +28,7 @@ pub(crate) fn compose_model_display(
     (config.model.clone(), details)
 }
 
-pub(crate) fn compose_agents_summary(config: &Config) -> String {
+pub fn compose_agents_summary(config: &Config) -> String {
     match discover_project_doc_paths(config) {
         Ok(paths) => {
             let mut rels: Vec<String> = Vec::new();
@@ -75,7 +72,7 @@ pub(crate) fn compose_agents_summary(config: &Config) -> String {
     }
 }
 
-pub(crate) fn compose_account_display(config: &Config) -> Option<StatusAccountDisplay> {
+pub fn compose_account_display(config: &Config) -> Option<StatusAccountDisplay> {
     let auth_file = get_auth_file(&config.codex_home);
     let auth = try_read_auth_json(&auth_file).ok()?;
 
@@ -95,7 +92,7 @@ pub(crate) fn compose_account_display(config: &Config) -> Option<StatusAccountDi
     None
 }
 
-pub(crate) fn format_tokens_compact(value: u64) -> String {
+pub fn format_tokens_compact(value: u64) -> String {
     if value == 0 {
         return "0".to_string();
     }
@@ -134,7 +131,7 @@ pub(crate) fn format_tokens_compact(value: u64) -> String {
     format!("{formatted}{suffix}")
 }
 
-pub(crate) fn format_directory_display(directory: &Path, max_width: Option<usize>) -> String {
+pub fn format_directory_display(directory: &Path, max_width: Option<usize>) -> String {
     let formatted = if let Some(rel) = relativize_to_home(directory) {
         if rel.as_os_str().is_empty() {
             "~".to_string()
@@ -157,7 +154,7 @@ pub(crate) fn format_directory_display(directory: &Path, max_width: Option<usize
     formatted
 }
 
-pub(crate) fn format_reset_timestamp(dt: DateTime<Local>, captured_at: DateTime<Local>) -> String {
+pub fn format_reset_timestamp(dt: DateTime<Local>, captured_at: DateTime<Local>) -> String {
     let time = dt.format("%H:%M").to_string();
     if dt.date_naive() == captured_at.date_naive() {
         time

--- a/codex-rs/tui/src/status/mod.rs
+++ b/codex-rs/tui/src/status/mod.rs
@@ -4,9 +4,20 @@ mod format;
 mod helpers;
 mod rate_limits;
 
+pub use account::StatusAccountDisplay;
 pub(crate) use card::new_status_output;
-pub(crate) use rate_limits::RateLimitSnapshotDisplay;
-pub(crate) use rate_limits::rate_limit_snapshot_display;
+pub use helpers::compose_account_display;
+pub use helpers::compose_agents_summary;
+pub use helpers::compose_model_display;
+pub use helpers::format_directory_display;
+pub use helpers::format_tokens_compact;
+pub use rate_limits::RateLimitSnapshotDisplay;
+pub use rate_limits::StatusRateLimitData;
+pub use rate_limits::StatusRateLimitRow;
+pub use rate_limits::compose_rate_limit_data;
+pub use rate_limits::format_status_limit_summary;
+pub use rate_limits::rate_limit_snapshot_display;
+pub use rate_limits::render_status_limit_progress_bar;
 
 #[cfg(test)]
 mod tests;

--- a/codex-rs/tui/src/status/rate_limits.rs
+++ b/codex-rs/tui/src/status/rate_limits.rs
@@ -13,20 +13,20 @@ const STATUS_LIMIT_BAR_FILLED: &str = "█";
 const STATUS_LIMIT_BAR_EMPTY: &str = "░";
 
 #[derive(Debug, Clone)]
-pub(crate) struct StatusRateLimitRow {
+pub struct StatusRateLimitRow {
     pub label: String,
     pub percent_used: f64,
     pub resets_at: Option<String>,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) enum StatusRateLimitData {
+pub enum StatusRateLimitData {
     Available(Vec<StatusRateLimitRow>),
     Missing,
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct RateLimitWindowDisplay {
+pub struct RateLimitWindowDisplay {
     pub used_percent: f64,
     pub resets_at: Option<String>,
     pub window_minutes: Option<u64>,
@@ -49,12 +49,12 @@ impl RateLimitWindowDisplay {
 }
 
 #[derive(Debug, Clone)]
-pub(crate) struct RateLimitSnapshotDisplay {
+pub struct RateLimitSnapshotDisplay {
     pub primary: Option<RateLimitWindowDisplay>,
     pub secondary: Option<RateLimitWindowDisplay>,
 }
 
-pub(crate) fn rate_limit_snapshot_display(
+pub fn rate_limit_snapshot_display(
     snapshot: &RateLimitSnapshot,
     captured_at: DateTime<Local>,
 ) -> RateLimitSnapshotDisplay {
@@ -70,9 +70,7 @@ pub(crate) fn rate_limit_snapshot_display(
     }
 }
 
-pub(crate) fn compose_rate_limit_data(
-    snapshot: Option<&RateLimitSnapshotDisplay>,
-) -> StatusRateLimitData {
+pub fn compose_rate_limit_data(snapshot: Option<&RateLimitSnapshotDisplay>) -> StatusRateLimitData {
     match snapshot {
         Some(snapshot) => {
             let mut rows = Vec::with_capacity(2);
@@ -113,7 +111,7 @@ pub(crate) fn compose_rate_limit_data(
     }
 }
 
-pub(crate) fn render_status_limit_progress_bar(percent_used: f64) -> String {
+pub fn render_status_limit_progress_bar(percent_used: f64) -> String {
     let ratio = (percent_used / 100.0).clamp(0.0, 1.0);
     let filled = (ratio * STATUS_LIMIT_BAR_SEGMENTS as f64).round() as usize;
     let filled = filled.min(STATUS_LIMIT_BAR_SEGMENTS);
@@ -125,7 +123,7 @@ pub(crate) fn render_status_limit_progress_bar(percent_used: f64) -> String {
     )
 }
 
-pub(crate) fn format_status_limit_summary(percent_used: f64) -> String {
+pub fn format_status_limit_summary(percent_used: f64) -> String {
     format!("{percent_used:.0}% used")
 }
 


### PR DESCRIPTION
Implements a new 'codex status' subcommand that displays configuration and session information in plain text format, mirroring the TUI '/status' card functionality.

Changes:
- Added cli/src/status.rs with status command implementation
- Wired Status subcommand into CLI through cli/src/main.rs
- Exposed status module in cli/src/lib.rs
- Made TUI status helpers public for code reuse:
  - compose_account_value() in tui/src/status/account.rs
  - compose_rate_limit_data() in tui/src/status/rate_limits.rs
  - DisplayField struct in tui/src/status/helpers.rs
- Exported status helpers from tui/src/lib.rs

The status command displays:
- Model configuration
- Current directory
- Approval policy
- Sandbox policy
- Agents.md file detection
- Account information (when authenticated)
- Token usage (when available)
- Rate limit information (when available)

Resolves #4493

