### PR TITLE
Fix handling of non-main default branches for cloud task submissions

### DIFF
--- a/codex-rs/cloud-tasks/src/lib.rs
+++ b/codex-rs/cloud-tasks/src/lib.rs
@@ -972,7 +972,19 @@ pub async fn run_main(_cli: Cli, _codex_linux_sandbox_exe: Option<PathBuf>) -> a
                                                 let backend = Arc::clone(&backend);
                                                 let best_of_n = page.best_of_n;
                                                 tokio::spawn(async move {
-                                                    let result = codex_cloud_tasks_client::CloudBackend::create_task(&*backend, &env, &text, "main", false, best_of_n).await;
+                                                    let git_ref = if let Ok(cwd) = std::env::current_dir() {
+                                                        if let Some(branch) = codex_core::git_info::default_branch_name(&cwd).await {
+                                                            branch
+                                                        } else if let Some(branch) = codex_core::git_info::current_branch_name(&cwd).await {
+                                                            branch
+                                                        } else {
+                                                            "main".to_string()
+                                                        }
+                                                    } else {
+                                                        "main".to_string()
+                                                    };
+
+                                                    let result = codex_cloud_tasks_client::CloudBackend::create_task(&*backend, &env, &text, &git_ref, false, best_of_n).await;
                                                     let evt = match result {
                                                         Ok(ok) => app::AppEvent::NewTaskSubmitted(Ok(ok)),
                                                         Err(e) => app::AppEvent::NewTaskSubmitted(Err(format!("{e}"))),

--- a/codex-rs/core/src/git_info.rs
+++ b/codex-rs/core/src/git_info.rs
@@ -260,6 +260,16 @@ async fn get_default_branch(cwd: &Path) -> Option<String> {
     get_default_branch_local(cwd).await
 }
 
+/// Determine the repository's default branch name, if available.
+///
+/// This inspects remote configuration first (including the symbolic `HEAD`
+/// reference) and falls back to common local defaults such as `main` or
+/// `master`. Returns `None` when the information cannot be determined, for
+/// example when the current directory is not inside a Git repository.
+pub async fn default_branch_name(cwd: &Path) -> Option<String> {
+    get_default_branch(cwd).await
+}
+
 /// Attempt to determine the repository's default branch name from local branches.
 async fn get_default_branch_local(cwd: &Path) -> Option<String> {
     for candidate in ["main", "master"] {


### PR DESCRIPTION
## Summary
- detect the repository's default branch before submitting a cloud task
- expose a helper in `codex_core::git_info` for retrieving the default branch name

Fixes #4888


------
https://chatgpt.com/codex/tasks/task_i_68e96093cf28832ca0c9c73fc618a309