### PR TITLE
feat: add file name to fuzzy search response

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol.rs
+++ b/codex-rs/app-server-protocol/src/protocol.rs
@@ -725,6 +725,7 @@ pub struct FuzzyFileSearchParams {
 pub struct FuzzyFileSearchResult {
     pub root: String,
     pub path: String,
+    pub file_name: String,
     pub score: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indices: Option<Vec<u32>>,

--- a/codex-rs/app-server/src/fuzzy_file_search.rs
+++ b/codex-rs/app-server/src/fuzzy_file_search.rs
@@ -1,5 +1,6 @@
 use std::num::NonZero;
 use std::num::NonZeroUsize;
+use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -56,9 +57,16 @@ pub(crate) async fn run_fuzzy_file_search(
         match res {
             Ok(Ok((root, res))) => {
                 for m in res.matches {
+                    let path = m.path;
+                    //TODO(shijie): Move file name generation to file_search lib.
+                    let file_name = Path::new(&path)
+                        .file_name()
+                        .map(|name| name.to_string_lossy().into_owned())
+                        .unwrap_or_else(|| path.clone());
                     let result = FuzzyFileSearchResult {
                         root: root.clone(),
-                        path: m.path,
+                        path,
+                        file_name,
                         score: m.score,
                         indices: m.indices,
                     };

--- a/codex-rs/app-server/tests/suite/fuzzy_file_search.rs
+++ b/codex-rs/app-server/tests/suite/fuzzy_file_search.rs
@@ -57,40 +57,37 @@ async fn test_fuzzy_file_search_sorts_and_includes_indices() -> Result<()> {
     .context("fuzzyFileSearch resp")?;
 
     let value = resp.result;
-    let files = value
-        .get("files")
-        .context("files missing")?
-        .as_array()
-        .context("files not array")?;
-    assert_eq!(files.len(), 3);
+    // The path separator on Windows affects the score.
+    let expected_score = if cfg!(windows) { 69 } else { 72 };
 
     assert_eq!(
-        files[0],
+        value,
         json!({
-            "root": root_path.clone(),
-            "path": "abexy",
-            "file_name": "abexy",
-            "score": 88,
-            "indices": [0, 1, 2]
+            "files": [
+                {
+                    "root": root_path.clone(),
+                    "path": "abexy",
+                    "file_name": "abexy",
+                    "score": 88,
+                    "indices": [0, 1, 2],
+                },
+                {
+                    "root": root_path.clone(),
+                    "path": "abcde",
+                    "file_name": "abcde",
+                    "score": 74,
+                    "indices": [0, 1, 4],
+                },
+                {
+                    "root": root_path.clone(),
+                    "path": sub_abce_rel,
+                    "file_name": "abce",
+                    "score": expected_score,
+                    "indices": [4, 5, 7],
+                },
+            ]
         })
     );
-    assert_eq!(
-        files[1],
-        json!({
-            "root": root_path.clone(),
-            "path": "abcde",
-            "file_name": "abcde",
-            "score": 74,
-            "indices": [0, 1, 4]
-        })
-    );
-
-    let third = &files[2];
-    assert_eq!(third["root"], json!(root_path));
-    assert_eq!(third["path"], json!(sub_abce_rel));
-    assert_eq!(third["file_name"], json!("abce"));
-    assert_eq!(third["indices"], json!([4, 5, 7]));
-    assert!(third["score"].is_number());
 
     Ok(())
 }

--- a/codex-rs/app-server/tests/suite/fuzzy_file_search.rs
+++ b/codex-rs/app-server/tests/suite/fuzzy_file_search.rs
@@ -14,11 +14,13 @@ async fn test_fuzzy_file_search_sorts_and_includes_indices() {
     let codex_home = TempDir::new().expect("create temp codex home");
     let root = TempDir::new().expect("create temp search root");
 
-    // Create files designed to have deterministic ordering for query "abc".
+    // Create files designed to have deterministic ordering for query "abe".
     std::fs::write(root.path().join("abc"), "x").expect("write file abc");
-    std::fs::write(root.path().join("abcde"), "x").expect("write file abcx");
-    std::fs::write(root.path().join("abexy"), "x").expect("write file abcx");
+    std::fs::write(root.path().join("abcde"), "x").expect("write file abcde");
+    std::fs::write(root.path().join("abexy"), "x").expect("write file abexy");
     std::fs::write(root.path().join("zzz.txt"), "x").expect("write file zzz");
+    std::fs::create_dir_all(root.path().join("sub")).expect("create sub dir");
+    std::fs::write(root.path().join("sub").join("abce"), "x").expect("write file sub/abce");
 
     // Start MCP server and initialize.
     let mut mcp = McpProcess::new(codex_home.path()).await.expect("spawn mcp");
@@ -48,8 +50,27 @@ async fn test_fuzzy_file_search_sorts_and_includes_indices() {
         value,
         json!({
             "files": [
-                { "root": root_path.clone(), "path": "abexy", "score": 88, "indices": [0, 1, 2] },
-                { "root": root_path.clone(), "path": "abcde", "score": 74, "indices": [0, 1, 4] },
+                {
+                    "root": root_path.clone(),
+                    "path": "abexy",
+                    "file_name": "abexy",
+                    "score": 88,
+                    "indices": [0, 1, 2],
+                },
+                {
+                    "root": root_path.clone(),
+                    "path": "abcde",
+                    "file_name": "abcde",
+                    "score": 74,
+                    "indices": [0, 1, 4],
+                },
+                {
+                    "root": root_path.clone(),
+                    "path": "sub/abce",
+                    "file_name": "abce",
+                    "score": 72,
+                    "indices": [4, 5, 7],
+                },
             ]
         })
     );

--- a/codex-rs/app-server/tests/suite/fuzzy_file_search.rs
+++ b/codex-rs/app-server/tests/suite/fuzzy_file_search.rs
@@ -21,8 +21,15 @@ async fn test_fuzzy_file_search_sorts_and_includes_indices() -> Result<()> {
     std::fs::write(root.path().join("abcde"), "x").context("write file abcde")?;
     std::fs::write(root.path().join("abexy"), "x").context("write file abexy")?;
     std::fs::write(root.path().join("zzz.txt"), "x").context("write file zzz")?;
-    std::fs::create_dir_all(root.path().join("sub")).context("create sub dir")?;
-    std::fs::write(root.path().join("sub").join("abce"), "x").context("write file sub/abce")?;
+    let sub_dir = root.path().join("sub");
+    std::fs::create_dir_all(&sub_dir).context("create sub dir")?;
+    let sub_abce_path = sub_dir.join("abce");
+    std::fs::write(&sub_abce_path, "x").context("write file sub/abce")?;
+    let sub_abce_rel = sub_abce_path
+        .strip_prefix(root.path())
+        .context("strip root prefix from sub/abce")?
+        .to_string_lossy()
+        .to_string();
 
     // Start MCP server and initialize.
     let mut mcp = McpProcess::new(codex_home.path())
@@ -70,7 +77,7 @@ async fn test_fuzzy_file_search_sorts_and_includes_indices() -> Result<()> {
                 },
                 {
                     "root": root_path.clone(),
-                    "path": "sub/abce",
+                    "path": sub_abce_rel,
                     "file_name": "abce",
                     "score": 72,
                     "indices": [4, 5, 7],

--- a/codex-rs/app-server/tests/suite/fuzzy_file_search.rs
+++ b/codex-rs/app-server/tests/suite/fuzzy_file_search.rs
@@ -57,34 +57,40 @@ async fn test_fuzzy_file_search_sorts_and_includes_indices() -> Result<()> {
     .context("fuzzyFileSearch resp")?;
 
     let value = resp.result;
+    let files = value
+        .get("files")
+        .context("files missing")?
+        .as_array()
+        .context("files not array")?;
+    assert_eq!(files.len(), 3);
+
     assert_eq!(
-        value,
+        files[0],
         json!({
-            "files": [
-                {
-                    "root": root_path.clone(),
-                    "path": "abexy",
-                    "file_name": "abexy",
-                    "score": 88,
-                    "indices": [0, 1, 2],
-                },
-                {
-                    "root": root_path.clone(),
-                    "path": "abcde",
-                    "file_name": "abcde",
-                    "score": 74,
-                    "indices": [0, 1, 4],
-                },
-                {
-                    "root": root_path.clone(),
-                    "path": sub_abce_rel,
-                    "file_name": "abce",
-                    "score": 72,
-                    "indices": [4, 5, 7],
-                },
-            ]
+            "root": root_path.clone(),
+            "path": "abexy",
+            "file_name": "abexy",
+            "score": 88,
+            "indices": [0, 1, 2]
         })
     );
+    assert_eq!(
+        files[1],
+        json!({
+            "root": root_path.clone(),
+            "path": "abcde",
+            "file_name": "abcde",
+            "score": 74,
+            "indices": [0, 1, 4]
+        })
+    );
+
+    let third = &files[2];
+    assert_eq!(third["root"], json!(root_path));
+    assert_eq!(third["path"], json!(sub_abce_rel));
+    assert_eq!(third["file_name"], json!("abce"));
+    assert_eq!(third["indices"], json!([4, 5, 7]));
+    assert!(third["score"].is_number());
 
     Ok(())
 }


### PR DESCRIPTION
### Summary
* Updated fuzzy search result to include the file name. 
* This should not affect CLI usage and the UI there will be addressed in a separate PR. 

### Testing
Tested locally and with the extension.

### Screenshot
<img width="431" height="244" alt="Screenshot 2025-10-02 at 11 08 44 AM" src="https://github.com/user-attachments/assets/ba2ca299-a81d-4453-9242-1750e945aea2" />
