### PR TITLE
feat(file-search): Use Nucleo struct for live updates

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1151,9 +1151,11 @@ dependencies = [
  "anyhow",
  "clap",
  "ignore",
+ "nucleo",
  "nucleo-matcher",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 
@@ -3663,6 +3665,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nucleo"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5262af4c94921c2646c5ac6ff7900c2af9cbb08dc26a797e18130a7019c039d4"
+dependencies = [
+ "nucleo-matcher",
+ "parking_lot",
+ "rayon",
+]
+
+[[package]]
 name = "nucleo-matcher"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4611,6 +4624,26 @@ dependencies = [
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.1",
+]
+
+[[package]]
+name = "rayon"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/codex-rs/file-search/Cargo.toml
+++ b/codex-rs/file-search/Cargo.toml
@@ -15,7 +15,11 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 ignore = { workspace = true }
+nucleo = "0.5.0"
 nucleo-matcher = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+
+[dev-dependencies]
+tempfile = "3.13.0"

--- a/codex-rs/file-search/src/lib.rs
+++ b/codex-rs/file-search/src/lib.rs
@@ -1,9 +1,5 @@
 use ignore::WalkBuilder;
 use ignore::overrides::OverrideBuilder;
-use nucleo::Config;
-use nucleo::Nucleo;
-use nucleo::Snapshot;
-use nucleo::Status;
 use nucleo_matcher::Matcher;
 use nucleo_matcher::Utf32Str;
 use nucleo_matcher::pattern::AtomKind;
@@ -16,18 +12,14 @@ use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::num::NonZero;
 use std::path::Path;
-use std::path::PathBuf;
 use std::sync::Arc;
-use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-use std::thread::JoinHandle;
-use std::thread::{self};
-use std::time::Duration;
 use tokio::process::Command;
 
 mod cli;
+pub mod search_manager;
 
 pub use cli::Cli;
 
@@ -58,153 +50,6 @@ pub trait Reporter {
     fn report_match(&self, file_match: &FileMatch);
     fn warn_matches_truncated(&self, total_match_count: usize, shown_match_count: usize);
     fn warn_no_search_pattern(&self, search_directory: &Path);
-}
-
-pub struct SearchManager {
-    nucleo: Nucleo<SearchItem>,
-    cancel_flag: Arc<AtomicBool>,
-    walk_handle: Option<JoinHandle<()>>,
-    limit: NonZero<usize>,
-    compute_indices: bool,
-    matcher: Mutex<Matcher>,
-    search_directory: PathBuf,
-    case_matching: CaseMatching,
-    normalization: Normalization,
-    current_pattern: String,
-}
-
-impl SearchManager {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        pattern: &str,
-        limit: NonZero<usize>,
-        search_directory: &Path,
-        exclude: Vec<String>,
-        threads: NonZero<usize>,
-        compute_indices: bool,
-        notify: Arc<dyn Fn() + Sync + Send>,
-    ) -> anyhow::Result<Self> {
-        let search_directory_buf = search_directory.to_path_buf();
-        let override_matcher = build_override_matcher(search_directory, exclude)?;
-        let cancel_flag = Arc::new(AtomicBool::new(false));
-        let mut nucleo = Nucleo::new(
-            Config::DEFAULT,
-            notify,
-            Some(threads.get()),
-            1, // Single column containing the relative file path.
-        );
-        nucleo
-            .pattern
-            .reparse(0, pattern, CaseMatching::Smart, Normalization::Smart, false);
-        let injector = nucleo.injector();
-        let walk_handle = Some(spawn_walker(
-            search_directory_buf.clone(),
-            threads.get(),
-            override_matcher,
-            cancel_flag.clone(),
-            injector,
-        )?);
-
-        Ok(Self {
-            nucleo,
-            cancel_flag,
-            walk_handle,
-            limit,
-            compute_indices,
-            matcher: Mutex::new(Matcher::new(nucleo_matcher::Config::DEFAULT)),
-            search_directory: search_directory_buf,
-            case_matching: CaseMatching::Smart,
-            normalization: Normalization::Smart,
-            current_pattern: pattern.to_string(),
-        })
-    }
-
-    pub fn update_pattern(&mut self, pattern: &str) {
-        let append = pattern.starts_with(&self.current_pattern);
-        self.nucleo
-            .pattern
-            .reparse(0, pattern, self.case_matching, self.normalization, append);
-        self.current_pattern.clear();
-        self.current_pattern.push_str(pattern);
-    }
-
-    pub fn tick(&mut self, timeout: Duration) -> Status {
-        let millis = timeout.as_millis();
-        let timeout_ms = millis.try_into().unwrap_or(u64::MAX);
-        self.nucleo.tick(timeout_ms)
-    }
-
-    pub fn injector(&self) -> nucleo::Injector<SearchItem> {
-        self.nucleo.injector()
-    }
-
-    pub fn snapshot(&self) -> &Snapshot<SearchItem> {
-        self.nucleo.snapshot()
-    }
-
-    pub fn current_results(&self) -> FileSearchResults {
-        let snapshot = self.nucleo.snapshot();
-        let matched = snapshot.matched_item_count();
-        let max_results = u32::try_from(self.limit.get()).unwrap_or(u32::MAX);
-        let take = std::cmp::min(max_results, matched);
-        let mut matcher = self.matcher.lock().expect("matcher mutex poisoned");
-        let pattern = snapshot.pattern().column_pattern(0);
-        let pattern_empty = pattern.atoms.is_empty();
-        let compute_indices = self.compute_indices;
-
-        let matches = snapshot
-            .matched_items(0..take)
-            .filter_map(|item| {
-                let haystack = item.matcher_columns[0].slice(..);
-                if pattern_empty {
-                    Some(FileMatch {
-                        score: 0,
-                        path: item.data.path.clone(),
-                        indices: None,
-                    })
-                } else if compute_indices {
-                    let mut indices = Vec::new();
-                    let score = pattern.indices(haystack, &mut matcher, &mut indices)?;
-                    indices.sort_unstable();
-                    indices.dedup();
-                    Some(FileMatch {
-                        score,
-                        path: item.data.path.clone(),
-                        indices: Some(indices),
-                    })
-                } else {
-                    let score = pattern.score(haystack, &mut matcher)?;
-                    Some(FileMatch {
-                        score,
-                        path: item.data.path.clone(),
-                        indices: None,
-                    })
-                }
-            })
-            .collect();
-
-        FileSearchResults {
-            matches,
-            total_match_count: matched as usize,
-        }
-    }
-
-    pub fn cancel(&self) {
-        self.cancel_flag.store(true, Ordering::Relaxed);
-    }
-
-    pub fn search_directory(&self) -> &Path {
-        &self.search_directory
-    }
-}
-
-impl Drop for SearchManager {
-    fn drop(&mut self) {
-        self.cancel_flag.store(true, Ordering::Relaxed);
-        if let Some(handle) = self.walk_handle.take() {
-            let _ = handle.join();
-        }
-    }
 }
 
 pub async fn run_main<T: Reporter>(
@@ -540,88 +385,6 @@ fn create_pattern(pattern: &str) -> Pattern {
         Normalization::Smart,
         AtomKind::Fuzzy,
     )
-}
-
-#[derive(Debug, Clone)]
-pub struct SearchItem {
-    pub path: String,
-}
-
-impl SearchItem {
-    fn new(path: String) -> Self {
-        Self { path }
-    }
-}
-
-fn spawn_walker(
-    search_directory: PathBuf,
-    threads: usize,
-    override_matcher: Option<ignore::overrides::Override>,
-    cancel_flag: Arc<AtomicBool>,
-    injector: nucleo::Injector<SearchItem>,
-) -> anyhow::Result<JoinHandle<()>> {
-    thread::Builder::new()
-        .name("codex-file-search-walker".to_string())
-        .spawn(move || {
-            let search_directory = Arc::new(search_directory);
-            let mut walk_builder = WalkBuilder::new(search_directory.as_path());
-            walk_builder
-                .threads(threads)
-                .hidden(false)
-                .require_git(false);
-
-            if let Some(override_matcher) = override_matcher {
-                walk_builder.overrides(override_matcher);
-            }
-
-            let walker = walk_builder.build_parallel();
-            walker.run(|| {
-                let injector = injector.clone();
-                let cancel_flag = cancel_flag.clone();
-                let search_directory = Arc::clone(&search_directory);
-                Box::new(move |entry| {
-                    if cancel_flag.load(Ordering::Relaxed) {
-                        return ignore::WalkState::Quit;
-                    }
-                    let entry = match entry {
-                        Ok(entry) => entry,
-                        Err(_) => return ignore::WalkState::Continue,
-                    };
-                    if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-                        return ignore::WalkState::Continue;
-                    }
-                    let path = entry.path();
-                    let rel_path = match path.strip_prefix(search_directory.as_path()) {
-                        Ok(rel) => rel,
-                        Err(_) => path,
-                    };
-                    let Some(path_str) = rel_path.to_str() else {
-                        return ignore::WalkState::Continue;
-                    };
-                    injector.push(SearchItem::new(path_str.to_string()), |item, columns| {
-                        columns[0] = item.path.as_str().into();
-                    });
-                    ignore::WalkState::Continue
-                })
-            });
-        })
-        .map_err(anyhow::Error::new)
-}
-
-fn build_override_matcher(
-    search_directory: &Path,
-    exclude: Vec<String>,
-) -> anyhow::Result<Option<ignore::overrides::Override>> {
-    if exclude.is_empty() {
-        return Ok(None);
-    }
-
-    let mut builder = OverrideBuilder::new(search_directory);
-    for pattern in exclude {
-        let exclude_pattern = format!("!{pattern}");
-        builder.add(&exclude_pattern)?;
-    }
-    Ok(Some(builder.build()?))
 }
 
 #[cfg(test)]

