### PR TITLE
tui: ^C in prompt area resets history navigation cursor

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -313,6 +313,11 @@ impl ChatComposer {
         self.sync_file_search_popup();
     }
 
+    pub(crate) fn clear_for_ctrl_c(&mut self) {
+        self.set_text_content(String::new());
+        self.history.reset_navigation();
+    }
+
     /// Get the current composer text.
     pub(crate) fn current_text(&self) -> String {
         self.textarea.text().to_string()

--- a/codex-rs/tui/src/bottom_pane/chat_composer_history.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer_history.rs
@@ -70,6 +70,12 @@ impl ChatComposerHistory {
         self.local_history.push(text.to_string());
     }
 
+    /// Reset navigation tracking so the next Up key resumes from the latest entry.
+    pub fn reset_navigation(&mut self) {
+        self.history_cursor = None;
+        self.last_history_text = None;
+    }
+
     /// Should Up/Down key presses be interpreted as history navigation given
     /// the current content and cursor position of `textarea`?
     pub fn should_handle_navigation(&self, text: &str, cursor: usize) -> bool {
@@ -270,5 +276,25 @@ mod tests {
             Some("older".into()),
             history.on_entry_response(1, 1, Some("older".into()))
         );
+    }
+
+    #[test]
+    fn reset_navigation_resets_cursor() {
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx);
+
+        let mut history = ChatComposerHistory::new();
+        history.set_metadata(1, 3);
+        history.fetched_history.insert(1, "command2".into());
+        history.fetched_history.insert(2, "command3".into());
+
+        assert_eq!(Some("command3".into()), history.navigate_up(&tx));
+        assert_eq!(Some("command2".into()), history.navigate_up(&tx));
+
+        history.reset_navigation();
+        assert!(history.history_cursor.is_none());
+        assert!(history.last_history_text.is_none());
+
+        assert_eq!(Some("command3".into()), history.navigate_up(&tx));
     }
 }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -236,7 +236,7 @@ impl BottomPane {
             CancellationEvent::NotHandled
         } else {
             self.view_stack.pop();
-            self.set_composer_text(String::new());
+            self.clear_composer_for_ctrl_c();
             self.show_ctrl_c_quit_hint();
             CancellationEvent::Handled
         }
@@ -267,6 +267,11 @@ impl BottomPane {
     /// Replace the composer text with `text`.
     pub(crate) fn set_composer_text(&mut self, text: String) {
         self.composer.set_text_content(text);
+        self.request_redraw();
+    }
+
+    pub(crate) fn clear_composer_for_ctrl_c(&mut self) {
+        self.composer.clear_for_ctrl_c();
         self.request_redraw();
     }
 


### PR DESCRIPTION
^C resets the history navigation, similar to zsh/bash.

Fixes #4834

------
https://chatgpt.com/codex/tasks/task_i_68e9674b6ac8832c8212bff6cba75e87