### PR TITLE
tui: show rate-limit resets in transcript footer

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -683,7 +683,11 @@ impl ChatWidget {
                     .bottom_pane
                     .status_widget()
                     .map(super::status_indicator_widget::StatusIndicatorWidget::elapsed_seconds);
-                self.add_to_history(history_cell::FinalMessageSeparator::new(elapsed_seconds));
+                let rate_limits = self.rate_limit_snapshot.clone();
+                self.add_to_history(history_cell::FinalMessageSeparator::new(
+                    elapsed_seconds,
+                    rate_limits,
+                ));
                 self.needs_final_message_separator = false;
             }
             self.stream_controller = Some(StreamController::new(

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -10,6 +10,7 @@ use crate::markdown::MarkdownCitationContext;
 use crate::markdown::append_markdown;
 use crate::render::line_utils::line_to_static;
 use crate::render::line_utils::prefix_lines;
+use crate::status::RateLimitSnapshotDisplay;
 use crate::style::user_message_style;
 use crate::terminal_palette::default_bg;
 use crate::text_formatting::format_and_truncate_tool_result;
@@ -1095,30 +1096,52 @@ pub(crate) fn new_reasoning_summary_block(
 #[derive(Debug)]
 pub struct FinalMessageSeparator {
     elapsed_seconds: Option<u64>,
+    rate_limits: Option<RateLimitSnapshotDisplay>,
 }
 impl FinalMessageSeparator {
-    pub(crate) fn new(elapsed_seconds: Option<u64>) -> Self {
-        Self { elapsed_seconds }
+    pub(crate) fn new(
+        elapsed_seconds: Option<u64>,
+        rate_limits: Option<RateLimitSnapshotDisplay>,
+    ) -> Self {
+        Self {
+            elapsed_seconds,
+            rate_limits,
+        }
     }
 }
 impl HistoryCell for FinalMessageSeparator {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
-        let elapsed_seconds = self
+        let mut segments: Vec<String> = Vec::new();
+
+        if let Some(elapsed) = self
             .elapsed_seconds
-            .map(super::status_indicator_widget::fmt_elapsed_compact);
-        if let Some(elapsed_seconds) = elapsed_seconds {
-            let worked_for = format!("─ Worked for {elapsed_seconds} ─");
-            let worked_for_width = worked_for.width();
-            vec![
-                Line::from_iter([
-                    worked_for,
-                    "─".repeat((width as usize).saturating_sub(worked_for_width)),
-                ])
-                .dim(),
-            ]
-        } else {
-            vec![Line::from_iter(["─".repeat(width as usize).dim()])]
+            .map(super::status_indicator_widget::fmt_elapsed_compact)
+        {
+            segments.push(format!("Worked for {elapsed}"));
         }
+
+        if let Some(rate_limits) = self.rate_limits.as_ref() {
+            segments.extend(rate_limits.summary_segments());
+        }
+
+        if segments.is_empty() {
+            return vec![Line::from("─".repeat(width as usize)).dim()];
+        }
+
+        let content = segments.join(" │ ");
+        let mut line = String::from("─");
+        if !content.is_empty() {
+            line.push(' ');
+            line.push_str(&content);
+            line.push(' ');
+        }
+
+        let used_width = line.width();
+        if width as usize > used_width {
+            line.push_str(&"─".repeat((width as usize).saturating_sub(used_width)));
+        }
+
+        vec![Line::from(line).dim()]
     }
 
     fn transcript_lines(&self) -> Vec<Line<'static>> {


### PR DESCRIPTION
Show the active rate-limit usage (with reset timestamps) in the transcript footer’s “Worked for …” separator.