### PR TITLE
feat: enable subfolder-based custom commands

### DIFF
--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -4,7 +4,10 @@ Save frequently used prompts as Markdown files and reuse them quickly from the s
 
 - Location: Put files in `$CODEX_HOME/prompts/` (defaults to `~/.codex/prompts/`).
 - File type: Only Markdown files with the `.md` extension are recognized.
-- Name: The filename without the `.md` extension becomes the slash entry. For a file named `my-prompt.md`, type `/my-prompt`.
+- Name: The filename without the `.md` extension becomes the slash entry. Nested directories are joined with `::` in the order they appear in the filesystem.
+- Nested directories:
+  - Every path segment between `prompts/` and the Markdown file is included in the slash command. For example, `~/.codex/prompts/team/review/high-priority.md` shows up as `/prompts:team::review::high-priority`.
+  - You can create deeper hierarchies (such as `~/.codex/prompts/bmad/agents/dev.md`) and access them as `/prompts:bmad::agents::dev`.
 - Content: The file contents are sent as your message when you select the item in the slash popup and press Enter.
 - Arguments: Local prompts support placeholders in their content:
   - `$1..$9` expand to the first nine positional arguments typed after the slash name


### PR DESCRIPTION
## Feature Explanation
This program allows codex to recognize md files in sub-folders of ~/.codex/prompts as custom commands
For codex users discussing Issue #4735, who may know major CLIs can recognize md files in sub-folders as custom commands, I've made the same feature. 

Now, we are organizing complex customs commands in the following structure.
This development-style is growing further than ever, and Codex should allow it.

```
prompts/                  
├── make-article.md          # custom command
└── article-strcutures/      # sub-folder
    ├── seo-friendly.txt         # SEO-specific format
    └── tech-post.txt            # tech-post format
```