### PR TITLE
fix: tui launch latency by disabling osc probe

### DIFF
--- a/codex-rs/tui/src/terminal_palette.rs
+++ b/codex-rs/tui/src/terminal_palette.rs
@@ -34,6 +34,8 @@ mod imp {
     use std::sync::Mutex;
     use std::sync::OnceLock;
 
+    const TERMINAL_QUERIES_ENABLED: bool = false;
+
     struct Cache<T> {
         attempted: bool,
         value: Option<T>,
@@ -70,6 +72,9 @@ mod imp {
     }
 
     pub(super) fn terminal_palette() -> Option<[(u8, u8, u8); 256]> {
+        if !TERMINAL_QUERIES_ENABLED {
+            return None;
+        }
         static CACHE: OnceLock<Option<[(u8, u8, u8); 256]>> = OnceLock::new();
         *CACHE.get_or_init(|| match query_terminal_palette() {
             Ok(Some(palette)) => Some(palette),
@@ -78,12 +83,18 @@ mod imp {
     }
 
     pub(super) fn default_colors() -> Option<DefaultColors> {
+        if !TERMINAL_QUERIES_ENABLED {
+            return None;
+        }
         let cache = default_colors_cache();
         let mut cache = cache.lock().ok()?;
         cache.get_or_init_with(|| query_default_colors().unwrap_or_default())
     }
 
     pub(super) fn requery_default_colors() {
+        if !TERMINAL_QUERIES_ENABLED {
+            return;
+        }
         if let Ok(mut cache) = default_colors_cache().lock() {
             cache.refresh_with(|| query_default_colors().unwrap_or_default());
         }


### PR DESCRIPTION
- Codex CLI startup slowed to ~1.5 s in Terminal and Ghostty.
- This was because because Tui::new requested the terminal’s 256-color palette via OSC 4. Trace logging showed the constructor waiting for 1.5s at query_terminal_palette before timing out, since many modern GPU terminals ignore OSC 4/10/11.
- This is a minimal change that disables those probes, but keeps it easy to bring the back for specific terminals that support it like iTerm or xterm, or with different more performant approach.