### PR TITLE
docs: fix broken link in contributing guide

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,7 +12,7 @@ If you want to add a new feature or change the behavior of an existing one, plea
 
 - Create a _topic branch_ from `main` - e.g. `feat/interactive-prompt`.
 - Keep your changes focused. Multiple unrelated fixes should be opened as separate PRs.
-- Following the [development setup](#development-workflow) instructions above, ensure your change is free of lint warnings and test failures.
+- Ensure your change is free of lint warnings and test failures.
 
 ### Writing high-impact code changes
 


### PR DESCRIPTION
## Summary

This PR fixes a broken self-referencing link in the contributing documentation.

## Changes

- Removed the phrase 'Following the [development setup](#development-workflow) instructions above' from the Development workflow section
- The link referenced a non-existent section and the phrase didn't make logical sense in context

## Before

The text referenced 'development setup instructions above' but:
1. No section called 'development setup' exists
2. There were no instructions 'above' that point
3. The link pointed to the same section it was in

## After

Simplified to: 'Ensure your change is free of lint warnings and test failures.'

## Type

Documentation fix


I have read the CLA Document and I hereby sign the CLA

