### PR TITLE
add(core): prefer_wsl

### DIFF
--- a/codex-rs/cli/src/windows.rs
+++ b/codex-rs/cli/src/windows.rs
@@ -1,225 +1,233 @@
 use codex_common::CliConfigOverrides;
 
 #[cfg(windows)]
-use anyhow::Context;
-#[cfg(windows)]
-use anyhow::anyhow;
-#[cfg(windows)]
-use codex_core::config::Config;
-#[cfg(windows)]
-use codex_core::config::ConfigOverrides;
-#[cfg(windows)]
-use std::env;
-#[cfg(windows)]
-use std::ffi::OsString;
-#[cfg(windows)]
-use std::fs;
-#[cfg(windows)]
-use std::path::Component;
-#[cfg(windows)]
-use std::path::Path;
-#[cfg(windows)]
-use std::path::PathBuf;
-#[cfg(windows)]
-use std::path::Prefix;
-#[cfg(windows)]
-use std::process::Command;
-#[cfg(windows)]
-use std::process::Stdio;
+mod windows_only {
+    use super::*;
+    use anyhow::Context;
+    use anyhow::anyhow;
+    use codex_core::config::Config;
+    use codex_core::config::ConfigOverrides;
+    use std::borrow::Cow;
+    use std::env;
+    use std::ffi::OsString;
+    use std::fs;
+    use std::path::Component;
+    use std::path::Path;
+    use std::path::PathBuf;
+    use std::path::Prefix;
+    use std::process::Command;
+    use std::process::Stdio;
 
-pub async fn maybe_relaunch_in_wsl(overrides: &CliConfigOverrides) -> anyhow::Result<()> {
-    maybe_relaunch_in_wsl_inner(overrides).await
+    pub(super) async fn maybe_relaunch_in_wsl_inner(
+        overrides: &CliConfigOverrides,
+    ) -> anyhow::Result<()> {
+        const SKIP_ENV: &str = "CODEX_SKIP_WSL_REDIRECT";
+
+        if env::var_os(SKIP_ENV).is_some() || running_inside_wsl() {
+            return Ok(());
+        }
+
+        let cli_overrides = overrides
+            .parse_overrides()
+            .map_err(|err| anyhow!("{err}"))?;
+
+        let config = Config::load_with_cli_overrides(cli_overrides, ConfigOverrides::default())
+            .await
+            .context("failed to load Codex config while evaluating windows.prefer_wsl")?;
+
+        let windows_cfg = config.windows;
+        if !windows_cfg.prefer_wsl {
+            return Ok(());
+        }
+
+        if !is_wsl_available() {
+            if !windows_cfg.hide_wsl_notice {
+                eprintln!("WSL not detected; continuing to run Codex on Windows");
+            }
+            return Ok(());
+        }
+
+        let current_dir = env::current_dir().context("failed to resolve current directory")?;
+        let wsl_cwd = match windows_path_to_wsl(&current_dir) {
+            Some(path) => path,
+            None => {
+                if !windows_cfg.hide_wsl_notice {
+                    eprintln!(
+                        "Unable to map current directory {} into WSL; continuing on Windows",
+                        current_dir.display()
+                    );
+                }
+                return Ok(());
+            }
+        };
+
+        let linux_binary = locate_linux_binary_path();
+        let (command_choice, notice_suffix) = match linux_binary {
+            Some(ref binary_path) => match windows_path_to_wsl(binary_path) {
+                Some(binary_wsl) => (
+                    CommandChoice::Binary(binary_wsl),
+                    "the bundled Linux binary",
+                ),
+                None => {
+                    if !windows_cfg.hide_wsl_notice {
+                        eprintln!(
+                            "Unable to translate Codex Linux binary path {} into WSL; continuing on Windows",
+                            binary_path.display()
+                        );
+                    }
+                    (CommandChoice::Fallback, "codex from WSL PATH")
+                }
+            },
+            None => (CommandChoice::Fallback, "codex from WSL PATH"),
+        };
+
+        let codex_home_override = env::var_os("CODEX_HOME").map(PathBuf::from);
+        let codex_home_display = codex_home_override.as_ref().unwrap_or(&config.codex_home);
+        let codex_home_wsl = codex_home_override
+            .as_ref()
+            .and_then(windows_path_to_wsl)
+            .or_else(|| windows_path_to_wsl(&config.codex_home));
+        let codex_home_wsl = match codex_home_wsl {
+            Some(path) => path,
+            None => {
+                if !windows_cfg.hide_wsl_notice {
+                    eprintln!(
+                        "Unable to translate Codex home {} into WSL; continuing on Windows",
+                        codex_home_display.display()
+                    );
+                }
+                return Ok(());
+            }
+        };
+
+        if !windows_cfg.hide_wsl_notice {
+            eprintln!(
+                "windows.prefer_wsl is enabled; re-launching Codex inside WSL using {notice_suffix}"
+            );
+        }
+
+        let args: Vec<OsString> = env::args_os().skip(1).collect();
+
+        let mut cmd = Command::new("wsl.exe");
+        cmd.arg("--cd").arg(&wsl_cwd);
+        match &command_choice {
+            CommandChoice::Binary(binary) => {
+                cmd.arg("--exec").arg(binary);
+            }
+            CommandChoice::Fallback => {
+                cmd.arg("--exec").arg("codex");
+            }
+        }
+        cmd.env(SKIP_ENV, "1");
+        cmd.env("CODEX_HOME", OsString::from(&codex_home_wsl));
+        cmd.args(args);
+        cmd.stdin(Stdio::inherit());
+        cmd.stdout(Stdio::inherit());
+        cmd.stderr(Stdio::inherit());
+
+        let status = cmd.status().context("failed to invoke wsl.exe")?;
+        if let Some(code) = status.code() {
+            std::process::exit(code);
+        }
+        std::process::exit(1);
+    }
+
+    #[derive(Clone, Debug)]
+    enum CommandChoice {
+        Binary(String),
+        Fallback,
+    }
+
+    fn running_inside_wsl() -> bool {
+        env::var_os("WSL_DISTRO_NAME").is_some() || env::var_os("WSL_INTEROP").is_some()
+    }
+
+    fn is_wsl_available() -> bool {
+        Command::new("wsl.exe")
+            .arg("--help")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .map(|status| status.success())
+            .unwrap_or(false)
+    }
+
+    fn locate_linux_binary_path() -> Option<PathBuf> {
+        let exe = env::current_exe().ok()?;
+        let vendor_dir = locate_vendor_root(&exe)?;
+        let linux_target = match env::consts::ARCH {
+            "x86_64" => "x86_64-unknown-linux-musl",
+            "aarch64" => "aarch64-unknown-linux-musl",
+            _ => return None,
+        };
+        let binary_path = vendor_dir.join(linux_target).join("codex").join("codex");
+        if binary_path.exists() {
+            Some(binary_path)
+        } else {
+            None
+        }
+    }
+
+    fn locate_vendor_root(exe_path: &Path) -> Option<PathBuf> {
+        let mut current = exe_path.parent()?;
+        for _ in 0..5 {
+            if current.file_name().and_then(|s| s.to_str()) == Some("vendor") {
+                return Some(current.to_path_buf());
+            }
+            current = current.parent()?;
+        }
+        None
+    }
+
+    fn windows_path_to_wsl(path: &Path) -> Option<String> {
+        let absolute = if path.is_absolute() {
+            Cow::Borrowed(path)
+        } else {
+            Cow::Owned(fs::canonicalize(path).ok()?)
+        };
+
+        let mut components = absolute.components();
+        let prefix = match components.next()? {
+            Component::Prefix(prefix) => prefix.kind(),
+            _ => return None,
+        };
+
+        let drive_letter = match prefix {
+            Prefix::Disk(letter) | Prefix::VerbatimDisk(letter) => letter as char,
+            _ => return None,
+        };
+
+        let mut parts = Vec::new();
+        for component in components {
+            match component {
+                Component::RootDir => {}
+                Component::Normal(segment) => {
+                    parts.push(segment.to_string_lossy().to_string());
+                }
+                Component::CurDir => {}
+                Component::ParentDir => return None,
+                Component::Prefix(_) => return None,
+            }
+        }
+
+        let drive = drive_letter.to_ascii_lowercase();
+        let mut wsl_path = format!("/mnt/{drive}");
+        if !parts.is_empty() {
+            wsl_path.push('/');
+            wsl_path.push_str(&parts.join("/"));
+        }
+        Some(wsl_path)
+    }
 }
+
+#[cfg(windows)]
+use windows_only::maybe_relaunch_in_wsl_inner;
 
 #[cfg(not(windows))]
 async fn maybe_relaunch_in_wsl_inner(_overrides: &CliConfigOverrides) -> anyhow::Result<()> {
     Ok(())
 }
 
-#[cfg(windows)]
-async fn maybe_relaunch_in_wsl_inner(overrides: &CliConfigOverrides) -> anyhow::Result<()> {
-    const SKIP_ENV: &str = "CODEX_SKIP_WSL_REDIRECT";
-
-    if env::var_os(SKIP_ENV).is_some() || running_inside_wsl() {
-        return Ok(());
-    }
-
-    let cli_overrides = overrides
-        .parse_overrides()
-        .map_err(|err| anyhow!("{err}"))?;
-
-    let config = Config::load_with_cli_overrides(cli_overrides, ConfigOverrides::default())
-        .await
-        .context("failed to load Codex config while evaluating windows.prefer_wsl")?;
-
-    let windows_cfg = config.windows;
-    if !windows_cfg.prefer_wsl {
-        return Ok(());
-    }
-
-    if !is_wsl_available() {
-        if !windows_cfg.hide_wsl_notice {
-            eprintln!("WSL not detected; continuing to run Codex on Windows");
-        }
-        return Ok(());
-    }
-
-    let current_dir = env::current_dir().context("failed to resolve current directory")?;
-    let wsl_cwd = match windows_path_to_wsl(&current_dir) {
-        Some(path) => path,
-        None => {
-            if !windows_cfg.hide_wsl_notice {
-                eprintln!(
-                    "Unable to map current directory {} into WSL; continuing on Windows",
-                    current_dir.display()
-                );
-            }
-            return Ok(());
-        }
-    };
-
-    let linux_binary = locate_linux_binary_path();
-    let (command_choice, notice_suffix) = match linux_binary {
-        Some(ref binary_path) => match windows_path_to_wsl(binary_path) {
-            Some(binary_wsl) => (
-                CommandChoice::Binary(binary_wsl),
-                "the bundled Linux binary",
-            ),
-            None => {
-                if !windows_cfg.hide_wsl_notice {
-                    eprintln!(
-                        "Unable to translate Codex Linux binary path {} into WSL; continuing on Windows",
-                        binary_path.display()
-                    );
-                }
-                (CommandChoice::Fallback, "codex from WSL PATH")
-            }
-        },
-        None => (CommandChoice::Fallback, "codex from WSL PATH"),
-    };
-
-    if !windows_cfg.hide_wsl_notice {
-        eprintln!(
-            "windows.prefer_wsl is enabled; re-launching Codex inside WSL using {notice_suffix}"
-        );
-    }
-
-    let args: Vec<OsString> = env::args_os().skip(1).collect();
-
-    let mut cmd = Command::new("wsl.exe");
-    cmd.arg("--cd").arg(&wsl_cwd);
-    match &command_choice {
-        CommandChoice::Binary(binary) => {
-            cmd.arg("--exec").arg(binary);
-        }
-        CommandChoice::Fallback => {
-            cmd.arg("--exec").arg("codex");
-        }
-    }
-    cmd.env(SKIP_ENV, "1");
-    cmd.args(args);
-    cmd.stdin(Stdio::inherit());
-    cmd.stdout(Stdio::inherit());
-    cmd.stderr(Stdio::inherit());
-
-    let status = cmd.status().context("failed to invoke wsl.exe")?;
-    if let Some(code) = status.code() {
-        std::process::exit(code);
-    }
-    std::process::exit(1);
-}
-
-#[cfg(windows)]
-#[derive(Clone, Debug)]
-enum CommandChoice {
-    Binary(String),
-    Fallback,
-}
-
-#[cfg(windows)]
-fn running_inside_wsl() -> bool {
-    env::var_os("WSL_DISTRO_NAME").is_some() || env::var_os("WSL_INTEROP").is_some()
-}
-
-#[cfg(windows)]
-fn is_wsl_available() -> bool {
-    Command::new("wsl.exe")
-        .arg("--help")
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|status| status.success())
-        .unwrap_or(false)
-}
-
-#[cfg(windows)]
-fn locate_linux_binary_path() -> Option<PathBuf> {
-    let exe = env::current_exe().ok()?;
-    let vendor_dir = locate_vendor_root(&exe)?;
-    let linux_target = match env::consts::ARCH {
-        "x86_64" => "x86_64-unknown-linux-musl",
-        "aarch64" => "aarch64-unknown-linux-musl",
-        _ => return None,
-    };
-    let binary_path = vendor_dir.join(linux_target).join("codex").join("codex");
-    if binary_path.exists() {
-        Some(binary_path)
-    } else {
-        None
-    }
-}
-
-#[cfg(windows)]
-fn locate_vendor_root(exe_path: &Path) -> Option<PathBuf> {
-    let mut current = exe_path.parent()?;
-    for _ in 0..5 {
-        if current.file_name().and_then(|s| s.to_str()) == Some("vendor") {
-            return Some(current.to_path_buf());
-        }
-        current = current.parent()?;
-    }
-    None
-}
-
-#[cfg(windows)]
-fn windows_path_to_wsl(path: &Path) -> Option<String> {
-    use std::borrow::Cow;
-
-    let absolute = if path.is_absolute() {
-        Cow::Borrowed(path)
-    } else {
-        Cow::Owned(fs::canonicalize(path).ok()?)
-    };
-
-    let mut components = absolute.components();
-    let prefix = match components.next()? {
-        Component::Prefix(prefix) => prefix.kind(),
-        _ => return None,
-    };
-
-    let drive_letter = match prefix {
-        Prefix::Disk(letter) | Prefix::VerbatimDisk(letter) => letter as char,
-        _ => return None,
-    };
-
-    let mut parts = Vec::new();
-    for component in components {
-        match component {
-            Component::RootDir => {}
-            Component::Normal(segment) => {
-                parts.push(segment.to_string_lossy().to_string());
-            }
-            Component::CurDir => {}
-            Component::ParentDir => return None,
-            Component::Prefix(_) => return None,
-        }
-    }
-
-    let drive = drive_letter.to_ascii_lowercase();
-    let mut wsl_path = format!("/mnt/{drive}");
-    if !parts.is_empty() {
-        wsl_path.push('/');
-        wsl_path.push_str(&parts.join("/"));
-    }
-    Some(wsl_path)
+pub async fn maybe_relaunch_in_wsl(overrides: &CliConfigOverrides) -> anyhow::Result<()> {
+    maybe_relaunch_in_wsl_inner(overrides).await
 }

--- a/codex-rs/cli/src/windows.rs
+++ b/codex-rs/cli/src/windows.rs
@@ -1,0 +1,225 @@
+use codex_common::CliConfigOverrides;
+
+#[cfg(windows)]
+use anyhow::Context;
+#[cfg(windows)]
+use anyhow::anyhow;
+#[cfg(windows)]
+use codex_core::config::Config;
+#[cfg(windows)]
+use codex_core::config::ConfigOverrides;
+#[cfg(windows)]
+use std::env;
+#[cfg(windows)]
+use std::ffi::OsString;
+#[cfg(windows)]
+use std::fs;
+#[cfg(windows)]
+use std::path::Component;
+#[cfg(windows)]
+use std::path::Path;
+#[cfg(windows)]
+use std::path::PathBuf;
+#[cfg(windows)]
+use std::path::Prefix;
+#[cfg(windows)]
+use std::process::Command;
+#[cfg(windows)]
+use std::process::Stdio;
+
+pub async fn maybe_relaunch_in_wsl(overrides: &CliConfigOverrides) -> anyhow::Result<()> {
+    maybe_relaunch_in_wsl_inner(overrides).await
+}
+
+#[cfg(not(windows))]
+async fn maybe_relaunch_in_wsl_inner(_overrides: &CliConfigOverrides) -> anyhow::Result<()> {
+    Ok(())
+}
+
+#[cfg(windows)]
+async fn maybe_relaunch_in_wsl_inner(overrides: &CliConfigOverrides) -> anyhow::Result<()> {
+    const SKIP_ENV: &str = "CODEX_SKIP_WSL_REDIRECT";
+
+    if env::var_os(SKIP_ENV).is_some() || running_inside_wsl() {
+        return Ok(());
+    }
+
+    let cli_overrides = overrides
+        .parse_overrides()
+        .map_err(|err| anyhow!("{err}"))?;
+
+    let config = Config::load_with_cli_overrides(cli_overrides, ConfigOverrides::default())
+        .await
+        .context("failed to load Codex config while evaluating windows.prefer_wsl")?;
+
+    let windows_cfg = config.windows;
+    if !windows_cfg.prefer_wsl {
+        return Ok(());
+    }
+
+    if !is_wsl_available() {
+        if !windows_cfg.hide_wsl_notice {
+            eprintln!("WSL not detected; continuing to run Codex on Windows");
+        }
+        return Ok(());
+    }
+
+    let current_dir = env::current_dir().context("failed to resolve current directory")?;
+    let wsl_cwd = match windows_path_to_wsl(&current_dir) {
+        Some(path) => path,
+        None => {
+            if !windows_cfg.hide_wsl_notice {
+                eprintln!(
+                    "Unable to map current directory {} into WSL; continuing on Windows",
+                    current_dir.display()
+                );
+            }
+            return Ok(());
+        }
+    };
+
+    let linux_binary = locate_linux_binary_path();
+    let (command_choice, notice_suffix) = match linux_binary {
+        Some(ref binary_path) => match windows_path_to_wsl(binary_path) {
+            Some(binary_wsl) => (
+                CommandChoice::Binary(binary_wsl),
+                "the bundled Linux binary",
+            ),
+            None => {
+                if !windows_cfg.hide_wsl_notice {
+                    eprintln!(
+                        "Unable to translate Codex Linux binary path {} into WSL; continuing on Windows",
+                        binary_path.display()
+                    );
+                }
+                (CommandChoice::Fallback, "codex from WSL PATH")
+            }
+        },
+        None => (CommandChoice::Fallback, "codex from WSL PATH"),
+    };
+
+    if !windows_cfg.hide_wsl_notice {
+        eprintln!(
+            "windows.prefer_wsl is enabled; re-launching Codex inside WSL using {notice_suffix}"
+        );
+    }
+
+    let args: Vec<OsString> = env::args_os().skip(1).collect();
+
+    let mut cmd = Command::new("wsl.exe");
+    cmd.arg("--cd").arg(&wsl_cwd);
+    match &command_choice {
+        CommandChoice::Binary(binary) => {
+            cmd.arg("--exec").arg(binary);
+        }
+        CommandChoice::Fallback => {
+            cmd.arg("--exec").arg("codex");
+        }
+    }
+    cmd.env(SKIP_ENV, "1");
+    cmd.args(args);
+    cmd.stdin(Stdio::inherit());
+    cmd.stdout(Stdio::inherit());
+    cmd.stderr(Stdio::inherit());
+
+    let status = cmd.status().context("failed to invoke wsl.exe")?;
+    if let Some(code) = status.code() {
+        std::process::exit(code);
+    }
+    std::process::exit(1);
+}
+
+#[cfg(windows)]
+#[derive(Clone, Debug)]
+enum CommandChoice {
+    Binary(String),
+    Fallback,
+}
+
+#[cfg(windows)]
+fn running_inside_wsl() -> bool {
+    env::var_os("WSL_DISTRO_NAME").is_some() || env::var_os("WSL_INTEROP").is_some()
+}
+
+#[cfg(windows)]
+fn is_wsl_available() -> bool {
+    Command::new("wsl.exe")
+        .arg("--help")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+#[cfg(windows)]
+fn locate_linux_binary_path() -> Option<PathBuf> {
+    let exe = env::current_exe().ok()?;
+    let vendor_dir = locate_vendor_root(&exe)?;
+    let linux_target = match env::consts::ARCH {
+        "x86_64" => "x86_64-unknown-linux-musl",
+        "aarch64" => "aarch64-unknown-linux-musl",
+        _ => return None,
+    };
+    let binary_path = vendor_dir.join(linux_target).join("codex").join("codex");
+    if binary_path.exists() {
+        Some(binary_path)
+    } else {
+        None
+    }
+}
+
+#[cfg(windows)]
+fn locate_vendor_root(exe_path: &Path) -> Option<PathBuf> {
+    let mut current = exe_path.parent()?;
+    for _ in 0..5 {
+        if current.file_name().and_then(|s| s.to_str()) == Some("vendor") {
+            return Some(current.to_path_buf());
+        }
+        current = current.parent()?;
+    }
+    None
+}
+
+#[cfg(windows)]
+fn windows_path_to_wsl(path: &Path) -> Option<String> {
+    use std::borrow::Cow;
+
+    let absolute = if path.is_absolute() {
+        Cow::Borrowed(path)
+    } else {
+        Cow::Owned(fs::canonicalize(path).ok()?)
+    };
+
+    let mut components = absolute.components();
+    let prefix = match components.next()? {
+        Component::Prefix(prefix) => prefix.kind(),
+        _ => return None,
+    };
+
+    let drive_letter = match prefix {
+        Prefix::Disk(letter) | Prefix::VerbatimDisk(letter) => letter as char,
+        _ => return None,
+    };
+
+    let mut parts = Vec::new();
+    for component in components {
+        match component {
+            Component::RootDir => {}
+            Component::Normal(segment) => {
+                parts.push(segment.to_string_lossy().to_string());
+            }
+            Component::CurDir => {}
+            Component::ParentDir => return None,
+            Component::Prefix(_) => return None,
+        }
+    }
+
+    let drive = drive_letter.to_ascii_lowercase();
+    let mut wsl_path = format!("/mnt/{drive}");
+    if !parts.is_empty() {
+        wsl_path.push('/');
+        wsl_path.push_str(&parts.join("/"));
+    }
+    Some(wsl_path)
+}

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -17,6 +17,8 @@ use crate::config_types::ShellEnvironmentPolicy;
 use crate::config_types::ShellEnvironmentPolicyToml;
 use crate::config_types::Tui;
 use crate::config_types::UriBasedFileOpener;
+use crate::config_types::WindowsConfig;
+use crate::config_types::WindowsConfigToml;
 use crate::git_info::resolve_root_git_project_for_trust;
 use crate::model_family::ModelFamily;
 use crate::model_family::derive_default_model_family;
@@ -169,6 +171,9 @@ pub struct Config {
     ///
     /// When this program is invoked, arg0 will be set to `codex-linux-sandbox`.
     pub codex_linux_sandbox_exe: Option<PathBuf>,
+
+    /// Windows-specific configuration toggles.
+    pub windows: WindowsConfig,
 
     /// Value to use for `reasoning.effort` when making a request using the
     /// Responses API.
@@ -696,6 +701,10 @@ pub struct ConfigToml {
     /// Collection of settings that are specific to the TUI.
     pub tui: Option<Tui>,
 
+    /// Windows-specific configuration options.
+    #[serde(default)]
+    pub windows: Option<WindowsConfigToml>,
+
     /// When set to `true`, `AgentReasoning` events will be hidden from the
     /// UI/output. Defaults to `false`.
     pub hide_agent_reasoning: Option<bool>,
@@ -978,6 +987,12 @@ impl Config {
             .or(cfg.tools.as_ref().and_then(|t| t.view_image))
             .unwrap_or(true);
 
+        let windows = cfg
+            .windows
+            .clone()
+            .map(WindowsConfig::from)
+            .unwrap_or_default();
+
         let model = model
             .or(config_profile.model)
             .or(cfg.model)
@@ -1063,6 +1078,7 @@ impl Config {
             history,
             file_opener: cfg.file_opener.unwrap_or(UriBasedFileOpener::VsCode),
             codex_linux_sandbox_exe,
+            windows,
 
             hide_agent_reasoning: cfg.hide_agent_reasoning.unwrap_or(false),
             show_raw_agent_reasoning: cfg
@@ -1223,6 +1239,7 @@ pub fn log_dir(cfg: &Config) -> std::io::Result<PathBuf> {
 mod tests {
     use crate::config_types::HistoryPersistence;
     use crate::config_types::Notifications;
+    use crate::config_types::WindowsConfig;
 
     use super::*;
     use pretty_assertions::assert_eq;
@@ -1870,6 +1887,7 @@ model_verbosity = "high"
                 history: History::default(),
                 file_opener: UriBasedFileOpener::VsCode,
                 codex_linux_sandbox_exe: None,
+                windows: WindowsConfig::default(),
                 hide_agent_reasoning: false,
                 show_raw_agent_reasoning: false,
                 model_reasoning_effort: Some(ReasoningEffort::High),
@@ -1931,6 +1949,7 @@ model_verbosity = "high"
             history: History::default(),
             file_opener: UriBasedFileOpener::VsCode,
             codex_linux_sandbox_exe: None,
+            windows: WindowsConfig::default(),
             hide_agent_reasoning: false,
             show_raw_agent_reasoning: false,
             model_reasoning_effort: None,
@@ -2007,6 +2026,7 @@ model_verbosity = "high"
             history: History::default(),
             file_opener: UriBasedFileOpener::VsCode,
             codex_linux_sandbox_exe: None,
+            windows: WindowsConfig::default(),
             hide_agent_reasoning: false,
             show_raw_agent_reasoning: false,
             model_reasoning_effort: None,
@@ -2069,6 +2089,7 @@ model_verbosity = "high"
             history: History::default(),
             file_opener: UriBasedFileOpener::VsCode,
             codex_linux_sandbox_exe: None,
+            windows: WindowsConfig::default(),
             hide_agent_reasoning: false,
             show_raw_agent_reasoning: false,
             model_reasoning_effort: Some(ReasoningEffort::High),

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -292,6 +292,39 @@ impl Default for Notifications {
     }
 }
 
+#[derive(Deserialize, Debug, Clone, PartialEq, Eq, Default)]
+pub struct WindowsConfigToml {
+    #[serde(default)]
+    pub prefer_wsl: Option<bool>,
+
+    #[serde(default)]
+    pub hide_wsl_notice: Option<bool>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WindowsConfig {
+    pub prefer_wsl: bool,
+    pub hide_wsl_notice: bool,
+}
+
+impl Default for WindowsConfig {
+    fn default() -> Self {
+        Self {
+            prefer_wsl: false,
+            hide_wsl_notice: false,
+        }
+    }
+}
+
+impl From<WindowsConfigToml> for WindowsConfig {
+    fn from(value: WindowsConfigToml) -> Self {
+        Self {
+            prefer_wsl: value.prefer_wsl.unwrap_or(false),
+            hide_wsl_notice: value.hide_wsl_notice.unwrap_or(false),
+        }
+    }
+}
+
 /// Collection of settings that are specific to the TUI.
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct Tui {

--- a/docs/config.md
+++ b/docs/config.md
@@ -673,6 +673,19 @@ Note this is **not** a general editor setting (like `$EDITOR`), as it only accep
 
 Currently, `"vscode"` is the default, though Codex does not verify VS Code is installed. As such, `file_opener` may default to `"none"` or something else in the future.
 
+## windows
+
+Windows-specific settings that control how the CLI behaves when launched from a Windows shell.
+
+```toml
+[windows]
+prefer_wsl = true
+hide_wsl_notice = false
+```
+
+- `prefer_wsl` (default: `false`) &mdash; when set to `true`, Codex detects WSL and automatically restarts the current command inside the default WSL distribution so that Linux tooling is used without additional aliases. If WSL is unavailable the command continues normally on Windows.
+- `hide_wsl_notice` (default: `false`) &mdash; suppresses the informational message that Codex prints before relaunching inside WSL. Set this to `true` if you prefer silent hand-offs.
+
 ## hide_agent_reasoning
 
 Codex intermittently emits "reasoning" events that show the model's internal "thinking" before it produces a final answer. Some users may find these events distracting, especially in CI logs or minimal terminal output.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -20,4 +20,4 @@ By default, Codex can modify files in your current working directory (Auto mode)
 
 ### Does it work on Windows?
 
-Running Codex directly on Windows may work, but is not officially supported. We recommend using [Windows Subsystem for Linux (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install).
+Running Codex directly on Windows may work, but is not officially supported. We recommend using [Windows Subsystem for Linux (WSL2)](https://learn.microsoft.com/en-us/windows/wsl/install). You can set `windows.prefer_wsl = true` in your Codex config to automatically re-launch any `codex` invocation inside WSL when it is available.


### PR DESCRIPTION
Add Windows config toggles that let Codex prefer WSL hand-offs while keeping other platforms untouched. The CLI now re-execs itself inside WSL when the new config is enabled and documentation explains the setup.

- Windows config struct adds prefer_wsl and notice knobs
- CLI re-launch path activates for codex and MCP commands
- Documentation calls out WSL-aware launch instructions

```toml
[windows]
# auto-run codex inside WSL when available
prefer_wsl = true
# suppress the informational WSL relaunch message
hide_wsl_notice = true
```
