### PR TITLE
Fix oauth .well-known metadata discovery

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -4757,8 +4757,7 @@ dependencies = [
 [[package]]
 name = "rmcp"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "534fd1cd0601e798ac30545ff2b7f4a62c6f14edd4aaed1cc5eb1e85f69f09af"
+source = "git+https://github.com/modelcontextprotocol/rust-sdk?rev=c0b777c7f784ba2d456b03c2ec3b98c9b28b5e10#c0b777c7f784ba2d456b03c2ec3b98c9b28b5e10"
 dependencies = [
  "base64",
  "bytes",
@@ -4791,8 +4790,7 @@ dependencies = [
 [[package]]
 name = "rmcp-macros"
 version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ba777eb0e5f53a757e36f0e287441da0ab766564ba7201600eeb92a4753022e"
+source = "git+https://github.com/modelcontextprotocol/rust-sdk?rev=c0b777c7f784ba2d456b03c2ec3b98c9b28b5e10#c0b777c7f784ba2d456b03c2ec3b98c9b28b5e10"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -142,6 +142,7 @@ rand = "0.9"
 ratatui = "0.29.0"
 regex-lite = "0.1.7"
 reqwest = "0.12"
+# When this gets bumped, remove the patch below.
 rmcp = { version = "0.7.0", default-features = false }
 schemars = "0.8.22"
 seccompiler = "0.5.0"
@@ -243,5 +244,11 @@ strip = "symbols"
 codegen-units = 1
 
 [patch.crates-io]
+# Uncomment to debug local changes.
 # ratatui = { path = "../../ratatui" }
 ratatui = { git = "https://github.com/nornagon/ratatui", branch = "nornagon-v0.29.0-patch" }
+
+# Uncomment to debug local changes.
+# rmcp = { path = "../../rust-sdk/crates/rmcp" }
+# 0.7.0 + https://github.com/modelcontextprotocol/rust-sdk/pull/459 which includes dynamic .well-known discovery which is required for Figma.
+rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", rev = "c0b777c7f784ba2d456b03c2ec3b98c9b28b5e10", default-features = false }


### PR DESCRIPTION
This picks up https://github.com/modelcontextprotocol/rust-sdk/pull/459 which is required for proper well-known metadata discovery for some MCPs such as Figma.