### PR TITLE
fix: show `HH:MM today` in status reset timestamps

### DIFF
--- a/codex-rs/tui/src/status/helpers.rs
+++ b/codex-rs/tui/src/status/helpers.rs
@@ -168,9 +168,10 @@ pub(crate) fn format_directory_display(directory: &Path, max_width: Option<usize
 pub(crate) fn format_reset_timestamp(dt: DateTime<Local>, captured_at: DateTime<Local>) -> String {
     let time = dt.format("%H:%M").to_string();
     if dt.date_naive() == captured_at.date_naive() {
-        time
+        format!("{time} today")
     } else {
-        format!("{time} on {}", dt.format("%-d %b"))
+        let date = dt.format("%-d %b");
+        format!("{time} on {date}")
     }
 }
 

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
@@ -4,17 +4,17 @@ expression: sanitized
 ---
 /status
 
-╭─────────────────────────────────────────────────────────────────────╮
-│  >_ OpenAI Codex (v0.0.0)                                           │
-│                                                                     │
-│  Model:            gpt-5-codex (reasoning high, summaries detailed) │
-│  Directory: [[workspace]]                                           │
-│  Approval:         on-request                                       │
-│  Sandbox:          workspace-write                                  │
-│  Agents.md:        <none>                                           │
-│                                                                     │
-│  Token usage:      1.9K total  (1K input + 900 output)              │
-│  Context window:   100% left (2.1K used / 272K)                     │
-│  5h limit:         [███████████████░░░░░] 72% used (resets 03:14)   │
-│  Weekly limit:     [█████████░░░░░░░░░░░] 45% used (resets 03:24)   │
-╰─────────────────────────────────────────────────────────────────────╯
+╭─────────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                               │
+│                                                                         │
+│  Model:            gpt-5-codex (reasoning high, summaries detailed)     │
+│  Directory: [[workspace]]                                               │
+│  Approval:         on-request                                           │
+│  Sandbox:          workspace-write                                      │
+│  Agents.md:        <none>                                               │
+│                                                                         │
+│  Token usage:      1.9K total  (1K input + 900 output)                  │
+│  Context window:   100% left (2.1K used / 272K)                         │
+│  5h limit:         [███████████████░░░░░] 72% used (resets 03:14 today) │
+│  Weekly limit:     [█████████░░░░░░░░░░░] 45% used (resets 03:24 today) │
+╰─────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
@@ -16,5 +16,5 @@ expression: sanitized
 │  Token usage:      1.9K total  (1K input + │
 │  Context window:   100% left (2.1K used /  │
 │  5h limit:         [███████████████░░░░░]  │
-│                    (resets 03:14)          │
+│                    (resets 03:14 today)    │
 ╰────────────────────────────────────────────╯


### PR DESCRIPTION
When user run `/status`, if the reset time is today, explicitly show “today” to avoid misunderstanding.

I’m not sure how the maintainer feels about issue #5115, but I think it makes sense. If the maintainer considers it unimportant, please feel free to close my PR.

Fixes #5115 