### PR TITLE
Remove instruction hack for /review

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1586,7 +1586,7 @@ async fn spawn_review_thread(
 
     // Seed the child task with the review prompt as the initial user message.
     let input: Vec<InputItem> = vec![InputItem::Text {
-        text: format!("{base_instructions}\n\n---\n\nNow, here's your task: {review_prompt}"),
+        text: review_prompt,
     }];
     let tc = Arc::new(review_turn_context);
 


### PR DESCRIPTION
We use to put the review prompt in the first user message as well to bypass statsig overrides, but now that's been resolved and instructions are being respected, so we're duplicating the review instructions.