### PR TITLE
feat: filter resume picker by current directory

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -710,6 +710,7 @@ impl CodexMessageProcessor {
             page_size,
             cursor_ref,
             INTERACTIVE_SESSION_SOURCES,
+            None, // TODO: Add cwd filter support
         )
         .await
         {

--- a/codex-rs/core/src/rollout/recorder.rs
+++ b/codex-rs/core/src/rollout/recorder.rs
@@ -92,13 +92,15 @@ impl RolloutRecorderParams {
 
 impl RolloutRecorder {
     /// List conversations (rollout files) under the provided Codex home directory.
+    /// If `cwd_filter` is provided, only conversations from that working directory are included.
     pub async fn list_conversations(
         codex_home: &Path,
         page_size: usize,
         cursor: Option<&Cursor>,
         allowed_sources: &[SessionSource],
+        cwd_filter: Option<&Path>,
     ) -> std::io::Result<ConversationsPage> {
-        get_conversations(codex_home, page_size, cursor, allowed_sources).await
+        get_conversations(codex_home, page_size, cursor, allowed_sources, cwd_filter).await
     }
 
     /// Attempt to create a new [`RolloutRecorder`]. If the sessions directory

--- a/codex-rs/core/src/rollout/tests.rs
+++ b/codex-rs/core/src/rollout/tests.rs
@@ -135,7 +135,7 @@ async fn test_list_conversations_latest_first() {
     )
     .unwrap();
 
-    let page = get_conversations(home, 10, None, INTERACTIVE_SESSION_SOURCES)
+    let page = get_conversations(home, 10, None, INTERACTIVE_SESSION_SOURCES, None)
         .await
         .unwrap();
 
@@ -276,7 +276,7 @@ async fn test_pagination_cursor() {
     )
     .unwrap();
 
-    let page1 = get_conversations(home, 2, None, INTERACTIVE_SESSION_SOURCES)
+    let page1 = get_conversations(home, 2, None, INTERACTIVE_SESSION_SOURCES, None)
         .await
         .unwrap();
     let p5 = home
@@ -339,6 +339,7 @@ async fn test_pagination_cursor() {
         2,
         page1.next_cursor.as_ref(),
         INTERACTIVE_SESSION_SOURCES,
+        None,
     )
     .await
     .unwrap();
@@ -402,6 +403,7 @@ async fn test_pagination_cursor() {
         2,
         page2.next_cursor.as_ref(),
         INTERACTIVE_SESSION_SOURCES,
+        None,
     )
     .await
     .unwrap();
@@ -446,7 +448,7 @@ async fn test_get_conversation_contents() {
     let ts = "2025-04-01T10-30-00";
     write_session_file(home, ts, uuid, 2, Some(SessionSource::VSCode)).unwrap();
 
-    let page = get_conversations(home, 1, None, INTERACTIVE_SESSION_SOURCES)
+    let page = get_conversations(home, 1, None, INTERACTIVE_SESSION_SOURCES, None)
         .await
         .unwrap();
     let path = &page.items[0].path;
@@ -565,7 +567,7 @@ async fn test_tail_includes_last_response_items() -> Result<()> {
     }
     drop(file);
 
-    let page = get_conversations(home, 1, None, INTERACTIVE_SESSION_SOURCES).await?;
+    let page = get_conversations(home, 1, None, INTERACTIVE_SESSION_SOURCES, None).await?;
     let item = page.items.first().expect("conversation item");
     let tail_len = item.tail.len();
     assert_eq!(tail_len, 10usize.min(total_messages));
@@ -648,7 +650,7 @@ async fn test_tail_handles_short_sessions() -> Result<()> {
     }
     drop(file);
 
-    let page = get_conversations(home, 1, None, INTERACTIVE_SESSION_SOURCES).await?;
+    let page = get_conversations(home, 1, None, INTERACTIVE_SESSION_SOURCES, None).await?;
     let tail = &page.items.first().expect("conversation item").tail;
 
     assert_eq!(tail.len(), 3);
@@ -747,7 +749,7 @@ async fn test_tail_skips_trailing_non_responses() -> Result<()> {
     writeln!(file, "{}", serde_json::to_string(&shutdown_event)?)?;
     drop(file);
 
-    let page = get_conversations(home, 1, None, INTERACTIVE_SESSION_SOURCES).await?;
+    let page = get_conversations(home, 1, None, INTERACTIVE_SESSION_SOURCES, None).await?;
     let tail = &page.items.first().expect("conversation item").tail;
 
     let expected: Vec<serde_json::Value> = (0..4)
@@ -789,7 +791,7 @@ async fn test_stable_ordering_same_second_pagination() {
     write_session_file(home, ts, u2, 0, Some(SessionSource::VSCode)).unwrap();
     write_session_file(home, ts, u3, 0, Some(SessionSource::VSCode)).unwrap();
 
-    let page1 = get_conversations(home, 2, None, INTERACTIVE_SESSION_SOURCES)
+    let page1 = get_conversations(home, 2, None, INTERACTIVE_SESSION_SOURCES, None)
         .await
         .unwrap();
 
@@ -845,6 +847,7 @@ async fn test_stable_ordering_same_second_pagination() {
         2,
         page1.next_cursor.as_ref(),
         INTERACTIVE_SESSION_SOURCES,
+        None,
     )
     .await
     .unwrap();

--- a/codex-rs/core/tests/suite/cli_stream.rs
+++ b/codex-rs/core/tests/suite/cli_stream.rs
@@ -76,7 +76,7 @@ async fn chat_mode_stream_cli() {
     server.verify().await;
 
     // Verify a new session rollout was created and is discoverable via list_conversations
-    let page = RolloutRecorder::list_conversations(home.path(), 10, None, &[])
+    let page = RolloutRecorder::list_conversations(home.path(), 10, None, &[], None)
         .await
         .expect("list conversations");
     assert!(

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -377,7 +377,7 @@ async fn resolve_resume_path(
     args: &crate::cli::ResumeArgs,
 ) -> anyhow::Result<Option<PathBuf>> {
     if args.last {
-        match codex_core::RolloutRecorder::list_conversations(&config.codex_home, 1, None, &[])
+        match codex_core::RolloutRecorder::list_conversations(&config.codex_home, 1, None, &[], None)
             .await
         {
             Ok(page) => Ok(page.items.first().map(|it| it.path.clone())),

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -22,6 +22,11 @@ pub struct Cli {
     #[clap(skip)]
     pub resume_last: bool,
 
+    /// Internal: show all conversations across all directories in the resume picker.
+    /// Set by the top-level `codex resume --all` wrapper; not exposed as a public flag.
+    #[clap(skip)]
+    pub resume_all: bool,
+
     /// Internal: resume a specific recorded session by id (UUID). Set by the
     /// top-level `codex resume <SESSION_ID>` wrapper; not exposed as a public flag.
     #[clap(skip)]

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -399,6 +399,7 @@ async fn run_ratatui_app(
             1,
             None,
             INTERACTIVE_SESSION_SOURCES,
+            None, // No cwd filter for resume_last
         )
         .await
         {
@@ -410,7 +411,11 @@ async fn run_ratatui_app(
             Err(_) => resume_picker::ResumeSelection::StartFresh,
         }
     } else if cli.resume_picker {
-        match resume_picker::run_resume_picker(&mut tui, &config.codex_home).await? {
+        // If --all flag is set, don't filter by cwd (pass None), otherwise filter by current directory
+        let cwd_filter = if cli.resume_all { None } else { Some(config.cwd.as_path()) };
+        match resume_picker::run_resume_picker(&mut tui, &config.codex_home, cwd_filter)
+            .await?
+        {
             resume_picker::ResumeSelection::Exit => {
                 restore();
                 session_log::log_session_end();


### PR DESCRIPTION
Addresses #4342. This changes the default behavior of `codex resume` to what users typically expect - showing only conversations from the current directory rather than all conversations system-wide.

## Summary

Filter the resume picker to show only conversations from the current working directory by default, with an `--all` flag to restore the previous behavior of showing all conversations.

## Motivation

When working on multiple projects, `codex resume` currently shows all conversations from all directories, making it difficult to find relevant sessions. This change makes the resume picker context-aware, showing only conversations from the current project directory by default.

## Changes

  - Add `cwd_filter` parameter to `list_conversations()` and `get_conversations()` to filter by working directory
  - Add `matches_cwd_filter()` function that checks the SessionMeta cwd field against the filter path
  - Add `--all` flag to `codex resume` command to show all conversations across all directories (restores previous behavior)
  - Update TUI to conditionally apply filtering based on the flag
  - Update all existing callsites to pass `None` for backward compatibility

## Usage

```bash
# Show only conversations from current directory (NEW DEFAULT)
codex resume

# Show all conversations across all directories (previous behavior)
codex resume --all
```

Breaking Change

This changes the default behavior of codex resume - it now filters to the current directory by default. Users who want to see all conversations can use the new --all flag.

I have read the CLA Document and I hereby sign the CLA.