### PR TITLE
Use response helpers when mounting SSE test responses

### DIFF
--- a/codex-rs/exec/tests/suite/auth_env.rs
+++ b/codex-rs/exec/tests/suite/auth_env.rs
@@ -1,26 +1,22 @@
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 use core_test_support::responses::ev_completed;
+use core_test_support::responses::mount_sse_once_match;
 use core_test_support::responses::sse;
-use core_test_support::responses::sse_response;
 use core_test_support::responses::start_mock_server;
 use core_test_support::test_codex_exec::test_codex_exec;
-use wiremock::Mock;
 use wiremock::matchers::header;
-use wiremock::matchers::method;
-use wiremock::matchers::path;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn exec_uses_codex_api_key_env_var() -> anyhow::Result<()> {
     let test = test_codex_exec();
     let server = start_mock_server().await;
 
-    Mock::given(method("POST"))
-        .and(path("/v1/responses"))
-        .and(header("Authorization", "Bearer dummy"))
-        .respond_with(sse_response(sse(vec![ev_completed("request_0")])))
-        .expect(1)
-        .mount(&server)
-        .await;
+    mount_sse_once_match(
+        &server,
+        header("Authorization", "Bearer dummy"),
+        sse(vec![ev_completed("request_0")]),
+    )
+    .await;
 
     test.cmd_with_server(&server)
         .arg("--skip-git-repo-check")


### PR DESCRIPTION
## Summary
- replace manual wiremock SSE mounts in the compact suite with the shared response helpers
- simplify the exec auth_env integration test by using the mount_sse_once_match helper
- rely on mount_sse_sequence plus server request collection to replace the bespoke SeqResponder utility in tests

## Testing
- just fmt

------
https://chatgpt.com/codex/tasks/task_i_68e2e238f2a88320a337f0b9e4098093