### PR TITLE
cloud-tasks: use workspace deps

### DIFF
--- a/codex-rs/cloud-tasks/Cargo.toml
+++ b/codex-rs/cloud-tasks/Cargo.toml
@@ -11,10 +11,10 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-anyhow = "1"
-base64 = "0.22"
-chrono = { version = "0.4", features = ["serde"] }
-clap = { version = "4", features = ["derive"] }
+anyhow = { workspace = true }
+base64 = { workspace = true }
+chrono = { workspace = true, features = ["serde"] }
+clap = { workspace = true, features = ["derive"] }
 codex-cloud-tasks-client = { path = "../cloud-tasks-client", features = [
     "mock",
     "online",
@@ -23,16 +23,16 @@ codex-common = { path = "../common", features = ["cli"] }
 codex-core = { path = "../core" }
 codex-login = { path = "../login" }
 codex-tui = { path = "../tui" }
-crossterm = { version = "0.28.1", features = ["event-stream"] }
-ratatui = { version = "0.29.0" }
-reqwest = { version = "0.12", features = ["json"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-tokio-stream = "0.1.17"
-tracing = { version = "0.1.41", features = ["log"] }
-tracing-subscriber = { version = "0.3.19", features = ["env-filter"] }
-unicode-width = "0.1"
+crossterm = { workspace = true, features = ["event-stream"] }
+ratatui = { workspace = true }
+reqwest = { workspace = true, features = ["json"] }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tokio-stream = { workspace = true }
+tracing = { workspace = true, features = ["log"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
+unicode-width = { workspace = true }
 
 [dev-dependencies]
-async-trait = "0.1"
+async-trait = { workspace = true }


### PR DESCRIPTION
This seems to be the way. It made life easier when I was locally forking
clap.
