### PR TITLE
Add confirmation dialog for TUI full access preset

### DIFF
--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -309,6 +309,10 @@ pub struct Tui {
     /// Defaults to `false`.
     #[serde(default)]
     pub notifications: Notifications,
+
+    /// Skip the confirmation warning shown before enabling the dangerous Full Access preset.
+    #[serde(default)]
+    pub skip_full_access_warning: bool,
 }
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -73,6 +73,20 @@ pub(crate) enum AppEvent {
     /// Update the current sandbox policy in the running app and widget.
     UpdateSandboxPolicy(SandboxPolicy),
 
+    /// Show the confirmation warning before enabling the Full Access preset.
+    OpenFullAccessWarning {
+        approval: AskForApproval,
+        sandbox: SandboxPolicy,
+    },
+
+    /// Update whether the Full Access warning should be skipped.
+    UpdateSkipFullAccessWarning(bool),
+
+    /// Persist the Full Access warning preference to config.toml.
+    PersistSkipFullAccessWarning {
+        skip: bool,
+    },
+
     /// Forwarded conversation history snapshot from the current conversation.
     ConversationHistory(ConversationPathResponseEvent),
 

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__full_access_warning_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__full_access_warning_popup.snap
@@ -1,0 +1,18 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: popup
+---
+  Full access gives Codex full control over this machine.
+  Codex can edit files, run any command, and access the network without
+  asking.
+  Only continue if you completely trust this session.
+  Enable Full Access?
+  Full access is dangerous and bypasses approval prompts.
+
+› 1. Accept full access          Enable full access for this session while
+                                 keeping future warnings.
+  2. Accept and don't ask again  Enable full access and remember this choice
+                                 for future sessions.
+  3. Deny                        Cancel and keep your current approvals
+
+  Press enter to confirm or esc to go back

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -31,6 +31,7 @@ use codex_core::protocol::ReviewFinding;
 use codex_core::protocol::ReviewLineRange;
 use codex_core::protocol::ReviewOutputEvent;
 use codex_core::protocol::ReviewRequest;
+use codex_core::protocol::SandboxPolicy;
 use codex_core::protocol::StreamErrorEvent;
 use codex_core::protocol::TaskCompleteEvent;
 use codex_core::protocol::TaskStartedEvent;
@@ -1055,6 +1056,16 @@ fn model_reasoning_selection_popup_snapshot() {
 
     let popup = render_bottom_popup(&chat, 80);
     assert_snapshot!("model_reasoning_selection_popup", popup);
+}
+
+#[test]
+fn full_access_warning_popup_snapshot() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual();
+
+    chat.open_full_access_warning(AskForApproval::Never, SandboxPolicy::DangerFullAccess);
+
+    let popup = render_bottom_popup(&chat, 80);
+    assert_snapshot!("full_access_warning_popup", popup);
 }
 
 #[test]

--- a/docs/config.md
+++ b/docs/config.md
@@ -763,6 +763,10 @@ notifications = true
 # You can optionally filter to specific notification types.
 # Available types are "agent-turn-complete" and "approval-requested".
 notifications = [ "agent-turn-complete", "approval-requested" ]
+
+# Skip the confirmation dialog when selecting the "Full Access" approvals preset in the TUI.
+# Defaults to false to keep the extra warning enabled.
+skip_full_access_warning = true
 ```
 
 > [!NOTE]


### PR DESCRIPTION
## Summary
- add a persistent `skip_full_access_warning` flag to the shared config loader and document the new `[tui]` option
- wire new TUI app events that show a warning popup when the Full Access preset is chosen and persist the skip preference when requested
- cover the new popup with a snapshot test and update the generated snapshot artifact

## Testing
- just fmt
- just fix -p codex-core
- just fix -p codex-tui
- cargo test -p codex-tui full_access_warning_popup_snapshot
- cargo test -p codex-core config::notifications_tests::test_skip_full_access_warning_true

------
https://chatgpt.com/codex/tasks/task_i_68e6c5c458088322a28efa3207058180