### PR TITLE
fix: align Node.js version requirement in codex-cli package

### DIFF
--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -7,7 +7,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=16"
+    "node": ">=22"
   },
   "files": [
     "bin",


### PR DESCRIPTION
## Summary

This PR fixes an inconsistency in Node.js version requirements across the monorepo.

## Changes

- Updated codex-cli/package.json to require Node.js >=22 instead of >=16
- This aligns with the root package.json which already requires Node.js >=22

## Why

Having consistent Node.js version requirements across the monorepo prevents potential runtime issues and confusion. The root package already enforces Node.js 22+, so the CLI package should match this requirement.

## Testing

- Verified that the change is a simple version bump
- No functional code changes, only package metadata