### PR TITLE
[MCP] Add the ability to explicitly specify a credentials store

### DIFF
--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -236,7 +236,7 @@ async fn run_login(config_overrides: &CliConfigOverrides, login_args: LoginArgs)
         _ => bail!("OAuth login is only supported for streamable HTTP servers."),
     };
 
-    perform_oauth_login(&name, &url, config.mcp_oauth_credentials_store).await?;
+    perform_oauth_login(&name, &url, config.mcp_oauth_credentials_store_mode).await?;
     println!("Successfully logged in to MCP server '{name}'.");
     Ok(())
 }
@@ -259,7 +259,7 @@ async fn run_logout(config_overrides: &CliConfigOverrides, logout_args: LogoutAr
         _ => bail!("OAuth logout is only supported for streamable_http transports."),
     };
 
-    match delete_oauth_tokens(&name, &url, config.mcp_oauth_credentials_store) {
+    match delete_oauth_tokens(&name, &url, config.mcp_oauth_credentials_store_mode) {
         Ok(true) => println!("Removed OAuth credentials for '{name}'."),
         Ok(false) => println!("No OAuth credentials stored for '{name}'."),
         Err(err) => return Err(anyhow!("failed to delete OAuth credentials: {err}")),

--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -236,7 +236,7 @@ async fn run_login(config_overrides: &CliConfigOverrides, login_args: LoginArgs)
         _ => bail!("OAuth login is only supported for streamable HTTP servers."),
     };
 
-    perform_oauth_login(&name, &url).await?;
+    perform_oauth_login(&name, &url, config.mcp_oauth_credentials_store).await?;
     println!("Successfully logged in to MCP server '{name}'.");
     Ok(())
 }
@@ -259,7 +259,7 @@ async fn run_logout(config_overrides: &CliConfigOverrides, logout_args: LogoutAr
         _ => bail!("OAuth logout is only supported for streamable_http transports."),
     };
 
