### PR TITLE
Add MCP Sampling Support to Enable Agentic MCP Tools

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1064,6 +1064,7 @@ dependencies = [
  "rand 0.9.2",
  "regex-lite",
  "reqwest",
+ "rmcp",
  "seccompiler",
  "serde",
  "serde_json",
@@ -1351,6 +1352,7 @@ name = "codex-rmcp-client"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "axum",
  "codex-protocol",
  "dirs",

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -40,6 +40,7 @@ portable-pty = { workspace = true }
 rand = { workspace = true }
 regex-lite = { workspace = true }
 reqwest = { workspace = true, features = ["json", "stream"] }
+rmcp = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha1 = { workspace = true }

--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -48,7 +48,10 @@ pub(crate) async fn stream_chat_completions(
     let mut messages = Vec::<serde_json::Value>::new();
 
     let full_instructions = prompt.get_full_instructions(model_family);
-    messages.push(json!({"role": "system", "content": full_instructions}));
+    // Only add system message if instructions are non-empty
+    if !full_instructions.is_empty() {
+        messages.push(json!({"role": "system", "content": full_instructions}));
+    }
 
     let input = prompt.get_formatted_input();
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -442,6 +442,13 @@ impl Session {
             model_reasoning_summary,
             conversation_id,
         );
+
+        // Set the model client in the MCP connection manager's sampling handler
+        // so that MCP servers can make LLM requests.
+        mcp_connection_manager
+            .set_model_client(Arc::new(client.clone()))
+            .await;
+
         let turn_context = TurnContext {
             client,
             tools_config: ToolsConfig::new(&ToolsConfigParams {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -443,11 +443,9 @@ impl Session {
             conversation_id,
         );
 
-        // Set the model client in the MCP connection manager's sampling handler
-        // so that MCP servers can make LLM requests.
-        mcp_connection_manager
-            .set_model_client(Arc::new(client.clone()))
-            .await;
+        // Set the config in the MCP connection manager's sampling handler
+        // so that MCP servers can make LLM requests with proper settings.
+        mcp_connection_manager.set_config(config.clone()).await;
 
         let turn_context = TurnContext {
             client,

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -34,6 +34,7 @@ pub mod git_info;
 pub mod landlock;
 pub mod mcp;
 mod mcp_connection_manager;
+mod mcp_sampling_handler;
 mod mcp_tool_call;
 mod message_history;
 mod model_provider_info;

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -359,13 +359,13 @@ impl McpConnectionManager {
         ))
     }
 
-    /// Set the ModelClient for the sampling handler.
+    /// Set the Config for the sampling handler.
     ///
-    /// This must be called after the ModelClient is created to enable
-    /// MCP servers to make LLM sampling requests.
-    pub async fn set_model_client(&self, client: Arc<crate::client::ModelClient>) {
+    /// This must be called after initialization to enable MCP servers
+    /// to make LLM sampling requests with proper configuration.
+    pub async fn set_config(&self, config: Arc<crate::config::Config>) {
         if let Some(handler) = &self.sampling_handler {
-            handler.set_model_client(client).await;
+            handler.set_config(config).await;
         }
     }
 

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -205,11 +205,7 @@ impl McpConnectionManager {
         store_mode: OAuthCredentialsStoreMode,
     ) -> Result<(Self, ClientStartErrors)> {
         // Create sampling handler if using rmcp client
-        let sampling_handler = if use_rmcp_client {
-            Some(Arc::new(CodexSamplingHandler::new()))
-        } else {
-            None
-        };
+        let sampling_handler = use_rmcp_client.then_some(Arc::new(CodexSamplingHandler::new()));
 
         // Early exit if no servers are configured.
         if mcp_servers.is_empty() {
@@ -260,7 +256,7 @@ impl McpConnectionManager {
                     capabilities: ClientCapabilities {
                         experimental: None,
                         roots: None,
-                        sampling: Some(json!({})),
+                        sampling: use_rmcp_client.then_some(json!({})),
                         // https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation#capabilities
                         // indicates this should be an empty object.
                         elicitation: Some(json!({})),

--- a/codex-rs/core/src/mcp_sampling_handler.rs
+++ b/codex-rs/core/src/mcp_sampling_handler.rs
@@ -1,0 +1,232 @@
+use std::sync::Arc;
+
+use anyhow::Result;
+use codex_rmcp_client::SamplingHandler;
+use futures::StreamExt;
+use tokio::sync::RwLock;
+use tracing::debug;
+use tracing::info;
+use tracing::warn;
+
+use crate::client::ModelClient;
+use crate::client_common::Prompt;
+use crate::client_common::ResponseEvent;
+use codex_protocol::models::ContentItem;
+use codex_protocol::models::ResponseInputItem;
+
+/// Implementation of SamplingHandler that uses Codex's ModelClient to provide
+/// real LLM responses to MCP sampling requests.
+///
+/// The ModelClient is stored in an RwLock because it needs to be set
+/// after the handler is created (due to initialization order constraints).
+pub struct CodexSamplingHandler {
+    model_client: RwLock<Option<Arc<ModelClient>>>,
+}
+
+impl Default for CodexSamplingHandler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl CodexSamplingHandler {
+    pub fn new() -> Self {
+        Self {
+            model_client: RwLock::new(None),
+        }
+    }
+
+    /// Set the ModelClient to use for sampling requests.
+    /// This must be called before any sampling requests are made.
+    pub async fn set_model_client(&self, client: Arc<ModelClient>) {
+        *self.model_client.write().await = Some(client);
+    }
+
+    /// Get a clone of the model client if it has been initialized.
+    async fn get_model_client(&self) -> Result<Arc<ModelClient>, rmcp::ErrorData> {
+        self.model_client.read().await.clone().ok_or_else(|| {
+            warn!("Sampling requested but ModelClient not yet initialized");
+            rmcp::ErrorData::internal_error("ModelClient not initialized for sampling", None)
+        })
+    }
+}
+
+#[async_trait::async_trait]
+impl SamplingHandler for CodexSamplingHandler {
+    async fn create_message(
+        &self,
+        params: rmcp::model::CreateMessageRequestParam,
+    ) -> Result<rmcp::model::CreateMessageResult, rmcp::ErrorData> {
+        use rmcp::model::Content;
+        use rmcp::model::CreateMessageResult;
+        use rmcp::model::Role;
+        use rmcp::model::SamplingMessage;
+
+        info!(
+            "Processing MCP sampling request with {} messages",
+            params.messages.len()
+        );
+
+        let model_client = self.get_model_client().await?;
+
+        let items = convert_sampling_messages_to_items(&params)?;
+
+        // Create prompt from items
+        let prompt = Prompt {
+            input: items.into_iter().map(Into::into).collect(),
+            ..Default::default()
+        };
+
+        debug!("Calling ModelClient with {} items", prompt.input.len());
+        let response_stream = model_client.stream(&prompt).await.map_err(|err| {
+            warn!("ModelClient stream failed: {err}");
+            rmcp::ErrorData::internal_error(format!("LLM call failed: {err}"), None)
+        })?;
+
+        let (response_text, stop_reason) = collect_response_from_stream(response_stream).await?;
+        let model_name = model_client.get_model();
+
+        info!("Generated response with {} characters", response_text.len());
+
+        Ok(CreateMessageResult {
+            message: SamplingMessage {
+                role: Role::Assistant,
+                content: Content::text(&response_text),
+            },
+            model: model_name,
+            stop_reason,
+        })
+    }
+}
+
+/// Convert MCP sampling messages to Codex response input items.
+fn convert_sampling_messages_to_items(
+    params: &rmcp::model::CreateMessageRequestParam,
+) -> Result<Vec<ResponseInputItem>, rmcp::ErrorData> {
+    use rmcp::model::Role;
+
+    let mut items = Vec::new();
+
+    // Add system prompt if provided
+    if let Some(system_prompt) = &params.system_prompt {
+        items.push(ResponseInputItem::Message {
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: system_prompt.clone(),
+            }],
+        });
+    }
+
+    // Convert each sampling message
+    for msg in &params.messages {
+        let role = match msg.role {
+            Role::User => "user",
+            Role::Assistant => "assistant",
+        }
+        .to_string();
+
+        let content = convert_message_content(&msg.content)?;
+        items.push(ResponseInputItem::Message { role, content });
+    }
+
+    Ok(items)
+}
+
+/// Convert MCP message content to Codex content items.
+fn convert_message_content(
+    content: &rmcp::model::Content,
+) -> Result<Vec<ContentItem>, rmcp::ErrorData> {
+    match &content.raw {
+        rmcp::model::RawContent::Text(text_content) => Ok(vec![ContentItem::InputText {
+            text: text_content.text.clone(),
+        }]),
+        rmcp::model::RawContent::Image(_) => {
+            warn!("Image content in sampling messages is not yet supported");
+            Err(rmcp::ErrorData::invalid_params(
+                "Image content is not supported",
+                None,
+            ))
+        }
+        rmcp::model::RawContent::Resource(_) | rmcp::model::RawContent::ResourceLink(_) => {
+            warn!("Resource content in sampling messages is not yet supported");
+            Err(rmcp::ErrorData::invalid_params(
+                "Resource content is not supported",
+                None,
+            ))
+        }
+        rmcp::model::RawContent::Audio(_) => {
+            warn!("Audio content in sampling messages is not yet supported");
+            Err(rmcp::ErrorData::invalid_params(
+                "Audio content is not supported",
+                None,
+            ))
+        }
+    }
+}
+
+/// Collect the text response from the model's response stream.
+async fn collect_response_from_stream(
+    response_stream: crate::client_common::ResponseStream,
+) -> Result<(String, Option<String>), rmcp::ErrorData> {
+    use rmcp::model::CreateMessageResult;
+
+    let mut response_text = String::new();
+    let mut stop_reason = None;
+
+    tokio::pin!(response_stream);
+
+    while let Some(event_result) = response_stream.next().await {
+        match event_result {
+            Ok(ResponseEvent::OutputItemDone(item)) => {
+                extract_text_from_item(&item, &mut response_text);
+            }
+            Ok(ResponseEvent::OutputTextDelta(text)) => {
+                response_text.push_str(&text);
+            }
+            Ok(ResponseEvent::Completed {
+                response_id,
+                token_usage,
+            }) => {
+                debug!("Response completed: id={response_id}, tokens={token_usage:?}");
+                stop_reason = Some(CreateMessageResult::STOP_REASON_END_TURN.to_string());
+            }
+            Ok(ResponseEvent::Created) => {
+                debug!("Response created");
+            }
+            Ok(ResponseEvent::RateLimits(_)) => {
+                debug!("Rate limits info received during sampling");
+            }
+            Ok(ResponseEvent::ReasoningSummaryDelta(_))
+            | Ok(ResponseEvent::ReasoningContentDelta(_))
+            | Ok(ResponseEvent::ReasoningSummaryPartAdded)
+            | Ok(ResponseEvent::WebSearchCallBegin { .. }) => {
+                // Ignore reasoning and web search events
+            }
+            Err(err) => {
+                warn!("Error in response stream: {err}");
+                return Err(rmcp::ErrorData::internal_error(
+                    format!("Stream error: {err}"),
+                    None,
+                ));
+            }
+        }
+    }
+
+    if response_text.is_empty() {
+        warn!("Model returned empty response");
+        response_text = "No response from model".to_string();
+    }
+
+    Ok((response_text, stop_reason))
+}
+
+/// Extract text content from a response item.
+fn extract_text_from_item(item: &codex_protocol::models::ResponseItem, output: &mut String) {
+    if let codex_protocol::models::ResponseItem::Message { content, .. } = item {
+        for content_item in content {
+            if let ContentItem::OutputText { text } = content_item {
+                output.push_str(text);
+            }
+        }
+    }
+}

--- a/codex-rs/core/src/mcp_sampling_handler.rs
+++ b/codex-rs/core/src/mcp_sampling_handler.rs
@@ -8,19 +8,18 @@ use tracing::debug;
 use tracing::info;
 use tracing::warn;
 
-use crate::client::ModelClient;
 use crate::client_common::Prompt;
 use crate::client_common::ResponseEvent;
+use crate::config::Config;
+use codex_protocol::ConversationId;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseInputItem;
 
-/// Implementation of SamplingHandler that uses Codex's ModelClient to provide
-/// real LLM responses to MCP sampling requests.
-///
-/// The ModelClient is stored in an RwLock because it needs to be set
-/// after the handler is created (due to initialization order constraints).
+/// Implementation of SamplingHandler that creates independent LLM calls
+/// for MCP sampling requests, respecting the request's systemPrompt and
+/// model preferences rather than reusing the session's ModelClient.
 pub struct CodexSamplingHandler {
-    model_client: RwLock<Option<Arc<ModelClient>>>,
+    config: RwLock<Option<Arc<Config>>>,
 }
 
 impl Default for CodexSamplingHandler {
@@ -32,21 +31,21 @@ impl Default for CodexSamplingHandler {
 impl CodexSamplingHandler {
     pub fn new() -> Self {
         Self {
-            model_client: RwLock::new(None),
+            config: RwLock::new(None),
         }
     }
 
-    /// Set the ModelClient to use for sampling requests.
+    /// Set the Config to use for sampling requests.
     /// This must be called before any sampling requests are made.
-    pub async fn set_model_client(&self, client: Arc<ModelClient>) {
-        *self.model_client.write().await = Some(client);
+    pub async fn set_config(&self, config: Arc<Config>) {
+        *self.config.write().await = Some(config);
     }
 
-    /// Get a clone of the model client if it has been initialized.
-    async fn get_model_client(&self) -> Result<Arc<ModelClient>, rmcp::ErrorData> {
-        self.model_client.read().await.clone().ok_or_else(|| {
-            warn!("Sampling requested but ModelClient not yet initialized");
-            rmcp::ErrorData::internal_error("ModelClient not initialized for sampling", None)
+    /// Get a clone of the config if it has been initialized.
+    async fn get_config(&self) -> Result<Arc<Config>, rmcp::ErrorData> {
+        self.config.read().await.clone().ok_or_else(|| {
+            warn!("Sampling requested but Config not yet initialized");
+            rmcp::ErrorData::internal_error("Config not initialized for sampling", None)
         })
     }
 }
@@ -67,26 +66,37 @@ impl SamplingHandler for CodexSamplingHandler {
             params.messages.len()
         );
 
-        let model_client = self.get_model_client().await?;
+        let config = self.get_config().await?;
 
+        // Build prompt for MCP sampling request.
+        // Per MCP spec: use the provided systemPrompt, or empty string if not provided
+        // (not Codex's default instructions).
         let items = convert_sampling_messages_to_items(&params)?;
-
-        // Create prompt from items
+        let system_prompt = params.system_prompt.clone().unwrap_or_default();
         let prompt = Prompt {
             input: items.into_iter().map(Into::into).collect(),
+            base_instructions_override: Some(system_prompt),
             ..Default::default()
         };
 
-        debug!("Calling ModelClient with {} items", prompt.input.len());
-        let response_stream = model_client.stream(&prompt).await.map_err(|err| {
-            warn!("ModelClient stream failed: {err}");
-            rmcp::ErrorData::internal_error(format!("LLM call failed: {err}"), None)
-        })?;
+        // Select model based on preferences or use config's default
+        let model_name = select_model_from_preferences(&params, &config);
+        debug!(
+            "Calling LLM for sampling with model={}, {} items, system_prompt={}",
+            model_name,
+            prompt.input.len(),
+            params.system_prompt.is_some()
+        );
+
+        // Create a temporary client for this sampling request
+        let response_stream = call_llm_for_sampling(&prompt, &model_name, &config).await?;
 
         let (response_text, stop_reason) = collect_response_from_stream(response_stream).await?;
-        let model_name = model_client.get_model();
 
-        info!("Generated response with {} characters", response_text.len());
+        info!(
+            "Generated sampling response with {} characters",
+            response_text.len()
+        );
 
         Ok(CreateMessageResult {
             message: SamplingMessage {
@@ -99,6 +109,67 @@ impl SamplingHandler for CodexSamplingHandler {
     }
 }
 
+/// Select model based on MCP sampling preferences or fall back to config default.
+fn select_model_from_preferences(
+    params: &rmcp::model::CreateMessageRequestParam,
+    config: &Config,
+) -> String {
+    if let Some(prefs) = &params.model_preferences
+        && let Some(hints) = &prefs.hints
+    {
+        for hint in hints {
+            if let Some(name) = &hint.name {
+                debug!("Using model from MCP preference: {name}");
+                return name.clone();
+            }
+        }
+    }
+
+    // Fall back to config's model
+    config.model.clone()
+}
+
+/// Call the LLM directly for sampling, bypassing the session's ModelClient.
+async fn call_llm_for_sampling(
+    prompt: &Prompt,
+    model: &str,
+    config: &Config,
+) -> Result<crate::client_common::ResponseStream, rmcp::ErrorData> {
+    use crate::chat_completions::stream_chat_completions;
+    use crate::default_client::create_client;
+    use crate::model_family::find_family_for_model;
+    use codex_otel::otel_event_manager::OtelEventManager;
+
+    let model_family = find_family_for_model(model).ok_or_else(|| {
+        warn!("Unknown model family for sampling: {model}");
+        rmcp::ErrorData::invalid_params(format!("Unknown model: {model}"), None)
+    })?;
+
+    let client = create_client();
+    let otel_manager = OtelEventManager::new(
+        ConversationId::new(),
+        model,
+        &model_family.slug,
+        None,  // No account_id for sampling
+        None,  // No auth_mode for sampling
+        false, // Don't log user prompts
+        "mcp-sampling".to_string(),
+    );
+
+    stream_chat_completions(
+        prompt,
+        &model_family,
+        &client,
+        &config.model_provider,
+        &otel_manager,
+    )
+    .await
+    .map_err(|err| {
+        warn!("LLM call failed for sampling: {err}");
+        rmcp::ErrorData::internal_error(format!("LLM call failed: {err}"), None)
+    })
+}
+
 /// Convert MCP sampling messages to Codex response input items.
 fn convert_sampling_messages_to_items(
     params: &rmcp::model::CreateMessageRequestParam,
@@ -106,16 +177,6 @@ fn convert_sampling_messages_to_items(
     use rmcp::model::Role;
 
     let mut items = Vec::new();
-
-    // Add system prompt if provided
-    if let Some(system_prompt) = &params.system_prompt {
-        items.push(ResponseInputItem::Message {
-            role: "user".to_string(),
-            content: vec![ContentItem::InputText {
-                text: system_prompt.clone(),
-            }],
-        });
-    }
 
     // Convert each sampling message
     for msg in &params.messages {

--- a/codex-rs/rmcp-client/Cargo.toml
+++ b/codex-rs/rmcp-client/Cargo.toml
@@ -8,11 +8,14 @@ workspace = true
 
 [dependencies]
 anyhow = "1"
+async-trait = { workspace = true }
 axum = { workspace = true, default-features = false, features = [
     "http1",
     "tokio",
 ] }
 codex-protocol = { workspace = true }
+dirs = { workspace = true }
+futures = { workspace = true, default-features = false, features = ["std"] }
 keyring = { workspace = true, features = [
     "apple-native",
     "crypto-rust",
@@ -20,6 +23,12 @@ keyring = { workspace = true, features = [
     "windows-native",
 ] }
 mcp-types = { path = "../mcp-types" }
+oauth2 = "5"
+reqwest = { version = "0.12", default-features = false, features = [
+    "json",
+    "stream",
+    "rustls-tls",
+] }
 rmcp = { workspace = true, default-features = false, features = [
     "auth",
     "base64",
@@ -31,17 +40,9 @@ rmcp = { workspace = true, default-features = false, features = [
     "transport-streamable-http-client-reqwest",
     "transport-streamable-http-server",
 ] }
-futures = { workspace = true, default-features = false, features = ["std"] }
-reqwest = { version = "0.12", default-features = false, features = [
-    "json",
-    "stream",
-    "rustls-tls",
-] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
-dirs = { workspace = true }
-oauth2 = "5"
 tiny_http = { workspace = true }
 tokio = { workspace = true, features = [
     "io-util",

--- a/codex-rs/rmcp-client/src/lib.rs
+++ b/codex-rs/rmcp-client/src/lib.rs
@@ -4,6 +4,7 @@ mod logging_client_handler;
 mod oauth;
 mod perform_oauth_login;
 mod rmcp_client;
+mod sampling_handler;
 mod utils;
 
 pub use auth_status::determine_streamable_http_auth_status;
@@ -16,3 +17,4 @@ pub(crate) use oauth::load_oauth_tokens;
 pub use oauth::save_oauth_tokens;
 pub use perform_oauth_login::perform_oauth_login;
 pub use rmcp_client::RmcpClient;
+pub use sampling_handler::SamplingHandler;

--- a/codex-rs/rmcp-client/src/logging_client_handler.rs
+++ b/codex-rs/rmcp-client/src/logging_client_handler.rs
@@ -4,6 +4,8 @@ use rmcp::model::CancelledNotificationParam;
 use rmcp::model::ClientInfo;
 use rmcp::model::CreateElicitationRequestParam;
 use rmcp::model::CreateElicitationResult;
+use rmcp::model::CreateMessageRequestParam;
+use rmcp::model::CreateMessageResult;
 use rmcp::model::ElicitationAction;
 use rmcp::model::LoggingLevel;
 use rmcp::model::LoggingMessageNotificationParam;
@@ -11,19 +13,48 @@ use rmcp::model::ProgressNotificationParam;
 use rmcp::model::ResourceUpdatedNotificationParam;
 use rmcp::service::NotificationContext;
 use rmcp::service::RequestContext;
+use std::sync::Arc;
 use tracing::debug;
 use tracing::error;
 use tracing::info;
 use tracing::warn;
 
-#[derive(Debug, Clone)]
+use crate::SamplingHandler;
+
+#[derive(Clone)]
 pub(crate) struct LoggingClientHandler {
     client_info: ClientInfo,
+    sampling_handler: Option<Arc<dyn SamplingHandler>>,
+}
+
+impl std::fmt::Debug for LoggingClientHandler {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("LoggingClientHandler")
+            .field("client_info", &self.client_info)
+            .field(
+                "sampling_handler",
+                &self.sampling_handler.as_ref().map(|_| "Some(...)"),
+            )
+            .finish()
+    }
 }
 
 impl LoggingClientHandler {
     pub(crate) fn new(client_info: ClientInfo) -> Self {
-        Self { client_info }
+        Self {
+            client_info,
+            sampling_handler: None,
+        }
+    }
+
+    pub(crate) fn with_sampling_handler(
+        client_info: ClientInfo,
+        handler: Arc<dyn SamplingHandler>,
+    ) -> Self {
+        Self {
+            client_info,
+            sampling_handler: Some(handler),
+        }
     }
 }
 
@@ -42,6 +73,41 @@ impl ClientHandler for LoggingClientHandler {
             action: ElicitationAction::Decline,
             content: None,
         })
+    }
+
+    async fn create_message(
+        &self,
+        params: CreateMessageRequestParam,
+        _context: RequestContext<RoleClient>,
+    ) -> Result<CreateMessageResult, rmcp::ErrorData> {
+        info!(
+            "MCP server requested sampling with {} messages",
+            params.messages.len()
+        );
+
+        // Log the sampling request details
+        debug!(
+            "Sampling parameters: max_tokens={}, temperature={:?}, system_prompt={:?}, model_preferences={:?}",
+            params.max_tokens,
+            params.temperature,
+            params
+                .system_prompt
+                .as_ref()
+                .map(|s| format!("{}...", &s[..s.len().min(50)])),
+            params.model_preferences
+        );
+
+        // Sampling handler is required
+        let Some(handler) = &self.sampling_handler else {
+            error!("MCP server requested sampling but no SamplingHandler was provided");
+            return Err(rmcp::ErrorData::internal_error(
+                "Sampling support requires a SamplingHandler to be configured",
+                None,
+            ));
+        };
+
+        debug!("Delegating sampling request to provided handler");
+        handler.create_message(params).await
     }
 
     async fn on_cancelled(
@@ -100,35 +166,19 @@ impl ClientHandler for LoggingClientHandler {
             logger,
             data,
         } = params;
+
         let logger = logger.as_deref();
+        let log_msg =
+            format!("MCP server log message (level: {level:?}, logger: {logger:?}, data: {data})");
+
         match level {
             LoggingLevel::Emergency
             | LoggingLevel::Alert
             | LoggingLevel::Critical
-            | LoggingLevel::Error => {
-                error!(
-                    "MCP server log message (level: {:?}, logger: {:?}, data: {})",
-                    level, logger, data
-                );
-            }
-            LoggingLevel::Warning => {
-                warn!(
-                    "MCP server log message (level: {:?}, logger: {:?}, data: {})",
-                    level, logger, data
-                );
-            }
-            LoggingLevel::Notice | LoggingLevel::Info => {
-                info!(
-                    "MCP server log message (level: {:?}, logger: {:?}, data: {})",
-                    level, logger, data
-                );
-            }
-            LoggingLevel::Debug => {
-                debug!(
-                    "MCP server log message (level: {:?}, logger: {:?}, data: {})",
-                    level, logger, data
-                );
-            }
+            | LoggingLevel::Error => error!("{log_msg}"),
+            LoggingLevel::Warning => warn!("{log_msg}"),
+            LoggingLevel::Notice | LoggingLevel::Info => info!("{log_msg}"),
+            LoggingLevel::Debug => debug!("{log_msg}"),
         }
     }
 }

--- a/codex-rs/rmcp-client/src/sampling_handler.rs
+++ b/codex-rs/rmcp-client/src/sampling_handler.rs
@@ -1,0 +1,21 @@
+use rmcp::model::CreateMessageRequestParam;
+use rmcp::model::CreateMessageResult;
+
+/// Trait for handling MCP sampling requests.
+///
+/// This trait should be implemented by the Codex core to provide actual LLM
+/// responses to MCP sampling requests. The default implementation in
+/// `LoggingClientHandler` returns simple mock responses.
+#[async_trait::async_trait]
+pub trait SamplingHandler: Send + Sync {
+    /// Handle a sampling/createMessage request from an MCP server.
+    ///
+    /// The implementation should:
+    /// 1. Convert the SamplingMessage(s) to the appropriate prompt format
+    /// 2. Call the LLM with the prompt
+    /// 3. Convert the LLM response back to CreateMessageResult
+    async fn create_message(
+        &self,
+        params: CreateMessageRequestParam,
+    ) -> Result<CreateMessageResult, rmcp::ErrorData>;
+}


### PR DESCRIPTION
## Summary

Implements MCP `sampling/createMessage` capability, allowing MCP servers to make independent LLM calls through Codex with their own prompts and model preferences.

Closes #4929, follows mcp sampling spec: https://modelcontextprotocol.io/specification/2025-06-18/client/sampling

## Key Changes

**New `CodexSamplingHandler`** (`codex-rs/core/src/mcp_sampling_handler.rs`)
- Creates independent LLM calls per sampling request
- Respects request's `systemPrompt` and `model_preferences.hints`
- Uses separate configuration from main Codex session

**Integration:**
- `chat_completions.rs`: Skip system message when instructions are empty
- `rmcp-client`: Added `SamplingHandler` trait for delegation
- `McpConnectionManager`: Wires sampling handler and declares capability

## Benefits

Write mini agents inside Codex using MCP tools. See this code review agent demo below - it can also run in background.

<img width="1610" height="1528" alt="image" src="https://github.com/user-attachments/assets/7b2e319a-09b1-4f87-abc3-3badfc5101db" />
<img width="3402" height="1166" alt="image" src="https://github.com/user-attachments/assets/7f475724-18ed-41f8-97a0-7366a836c410" />

## Checks Passed

✅ cargo test -p codex-core 
✅ just fix -p codex-core 
✅ just fix -p codex-rmcp-client 

