### PR TITLE
detect Bun installs in CLI update banner

### DIFF
--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -114,7 +114,10 @@ if (existsSync(pathDir)) {
 const updatedPath = getUpdatedPath(additionalDirs);
 
 const env = { ...process.env, PATH: updatedPath };
-const packageManagerEnvVar = detectPackageManager() === "bun" ? "CODEX_MANAGED_BY_BUN" : "CODEX_MANAGED_BY_NPM";
+const packageManagerEnvVar =
+  detectPackageManager() === "bun"
+    ? "CODEX_MANAGED_BY_BUN"
+    : "CODEX_MANAGED_BY_NPM";
 env[packageManagerEnvVar] = "1";
 
 const child = spawn(binaryPath, process.argv.slice(2), {

--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -80,6 +80,10 @@ function getUpdatedPath(newDirs) {
   return updatedPath;
 }
 
+/**
+ * Use heuristics to detect the package manager that was used to install Codex
+ * in order to give the user a hint about how to update it.
+ */
 function detectPackageManager() {
   const userAgent = process.env.npm_config_user_agent || "";
   if (/\bbun\//.test(userAgent)) {
@@ -99,11 +103,7 @@ function detectPackageManager() {
     return "bun";
   }
 
-  if (userAgent) {
-    return "npm";
-  }
-
-  return null;
+  return userAgent ? "npm" : null;
 }
 
 const additionalDirs = [];
@@ -114,12 +114,8 @@ if (existsSync(pathDir)) {
 const updatedPath = getUpdatedPath(additionalDirs);
 
 const env = { ...process.env, PATH: updatedPath };
-const packageManager = detectPackageManager();
-if (packageManager === "bun") {
-  env.CODEX_MANAGED_BY_BUN = "1";
-} else {
-  env.CODEX_MANAGED_BY_NPM = "1";
-}
+const packageManagerEnvVar = detectPackageManager() === "bun" ? "CODEX_MANAGED_BY_BUN" : "CODEX_MANAGED_BY_NPM";
+env[packageManagerEnvVar] = "1";
 
 const child = spawn(binaryPath, process.argv.slice(2), {
   stdio: "inherit",

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -310,6 +310,7 @@ async fn run_ratatui_app(
 
         let current_version = env!("CARGO_PKG_VERSION");
         let exe = std::env::current_exe()?;
+        let managed_by_bun = std::env::var_os("CODEX_MANAGED_BY_BUN").is_some();
         let managed_by_npm = std::env::var_os("CODEX_MANAGED_BY_NPM").is_some();
 
         let mut content_lines: Vec<Line<'static>> = vec![
@@ -330,7 +331,14 @@ async fn run_ratatui_app(
             Line::from(""),
         ];
 
-        if managed_by_npm {
+        if managed_by_bun {
+            let bun_cmd = "bun install -g @openai/codex@latest";
+            content_lines.push(Line::from(vec![
+                "Run ".into(),
+                bun_cmd.cyan(),
+                " to update.".into(),
+            ]));
+        } else if managed_by_npm {
             let npm_cmd = "npm install -g @openai/codex@latest";
             content_lines.push(Line::from(vec![
                 "Run ".into(),


### PR DESCRIPTION
## Summary
- detect Bun-managed installs in the JavaScript launcher and set a dedicated environment flag
- show a Bun-specific upgrade command in the update banner when that flag is present

Fixes #5012

------
https://chatgpt.com/codex/tasks/task_i_68e95c439494832c835bdf34b3b1774e