--- a/codex-rs/file-search/src/lib.rs
+++ b/codex-rs/file-search/src/lib.rs
@@ -1,5 +1,9 @@
 use ignore::WalkBuilder;
 use ignore::overrides::OverrideBuilder;
+use nucleo::Config;
+use nucleo::Nucleo;
+use nucleo::Snapshot;
+use nucleo::Status;
 use nucleo_matcher::Matcher;
 use nucleo_matcher::Utf32Str;
 use nucleo_matcher::pattern::AtomKind;
@@ -12,10 +16,15 @@ use std::cmp::Reverse;
 use std::collections::BinaryHeap;
 use std::num::NonZero;
 use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
+use std::sync::Mutex;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
+use std::thread::JoinHandle;
+use std::thread::{self};
+use std::time::Duration;
 use tokio::process::Command;
 
 mod cli;
@@ -49,6 +58,153 @@ pub trait Reporter {
     fn report_match(&self, file_match: &FileMatch);
     fn warn_matches_truncated(&self, total_match_count: usize, shown_match_count: usize);
     fn warn_no_search_pattern(&self, search_directory: &Path);
+}
+
+pub struct SearchManager {
+    nucleo: Nucleo<SearchItem>,
+    cancel_flag: Arc<AtomicBool>,
+    walk_handle: Option<JoinHandle<()>>,
+    limit: NonZero<usize>,
+    compute_indices: bool,
+    matcher: Mutex<Matcher>,
+    search_directory: PathBuf,
+    case_matching: CaseMatching,
+    normalization: Normalization,
+    current_pattern: String,
+}
+
+impl SearchManager {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        pattern: &str,
+        limit: NonZero<usize>,
+        search_directory: &Path,
+        exclude: Vec<String>,
+        threads: NonZero<usize>,
+        compute_indices: bool,
+        notify: Arc<dyn Fn() + Sync + Send>,
+    ) -> anyhow::Result<Self> {
+        let search_directory_buf = search_directory.to_path_buf();
+        let override_matcher = build_override_matcher(search_directory, exclude)?;
+        let cancel_flag = Arc::new(AtomicBool::new(false));
+        let mut nucleo = Nucleo::new(
+            Config::DEFAULT,
+            notify,
+            Some(threads.get()),
+            1, // Single column containing the relative file path.
+        );
+        nucleo
+            .pattern
+            .reparse(0, pattern, CaseMatching::Smart, Normalization::Smart, false);
+        let injector = nucleo.injector();
+        let walk_handle = Some(spawn_walker(
+            search_directory_buf.clone(),
+            threads.get(),
+            override_matcher,
+            cancel_flag.clone(),
+            injector,
+        )?);
+
+        Ok(Self {
+            nucleo,
+            cancel_flag,
+            walk_handle,
+            limit,
+            compute_indices,
+            matcher: Mutex::new(Matcher::new(nucleo_matcher::Config::DEFAULT)),
+            search_directory: search_directory_buf,
+            case_matching: CaseMatching::Smart,
+            normalization: Normalization::Smart,
+            current_pattern: pattern.to_string(),
+        })
+    }
+
+    pub fn update_pattern(&mut self, pattern: &str) {
+        let append = pattern.starts_with(&self.current_pattern);
+        self.nucleo
+            .pattern
+            .reparse(0, pattern, self.case_matching, self.normalization, append);
+        self.current_pattern.clear();
+        self.current_pattern.push_str(pattern);
+    }
+
+    pub fn tick(&mut self, timeout: Duration) -> Status {
+        let millis = timeout.as_millis();
+        let timeout_ms = millis.try_into().unwrap_or(u64::MAX);
+        self.nucleo.tick(timeout_ms)
+    }
+
+    pub fn injector(&self) -> nucleo::Injector<SearchItem> {
+        self.nucleo.injector()
+    }
+
+    pub fn snapshot(&self) -> &Snapshot<SearchItem> {
+        self.nucleo.snapshot()
+    }
+
+    pub fn current_results(&self) -> FileSearchResults {
+        let snapshot = self.nucleo.snapshot();
+        let matched = snapshot.matched_item_count();
+        let max_results = u32::try_from(self.limit.get()).unwrap_or(u32::MAX);
+        let take = std::cmp::min(max_results, matched);
+        let mut matcher = self.matcher.lock().expect("matcher mutex poisoned");
+        let pattern = snapshot.pattern().column_pattern(0);
+        let pattern_empty = pattern.atoms.is_empty();
+        let compute_indices = self.compute_indices;
+
+        let matches = snapshot
+            .matched_items(0..take)
+            .filter_map(|item| {
+                let haystack = item.matcher_columns[0].slice(..);
+                if pattern_empty {
+                    Some(FileMatch {
+                        score: 0,
+                        path: item.data.path.clone(),
+                        indices: None,
+                    })
+                } else if compute_indices {
+                    let mut indices = Vec::new();
+                    let score = pattern.indices(haystack, &mut matcher, &mut indices)?;
+                    indices.sort_unstable();
+                    indices.dedup();
+                    Some(FileMatch {
+                        score,
+                        path: item.data.path.clone(),
+                        indices: Some(indices),
+                    })
+                } else {
+                    let score = pattern.score(haystack, &mut matcher)?;
+                    Some(FileMatch {
+                        score,
+                        path: item.data.path.clone(),
+                        indices: None,
+                    })
+                }
+            })
+            .collect();
+
+        FileSearchResults {
+            matches,
+            total_match_count: matched as usize,
+        }
+    }
+
+    pub fn cancel(&self) {
+        self.cancel_flag.store(true, Ordering::Relaxed);
+    }
+
+    pub fn search_directory(&self) -> &Path {
+        &self.search_directory
+    }
+}
+
+impl Drop for SearchManager {
+    fn drop(&mut self) {
+        self.cancel_flag.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.walk_handle.take() {
+            let _ = handle.join();
+        }
+    }
 }
 
 pub async fn run_main<T: Reporter>(
@@ -384,6 +540,88 @@ fn create_pattern(pattern: &str) -> Pattern {
         Normalization::Smart,
         AtomKind::Fuzzy,
     )
+}
+
+#[derive(Debug, Clone)]
+pub struct SearchItem {
+    pub path: String,
+}
+
+impl SearchItem {
+    fn new(path: String) -> Self {
+        Self { path }
+    }
+}
+
+fn spawn_walker(
+    search_directory: PathBuf,
+    threads: usize,
+    override_matcher: Option<ignore::overrides::Override>,
+    cancel_flag: Arc<AtomicBool>,
+    injector: nucleo::Injector<SearchItem>,
+) -> anyhow::Result<JoinHandle<()>> {
+    thread::Builder::new()
+        .name("codex-file-search-walker".to_string())
+        .spawn(move || {
+            let search_directory = Arc::new(search_directory);
+            let mut walk_builder = WalkBuilder::new(search_directory.as_path());
+            walk_builder
+                .threads(threads)
+                .hidden(false)
+                .require_git(false);
+
+            if let Some(override_matcher) = override_matcher {
+                walk_builder.overrides(override_matcher);
+            }
+
+            let walker = walk_builder.build_parallel();
+            walker.run(|| {
+                let injector = injector.clone();
+                let cancel_flag = cancel_flag.clone();
+                let search_directory = Arc::clone(&search_directory);
+                Box::new(move |entry| {
+                    if cancel_flag.load(Ordering::Relaxed) {
+                        return ignore::WalkState::Quit;
+                    }
+                    let entry = match entry {
+                        Ok(entry) => entry,
+                        Err(_) => return ignore::WalkState::Continue,
+                    };
+                    if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                        return ignore::WalkState::Continue;
+                    }
+                    let path = entry.path();
+                    let rel_path = match path.strip_prefix(search_directory.as_path()) {
+                        Ok(rel) => rel,
+                        Err(_) => path,
+                    };
+                    let Some(path_str) = rel_path.to_str() else {
+                        return ignore::WalkState::Continue;
+                    };
+                    injector.push(SearchItem::new(path_str.to_string()), |item, columns| {
+                        columns[0] = item.path.as_str().into();
+                    });
+                    ignore::WalkState::Continue
+                })
+            });
+        })
+        .map_err(anyhow::Error::new)
+}
+
+fn build_override_matcher(
+    search_directory: &Path,
+    exclude: Vec<String>,
+) -> anyhow::Result<Option<ignore::overrides::Override>> {
+    if exclude.is_empty() {
+        return Ok(None);
+    }
+
+    let mut builder = OverrideBuilder::new(search_directory);
+    for pattern in exclude {
+        let exclude_pattern = format!("!{pattern}");
+        builder.add(&exclude_pattern)?;
+    }
+    Ok(Some(builder.build()?))
 }
 
 #[cfg(test)]

