### PR TITLE
Add base64 prompt decoding option

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -662,6 +662,7 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
+ "base64",
  "chrono",
  "clap",
  "codex-arg0",

--- a/codex-rs/exec/Cargo.toml
+++ b/codex-rs/exec/Cargo.toml
@@ -16,6 +16,7 @@ workspace = true
 
 [dependencies]
 anyhow = "1"
+base64 = "0.22"
 chrono = "0.4.40"
 clap = { version = "4", features = ["derive"] }
 codex-arg0 = { path = "../arg0" }

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -63,6 +63,10 @@ pub struct Cli {
     #[arg(long = "output-last-message")]
     pub last_message_file: Option<PathBuf>,
 
+    /// Treat the prompt argument as base64-encoded text and decode it before use.
+    #[arg(long = "base64", default_value_t = false)]
+    pub base64: bool,
+
     /// Initial instructions for the agent. If not provided as an argument (or
     /// if `-` is used), instructions are read from stdin.
     #[arg(value_name = "PROMPT")]

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -9,6 +9,10 @@ pub struct Cli {
     /// Optional user prompt to start the session.
     pub prompt: Option<String>,
 
+    /// Treat the prompt argument as base64-encoded text and decode it before use.
+    #[arg(long = "base64", default_value_t = false)]
+    pub base64: bool,
+
     /// Optional image(s) to attach to the initial prompt.
     #[arg(long = "image", short = 'i', value_name = "FILE", value_delimiter = ',', num_args = 1..)]
     pub images: Vec<PathBuf>,


### PR DESCRIPTION
## Summary
- add a `--base64` flag to the exec and TUI CLIs so prompt arguments can be decoded before use
- decode prompts when requested, trimming whitespace and surfacing clear errors if decoding fails
- cover the new helpers with unit tests

## Testing
- cargo fmt
- cargo test -p codex-exec *(fails: linux landlock sandbox unavailable in CI environment)*
- cargo test -p codex-exec --lib
- cargo test -p codex-tui


------
https://chatgpt.com/codex/tasks/task_i_68dfe537c8188322b438522978a9e62d