### PR TITLE
[MCP] Upgrade rmcp to 0.8

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -4757,8 +4757,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.7.0"
-source = "git+https://github.com/modelcontextprotocol/rust-sdk?rev=c0b777c7f784ba2d456b03c2ec3b98c9b28b5e10#c0b777c7f784ba2d456b03c2ec3b98c9b28b5e10"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "583d060e99feb3a3683fb48a1e4bf5f8d4a50951f429726f330ee5ff548837f8"
 dependencies = [
  "base64",
  "bytes",
@@ -4790,8 +4791,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.7.0"
-source = "git+https://github.com/modelcontextprotocol/rust-sdk?rev=c0b777c7f784ba2d456b03c2ec3b98c9b28b5e10#c0b777c7f784ba2d456b03c2ec3b98c9b28b5e10"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421d8b0ba302f479214889486f9550e63feca3af310f1190efcf6e2016802693"
 dependencies = [
  "darling 0.21.3",
  "proc-macro2",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -142,8 +142,7 @@ rand = "0.9"
 ratatui = "0.29.0"
 regex-lite = "0.1.7"
 reqwest = "0.12"
-# When this gets bumped, remove the patch below.
-rmcp = { version = "0.7.0", default-features = false }
+rmcp = { version = "0.8.0", default-features = false }
 schemars = "0.8.22"
 seccompiler = "0.5.0"
 serde = "1"
@@ -250,5 +249,3 @@ ratatui = { git = "https://github.com/nornagon/ratatui", branch = "nornagon-v0.2
 
 # Uncomment to debug local changes.
 # rmcp = { path = "../../rust-sdk/crates/rmcp" }
-# 0.7.0 + https://github.com/modelcontextprotocol/rust-sdk/pull/459 which includes dynamic .well-known discovery which is required for Figma.
-rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", rev = "c0b777c7f784ba2d456b03c2ec3b98c9b28b5e10", default-features = false }

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -47,7 +47,9 @@ pub async fn perform_oauth_login(server_name: &str, server_url: &str) -> Result<
     spawn_callback_server(server, tx);
 
     let mut oauth_state = OAuthState::new(server_url, None).await?;
-    oauth_state.start_authorization(&[], &redirect_uri).await?;
+    oauth_state
+        .start_authorization(&[], &redirect_uri, Some("Codex"))
+        .await?;
     let auth_url = oauth_state.get_authorization_url().await?;
 
     println!("Authorize `{server_name}` by opening this URL in your browser:\n{auth_url}\n");


### PR DESCRIPTION
The version with the well-known discovery and my MCP client name change were just released

https://github.com/modelcontextprotocol/rust-sdk/releases