### PR TITLE
Add reverse-i-search when user presses Ctrl+R

### DIFF
--- a/codex-rs/tui/src/bottom_pane/footer.rs
+++ b/codex-rs/tui/src/bottom_pane/footer.rs
@@ -144,6 +144,7 @@ fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
     let mut paste_image = Line::from("");
     let mut edit_previous = Line::from("");
     let mut quit = Line::from("");
+    let mut reverse_search = Line::from("");
     let mut show_transcript = Line::from("");
 
     for descriptor in SHORTCUTS {
@@ -154,21 +155,31 @@ fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
                 ShortcutId::FilePaths => file_paths = text,
                 ShortcutId::PasteImage => paste_image = text,
                 ShortcutId::EditPrevious => edit_previous = text,
+                ShortcutId::ReverseISearch => reverse_search = text,
                 ShortcutId::Quit => quit = text,
                 ShortcutId::ShowTranscript => show_transcript = text,
             }
         }
     }
 
+    // Keep Ctrl+<char> bindings in the right column by pairing rows as:
+    // [non‑Ctrl, Ctrl] and using blank left entries when needed.
     let ordered = vec![
-        commands,
-        newline,
-        file_paths,
-        paste_image,
-        edit_previous,
-        quit,
-        Line::from(""),
-        show_transcript,
+        // Row 0
+        commands, // left: '/ for commands'
+        newline,  // right: Shift+Enter or Ctrl+J for newline
+        // Row 1
+        file_paths,  // left: '@ for file paths'
+        paste_image, // right: Ctrl+V to paste images
+        // Row 2
+        edit_previous,  // left: Esc to edit previous message
+        reverse_search, // right: Ctrl+R for reverse search
+        // Row 3
+        Line::from(""), // left: blank to align Quit on right
+        quit,           // right: Ctrl+C to exit
+        // Row 4
+        Line::from(""),  // left: blank to align transcript on right
+        show_transcript, // right: Ctrl+T to view transcript
     ];
 
     build_columns(ordered)
@@ -233,6 +244,7 @@ enum ShortcutId {
     FilePaths,
     PasteImage,
     EditPrevious,
+    ReverseISearch,
     Quit,
     ShowTranscript,
 }
@@ -350,6 +362,15 @@ const SHORTCUTS: &[ShortcutDescriptor] = &[
         }],
         prefix: "",
         label: "",
+    },
+    ShortcutDescriptor {
+        id: ShortcutId::ReverseISearch,
+        bindings: &[ShortcutBinding {
+            key: key_hint::ctrl(KeyCode::Char('r')),
+            condition: DisplayCondition::Always,
+        }],
+        prefix: "",
+        label: " for reverse search",
     },
     ShortcutDescriptor {
         id: ShortcutId::Quit,

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
@@ -12,5 +12,6 @@ expression: terminal.backend()
 "                                                                                                    "
 "  / for commands                            shift + enter for newline                               "
 "  @ for file paths                          ctrl + v to paste images                                "
-"  esc again to edit previous message        ctrl + c to exit                                        "
+"  esc again to edit previous message        ctrl + r for reverse search                             "
+"                                            ctrl + c to exit                                        "
 "                                            ctrl + t to view transcript                             "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
@@ -4,5 +4,6 @@ expression: terminal.backend()
 ---
 "  / for commands                            shift + enter for newline           "
 "  @ for file paths                          ctrl + v to paste images            "
-"  esc again to edit previous message        ctrl + c to exit                    "
+"  esc again to edit previous message        ctrl + r for reverse search         "
+"                                            ctrl + c to exit                    "
 "                                            ctrl + t to view transcript         "

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1032,6 +1032,11 @@ impl ChatWidget {
     }
 
     pub(crate) fn handle_key_event(&mut self, key_event: KeyEvent) {
+        // If reverse-i-search is active, accept the current selection into the
+        // composer for non-visible/global keys before higher-level handlers.
+        if key_event.kind == KeyEventKind::Press {
+            let _ = self.bottom_pane.accept_reverse_search_for_key(&key_event);
+        }
         match key_event {
             KeyEvent {
                 code: KeyCode::Char(c),


### PR DESCRIPTION
- Add reverse-i-search (Ctrl+R) in the TUI composer
- Tried to make it as close as possible to bash behavior
  - Press Ctrl+R to activate it
  - Start typing part of an old command
  - It searches backward through your history as you type
  - Cycling through matches by pressing Ctrl + r again; Ctrl + s goes back to newer
  - Press Enter → executes it immediately
  - Press → (right arrow) or any other navigation key → copies it to your prompt so you can edit it first
  - Ctrl + g cancels the search
  - Esc --- I couldn't make Esc behave well
- Help ? text updated
  | Before                                                       | After                                                        |
  | ------------------------------------------------------------ | ------------------------------------------------------------ |
  | <img width="502" height="122" alt="Screenshot 2025-10-10 at 09 14 06" src="https://github.com/user-attachments/assets/1fa5e16e-7050-423d-a656-f856f8eb518f" /> | <img width="506" height="132" alt="Screenshot 2025-10-10 at 09 14 12" src="https://github.com/user-attachments/assets/a588e23e-fdbc-4779-95a4-275b7ed0ede4" /> |

https://github.com/user-attachments/assets/4da9ee5d-5500-4a4f-b8c1-4574b0a64701


Supersedes #1773 