### PR TITLE
fix: input textarea background not rendering correctly in tmux session

### DIFF
--- a/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
+++ b/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
@@ -6,6 +6,7 @@ use ratatui::layout::Rect;
 use ratatui::style::Stylize;
 use ratatui::text::Line;
 use ratatui::text::Span;
+use ratatui::widgets::Block;
 use ratatui::widgets::Clear;
 use ratatui::widgets::Paragraph;
 use ratatui::widgets::StatefulWidgetRef;
@@ -170,6 +171,10 @@ impl Renderable for CustomPromptView {
             height: input_height,
         };
         if input_area.width >= 2 {
+            let input_style =
+                crate::style::user_message_style(crate::terminal_palette::default_bg());
+            Block::default().style(input_style).render(input_area, buf);
+
             for row in 0..input_area.height {
                 Paragraph::new(Line::from(vec![gutter()])).render(
                     Rect {
@@ -191,7 +196,7 @@ impl Renderable for CustomPromptView {
                         width: input_area.width.saturating_sub(2),
                         height: 1,
                     };
-                    Clear.render(blank_rect, buf);
+                    Block::default().style(input_style).render(blank_rect, buf);
                 }
                 let textarea_rect = Rect {
                     x: input_area.x.saturating_add(2),

--- a/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
+++ b/codex-rs/tui/src/bottom_pane/custom_prompt_view.rs
@@ -196,7 +196,8 @@ impl Renderable for CustomPromptView {
                         width: input_area.width.saturating_sub(2),
                         height: 1,
                     };
-                    Block::default().style(input_style).render(blank_rect, buf);
+                    Clear.render(blank_rect, buf);
+                    buf.set_style(blank_rect, input_style);
                 }
                 let textarea_rect = Rect {
                     x: input_area.x.saturating_add(2),


### PR DESCRIPTION
Fixes #4744 

| Before | After |
|--------|--------|
| <img width="949" height="680" alt="image" src="https://github.com/user-attachments/assets/9dca9896-00c9-40ac-a37b-6dcf2ba9b762" /> | <img width="944" height="760" alt="image" src="https://github.com/user-attachments/assets/c092428c-9456-421b-9f25-07a8ffaa5fc4" /> |

## What
- render the custom prompt input area with the same shaded background block as the main composer
- tunnel OSC color queries through tmux so the TUI can detect the real terminal colors
- fall back to COLORFGBG when OSC queries are blocked

## Why
- inside tmux the prompt background collapsed to the default terminal color, making it look different from the standard view
- tmux was filtering OSC 4/10/11 responses, so Codex couldn’t determine the terminal palette and default background

## How
- render a styled `Block` over the prompt input area (including the spacer row) before drawing textarea contents
- wrap OSC queries in tmux DCS passthrough escape sequences to reach Alacritty
- add a minimal COLORFGBG-based fallback for environments that still block OSC responses

## Tests
- cargo fmt
- cargo test -p codex-tui

