### PR TITLE
feat(tui): warn high effort rate use

### DIFF
--- a/codex-rs/tui/src/bottom_pane/list_selection_view.rs
+++ b/codex-rs/tui/src/bottom_pane/list_selection_view.rs
@@ -37,6 +37,7 @@ pub(crate) struct SelectionItem {
     pub name: String,
     pub display_shortcut: Option<KeyBinding>,
     pub description: Option<String>,
+    pub selected_description: Option<String>,
     pub is_current: bool,
     pub actions: Vec<SelectionAction>,
     pub dismiss_on_select: bool,
@@ -193,12 +194,16 @@ impl ListSelectionView {
                     } else {
                         format!("{prefix} {n}. {name_with_marker}")
                     };
+                    let description = is_selected
+                        .then(|| item.selected_description.clone())
+                        .flatten()
+                        .or_else(|| item.description.clone());
                     GenericDisplayRow {
                         name: display_name,
                         display_shortcut: item.display_shortcut,
                         match_indices: None,
                         is_current: item.is_current,
-                        description: item.description.clone(),
+                        description,
                     }
                 })
             })

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -53,6 +53,8 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Constraint;
 use ratatui::layout::Layout;
 use ratatui::layout::Rect;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
 use ratatui::widgets::Widget;
 use ratatui::widgets::WidgetRef;
 use tokio::sync::mpsc::UnboundedSender;
@@ -81,6 +83,7 @@ use crate::history_cell::AgentMessageCell;
 use crate::history_cell::HistoryCell;
 use crate::history_cell::McpToolCallCell;
 use crate::markdown::append_markdown;
+use crate::render::renderable::ColumnRenderable;
 use crate::slash_command::SlashCommand;
 use crate::status::RateLimitSnapshotDisplay;
 use crate::text_formatting::truncate_text;
@@ -1718,6 +1721,9 @@ impl ChatWidget {
         } else {
             default_choice
         };
+        let show_high_effort_warning = choices
+            .iter()
+            .any(|choice| choice.display == ReasoningEffortConfig::High);
 
         let mut items: Vec<SelectionItem> = Vec::new();
         for choice in choices.iter() {
@@ -1777,9 +1783,19 @@ impl ChatWidget {
             });
         }
 
+        let mut header = ColumnRenderable::new();
+        header.push(Line::from("Select Reasoning Level".bold()));
+        header.push(Line::from(
+            format!("Reasoning for model {model_slug}").dim(),
+        ));
+        if show_high_effort_warning {
+            header.push(Line::from(
+                "⚠ High reasoning effort can quickly consume Plus plan rate limits.".red(),
+            ));
+        }
+
         self.bottom_pane.show_selection_view(SelectionViewParams {
-            title: Some("Select Reasoning Level".to_string()),
-            subtitle: Some(format!("Reasoning for model {model_slug}")),
+            header: Box::new(header),
             footer_hint: Some(standard_popup_hint_line()),
             items,
             ..Default::default()

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_reasoning_selection_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_reasoning_selection_popup.snap
@@ -4,6 +4,7 @@ expression: popup
 ---
   Select Reasoning Level
   Reasoning for model gpt-5-codex
+  ⚠ High reasoning effort can quickly consume Plus plan rate limits.
 
   1. Low               Fastest responses with limited reasoning
   2. Medium (default)  Dynamically adjusts reasoning based on the task

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_reasoning_selection_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_reasoning_selection_popup.snap
@@ -2,13 +2,13 @@
 source: tui/src/chatwidget/tests.rs
 expression: popup
 ---
-  Select Reasoning Level
-  Reasoning for model gpt-5-codex
-  ⚠ High reasoning effort can quickly consume Plus plan rate limits.
+  Select Reasoning Level for gpt-5-codex
 
   1. Low               Fastest responses with limited reasoning
   2. Medium (default)  Dynamically adjusts reasoning based on the task
 › 3. High (current)    Maximizes reasoning depth for complex or ambiguous
                        problems
+                       ⚠ High reasoning effort can quickly consume Plus plan
+                       rate limits.
 
   Press enter to confirm or esc to go back


### PR DESCRIPTION
Highlight that selecting a high reasoning level will hit Plus plan rate limits faster. The warning is presented inline in the reasoning popup header so users see it while choosing an effort.