### PR TITLE
Surface context window error to the client

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -936,12 +936,7 @@ fn is_context_window_error(error: &Error) -> bool {
     if error.code.as_deref() == Some("context_length_exceeded") {
         return true;
     }
-
-    error
-        .message
-        .as_ref()
-        .map(|msg| msg.to_ascii_lowercase())
-        .is_some_and(|msg| msg.contains("context window"))
+    false
 }
 
 #[cfg(test)]

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -926,10 +926,7 @@ fn try_parse_retry_after(err: &Error) -> Option<Duration> {
 }
 
 fn is_context_window_error(error: &Error) -> bool {
-    if error.code.as_deref() == Some("context_length_exceeded") {
-        return true;
-    }
-    false
+    error.code.as_deref() == Some("context_length_exceeded")
 }
 
 #[cfg(test)]

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -63,7 +63,6 @@ struct ErrorResponse {
 #[derive(Debug, Deserialize)]
 struct Error {
     r#type: Option<String>,
-    #[allow(dead_code)]
     code: Option<String>,
     message: Option<String>,
 
@@ -793,10 +792,21 @@ async fn process_sse<S>(
 
                     if let Some(error) = error {
                         match serde_json::from_value::<Error>(error.clone()) {
-                            Ok(error) => {
-                                let delay = try_parse_retry_after(&error);
-                                let message = error.message.unwrap_or_default();
-                                response_error = Some(CodexErr::Stream(message, delay));
+                            Ok(mut error) => {
+                                if is_context_window_error(&error) {
+                                    let message = error
+                                        .message
+                                        .take()
+                                        .unwrap_or_else(|| {
+                                            "Your input exceeds the context window of this model.".
+                                                to_string()
+                                        });
+                                    response_error = Some(CodexErr::ContextWindowExceeded(message));
+                                } else {
+                                    let delay = try_parse_retry_after(&error);
+                                    let message = error.message.take().unwrap_or_default();
+                                    response_error = Some(CodexErr::Stream(message, delay));
+                                }
                             }
                             Err(e) => {
                                 let error = format!("failed to parse ErrorResponse: {e}");
@@ -920,6 +930,18 @@ fn try_parse_retry_after(err: &Error) -> Option<Duration> {
         }
     }
     None
+}
+
+fn is_context_window_error(error: &Error) -> bool {
+    if error.code.as_deref() == Some("context_length_exceeded") {
+        return true;
+    }
+
+    error
+        .message
+        .as_ref()
+        .map(|msg| msg.to_ascii_lowercase())
+        .is_some_and(|msg| msg.contains("context window"))
 }
 
 #[cfg(test)]
@@ -1176,6 +1198,80 @@ mod tests {
                 assert_eq!(*delay, Some(Duration::from_secs_f64(11.054)));
             }
             other => panic!("unexpected second event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn context_window_error_is_fatal() {
+        let raw_error = r#"{"type":"response.failed","sequence_number":3,"response":{"id":"resp_5c66275b97b9baef1ed95550adb3b7ec13b17aafd1d2f11b","object":"response","created_at":1759510079,"status":"failed","background":false,"error":{"code":"context_length_exceeded","message":"Your input exceeds the context window of this model. Please adjust your input and try again."},"usage":null,"user":null,"metadata":{}}}"#;
+
+        let sse1 = format!("event: response.failed\ndata: {raw_error}\n\n");
+        let provider = ModelProviderInfo {
+            name: "test".to_string(),
+            base_url: Some("https://test.com".to_string()),
+            env_key: Some("TEST_API_KEY".to_string()),
+            env_key_instructions: None,
+            wire_api: WireApi::Responses,
+            query_params: None,
+            http_headers: None,
+            env_http_headers: None,
+            request_max_retries: Some(0),
+            stream_max_retries: Some(0),
+            stream_idle_timeout_ms: Some(1000),
+            requires_openai_auth: false,
+        };
+
+        let otel_event_manager = otel_event_manager();
+
+        let events = collect_events(&[sse1.as_bytes()], provider, otel_event_manager).await;
+
+        assert_eq!(events.len(), 1);
+
+        match &events[0] {
+            Err(CodexErr::ContextWindowExceeded(message)) => {
+                assert_eq!(
+                    message,
+                    "Your input exceeds the context window of this model. Please adjust your input and try again."
+                );
+            }
+            other => panic!("unexpected context window event: {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn context_window_error_with_newline_is_fatal() {
+        let raw_error = r#"{"type":"response.failed","sequence_number":4,"response":{"id":"resp_fatal_newline","object":"response","created_at":1759510080,"status":"failed","background":false,"error":{"code":"context_length_exceeded","message":"Your input exceeds the context window of this model. Please adjust your input and try\nagain."},"usage":null,"user":null,"metadata":{}}}"#;
+
+        let sse1 = format!("event: response.failed\ndata: {raw_error}\n\n");
+        let provider = ModelProviderInfo {
+            name: "test".to_string(),
+            base_url: Some("https://test.com".to_string()),
+            env_key: Some("TEST_API_KEY".to_string()),
+            env_key_instructions: None,
+            wire_api: WireApi::Responses,
+            query_params: None,
+            http_headers: None,
+            env_http_headers: None,
+            request_max_retries: Some(0),
+            stream_max_retries: Some(0),
+            stream_idle_timeout_ms: Some(1000),
+            requires_openai_auth: false,
+        };
+
+        let otel_event_manager = otel_event_manager();
+
+        let events = collect_events(&[sse1.as_bytes()], provider, otel_event_manager).await;
+
+        assert_eq!(events.len(), 1);
+
+        match &events[0] {
+            Err(CodexErr::ContextWindowExceeded(message)) => {
+                assert_eq!(
+                    message,
+                    "Your input exceeds the context window of this model. Please adjust your input and try\nagain."
+                );
+            }
+            other => panic!("unexpected context window event: {other:?}"),
         }
     }
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -791,9 +791,6 @@ impl Session {
         if let (Some(token_info), Some(context_window)) = (token_info, context_window) {
             let mut token_info = token_info;
             token_info.total_token_usage.total_tokens = context_window;
-            if token_info.model_context_window.is_none() {
-                token_info.model_context_window = Some(context_window);
-            }
             self.update_token_usage_info(sub_id, turn_context, Some(&token_info.last_token_usage))
                 .await;
         }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -794,8 +794,10 @@ impl Session {
             };
 
             let delta = context_window.saturating_sub(current_total);
-            let mut last_usage = TokenUsage::default();
-            last_usage.total_tokens = delta;
+            let last_usage = TokenUsage {
+                total_tokens: delta,
+                ..TokenUsage::default()
+            };
 
             self.update_token_usage_info(sub_id, turn_context, Some(&last_usage))
                 .await;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2610,63 +2610,6 @@ mod tests {
     }
 
     #[test]
-    fn context_window_error_records_token_usage() {
-        let (session, turn_context) = make_session_and_context();
-        let context_window = turn_context
-            .client
-            .get_model_context_window()
-            .expect("context window available");
-
-        let initial_usage = TokenUsage {
-            input_tokens: 42,
-            cached_input_tokens: 7,
-            output_tokens: 13,
-            reasoning_output_tokens: 5,
-            total_tokens: 67,
-        };
-
-        tokio_test::block_on(async {
-            let mut state = session.state.lock().await;
-            state.update_token_info_from_usage(
-                &initial_usage,
-                turn_context.client.get_model_context_window(),
-            );
-        });
-
-        tokio_test::block_on(async {
-            session.set_total_tokens_full("sub", &turn_context).await;
-        });
-
-        let token_info = tokio_test::block_on(async {
-            let state = session.state.lock().await;
-            state.token_info.clone()
-        })
-        .expect("token info recorded");
-
-        assert_eq!(token_info.total_token_usage.total_tokens, context_window);
-        assert_eq!(
-            token_info.total_token_usage.input_tokens,
-            initial_usage.input_tokens
-        );
-        assert_eq!(
-            token_info.total_token_usage.cached_input_tokens,
-            initial_usage.cached_input_tokens
-        );
-        assert_eq!(
-            token_info.total_token_usage.output_tokens,
-            initial_usage.output_tokens
-        );
-        assert_eq!(
-            token_info.total_token_usage.reasoning_output_tokens,
-            initial_usage.reasoning_output_tokens
-        );
-        assert_eq!(
-            token_info.last_token_usage.total_tokens,
-            context_window - initial_usage.total_tokens
-        );
-    }
-
-    #[test]
     fn falls_back_to_content_when_structured_is_null() {
         let ctr = CallToolResult {
             content: vec![text_block("hello"), text_block("world")],

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -786,7 +786,6 @@ impl Session {
     async fn set_total_tokens_full(&self, sub_id: &str, turn_context: &TurnContext) {
         let context_window = turn_context.client.get_model_context_window();
         if let Some(context_window) = context_window {
-            let mut updated = false;
             {
                 let mut state = self.state.lock().await;
                 if let Some(mut token_info) = state.get_token_info() {
@@ -798,7 +797,6 @@ impl Session {
                         ..TokenUsage::default()
                     };
                     state.set_token_info(token_info);
-                    updated = true;
                 } else {
                     let token_info = TokenUsageInfo {
                         total_token_usage: TokenUsage {
@@ -812,12 +810,9 @@ impl Session {
                         model_context_window: Some(context_window),
                     };
                     state.set_token_info(token_info);
-                    updated = true;
                 }
             }
-            if updated {
-                self.send_token_count_event(sub_id).await;
-            }
+            self.send_token_count_event(sub_id).await;
         }
     }
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -791,11 +791,18 @@ impl Session {
                 if let Some(mut token_info) = state.get_token_info() {
                     let previous_total = token_info.total_token_usage.total_tokens;
                     token_info.total_token_usage.total_tokens = context_window;
-                    let delta = context_window.saturating_sub(previous_total);
+                    let delta = if previous_total >= context_window {
+                        context_window
+                    } else {
+                        context_window - previous_total
+                    };
                     token_info.last_token_usage = TokenUsage {
                         total_tokens: delta,
                         ..TokenUsage::default()
                     };
+                    if token_info.model_context_window.is_none() {
+                        token_info.model_context_window = Some(context_window);
+                    }
                     state.set_token_info(token_info);
                 } else {
                     let token_info = TokenUsageInfo {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -793,16 +793,6 @@ impl Session {
                     .unwrap_or(0)
             };
 
-            {
-                let mut state = self.state.lock().await;
-                if let Some(mut token_info) = state.get_token_info() {
-                    if token_info.model_context_window.is_none() {
-                        token_info.model_context_window = Some(context_window);
-                        state.set_token_info(token_info);
-                    }
-                }
-            }
-
             let delta = context_window.saturating_sub(current_total);
             let mut last_usage = TokenUsage::default();
             last_usage.total_tokens = delta;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -89,6 +89,7 @@ use crate::protocol::StreamErrorEvent;
 use crate::protocol::Submission;
 use crate::protocol::TokenCountEvent;
 use crate::protocol::TokenUsage;
+use crate::protocol::TokenUsageInfo;
 use crate::protocol::TurnDiffEvent;
 use crate::protocol::WebSearchBeginEvent;
 use crate::rollout::RolloutRecorder;
@@ -795,6 +796,20 @@ impl Session {
                     token_info.last_token_usage = TokenUsage {
                         total_tokens: delta,
                         ..TokenUsage::default()
+                    };
+                    state.set_token_info(token_info);
+                    updated = true;
+                } else {
+                    let token_info = TokenUsageInfo {
+                        total_token_usage: TokenUsage {
+                            total_tokens: context_window,
+                            ..TokenUsage::default()
+                        },
+                        last_token_usage: TokenUsage {
+                            total_tokens: context_window,
+                            ..TokenUsage::default()
+                        },
+                        model_context_window: Some(context_window),
                     };
                     state.set_token_info(token_info);
                     updated = true;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -783,31 +783,19 @@ impl Session {
     }
 
     async fn set_total_tokens_full(&self, sub_id: &str, turn_context: &TurnContext) {
-        if let Some(context_window) = turn_context.client.get_model_context_window() {
-            let delta_usage = {
-                let state = self.state.lock().await;
-                let current_total = state
-                    .token_info
-                    .as_ref()
-                    .map(|info| info.total_token_usage.total_tokens)
-                    .unwrap_or(0);
-                if current_total >= context_window {
-                    None
-                } else {
-                    Some(TokenUsage {
-                        input_tokens: 0,
-                        cached_input_tokens: 0,
-                        output_tokens: 0,
-                        reasoning_output_tokens: 0,
-                        total_tokens: context_window - current_total,
-                    })
-                }
-            };
-
-            if let Some(usage_delta) = delta_usage {
-                self.update_token_usage_info(sub_id, turn_context, Some(&usage_delta))
-                    .await;
+        let context_window = turn_context.client.get_model_context_window();
+        let token_info = {
+            let state = self.state.lock().await;
+            state.get_token_info()
+        };
+        if let (Some(token_info), Some(context_window)) = (token_info, context_window) {
+            let mut token_info = token_info;
+            token_info.total_token_usage.total_tokens = context_window;
+            if token_info.model_context_window.is_none() {
+                token_info.model_context_window = Some(context_window);
             }
+            self.update_token_usage_info(sub_id, turn_context, Some(&token_info.last_token_usage))
+                .await;
         }
     }
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -796,9 +796,6 @@ impl Session {
                     } else {
                         context_window - previous_total
                     };
-                    println!(
-                        "set_total_tokens_full existing info: prev={previous_total}, delta={delta}, context={context_window}"
-                    );
                     token_info.last_token_usage = TokenUsage {
                         total_tokens: delta,
                         ..TokenUsage::default()
@@ -819,7 +816,6 @@ impl Session {
                         },
                         model_context_window: Some(context_window),
                     };
-                    println!("set_total_tokens_full new info: context={context_window}");
                     state.set_token_info(token_info);
                 }
             }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1938,6 +1938,7 @@ async fn run_turn(
             Err(CodexErr::Interrupted) => return Err(CodexErr::Interrupted),
             Err(CodexErr::EnvVar(var)) => return Err(CodexErr::EnvVar(var)),
             Err(e @ CodexErr::Fatal(_)) => return Err(e),
+            Err(e @ CodexErr::ContextWindowExceeded(_)) => return Err(e),
             Err(CodexErr::UsageLimitReached(e)) => {
                 let rate_limits = e.rate_limits.clone();
                 if let Some(rate_limits) = rate_limits {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -796,6 +796,9 @@ impl Session {
                     } else {
                         context_window - previous_total
                     };
+                    println!(
+                        "set_total_tokens_full existing info: prev={previous_total}, delta={delta}, context={context_window}"
+                    );
                     token_info.last_token_usage = TokenUsage {
                         total_tokens: delta,
                         ..TokenUsage::default()
@@ -816,6 +819,7 @@ impl Session {
                         },
                         model_context_window: Some(context_window),
                     };
+                    println!("set_total_tokens_full new info: context={context_window}");
                     state.set_token_info(token_info);
                 }
             }

--- a/codex-rs/core/src/codex/compact.rs
+++ b/codex-rs/core/src/codex/compact.rs
@@ -103,7 +103,7 @@ async fn run_compact_task_inner(
             Err(CodexErr::Interrupted) => {
                 return;
             }
-            Err(e @ CodexErr::ContextWindowExceeded(_)) => {
+            Err(e @ CodexErr::ContextWindowExceeded) => {
                 sess.set_total_tokens_full(&sub_id, turn_context.as_ref())
                     .await;
                 let event = Event {

--- a/codex-rs/core/src/codex/compact.rs
+++ b/codex-rs/core/src/codex/compact.rs
@@ -104,7 +104,7 @@ async fn run_compact_task_inner(
                 return;
             }
             Err(e @ CodexErr::ContextWindowExceeded(_)) => {
-                sess.record_context_window_token_usage(&sub_id, turn_context.as_ref())
+                sess.set_total_tokens_full(&sub_id, turn_context.as_ref())
                     .await;
                 let event = Event {
                     id: sub_id.clone(),

--- a/codex-rs/core/src/codex/compact.rs
+++ b/codex-rs/core/src/codex/compact.rs
@@ -104,6 +104,8 @@ async fn run_compact_task_inner(
                 return;
             }
             Err(e @ CodexErr::ContextWindowExceeded(_)) => {
+                sess.record_context_window_token_usage(&sub_id, turn_context.as_ref())
+                    .await;
                 let event = Event {
                     id: sub_id.clone(),
                     msg: EventMsg::Error(ErrorEvent {

--- a/codex-rs/core/src/codex/compact.rs
+++ b/codex-rs/core/src/codex/compact.rs
@@ -103,6 +103,16 @@ async fn run_compact_task_inner(
             Err(CodexErr::Interrupted) => {
                 return;
             }
+            Err(e @ CodexErr::ContextWindowExceeded(_)) => {
+                let event = Event {
+                    id: sub_id.clone(),
+                    msg: EventMsg::Error(ErrorEvent {
+                        message: e.to_string(),
+                    }),
+                };
+                sess.send_event(event).await;
+                return;
+            }
             Err(e) => {
                 if retries < max_retries {
                     retries += 1;

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -55,6 +55,9 @@ pub enum CodexErr {
     #[error("stream disconnected before completion: {0}")]
     Stream(String, Option<Duration>),
 
+    #[error("{0}")]
+    ContextWindowExceeded(String),
+
     #[error("no conversation with id: {0}")]
     ConversationNotFound(ConversationId),
 

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -55,8 +55,10 @@ pub enum CodexErr {
     #[error("stream disconnected before completion: {0}")]
     Stream(String, Option<Duration>),
 
-    #[error("{0}")]
-    ContextWindowExceeded(String),
+    #[error(
+        "Codex ran out of room in the model's context window. Start a new conversation or clear earlier history before retrying."
+    )]
+    ContextWindowExceeded,
 
     #[error("no conversation with id: {0}")]
     ConversationNotFound(ConversationId),

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -62,10 +62,6 @@ impl SessionState {
         self.latest_rate_limits = Some(snapshot);
     }
 
-    pub(crate) fn set_token_info(&mut self, info: TokenUsageInfo) {
-        self.token_info = Some(info);
-    }
-
     pub(crate) fn token_info_and_rate_limits(
         &self,
     ) -> (Option<TokenUsageInfo>, Option<RateLimitSnapshot>) {

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -54,23 +54,6 @@ impl SessionState {
         );
     }
 
-    pub(crate) fn set_total_tokens_full(
-        &mut self,
-        total_tokens: u64,
-        model_context_window: Option<u64>,
-    ) {
-        let mut token_info = self.token_info.clone().unwrap_or(TokenUsageInfo {
-            total_token_usage: TokenUsage::default(),
-            last_token_usage: TokenUsage::default(),
-            model_context_window,
-        });
-        token_info.total_token_usage.total_tokens = total_tokens;
-        if token_info.model_context_window.is_none() {
-            token_info.model_context_window = model_context_window;
-        }
-        self.token_info = Some(token_info);
-    }
-
     pub(crate) fn set_rate_limits(&mut self, snapshot: RateLimitSnapshot) {
         self.latest_rate_limits = Some(snapshot);
     }

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -54,10 +54,6 @@ impl SessionState {
         );
     }
 
-    pub(crate) fn get_token_info(&self) -> Option<TokenUsageInfo> {
-        self.token_info.clone()
-    }
-
     pub(crate) fn set_rate_limits(&mut self, snapshot: RateLimitSnapshot) {
         self.latest_rate_limits = Some(snapshot);
     }
@@ -66,6 +62,15 @@ impl SessionState {
         &self,
     ) -> (Option<TokenUsageInfo>, Option<RateLimitSnapshot>) {
         (self.token_info.clone(), self.latest_rate_limits.clone())
+    }
+
+    pub(crate) fn set_token_usage_full(&mut self, context_window: u64) {
+        match &mut self.token_info {
+            Some(info) => info.fill_to_context_window(context_window),
+            None => {
+                self.token_info = Some(TokenUsageInfo::full_context_window(context_window));
+            }
+        }
     }
 
     // Pending input/approval moved to TurnState.

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -54,26 +54,21 @@ impl SessionState {
         );
     }
 
-    pub(crate) fn set_total_tokens(
+    pub(crate) fn set_total_tokens_full(
         &mut self,
         total_tokens: u64,
         model_context_window: Option<u64>,
     ) {
-        if let Some(info) = self.token_info.as_mut() {
-            info.total_token_usage.total_tokens = total_tokens;
-            if info.model_context_window.is_none() {
-                info.model_context_window = model_context_window;
-            }
-        } else {
-            self.token_info = Some(TokenUsageInfo {
-                total_token_usage: TokenUsage {
-                    total_tokens,
-                    ..TokenUsage::default()
-                },
-                last_token_usage: TokenUsage::default(),
-                model_context_window,
-            });
+        let mut token_info = self.token_info.clone().unwrap_or(TokenUsageInfo {
+            total_token_usage: TokenUsage::default(),
+            last_token_usage: TokenUsage::default(),
+            model_context_window,
+        });
+        token_info.total_token_usage.total_tokens = total_tokens;
+        if token_info.model_context_window.is_none() {
+            token_info.model_context_window = model_context_window;
         }
+        self.token_info = Some(token_info);
     }
 
     pub(crate) fn set_rate_limits(&mut self, snapshot: RateLimitSnapshot) {

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -54,6 +54,10 @@ impl SessionState {
         );
     }
 
+    pub(crate) fn get_token_info(&self) -> Option<TokenUsageInfo> {
+        self.token_info.clone()
+    }
+
     pub(crate) fn set_rate_limits(&mut self, snapshot: RateLimitSnapshot) {
         self.latest_rate_limits = Some(snapshot);
     }

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -54,6 +54,28 @@ impl SessionState {
         );
     }
 
+    pub(crate) fn set_total_tokens(
+        &mut self,
+        total_tokens: u64,
+        model_context_window: Option<u64>,
+    ) {
+        if let Some(info) = self.token_info.as_mut() {
+            info.total_token_usage.total_tokens = total_tokens;
+            if info.model_context_window.is_none() {
+                info.model_context_window = model_context_window;
+            }
+        } else {
+            self.token_info = Some(TokenUsageInfo {
+                total_token_usage: TokenUsage {
+                    total_tokens,
+                    ..TokenUsage::default()
+                },
+                last_token_usage: TokenUsage::default(),
+                model_context_window,
+            });
+        }
+    }
+
     pub(crate) fn set_rate_limits(&mut self, snapshot: RateLimitSnapshot) {
         self.latest_rate_limits = Some(snapshot);
     }

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -62,6 +62,10 @@ impl SessionState {
         self.latest_rate_limits = Some(snapshot);
     }
 
+    pub(crate) fn set_token_info(&mut self, info: TokenUsageInfo) {
+        self.token_info = Some(info);
+    }
+
     pub(crate) fn token_info_and_rate_limits(
         &self,
     ) -> (Option<TokenUsageInfo>, Option<RateLimitSnapshot>) {

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -135,6 +135,16 @@ pub fn ev_apply_patch_function_call(call_id: &str, patch: &str) -> Value {
     })
 }
 
+pub fn sse_failed(id: &str, code: &str, message: &str) -> String {
+    sse(vec![serde_json::json!({
+        "type": "response.failed",
+        "response": {
+            "id": id,
+            "error": {"code": code, "message": message}
+        }
+    })])
+}
+
 pub fn sse_response(body: String) -> ResponseTemplate {
     ResponseTemplate::new(200)
         .insert_header("content-type", "text/event-stream")

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -1005,9 +1005,11 @@ async fn context_window_error_sets_total_tokens_to_model_window() -> anyhow::Res
     skip_if_no_network!(Ok(()));
     let server = MockServer::start().await;
 
-    let raw_error = r#"{"type":"response.failed","sequence_number":3,"response":{"id":"resp_context_window","object":"response","created_at":1759510079,"status":"failed","background":false,"error":{"code":"context_length_exceeded","message":"Your input exceeds the context window of this model. Please adjust your input and try again."},"usage":null,"user":null,"metadata":{}}}"#;
-
-    let error_stream = format!("event: response.failed\ndata: {raw_error}\n\n");
+    let error_stream = responses::sse_failed(
+        "resp_context_window",
+        "context_length_exceeded",
+        "Your input exceeds the context window of this model. Please adjust your input and try again.",
+    );
 
     let second_turn = ResponseTemplate::new(200)
         .insert_header("content-type", "text/event-stream")

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -1083,10 +1083,7 @@ async fn context_window_error_sets_total_tokens_to_model_window() -> anyhow::Res
     }
 
     let token_payload = token_payload.unwrap_or_else(|| {
-        panic!(
-            "did not observe expected TokenCount event; events observed: {:?}",
-            observed
-        )
+        panic!("did not observe expected TokenCount event; events observed: {observed:?}")
     });
 
     let info = token_payload

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -590,6 +590,31 @@ impl TokenUsageInfo {
         self.total_token_usage.add_assign(last);
         self.last_token_usage = last.clone();
     }
+
+    pub fn fill_to_context_window(&mut self, context_window: u64) {
+        let previous_total = self.total_token_usage.total_tokens;
+        let delta = context_window.saturating_sub(previous_total);
+
+        self.model_context_window = Some(context_window);
+        self.total_token_usage = TokenUsage {
+            total_tokens: context_window,
+            ..TokenUsage::default()
+        };
+        self.last_token_usage = TokenUsage {
+            total_tokens: delta,
+            ..TokenUsage::default()
+        };
+    }
+
+    pub fn full_context_window(context_window: u64) -> Self {
+        let mut info = Self {
+            total_token_usage: TokenUsage::default(),
+            last_token_usage: TokenUsage::default(),
+            model_context_window: Some(context_window),
+        };
+        info.fill_to_context_window(context_window);
+        info
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, TS)]


### PR DESCRIPTION
In the past, we were treating `input exceeded context window` as a streaming error and retrying on it. Retrying on it has no point because it won't change the behavior. In this PR, we surface the error to the client without retry and also send a token count event to indicate that the context window is full.

<img width="650" height="125" alt="image" src="https://github.com/user-attachments/assets/c26b1213-4c27-4bfc-90f4-51a270a3efd5" />
