### PR TITLE
fix: replace --api-key with --with-api-key in `codex login`

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -5,8 +5,16 @@
 If you prefer to pay-as-you-go, you can still authenticate with your OpenAI API key:
 
 ```shell
-codex login --api-key "your-api-key-here"
+printenv OPENAI_API_KEY | codex login --with-api-key
 ```
+
+Alternatively, read from a file:
+
+```shell
+codex login --with-api-key < my_key.txt
+```
+
+The legacy `--api-key` flag now exits with an error instructing you to use `--with-api-key` so that the key never appears in shell history or process listings.
 
 This key must, at minimum, have write access to the Responses API.
 


### PR DESCRIPTION
Previously, users could supply their API key directly via:

```shell
codex login --api-key KEY
```

but this has the drawback that `KEY` is more likely to end up in shell history, can be read from `/proc`, etc.

This PR removes support for `--api-key` and replaces it with `--with-api-key`, which reads the key from stdin, so either of these are better options:

```
printenv OPENAI_API_KEY | codex login --with-api-key
codex login --with-api-key < my_key.txt
```

Other CLIs, such as `gh auth login --with-token`, follow the same practice.