### PR TITLE
Fix notify documentation to use emitted input-messages key

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -638,7 +638,7 @@ def main() -> int:
                 title = f"Codex: {assistant_message}"
             else:
                 title = "Codex: Turn Complete!"
-            input_messages = notification.get("input_messages", [])
+            input_messages = notification.get("input-messages", [])
             message = " ".join(input_messages)
             title += message
         case _:


### PR DESCRIPTION
## Summary
- align the notify configuration example with the CLI payload by reading the `input-messages` key

Fixes #4954


------
https://chatgpt.com/codex/tasks/task_i_68e95e2be6ec832c8d09d6c65aac7c93