--- a/codex-rs/file-search/src/search_manager.rs
+++ b/codex-rs/file-search/src/search_manager.rs
@@ -1,0 +1,252 @@
+use ignore::WalkBuilder;
+use ignore::overrides::OverrideBuilder;
+use nucleo::Config;
+use nucleo::Nucleo;
+use nucleo::Snapshot;
+use nucleo::Status;
+use nucleo_matcher::Matcher;
+use nucleo_matcher::pattern::CaseMatching;
+use nucleo_matcher::pattern::Normalization;
+use std::num::NonZero;
+use std::path::Path;
+use std::path::PathBuf;
+use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::Ordering;
+use std::thread::JoinHandle;
+use std::thread::{self};
+use std::time::Duration;
+
+use crate::FileMatch;
+use crate::FileSearchResults;
+
+#[derive(Debug, Clone)]
+pub struct SearchItem {
+    pub path: String,
+}
+
+impl SearchItem {
+    fn new(path: String) -> Self {
+        Self { path }
+    }
+}
+
+
+pub struct SearchManager {
+    nucleo: Nucleo<SearchItem>,
+    cancel_flag: Arc<AtomicBool>,
+    walk_handle: Option<JoinHandle<()>>,
+    limit: NonZero<usize>,
+    compute_indices: bool,
+    matcher: Mutex<Matcher>,
+    search_directory: PathBuf,
+    case_matching: CaseMatching,
+    normalization: Normalization,
+    current_pattern: String,
+}
+
+impl SearchManager {
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        pattern: &str,
+        limit: NonZero<usize>,
+        search_directory: &Path,
+        exclude: Vec<String>,
+        threads: NonZero<usize>,
+        compute_indices: bool,
+        notify: Arc<dyn Fn() + Sync + Send>,
+    ) -> anyhow::Result<Self> {
+        let search_directory_buf = search_directory.to_path_buf();
+        let override_matcher = build_override_matcher(search_directory, exclude)?;
+        let cancel_flag = Arc::new(AtomicBool::new(false));
+        let mut nucleo = Nucleo::new(
+            Config::DEFAULT,
+            notify,
+            Some(threads.get()),
+            1, // Single column containing the relative file path.
+        );
+        nucleo
+            .pattern
+            .reparse(0, pattern, CaseMatching::Smart, Normalization::Smart, false);
+        let injector = nucleo.injector();
+        let walk_handle = Some(spawn_walker(
+            search_directory_buf.clone(),
+            threads.get(),
+            override_matcher,
+            cancel_flag.clone(),
+            injector,
+        )?);
+
+        Ok(Self {
+            nucleo,
+            cancel_flag,
+            walk_handle,
+            limit,
+            compute_indices,
+            matcher: Mutex::new(Matcher::new(nucleo_matcher::Config::DEFAULT)),
+            search_directory: search_directory_buf,
+            case_matching: CaseMatching::Smart,
+            normalization: Normalization::Smart,
+            current_pattern: pattern.to_string(),
+        })
+    }
+
+    pub fn update_pattern(&mut self, pattern: &str) {
+        let append = pattern.starts_with(&self.current_pattern);
+        self.nucleo
+            .pattern
+            .reparse(0, pattern, self.case_matching, self.normalization, append);
+        self.current_pattern.clear();
+        self.current_pattern.push_str(pattern);
+    }
+
+    pub fn tick(&mut self, timeout: Duration) -> Status {
+        let millis = timeout.as_millis();
+        let timeout_ms = millis.try_into().unwrap_or(u64::MAX);
+        self.nucleo.tick(timeout_ms)
+    }
+
+    pub fn injector(&self) -> nucleo::Injector<SearchItem> {
+        self.nucleo.injector()
+    }
+
+    pub fn snapshot(&self) -> &Snapshot<SearchItem> {
+        self.nucleo.snapshot()
+    }
+
+    pub fn current_results(&self) -> FileSearchResults {
+        let snapshot = self.nucleo.snapshot();
+        let matched = snapshot.matched_item_count();
+        let max_results = u32::try_from(self.limit.get()).unwrap_or(u32::MAX);
+        let take = std::cmp::min(max_results, matched);
+        let mut matcher = self.matcher.lock().expect("matcher mutex poisoned");
+        let pattern = snapshot.pattern().column_pattern(0);
+        let pattern_empty = pattern.atoms.is_empty();
+        let compute_indices = self.compute_indices;
+
+        let matches = snapshot
+            .matched_items(0..take)
+            .filter_map(|item| {
+                let haystack = item.matcher_columns[0].slice(..);
+                if pattern_empty {
+                    Some(FileMatch {
+                        score: 0,
+                        path: item.data.path.clone(),
+                        indices: None,
+                    })
+                } else if compute_indices {
+                    let mut indices = Vec::new();
+                    let score = pattern.indices(haystack, &mut matcher, &mut indices)?;
+                    indices.sort_unstable();
+                    indices.dedup();
+                    Some(FileMatch {
+                        score,
+                        path: item.data.path.clone(),
+                        indices: Some(indices),
+                    })
+                } else {
+                    let score = pattern.score(haystack, &mut matcher)?;
+                    Some(FileMatch {
+                        score,
+                        path: item.data.path.clone(),
+                        indices: None,
+                    })
+                }
+            })
+            .collect();
+
+        FileSearchResults {
+            matches,
+            total_match_count: matched as usize,
+        }
+    }
+
+    pub fn cancel(&self) {
+        self.cancel_flag.store(true, Ordering::Relaxed);
+    }
+
+    pub fn search_directory(&self) -> &Path {
+        &self.search_directory
+    }
+}
+
+impl Drop for SearchManager {
+    fn drop(&mut self) {
+        self.cancel_flag.store(true, Ordering::Relaxed);
+        if let Some(handle) = self.walk_handle.take() {
+            let _ = handle.join();
+        }
+    }
+}
+
+fn spawn_walker(
+    search_directory: PathBuf,
+    threads: usize,
+    override_matcher: Option<ignore::overrides::Override>,
+    cancel_flag: Arc<AtomicBool>,
+    injector: nucleo::Injector<SearchItem>,
+) -> anyhow::Result<JoinHandle<()>> {
+    thread::Builder::new()
+        .name("codex-file-search-walker".to_string())
+        .spawn(move || {
+            let search_directory = Arc::new(search_directory);
+            let mut walk_builder = WalkBuilder::new(search_directory.as_path());
+            walk_builder
+                .threads(threads)
+                .hidden(false)
+                .require_git(false);
+
+            if let Some(override_matcher) = override_matcher {
+                walk_builder.overrides(override_matcher);
+            }
+
+            let walker = walk_builder.build_parallel();
+            walker.run(|| {
+                let injector = injector.clone();
+                let cancel_flag = cancel_flag.clone();
+                let search_directory = Arc::clone(&search_directory);
+                Box::new(move |entry| {
+                    if cancel_flag.load(Ordering::Relaxed) {
+                        return ignore::WalkState::Quit;
+                    }
+                    let entry = match entry {
+                        Ok(entry) => entry,
+                        Err(_) => return ignore::WalkState::Continue,
+                    };
+                    if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                        return ignore::WalkState::Continue;
+                    }
+                    let path = entry.path();
+                    let rel_path = match path.strip_prefix(search_directory.as_path()) {
+                        Ok(rel) => rel,
+                        Err(_) => path,
+                    };
+                    let Some(path_str) = rel_path.to_str() else {
+                        return ignore::WalkState::Continue;
+                    };
+                    injector.push(SearchItem::new(path_str.to_string()), |item, columns| {
+                        columns[0] = item.path.as_str().into();
+                    });
+                    ignore::WalkState::Continue
+                })
+            });
+        })
+        .map_err(anyhow::Error::new)
+}
+
+fn build_override_matcher(
+    search_directory: &Path,
+    exclude: Vec<String>,
+) -> anyhow::Result<Option<ignore::overrides::Override>> {
+    if exclude.is_empty() {
+        return Ok(None);
+    }
+
+    let mut builder = OverrideBuilder::new(search_directory);
+    for pattern in exclude {
+        let exclude_pattern = format!("!{pattern}");
+        builder.add(&exclude_pattern)?;
+    }
+    Ok(Some(builder.build()?))
+}

