### PR TITLE
Add helper for response created SSE events in tests

### DIFF
--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -34,6 +34,16 @@ pub fn ev_completed(id: &str) -> Value {
     })
 }
 
+/// Convenience: SSE event for a created response with a specific id.
+pub fn ev_response_created(id: &str) -> Value {
+    serde_json::json!({
+        "type": "response.created",
+        "response": {
+            "id": id,
+        }
+    })
+}
+
 pub fn ev_completed_with_tokens(id: &str, total_tokens: u64) -> Value {
     serde_json::json!({
         "type": "response.completed",

--- a/codex-rs/core/tests/suite/read_file.rs
+++ b/codex-rs/core/tests/suite/read_file.rs
@@ -10,6 +10,7 @@ use core_test_support::responses;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
+use core_test_support::responses::ev_response_created;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
@@ -46,10 +47,7 @@ async fn read_file_tool_returns_requested_lines() -> anyhow::Result<()> {
     .to_string();
 
     let first_response = sse(vec![
-        serde_json::json!({
-            "type": "response.created",
-            "response": {"id": "resp-1"}
-        }),
+        ev_response_created("resp-1"),
         ev_function_call(call_id, "read_file", &arguments),
         ev_completed("resp-1"),
     ]);

--- a/codex-rs/core/tests/suite/rmcp_client.rs
+++ b/codex-rs/core/tests/suite/rmcp_client.rs
@@ -47,10 +47,7 @@ async fn stdio_server_round_trip() -> anyhow::Result<()> {
         &server,
         any(),
         responses::sse(vec![
-            serde_json::json!({
-                "type": "response.created",
-                "response": {"id": "resp-1"}
-            }),
+            responses::ev_response_created("resp-1"),
             responses::ev_function_call(call_id, &tool_name, "{\"message\":\"ping\"}"),
             responses::ev_completed("resp-1"),
         ]),
@@ -184,10 +181,7 @@ async fn streamable_http_tool_call_round_trip() -> anyhow::Result<()> {
         &server,
         any(),
         responses::sse(vec![
-            serde_json::json!({
-                "type": "response.created",
-                "response": {"id": "resp-1"}
-            }),
+            responses::ev_response_created("resp-1"),
             responses::ev_function_call(call_id, &tool_name, "{\"message\":\"ping\"}"),
             responses::ev_completed("resp-1"),
         ]),
@@ -352,10 +346,7 @@ async fn streamable_http_with_oauth_round_trip() -> anyhow::Result<()> {
         &server,
         any(),
         responses::sse(vec![
-            serde_json::json!({
-                "type": "response.created",
-                "response": {"id": "resp-1"}
-            }),
+            responses::ev_response_created("resp-1"),
             responses::ev_function_call(call_id, &tool_name, "{\"message\":\"ping\"}"),
             responses::ev_completed("resp-1"),
         ]),

--- a/codex-rs/core/tests/suite/shell_serialization.rs
+++ b/codex-rs/core/tests/suite/shell_serialization.rs
@@ -11,6 +11,7 @@ use codex_protocol::config_types::ReasoningSummary;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
+use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
@@ -88,7 +89,7 @@ async fn shell_output_stays_json_without_freeform_apply_patch() -> Result<()> {
     });
     let responses = vec![
         sse(vec![
-            json!({"type": "response.created", "response": {"id": "resp-1"}}),
+            ev_response_created("resp-1"),
             ev_function_call(call_id, "shell", &serde_json::to_string(&args)?),
             ev_completed("resp-1"),
         ]),
@@ -155,7 +156,7 @@ async fn shell_output_is_structured_with_freeform_apply_patch() -> Result<()> {
     });
     let responses = vec![
         sse(vec![
-            json!({"type": "response.created", "response": {"id": "resp-1"}}),
+            ev_response_created("resp-1"),
             ev_function_call(call_id, "shell", &serde_json::to_string(&args)?),
             ev_completed("resp-1"),
         ]),
@@ -224,7 +225,7 @@ async fn shell_output_reserializes_truncated_content() -> Result<()> {
     });
     let responses = vec![
         sse(vec![
-            json!({"type": "response.created", "response": {"id": "resp-1"}}),
+            ev_response_created("resp-1"),
             ev_function_call(call_id, "shell", &serde_json::to_string(&args)?),
             ev_completed("resp-1"),
         ]),

--- a/codex-rs/core/tests/suite/tool_harness.rs
+++ b/codex-rs/core/tests/suite/tool_harness.rs
@@ -14,6 +14,7 @@ use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
 use core_test_support::responses::ev_local_shell_call;
+use core_test_support::responses::ev_response_created;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
@@ -68,10 +69,7 @@ async fn shell_tool_executes_command_and_streams_output() -> anyhow::Result<()> 
     let call_id = "shell-tool-call";
     let command = vec!["/bin/echo", "tool harness"];
     let first_response = sse(vec![
-        serde_json::json!({
-            "type": "response.created",
-            "response": {"id": "resp-1"}
-        }),
+        ev_response_created("resp-1"),
         ev_local_shell_call(call_id, "completed", command),
         ev_completed("resp-1"),
     ]);
@@ -152,10 +150,7 @@ async fn update_plan_tool_emits_plan_update_event() -> anyhow::Result<()> {
     .to_string();
 
     let first_response = sse(vec![
-        serde_json::json!({
-            "type": "response.created",
-            "response": {"id": "resp-1"}
-        }),
+        ev_response_created("resp-1"),
         ev_function_call(call_id, "update_plan", &plan_args),
         ev_completed("resp-1"),
     ]);
@@ -247,10 +242,7 @@ async fn update_plan_tool_rejects_malformed_payload() -> anyhow::Result<()> {
     .to_string();
 
     let first_response = sse(vec![
-        serde_json::json!({
-            "type": "response.created",
-            "response": {"id": "resp-1"}
-        }),
+        ev_response_created("resp-1"),
         ev_function_call(call_id, "update_plan", &invalid_args),
         ev_completed("resp-1"),
     ]);
@@ -353,10 +345,7 @@ async fn apply_patch_tool_executes_and_emits_patch_events() -> anyhow::Result<()
 *** End Patch"#;
 
     let first_response = sse(vec![
-        serde_json::json!({
-            "type": "response.created",
-            "response": {"id": "resp-1"}
-        }),
+        ev_response_created("resp-1"),
         ev_apply_patch_function_call(call_id, patch_content),
         ev_completed("resp-1"),
     ]);
@@ -482,10 +471,7 @@ async fn apply_patch_reports_parse_diagnostics() -> anyhow::Result<()> {
 *** End Patch";
 
     let first_response = sse(vec![
-        serde_json::json!({
-            "type": "response.created",
-            "response": {"id": "resp-1"}
-        }),
+        ev_response_created("resp-1"),
         ev_apply_patch_function_call(call_id, patch_content),
         ev_completed("resp-1"),
     ]);

--- a/codex-rs/core/tests/suite/tools.rs
+++ b/codex-rs/core/tests/suite/tools.rs
@@ -13,6 +13,7 @@ use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_custom_tool_call;
 use core_test_support::responses::ev_function_call;
+use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
@@ -106,7 +107,7 @@ async fn custom_tool_unknown_returns_custom_output_error() -> Result<()> {
 
     let responses = vec![
         sse(vec![
-            json!({"type": "response.created", "response": {"id": "resp-1"}}),
+            ev_response_created("resp-1"),
             ev_custom_tool_call(call_id, tool_name, "\"payload\""),
             ev_completed("resp-1"),
         ]),
@@ -169,7 +170,7 @@ async fn shell_escalated_permissions_rejected_then_ok() -> Result<()> {
 
     let responses = vec![
         sse(vec![
-            json!({"type": "response.created", "response": {"id": "resp-1"}}),
+            ev_response_created("resp-1"),
             ev_function_call(
                 call_id_blocked,
                 "shell",
@@ -178,7 +179,7 @@ async fn shell_escalated_permissions_rejected_then_ok() -> Result<()> {
             ev_completed("resp-1"),
         ]),
         sse(vec![
-            json!({"type": "response.created", "response": {"id": "resp-2"}}),
+            ev_response_created("resp-2"),
             ev_function_call(
                 call_id_success,
                 "shell",
@@ -283,7 +284,7 @@ async fn local_shell_missing_ids_maps_to_function_output_error() -> Result<()> {
 
     let responses = vec![
         sse(vec![
-            json!({"type": "response.created", "response": {"id": "resp-1"}}),
+            ev_response_created("resp-1"),
             local_shell_event,
             ev_completed("resp-1"),
         ]),
@@ -324,7 +325,7 @@ async fn collect_tools(use_unified_exec: bool) -> Result<Vec<String>> {
     let server = start_mock_server().await;
 
     let responses = vec![sse(vec![
-        json!({"type": "response.created", "response": {"id": "resp-1"}}),
+        ev_response_created("resp-1"),
         ev_assistant_message("msg-1", "done"),
         ev_completed("resp-1"),
     ])];
@@ -393,7 +394,7 @@ async fn shell_timeout_includes_timeout_prefix_and_metadata() -> Result<()> {
 
     let responses = vec![
         sse(vec![
-            json!({"type": "response.created", "response": {"id": "resp-1"}}),
+            ev_response_created("resp-1"),
             ev_function_call(call_id, "shell", &serde_json::to_string(&args)?),
             ev_completed("resp-1"),
         ]),
@@ -485,7 +486,7 @@ async fn shell_sandbox_denied_truncates_error_output() -> Result<()> {
 
     let responses = vec![
         sse(vec![
-            json!({"type": "response.created", "response": {"id": "resp-1"}}),
+            ev_response_created("resp-1"),
             ev_function_call(call_id, "shell", &serde_json::to_string(&args)?),
             ev_completed("resp-1"),
         ]),
@@ -571,7 +572,7 @@ async fn shell_spawn_failure_truncates_exec_error() -> Result<()> {
 
     let responses = vec![
         sse(vec![
-            json!({"type": "response.created", "response": {"id": "resp-1"}}),
+            ev_response_created("resp-1"),
             ev_function_call(call_id, "shell", &serde_json::to_string(&args)?),
             ev_completed("resp-1"),
         ]),

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -12,6 +12,7 @@ use codex_protocol::config_types::ReasoningSummary;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
+use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
@@ -82,7 +83,7 @@ async fn unified_exec_reuses_session_via_stdin() -> Result<()> {
 
     let responses = vec![
         sse(vec![
-            serde_json::json!({"type": "response.created", "response": {"id": "resp-1"}}),
+            ev_response_created("resp-1"),
             ev_function_call(
                 first_call_id,
                 "unified_exec",
@@ -91,7 +92,7 @@ async fn unified_exec_reuses_session_via_stdin() -> Result<()> {
             ev_completed("resp-1"),
         ]),
         sse(vec![
-            serde_json::json!({"type": "response.created", "response": {"id": "resp-2"}}),
+            ev_response_created("resp-2"),
             ev_function_call(
                 second_call_id,
                 "unified_exec",
@@ -198,7 +199,7 @@ async fn unified_exec_timeout_and_followup_poll() -> Result<()> {
 
     let responses = vec![
         sse(vec![
-            serde_json::json!({"type": "response.created", "response": {"id": "resp-1"}}),
+            ev_response_created("resp-1"),
             ev_function_call(
                 first_call_id,
                 "unified_exec",
@@ -207,7 +208,7 @@ async fn unified_exec_timeout_and_followup_poll() -> Result<()> {
             ev_completed("resp-1"),
         ]),
         sse(vec![
-            serde_json::json!({"type": "response.created", "response": {"id": "resp-2"}}),
+            ev_response_created("resp-2"),
             ev_function_call(
                 second_call_id,
                 "unified_exec",

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -12,6 +12,7 @@ use core_test_support::responses;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
+use core_test_support::responses::ev_response_created;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
@@ -89,10 +90,7 @@ async fn view_image_tool_attaches_local_image() -> anyhow::Result<()> {
     let arguments = serde_json::json!({ "path": rel_path }).to_string();
 
     let first_response = sse(vec![
-        serde_json::json!({
-            "type": "response.created",
-            "response": {"id": "resp-1"}
-        }),
+        ev_response_created("resp-1"),
         ev_function_call(call_id, "view_image", &arguments),
         ev_completed("resp-1"),
     ]);
@@ -202,10 +200,7 @@ async fn view_image_tool_errors_when_path_is_directory() -> anyhow::Result<()> {
     let arguments = serde_json::json!({ "path": rel_path }).to_string();
 
     let first_response = sse(vec![
-        serde_json::json!({
-            "type": "response.created",
-            "response": {"id": "resp-1"}
-        }),
+        ev_response_created("resp-1"),
         ev_function_call(call_id, "view_image", &arguments),
         ev_completed("resp-1"),
     ]);
@@ -282,10 +277,7 @@ async fn view_image_tool_errors_when_file_missing() -> anyhow::Result<()> {
     let arguments = serde_json::json!({ "path": rel_path }).to_string();
 
     let first_response = sse(vec![
-        serde_json::json!({
-            "type": "response.created",
-            "response": {"id": "resp-1"}
-        }),
+        ev_response_created("resp-1"),
         ev_function_call(call_id, "view_image", &arguments),
         ev_completed("resp-1"),
     ]);

--- a/codex-rs/exec/tests/suite/output_schema.rs
+++ b/codex-rs/exec/tests/suite/output_schema.rs
@@ -24,10 +24,7 @@ async fn exec_includes_output_schema_in_request() -> anyhow::Result<()> {
 
     let server = responses::start_mock_server().await;
     let body = responses::sse(vec![
-        serde_json::json!({
-            "type": "response.created",
-            "response": {"id": "resp1"}
-        }),
+        responses::ev_response_created("resp1"),
         responses::ev_assistant_message("m1", "fixture hello"),
         responses::ev_completed("resp1"),
     ]);


### PR DESCRIPTION
## Summary
- add a reusable `ev_response_created` helper that builds `response.created` SSE events for integration tests
- update the exec and core integration suites to use the new helper instead of repeating manual JSON literals
- keep the streaming fixtures consistent by relying on the shared helper in every touched test

## Testing
- `just fmt`


------
https://chatgpt.com/codex/tasks/task_i_68e1fe885bb883208aafffb94218da61