### PR TITLE
Normalize model family detection for prefixed slugs

### DIFF
--- a/codex-rs/core/src/model_family.rs
+++ b/codex-rs/core/src/model_family.rs
@@ -82,37 +82,39 @@ pub fn find_family_for_model(mut slug: &str) -> Option<ModelFamily> {
     if matches!(std::env::var("CODEX_EXPERIMENTAL").as_deref(), Ok("1")) {
         slug = "codex-experimental";
     }
-    if slug.starts_with("o3") {
+    let normalized_slug = slug.rsplit('/').next().unwrap_or(slug);
+
+    if normalized_slug.starts_with("o3") {
         model_family!(
             slug, "o3",
             supports_reasoning_summaries: true,
             needs_special_apply_patch_instructions: true,
         )
-    } else if slug.starts_with("o4-mini") {
+    } else if normalized_slug.starts_with("o4-mini") {
         model_family!(
             slug, "o4-mini",
             supports_reasoning_summaries: true,
             needs_special_apply_patch_instructions: true,
         )
-    } else if slug.starts_with("codex-mini-latest") {
+    } else if normalized_slug.starts_with("codex-mini-latest") {
         model_family!(
             slug, "codex-mini-latest",
             supports_reasoning_summaries: true,
             uses_local_shell_tool: true,
             needs_special_apply_patch_instructions: true,
         )
-    } else if slug.starts_with("gpt-4.1") {
+    } else if normalized_slug.starts_with("gpt-4.1") {
         model_family!(
             slug, "gpt-4.1",
             needs_special_apply_patch_instructions: true,
         )
-    } else if slug.starts_with("gpt-oss") || slug.starts_with("openai/gpt-oss") {
+    } else if normalized_slug.starts_with("gpt-oss") {
         model_family!(slug, "gpt-oss", apply_patch_tool_type: Some(ApplyPatchToolType::Function))
-    } else if slug.starts_with("gpt-4o") {
+    } else if normalized_slug.starts_with("gpt-4o") {
         model_family!(slug, "gpt-4o", needs_special_apply_patch_instructions: true)
-    } else if slug.starts_with("gpt-3.5") {
+    } else if normalized_slug.starts_with("gpt-3.5") {
         model_family!(slug, "gpt-3.5", needs_special_apply_patch_instructions: true)
-    } else if slug.starts_with("test-gpt-5-codex") {
+    } else if normalized_slug.starts_with("test-gpt-5-codex") {
         model_family!(
             slug, slug,
             supports_reasoning_summaries: true,
@@ -128,7 +130,7 @@ pub fn find_family_for_model(mut slug: &str) -> Option<ModelFamily> {
         )
 
     // Internal models.
-    } else if slug.starts_with("codex-") {
+    } else if normalized_slug.starts_with("codex-") {
         model_family!(
             slug, slug,
             supports_reasoning_summaries: true,
@@ -144,7 +146,7 @@ pub fn find_family_for_model(mut slug: &str) -> Option<ModelFamily> {
         )
 
     // Production models.
-    } else if slug.starts_with("gpt-5-codex") {
+    } else if normalized_slug.starts_with("gpt-5-codex") {
         model_family!(
             slug, slug,
             supports_reasoning_summaries: true,
@@ -152,7 +154,7 @@ pub fn find_family_for_model(mut slug: &str) -> Option<ModelFamily> {
             base_instructions: GPT_5_CODEX_INSTRUCTIONS.to_string(),
             apply_patch_tool_type: Some(ApplyPatchToolType::Freeform),
         )
-    } else if slug.starts_with("gpt-5") {
+    } else if normalized_slug.starts_with("gpt-5") {
         model_family!(
             slug, "gpt-5",
             supports_reasoning_summaries: true,
@@ -175,5 +177,19 @@ pub fn derive_default_model_family(model: &str) -> ModelFamily {
         apply_patch_tool_type: None,
         base_instructions: BASE_INSTRUCTIONS.to_string(),
         experimental_supported_tools: Vec::new(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn openrouter_prefixed_gpt5_codex_supports_reasoning() {
+        let model_family =
+            find_family_for_model("openai/gpt-5-codex").expect("expected to resolve model family");
+
+        assert!(model_family.supports_reasoning_summaries);
+        assert_eq!(model_family.slug, "openai/gpt-5-codex");
     }
 }


### PR DESCRIPTION
## Summary
- ensure prefixed model slugs (like OpenRouter variants) resolve to families that allow reasoning support
- cover the OpenRouter GPT-5 Codex slug with a regression test

## Testing
- just fmt
- cargo test -p codex-core *(fails: requires managed config auth env variables and long-running CLI integration tests in this environment)*

------
https://chatgpt.com/codex/tasks/task_i_68e95a3e9248832c9e96561b391755d0