--- a/codex-rs/file-search/tests/search_manager.rs
+++ b/codex-rs/file-search/tests/search_manager.rs
@@ -1,0 +1,72 @@
+use std::sync::Arc;
+use std::sync::atomic::AtomicUsize;
+use std::sync::atomic::Ordering;
+use std::time::Duration;
+
+use codex_file_search::SearchItem;
+use codex_file_search::SearchManager;
+
+fn push(injector: &nucleo::Injector<SearchItem>, path: &str) {
+    injector.push(
+        SearchItem {
+            path: path.to_string(),
+        },
+        |item, columns| {
+            columns[0] = item.path.as_str().into();
+        },
+    );
+}
+
+#[test]
+fn search_manager_streams_results() {
+    let temp_dir = tempfile::tempdir().unwrap();
+
+    let tick_counter = Arc::new(AtomicUsize::new(0));
+    let notify_counter = Arc::clone(&tick_counter);
+    let notify = Arc::new(move || {
+        notify_counter.fetch_add(1, Ordering::Relaxed);
+    });
+
+    let limit = std::num::NonZero::new(10).unwrap();
+    let threads = std::num::NonZero::new(1).unwrap();
+
+    let mut manager = SearchManager::new(
+        "g",
+        limit,
+        temp_dir.path(),
+        Vec::new(),
+        threads,
+        false,
+        notify,
+    )
+    .unwrap();
+
+    let injector = manager.injector();
+
+    push(&injector, "alpha.txt");
+    manager.tick(Duration::from_millis(10));
+    assert!(manager.current_results().matches.is_empty());
+
+    push(&injector, "subdir/gamma.rs");
+    for _ in 0..50 {
+        let status = manager.tick(Duration::from_millis(10));
+        if !status.running {
+            break;
+        }
+    }
+
+    let final_results = manager.current_results();
+    assert!(
+        final_results
+            .matches
+            .iter()
+            .any(|m| m.path.ends_with("gamma.rs")),
+        "expected to find gamma.rs; results={:?}",
+        final_results
+            .matches
+            .iter()
+            .map(|m| m.path.clone())
+            .collect::<Vec<_>>()
+    );
+    assert!(tick_counter.load(Ordering::Relaxed) >= 2);
+}

