### PR TITLE
Normalize openai/ prefixed model slugs

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1063,8 +1063,14 @@ impl Config {
             .or(cfg.model)
             .unwrap_or_else(default_model);
 
-        let mut model_family =
-            find_family_for_model(&model).unwrap_or_else(|| derive_default_model_family(&model));
+        let normalized_model = if let Some(stripped) = model.strip_prefix("openai/") {
+            stripped
+        } else {
+            &model
+        };
+
+        let mut model_family = find_family_for_model(normalized_model)
+            .unwrap_or_else(|| derive_default_model_family(normalized_model));
 
         if let Some(supports_reasoning_summaries) = cfg.model_supports_reasoning_summaries {
             model_family.supports_reasoning_summaries = supports_reasoning_summaries;

--- a/codex-rs/core/src/model_family.rs
+++ b/codex-rs/core/src/model_family.rs
@@ -78,6 +78,9 @@ macro_rules! model_family {
 /// Returns a `ModelFamily` for the given model slug, or `None` if the slug
 /// does not match any known model family.
 pub fn find_family_for_model(mut slug: &str) -> Option<ModelFamily> {
+    if let Some(stripped) = slug.strip_prefix("openai/") {
+        slug = stripped;
+    }
     // TODO(jif) clean once we have proper feature flags
     if matches!(std::env::var("CODEX_EXPERIMENTAL").as_deref(), Ok("1")) {
         slug = "codex-experimental";

--- a/codex-rs/core/src/openai_model_info.rs
+++ b/codex-rs/core/src/openai_model_info.rs
@@ -29,7 +29,10 @@ impl ModelInfo {
 }
 
 pub(crate) fn get_model_info(model_family: &ModelFamily) -> Option<ModelInfo> {
-    let slug = model_family.slug.as_str();
+    let slug = match model_family.slug.strip_prefix("openai/") {
+        Some(stripped) => stripped,
+        None => model_family.slug.as_str(),
+    };
     match slug {
         // OSS models have a 128k shared token pool.
         // Arbitrarily splitting it: 3/4 input context, 1/4 output.


### PR DESCRIPTION
#### Summary 
 - Strip the openai/ prefix before resolving a model slug to a ModelFamily, so entries like openai/gpt-5, openai/gpt-5-codex, openai/o4-mini, and openai/o3
    map to the correct metadata.
  - Update Config::load_from_base_config_with_overrides to normalize the model value before fetching family data, ensuring reasoning flags and derived
    defaults align with the intended model.
  - Normalize slugs inside openai_model_info so prefixed models still pick up the right token limits and context window settings.
  
  I have read the CLA Document and I hereby sign the CLA