-    match delete_oauth_tokens(&name, &url) {
+    match delete_oauth_tokens(&name, &url, config.mcp_oauth_credentials_store) {
         Ok(true) => println!("Removed OAuth credentials for '{name}'."),
         Ok(false) => println!("No OAuth credentials stored for '{name}'."),
         Err(err) => return Err(anyhow!("failed to delete OAuth credentials: {err}")),

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -362,6 +362,7 @@ impl Session {
         let mcp_fut = McpConnectionManager::new(
             config.mcp_servers.clone(),
             config.use_experimental_use_rmcp_client,
+            config.mcp_oauth_credentials_store,
         );
         let default_shell_fut = shell::default_user_shell();
         let history_meta_fut = crate::message_history::history_metadata(&config);

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -362,7 +362,7 @@ impl Session {
         let mcp_fut = McpConnectionManager::new(
             config.mcp_servers.clone(),
             config.use_experimental_use_rmcp_client,
-            config.mcp_oauth_credentials_store,
+            config.mcp_oauth_credentials_store_mode,
         );
         let default_shell_fut = shell::default_user_shell();
         let history_meta_fut = crate::message_history::history_metadata(&config);

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -33,7 +33,7 @@ use codex_protocol::config_types::ReasoningEffort;
 use codex_protocol::config_types::ReasoningSummary;
 use codex_protocol::config_types::SandboxMode;
 use codex_protocol::config_types::Verbosity;
-use codex_rmcp_client::OAuthCredentialsStore;
+use codex_rmcp_client::OAuthCredentialsStoreMode;
 use dirs::home_dir;
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -143,8 +143,12 @@ pub struct Config {
     /// Definition for MCP servers that Codex can reach out to for tool calls.
     pub mcp_servers: HashMap<String, McpServerConfig>,
 
-    /// Preferred backend for storing MCP OAuth credentials.
-    pub mcp_oauth_credentials_store: OAuthCredentialsStore,
+    /// Preferred store for MCP OAuth credentials.
+    /// keyring: Use an OS-specific keyring service.
+    ///          https://github.com/openai/codex/blob/main/codex-rs/rmcp-client/src/oauth.rs#L2
+    /// file: Use a file in the Codex home directory.
+    /// auto (default): Use the OS-specific keyring service if available, otherwise use a file.
+    pub mcp_oauth_credentials_store_mode: OAuthCredentialsStoreMode,
 
     /// Combined provider map (defaults merged with user-defined overrides).
     pub model_providers: HashMap<String, ModelProviderInfo>,
@@ -699,7 +703,11 @@ pub struct ConfigToml {
     pub mcp_servers: HashMap<String, McpServerConfig>,
 
     /// Preferred backend for storing MCP OAuth credentials.
-    pub mcp_oauth_credentials_store: Option<OAuthCredentialsStore>,
+    /// keyring: Use an OS-specific keyring service.
+    ///          https://github.com/openai/codex/blob/main/codex-rs/rmcp-client/src/oauth.rs#L2
+    /// file: Use a file in the Codex home directory.
+    /// auto (default): Use the OS-specific keyring service if available, otherwise use a file.
+    pub mcp_oauth_credentials_store: Option<OAuthCredentialsStoreMode>,
 
     /// User-defined provider entries that extend/override the built-in list.
     #[serde(default)]
@@ -1081,7 +1089,9 @@ impl Config {
             user_instructions,
             base_instructions,
             mcp_servers: cfg.mcp_servers,
-            mcp_oauth_credentials_store: cfg.mcp_oauth_credentials_store.unwrap_or_default(),
+            // The config.toml omits "_mode" because it's a config file. However, "_mode"
+            // is important in code to differentiate the mode from the store implementation.
+            mcp_oauth_credentials_store_mode: cfg.mcp_oauth_credentials_store.unwrap_or_default(),
             model_providers,
             project_doc_max_bytes: cfg.project_doc_max_bytes.unwrap_or(PROJECT_DOC_MAX_BYTES),
             project_doc_fallback_filenames: cfg
@@ -1904,7 +1914,7 @@ model_verbosity = "high"
                 notify: None,
                 cwd: fixture.cwd(),
                 mcp_servers: HashMap::new(),
-                mcp_oauth_credentials_store: Default::default(),
+                mcp_oauth_credentials_store_mode: Default::default(),
                 model_providers: fixture.model_provider_map.clone(),
                 project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
                 project_doc_fallback_filenames: Vec::new(),
@@ -1967,7 +1977,7 @@ model_verbosity = "high"
             notify: None,
             cwd: fixture.cwd(),
             mcp_servers: HashMap::new(),
-            mcp_oauth_credentials_store: Default::default(),
+            mcp_oauth_credentials_store_mode: Default::default(),
             model_providers: fixture.model_provider_map.clone(),
             project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
             project_doc_fallback_filenames: Vec::new(),
@@ -2045,7 +2055,7 @@ model_verbosity = "high"
             notify: None,
             cwd: fixture.cwd(),
             mcp_servers: HashMap::new(),
-            mcp_oauth_credentials_store: Default::default(),
+            mcp_oauth_credentials_store_mode: Default::default(),
             model_providers: fixture.model_provider_map.clone(),
             project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
             project_doc_fallback_filenames: Vec::new(),
@@ -2109,7 +2119,7 @@ model_verbosity = "high"
             notify: None,
             cwd: fixture.cwd(),
             mcp_servers: HashMap::new(),
-            mcp_oauth_credentials_store: Default::default(),
+            mcp_oauth_credentials_store_mode: Default::default(),
             model_providers: fixture.model_provider_map.clone(),
             project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
             project_doc_fallback_filenames: Vec::new(),

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -33,6 +33,7 @@ use codex_protocol::config_types::ReasoningEffort;
 use codex_protocol::config_types::ReasoningSummary;
 use codex_protocol::config_types::SandboxMode;
 use codex_protocol::config_types::Verbosity;
+use codex_rmcp_client::OAuthCredentialsStore;
 use dirs::home_dir;
 use serde::Deserialize;
 use std::collections::BTreeMap;
@@ -141,6 +142,9 @@ pub struct Config {
 
     /// Definition for MCP servers that Codex can reach out to for tool calls.
     pub mcp_servers: HashMap<String, McpServerConfig>,
+
+    /// Preferred backend for storing MCP OAuth credentials.
+    pub mcp_oauth_credentials_store: OAuthCredentialsStore,
 
     /// Combined provider map (defaults merged with user-defined overrides).
     pub model_providers: HashMap<String, ModelProviderInfo>,
@@ -694,6 +698,9 @@ pub struct ConfigToml {
     #[serde(default)]
     pub mcp_servers: HashMap<String, McpServerConfig>,
 
+    /// Preferred backend for storing MCP OAuth credentials.
+    pub mcp_oauth_credentials_store: Option<OAuthCredentialsStore>,
+
     /// User-defined provider entries that extend/override the built-in list.
     #[serde(default)]
     pub model_providers: HashMap<String, ModelProviderInfo>,
@@ -1074,6 +1081,7 @@ impl Config {
             user_instructions,
             base_instructions,
             mcp_servers: cfg.mcp_servers,
+            mcp_oauth_credentials_store: cfg.mcp_oauth_credentials_store.unwrap_or_default(),
             model_providers,
             project_doc_max_bytes: cfg.project_doc_max_bytes.unwrap_or(PROJECT_DOC_MAX_BYTES),
             project_doc_fallback_filenames: cfg
@@ -1896,6 +1904,7 @@ model_verbosity = "high"
                 notify: None,
                 cwd: fixture.cwd(),
                 mcp_servers: HashMap::new(),
+                mcp_oauth_credentials_store: Default::default(),
                 model_providers: fixture.model_provider_map.clone(),
                 project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
                 project_doc_fallback_filenames: Vec::new(),
@@ -1958,6 +1967,7 @@ model_verbosity = "high"
             notify: None,
             cwd: fixture.cwd(),
             mcp_servers: HashMap::new(),
+            mcp_oauth_credentials_store: Default::default(),
             model_providers: fixture.model_provider_map.clone(),
             project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
             project_doc_fallback_filenames: Vec::new(),
@@ -2035,6 +2045,7 @@ model_verbosity = "high"
             notify: None,
             cwd: fixture.cwd(),
             mcp_servers: HashMap::new(),
+            mcp_oauth_credentials_store: Default::default(),
             model_providers: fixture.model_provider_map.clone(),
             project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
             project_doc_fallback_filenames: Vec::new(),
@@ -2098,6 +2109,7 @@ model_verbosity = "high"
             notify: None,
             cwd: fixture.cwd(),
             mcp_servers: HashMap::new(),
+            mcp_oauth_credentials_store: Default::default(),
             model_providers: fixture.model_provider_map.clone(),
             project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
             project_doc_fallback_filenames: Vec::new(),

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -709,6 +709,7 @@ pub struct ConfigToml {
     ///          https://github.com/openai/codex/blob/main/codex-rs/rmcp-client/src/oauth.rs#L2
     /// file: Use a file in the Codex home directory.
     /// auto (default): Use the OS-specific keyring service if available, otherwise use a file.
+    #[serde(default)]
     pub mcp_oauth_credentials_store: Option<OAuthCredentialsStoreMode>,
 
     /// User-defined provider entries that extend/override the built-in list.

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -16,6 +16,7 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use codex_mcp_client::McpClient;
+use codex_rmcp_client::OAuthCredentialsStore;
 use codex_rmcp_client::RmcpClient;
 use mcp_types::ClientCapabilities;
 use mcp_types::Implementation;
@@ -125,9 +126,16 @@ impl McpClientAdapter {
         bearer_token: Option<String>,
         params: mcp_types::InitializeRequestParams,
         startup_timeout: Duration,
+        credentials_store: OAuthCredentialsStore,
     ) -> Result<Self> {
         let client = Arc::new(
-            RmcpClient::new_streamable_http_client(&server_name, &url, bearer_token).await?,
+            RmcpClient::new_streamable_http_client(
+                &server_name,
+                &url,
+                bearer_token,
+                credentials_store,
+            )
+            .await?,
         );
         client.initialize(params, Some(startup_timeout)).await?;
         Ok(McpClientAdapter::Rmcp(client))
@@ -182,6 +190,7 @@ impl McpConnectionManager {
     pub async fn new(
         mcp_servers: HashMap<String, McpServerConfig>,
         use_rmcp_client: bool,
+        credentials_store: OAuthCredentialsStore,
     ) -> Result<(Self, ClientStartErrors)> {
         // Early exit if no servers are configured.
         if mcp_servers.is_empty() {
@@ -249,6 +258,7 @@ impl McpConnectionManager {
                             bearer_token,
                             params,
                             startup_timeout,
+                            credentials_store,
                         )
                         .await
                     }

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -126,16 +126,11 @@ impl McpClientAdapter {
         bearer_token: Option<String>,
         params: mcp_types::InitializeRequestParams,
         startup_timeout: Duration,
-        credentials_store: OAuthCredentialsStoreMode,
+        store_mode: OAuthCredentialsStoreMode,
     ) -> Result<Self> {
         let client = Arc::new(
-            RmcpClient::new_streamable_http_client(
-                &server_name,
-                &url,
-                bearer_token,
-                credentials_store,
-            )
-            .await?,
+            RmcpClient::new_streamable_http_client(&server_name, &url, bearer_token, store_mode)
+                .await?,
         );
         client.initialize(params, Some(startup_timeout)).await?;
         Ok(McpClientAdapter::Rmcp(client))
@@ -190,7 +185,7 @@ impl McpConnectionManager {
     pub async fn new(
         mcp_servers: HashMap<String, McpServerConfig>,
         use_rmcp_client: bool,
-        credentials_store: OAuthCredentialsStoreMode,
+        store_mode: OAuthCredentialsStoreMode,
     ) -> Result<(Self, ClientStartErrors)> {
         // Early exit if no servers are configured.
         if mcp_servers.is_empty() {
@@ -258,7 +253,7 @@ impl McpConnectionManager {
                             bearer_token,
                             params,
                             startup_timeout,
-                            credentials_store,
+                            store_mode,
                         )
                         .await
                     }

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -16,7 +16,7 @@ use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
 use codex_mcp_client::McpClient;
-use codex_rmcp_client::OAuthCredentialsStore;
+use codex_rmcp_client::OAuthCredentialsStoreMode;
 use codex_rmcp_client::RmcpClient;
 use mcp_types::ClientCapabilities;
 use mcp_types::Implementation;
@@ -126,7 +126,7 @@ impl McpClientAdapter {
         bearer_token: Option<String>,
         params: mcp_types::InitializeRequestParams,
         startup_timeout: Duration,
-        credentials_store: OAuthCredentialsStore,
+        credentials_store: OAuthCredentialsStoreMode,
     ) -> Result<Self> {
         let client = Arc::new(
             RmcpClient::new_streamable_http_client(
@@ -190,7 +190,7 @@ impl McpConnectionManager {
     pub async fn new(
         mcp_servers: HashMap<String, McpServerConfig>,
         use_rmcp_client: bool,
-        credentials_store: OAuthCredentialsStore,
+        credentials_store: OAuthCredentialsStoreMode,
     ) -> Result<(Self, ClientStartErrors)> {
         // Early exit if no servers are configured.
         if mcp_servers.is_empty() {

--- a/codex-rs/rmcp-client/src/lib.rs
+++ b/codex-rs/rmcp-client/src/lib.rs
@@ -5,7 +5,7 @@ mod perform_oauth_login;
 mod rmcp_client;
 mod utils;
 
-pub use oauth::OAuthCredentialsStore;
+pub use oauth::OAuthCredentialsStoreMode;
 pub use oauth::StoredOAuthTokens;
 pub use oauth::WrappedOAuthTokenResponse;
 pub use oauth::delete_oauth_tokens;

--- a/codex-rs/rmcp-client/src/lib.rs
+++ b/codex-rs/rmcp-client/src/lib.rs
@@ -5,6 +5,7 @@ mod perform_oauth_login;
 mod rmcp_client;
 mod utils;
 
+pub use oauth::OAuthCredentialsStore;
 pub use oauth::StoredOAuthTokens;
 pub use oauth::WrappedOAuthTokenResponse;
 pub use oauth::delete_oauth_tokens;

--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -58,15 +58,19 @@ pub struct StoredOAuthTokens {
     pub token_response: WrappedOAuthTokenResponse,
 }
 
+/// Determine where Codex should store and read MCP credentials.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
-pub enum OAuthCredentialsStore {
+pub enum OAuthCredentialsStoreMode {
+    /// Keyring when available, otherwise file.
     Auto,
+    /// File in the Codex home directory.
     File,
+    /// Keyring when available, otherwise fail.
     Keyring,
 }
 
-impl Default for OAuthCredentialsStore {
+impl Default for OAuthCredentialsStoreMode {
     fn default() -> Self {
         Self::Auto
     }
@@ -146,15 +150,15 @@ impl PartialEq for WrappedOAuthTokenResponse {
 pub(crate) fn load_oauth_tokens(
     server_name: &str,
     url: &str,
-    store: OAuthCredentialsStore,
+    store: OAuthCredentialsStoreMode,
 ) -> Result<Option<StoredOAuthTokens>> {
     let keyring_store = KeyringCredentialStore;
     match store {
-        OAuthCredentialsStore::Auto => {
+        OAuthCredentialsStoreMode::Auto => {
             load_oauth_tokens_from_keyring_with_fallback_to_file(&keyring_store, server_name, url)
         }
-        OAuthCredentialsStore::File => load_oauth_tokens_from_file(server_name, url),
-        OAuthCredentialsStore::Keyring => {
+        OAuthCredentialsStoreMode::File => load_oauth_tokens_from_file(server_name, url),
+        OAuthCredentialsStoreMode::Keyring => {
             load_oauth_tokens_from_keyring(&keyring_store, server_name, url)
                 .with_context(|| "failed to read OAuth tokens from keyring".to_string())
         }
@@ -197,15 +201,15 @@ fn load_oauth_tokens_from_keyring<C: CredentialStore>(
 pub fn save_oauth_tokens(
     server_name: &str,
     tokens: &StoredOAuthTokens,
-    store: OAuthCredentialsStore,
+    store: OAuthCredentialsStoreMode,
 ) -> Result<()> {
     let keyring_store = KeyringCredentialStore;
     match store {
-        OAuthCredentialsStore::Auto => {
+        OAuthCredentialsStoreMode::Auto => {
             save_oauth_tokens_with_store(&keyring_store, server_name, tokens, true)
         }
-        OAuthCredentialsStore::File => save_oauth_tokens_to_file(tokens),
-        OAuthCredentialsStore::Keyring => {
+        OAuthCredentialsStoreMode::File => save_oauth_tokens_to_file(tokens),
+        OAuthCredentialsStoreMode::Keyring => {
             save_oauth_tokens_with_store(&keyring_store, server_name, tokens, false)
         }
     }
@@ -246,14 +250,14 @@ fn save_oauth_tokens_with_store<C: CredentialStore>(
 pub fn delete_oauth_tokens(
     server_name: &str,
     url: &str,
-    store: OAuthCredentialsStore,
+    store: OAuthCredentialsStoreMode,
 ) -> Result<bool> {
     match store {
-        OAuthCredentialsStore::Auto | OAuthCredentialsStore::Keyring => {
+        OAuthCredentialsStoreMode::Auto | OAuthCredentialsStoreMode::Keyring => {
             let keyring_store = KeyringCredentialStore;
             delete_oauth_tokens_with_store(&keyring_store, server_name, url)
         }
-        OAuthCredentialsStore::File => {
+        OAuthCredentialsStoreMode::File => {
             let key = compute_store_key(server_name, url)?;
             delete_oauth_tokens_from_file(&key)
         }
@@ -288,7 +292,7 @@ struct OAuthPersistorInner {
     server_name: String,
     url: String,
     authorization_manager: Arc<Mutex<AuthorizationManager>>,
-    credentials_store: OAuthCredentialsStore,
+    credentials_store: OAuthCredentialsStoreMode,
     last_credentials: Mutex<Option<StoredOAuthTokens>>,
 }
 
@@ -297,7 +301,7 @@ impl OAuthPersistor {
         server_name: String,
         url: String,
         manager: Arc<Mutex<AuthorizationManager>>,
-        credentials_store: OAuthCredentialsStore,
+        credentials_store: OAuthCredentialsStoreMode,
         initial_credentials: Option<StoredOAuthTokens>,
     ) -> Self {
         Self {

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -12,7 +12,7 @@ use tokio::sync::oneshot;
 use tokio::time::timeout;
 use urlencoding::decode;
 
-use crate::OAuthCredentialsStore;
+use crate::OAuthCredentialsStoreMode;
 use crate::StoredOAuthTokens;
 use crate::WrappedOAuthTokenResponse;
 use crate::save_oauth_tokens;
@@ -30,7 +30,7 @@ impl Drop for CallbackServerGuard {
 pub async fn perform_oauth_login(
     server_name: &str,
     server_url: &str,
-    store: OAuthCredentialsStore,
+    store: OAuthCredentialsStoreMode,
 ) -> Result<()> {
     let server = Arc::new(Server::http("127.0.0.1:0").map_err(|err| anyhow!(err))?);
     let guard = CallbackServerGuard {

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -12,6 +12,7 @@ use tokio::sync::oneshot;
 use tokio::time::timeout;
 use urlencoding::decode;
 
+use crate::OAuthCredentialsStore;
 use crate::StoredOAuthTokens;
 use crate::WrappedOAuthTokenResponse;
 use crate::save_oauth_tokens;
@@ -26,7 +27,11 @@ impl Drop for CallbackServerGuard {
     }
 }
 
-pub async fn perform_oauth_login(server_name: &str, server_url: &str) -> Result<()> {
+pub async fn perform_oauth_login(
+    server_name: &str,
+    server_url: &str,
+    store: OAuthCredentialsStore,
+) -> Result<()> {
     let server = Arc::new(Server::http("127.0.0.1:0").map_err(|err| anyhow!(err))?);
     let guard = CallbackServerGuard {
         server: Arc::clone(&server),
@@ -81,7 +86,7 @@ pub async fn perform_oauth_login(server_name: &str, server_url: &str) -> Result<
         client_id,
         token_response: WrappedOAuthTokenResponse(credentials),
     };
-    save_oauth_tokens(server_name, &stored)?;
+    save_oauth_tokens(server_name, &stored, store)?;
 
     drop(guard);
     Ok(())

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -30,7 +30,7 @@ impl Drop for CallbackServerGuard {
 pub async fn perform_oauth_login(
     server_name: &str,
     server_url: &str,
-    store: OAuthCredentialsStoreMode,
+    store_mode: OAuthCredentialsStoreMode,
 ) -> Result<()> {
     let server = Arc::new(Server::http("127.0.0.1:0").map_err(|err| anyhow!(err))?);
     let guard = CallbackServerGuard {
@@ -86,7 +86,7 @@ pub async fn perform_oauth_login(
         client_id,
         token_response: WrappedOAuthTokenResponse(credentials),
     };
-    save_oauth_tokens(server_name, &stored, store)?;
+    save_oauth_tokens(server_name, &stored, store_mode)?;
 
     drop(guard);
     Ok(())

--- a/codex-rs/rmcp-client/src/rmcp_client.rs
+++ b/codex-rs/rmcp-client/src/rmcp_client.rs
@@ -35,6 +35,7 @@ use tracing::warn;
 
 use crate::load_oauth_tokens;
 use crate::logging_client_handler::LoggingClientHandler;
+use crate::oauth::OAuthCredentialsStore;
 use crate::oauth::OAuthPersistor;
 use crate::oauth::StoredOAuthTokens;
 use crate::utils::convert_call_tool_result;
@@ -120,7 +121,8 @@ impl RmcpClient {
         url: &str,
         bearer_token: Option<String>,
     ) -> Result<Self> {
-        let initial_tokens = match load_oauth_tokens(server_name, url) {
+        let initial_tokens = match load_oauth_tokens(server_name, url, OAuthCredentialsStore::Auto)
+        {
             Ok(tokens) => tokens,
             Err(err) => {
                 warn!("failed to read tokens for server `{server_name}`: {err}");

--- a/codex-rs/rmcp-client/src/rmcp_client.rs
+++ b/codex-rs/rmcp-client/src/rmcp_client.rs
@@ -35,7 +35,7 @@ use tracing::warn;
 
 use crate::load_oauth_tokens;
 use crate::logging_client_handler::LoggingClientHandler;
-use crate::oauth::OAuthCredentialsStore;
+use crate::oauth::OAuthCredentialsStoreMode;
 use crate::oauth::OAuthPersistor;
 use crate::oauth::StoredOAuthTokens;
 use crate::utils::convert_call_tool_result;
@@ -120,7 +120,7 @@ impl RmcpClient {
         server_name: &str,
         url: &str,
         bearer_token: Option<String>,
-        credentials_store: OAuthCredentialsStore,
+        credentials_store: OAuthCredentialsStoreMode,
     ) -> Result<Self> {
         let initial_tokens = match load_oauth_tokens(server_name, url, credentials_store) {
             Ok(tokens) => tokens,
@@ -290,7 +290,7 @@ async fn create_oauth_transport_and_runtime(
     server_name: &str,
     url: &str,
     initial_tokens: StoredOAuthTokens,
-    credentials_store: OAuthCredentialsStore,
+    credentials_store: OAuthCredentialsStoreMode,
 ) -> Result<(
     StreamableHttpClientTransport<AuthClient<reqwest::Client>>,
     OAuthPersistor,

--- a/codex-rs/rmcp-client/src/rmcp_client.rs
+++ b/codex-rs/rmcp-client/src/rmcp_client.rs
@@ -120,11 +120,11 @@ impl RmcpClient {
         server_name: &str,
         url: &str,
         bearer_token: Option<String>,
-        credentials_store: OAuthCredentialsStoreMode,
+        store_mode: OAuthCredentialsStoreMode,
     ) -> Result<Self> {
         let initial_oauth_tokens = match bearer_token {
             Some(_) => None,
-            None => match load_oauth_tokens(server_name, url, credentials_store) {
+            None => match load_oauth_tokens(server_name, url, store_mode) {
                 Ok(tokens) => tokens,
                 Err(err) => {
                     warn!("failed to read tokens for server `{server_name}`: {err}");
@@ -133,13 +133,9 @@ impl RmcpClient {
             },
         };
         let transport = if let Some(initial_tokens) = initial_oauth_tokens.clone() {
-            let (transport, oauth_persistor) = create_oauth_transport_and_runtime(
-                server_name,
-                url,
-                initial_tokens,
-                credentials_store,
-            )
-            .await?;
+            let (transport, oauth_persistor) =
+                create_oauth_transport_and_runtime(server_name, url, initial_tokens, store_mode)
+                    .await?;
             PendingTransport::StreamableHttpWithOAuth {
                 transport,
                 oauth_persistor,


### PR DESCRIPTION
This lets users/companies explicitly choose whether to force/disallow the keyring/fallback file storage for mcp credentials.

People who develop with Codex will want to use this until we sign binaries or else each ad-hoc debug builds will require keychain access on every build. I don't love this and am open to other ideas for how to handle that.


```toml
mcp_oauth_credentials_store = "auto"
mcp_oauth_credentials_store = "file"
mcp_oauth_credentials_store = "keyrung"
```
Defaults to `auto`