### PR TITLE
feat: set TUI window title via /title command

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -456,6 +456,9 @@ fn merge_resume_cli_flags(interactive: &mut TuiCli, resume_cli: TuiCli) {
     if let Some(prompt) = resume_cli.prompt {
         interactive.prompt = Some(prompt);
     }
+    if let Some(title) = resume_cli.title {
+        interactive.title = Some(title);
+    }
 
     interactive
         .config_overrides

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -335,6 +335,10 @@ impl App {
             app_event_tx: self.app_event_tx.clone(),
             initial_prompt: None,
             initial_images: Vec::new(),
+            window_title: self
+                .chat_widget
+                .window_title()
+                .map(std::string::ToString::to_string),
             enhanced_keys_supported: self.enhanced_keys_supported,
             auth_manager: self.auth_manager.clone(),
         };

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -43,6 +43,9 @@ pub(crate) enum AppEvent {
     /// Result of computing a `/diff` command.
     DiffResult(String),
 
+    /// Update the terminal window title.
+    SetWindowTitle(String),
+
     InsertHistoryCell(Box<dyn HistoryCell>),
 
     StartCommitAnimation,

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -10,6 +10,10 @@ pub struct Cli {
     #[arg(value_name = "PROMPT")]
     pub prompt: Option<String>,
 
+    /// Set the terminal window title on launch.
+    #[arg(long = "title", value_name = "TEXT")]
+    pub title: Option<String>,
+
     /// Optional image(s) to attach to the initial prompt.
     #[arg(long = "image", short = 'i', value_name = "FILE", value_delimiter = ',', num_args = 1..)]
     pub images: Vec<PathBuf>,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -296,6 +296,9 @@ async fn run_ratatui_app(
     terminal.clear()?;
 
     let mut tui = Tui::new(terminal);
+    if let Some(title) = cli.title.as_deref() {
+        tui.set_window_title(title);
+    }
 
     // Show update banner in terminal history (instead of stderr) so it is visible
     // within the TUI scrollback. Building spans keeps styling consistent.
@@ -425,7 +428,12 @@ async fn run_ratatui_app(
         resume_picker::ResumeSelection::StartFresh
     };
 
-    let Cli { prompt, images, .. } = cli;
+    let Cli {
+        prompt,
+        images,
+        title,
+        ..
+    } = cli;
 
     let app_result = App::run(
         &mut tui,
@@ -434,6 +442,7 @@ async fn run_ratatui_app(
         active_profile,
         prompt,
         images,
+        title,
         resume_selection,
     )
     .await;

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -22,6 +22,7 @@ pub enum SlashCommand {
     Diff,
     Mention,
     Status,
+    Title,
     Mcp,
     Logout,
     Quit,
@@ -42,6 +43,7 @@ impl SlashCommand {
             SlashCommand::Diff => "show git diff (including untracked files)",
             SlashCommand::Mention => "mention a file",
             SlashCommand::Status => "show current session configuration and token usage",
+            SlashCommand::Title => "set the terminal window title",
             SlashCommand::Model => "choose what model and reasoning effort to use",
             SlashCommand::Approvals => "choose what Codex can do without approval",
             SlashCommand::Mcp => "list configured MCP tools",
@@ -71,6 +73,7 @@ impl SlashCommand {
             SlashCommand::Diff
             | SlashCommand::Mention
             | SlashCommand::Status
+            | SlashCommand::Title
             | SlashCommand::Mcp
             | SlashCommand::Quit => true,
 

--- a/codex-rs/tui/src/status/tests.rs
+++ b/codex-rs/tui/src/status/tests.rs
@@ -103,7 +103,14 @@ fn status_snapshot_includes_reasoning_details() {
         .expect("timestamp");
     let rate_display = rate_limit_snapshot_display(&snapshot, captured_at);
 
-    let composite = new_status_output(&config, &usage, Some(&usage), &None, Some(&rate_display));
+    let composite = new_status_output(
+        &config,
+        &usage,
+        Some(&usage),
+        &None,
+        None,
+        Some(&rate_display),
+    );
     let mut rendered_lines = render_lines(&composite.display_lines(80));
     if cfg!(windows) {
         for line in &mut rendered_lines {
@@ -112,6 +119,23 @@ fn status_snapshot_includes_reasoning_details() {
     }
     let sanitized = sanitize_directory(rendered_lines).join("\n");
     assert_snapshot!(sanitized);
+}
+
+#[test]
+fn status_output_includes_window_title() {
+    let temp_home = TempDir::new().expect("temp home");
+    let config = test_config(&temp_home);
+    let usage = TokenUsage::default();
+
+    let composite = new_status_output(&config, &usage, Some(&usage), &None, Some("My Title"), None);
+    let rendered = render_lines(&composite.display_lines(80));
+
+    assert!(
+        rendered
+            .iter()
+            .any(|line| line.contains("Title:") && line.contains("My Title")),
+        "expected status output to include window title, got: {rendered:?}"
+    );
 }
 
 #[test]
@@ -144,7 +168,14 @@ fn status_snapshot_includes_monthly_limit() {
         .expect("timestamp");
     let rate_display = rate_limit_snapshot_display(&snapshot, captured_at);
 
-    let composite = new_status_output(&config, &usage, Some(&usage), &None, Some(&rate_display));
+    let composite = new_status_output(
+        &config,
+        &usage,
+        Some(&usage),
+        &None,
+        None,
+        Some(&rate_display),
+    );
     let mut rendered_lines = render_lines(&composite.display_lines(80));
     if cfg!(windows) {
         for line in &mut rendered_lines {
@@ -170,7 +201,7 @@ fn status_card_token_usage_excludes_cached_tokens() {
         total_tokens: 2_100,
     };
 
-    let composite = new_status_output(&config, &usage, Some(&usage), &None, None);
+    let composite = new_status_output(&config, &usage, Some(&usage), &None, None, None);
     let rendered = render_lines(&composite.display_lines(120));
 
     assert!(
@@ -211,7 +242,14 @@ fn status_snapshot_truncates_in_narrow_terminal() {
         .expect("timestamp");
     let rate_display = rate_limit_snapshot_display(&snapshot, captured_at);
 
-    let composite = new_status_output(&config, &usage, Some(&usage), &None, Some(&rate_display));
+    let composite = new_status_output(
+        &config,
+        &usage,
+        Some(&usage),
+        &None,
+        None,
+        Some(&rate_display),
+    );
     let mut rendered_lines = render_lines(&composite.display_lines(46));
     if cfg!(windows) {
         for line in &mut rendered_lines {
@@ -238,7 +276,7 @@ fn status_snapshot_shows_missing_limits_message() {
         total_tokens: 750,
     };
 
-    let composite = new_status_output(&config, &usage, Some(&usage), &None, None);
+    let composite = new_status_output(&config, &usage, Some(&usage), &None, None, None);
     let mut rendered_lines = render_lines(&composite.display_lines(80));
     if cfg!(windows) {
         for line in &mut rendered_lines {
@@ -274,7 +312,14 @@ fn status_snapshot_shows_empty_limits_message() {
         .expect("timestamp");
     let rate_display = rate_limit_snapshot_display(&snapshot, captured_at);
 
-    let composite = new_status_output(&config, &usage, Some(&usage), &None, Some(&rate_display));
+    let composite = new_status_output(
+        &config,
+        &usage,
+        Some(&usage),
+        &None,
+        None,
+        Some(&rate_display),
+    );
     let mut rendered_lines = render_lines(&composite.display_lines(80));
     if cfg!(windows) {
         for line in &mut rendered_lines {
@@ -306,7 +351,7 @@ fn status_context_window_uses_last_usage() {
         total_tokens: 13_679,
     };
 
-    let composite = new_status_output(&config, &total_usage, Some(&last_usage), &None, None);
+    let composite = new_status_output(&config, &total_usage, Some(&last_usage), &None, None, None);
     let rendered_lines = render_lines(&composite.display_lines(80));
     let context_line = rendered_lines
         .into_iter()

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -28,6 +28,7 @@ use crossterm::event::PopKeyboardEnhancementFlags;
 use crossterm::event::PushKeyboardEnhancementFlags;
 use crossterm::terminal::EnterAlternateScreen;
 use crossterm::terminal::LeaveAlternateScreen;
+use crossterm::terminal::SetTitle;
 use crossterm::terminal::supports_keyboard_enhancement;
 use ratatui::backend::Backend;
 use ratatui::backend::CrosstermBackend;
@@ -304,6 +305,10 @@ impl Tui {
 
     pub fn enhanced_keys_supported(&self) -> bool {
         self.enhanced_keys_supported
+    }
+
+    pub fn set_window_title(&mut self, title: &str) {
+        let _ = execute!(self.terminal.backend_mut(), SetTitle(title));
     }
 
     pub fn event_stream(&self) -> Pin<Box<dyn Stream<Item = TuiEvent> + Send + 'static>> {


### PR DESCRIPTION
- add /title slash command that sends OSC 2 updates and persists the value
- plumb initial title through CLI, resume flow, and status output
- expand composer/chatwidget handling and tests to carry command arguments

<img width="1214" height="910" alt="Screenshot 2025-10-02 at 12 43 51" src="https://github.com/user-attachments/assets/cfe913ef-7640-43b3-bd39-24670b386335" />
