### PR TITLE
feat: session names

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -306,6 +306,18 @@ impl App {
                 ));
                 tui.frame_requester().schedule_frame();
             }
+            AppEvent::OpenRenamePopup => {
+                self.chat_widget.open_rename_popup();
+                tui.frame_requester().schedule_frame();
+            }
+            AppEvent::UpdateSessionName(name) => {
+                let label = if name.trim().is_empty() {
+                    None
+                } else {
+                    Some(name)
+                };
+                self.chat_widget.set_session_name(label);
+            }
             AppEvent::StartFileSearch(query) => {
                 if !query.is_empty() {
                     self.file_search.on_user_query(query);

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -87,4 +87,10 @@ pub(crate) enum AppEvent {
 
     /// Open the approval popup.
     FullScreenApprovalRequest(ApprovalRequest),
+
+    /// Update the current session's display name in the UI.
+    UpdateSessionName(String),
+
+    /// Open the rename session popup.
+    OpenRenamePopup,
 }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -29,6 +29,7 @@ mod prompt_args;
 pub(crate) use list_selection_view::SelectionViewParams;
 mod paste_burst;
 pub mod popup_consts;
+pub mod rename_session_view;
 mod scroll_state;
 mod selection_popup_common;
 mod textarea;
@@ -366,6 +367,11 @@ impl BottomPane {
         self.push_view(Box::new(view));
     }
 
+    /// Show a simple custom view (e.g., rename input).
+    pub(crate) fn show_view(&mut self, view: Box<dyn BottomPaneView>) {
+        self.push_view(view);
+    }
+
     /// Update the queued messages shown under the status header.
     pub(crate) fn set_queued_user_messages(&mut self, queued: Vec<String>) {
         self.queued_user_messages = queued.clone();
@@ -373,6 +379,16 @@ impl BottomPane {
             status.set_queued_messages(queued);
         }
         self.request_redraw();
+    }
+
+    /// Update the optional session name label shown in the footer.
+    pub(crate) fn set_session_name(&mut self, name: Option<String>) {
+        self.composer.set_session_name(name);
+        self.request_redraw();
+    }
+
+    pub(crate) fn session_name(&self) -> Option<String> {
+        self.composer.session_name()
     }
 
     /// Update custom prompts available for the slash popup.
@@ -394,10 +410,6 @@ impl BottomPane {
     /// use Esc-Esc for backtracking from the main view.
     pub(crate) fn is_normal_backtrack_mode(&self) -> bool {
         !self.is_task_running && self.view_stack.is_empty() && !self.composer.popup_active()
-    }
-
-    pub(crate) fn show_view(&mut self, view: Box<dyn BottomPaneView>) {
-        self.push_view(view);
     }
 
     /// Called when the agent requests user approval.

--- a/codex-rs/tui/src/bottom_pane/rename_session_view.rs
+++ b/codex-rs/tui/src/bottom_pane/rename_session_view.rs
@@ -1,0 +1,193 @@
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use crossterm::event::KeyModifiers;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::text::Span;
+use ratatui::widgets::Block;
+use ratatui::widgets::Clear;
+use ratatui::widgets::Paragraph;
+use ratatui::widgets::StatefulWidgetRef;
+use ratatui::widgets::Widget;
+use std::cell::RefCell;
+
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+use crate::render::Insets;
+use crate::render::RectExt;
+use crate::render::renderable::Renderable;
+use crate::style::user_message_style;
+use crate::terminal_palette;
+
+use super::popup_consts::standard_popup_hint_line;
+
+use super::CancellationEvent;
+use super::bottom_pane_view::BottomPaneView;
+use super::textarea::TextArea;
+use super::textarea::TextAreaState;
+
+/// Simple single-line input to rename the current session.
+pub(crate) struct RenameSessionView {
+    app_event_tx: AppEventSender,
+    textarea: TextArea,
+    textarea_state: RefCell<TextAreaState>,
+    complete: bool,
+}
+
+impl RenameSessionView {
+    pub(crate) fn new(app_event_tx: AppEventSender, initial: Option<String>) -> Self {
+        let mut textarea = TextArea::new();
+        if let Some(name) = initial {
+            textarea.set_text(&name);
+            textarea.set_cursor(name.len());
+        }
+        Self {
+            app_event_tx,
+            textarea,
+            textarea_state: RefCell::new(TextAreaState::default()),
+            complete: false,
+        }
+    }
+}
+
+impl BottomPaneView for RenameSessionView {
+    fn handle_key_event(&mut self, key_event: KeyEvent) {
+        match key_event {
+            KeyEvent {
+                code: KeyCode::Esc, ..
+            } => {
+                self.on_ctrl_c();
+            }
+            KeyEvent {
+                code: KeyCode::Enter,
+                modifiers: KeyModifiers::NONE,
+                ..
+            } => {
+                // Empty name clears the label.
+                let text = self.textarea.text().trim().to_string();
+                self.app_event_tx.send(AppEvent::UpdateSessionName(text));
+                self.complete = true;
+            }
+            other => {
+                self.textarea.input(other);
+            }
+        }
+    }
+
+    fn on_ctrl_c(&mut self) -> CancellationEvent {
+        self.complete = true;
+        CancellationEvent::Handled
+    }
+
+    fn is_complete(&self) -> bool {
+        self.complete
+    }
+
+    fn handle_paste(&mut self, pasted: String) -> bool {
+        if pasted.is_empty() {
+            return false;
+        }
+        self.textarea.insert_str(&pasted);
+        true
+    }
+
+    fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
+        if area.height < 7 || area.width <= 4 {
+            return None;
+        }
+        // Mirror render() layout: panel excludes hint; inner has 1v/2h padding.
+        let panel = Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: area.height.saturating_sub(1),
+        };
+        let inner = panel.inset(Insets::vh(1, 2));
+        // Title at inner.y, spacer at inner.y+1, gutter/input at inner.y+2
+        let textarea_rect = Rect {
+            x: inner.x.saturating_add(2),
+            y: inner.y.saturating_add(2),
+            width: inner.width.saturating_sub(2),
+            height: 1,
+        };
+        let state = *self.textarea_state.borrow();
+        self.textarea.cursor_pos_with_state(textarea_rect, state)
+    }
+}
+
+impl Renderable for RenameSessionView {
+    fn desired_height(&self, _width: u16) -> u16 {
+        7
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        if area.height == 0 || area.width == 0 {
+            return;
+        }
+
+        // Background panel (content rows only). Last row is the hint line.
+        let panel_area = Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: area.height.saturating_sub(1),
+        };
+        Block::default()
+            .style(user_message_style(terminal_palette::default_bg()))
+            .render(panel_area, buf);
+        let inner = panel_area.inset(Insets::vh(1, 2));
+
+        // Title (indented by panel padding)
+        let title: Line = vec!["Rename Session".bold()].into();
+        Paragraph::new(title).render(
+            Rect {
+                x: inner.x,
+                y: inner.y,
+                width: inner.width,
+                height: 1,
+            },
+            buf,
+        );
+
+        // Input gutter and line
+        let gutter: Span<'static> = "▌ ".cyan();
+        let input_y = inner.y.saturating_add(2);
+        Paragraph::new(Line::from(vec![gutter.clone()])).render(
+            Rect {
+                x: inner.x,
+                y: input_y,
+                width: 2,
+                height: 1,
+            },
+            buf,
+        );
+
+        // Render one-line textarea on the same row as the gutter (no extra blank row).
+        if inner.width > 4 {
+            let textarea_rect = Rect {
+                x: inner.x.saturating_add(2),
+                y: input_y,
+                width: inner.width.saturating_sub(2),
+                height: 1,
+            };
+            let mut state = self.textarea_state.borrow_mut();
+            StatefulWidgetRef::render_ref(&(&self.textarea), textarea_rect, buf, &mut state);
+            if self.textarea.text().is_empty() {
+                Paragraph::new(Line::from("Enter a name (blank to clear)".dim()))
+                    .render(textarea_rect, buf);
+            }
+        }
+
+        // Hint line below (not covered by the panel)
+        let hint_area = Rect {
+            x: area.x,
+            y: area.y.saturating_add(area.height.saturating_sub(1)),
+            width: area.width,
+            height: 1,
+        };
+        Clear.render(hint_area, buf);
+        Paragraph::new(standard_popup_hint_line()).render(hint_area, buf);
+    }
+}

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
@@ -12,5 +12,6 @@ expression: terminal.backend()
 "                                                                                                    "
 "  / for commands                            shift + enter for newline                               "
 "  @ for file paths                          ctrl + v to paste images                                "
