### PR TITLE
print codex resume note when quitting after codex resume

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -279,7 +279,8 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
                 last,
                 config_overrides,
             );
-            codex_tui::run_main(interactive, codex_linux_sandbox_exe).await?;
+            let exit_info = codex_tui::run_main(interactive, codex_linux_sandbox_exe).await?;
+            print_exit_messages(exit_info);
         }
         Some(Subcommand::Login(mut login_cli)) => {
             prepend_config_flags(


### PR DESCRIPTION
when exiting a session that was started with `codex resume`, the note about how to resume again wasn't being printed.

thanks @aibrahim-oai for pointing out this issue!