### PR TITLE
Support CODEX_API_KEY for codex exec

### DIFF
--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -34,7 +34,7 @@ impl MessageProcessor {
         config: Arc<Config>,
     ) -> Self {
         let outgoing = Arc::new(outgoing);
-        let auth_manager = AuthManager::shared(config.codex_home.clone());
+        let auth_manager = AuthManager::shared(config.codex_home.clone(), false);
         let conversation_manager = Arc::new(ConversationManager::new(auth_manager.clone()));
         let codex_message_processor = CodexMessageProcessor::new(
             auth_manager,

--- a/codex-rs/cloud-tasks/src/lib.rs
+++ b/codex-rs/cloud-tasks/src/lib.rs
@@ -190,7 +190,7 @@ pub async fn run_main(_cli: Cli, _codex_linux_sandbox_exe: Option<PathBuf>) -> a
         // Require ChatGPT login (SWIC). Exit with a clear message if missing.
         let _token = match codex_core::config::find_codex_home()
             .ok()
-            .map(codex_login::AuthManager::new)
+            .map(|home| codex_login::AuthManager::new(home, false))
             .and_then(|am| am.auth())
         {
             Some(auth) => {

--- a/codex-rs/cloud-tasks/src/util.rs
+++ b/codex-rs/cloud-tasks/src/util.rs
@@ -70,7 +70,7 @@ pub async fn build_chatgpt_headers() -> HeaderMap {
         HeaderValue::from_str(&ua).unwrap_or(HeaderValue::from_static("codex-cli")),
     );
     if let Ok(home) = codex_core::config::find_codex_home() {
-        let am = codex_login::AuthManager::new(home);
+        let am = codex_login::AuthManager::new(home, false);
         if let Some(auth) = am.auth()
             && let Ok(tok) = auth.get_token().await
             && !tok.is_empty()

--- a/codex-rs/core/tests/common/test_codex_exec.rs
+++ b/codex-rs/core/tests/common/test_codex_exec.rs
@@ -1,4 +1,5 @@
 #![allow(clippy::expect_used)]
+use codex_core::auth::CODEX_API_KEY_ENV_VAR;
 use std::path::Path;
 use tempfile::TempDir;
 use wiremock::MockServer;
@@ -14,7 +15,7 @@ impl TestCodexExecBuilder {
             .expect("should find binary for codex-exec");
         cmd.current_dir(self.cwd.path())
             .env("CODEX_HOME", self.home.path())
-            .env("OPENAI_API_KEY", "dummy");
+            .env(CODEX_API_KEY_ENV_VAR, "dummy");
         cmd
     }
     pub fn cmd_with_server(&self, server: &MockServer) -> assert_cmd::Command {

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -236,8 +236,8 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         std::process::exit(1);
     }
 
-    let conversation_manager =
-        ConversationManager::new(AuthManager::shared(config.codex_home.clone()));
+    let auth_manager = AuthManager::shared(config.codex_home.clone(), true);
+    let conversation_manager = ConversationManager::new(auth_manager.clone());
 
     // Handle resume subcommand by resolving a rollout path and using explicit resume API.
     let NewConversation {
@@ -249,11 +249,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
 
         if let Some(path) = resume_path {
             conversation_manager
-                .resume_conversation_from_rollout(
-                    config.clone(),
-                    path,
-                    AuthManager::shared(config.codex_home.clone()),
-                )
+                .resume_conversation_from_rollout(config.clone(), path, auth_manager.clone())
                 .await?
         } else {
             conversation_manager

--- a/codex-rs/exec/tests/suite/auth_env.rs
+++ b/codex-rs/exec/tests/suite/auth_env.rs
@@ -1,0 +1,34 @@
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+use core_test_support::responses::ev_completed;
+use core_test_support::responses::sse;
+use core_test_support::responses::sse_response;
+use core_test_support::responses::start_mock_server;
+use core_test_support::test_codex_exec::test_codex_exec;
+use wiremock::Mock;
+use wiremock::matchers::header;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exec_uses_codex_api_key_env_var() -> anyhow::Result<()> {
+    let test = test_codex_exec();
+    let server = start_mock_server().await;
+
+    Mock::given(method("POST"))
+        .and(path("/v1/responses"))
+        .and(header("Authorization", "Bearer dummy"))
+        .respond_with(sse_response(sse(vec![ev_completed("request_0")])))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    test.cmd_with_server(&server)
+        .arg("--skip-git-repo-check")
+        .arg("-C")
+        .arg(env!("CARGO_MANIFEST_DIR"))
+        .arg("echo testing codex api key")
+        .assert()
+        .success();
+
+    Ok(())
+}

--- a/codex-rs/exec/tests/suite/mod.rs
+++ b/codex-rs/exec/tests/suite/mod.rs
@@ -1,5 +1,6 @@
 // Aggregates all former standalone integration tests as modules.
 mod apply_patch;
+mod auth_env;
 mod output_schema;
 mod resume;
 mod sandbox;

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -14,6 +14,7 @@ pub use codex_core::AuthManager;
 pub use codex_core::CodexAuth;
 pub use codex_core::auth::AuthDotJson;
 pub use codex_core::auth::CLIENT_ID;
+pub use codex_core::auth::CODEX_API_KEY_ENV_VAR;
 pub use codex_core::auth::OPENAI_API_KEY_ENV_VAR;
 pub use codex_core::auth::get_auth_file;
 pub use codex_core::auth::login_with_api_key;

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -52,7 +52,7 @@ impl MessageProcessor {
         config: Arc<Config>,
     ) -> Self {
         let outgoing = Arc::new(outgoing);
-        let auth_manager = AuthManager::shared(config.codex_home.clone());
+        let auth_manager = AuthManager::shared(config.codex_home.clone(), false);
         let conversation_manager = Arc::new(ConversationManager::new(auth_manager));
         Self {
             outgoing,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -361,7 +361,7 @@ async fn run_ratatui_app(
     // Initialize high-fidelity session event logging if enabled.
     session_log::maybe_init(&config);
 
-    let auth_manager = AuthManager::shared(config.codex_home.clone());
+    let auth_manager = AuthManager::shared(config.codex_home.clone(), false);
     let login_status = get_login_status(&config);
     let should_show_onboarding =
         should_show_onboarding(login_status, &config, should_show_trust_screen);

--- a/sdk/typescript/src/exec.ts
+++ b/sdk/typescript/src/exec.ts
@@ -58,7 +58,7 @@ export class CodexExec {
       env.OPENAI_BASE_URL = args.baseUrl;
     }
     if (args.apiKey) {
-      env.OPENAI_API_KEY = args.apiKey;
+      env.CODEX_API_KEY = args.apiKey;
     }
 
     const child = spawn(this.executablePath, commandArgs, {


### PR DESCRIPTION
Allows to set API key per invocation of `codex exec`