### PR TITLE
fix: align Node.js version requirement in codex-cli package

### DIFF
--- a/codex-cli/package.json
+++ b/codex-cli/package.json
@@ -7,7 +7,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=16"
+    "node": ">=22"
   },
   "files": [
     "bin",


### PR DESCRIPTION
The root package.json requires Node.js >=22, but codex-cli/package.json only required >=16. This updates codex-cli to match the root requirement for consistency across the monorepo.


I have read the CLA Document and I hereby sign the CLA
.





