### PR TITLE
[feat] Support adding HTTP MCP servers with cli

### DIFF
--- a/codex-rs/cli/tests/mcp_add_remove.rs
+++ b/codex-rs/cli/tests/mcp_add_remove.rs
@@ -154,3 +154,45 @@ async fn add_streamable_http_server_rejects_command_args() -> Result<()> {
 
     Ok(())
 }
+
+#[tokio::test]
+async fn add_streamable_http_server_rejects_env_flag() -> Result<()> {
+    let codex_home = TempDir::new()?;
+
+    let mut add_cmd = codex_command(codex_home.path())?;
+    add_cmd
+        .args([
+            "mcp",
+            "add",
+            "broken",
+            "--url",
+            "http://127.0.0.1:3945/mcp",
+            "--env",
+            "FOO=bar",
+        ])
+        .assert()
+        .failure()
+        .stderr(contains("cannot be used with '--env"));
+
+    let servers = load_global_mcp_servers(codex_home.path()).await?;
+    assert!(servers.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn add_bearer_token_requires_url() -> Result<()> {
+    let codex_home = TempDir::new()?;
+
+    let mut add_cmd = codex_command(codex_home.path())?;
+    add_cmd
+        .args(["mcp", "add", "broken", "--bearer-token", "secret"])
+        .assert()
+        .failure()
+        .stderr(contains("required arguments were not provided"));
+
+    let servers = load_global_mcp_servers(codex_home.path()).await?;
+    assert!(servers.is_empty());
+
+    Ok(())
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -392,8 +392,11 @@ experimental_use_rmcp_client = true
 ### MCP CLI commands
 
 ```shell
-# Add a server (env can be repeated; `--` separates the launcher command)
+# Add a stdio server (env can be repeated; `--` separates the launcher command)
 codex mcp add docs -- docs-server --port 4000
+
+# Add a streamable HTTP server (requires experimental_use_rmcp_client = true)
+codex mcp add figma --url http://127.0.0.1:3845/mcp --bearer-token token
 
 # List configured servers (pretty table or JSON)
 codex mcp list


### PR DESCRIPTION
# Description
This PR extends `codex mcp add` so that it works with HTTP servers in addition to `stdio` servers.

## Testing and documentation
I've added tests and have updated the documentation