--- a/codex-rs/file-search/tests/search_manager.rs
+++ b/codex-rs/file-search/tests/search_manager.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
@@ -27,8 +28,8 @@ fn search_manager_streams_results() {
         notify_counter.fetch_add(1, Ordering::Relaxed);
     });
 
-    let limit = std::num::NonZero::new(10).unwrap();
-    let threads = std::num::NonZero::new(1).unwrap();
+    let limit = NonZeroUsize::new(10).unwrap();
+    let threads = NonZeroUsize::new(2).unwrap();
 
     let mut manager = SearchManager::new(
         "g",
@@ -69,4 +70,63 @@ fn search_manager_streams_results() {
             .collect::<Vec<_>>()
     );
     assert!(tick_counter.load(Ordering::Relaxed) >= 2);
+}
+
+#[test]
+fn search_manager_walk_finds_files() {
+    let temp_dir = tempfile::tempdir().unwrap();
+    let nested_dir = temp_dir.path().join("subdir");
+    std::fs::create_dir_all(&nested_dir).unwrap();
+    std::fs::write(nested_dir.join("gamma.rs"), "fn main() {}").unwrap();
+    std::fs::write(temp_dir.path().join("alpha.txt"), "alpha").unwrap();
+
+    let notify_flag = Arc::new(AtomicUsize::new(0));
+    let notify_counter = Arc::clone(&notify_flag);
+    let notify = Arc::new(move || {
+        notify_counter.fetch_add(1, Ordering::Relaxed);
+    });
+
+    let limit = NonZeroUsize::new(10).unwrap();
+    let threads = NonZeroUsize::new(1).unwrap();
+
+    let mut manager = SearchManager::new(
+        "gam",
+        limit,
+        temp_dir.path(),
+        Vec::new(),
+        threads,
+        true,
+        notify,
+    )
+    .unwrap();
+
+    let start = std::time::Instant::now();
+    let mut found = false;
+
+    loop {
+        let status = manager.tick(Duration::from_millis(20));
+        let _ = notify_flag.swap(0, Ordering::AcqRel);
+        let results = manager.current_results();
+        if results.matches.iter().any(|m| m.path.ends_with("gamma.rs")) {
+            found = true;
+            break;
+        }
+        if !status.running && start.elapsed() > Duration::from_secs(1) {
+            break;
+        }
+        if start.elapsed() > Duration::from_secs(5) {
+            break;
+        }
+    }
+
+    assert!(
+        found,
+        "expected walker to find gamma.rs; matches: {:?}",
+        manager
+            .current_results()
+            .matches
+            .iter()
+            .map(|m| m.path.clone())
+            .collect::<Vec<_>>()
+    );
 }

