### PR TITLE
feat: session names

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -232,6 +232,17 @@ impl App {
                 self.chat_widget = ChatWidget::new(init, self.server.clone());
                 tui.frame_requester().schedule_frame();
             }
+            // OpenRenameSessionPopup removed; Ctrl+R handler opens popup directly.
+            AppEvent::UpdateSessionName(name) => {
+                let trimmed = name.trim().to_string();
+                let name_opt = if trimmed.is_empty() {
+                    None
+                } else {
+                    Some(trimmed)
+                };
+                self.chat_widget.set_session_name(name_opt);
+                tui.frame_requester().schedule_frame();
+            }
             AppEvent::InsertHistoryCell(cell) => {
                 let cell: Arc<dyn HistoryCell> = cell.into();
                 if let Some(Overlay::Transcript(t)) = &mut self.overlay {
@@ -424,6 +435,15 @@ impl App {
                 // Enter alternate screen and set viewport to full size.
                 let _ = tui.enter_alt_screen();
                 self.overlay = Some(Overlay::new_transcript(self.transcript_cells.clone()));
+                tui.frame_requester().schedule_frame();
+            }
+            KeyEvent {
+                code: KeyCode::Char('r'),
+                modifiers: crossterm::event::KeyModifiers::CONTROL,
+                kind: KeyEventKind::Press,
+                ..
+            } => {
+                self.chat_widget.open_rename_popup();
                 tui.frame_requester().schedule_frame();
             }
             // Esc primes/advances backtracking only in normal (not working) mode

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -87,4 +87,7 @@ pub(crate) enum AppEvent {
 
     /// Open the approval popup.
     FullScreenApprovalRequest(ApprovalRequest),
+
+    /// Update the current session's display name in the UI.
+    UpdateSessionName(String),
 }

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -1547,15 +1547,20 @@ impl WidgetRef for ChatComposer {
                             // Simple truncation: cap to a small max and the available row width.
                             let max_cols = custom_rect.width.min(24) as usize;
                             if max_cols > 0 {
-                                let truncated =
-                                    crate::text_formatting::truncate_text(name, max_cols);
-                                let right_width = UnicodeWidthStr::width(truncated.as_str()) as u16;
+                                let inner_max = max_cols.saturating_sub(2);
+                                let inner = if inner_max > 0 {
+                                    crate::text_formatting::truncate_text(name, inner_max)
+                                } else {
+                                    String::new()
+                                };
+                                let quoted = format!("\"{inner}\"");
+                                let right_width = UnicodeWidthStr::width(quoted.as_str()) as u16;
                                 let right_x = custom_rect
                                     .x
                                     .saturating_add(custom_rect.width.saturating_sub(right_width));
                                 let y = custom_rect.y;
                                 WidgetRef::render_ref(
-                                    &Span::from(truncated).dim(),
+                                    &Span::from(quoted).dim(),
                                     Rect::new(right_x, y, right_width, 1),
                                     buf,
                                 );
@@ -1573,14 +1578,20 @@ impl WidgetRef for ChatComposer {
                     {
                         let max_cols = hint_rect.width.min(24) as usize;
                         if max_cols > 0 {
-                            let truncated = crate::text_formatting::truncate_text(name, max_cols);
-                            let right_width = UnicodeWidthStr::width(truncated.as_str()) as u16;
+                            let inner_max = max_cols.saturating_sub(2);
+                            let inner = if inner_max > 0 {
+                                crate::text_formatting::truncate_text(name, inner_max)
+                            } else {
+                                String::new()
+                            };
+                            let quoted = format!("\"{inner}\"");
+                            let right_width = UnicodeWidthStr::width(quoted.as_str()) as u16;
                             let right_x = hint_rect
                                 .x
                                 .saturating_add(hint_rect.width.saturating_sub(right_width));
                             let y = hint_rect.y;
                             WidgetRef::render_ref(
-                                &Span::from(truncated).dim(),
+                                &Span::from(quoted).dim(),
                                 Rect::new(right_x, y, right_width, 1),
                                 buf,
                             );

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -1367,13 +1367,10 @@ impl ChatComposer {
         self.session_name = name.filter(|s| !s.trim().is_empty());
     }
 
-    /// Render the right-aligned session name in quotes within `area`, respecting
+    /// Render the right-aligned session name within `area`, respecting
     /// the current footer mode and a small width cap to avoid overlap.
     fn render_session_name_footer(&self, area: ratatui::layout::Rect, buf: &mut Buffer) {
         use super::footer::FooterMode;
-        if self.session_name.is_none() {
-            return;
-        }
         if matches!(self.footer_mode(), FooterMode::ShortcutOverlay) || area.width == 0 {
             return;
         }
@@ -1381,21 +1378,23 @@ impl ChatComposer {
         if max_cols == 0 {
             return;
         }
-        let name = self.session_name.as_ref().unwrap();
-        let inner_max = max_cols.saturating_sub(2);
+        let Some(name) = self.session_name.as_ref() else {
+            return;
+        };
+        let inner_max = max_cols;
         let inner = if inner_max > 0 {
             crate::text_formatting::truncate_text(name, inner_max)
         } else {
             String::new()
         };
-        let quoted = format!("\"{inner}\"");
-        let right_width = UnicodeWidthStr::width(quoted.as_str()) as u16;
+        let label = inner;
+        let right_width = UnicodeWidthStr::width(label.as_str()) as u16;
         let right_x = area
             .x
             .saturating_add(area.width.saturating_sub(right_width));
         let y = area.y;
         WidgetRef::render_ref(
-            &Span::from(quoted).dim(),
+            &Span::from(label).cyan(),
             ratatui::layout::Rect::new(right_x, y, right_width, 1),
             buf,
         );

--- a/codex-rs/tui/src/bottom_pane/footer.rs
+++ b/codex-rs/tui/src/bottom_pane/footer.rs
@@ -142,6 +142,7 @@ fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
     let mut edit_previous = Line::from("");
     let mut quit = Line::from("");
     let mut show_transcript = Line::from("");
+    let mut rename = Line::from("");
 
     for descriptor in SHORTCUTS {
         if let Some(text) = descriptor.overlay_entry(state) {
@@ -153,6 +154,7 @@ fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
                 ShortcutId::EditPrevious => edit_previous = text,
                 ShortcutId::Quit => quit = text,
                 ShortcutId::ShowTranscript => show_transcript = text,
+                ShortcutId::Rename => rename = text,
             }
         }
     }
@@ -166,6 +168,7 @@ fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
         quit,
         Line::from(""),
         show_transcript,
+        rename,
     ];
 
     build_columns(ordered)
@@ -242,6 +245,7 @@ enum ShortcutId {
     EditPrevious,
     Quit,
     ShowTranscript,
+    Rename,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -375,6 +379,15 @@ const SHORTCUTS: &[ShortcutDescriptor] = &[
         }],
         prefix: "",
         label: " to view transcript",
+    },
+    ShortcutDescriptor {
+        id: ShortcutId::Rename,
+        bindings: &[ShortcutBinding {
+            key: key_hint::ctrl(KeyCode::Char('r')),
+            condition: DisplayCondition::Always,
+        }],
+        prefix: "",
+        label: " to rename session",
     },
 ];
 

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -29,9 +29,12 @@ mod prompt_args;
 pub(crate) use list_selection_view::SelectionViewParams;
 mod paste_burst;
 pub mod popup_consts;
+mod rename_session_view;
 mod scroll_state;
 mod selection_popup_common;
 mod textarea;
+
+pub(crate) use rename_session_view::RenameSessionView;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CancellationEvent {
@@ -69,6 +72,8 @@ pub(crate) struct BottomPane {
     /// Queued user messages to show under the status indicator.
     queued_user_messages: Vec<String>,
     context_window_percent: Option<u8>,
+    // Optional user-visible session name for footer display.
+    session_name: Option<String>,
 }
 
 pub(crate) struct BottomPaneParams {
@@ -102,6 +107,7 @@ impl BottomPane {
             queued_user_messages: Vec::new(),
             esc_backtrack_hint: false,
             context_window_percent: None,
+            session_name: None,
         }
     }
 
@@ -358,6 +364,15 @@ impl BottomPane {
         self.context_window_percent = percent;
         self.composer.set_context_window_percent(percent);
         self.request_redraw();
+    }
+
+    /// Update the session name; forwarded to the composer for footer rendering.
+    pub(crate) fn set_session_name(&mut self, name: Option<String>) {
+        if self.session_name != name {
+            self.session_name = name.clone();
+            self.composer.set_session_name(name);
+            self.request_redraw();
+        }
     }
 
     /// Show a generic list selection view with the provided items.

--- a/codex-rs/tui/src/bottom_pane/rename_session_view.rs
+++ b/codex-rs/tui/src/bottom_pane/rename_session_view.rs
@@ -128,13 +128,20 @@ impl BottomPaneView for RenameSessionView {
     }
 
     fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
-        // Match panel layout: content inset + input row placement
+        // Reproduce the exact layout used in render to position the caret.
         let [content_area, _] =
             Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).areas(area);
         let inset = content_area.inset(Insets::vh(1, 2));
+        let [header_area, _, input_area] = Layout::vertical([
+            Constraint::Length(2),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .areas(inset);
+        let _ = header_area; // maintain parity with render; not used directly
         let label_cols: u16 = 6; // "Name: "
-        let input_y = inset.y + 3; // header(2) + spacer(1)
-        let x = inset.x + label_cols + (self.input.cursor() as u16);
-        Some((x, input_y))
+        let x = input_area.x + label_cols + (self.input.cursor() as u16);
+        let y = input_area.y;
+        Some((x, y))
     }
 }

--- a/codex-rs/tui/src/bottom_pane/rename_session_view.rs
+++ b/codex-rs/tui/src/bottom_pane/rename_session_view.rs
@@ -1,0 +1,122 @@
+use std::cell::RefCell;
+
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use crossterm::event::KeyEventKind;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Constraint;
+use ratatui::layout::Layout;
+use ratatui::layout::Rect;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::text::Span;
+use ratatui::widgets::WidgetRef;
+
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+use crate::bottom_pane::bottom_pane_view::BottomPaneView;
+use crate::bottom_pane::popup_consts::standard_popup_hint_line;
+use crate::bottom_pane::textarea::TextArea;
+use crate::bottom_pane::textarea::TextAreaState;
+
+/// Simple bottom-pane view to rename the current session.
+pub(crate) struct RenameSessionView {
+    tx: AppEventSender,
+    input: TextArea,
+    input_state: RefCell<TextAreaState>,
+    done: bool,
+}
+
+impl RenameSessionView {
+    pub(crate) fn new(tx: AppEventSender, initial: &str) -> Self {
+        let mut input = TextArea::new();
+        input.set_text(initial);
+        input.set_cursor(initial.len());
+        Self {
+            tx,
+            input,
+            input_state: RefCell::new(TextAreaState::default()),
+            done: false,
+        }
+    }
+}
+
+impl crate::render::renderable::Renderable for RenameSessionView {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        // Two rows layout: title and input + hint
+        let [title, input, hint] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .areas(area);
+
+        let title_line: Line = vec!["Rename session".bold().cyan()].into();
+        WidgetRef::render_ref(&title_line, title, buf);
+
+        // Render single-line input prefixed with label
+        let label = "Name: ";
+        let label_width = label.len() as u16;
+        // Draw label
+        WidgetRef::render_ref(&Line::from(Span::from(label).dim()), input, buf);
+
+        // Draw the editable field after the label
+        let mut input_rect = input;
+        if input_rect.width > label_width {
+            input_rect.x += label_width;
+            input_rect.width = input_rect.width.saturating_sub(label_width);
+        }
+        let mut state = self.input_state.borrow_mut();
+        ratatui::widgets::StatefulWidgetRef::render_ref(
+            &(&self.input),
+            input_rect,
+            buf,
+            &mut state,
+        );
+
+        // Footer hint
+        WidgetRef::render_ref(&standard_popup_hint_line(), hint, buf);
+    }
+
+    fn desired_height(&self, _width: u16) -> u16 {
+        3
+    }
+}
+
+impl BottomPaneView for RenameSessionView {
+    fn handle_key_event(&mut self, key_event: KeyEvent) {
+        if matches!(key_event.kind, KeyEventKind::Release) {
+            return;
+        }
+        match key_event {
+            KeyEvent {
+                code: KeyCode::Enter,
+                ..
+            } => {
+                let name = self.input.text().trim().to_string();
+                self.tx.send(AppEvent::UpdateSessionName(name));
+                self.done = true;
+            }
+            KeyEvent {
+                code: KeyCode::Esc, ..
+            } => {
+                self.done = true;
+            }
+            other => {
+                // Delegate to the text area for editing behavior.
+                self.input.input(other);
+            }
+        }
+    }
+
+    fn is_complete(&self) -> bool {
+        self.done
+    }
+
+    fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
+        // Cursor appears in the input line, after the "Name: " label.
+        let label_cols: u16 = 6; // "Name: "
+        let y = area.y + 1; // second row
+        Some((area.x + label_cols + (self.input.cursor() as u16), y))
+    }
+}

--- a/codex-rs/tui/src/bottom_pane/rename_session_view.rs
+++ b/codex-rs/tui/src/bottom_pane/rename_session_view.rs
@@ -10,6 +10,9 @@ use ratatui::layout::Rect;
 use ratatui::style::Stylize;
 use ratatui::text::Line;
 use ratatui::text::Span;
+use ratatui::widgets::Block;
+use ratatui::widgets::Paragraph;
+use ratatui::widgets::Widget;
 use ratatui::widgets::WidgetRef;
 
 use crate::app_event::AppEvent;
@@ -18,6 +21,10 @@ use crate::bottom_pane::bottom_pane_view::BottomPaneView;
 use crate::bottom_pane::popup_consts::standard_popup_hint_line;
 use crate::bottom_pane::textarea::TextArea;
 use crate::bottom_pane::textarea::TextAreaState;
+use crate::render::Insets;
+use crate::render::RectExt as _;
+use crate::style::user_message_style;
+use crate::terminal_palette;
 
 /// Simple bottom-pane view to rename the current session.
 pub(crate) struct RenameSessionView {
@@ -43,43 +50,50 @@ impl RenameSessionView {
 
 impl crate::render::renderable::Renderable for RenameSessionView {
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        // Two rows layout: title and input + hint
-        let [title, input, hint] = Layout::vertical([
-            Constraint::Length(1),
+        if area.height == 0 || area.width == 0 {
+            return;
+        }
+
+        // Panel background + hint line layout
+        let [content_area, footer_area] =
+            Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).areas(area);
+
+        Block::default()
+            .style(user_message_style(terminal_palette::default_bg()))
+            .render(content_area, buf);
+
+        // Inside panel: header (title + subtitle), spacer, then input row
+        let [header_area, _, input_area] = Layout::vertical([
+            Constraint::Length(2),
             Constraint::Length(1),
             Constraint::Length(1),
         ])
-        .areas(area);
+        .areas(content_area.inset(Insets::vh(1, 2)));
 
-        let title_line: Line = vec!["Rename session".bold().cyan()].into();
-        WidgetRef::render_ref(&title_line, title, buf);
+        Paragraph::new(vec![
+            Line::from("Rename Session".bold().cyan()),
+            Line::from("Set a short display name for this session".dim()),
+        ])
+        .render(header_area, buf);
 
-        // Render single-line input prefixed with label
+        // Input label + field
         let label = "Name: ";
+        WidgetRef::render_ref(&Line::from(Span::from(label).dim()), input_area, buf);
+        let mut text_rect = input_area;
         let label_width = label.len() as u16;
-        // Draw label
-        WidgetRef::render_ref(&Line::from(Span::from(label).dim()), input, buf);
-
-        // Draw the editable field after the label
-        let mut input_rect = input;
-        if input_rect.width > label_width {
-            input_rect.x += label_width;
-            input_rect.width = input_rect.width.saturating_sub(label_width);
+        if text_rect.width > label_width {
+            text_rect.x += label_width;
+            text_rect.width = text_rect.width.saturating_sub(label_width);
         }
         let mut state = self.input_state.borrow_mut();
-        ratatui::widgets::StatefulWidgetRef::render_ref(
-            &(&self.input),
-            input_rect,
-            buf,
-            &mut state,
-        );
+        ratatui::widgets::StatefulWidgetRef::render_ref(&(&self.input), text_rect, buf, &mut state);
 
-        // Footer hint
-        WidgetRef::render_ref(&standard_popup_hint_line(), hint, buf);
+        // Footer hint, outside the panel
+        WidgetRef::render_ref(&standard_popup_hint_line().dim(), footer_area, buf);
     }
 
     fn desired_height(&self, _width: u16) -> u16 {
-        3
+        5
     }
 }
 
@@ -114,9 +128,13 @@ impl BottomPaneView for RenameSessionView {
     }
 
     fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
-        // Cursor appears in the input line, after the "Name: " label.
+        // Match panel layout: content inset + input row placement
+        let [content_area, _] =
+            Layout::vertical([Constraint::Fill(1), Constraint::Length(1)]).areas(area);
+        let inset = content_area.inset(Insets::vh(1, 2));
         let label_cols: u16 = 6; // "Name: "
-        let y = area.y + 1; // second row
-        Some((area.x + label_cols + (self.input.cursor() as u16), y))
+        let input_y = inset.y + 3; // header(2) + spacer(1)
+        let x = inset.x + label_cols + (self.input.cursor() as u16);
+        Some((x, input_y))
     }
 }

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
@@ -14,3 +14,4 @@ expression: terminal.backend()
 "  @ for file paths                          ctrl + v to paste images                                "
 "  esc again to edit previous message        ctrl + c to exit                                        "
 "                                            ctrl + t to view transcript                             "
+"  ctrl + r to rename session                                                                        "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
@@ -6,3 +6,4 @@ expression: terminal.backend()
 "  @ for file paths                          ctrl + v to paste images            "
 "  esc again to edit previous message        ctrl + c to exit                    "
 "                                            ctrl + t to view transcript         "
+"  ctrl + r to rename session                                                    "

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1126,6 +1126,9 @@ impl ChatWidget {
             SlashCommand::New => {
                 self.app_event_tx.send(AppEvent::NewSession);
             }
+            SlashCommand::Rename => {
+                self.open_rename_popup();
+            }
             SlashCommand::Init => {
                 const INIT_PROMPT: &str = include_str!("../prompt_for_init_command.md");
                 self.submit_text_message(INIT_PROMPT.to_string());

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -260,6 +260,8 @@ pub(crate) struct ChatWidget {
     needs_final_message_separator: bool,
 
     last_rendered_width: std::cell::Cell<Option<usize>>,
+    // Optional user-set session name for footer display.
+    session_name: Option<String>,
 }
 
 struct UserMessage {
@@ -938,6 +940,7 @@ impl ChatWidget {
             ghost_snapshots_disabled: true,
             needs_final_message_separator: false,
             last_rendered_width: std::cell::Cell::new(None),
+            session_name: None,
         }
     }
 
@@ -1001,6 +1004,7 @@ impl ChatWidget {
             ghost_snapshots_disabled: true,
             needs_final_message_separator: false,
             last_rendered_width: std::cell::Cell::new(None),
+            session_name: None,
         }
     }
 
@@ -1010,6 +1014,21 @@ impl ChatWidget {
                 .active_cell
                 .as_ref()
                 .map_or(0, |c| c.desired_height(width) + 1)
+    }
+
+    /// Open a bottom-pane popup to rename the current session.
+    pub(crate) fn open_rename_popup(&mut self) {
+        use crate::bottom_pane::RenameSessionView;
+        let current = self.session_name.clone().unwrap_or_default();
+        let view = RenameSessionView::new(self.app_event_tx.clone(), &current);
+        self.bottom_pane.show_view(Box::new(view));
+    }
+
+    /// Update the current session name and propagate it to the bottom pane for footer display.
+    pub(crate) fn set_session_name(&mut self, name: Option<String>) {
+        self.session_name = name.clone();
+        self.bottom_pane.set_session_name(name);
+        self.request_redraw();
     }
 
     pub(crate) fn handle_key_event(&mut self, key_event: KeyEvent) {

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -287,6 +287,7 @@ fn make_chatwidget_manual() -> (
         needs_final_message_separator: false,
         last_rendered_width: std::cell::Cell::new(None),
         session_name: None,
+        rollout_path: None,
     };
     (widget, rx, op_rx)
 }

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -286,6 +286,7 @@ fn make_chatwidget_manual() -> (
         ghost_snapshots_disabled: false,
         needs_final_message_separator: false,
         last_rendered_width: std::cell::Cell::new(None),
+        session_name: None,
     };
     (widget, rx, op_rx)
 }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -60,6 +60,7 @@ pub mod public_widgets;
 mod render;
 mod resume_picker;
 mod session_log;
+mod session_name_store;
 mod shimmer;
 mod slash_command;
 mod status;

--- a/codex-rs/tui/src/session_name_store.rs
+++ b/codex-rs/tui/src/session_name_store.rs
@@ -1,0 +1,116 @@
+use std::collections::BTreeMap;
+use std::collections::HashMap;
+use std::fs::OpenOptions;
+use std::io;
+use std::path::Path;
+use std::path::PathBuf;
+
+use tracing::warn;
+
+const SESSION_NAMES_FILE: &str = "session-names.json";
+
+fn store_path(codex_home: &Path) -> PathBuf {
+    codex_home.join(SESSION_NAMES_FILE)
+}
+
+fn read_raw_map(path: &Path) -> io::Result<BTreeMap<String, String>> {
+    match std::fs::read_to_string(path) {
+        Ok(contents) => {
+            if contents.trim().is_empty() {
+                return Ok(BTreeMap::new());
+            }
+            match serde_json::from_str::<BTreeMap<String, String>>(&contents) {
+                Ok(raw) => Ok(raw),
+                Err(err) => {
+                    warn!("failed to parse session names file {:?}: {}", path, err);
+                    Ok(BTreeMap::new())
+                }
+            }
+        }
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(BTreeMap::new()),
+        Err(err) => Err(err),
+    }
+}
+
+fn write_raw_map(path: &Path, map: &BTreeMap<String, String>) -> io::Result<()> {
+    if map.is_empty() {
+        if let Err(err) = std::fs::remove_file(path) {
+            if err.kind() != io::ErrorKind::NotFound {
+                return Err(err);
+            }
+        }
+        return Ok(());
+    }
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+
+    let contents = serde_json::to_string_pretty(map)?;
+    let mut options = OpenOptions::new();
+    options.write(true).truncate(true).create(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+    let mut file = options.open(path)?;
+    use std::io::Write as _;
+    file.write_all(contents.as_bytes())?;
+    file.flush()?;
+    Ok(())
+}
+
+pub(crate) fn load_all(codex_home: &Path) -> HashMap<PathBuf, String> {
+    let path = store_path(codex_home);
+    let raw = match read_raw_map(&path) {
+        Ok(map) => map,
+        Err(err) => {
+            warn!("failed to read session names store {:?}: {}", path, err);
+            return HashMap::new();
+        }
+    };
+
+    raw.into_iter()
+        .filter_map(|(key, value)| {
+            let trimmed = value.trim().to_string();
+            if trimmed.is_empty() {
+                return None;
+            }
+            let path = PathBuf::from(key);
+            if path.as_os_str().is_empty() {
+                return None;
+            }
+            Some((path, trimmed))
+        })
+        .collect()
+}
+
+pub(crate) fn read(codex_home: &Path, rollout_path: &Path) -> Option<String> {
+    let key = key_for(rollout_path);
+    let path = store_path(codex_home);
+    read_raw_map(&path)
+        .ok()
+        .and_then(|map| map.get(&key).cloned())
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}
+
+pub(crate) fn write(codex_home: &Path, rollout_path: &Path, name: Option<&str>) -> io::Result<()> {
+    let path = store_path(codex_home);
+    let mut map = read_raw_map(&path)?;
+    let key = key_for(rollout_path);
+    match name.map(str::trim).filter(|s| !s.is_empty()) {
+        Some(value) => {
+            map.insert(key, value.to_string());
+        }
+        None => {
+            map.remove(&key);
+        }
+    }
+    write_raw_map(&path, &map)
+}
+
+fn key_for(path: &Path) -> String {
+    path.to_string_lossy().into_owned()
+}

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -15,6 +15,7 @@ pub enum SlashCommand {
     Model,
     Approvals,
     Review,
+    Rename,
     New,
     Init,
     Compact,
@@ -33,6 +34,7 @@ impl SlashCommand {
     /// User-visible description shown in the popup.
     pub fn description(self) -> &'static str {
         match self {
+            SlashCommand::Rename => "rename this session",
             SlashCommand::New => "start a new chat during a conversation",
             SlashCommand::Init => "create an AGENTS.md file with instructions for Codex",
             SlashCommand::Compact => "summarize conversation to prevent hitting the context limit",
@@ -61,6 +63,7 @@ impl SlashCommand {
     pub fn available_during_task(self) -> bool {
         match self {
             SlashCommand::New
+            | SlashCommand::Rename
             | SlashCommand::Init
             | SlashCommand::Compact
             | SlashCommand::Undo


### PR DESCRIPTION
This is something I needed. Ideally, the model should automatically name the session as it does on ChatGPT, however I think that would be best done by OpenAI.

### What
- Add a Ctrl+R rename popup and /rename command styled like the other dialogs.
- Render the session name in the footer and resume picker with cyan labels
  and truncation.
- Persist session names in `~/.codex/session-names.json`
### Why
- Allows users to name their sessions, so they can recognize them in the chat widget and later in `codex resume`
- Highly valuable for terminal pane-splitters:
<img width="1051" height="440" alt="image" src="https://github.com/user-attachments/assets/2f3f386e-fb68-4640-8154-70b7c6247133" />

### How
- Introduced a shared session-name store and wired ChatWidget to load/save it.
- Updated footer and picker rendering paths to inject the label safely.
- Added tests/adjustments to cover the new data flow.
### Screenshots
<img width="361" height="122" alt="image" src="https://github.com/user-attachments/assets/c7159361-bd34-4a62-b021-0ff14be050c6" />
<img width="696" height="114" alt="image" src="https://github.com/user-attachments/assets/ecd4fd16-8cff-4c20-a4c7-9ddf72a3a064" />
<img width="485" height="154" alt="image" src="https://github.com/user-attachments/assets/897bbbc1-8206-4902-8138-cb01208a5f3a" />

**Note**: the resume screenshot is from a build based on v0.44, just because there are a few visual glitches in the `main` branch right now, unrelated to this PR:
<img width="515" height="202" alt="image" src="https://github.com/user-attachments/assets/b88f4336-8df6-4dcd-b0da-93d52126cf47" />

---
If there's interesting in this feature, I'm willing to refactor and improve the PR.