### PR TITLE
Document bearer_token_env_var for streamable HTTP

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -370,9 +370,11 @@ API_KEY = "value"
 experimental_use_rmcp_client = true
 [mcp_servers.figma]
 url = "https://mcp.linear.app/mcp"
-# Optional bearer token to be passed into an `Authorization: Bearer <token>` header
-# Use this with caution because the token is in plaintext and can be read by Codex itself.
-bearer_token = "<token>"
+# Optional: set `bearer_token_env_var` to the name of an environment variable whose
+# value should be passed into an `Authorization: Bearer <token>` header.
+# Export the environment variable before launching Codex so the MCP client can read it.
+# (Inline `bearer_token` values are no longer supported.)
+bearer_token_env_var = "FIGMA_MCP_TOKEN"
 ```
 
 For oauth login, you must enable `experimental_use_rmcp_client = true` and then run `codex mcp login server_name`


### PR DESCRIPTION
## Summary
- update the streamable HTTP MCP configuration example to reference bearer_token_env_var
- explain that inline bearer_token values are no longer supported and the token should come from an environment variable

Fixes #5011


------
https://chatgpt.com/codex/tasks/task_i_68e95c4e1548832cac0497842d4b63d1