### PR TITLE
Fix formatting of line range instruction in review prompt

### DIFF
--- a/codex-rs/core/review_prompt.md
+++ b/codex-rs/core/review_prompt.md
@@ -82,6 +82,6 @@ OUTPUT FORMAT:
 
 * **Do not** wrap the JSON in markdown fences or extra prose.
 * The code_location field is required and must include absolute_file_path and line_range.
-*Line ranges must be as short as possible for interpreting the issue (avoid ranges over 5–10 lines; pick the most suitable subrange).
+* Line ranges must be as short as possible for interpreting the issue (avoid ranges over 5–10 lines; pick the most suitable subrange).
 * The code_location should overlap with the diff.
 * Do not generate a PR fix.


### PR DESCRIPTION
adds a missing space ^^

> What? Why? How?

should be fairly straight-forward.