--- a/codex-rs/file-search/tests/search_manager.rs
+++ b/codex-rs/file-search/tests/search_manager.rs
@@ -4,8 +4,8 @@ use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
 use std::time::Duration;
 
-use codex_file_search::SearchItem;
-use codex_file_search::SearchManager;
+use codex_file_search::search_manager::SearchItem;
+use codex_file_search::search_manager::SearchManager;
 
 fn push(injector: &nucleo::Injector<SearchItem>, path: &str) {
     injector.push(

--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -199,7 +199,7 @@ impl FileSearchManager {
                 })
             };
 
-            let mut manager = match file_search::SearchManager::new(
+            let mut manager = match file_search::search_manager::SearchManager::new(
                 &query,
                 MAX_FILE_SEARCH_RESULTS,
                 &search_dir,

--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -27,6 +27,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::atomic::Ordering;
 use std::thread;
 use std::time::Duration;
+use std::time::Instant;
 
 use crate::app_event::AppEvent;
 use crate::app_event_sender::AppEventSender;
@@ -39,6 +40,8 @@ const NUM_FILE_SEARCH_THREADS: NonZeroUsize = NonZeroUsize::new(2).unwrap();
 const FILE_SEARCH_DEBOUNCE: Duration = Duration::from_millis(100);
 
 const ACTIVE_SEARCH_COMPLETE_POLL_INTERVAL: Duration = Duration::from_millis(20);
+const SEARCH_MANAGER_TICK_TIMEOUT: Duration = Duration::from_millis(16);
+const SEARCH_MANAGER_FIRST_RESULT_TIMEOUT: Duration = Duration::from_millis(200);
 
 /// State machine for file-search orchestration.
 pub(crate) struct FileSearchManager {
@@ -47,6 +50,59 @@ pub(crate) struct FileSearchManager {
 
     search_dir: PathBuf,
     app_tx: AppEventSender,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_event::AppEvent;
+    use std::time::Instant;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    #[test]
+    fn file_search_manager_emits_results() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let nested = temp_dir.path().join("src");
+        std::fs::create_dir_all(&nested).unwrap();
+        std::fs::write(nested.join("gamma.rs"), "fn main() {}").unwrap();
+
+        let (tx, mut rx) = unbounded_channel();
+        let manager =
+            FileSearchManager::new(temp_dir.path().to_path_buf(), AppEventSender::new(tx));
+        manager.on_user_query("gam".to_string());
+
+        let start = Instant::now();
+        let mut saw_match = false;
+
+        let mut captured: Vec<String> = Vec::new();
+        while start.elapsed() < Duration::from_secs(2) {
+            while let Ok(event) = rx.try_recv() {
+                if let AppEvent::FileSearchResult { matches, .. } = &event {
+                    if matches.iter().any(|m| m.path.ends_with("gamma.rs")) {
+                        saw_match = true;
+                        captured.push(format!("{event:?}"));
+                        break;
+                    }
+                }
+                captured.push(format!("{event:?}"));
+            }
+            if saw_match {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+
+        if !saw_match {
+            while let Ok(event) = rx.try_recv() {
+                captured.push(format!("{event:?}"));
+            }
+        }
+
+        assert!(
+            saw_match,
+            "file search did not emit expected result; captured events: {captured:?}"
+        );
+    }
 }
 
 struct SearchState {
@@ -63,6 +119,29 @@ struct SearchState {
 struct ActiveSearch {
     query: String,
     cancellation_token: Arc<AtomicBool>,
+}
+
+struct ActiveSearchGuard {
+    state: Arc<Mutex<SearchState>>,
+    token: Arc<AtomicBool>,
+}
+
+impl ActiveSearchGuard {
+    fn new(state: Arc<Mutex<SearchState>>, token: Arc<AtomicBool>) -> Self {
+        Self { state, token }
+    }
+}
+
+impl Drop for ActiveSearchGuard {
+    fn drop(&mut self) {
+        #[expect(clippy::unwrap_used)]
+        let mut st = self.state.lock().unwrap();
+        if let Some(active_search) = &st.active_search
+            && Arc::ptr_eq(&active_search.cancellation_token, &self.token)
+        {
+            st.active_search = None;
+        }
+    }
 }
 
 impl FileSearchManager {
@@ -164,33 +243,88 @@ impl FileSearchManager {
     ) {
         let compute_indices = true;
         std::thread::spawn(move || {
-            let matches = file_search::run(
+            let _guard = ActiveSearchGuard::new(search_state.clone(), cancellation_token.clone());
+            let notify_flag = Arc::new(AtomicBool::new(false));
+            let notify = {
+                let flag = notify_flag.clone();
+                Arc::new(move || {
+                    flag.store(true, Ordering::Release);
+                })
+            };
+
+            let mut manager = match file_search::SearchManager::new(
                 &query,
                 MAX_FILE_SEARCH_RESULTS,
                 &search_dir,
                 Vec::new(),
                 NUM_FILE_SEARCH_THREADS,
-                cancellation_token.clone(),
                 compute_indices,
-            )
-            .map(|res| res.matches)
-            .unwrap_or_default();
+                notify,
+            ) {
+                Ok(manager) => manager,
+                Err(err) => {
+                    tracing::error!("file search initialization failed: {err:?}");
+                    tx.send(AppEvent::FileSearchResult {
+                        query: query.clone(),
+                        matches: Vec::new(),
+                    });
+                    return;
+                }
+            };
 
-            let is_cancelled = cancellation_token.load(Ordering::Relaxed);
-            if !is_cancelled {
-                tx.send(AppEvent::FileSearchResult { query, matches });
-            }
+            let mut last_sent_paths: Vec<String> = Vec::new();
+            let mut sent_once = false;
+            let start = Instant::now();
+            let mut last_progress = start;
 
-            // Reset the active search state. Do a pointer comparison to verify
-            // that we are clearing the ActiveSearch that corresponds to the
-            // cancellation token we were given.
-            {
-                #[expect(clippy::unwrap_used)]
-                let mut st = search_state.lock().unwrap();
-                if let Some(active_search) = &st.active_search
-                    && Arc::ptr_eq(&active_search.cancellation_token, &cancellation_token)
-                {
-                    st.active_search = None;
+            loop {
+                if cancellation_token.load(Ordering::Relaxed) {
+                    manager.cancel();
+                }
+
+                let status = manager.tick(SEARCH_MANAGER_TICK_TIMEOUT);
+                let flag_was_set = notify_flag.swap(false, Ordering::AcqRel);
+                let results = manager.current_results();
+                let matches = results.matches;
+                let paths: Vec<String> = matches.iter().map(|m| m.path.clone()).collect();
+
+                let paths_changed = paths != last_sent_paths;
+                let timeout_elapsed = start.elapsed() >= SEARCH_MANAGER_FIRST_RESULT_TIMEOUT;
+
+                let should_emit = !cancellation_token.load(Ordering::Relaxed)
+                    && (paths_changed
+                        || (!sent_once
+                            && (flag_was_set
+                                || status.changed
+                                || !status.running
+                                || timeout_elapsed)));
+
+                if should_emit {
+                    tx.send(AppEvent::FileSearchResult {
+                        query: query.clone(),
+                        matches: matches.clone(),
+                    });
+                    sent_once = true;
+                    last_sent_paths = paths;
+                    last_progress = Instant::now();
+                }
+
+                if cancellation_token.load(Ordering::Relaxed) && sent_once {
+                    break;
+                }
+
+                if !status.running && !flag_was_set {
+                    if sent_once {
+                        if last_progress.elapsed() >= SEARCH_MANAGER_FIRST_RESULT_TIMEOUT {
+                            break;
+                        }
+                    } else if timeout_elapsed {
+                        tx.send(AppEvent::FileSearchResult {
+                            query: query.clone(),
+                            matches,
+                        });
+                        break;
+                    }
                 }
             }
         });


### PR DESCRIPTION
Caveat - this PR is not ready to merge, but I'm introducing it as a draft before finalizing, in case we have strong feelings about migrating our dependency, and for ease of testing on larger codebases.

## Summary
Introduces the SearchManager struct, which wraps the higher-level Nucleo package. Using Nucleo instead of nucleo_matcher comes with some tradeoffs, but makes it much easier for us to provide 

## Testing
- [x] Added integration tests
- [x] Tested locally