### PR TITLE
full-auto approval policy = on-failure, matching documentation

### DIFF
--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -99,7 +99,7 @@ pub async fn run_main(
     let (sandbox_mode, approval_policy) = if cli.full_auto {
         (
             Some(SandboxMode::WorkspaceWrite),
-            Some(AskForApproval::OnRequest),
+            Some(AskForApproval::OnFailure),
         )
     } else if cli.dangerously_bypass_approvals_and_sandbox {
         (


### PR DESCRIPTION
## Summary
- ensure the `--full-auto` flag applies the on-failure approval policy as documented

Closes #4847 

------
https://chatgpt.com/codex/tasks/task_i_68e9626a9828832cb0fb5ea0100bb7d3