### PR TITLE
add: support for bun/yarn in addition to npm for upgrade

### DIFF
--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -104,18 +104,18 @@ fn detect_node_package_manager() -> NodePackageManager {
     }
 
     for var in ["npm_execpath", "NPM_EXECPATH"] {
-        if let Ok(value) = std::env::var(var) {
-            if let Some(package_manager) = parse_hint(&value) {
-                return package_manager;
-            }
+        if let Ok(value) = std::env::var(var)
+            && let Some(package_manager) = parse_hint(&value)
+        {
+            return package_manager;
         }
     }
 
     for var in ["npm_config_user_agent", "NPM_CONFIG_USER_AGENT"] {
-        if let Ok(value) = std::env::var(var) {
-            if let Some(package_manager) = parse_hint(&value) {
-                return package_manager;
-            }
+        if let Ok(value) = std::env::var(var)
+            && let Some(package_manager) = parse_hint(&value)
+        {
+            return package_manager;
         }
     }
 


### PR DESCRIPTION
## Summary
- detect which JavaScript package manager launched the CLI when the node shim is present
- show bun/yarn/npm specific upgrade guidance in the update banner instead of always recommending npm

## Testing
- cargo test -p codex-tui

------
https://chatgpt.com/codex/tasks/task_i_68e81dec68b8832da67e1fe6259b37f5