### PR TITLE
feat: make conversationId optional in codex-reply MCP tool

### DIFF
--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -182,7 +182,9 @@ impl CodexToolCallParam {
 #[serde(rename_all = "camelCase")]
 pub struct CodexToolCallReplyParam {
     /// The conversation id for this Codex session.
-    pub conversation_id: String,
+    /// If omitted, uses the most recently started conversation in this MCP session.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_id: Option<String>,
 
     /// The *next user prompt* to continue the Codex conversation.
     pub prompt: String,
@@ -313,7 +315,7 @@ mod tests {
           "inputSchema": {
             "properties": {
               "conversationId": {
-                "description": "The conversation id for this Codex session.",
+                "description": "The conversation id for this Codex session. If omitted, uses the most recently started conversation in this MCP session.",
                 "type": "string"
               },
               "prompt": {
@@ -322,7 +324,6 @@ mod tests {
               },
             },
             "required": [
-              "conversationId",
               "prompt",
             ],
             "type": "object",

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -43,6 +43,7 @@ pub async fn run_codex_tool_session(
     outgoing: Arc<OutgoingMessageSender>,
     conversation_manager: Arc<ConversationManager>,
     running_requests_id_to_codex_uuid: Arc<Mutex<HashMap<RequestId, ConversationId>>>,
+    current_conversation_id: Arc<Mutex<Option<ConversationId>>>,
 ) {
     let NewConversation {
         conversation_id,
@@ -88,6 +89,10 @@ pub async fn run_codex_tool_session(
         .lock()
         .await
         .insert(id.clone(), conversation_id);
+
+    // Store this as the current conversation for this MCP session
+    *current_conversation_id.lock().await = Some(conversation_id);
+
     let submission = Submission {
         id: sub_id.clone(),
         op: Op::UserInput {

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -41,6 +41,9 @@ pub(crate) struct MessageProcessor {
     codex_linux_sandbox_exe: Option<PathBuf>,
     conversation_manager: Arc<ConversationManager>,
     running_requests_id_to_codex_uuid: Arc<Mutex<HashMap<RequestId, ConversationId>>>,
+    /// The most recently started conversation in this MCP session.
+    /// Used as the default when codex-reply is called without an explicit conversationId.
+    current_conversation_id: Arc<Mutex<Option<ConversationId>>>,
 }
 
 impl MessageProcessor {
@@ -60,6 +63,7 @@ impl MessageProcessor {
             codex_linux_sandbox_exe,
             conversation_manager,
             running_requests_id_to_codex_uuid: Arc::new(Mutex::new(HashMap::new())),
+            current_conversation_id: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -396,6 +400,7 @@ impl MessageProcessor {
         let outgoing = self.outgoing.clone();
         let conversation_manager = self.conversation_manager.clone();
         let running_requests_id_to_codex_uuid = self.running_requests_id_to_codex_uuid.clone();
+        let current_conversation_id = self.current_conversation_id.clone();
 
         // Spawn an async task to handle the Codex session so that we do not
         // block the synchronous message-processing loop.
@@ -408,6 +413,7 @@ impl MessageProcessor {
                 outgoing,
                 conversation_manager,
                 running_requests_id_to_codex_uuid,
+                current_conversation_id,
             )
             .await;
         });
@@ -445,12 +451,12 @@ impl MessageProcessor {
             },
             None => {
                 tracing::error!(
-                    "Missing arguments for codex-reply tool-call; the `conversation_id` and `prompt` fields are required."
+                    "Missing arguments for codex-reply tool-call; the `prompt` field is required."
                 );
                 let result = CallToolResult {
                     content: vec![ContentBlock::TextContent(TextContent {
                         r#type: "text".to_owned(),
-                        text: "Missing arguments for codex-reply tool-call; the `conversation_id` and `prompt` fields are required.".to_owned(),
+                        text: "Missing arguments for codex-reply tool-call; the `prompt` field is required.".to_owned(),
                         annotations: None,
                     })],
                     is_error: Some(true),
@@ -461,22 +467,47 @@ impl MessageProcessor {
                 return;
             }
         };
-        let conversation_id = match ConversationId::from_string(&conversation_id) {
-            Ok(id) => id,
-            Err(e) => {
-                tracing::error!("Failed to parse conversation_id: {e}");
-                let result = CallToolResult {
-                    content: vec![ContentBlock::TextContent(TextContent {
-                        r#type: "text".to_owned(),
-                        text: format!("Failed to parse conversation_id: {e}"),
-                        annotations: None,
-                    })],
-                    is_error: Some(true),
-                    structured_content: None,
-                };
-                self.send_response::<mcp_types::CallToolRequest>(request_id, result)
-                    .await;
-                return;
+
+        // If conversation_id is not provided, use the current conversation
+        let conversation_id = match conversation_id {
+            Some(id_str) => match ConversationId::from_string(&id_str) {
+                Ok(id) => id,
+                Err(e) => {
+                    tracing::error!("Failed to parse conversation_id: {e}");
+                    let result = CallToolResult {
+                        content: vec![ContentBlock::TextContent(TextContent {
+                            r#type: "text".to_owned(),
+                            text: format!("Failed to parse conversation_id: {e}"),
+                            annotations: None,
+                        })],
+                        is_error: Some(true),
+                        structured_content: None,
+                    };
+                    self.send_response::<mcp_types::CallToolRequest>(request_id, result)
+                        .await;
+                    return;
+                }
+            },
+            None => {
+                // Use the current conversation from this MCP session
+                match *self.current_conversation_id.lock().await {
+                    Some(id) => id,
+                    None => {
+                        tracing::error!("No current conversation found. Call 'codex' tool first.");
+                        let result = CallToolResult {
+                            content: vec![ContentBlock::TextContent(TextContent {
+                                r#type: "text".to_owned(),
+                                text: "No current conversation found. Call 'codex' tool first to start a conversation.".to_owned(),
+                                annotations: None,
+                            })],
+                            is_error: Some(true),
+                            structured_content: None,
+                        };
+                        self.send_response::<mcp_types::CallToolRequest>(request_id, result)
+                            .await;
+                        return;
+                    }
+                }
             }
         };
 


### PR DESCRIPTION
When conversationId is omitted from codex-reply, automatically use the most recently started conversation in the current MCP session. This value is retained in memory in the MCP server, so it goes away if the mcp server restarts, at which point a conversationId is required. 

This is an alternative to #4413, which is unfortunately pretty useless as structuredContent isn't shown to most cli agents (e.g. Claude Code).

**Implementation:**
- Made conversationId optional in CodexToolCallReplyParam
- Added current_conversation_id tracking to MessageProcessor
- Store conversation ID when codex tool completes
- Auto-lookup current conversation when codex-reply called without ID
- Return clear error if no current conversation exists

This provides a better user experience since the LLM can now call codex-reply without needing to extract the conversationId from structured content.

I have read the CLA Document and I hereby sign the CLA.