-"  esc again to edit previous message        ctrl + c to exit                                        "
-"                                            ctrl + t to view transcript                             "
+"  esc again to edit previous message        ctrl + r rename session                                 "
+"  ctrl + c to exit                                                                                  "
+"  ctrl + t to view transcript                                                                       "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
@@ -4,5 +4,6 @@ expression: terminal.backend()
 ---
 "  / for commands                            shift + enter for newline           "
 "  @ for file paths                          ctrl + v to paste images            "
-"  esc again to edit previous message        ctrl + c to exit                    "
-"                                            ctrl + t to view transcript         "
+"  esc again to edit previous message        ctrl + r rename session             "
+"  ctrl + c to exit                                                              "
+"  ctrl + t to view transcript                                                   "

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -276,6 +276,7 @@ fn make_chatwidget_manual() -> (
         reasoning_buffer: String::new(),
         full_reasoning_buffer: String::new(),
         conversation_id: None,
+        rollout_path: None,
         frame_requester: FrameRequester::test_dummy(),
         show_welcome_banner: true,
         queued_user_messages: VecDeque::new(),

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -60,6 +60,7 @@ pub mod public_widgets;
 mod render;
 mod resume_picker;
 mod session_log;
+mod session_name_sidecar;
 mod shimmer;
 mod slash_command;
 mod status;

--- a/codex-rs/tui/src/session_name_sidecar.rs
+++ b/codex-rs/tui/src/session_name_sidecar.rs
@@ -1,0 +1,62 @@
+use std::fs::OpenOptions;
+use std::io::Read;
+use std::io::Write;
+use std::io::{self};
+use std::path::Path;
+use std::path::PathBuf;
+
+/// Compute the sidecar path for a rollout file. For standard rollouts with a
+/// `.jsonl` extension, this produces `*.jsonl.name` next to the rollout.
+/// For other extensions, appends `.name` to the existing extension.
+pub(crate) fn sidecar_path_for(rollout: &Path) -> PathBuf {
+    match rollout.extension().and_then(|e| e.to_str()) {
+        Some("jsonl") => rollout.with_extension("jsonl.name"),
+        Some(ext) => rollout.with_extension(format!("{ext}.name")),
+        None => rollout.with_extension("name"),
+    }
+}
+
+/// Read the display name sidecar, if present. Returns Ok(None) when missing.
+pub(crate) fn read(rollout: &Path) -> io::Result<Option<String>> {
+    let path = sidecar_path_for(rollout);
+    let mut f = match std::fs::File::open(&path) {
+        Ok(f) => f,
+        Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(None),
+        Err(err) => return Err(err),
+    };
+    let mut buf = String::new();
+    f.read_to_string(&mut buf)?;
+    let trimmed = buf.trim().to_string();
+    if trimmed.is_empty() {
+        Ok(None)
+    } else {
+        Ok(Some(trimmed))
+    }
+}
+
+/// Write or remove the sidecar file. When `name` is None or empty, removes the
+/// sidecar (best-effort). When set, truncates/creates the file and writes the
+/// trimmed name.
+pub(crate) fn write(rollout: &Path, name: Option<&str>) -> io::Result<()> {
+    let path = sidecar_path_for(rollout);
+    let trimmed = name.unwrap_or("").trim();
+    if trimmed.is_empty() {
+        match std::fs::remove_file(&path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {}
+            Err(err) => return Err(err),
+        }
+        return Ok(());
+    }
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let mut f = OpenOptions::new()
+        .create(true)
+        .truncate(true)
+        .write(true)
+        .open(&path)?;
+    f.write_all(trimmed.as_bytes())?;
+    Ok(())
+}

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -23,6 +23,7 @@ pub enum SlashCommand {
     Mention,
     Status,
     Mcp,
+    Rename,
     Logout,
     Quit,
     #[cfg(debug_assertions)]
@@ -45,6 +46,7 @@ impl SlashCommand {
             SlashCommand::Model => "choose what model and reasoning effort to use",
             SlashCommand::Approvals => "choose what Codex can do without approval",
             SlashCommand::Mcp => "list configured MCP tools",
+            SlashCommand::Rename => "rename this session",
             SlashCommand::Logout => "log out of Codex",
             #[cfg(debug_assertions)]
             SlashCommand::TestApproval => "test approval request",
@@ -72,6 +74,7 @@ impl SlashCommand {
             | SlashCommand::Mention
             | SlashCommand::Status
             | SlashCommand::Mcp
+            | SlashCommand::Rename
             | SlashCommand::Quit => true,
 
             #[cfg(debug_assertions)]


### PR DESCRIPTION
Name your session so you can recognize it in the chat UI, and later with `codex resume`.

This is what I needed for terminal pane-splitting, otherwise I never remember which pane does what!

<img width="1051" height="440" alt="image" src="https://github.com/user-attachments/assets/2f3f386e-fb68-4640-8154-70b7c6247133" />

Ideally, the model should be the first to name the sessions as it does in ChatGPT, however I think this is for OpenAI to do.

### What
  - Add session names to the TUI: rename (Ctrl+R, /rename), footer label, and “resume” prefix.
  - Persist names across runs.

### How
  - Store name in a per‑rollout sidecar (*.jsonl.name); write on rename, read on
    SessionConfigured.
  - Cache display names in resume rows (no render‑time IO).
  - Modal matches existing styling; caret aligned; Ctrl+R shown in shortcuts overlay.

### Screenshots
<img width="361" height="122" alt="image" src="https://github.com/user-attachments/assets/c7159361-bd34-4a62-b021-0ff14be050c6" />
<img width="696" height="114" alt="image" src="https://github.com/user-attachments/assets/ecd4fd16-8cff-4c20-a4c7-9ddf72a3a064" />
<img width="485" height="154" alt="image" src="https://github.com/user-attachments/assets/897bbbc1-8206-4902-8138-cb01208a5f3a" />

---
If there's interest in this feature, I'm willing to refactor and improve the PR.