### PR TITLE
Feat(mobile codex)/websocket bridge

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -14,9 +14,9 @@ dependencies = [
 
 [[package]]
 name = "addr2line"
-version = "0.24.2"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfbe277e56a376000877090da837660b4427aad530e3028d44e0bffe4f89a1c1"
+checksum = "1b5d307320b3181d6d7954e663bd7c774a838b8220fe0593c86d9fb09f498b4b"
 dependencies = [
  "gimli",
 ]
@@ -80,7 +80,7 @@ checksum = "fe233a377643e0fc1a56421d7c90acdec45c291b30345eb9f08e8d0ddce5a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -122,9 +122,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.19"
+version = "0.6.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "301af1932e46185686725e0fad2f8f2aa7da69dd70bf6ecc44d6b703844a3933"
+checksum = "3ae563653d1938f79b1ab1b5e668c87c76a9930414574a6583a7b7e11a8e6192"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -152,29 +152,29 @@ dependencies = [
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c8bdeb6047d8983be085bab0ba1472e6dc604e7041dbf6fcd5e71523014fae9"
+checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.9"
+version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403f75924867bb1033c59fbf0797484329750cfbe3c4325cd33127941fabc882"
+checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.99"
+version = "1.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
 
 [[package]]
 name = "app_test_support"
@@ -191,9 +191,9 @@ dependencies = [
 
 [[package]]
 name = "arboard"
-version = "3.6.0"
+version = "3.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f533f8e0af236ffe5eb979b99381df3258853f00ba2e44b6e1955292c75227"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
 dependencies = [
  "clipboard-win",
  "image",
@@ -205,7 +205,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -256,7 +256,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -368,7 +368,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "slab",
  "windows-sys 0.61.1",
 ]
@@ -399,7 +399,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 1.0.8",
+ "rustix 1.1.2",
 ]
 
 [[package]]
@@ -410,7 +410,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -425,7 +425,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.1",
@@ -450,7 +450,7 @@ checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -467,7 +467,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -484,12 +484,14 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
+checksum = "98e529aee37b5c8206bb4bf4c44797127566d72f76952c970bd3d1e85de8f4e2"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
+ "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -502,20 +504,25 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rustversion",
- "serde",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "axum-core"
-version = "0.5.2"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68464cd0412f486726fb3373129ef5d2993f90c34bc2bc1c1e9943b2f4fc7ca6"
+checksum = "0ac7a6beb1182c7e30253ee75c3e918080bfb83f5a3023bcdf7209d85fd147e6"
 dependencies = [
  "bytes",
  "futures-core",
@@ -524,17 +531,17 @@ dependencies = [
  "http-body-util",
  "mime",
  "pin-project-lite",
- "rustversion",
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
 name = "backtrace"
-version = "0.3.75"
+version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6806a6321ec58106fea15becdad98371e28d92ccbc7c8f1b3b6dd724fe8f1002"
+checksum = "bb531853791a215d7c62a30daf0dde835f381ab5de4589cfe7c649d2cbe92bd6"
 dependencies = [
  "addr2line",
  "cfg-if",
@@ -542,7 +549,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-targets 0.52.6",
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -589,9 +596,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "block-buffer"
@@ -643,9 +650,9 @@ checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "bytemuck"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c76a5792e44e4abe34d3abf15636779261d45a7450612059293d1d2cfc63422"
+checksum = "3995eaeebcdf32f91f980d360f78732ddc061097ab4e39991ae7a6ace9194677"
 
 [[package]]
 name = "byteorder"
@@ -691,10 +698,11 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.30"
+version = "1.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deec109607ca693028562ed836a5f1c4b8bd77755c4e132fc5ce11b0b6211ae7"
+checksum = "e1354349954c6fc9cb0deab020f27f783cf0b604e8bb754dc4658ecf0d29c35f"
 dependencies = [
+ "find-msvc-tools",
  "shlex",
 ]
 
@@ -706,9 +714,9 @@ checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
 
 [[package]]
 name = "cfg_aliases"
@@ -754,9 +762,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eac00902d9d136acd712710d71823fb8ac8004ca445a89e73a41d45aa712931"
+checksum = "e2134bb3ea021b78629caa971416385309e0131b351b25e01dc16fb54e1b5fae"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -764,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.47"
+version = "4.5.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ad9bbf750e73b5884fb8a211a9424a1906c1e156724260fdae972f31d70e1d6"
+checksum = "c2ba64afa3c0a6df7fa517765e31314e983f51dda798ffba27b988194fb65dc9"
 dependencies = [
  "anstream",
  "anstyle",
@@ -777,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "clap_complete"
-version = "4.5.57"
+version = "4.5.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d9501bd3f5f09f7bbee01da9a511073ed30a80cd7a509f1214bb74eadea71ad"
+checksum = "75bf0b32ad2e152de789bb635ea4d3078f6b838ad7974143e99b99f45a04af4a"
 dependencies = [
  "clap",
 ]
@@ -793,7 +801,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -869,6 +877,34 @@ dependencies = [
  "strum_macros 0.27.2",
  "ts-rs",
  "uuid",
+]
+
+[[package]]
+name = "codex-app-server-ws"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "app_test_support",
+ "axum",
+ "clap",
+ "codex-app-server",
+ "codex-app-server-protocol",
+ "codex-common",
+ "codex-core",
+ "codex-protocol",
+ "futures",
+ "futures-util",
+ "http",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "tokio-stream",
+ "tokio-tungstenite",
+ "tracing",
+ "tracing-subscriber",
+ "url",
 ]
 
 [[package]]
@@ -1051,7 +1087,7 @@ dependencies = [
  "escargot",
  "eventsource-stream",
  "futures",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "landlock",
  "libc",
  "maplit",
@@ -1644,7 +1680,7 @@ version = "0.28.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "crossterm_winapi",
  "futures-core",
  "mio",
@@ -1737,7 +1773,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1751,7 +1787,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1762,7 +1798,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1773,8 +1809,14 @@ checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
+
+[[package]]
+name = "data-encoding"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
 name = "dbus"
@@ -1882,7 +1924,7 @@ dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "unicode-xid",
 ]
 
@@ -1894,7 +1936,7 @@ checksum = "bda628edc44c4bb645fbe0f758797143e4e07926f7ebf4e9bdfbd3d2ce621df3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "unicode-xid",
 ]
 
@@ -1957,7 +1999,7 @@ checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
 dependencies = [
  "libc",
  "option-ext",
- "redox_users 0.5.0",
+ "redox_users 0.5.2",
  "windows-sys 0.61.1",
 ]
 
@@ -1978,7 +2020,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "objc2",
 ]
 
@@ -2000,7 +2042,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2059,14 +2101,14 @@ checksum = "83e195b4945e88836d826124af44fdcb262ec01ef94d44f14f4fb5103f19892a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -2128,7 +2170,7 @@ checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2177,12 +2219,12 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.13"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -2204,9 +2246,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener"
-version = "5.4.0"
+version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -2267,7 +2309,7 @@ checksum = "a0aca10fb742cb43f9e7bb8467c91aa9bcb8e3ffbc6a6f7389bb93ffc920577d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2277,7 +2319,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce92ff622d6dadf7349484f42c93271a0d49b7cc4d466a936405bacbe10aa78"
 dependencies = [
  "cfg-if",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "windows-sys 0.59.0",
 ]
 
@@ -2300,6 +2342,12 @@ dependencies = [
  "thiserror 1.0.69",
  "winapi",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ced73b1dacfc750a6db6c0a0c3a3853c8b41997e2e2c563dc90804ae6867959"
 
 [[package]]
 name = "fixed_decimal"
@@ -2366,9 +2414,9 @@ checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -2451,7 +2499,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -2505,19 +2553,19 @@ dependencies = [
 
 [[package]]
 name = "gethostname"
-version = "0.4.3"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0176e0459c2e4a1fe232f984bca6890e681076abb9934f6cea7c326f3fc47818"
+checksum = "fc257fdb4038301ce4b9cd1b3b51704509692bb3ff716a410cbd07925d9dae55"
 dependencies = [
- "libc",
- "windows-targets 0.48.5",
+ "rustix 1.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "getopts"
-version = "0.2.23"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cba6ae63eb948698e300f645f87c70f76630d505f23b8907cf1e193ee85048c1"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
  "unicode-width 0.2.1",
 ]
@@ -2545,15 +2593,15 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi",
- "wasi 0.14.2+wasi-0.2.4",
+ "wasi 0.14.7+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "gimli"
-version = "0.31.1"
+version = "0.32.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "globset"
@@ -2565,14 +2613,14 @@ dependencies = [
  "bstr",
  "log",
  "regex-automata",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
 name = "h2"
-version = "0.4.11"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17da50a276f1e01e0ba6c029e47b7100754904ee8a278f886546e98575380785"
+checksum = "f3c0b69cfcb4e1b9f1bf2f53f95f766e4661169728ec61cd3fe5a0166f2d1386"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2580,7 +2628,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "slab",
  "tokio",
  "tokio-util",
@@ -2615,14 +2663,20 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.4"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5971ac85611da7067dbfcabef3c70ebb5606018acd9e2a3903a0da507521e0d5"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
 
 [[package]]
 name = "heck"
@@ -2796,9 +2850,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9b05277c7e8da2c93a568989bb6207bef0112e8d17df7a6eda4a3cf143bc5e"
+checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
 dependencies = [
  "base64",
  "bytes",
@@ -2822,9 +2876,9 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.63"
+version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+checksum = "33e57f83510bb73707521ebaffa789ec8caf86f9657cad665b092b581d40e9fb"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
@@ -2832,7 +2886,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core",
+ "windows-core 0.62.1",
 ]
 
 [[package]]
@@ -2983,9 +3037,9 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -3036,9 +3090,9 @@ dependencies = [
 
 [[package]]
 name = "indenter"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
+checksum = "964de6e86d545b246d84badc0fef527924ace5134f30641c203ef52ba83f58d5"
 
 [[package]]
 name = "indexmap"
@@ -3053,13 +3107,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.10.0"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.4",
+ "hashbrown 0.16.0",
  "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3119,25 +3174,25 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "inventory"
-version = "0.3.20"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab08d7cd2c5897f2c949e5383ea7c7db03fb19130ffcfbf7eda795137ae3cb83"
+checksum = "bc61209c082fbeb19919bee74b176221b27223e27b65d781eb91af24eb1fb46e"
 dependencies = [
  "rustversion",
 ]
 
 [[package]]
 name = "io-uring"
-version = "0.7.9"
+version = "0.7.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d93587f37623a1a17d94ef2bc9ada592f5465fe7732084ab7beefabe5c77c0c4"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "cfg-if",
  "libc",
 ]
@@ -3235,7 +3290,7 @@ checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3262,9 +3317,9 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "js-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
+checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -3282,7 +3337,7 @@ dependencies = [
  "log",
  "secret-service",
  "security-framework 2.11.1",
- "security-framework 3.5.1",
+ "security-framework 3.3.0",
  "windows-sys 0.60.2",
  "zbus",
  "zeroize",
@@ -3341,9 +3396,9 @@ dependencies = [
 
 [[package]]
 name = "landlock"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3d2ef408b88e913bfc6594f5e693d57676f6463ded7d8bf994175364320c706"
+checksum = "affe8b77dce5b172f8e290bd801b12832a77cd1942d1ea98259916e89d5829d6"
 dependencies = [
  "enumflags2",
  "libc",
@@ -3358,9 +3413,9 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.175"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libdbus-sys"
@@ -3379,11 +3434,11 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libredox"
-version = "0.1.6"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4488594b9328dee448adb906d8b126d9b7deb7cf5c22161ee591610bb1be83c0"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "libc",
 ]
 
@@ -3393,7 +3448,7 @@ version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "761e49ec5fd8a5a463f9b84e877c373d888935b71c6be78f3767fe2ae6bed18e"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "libc",
 ]
 
@@ -3405,9 +3460,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
@@ -3460,7 +3515,7 @@ version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
 dependencies = [
- "hashbrown 0.15.4",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -3531,9 +3586,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.5"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "memoffset"
@@ -3660,7 +3715,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "cfg-if",
  "cfg_aliases 0.1.1",
  "libc",
@@ -3672,7 +3727,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -3685,7 +3740,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "cfg-if",
  "cfg_aliases 0.2.1",
  "libc",
@@ -3883,7 +3938,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6f29f568bec459b0ddff777cec4fe3fd8666d82d5a40ebd0ff7e66134f89bcc"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "objc2",
  "objc2-core-graphics",
  "objc2-foundation",
@@ -3895,7 +3950,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c10c2894a6fed806ade6027bcd50662746363a9589d3ec9d9bef30a4e4bc166"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "dispatch2",
  "objc2",
 ]
@@ -3906,7 +3961,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "989c6c68c13021b5c2d6b71456ebb0f9dc78d752e86a98da7c716f4f9470f5a4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -3925,7 +3980,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "900831247d2fe1a09a683278e5384cfb8c80c79fe6b166f9d14bfdde0ea1b03c"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3936,16 +3991,16 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7282e9ac92529fa3457ce90ebb15f4ecbc383e8338060960760fa2cf75420c3c"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "objc2",
  "objc2-core-foundation",
 ]
 
 [[package]]
 name = "object"
-version = "0.36.7"
+version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
+checksum = "ff76201f031d8863c38aa7f905eca4f53abbfa15f609db4277d44cd8938f33fe"
 dependencies = [
  "memchr",
 ]
@@ -3968,7 +4023,7 @@ version = "0.10.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8505734d46c8ab1e19a1dce3aef597ad87dcb4c37e7188231769bd6bd51cebf8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "cfg-if",
  "foreign-types",
  "libc",
@@ -3985,7 +4040,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -3996,9 +4051,9 @@ checksum = "d05e27ee213611ffe7d6348b942e8f942b37114c00cc03cec254295a4a17852e"
 
 [[package]]
 name = "openssl-src"
-version = "300.5.1+3.5.1"
+version = "300.5.2+3.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "735230c832b28c000e3bc117119e6466a663ec73506bc0a9907ea4187508e42a"
+checksum = "d270b79e2926f5150189d475bc7e9d2c69f9c4697b185fa917d5a32b792d21b4"
 dependencies = [
  "cc",
 ]
@@ -4215,9 +4270,9 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
@@ -4226,7 +4281,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4c5cc86750666a3ed20bdaf5ca2a0344f9c67674cae0515bec2da16fbaa47db"
 dependencies = [
  "fixedbitset",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
 ]
 
 [[package]]
@@ -4255,7 +4310,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4289,12 +4344,12 @@ checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plist"
-version = "1.7.4"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
+checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "quick-xml",
  "serde",
  "time",
@@ -4306,7 +4361,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97baced388464909d42d89643fe4361939af9b7ce7a31ee32a168f832a70f2a0"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "crc32fast",
  "fdeflate",
  "flate2",
@@ -4323,7 +4378,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "windows-sys 0.61.1",
 ]
 
@@ -4365,9 +4420,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7c30837279ca13e7c867e9e40053bc68740f988cb07f7ca6df43cc734b585"
+checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
 dependencies = [
  "serde",
  "zerovec",
@@ -4445,9 +4500,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.95"
+version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
+checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
 dependencies = [
  "unicode-ident",
 ]
@@ -4459,7 +4514,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
 dependencies = [
  "futures",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "nix 0.30.1",
  "tokio",
  "tracing",
@@ -4486,7 +4541,7 @@ dependencies = [
  "itertools 0.14.0",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -4495,7 +4550,7 @@ version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76979bea66e7875e7509c4ec5300112b316af87fa7a252ca91c448b32dfe3993"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -4510,9 +4565,9 @@ checksum = "bd348ff538bc9caeda7ee8cad2d1d48236a1f443c1fa3913c6a02fe0043b1dd3"
 
 [[package]]
 name = "pxfm"
-version = "0.1.23"
+version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f55f4fedc84ed39cb7a489322318976425e42a147e2be79d8f878e2884f94e84"
+checksum = "83f9b339b02259ada5c0f4a389b7fb472f933aa17ce176fd2ad98f28bb401fde"
 dependencies = [
  "num-traits",
 ]
@@ -4525,18 +4580,18 @@ checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.0"
+version = "0.38.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8927b0664f5c5a98265138b7e3f90aa19a6b21353182469ace36d4ac527b7b1b"
+checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quinn"
-version = "0.11.9"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+checksum = "626214629cda6781b6dc1d316ba307189c85ba657213ce642d9c77670f8202c8"
 dependencies = [
  "bytes",
  "cfg_aliases 0.2.1",
@@ -4545,7 +4600,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -4554,9 +4609,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "49df843a9161c85bb8aae55f101bc0bac8bcafd637a620d9122fd7e0b2f7422e"
 dependencies = [
  "bytes",
  "getrandom 0.3.3",
@@ -4575,16 +4630,16 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.14"
+version = "0.5.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+checksum = "fcebb1209ee276352ef14ff8732e24cc2b02bbac986cd74a4c81bcb2f9881970"
 dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4676,7 +4731,7 @@ name = "ratatui"
 version = "0.29.0"
 source = "git+https://github.com/nornagon/ratatui?branch=nornagon-v0.29.0-patch#9b2ad1298408c45918ee9f8241a6f95498cdbed2"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "cassowary",
  "compact_str",
  "crossterm",
@@ -4693,11 +4748,11 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.15"
+version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e8af0dde094006011e6a740d4879319439489813bd0bcdc7d821beaeeff48ec"
+checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
 ]
 
 [[package]]
@@ -4713,9 +4768,9 @@ dependencies = [
 
 [[package]]
 name = "redox_users"
-version = "0.5.0"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
 dependencies = [
  "getrandom 0.2.16",
  "libredox",
@@ -4739,30 +4794,30 @@ checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "regex"
-version = "1.11.1"
+version = "1.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
+checksum = "8b5288124840bee7b386bc413c487869b360b2b4ec421ea56425128692f2a82c"
 dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.9"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
+checksum = "833eb9ce86d40ef33cb1306d8accf7bc8ec2bfea4355cbdebb3df68b40925cad"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
 ]
 
 [[package]]
@@ -4779,9 +4834,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
 
 [[package]]
 name = "reqwest"
@@ -4890,14 +4945,14 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.25"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -4911,7 +4966,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4920,22 +4975,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.0.8"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "errno",
  "libc",
- "linux-raw-sys 0.9.4",
- "windows-sys 0.60.2",
+ "linux-raw-sys 0.11.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.29"
+version = "0.23.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
+checksum = "cd3c25631629d034ce7cd9940adc9d45762d46de2b0f57193c4443b92c6d4d40"
 dependencies = [
  "once_cell",
  "ring",
@@ -4954,7 +5009,7 @@ dependencies = [
  "openssl-probe",
  "rustls-pki-types",
  "schannel",
- "security-framework 3.5.1",
+ "security-framework 3.3.0",
 ]
 
 [[package]]
@@ -4969,9 +5024,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.4"
+version = "0.103.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a17884ae0c1b773f1ccd2bd4a8c72f16da897310a98b0e84bf349ad5ead92fc"
+checksum = "8572f3c2cb9934231157b45499fc41e1f58c589fdfb81a844ba873265e80f8eb"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4980,9 +5035,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "rustyline"
@@ -4990,7 +5045,7 @@ version = "14.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7803e8936da37efd9b6d4478277f4b2b9bb5cdb37a113e8d63222e58da647e63"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "cfg-if",
  "clipboard-win",
  "fd-lock",
@@ -5128,7 +5183,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5140,7 +5195,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5189,7 +5244,7 @@ version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "897b2245f0b511c87893af39b033e5ca9cce68824c4d7e7630b5a1d339658d02"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "core-foundation 0.9.4",
  "core-foundation-sys",
  "libc",
@@ -5198,11 +5253,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "80fb1d92c5028aa318b4b8bd7302a5bfcf48be96a37fc6fc790f806b0004ee0c"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -5221,9 +5276,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.226"
+version = "1.0.227"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dca6411025b24b60bfa7ec1fe1f8e710ac09782dca409ee8237ba74b51295fd"
+checksum = "80ece43fc6fbed4eb5392ab50c07334d3e577cbf40997ee896fe7af40bba4245"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -5231,22 +5286,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.226"
+version = "1.0.227"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba2ba63999edb9dac981fb34b3e5c0d111a69b0924e253ed29d83f7c99e966a4"
+checksum = "7a576275b607a2c86ea29e410193df32bc680303c82f31e275bbfcafe8b33be5"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.226"
+version = "1.0.227"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8db53ae22f34573731bafa1db20f04027b2d25e02d8205921b569171699cdb33"
+checksum = "51e694923b8824cf0e9b382adf0f60d4e05f348f357b38833a3fa5ed7c2ede04"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5257,7 +5312,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5266,7 +5321,7 @@ version = "1.0.145"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "402a6f66d8c709116cf22f558eab210f5a50187f702eb4d7e5ef38d9a7f1c79c"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "itoa",
  "memchr",
  "ryu",
@@ -5293,16 +5348,16 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "serde_spanned"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
+checksum = "5417783452c2be558477e104686f7de5dae53dba813c28435e0e70f82d9b04ee"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -5319,15 +5374,15 @@ dependencies = [
 
 [[package]]
 name = "serde_with"
-version = "3.14.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2c45cd61fefa9db6f254525d46e392b852e0e61d9a1fd36e5bd183450a556d5"
+checksum = "c522100790450cf78eeac1507263d0a350d4d5b30df0c8e1fe051a10c22b376e"
 dependencies = [
  "base64",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "schemars 0.9.0",
  "schemars 1.0.4",
  "serde",
@@ -5339,21 +5394,21 @@ dependencies = [
 
 [[package]]
 name = "serde_with_macros"
-version = "3.14.0"
+version = "3.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de90945e6565ce0d9a25098082ed4ee4002e047cb59892c318d66821e14bb30f"
+checksum = "327ada00f7d64abaac1e55a6911e90cf665aa051b9a561c7006c157f4633135e"
 dependencies = [
- "darling 0.20.11",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "serial2"
-version = "0.2.31"
+version = "0.2.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26e1e5956803a69ddd72ce2de337b577898801528749565def03515f82bad5bb"
+checksum = "8cc76fa68e25e771492ca1e3c53d447ef0be3093e05cd3b47f4b712ba10c6f3c"
 dependencies = [
  "cfg-if",
  "libc",
@@ -5382,7 +5437,7 @@ checksum = "5d69265a08751de7844521fd15003ae0a888e035773ba05695c5c759a6f89eef"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5461,9 +5516,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.5"
+version = "1.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
+checksum = "b2a4719bff48cee6b39d12c020eeb490953ad2443b7055bd0b21fca26bd8c28b"
 dependencies = [
  "libc",
 ]
@@ -5598,7 +5653,7 @@ dependencies = [
  "dupe",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5700,7 +5755,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5712,7 +5767,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5743,9 +5798,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.104"
+version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b6f705963418cdb9927482fa304bc562ece2fdd4f616084c50b7023b435a40"
+checksum = "ede7c438028d4436d71104916910f5bb611972c5cfd7f89b8300a8186e6fada6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5769,7 +5824,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5787,7 +5842,7 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -5811,7 +5866,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.3",
  "once_cell",
- "rustix 1.0.8",
+ "rustix 1.1.2",
  "windows-sys 0.61.1",
 ]
 
@@ -5837,12 +5892,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
 dependencies = [
- "rustix 1.0.8",
- "windows-sys 0.59.0",
+ "rustix 1.1.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5897,7 +5952,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -5908,7 +5963,7 @@ checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6041,7 +6096,7 @@ checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6056,9 +6111,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.2"
+version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
  "tokio",
@@ -6089,6 +6144,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6104,12 +6171,12 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.9.5"
+version = "0.9.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75129e1dc5000bfbaa9fee9d1b21f974f9fbad9daec557a521ee6e080825f6e8"
+checksum = "00e5e5d9bf2475ac9d4f0d9edab68cc573dc2fd644b0dba36b0c30a92dd9eaa0"
 dependencies = [
- "indexmap 2.10.0",
- "serde",
+ "indexmap 2.11.4",
+ "serde_core",
  "serde_spanned",
  "toml_datetime",
  "toml_parser",
@@ -6119,20 +6186,20 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.0"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+checksum = "32f1085dec27c2b6632b04c80b3bb1b4300d6495d1e129693bdda7d91e72eec1"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.4"
+version = "0.23.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7211ff1b8f0d3adae1663b7da9ffe396eabe1ca25f0b0bee42b0da29a9ddce93"
+checksum = "f3effe7c0e86fdff4f69cdd2ccc1b96f933e24811c5441d44904e8683e27184b"
 dependencies = [
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "toml_datetime",
  "toml_parser",
  "toml_writer",
@@ -6141,18 +6208,18 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b551886f449aa90d4fe2bdaa9f4a2577ad2dde302c61ecf262d80b116db95c10"
+checksum = "4cf893c33be71572e0e9aa6dd15e6677937abd686b066eac3f8cd3531688a627"
 dependencies = [
  "winnow",
 ]
 
 [[package]]
 name = "toml_writer"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
+checksum = "d163a63c116ce562a22cda521fcc4d79152e7aba014456fb5eb442f6d6a10109"
 
 [[package]]
 name = "tonic"
@@ -6191,7 +6258,7 @@ checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.10.0",
+ "indexmap 2.11.4",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -6208,7 +6275,7 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.9.4",
  "bytes",
  "futures-util",
  "http",
@@ -6264,7 +6331,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6334,7 +6401,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
 dependencies = [
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6345,7 +6412,7 @@ checksum = "78f873475d258561b06f1c595d93308a7ed124d9977cb26b148c2084a4a3cc87"
 dependencies = [
  "cc",
  "regex",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.8.6",
  "serde_json",
  "streaming-iterator",
  "tree-sitter-language",
@@ -6405,8 +6472,25 @@ checksum = "e9d4ed7b4c18cc150a6a0a1e9ea1ecfa688791220781af6e119f9599a8502a0a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "termcolor",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.2",
+ "sha1",
+ "thiserror 2.0.16",
+ "utf-8",
 ]
 
 [[package]]
@@ -6434,9 +6518,9 @@ checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.18"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
+checksum = "f63a545481291138910575129486daeaf8ac54aee4387fe7906919f7830c7d9d"
 
 [[package]]
 name = "unicode-linebreak"
@@ -6487,9 +6571,9 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "08bc136a29a3d1758e07a9cca267be308aeebf5cfd5a10f3f67ab2097683ef5b"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -6502,6 +6586,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -6602,44 +6692,54 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasi"
-version = "0.14.2+wasi-0.2.4"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen-rt",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
+checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
 dependencies = [
  "bumpalo",
  "log",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.50"
+version = "0.4.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
+checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -6650,9 +6750,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
+checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6660,22 +6760,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
+checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.100"
+version = "0.2.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
+checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
 dependencies = [
  "unicode-ident",
 ]
@@ -6695,9 +6795,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.77"
+version = "0.3.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
+checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6780,11 +6880,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
+checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -6800,7 +6900,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
 dependencies = [
  "windows-collections",
- "windows-core",
+ "windows-core 0.61.2",
  "windows-future",
  "windows-link 0.1.3",
  "windows-numerics",
@@ -6812,7 +6912,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -6824,8 +6924,21 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.62.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6844ee5416b285084d3d3fffd743b925a6c9385455f64f6d4fa3031c4c2749a9"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.2.0",
+ "windows-result 0.4.0",
+ "windows-strings 0.5.0",
 ]
 
 [[package]]
@@ -6834,31 +6947,31 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
  "windows-threading",
 ]
 
 [[package]]
 name = "windows-implement"
-version = "0.60.0"
+version = "0.60.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a47fddd13af08290e67f4acabf4b459f647552718f683a7b415d290ac744a836"
+checksum = "edb307e42a74fb6de9bf3a02d9712678b22399c87e6fa869d6dfcd8c1b7754e0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.1"
+version = "0.59.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
+checksum = "c0abd1ddbc6964ac14db11c7213d6532ef34bd9aa042c2e5935f59d7908b46a5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -6879,7 +6992,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
- "windows-core",
+ "windows-core 0.61.2",
  "windows-link 0.1.3",
 ]
 
@@ -6890,8 +7003,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
 dependencies = [
  "windows-link 0.1.3",
- "windows-result",
- "windows-strings",
+ "windows-result 0.3.4",
+ "windows-strings 0.4.2",
 ]
 
 [[package]]
@@ -6904,12 +7017,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-result"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7084dcc306f89883455a206237404d3eaf961e5bd7e0f312f7c91f57eb44167f"
+dependencies = [
+ "windows-link 0.2.0",
+]
+
+[[package]]
 name = "windows-strings"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -6945,7 +7076,7 @@ version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
- "windows-targets 0.53.2",
+ "windows-targets 0.53.4",
 ]
 
 [[package]]
@@ -6974,21 +7105,6 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
-]
-
-[[package]]
-name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
@@ -7005,10 +7121,11 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
-version = "0.53.2"
+version = "0.53.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c66f69fcc9ce11da9966ddb31a40968cad001c5bedeb5c2b82ede4253ab48aef"
+checksum = "2d42b7b7f66d2a06854650af09cfdf8713e427a439c97ad65a6375318033ac4b"
 dependencies = [
+ "windows-link 0.2.0",
  "windows_aarch64_gnullvm 0.53.0",
  "windows_aarch64_msvc 0.53.0",
  "windows_i686_gnu 0.53.0",
@@ -7036,12 +7153,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -7060,12 +7171,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -7081,12 +7186,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7120,12 +7219,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -7141,12 +7234,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7168,12 +7255,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -7192,12 +7273,6 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
-
-[[package]]
-name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
@@ -7210,9 +7285,9 @@ checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
-version = "0.7.12"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3edebf492c8125044983378ecb5766203ad3b4c2f7a922bd7dd207f6d443e95"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
@@ -7256,13 +7331,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen-rt"
-version = "0.39.0"
+name = "wit-bindgen"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
-dependencies = [
- "bitflags 2.9.1",
-]
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
@@ -7272,20 +7344,20 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "x11rb"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d91ffca73ee7f68ce055750bf9f6eca0780b8c85eff9bc046a3b0da41755e12"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
 dependencies = [
  "gethostname",
- "rustix 0.38.44",
+ "rustix 1.1.2",
  "x11rb-protocol",
 ]
 
 [[package]]
 name = "x11rb-protocol"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec107c4503ea0b4a98ef47356329af139c0a4f7750e621cf2973cd3385ebcb3d"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "xdg-home"
@@ -7323,7 +7395,7 @@ checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -7374,7 +7446,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "zvariant_utils",
 ]
 
@@ -7391,22 +7463,22 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1039dd0d3c310cf05de012d8a39ff557cb0d23087fd44cad61df08fc31907a2f"
+checksum = "0894878a5fa3edfd6da3f88c4805f4c8558e2b996227a3d864f47fe11e38282c"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.26"
+version = "0.8.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ecf5b4cc5364572d7f4c329661bcc82724222973f2cab6f050a4e5c22f75181"
+checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7426,7 +7498,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "synstructure",
 ]
 
@@ -7447,7 +7519,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7463,9 +7535,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a05eb080e015ba39cc9e23bbe5e7fb04d5fb040350f99f34e338d5fdd294428"
+checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -7480,7 +7552,7 @@ checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -7491,9 +7563,9 @@ checksum = "3f423a2c17029964870cfaabb1f13dfab7d092a62a29a89264f4d36990ca414a"
 
 [[package]]
 name = "zune-jpeg"
-version = "0.4.19"
+version = "0.4.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c9e525af0a6a658e031e95f14b7f889976b74a11ba0eca5a5fc9ac8a1c43a6a"
+checksum = "29ce2c8a9384ad323cf564b67da86e21d3cfdff87908bc1223ed5c99bc792713"
 dependencies = [
  "zune-core",
 ]
@@ -7520,7 +7592,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
  "zvariant_utils",
 ]
 
@@ -7532,5 +7604,5 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.104",
+ "syn 2.0.106",
 ]

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "ansi-escape",
     "app-server",
     "app-server-protocol",
+    "app-server-ws",
     "apply-patch",
     "arg0",
     "codex-backend-openapi-models",

--- a/codex-rs/REMOTE_ACCESS.md
+++ b/codex-rs/REMOTE_ACCESS.md
@@ -1,0 +1,129 @@
+# Remote Access Architecture
+
+The dream scenario I always want to do is after housrs working on desktop, I can
+walk away and continue my work from the my iphone, dictate and complete my work.
+As as models mature, we find there are less time to do code editon in an editor,
+that will make operate everything from an mobile phone possible, I believe the
+time to code from a mobile phone has finally come!
+
+This is the part one of the project, which bridges json-rpc with websocket, which
+allows any remote client to talk to json-rpc through websocket.
+I have already created an iOS project which will just do most the TUI client can
+do. It is very cool to sit on the sofa and do the work.
+Part III is to modify the TUI client to connect to the WS Bridge, so we can share
+the same session amont the clients.
+
+## Codex Remote Access WebSocket Bridge
+
+The websocket bridge turns the Codex JSON-RPC API into a WebSocket endpoint so a
+remote device can stay in lockstep with the desktop session. Any client that can
+open a WebSocket and speak JSON-RPC 2.0 inherits the full Codex feature set:
+submit tasks, receive streamed responses, handle approvals, and resume work from
+anywhere without installing the full stack.
+
+## Architecture
+
+```
+┌────────────────────────┐
+│ Remote Client          │
+│ (mobile / browser /    │
+│  thin CLI)             │
+└─────────▲──────────────┘
+          │ WebSocket (JSON-RPC text frames)
+          ▼
+┌─────────┴──────────────┐
+│ codex-app-server-ws    │
+│ (Axum WebSocket proxy) │
+└─────────▲──────────────┘
+          │ Shared in-process API
+          ▼
+┌─────────┴──────────────┐
+│ AppServerEngine        │
+│ (codex-app-server)     │
+└─────────▲──────────────┘
+          │ Conversations, tools, sandbox
+          ▼
+┌────────────────────────┐
+│ codex-core + toolchain │
+└────────────────────────┘
+```
+
+- Each WebSocket session instantiates `AppServerEngine::new_connection()` and
+  gets a dedicated `AppServerConnection` while reusing the shared `AuthManager`
+  and `ConversationManager` (tagged `SessionSource::WSRemote`).
+- Outbound engine events are forwarded to the client as newline-terminated JSON
+  strings over a bounded channel, so stalled clients cannot build unbounded
+  backlogs.
+- Inbound text frames are parsed into `JSONRPCMessage` variants and dispatched to
+  the engine (`process_request`, `process_notification`, `process_response`).
+- An optional bearer token enforces basic auth on the upgrade request.
+
+## Message Flow
+
+1. Client connects to `ws://<host>:<port>/ws`.
+2. If `--auth-token` was supplied, the handshake must include
+   `Authorization: Bearer <token>`.
+3. The bridge splits the socket: one task relays engine events to the client,
+   the other consumes client messages and forwards them to the engine.
+4. Binary frames, ping/pong frames, and parse failures are ignored; close frames
+   or socket errors terminate the session.
+
+## Running the Bridge
+
+```
+cd codex-rs
+cargo run -p codex-app-server-ws -- \
+    --bind 0.0.0.0:9100 \
+    --auth-token my-secret \
+    --profile remote \
+    --sandbox workspace-write \
+    --ask-for-approval on-failure
+```
+
+### CLI Flags
+
+| Flag                               | Description                                                                   |
+| ---------------------------------- | ----------------------------------------------------------------------------- |
+| `--bind <host:port>`               | Address to listen on (default `127.0.0.1:9100`).                              |
+| `--auth-token <token>`             | Require `Authorization: Bearer <token>` during handshake.                     |
+| `--codex-linux-sandbox-exe <path>` | Override the sandbox binary on Linux.                                         |
+| `-c key=value`                     | Apply repeatable config overrides from `config.toml`.                         |
+| `-m, --model <name>`               | Force a specific model for the session.                                       |
+| `-p, --profile <name>`             | Load defaults from a named profile.                                           |
+| `-s, --sandbox <policy>`           | Select sandbox policy (`workspace-write`, etc.).                              |
+| `-a, --ask-for-approval <policy>`  | Configure approval gating (`never`, `on-failure`, ...).                       |
+| `-C, --cd <path>`                  | Set the working directory for the engine session.                             |
+| `--full-auto`                      | Shortcut for `--sandbox workspace-write` and `--ask-for-approval on-failure`. |
+
+All overrides flow through `Config::load_with_cli_overrides`, so the bridge
+shares config parsing logic with the other Codex binaries.
+
+## Client Integration Tips
+
+- Speak standard JSON-RPC 2.0; notifications (no `id`) and responses are both
+  supported.
+- Keep the socket open for streaming updates—Codex emits intermediate progress
+  as notifications before sending the final result.
+- Approval prompts arrive as JSON-RPC requests; clients must reply with either a
+  result or an error.
+- Implement reconnect logic: new connections spin up fresh engine sessions, so
+  persist UI state locally if you need continuity beyond conversation history.
+- Send periodic pings if you expect to run behind NATs or mobile networks that
+  silently drop idle TCP connections.
+
+## Security Considerations
+
+- Prefer binding to `127.0.0.1` and routing traffic through SSH, WireGuard, or
+  Tailscale tunnels when operating over the internet.
+- Always set `--auth-token` for any deployment beyond your laptop.
+- Logging is handled via `tracing`; set `RUST_LOG=info` (or `debug`) to observe
+  connection events without exposing payload contents.
+- The bridge inherits sandbox and approval policies from `codex-core`. Choose a
+  conservative policy when the agent runs unattended.
+
+## Roadmap
+
+- **Part II**: Ship the native iOS client that speaks the same WebSocket
+  protocol, matching the existing TUI feature set with touch-first UX.
+- **Part III**: Update the TUI to connect through this bridge so every frontend
+  (desktop, mobile, browser) shares the same live session by default.

--- a/codex-rs/app-server-ws/Cargo.toml
+++ b/codex-rs/app-server-ws/Cargo.toml
@@ -1,0 +1,34 @@
+[package]
+name = "codex-app-server-ws"
+version = { workspace = true }
+edition = "2024"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = "1"
+axum = { version = "0.8", features = ["ws", "http1"] }
+clap = { version = "4", features = ["derive"] }
+futures = "0.3"
+futures-util = "0.3"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tokio = { version = "1", features = ["full"] }
+tokio-stream = "0.1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+
+codex-common = { path = "../common", features = ["cli"] }
+codex-core = { path = "../core" }
+codex-app-server = { path = "../app-server" }
+codex-app-server-protocol = { path = "../app-server-protocol" }
+
+[dev-dependencies]
+tokio-tungstenite = "0.28"
+reqwest = { version = "0.12", features = ["json"] }
+tempfile = "3"
+http = "1"
+url = "2"
+app_test_support = { workspace = true }
+codex-protocol = { workspace = true }

--- a/codex-rs/app-server-ws/src/lib.rs
+++ b/codex-rs/app-server-ws/src/lib.rs
@@ -1,0 +1,271 @@
+use axum::Router;
+use axum::extract::State;
+use axum::extract::ws::Message;
+use axum::extract::ws::WebSocket;
+use axum::extract::ws::WebSocketUpgrade;
+use axum::http::HeaderMap;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use codex_app_server::public_api::AppServerEngine;
+use codex_app_server_protocol::JSONRPCMessage;
+use futures_util::StreamExt;
+use futures_util::sink::SinkExt;
+use tracing::warn;
+
+#[derive(Clone)]
+pub struct AppState {
+    pub auth_token: Option<String>,
+    pub engine: AppServerEngine,
+}
+
+pub fn build_router(state: AppState) -> Router {
+    Router::new()
+        .route("/ws", get(ws_handler))
+        .with_state(state)
+}
+
+async fn ws_handler(
+    headers: HeaderMap,
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    if let Some(expected) = state.auth_token.clone() {
+        let ok = headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|h| h == format!("Bearer {expected}"));
+        if !ok {
+            return axum::http::StatusCode::UNAUTHORIZED.into_response();
+        }
+    }
+    ws.on_upgrade(move |socket| handle_socket(state, socket))
+}
+
+async fn handle_socket(state: AppState, socket: WebSocket) {
+    let (mut conn, mut rx_json) = state.engine.new_connection();
+
+    let (mut ws_tx, mut ws_rx) = socket.split();
+    // Forward server → client messages.
+    let to_ws = tokio::spawn(async move {
+        while let Some(value) = rx_json.recv().await {
+            let Ok(mut text) = serde_json::to_string(&value) else {
+                continue;
+            };
+            text.push('\n');
+            if ws_tx.send(Message::Text(text.into())).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Forward client → server messages.
+    while let Some(msg) = ws_rx.next().await {
+        match msg {
+            Ok(Message::Text(text)) => match serde_json::from_str::<JSONRPCMessage>(&text) {
+                Ok(JSONRPCMessage::Request(req)) => conn.process_request(req).await,
+                Ok(JSONRPCMessage::Notification(n)) => conn.process_notification(n).await,
+                Ok(JSONRPCMessage::Response(resp)) => conn.process_response(resp).await,
+                Ok(JSONRPCMessage::Error(_)) => {}
+                Err(_) => {}
+            },
+            Ok(Message::Close(_)) => break,
+            Ok(Message::Binary(_)) => {}
+            Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {}
+            Err(e) => {
+                warn!("websocket error: {e}");
+                break;
+            }
+        }
+    }
+    let _ = to_ws.await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use serde_json::json;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::connect_async;
+
+    use codex_common::CliConfigOverrides;
+    use codex_core::config::Config;
+    use codex_core::config::ConfigOverrides;
+
+    async fn spawn_server(state: AppState) -> std::net::SocketAddr {
+        let app: Router = crate::build_router(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        addr
+    }
+
+    async fn default_engine() -> AppServerEngine {
+        let overrides_cli = CliConfigOverrides {
+            raw_overrides: vec![],
+        };
+        let cli_overrides = overrides_cli.parse_overrides().unwrap();
+        let config = Config::load_with_cli_overrides(cli_overrides, ConfigOverrides::default())
+            .await
+            .expect("load config");
+        AppServerEngine::new(std::sync::Arc::new(config), None)
+    }
+
+    #[tokio::test]
+    async fn auth_accepts_with_correct_header() {
+        let engine = default_engine().await;
+        let state = AppState {
+            auth_token: Some("topsecret".to_string()),
+            engine,
+        };
+        let addr = spawn_server(state).await;
+
+        use tokio_tungstenite::tungstenite::client::IntoClientRequest;
+        let url = format!("ws://{addr}/ws");
+        let mut req = url.into_client_request().expect("build client request");
+        req.headers_mut().insert(
+            http::header::AUTHORIZATION,
+            http::HeaderValue::from_str("Bearer topsecret").unwrap(),
+        );
+        let (_ws, _resp) = connect_async(req).await.expect("handshake ok");
+        // If we reached here, the auth header was accepted and the connection opened.
+    }
+
+    #[tokio::test]
+    async fn auth_rejects_with_wrong_header() {
+        let engine = default_engine().await;
+        let state = AppState {
+            auth_token: Some("topsecret".to_string()),
+            engine,
+        };
+        let addr = spawn_server(state).await;
+
+        let url = format!("ws://{addr}/ws");
+        let req = http::Request::builder()
+            .uri(url)
+            .header(http::header::AUTHORIZATION, "Bearer notit")
+            .body(())
+            .unwrap();
+        let res = connect_async(req).await;
+        assert!(
+            res.is_err(),
+            "expected handshake rejection with wrong token"
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_json_is_ignored_then_valid_flow_works() {
+        use tokio::time::Duration;
+        use tokio::time::timeout;
+        use tokio_tungstenite::tungstenite::Message as WsMsg;
+
+        let engine = default_engine().await;
+        let state = AppState {
+            auth_token: None,
+            engine,
+        };
+        let addr = spawn_server(state).await;
+
+        let url = format!("ws://{addr}/ws");
+        let (mut ws, _resp) = connect_async(url).await.unwrap();
+
+        // Send garbage JSON first; the server should ignore it and keep the connection alive.
+        ws.send(WsMsg::Text("this is not json".into()))
+            .await
+            .unwrap();
+
+        // Now perform the normal init + newConversation flow and expect sessionConfigured.
+        let init = json!({
+            "method": "initialize",
+            "id": 1,
+            "params": { "clientInfo": { "name": "tests", "version": "0.0.0" } }
+        });
+        ws.send(WsMsg::Text(init.to_string().into())).await.unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let new_conv = json!({
+            "method": "newConversation",
+            "id": 2,
+            "params": { "cwd": tmp.path().to_string_lossy() }
+        });
+        ws.send(WsMsg::Text(new_conv.to_string().into()))
+            .await
+            .unwrap();
+
+        let mut saw_session_configured = false;
+        for _ in 0..50 {
+            if let Ok(Some(Ok(WsMsg::Text(txt)))) =
+                timeout(Duration::from_millis(200), ws.next()).await
+                && let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt)
+                    && v.get("method").and_then(|m| m.as_str()) == Some("sessionConfigured")
+                {
+                    saw_session_configured = true;
+                    break;
+                }
+        }
+        assert!(
+            saw_session_configured,
+            "expected sessionConfigured after valid flow"
+        );
+    }
+
+    #[tokio::test]
+    async fn binary_ping_frames_are_ignored() {
+        use tokio::time::Duration;
+        use tokio::time::timeout;
+        use tokio_tungstenite::tungstenite::Message as WsMsg;
+
+        let engine = default_engine().await;
+        let state = AppState {
+            auth_token: None,
+            engine,
+        };
+        let addr = spawn_server(state).await;
+
+        let url = format!("ws://{addr}/ws");
+        let (mut ws, _resp) = connect_async(url).await.unwrap();
+
+        // Send frames the server ignores.
+        ws.send(WsMsg::Binary(vec![1, 2, 3].into())).await.unwrap();
+        ws.send(WsMsg::Ping(b"hi".to_vec().into())).await.unwrap();
+
+        // Proceed with init/newConversation to ensure connection still works.
+        let init = json!({
+            "method": "initialize",
+            "id": 1,
+            "params": { "clientInfo": { "name": "tests", "version": "0.0.0" } }
+        });
+        ws.send(WsMsg::Text(init.to_string().into())).await.unwrap();
+
+        let tmp = tempfile::tempdir().unwrap();
+        let new_conv = json!({
+            "method": "newConversation",
+            "id": 2,
+            "params": { "cwd": tmp.path().to_string_lossy() }
+        });
+        ws.send(WsMsg::Text(new_conv.to_string().into()))
+            .await
+            .unwrap();
+
+        // Expect an ack for id=2 to confirm progress.
+        let mut saw_ack = false;
+        for _ in 0..50 {
+            if let Ok(Some(Ok(WsMsg::Text(txt)))) =
+                timeout(Duration::from_millis(200), ws.next()).await
+                && serde_json::from_str::<serde_json::Value>(&txt)
+                    .ok()
+                    .and_then(|v| v.get("id").and_then(serde_json::Value::as_i64))
+                    == Some(2)
+                {
+                    saw_ack = true;
+                    break;
+                }
+        }
+        assert!(
+            saw_ack,
+            "expected ack for newConversation despite prior ignored frames"
+        );
+    }
+}

--- a/codex-rs/app-server-ws/src/main.rs
+++ b/codex-rs/app-server-ws/src/main.rs
@@ -1,0 +1,465 @@
+use axum::Router;
+use axum::extract::State;
+use axum::extract::ws::Message;
+use axum::extract::ws::WebSocket;
+use axum::extract::ws::WebSocketUpgrade;
+use axum::http::HeaderMap;
+use axum::response::IntoResponse;
+use axum::routing::get;
+use clap::Parser;
+use codex_app_server::public_api::AppServerEngine;
+use codex_app_server_protocol::JSONRPCMessage;
+use codex_common::ApprovalModeCliArg;
+use codex_common::CliConfigOverrides;
+use codex_common::SandboxModeCliArg;
+use codex_core::config::Config;
+use codex_core::config::ConfigOverrides;
+use codex_core::protocol::AskForApproval;
+use codex_core::protocol_config_types::SandboxMode;
+use futures_util::StreamExt;
+use futures_util::sink::SinkExt;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::sync::Arc;
+use tracing::info;
+use tracing::warn;
+
+#[derive(Clone)]
+struct AppState {
+    auth_token: Option<String>,
+    engine: AppServerEngine,
+}
+
+/// Codex App Server over WebSocket (in‑process) bridge.
+#[derive(Debug, Parser)]
+#[command(
+    name = "codex-app-server-ws",
+    about = "WebSocket bridge for the Codex App Server (JSON-RPC)"
+)]
+struct Args {
+    /// Address to bind for the WebSocket server (host:port)
+    #[arg(long = "bind", default_value = "127.0.0.1:9100")]
+    bind: String,
+
+    /// Optional bearer token required in the Authorization header.
+    #[arg(long = "auth-token")]
+    auth_token: Option<String>,
+
+    /// Optional path to codex-linux-sandbox executable (Linux only).
+    #[arg(long = "codex-linux-sandbox-exe", value_name = "PATH")]
+    codex_linux_sandbox_exe: Option<PathBuf>,
+
+    /// Config overrides: -c key=value (repeatable)
+    #[clap(flatten)]
+    config_overrides: CliConfigOverrides,
+
+    /// Model to use for the engine (overrides config).
+    #[arg(long, short = 'm')]
+    model: Option<String>,
+
+    /// Configuration profile from config.toml to specify default options.
+    #[arg(long = "profile", short = 'p')]
+    profile: Option<String>,
+
+    /// Select the sandbox policy for executed commands.
+    #[arg(long = "sandbox", short = 's')]
+    sandbox_mode: Option<SandboxModeCliArg>,
+
+    /// Configure when to ask for approval before executing commands.
+    #[arg(long = "ask-for-approval", short = 'a')]
+    approval_policy: Option<ApprovalModeCliArg>,
+
+    /// Working directory for the engine session.
+    #[arg(long = "cd", short = 'C')]
+    cwd: Option<PathBuf>,
+
+    /// Convenience alias: --sandbox workspace-write and -a on-failure.
+    #[arg(long = "full-auto", default_value_t = false)]
+    full_auto: bool,
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .init();
+
+    let args = Args::parse();
+
+    // Load config via CLI overrides.
+    let overrides = match args.config_overrides.parse_overrides() {
+        Ok(v) => v,
+        Err(e) => anyhow::bail!("error parsing -c overrides: {e}"),
+    };
+    let mut typed = ConfigOverrides::default();
+    if let Some(m) = args.model.clone() {
+        typed.model = Some(m);
+    }
+    if let Some(p) = args.profile.clone() {
+        typed.config_profile = Some(p);
+    }
+    if let Some(s) = args.sandbox_mode {
+        typed.sandbox_mode = Some(s.into());
+    }
+    if let Some(a) = args.approval_policy {
+        typed.approval_policy = Some(a.into());
+    }
+    if let Some(dir) = args.cwd.clone() {
+        typed.cwd = Some(dir);
+    }
+    if args.full_auto {
+        if typed.sandbox_mode.is_none() {
+            typed.sandbox_mode = Some(SandboxMode::WorkspaceWrite);
+        }
+        if typed.approval_policy.is_none() {
+            typed.approval_policy = Some(AskForApproval::OnFailure);
+        }
+    }
+    let config = Config::load_with_cli_overrides(overrides, typed).await?;
+    let engine = AppServerEngine::new(Arc::new(config), args.codex_linux_sandbox_exe);
+
+    let state = AppState {
+        auth_token: args.auth_token,
+        engine,
+    };
+
+    let app = Router::new()
+        .route("/ws", get(ws_handler))
+        .with_state(state);
+
+    let addr: SocketAddr = args
+        .bind
+        .parse()
+        .map_err(|e| anyhow::anyhow!("invalid bind address {}: {e}", args.bind))?;
+    info!("codex-app-server-ws listening on {addr}");
+    axum::serve(tokio::net::TcpListener::bind(addr).await?, app).await?;
+    Ok(())
+}
+
+async fn ws_handler(
+    headers: HeaderMap,
+    ws: WebSocketUpgrade,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    // If an auth token is configured, require an Authorization: Bearer header.
+    if let Some(expected) = state.auth_token.clone() {
+        let ok = headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|h| h == format!("Bearer {expected}"));
+        if !ok {
+            return axum::http::StatusCode::UNAUTHORIZED.into_response();
+        }
+    }
+
+    ws.on_upgrade(move |socket| handle_socket(state, socket))
+}
+
+async fn handle_socket(state: AppState, socket: WebSocket) {
+    let (mut conn, mut rx_json) = state.engine.new_connection();
+
+    let (mut ws_tx, mut ws_rx) = socket.split();
+    // Forward server → client messages.
+    let to_ws = tokio::spawn(async move {
+        while let Some(value) = rx_json.recv().await {
+            let Ok(mut text) = serde_json::to_string(&value) else {
+                continue;
+            };
+            text.push('\n');
+            if ws_tx.send(Message::Text(text.into())).await.is_err() {
+                break;
+            }
+        }
+    });
+
+    // Forward client → server messages.
+    while let Some(msg) = ws_rx.next().await {
+        match msg {
+            Ok(Message::Text(text)) => match serde_json::from_str::<JSONRPCMessage>(&text) {
+                Ok(JSONRPCMessage::Request(req)) => conn.process_request(req).await,
+                Ok(JSONRPCMessage::Notification(n)) => conn.process_notification(n).await,
+                Ok(JSONRPCMessage::Response(resp)) => conn.process_response(resp).await,
+                Ok(JSONRPCMessage::Error(_)) => {}
+                Err(_) => {}
+            },
+            Ok(Message::Close(_)) => break,
+            Ok(Message::Binary(_)) => {}
+            Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {}
+            Err(e) => {
+                warn!("websocket error: {e}");
+                break;
+            }
+        }
+    }
+
+    let _ = to_ws.await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::Router;
+    use serde_json::json;
+    use tokio::net::TcpListener;
+    use tokio_tungstenite::connect_async;
+
+    async fn spawn_server(state: AppState) -> SocketAddr {
+        let app: Router = Router::new()
+            .route("/ws", get(ws_handler))
+            .with_state(state);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        addr
+    }
+
+    #[tokio::test]
+    async fn ws_flow_session_configured() {
+        // Build minimal config and engine
+        let overrides_cli = CliConfigOverrides {
+            raw_overrides: vec![],
+        };
+        let cli_overrides = overrides_cli.parse_overrides().unwrap();
+        let config = Config::load_with_cli_overrides(cli_overrides, ConfigOverrides::default())
+            .await
+            .expect("load config");
+        let engine = AppServerEngine::new(Arc::new(config), None);
+        let state = AppState {
+            auth_token: None,
+            engine,
+        };
+        let addr = spawn_server(state).await;
+
+        // Connect WS
+        let url = format!("ws://{addr}/ws");
+        let (mut ws, _resp) = connect_async(url).await.unwrap();
+
+        // Initialize
+        let init = json!({
+            "method": "initialize",
+            "id": 1,
+            "params": { "clientInfo": { "name": "tests", "version": "0.0.0" } }
+        });
+        use tokio_tungstenite::tungstenite::Message as WsMsg;
+        ws.send(WsMsg::Text(init.to_string().into())).await.unwrap();
+
+        // newConversation
+        let tmp = tempfile::tempdir().unwrap();
+        let new_conv = json!({
+            "method": "newConversation",
+            "id": 2,
+            "params": { "cwd": tmp.path().to_string_lossy() }
+        });
+        ws.send(WsMsg::Text(new_conv.to_string().into()))
+            .await
+            .unwrap();
+
+        // Expect a sessionConfigured server notification shortly after
+        use tokio::time::Duration;
+        use tokio::time::timeout;
+        let mut saw_session_configured = false;
+        for _ in 0..50 {
+            match timeout(Duration::from_millis(200), ws.next()).await {
+                Ok(Some(Ok(WsMsg::Text(txt)))) => {
+                    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt)
+                        && v.get("method").and_then(|m| m.as_str()) == Some("sessionConfigured")
+                    {
+                        saw_session_configured = true;
+                        break;
+                    }
+                }
+                Ok(Some(_)) => continue,
+                Ok(None) => continue,
+                Err(_) => continue, // soft timeout; keep polling up to ~10s
+            }
+        }
+        assert!(
+            saw_session_configured,
+            "expected sessionConfigured notification"
+        );
+    }
+
+    #[tokio::test]
+    async fn auth_rejects_without_header() {
+        let overrides_cli = CliConfigOverrides {
+            raw_overrides: vec![],
+        };
+        let cli_overrides = overrides_cli.parse_overrides().unwrap();
+        let config = Config::load_with_cli_overrides(cli_overrides, ConfigOverrides::default())
+            .await
+            .expect("load config");
+        let engine = AppServerEngine::new(Arc::new(config), None);
+        let state = AppState {
+            auth_token: Some("secret".to_string()),
+            engine,
+        };
+        let addr = spawn_server(state).await;
+
+        // Without Authorization header, WS handshake should fail.
+        let url = format!("ws://{addr}/ws");
+        let req = http::Request::builder().uri(url).body(()).unwrap();
+        let res = connect_async(req).await;
+        assert!(
+            res.is_err(),
+            "expected WS handshake to be rejected without Authorization header"
+        );
+    }
+
+    #[tokio::test]
+    async fn ws_send_user_turn_emits_task_complete() {
+        // Minimal config from defaults; only assert engine activity (no network required).
+        let tmp = tempfile::tempdir().expect("tmp dir");
+        let overrides_cli = CliConfigOverrides {
+            raw_overrides: vec![],
+        };
+        let cli_overrides = overrides_cli.parse_overrides().unwrap();
+        let config = Config::load_with_cli_overrides(cli_overrides, ConfigOverrides::default())
+            .await
+            .expect("load config");
+        let engine = AppServerEngine::new(Arc::new(config), None);
+        let state = AppState {
+            auth_token: None,
+            engine,
+        };
+        let addr = spawn_server(state).await;
+
+        // Connect WS and initialize
+        let url = format!("ws://{addr}/ws");
+        let (mut ws, _resp) = connect_async(url).await.unwrap();
+        use tokio_tungstenite::tungstenite::Message as WsMsg;
+        let init = json!({
+            "method": "initialize",
+            "id": 1,
+            "params": { "clientInfo": { "name": "tests", "version": "0.0.0" } }
+        });
+        ws.send(WsMsg::Text(init.to_string().into())).await.unwrap();
+
+        // Create conversation
+        let new_conv = json!({
+            "method": "newConversation",
+            "id": 2,
+            "params": { "cwd": tmp.path().to_string_lossy() }
+        });
+        ws.send(WsMsg::Text(new_conv.to_string().into()))
+            .await
+            .unwrap();
+
+        // Await newConversation response for conversationId
+        use tokio::time::Duration;
+        use tokio::time::timeout;
+        let mut conversation_id: Option<String> = None;
+        for _ in 0..50 {
+            if let Ok(Some(Ok(WsMsg::Text(txt)))) =
+                timeout(Duration::from_millis(200), ws.next()).await
+                && let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt)
+                && v.get("id").and_then(serde_json::Value::as_i64) == Some(2)
+            {
+                conversation_id = v
+                    .get("result")
+                    .and_then(|r| r.get("conversationId"))
+                    .and_then(|s| s.as_str())
+                    .map(str::to_string);
+                break;
+            }
+        }
+        let conversation_id = conversation_id.expect("conversationId");
+
+        // Subscribe to events
+        let subscribe = json!({
+            "method": "addConversationListener",
+            "id": 3,
+            "params": { "conversationId": conversation_id }
+        });
+        ws.send(WsMsg::Text(subscribe.to_string().into()))
+            .await
+            .unwrap();
+        // Wait for addConversationListener response
+        for _ in 0..50 {
+            if let Ok(Some(Ok(WsMsg::Text(txt)))) =
+                timeout(Duration::from_millis(200), ws.next()).await
+                && serde_json::from_str::<serde_json::Value>(&txt)
+                    .ok()
+                    .and_then(|v| v.get("id").and_then(serde_json::Value::as_i64))
+                    == Some(3)
+            {
+                break;
+            }
+        }
+
+        // Send a user turn (build via typed protocol to ensure correct shape)
+        use codex_app_server_protocol::InputItem as RpcInputItem;
+        use codex_app_server_protocol::JSONRPCMessage as RpcMessage;
+        use codex_app_server_protocol::JSONRPCRequest as RpcRequest;
+        use codex_app_server_protocol::RequestId as RpcRequestId;
+        use codex_app_server_protocol::SendUserTurnParams as RpcSendUserTurnParams;
+        use codex_protocol::ConversationId as ConvId;
+        use codex_protocol::config_types::ReasoningEffort;
+        use codex_protocol::config_types::ReasoningSummary;
+        use codex_protocol::protocol::AskForApproval;
+        use codex_protocol::protocol::SandboxPolicy;
+
+        let cid = ConvId::from_string(&conversation_id).expect("parse conversationId");
+        let params = RpcSendUserTurnParams {
+            conversation_id: cid,
+            items: vec![RpcInputItem::Text {
+                text: "Hello".to_string(),
+            }],
+            cwd: tmp.path().to_path_buf(),
+            approval_policy: AskForApproval::Never,
+            sandbox_policy: SandboxPolicy::DangerFullAccess,
+            model: "mock-model".to_string(),
+            effort: Some(ReasoningEffort::Medium),
+            summary: ReasoningSummary::Auto,
+        };
+        let req = RpcRequest {
+            id: RpcRequestId::Integer(4),
+            method: "sendUserTurn".to_string(),
+            params: Some(serde_json::to_value(&params).unwrap()),
+        };
+        let wire = serde_json::to_string(&RpcMessage::Request(req)).unwrap();
+        ws.send(WsMsg::Text(wire.into())).await.unwrap();
+
+        // Ack for sendUserTurn (id=4)
+        for _ in 0..50 {
+            if let Ok(Some(Ok(WsMsg::Text(txt)))) =
+                timeout(Duration::from_millis(200), ws.next()).await
+                && serde_json::from_str::<serde_json::Value>(&txt)
+                    .ok()
+                    .and_then(|v| v.get("id").and_then(serde_json::Value::as_i64))
+                    == Some(4)
+            {
+                eprintln!("ACK <- {txt}");
+                break;
+            }
+        }
+
+        // Expect some activity from the stream
+        let mut saw_activity = false;
+        for _ in 0..100 {
+            if let Ok(Some(Ok(WsMsg::Text(txt)))) =
+                timeout(Duration::from_millis(200), ws.next()).await
+            {
+                eprintln!("WS <- {txt}");
+                if let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt)
+                    && let Some(method) = v.get("method").and_then(|m| m.as_str())
+                    && matches!(
+                        method,
+                        "codex/event/task_started"
+                            | "codex/event/agent_message"
+                            | "codex/event/task_complete"
+                    )
+                {
+                    saw_activity = true;
+                    break;
+                }
+            }
+        }
+        assert!(
+            saw_activity,
+            "expected activity (task_started/agent_message/task_complete)"
+        );
+    }
+}

--- a/codex-rs/app-server-ws/tests/parity.rs
+++ b/codex-rs/app-server-ws/tests/parity.rs
@@ -1,0 +1,578 @@
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use app_test_support::McpProcess;
+use app_test_support::create_final_assistant_message_sse_response;
+use app_test_support::create_mock_chat_completions_server;
+use codex_app_server::public_api::AppServerEngine;
+use codex_app_server_protocol::AddConversationListenerParams;
+use codex_app_server_protocol::JSONRPCMessage as RpcMessage;
+use codex_app_server_protocol::JSONRPCRequest as RpcRequest;
+use codex_app_server_protocol::RequestId as RpcRequestId;
+use codex_app_server_protocol::SendUserTurnParams as RpcSendUserTurnParams;
+use codex_core::config::Config;
+use codex_core::config::ConfigOverrides;
+use codex_core::protocol::AskForApproval;
+use codex_core::protocol::SandboxPolicy;
+use codex_protocol::ConversationId as ConvId;
+use codex_protocol::config_types::ReasoningEffort;
+use codex_protocol::config_types::ReasoningSummary;
+use futures_util::sink::SinkExt;
+use futures_util::stream::StreamExt;
+use serde_json::json;
+use tokio::net::TcpListener;
+use tokio_tungstenite::connect_async;
+
+fn write_mock_config(codex_home: &std::path::Path, base_url: &str) {
+    let config_toml = codex_home.join("config.toml");
+    std::fs::write(
+        &config_toml,
+        format!(
+            r#"
+model = "mock-model"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+
+model_provider = "mock_provider"
+
+[model_providers.mock_provider]
+name = "Mock provider for test"
+base_url = "{base_url}/v1"
+wire_api = "chat"
+request_max_retries = 0
+stream_max_retries = 0
+requires_openai_auth = false
+"#
+        ),
+    )
+    .expect("write config.toml");
+}
+
+async fn spawn_ws(engine: AppServerEngine) -> SocketAddr {
+    let state = codex_app_server_ws::AppState {
+        auth_token: None,
+        engine,
+    };
+    let app = codex_app_server_ws::build_router(state);
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    addr
+}
+
+async fn collect_ws_methods(addr: SocketAddr, cwd: &str) -> Vec<String> {
+    use tokio::time::timeout;
+    use tokio_tungstenite::tungstenite::Message as WsMsg;
+
+    let url = format!("ws://{addr}/ws");
+    let (mut ws, _resp) = connect_async(url).await.unwrap();
+
+    // initialize
+    let init = json!({
+        "method": "initialize",
+        "id": 1,
+        "params": { "clientInfo": { "name": "tests", "version": "0.0.0" } }
+    });
+    ws.send(WsMsg::Text(init.to_string().into())).await.unwrap();
+
+    // newConversation
+    let new_conv = json!({
+        "method": "newConversation",
+        "id": 2,
+        "params": { "cwd": cwd }
+    });
+    ws.send(WsMsg::Text(new_conv.to_string().into()))
+        .await
+        .unwrap();
+
+    // await response id=2
+    let mut conversation_id: Option<String> = None;
+    for _ in 0..50 {
+        if let Ok(Some(Ok(WsMsg::Text(txt)))) = timeout(Duration::from_millis(200), ws.next()).await
+            && let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt)
+            && v.get("id").and_then(serde_json::Value::as_i64) == Some(2)
+        {
+            conversation_id = v
+                .get("result")
+                .and_then(|r| r.get("conversationId"))
+                .and_then(|s| s.as_str())
+                .map(str::to_string);
+            break;
+        }
+    }
+    let conversation_id = conversation_id.expect("conv id");
+
+    // subscribe
+    let subscribe = json!({
+        "method": "addConversationListener",
+        "id": 3,
+        "params": { "conversationId": conversation_id }
+    });
+    ws.send(WsMsg::Text(subscribe.to_string().into()))
+        .await
+        .unwrap();
+    for _ in 0..50 {
+        if let Ok(Some(Ok(WsMsg::Text(txt)))) = timeout(Duration::from_millis(200), ws.next()).await
+            && let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt)
+            && v.get("id").and_then(serde_json::Value::as_i64) == Some(3)
+        {
+            break;
+        }
+    }
+
+    // sendUserTurn (typed)
+    let cid = ConvId::from_string(&conversation_id).expect("cid parse");
+    let params = RpcSendUserTurnParams {
+        conversation_id: cid,
+        items: vec![codex_app_server_protocol::InputItem::Text {
+            text: "Hello".to_string(),
+        }],
+        cwd: std::path::PathBuf::from(cwd),
+        approval_policy: AskForApproval::Never,
+        sandbox_policy: SandboxPolicy::DangerFullAccess,
+        model: "mock-model".to_string(),
+        effort: Some(ReasoningEffort::Medium),
+        summary: ReasoningSummary::Auto,
+    };
+    let req = RpcRequest {
+        id: RpcRequestId::Integer(4),
+        method: "sendUserTurn".to_string(),
+        params: Some(serde_json::to_value(&params).unwrap()),
+    };
+    let wire = serde_json::to_string(&RpcMessage::Request(req)).unwrap();
+    ws.send(WsMsg::Text(wire.into())).await.unwrap();
+    // ack
+    for _ in 0..50 {
+        if let Ok(Some(Ok(WsMsg::Text(txt)))) = timeout(Duration::from_millis(200), ws.next()).await
+            && serde_json::from_str::<serde_json::Value>(&txt)
+                .ok()
+                .and_then(|v| v.get("id").and_then(serde_json::Value::as_i64))
+                == Some(4)
+        {
+            break;
+        }
+    }
+
+    // collect methods until task_complete
+    let mut methods: Vec<String> = Vec::new();
+    for _ in 0..150 {
+        if let Ok(Some(Ok(WsMsg::Text(txt)))) = timeout(Duration::from_millis(200), ws.next()).await
+            && let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt)
+                && let Some(m) = v.get("method").and_then(|m| m.as_str())
+                && m.starts_with("codex/event/")
+            {
+                methods.push(m.to_string());
+                if m == "codex/event/task_complete" {
+                    break;
+                }
+            }
+    }
+    methods
+}
+
+async fn collect_inprocess_methods(
+    codex_home: &std::path::Path,
+    cwd: &std::path::Path,
+) -> Vec<String> {
+    use tokio::time::timeout;
+    let mut mcp = McpProcess::new(codex_home).await.expect("spawn app-server");
+    timeout(Duration::from_secs(5), mcp.initialize())
+        .await
+        .expect("init timeout")
+        .expect("init ok");
+
+    // newConversation
+    let new_id = mcp
+        .send_new_conversation_request(codex_app_server_protocol::NewConversationParams {
+            model: None,
+            profile: None,
+            cwd: Some(cwd.to_string_lossy().to_string()),
+            approval_policy: Some(AskForApproval::Never),
+            sandbox: Some(codex_protocol::config_types::SandboxMode::DangerFullAccess),
+            config: None,
+            base_instructions: None,
+            include_plan_tool: None,
+            include_apply_patch_tool: None,
+        })
+        .await
+        .expect("send newConv");
+    let new_resp = timeout(
+        Duration::from_secs(5),
+        mcp.read_stream_until_response_message(RpcRequestId::Integer(new_id)),
+    )
+    .await
+    .expect("newConv timeout")
+    .expect("newConv resp");
+    let new_conv: codex_app_server_protocol::NewConversationResponse =
+        app_test_support::to_response::<_>(new_resp).expect("parse newConversation");
+    let conversation_id = new_conv.conversation_id;
+
+    // addListener
+    let add_id = mcp
+        .send_add_conversation_listener_request(AddConversationListenerParams { conversation_id })
+        .await
+        .expect("send addListener");
+    let _add_resp = timeout(
+        Duration::from_secs(5),
+        mcp.read_stream_until_response_message(RpcRequestId::Integer(add_id)),
+    )
+    .await
+    .expect("addListener timeout")
+    .expect("addListener resp");
+
+    // sendUserTurn
+    let turn_id = mcp
+        .send_send_user_turn_request(RpcSendUserTurnParams {
+            conversation_id,
+            items: vec![codex_app_server_protocol::InputItem::Text {
+                text: "Hello".to_string(),
+            }],
+            cwd: cwd.to_path_buf(),
+            approval_policy: AskForApproval::Never,
+            sandbox_policy: SandboxPolicy::DangerFullAccess,
+            model: "mock-model".to_string(),
+            effort: Some(ReasoningEffort::Medium),
+            summary: ReasoningSummary::Auto,
+        })
+        .await
+        .expect("send turn");
+    let _turn_ack = timeout(
+        Duration::from_secs(5),
+        mcp.read_stream_until_response_message(RpcRequestId::Integer(turn_id)),
+    )
+    .await
+    .expect("turn ack timeout")
+    .expect("turn ack resp");
+
+    // Expect agent_message then task_complete via public helpers
+    let mut methods: Vec<String> = Vec::new();
+    let _ = timeout(
+        Duration::from_secs(5),
+        mcp.read_stream_until_notification_message("codex/event/agent_message"),
+    )
+    .await
+    .expect("agent_message timeout")
+    .expect("agent_message notif");
+    methods.push("codex/event/agent_message".to_string());
+
+    let _ = timeout(
+        Duration::from_secs(5),
+        mcp.read_stream_until_notification_message("codex/event/task_complete"),
+    )
+    .await
+    .expect("task_complete timeout")
+    .expect("task_complete notif");
+    methods.push("codex/event/task_complete".to_string());
+    methods
+}
+
+#[tokio::test]
+#[ignore = "end-to-end parity with SSE mocks can be slow/flaky; run explicitly"]
+async fn parity_basic_turn_produces_same_event_order() {
+    // Mock model server with two completions (session start + user turn)
+    let responses_ws = vec![
+        create_final_assistant_message_sse_response("Welcome").expect("resp1"),
+        create_final_assistant_message_sse_response("Done").expect("resp2"),
+    ];
+    let responses_ip = vec![
+        create_final_assistant_message_sse_response("Welcome").expect("resp1"),
+        create_final_assistant_message_sse_response("Done").expect("resp2"),
+    ];
+    let mock_ws = create_mock_chat_completions_server(responses_ws).await;
+    let mock_ip = create_mock_chat_completions_server(responses_ip).await;
+
+    // Shared config for both runs under a temp home
+    let codex_home = tempfile::tempdir().expect("tmp");
+    write_mock_config(codex_home.path(), &mock_ws.uri());
+
+    // WS engine from the same config
+    let cfg_toml =
+        codex_core::config::load_config_as_toml_with_cli_overrides(codex_home.path(), vec![])
+            .await
+            .expect("parse config");
+    let config = Config::load_from_base_config_with_overrides(
+        cfg_toml,
+        ConfigOverrides::default(),
+        codex_home.path().to_path_buf(),
+    )
+    .expect("materialize Config");
+    let engine = AppServerEngine::new(std::sync::Arc::new(config), None);
+    let addr = spawn_ws(engine).await;
+
+    // Collect event methods from both paths
+    let cwd = codex_home.path().to_string_lossy().to_string();
+    let ws_methods = collect_ws_methods(addr, &cwd).await;
+    // Re-point the config to a fresh mock server for in-process run.
+    write_mock_config(codex_home.path(), &mock_ip.uri());
+    let inproc_methods = collect_inprocess_methods(codex_home.path(), codex_home.path()).await;
+
+    // Normalize by filtering environment_context noise (keep meaningful events)
+    let f = |m: &String| m != "codex/event/user_message"; // environment_context appears as a user_message
+    let ws_filtered: Vec<_> = ws_methods.into_iter().filter(f).collect();
+    let inproc_filtered: Vec<_> = inproc_methods.into_iter().filter(f).collect();
+
+    // WS should contain task_started; in-process must complete
+    assert!(ws_filtered.contains(&"codex/event/task_started".to_string()));
+    assert_eq!(
+        inproc_filtered.last(),
+        Some(&"codex/event/task_complete".to_string())
+    );
+    let ws_last = ws_filtered.last().cloned();
+    assert!(
+        ws_last == Some("codex/event/task_complete".to_string())
+            || ws_last == Some("codex/event/stream_error".to_string()),
+        "ws last={ws_last:?}"
+    );
+}
+
+#[tokio::test]
+#[ignore = "approval roundtrip uses SSE mocks and is environment-sensitive; run explicitly"]
+async fn parity_exec_approval_roundtrip() {
+    // Mock sequence: first SSE triggers a shell tool call; second SSE finalizes message
+    let responses_ws = vec![
+        app_test_support::create_shell_sse_response(
+            vec!["bash".into(), "-lc".into(), "echo hi".into()],
+            None,
+            Some(5000),
+            "call1",
+        )
+        .expect("shell sse"),
+        create_final_assistant_message_sse_response("done").expect("final sse"),
+    ];
+    let responses_ip = vec![
+        app_test_support::create_shell_sse_response(
+            vec!["bash".into(), "-lc".into(), "echo hi".into()],
+            None,
+            Some(5000),
+            "call1",
+        )
+        .expect("shell sse"),
+        create_final_assistant_message_sse_response("done").expect("final sse"),
+    ];
+    let mock_ws = create_mock_chat_completions_server(responses_ws).await;
+    let mock_ip = create_mock_chat_completions_server(responses_ip).await;
+
+    // Shared config under temp home
+    let codex_home = tempfile::tempdir().expect("tmp");
+    write_mock_config(codex_home.path(), &mock_ws.uri());
+
+    // WS engine
+    let cfg_toml =
+        codex_core::config::load_config_as_toml_with_cli_overrides(codex_home.path(), vec![])
+            .await
+            .expect("parse config");
+    let config = Config::load_from_base_config_with_overrides(
+        cfg_toml,
+        ConfigOverrides::default(),
+        codex_home.path().to_path_buf(),
+    )
+    .expect("config");
+    let engine = AppServerEngine::new(std::sync::Arc::new(config), None);
+    let addr = spawn_ws(engine).await;
+
+    // WS client flow with approval handling
+    use tokio::time::timeout;
+    use tokio_tungstenite::tungstenite::Message as WsMsg;
+    let url = format!("ws://{addr}/ws");
+    let (mut ws, _resp) = connect_async(url).await.unwrap();
+    // initialize
+    let init = json!({
+        "method": "initialize",
+        "id": 1,
+        "params": { "clientInfo": { "name": "tests", "version": "0.0.0" } }
+    });
+    ws.send(WsMsg::Text(init.to_string().into())).await.unwrap();
+    // new conversation
+    let tmp = tempfile::tempdir().unwrap();
+    let new_conv = json!({
+        "method": "newConversation",
+        "id": 2,
+        "params": { "cwd": tmp.path().to_string_lossy() }
+    });
+    ws.send(WsMsg::Text(new_conv.to_string().into()))
+        .await
+        .unwrap();
+    // capture id
+    let mut conversation_id: Option<String> = None;
+    for _ in 0..50 {
+        if let Ok(Some(Ok(WsMsg::Text(txt)))) = timeout(Duration::from_millis(200), ws.next()).await
+            && let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt)
+            && v.get("id").and_then(serde_json::Value::as_i64) == Some(2)
+        {
+            conversation_id = v
+                .get("result")
+                .and_then(|r| r.get("conversationId"))
+                .and_then(|s| s.as_str())
+                .map(str::to_string);
+            break;
+        }
+    }
+    let conversation_id = conversation_id.expect("cid");
+    // subscribe
+    let subscribe = json!({
+        "method": "addConversationListener",
+        "id": 3,
+        "params": { "conversationId": conversation_id }
+    });
+    ws.send(WsMsg::Text(subscribe.to_string().into()))
+        .await
+        .unwrap();
+    for _ in 0..50 {
+        if let Ok(Some(Ok(WsMsg::Text(txt)))) = timeout(Duration::from_millis(200), ws.next()).await
+            && serde_json::from_str::<serde_json::Value>(&txt)
+                .ok()
+                .and_then(|v| v.get("id").and_then(serde_json::Value::as_i64))
+                == Some(3)
+        {
+            break;
+        }
+    }
+    // sendUserTurn with approval_policy on-request
+    let cid = ConvId::from_string(&conversation_id).unwrap();
+    let turn = RpcSendUserTurnParams {
+        conversation_id: cid,
+        items: vec![codex_app_server_protocol::InputItem::Text {
+            text: "Run shell".to_string(),
+        }],
+        cwd: tmp.path().to_path_buf(),
+        approval_policy: AskForApproval::OnRequest,
+        sandbox_policy: SandboxPolicy::DangerFullAccess,
+        model: "mock-model".into(),
+        effort: Some(ReasoningEffort::Medium),
+        summary: ReasoningSummary::Auto,
+    };
+    let req = RpcRequest {
+        id: RpcRequestId::Integer(4),
+        method: "sendUserTurn".into(),
+        params: Some(serde_json::to_value(&turn).unwrap()),
+    };
+    let wire = serde_json::to_string(&RpcMessage::Request(req)).unwrap();
+    ws.send(WsMsg::Text(wire.into())).await.unwrap();
+    // ack
+    for _ in 0..50 {
+        if let Ok(Some(Ok(WsMsg::Text(txt)))) = timeout(Duration::from_millis(200), ws.next()).await
+            && serde_json::from_str::<serde_json::Value>(&txt)
+                .ok()
+                .and_then(|v| v.get("id").and_then(serde_json::Value::as_i64))
+                == Some(4)
+        {
+            break;
+        }
+    }
+    // Handle approval request and then assert completion
+    let mut saw_task_complete = false;
+    for _ in 0..200 {
+        if let Ok(Some(Ok(WsMsg::Text(txt)))) = timeout(Duration::from_millis(200), ws.next()).await
+            && let Ok(v) = serde_json::from_str::<serde_json::Value>(&txt)
+                && let Some(method) = v.get("method").and_then(|m| m.as_str())
+            {
+                if method == "execCommandApproval" {
+                    let id = v.get("id").cloned().unwrap();
+                    let resp = RpcMessage::Response(codex_app_server_protocol::JSONRPCResponse {
+                        id: serde_json::from_value(id).unwrap(),
+                        result: serde_json::json!({"decision": codex_core::protocol::ReviewDecision::Approved}),
+                    });
+                    ws.send(WsMsg::Text(serde_json::to_string(&resp).unwrap().into()))
+                        .await
+                        .unwrap();
+                } else if method == "codex/event/task_complete" {
+                    saw_task_complete = true;
+                    break;
+                }
+            }
+    }
+    assert!(saw_task_complete, "ws did not complete after approval");
+
+    // In-process flow: expect approval request and approve
+    // Point the in-process run at a fresh mock server
+    write_mock_config(codex_home.path(), &mock_ip.uri());
+    let mut mcp = McpProcess::new(codex_home.path())
+        .await
+        .expect("spawn app-server");
+    tokio::time::timeout(Duration::from_secs(5), mcp.initialize())
+        .await
+        .expect("init timeout")
+        .expect("init ok");
+    let new_id = mcp
+        .send_new_conversation_request(codex_app_server_protocol::NewConversationParams {
+            cwd: Some(tmp.path().to_string_lossy().to_string()),
+            ..Default::default()
+        })
+        .await
+        .expect("send newConv");
+    let new_resp = tokio::time::timeout(
+        Duration::from_secs(5),
+        mcp.read_stream_until_response_message(RpcRequestId::Integer(new_id)),
+    )
+    .await
+    .expect("new timeout")
+    .expect("new resp");
+    let new_conv: codex_app_server_protocol::NewConversationResponse =
+        app_test_support::to_response::<_>(new_resp).expect("parse new conv");
+    let conversation_id = new_conv.conversation_id;
+    // addListener
+    let _ = tokio::time::timeout(Duration::from_secs(5), async {
+        let add_id = mcp
+            .send_add_conversation_listener_request(AddConversationListenerParams {
+                conversation_id,
+            })
+            .await
+            .unwrap();
+        mcp.read_stream_until_response_message(RpcRequestId::Integer(add_id))
+            .await
+    })
+    .await
+    .expect("add timeout")
+    .expect("add resp");
+    // sendUserMessage (policy OnRequest via subsequent turn overrides is cumbersome; use sendUserTurn directly)
+    let turn_id = mcp
+        .send_send_user_turn_request(RpcSendUserTurnParams {
+            conversation_id,
+            items: vec![codex_app_server_protocol::InputItem::Text { text: "run".into() }],
+            cwd: tmp.path().to_path_buf(),
+            approval_policy: AskForApproval::OnRequest,
+            sandbox_policy: SandboxPolicy::DangerFullAccess,
+            model: "mock-model".into(),
+            effort: Some(ReasoningEffort::Medium),
+            summary: ReasoningSummary::Auto,
+        })
+        .await
+        .expect("send turn");
+    let _ = tokio::time::timeout(
+        Duration::from_secs(5),
+        mcp.read_stream_until_response_message(RpcRequestId::Integer(turn_id)),
+    )
+    .await
+    .expect("turn timeout")
+    .expect("turn ack");
+    // Expect approval request
+    let server_req = tokio::time::timeout(
+        Duration::from_secs(5),
+        mcp.read_stream_until_request_message(),
+    )
+    .await
+    .expect("approval timeout")
+    .expect("approval req");
+    if let codex_app_server_protocol::ServerRequest::ExecCommandApproval { request_id, .. } =
+        server_req
+    {
+        mcp.send_response(
+            request_id,
+            serde_json::json!({"decision": codex_core::protocol::ReviewDecision::Approved}),
+        )
+        .await
+        .expect("approve resp");
+    } else {
+        panic!("expected ExecCommandApproval request");
+    }
+    // Expect task_complete
+    let _ = tokio::time::timeout(
+        Duration::from_secs(5),
+        mcp.read_stream_until_notification_message("codex/event/task_complete"),
+    )
+    .await
+    .expect("complete timeout")
+    .expect("complete notif");
+}

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -674,6 +674,21 @@ impl CodexMessageProcessor {
                     session_configured,
                     ..
                 } = conversation_id;
+                // Emit a top-level ServerNotification so late subscribers can still
+                // observe initial configuration without racing the event stream.
+                self.outgoing
+                    .send_server_notification(ServerNotification::SessionConfigured(
+                        SessionConfiguredNotification {
+                            session_id: session_configured.session_id,
+                            model: session_configured.model.clone(),
+                            reasoning_effort: session_configured.reasoning_effort,
+                            history_log_id: session_configured.history_log_id,
+                            history_entry_count: session_configured.history_entry_count,
+                            initial_messages: session_configured.initial_messages.clone(),
+                            rollout_path: session_configured.rollout_path.clone(),
+                        },
+                    ))
+                    .await;
                 let response = NewConversationResponse {
                     conversation_id,
                     model: session_configured.model,

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -28,6 +28,7 @@ mod error_code;
 mod fuzzy_file_search;
 mod message_processor;
 mod outgoing_message;
+pub mod public_api;
 
 /// Size of the bounded channels used to communicate between tasks. The value
 /// is a balance between throughput and memory usage – 128 messages should be
@@ -47,7 +48,7 @@ pub async fn run_main(
 
     // Set up channels.
     let (incoming_tx, mut incoming_rx) = mpsc::channel::<JSONRPCMessage>(CHANNEL_CAPACITY);
-    let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel::<OutgoingMessage>();
+    let (outgoing_tx, mut outgoing_rx) = mpsc::channel::<OutgoingMessage>(CHANNEL_CAPACITY);
 
     // Task: read from stdin, push to `incoming_tx`.
     let stdin_reader_handle = tokio::spawn({

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -48,6 +48,8 @@ pub async fn run_main(
 
     // Set up channels.
     let (incoming_tx, mut incoming_rx) = mpsc::channel::<JSONRPCMessage>(CHANNEL_CAPACITY);
+    // Match the websocket bridge by bounding the outgoing queue; this avoids
+    // unbounded buffering if stdout's reader ever stalls.
     let (outgoing_tx, mut outgoing_rx) = mpsc::channel::<OutgoingMessage>(CHANNEL_CAPACITY);
 
     // Task: read from stdin, push to `incoming_tx`.

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -55,6 +55,30 @@ impl MessageProcessor {
         }
     }
 
+    /// Create a `MessageProcessor` that shares a provided [`AuthManager`] and
+    /// [`ConversationManager`] across multiple connections.
+    pub(crate) fn new_with_shared(
+        outgoing: OutgoingMessageSender,
+        codex_linux_sandbox_exe: Option<PathBuf>,
+        config: Arc<Config>,
+        auth_manager: Arc<AuthManager>,
+        conversation_manager: Arc<ConversationManager>,
+    ) -> Self {
+        let outgoing = Arc::new(outgoing);
+        let codex_message_processor = CodexMessageProcessor::new(
+            auth_manager,
+            conversation_manager,
+            outgoing.clone(),
+            codex_linux_sandbox_exe,
+            config,
+        );
+        Self {
+            outgoing,
+            codex_message_processor,
+            initialized: false,
+        }
+    }
+
     pub(crate) async fn process_request(&mut self, request: JSONRPCRequest) {
         let request_id = request.id.clone();
         if let Ok(request_json) = serde_json::to_value(request)

--- a/codex-rs/app-server/src/outgoing_message.rs
+++ b/codex-rs/app-server/src/outgoing_message.rs
@@ -19,12 +19,12 @@ use crate::error_code::INTERNAL_ERROR_CODE;
 /// Sends messages to the client and manages request callbacks.
 pub(crate) struct OutgoingMessageSender {
     next_request_id: AtomicI64,
-    sender: mpsc::UnboundedSender<OutgoingMessage>,
+    sender: mpsc::Sender<OutgoingMessage>,
     request_id_to_callback: Mutex<HashMap<RequestId, oneshot::Sender<Result>>>,
 }
 
 impl OutgoingMessageSender {
-    pub(crate) fn new(sender: mpsc::UnboundedSender<OutgoingMessage>) -> Self {
+    pub(crate) fn new(sender: mpsc::Sender<OutgoingMessage>) -> Self {
         Self {
             next_request_id: AtomicI64::new(0),
             sender,
@@ -45,8 +45,11 @@ impl OutgoingMessageSender {
         }
 
         let outgoing_message =
-            OutgoingMessage::Request(request.request_with_id(outgoing_message_id));
-        let _ = self.sender.send(outgoing_message);
+            OutgoingMessage::Request(request.request_with_id(outgoing_message_id.clone()));
+        if self.sender.send(outgoing_message).await.is_err() {
+            let mut request_id_to_callback = self.request_id_to_callback.lock().await;
+            request_id_to_callback.remove_entry(&outgoing_message_id);
+        }
         rx_approve
     }
 
@@ -72,7 +75,9 @@ impl OutgoingMessageSender {
         match serde_json::to_value(response) {
             Ok(result) => {
                 let outgoing_message = OutgoingMessage::Response(OutgoingResponse { id, result });
-                let _ = self.sender.send(outgoing_message);
+                if self.sender.send(outgoing_message).await.is_err() {
+                    warn!("failed to enqueue response for client");
+                }
             }
             Err(err) => {
                 self.send_error(
@@ -89,21 +94,30 @@ impl OutgoingMessageSender {
     }
 
     pub(crate) async fn send_server_notification(&self, notification: ServerNotification) {
-        let _ = self
+        if self
             .sender
-            .send(OutgoingMessage::AppServerNotification(notification));
+            .send(OutgoingMessage::AppServerNotification(notification))
+            .await
+            .is_err()
+        {
+            warn!("failed to enqueue server notification for client");
+        }
     }
 
     /// All notifications should be migrated to [`ServerNotification`] and
     /// [`OutgoingMessage::Notification`] should be removed.
     pub(crate) async fn send_notification(&self, notification: OutgoingNotification) {
         let outgoing_message = OutgoingMessage::Notification(notification);
-        let _ = self.sender.send(outgoing_message);
+        if self.sender.send(outgoing_message).await.is_err() {
+            warn!("failed to enqueue notification for client");
+        }
     }
 
     pub(crate) async fn send_error(&self, id: RequestId, error: JSONRPCErrorError) {
         let outgoing_message = OutgoingMessage::Error(OutgoingError { id, error });
-        let _ = self.sender.send(outgoing_message);
+        if self.sender.send(outgoing_message).await.is_err() {
+            warn!("failed to enqueue error for client");
+        }
     }
 }
 

--- a/codex-rs/app-server/src/public_api.rs
+++ b/codex-rs/app-server/src/public_api.rs
@@ -1,0 +1,109 @@
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use crate::message_processor::MessageProcessor;
+use crate::outgoing_message::OutgoingMessage;
+use crate::outgoing_message::OutgoingMessageSender;
+use codex_app_server_protocol::JSONRPCNotification;
+use codex_app_server_protocol::JSONRPCRequest;
+use codex_app_server_protocol::JSONRPCResponse;
+use codex_core::AuthManager;
+use codex_core::ConversationManager;
+use codex_core::config::Config;
+use codex_protocol::protocol::SessionSource;
+
+const OUTGOING_MESSAGE_BUFFER: usize = 128;
+const JSON_MESSAGE_BUFFER: usize = 128;
+
+/// Shared in‑process Codex App Server engine. Holds shared configuration and
+/// creates per‑connection processors that can be driven by a JSON‑RPC transport.
+#[derive(Clone)]
+pub struct AppServerEngine {
+    config: Arc<Config>,
+    codex_linux_sandbox_exe: Option<PathBuf>,
+    auth_manager: Arc<AuthManager>,
+    conversation_manager: Arc<ConversationManager>,
+}
+
+impl AppServerEngine {
+    pub fn new(config: Arc<Config>, codex_linux_sandbox_exe: Option<PathBuf>) -> Self {
+        let auth_manager = AuthManager::shared(config.codex_home.clone(), false);
+        let conversation_manager = Arc::new(ConversationManager::new(
+            auth_manager.clone(),
+            SessionSource::WSRemote,
+        ));
+        Self {
+            config,
+            codex_linux_sandbox_exe,
+            auth_manager,
+            conversation_manager,
+        }
+    }
+
+    /// Create a new logical connection. Returns an [`AppServerConnection`] and
+    /// a bounded receiver of JSON values that should be forwarded to the client.
+    pub fn new_connection(&self) -> (AppServerConnection, mpsc::Receiver<serde_json::Value>) {
+        // Outgoing channel used internally by the message processor.
+        let (tx_outgoing, mut rx_outgoing) =
+            mpsc::channel::<OutgoingMessage>(OUTGOING_MESSAGE_BUFFER);
+        let outgoing_sender = OutgoingMessageSender::new(tx_outgoing);
+
+        // Convert internal OutgoingMessage into JSON values for transport.
+        let (tx_json, rx_json) = mpsc::channel::<serde_json::Value>(JSON_MESSAGE_BUFFER);
+        tokio::spawn(async move {
+            let tx_json = tx_json;
+            while let Some(msg) = rx_outgoing.recv().await {
+                match serde_json::to_value(msg) {
+                    Ok(value) => {
+                        if tx_json.send(value).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(err) => {
+                        // No direct logging here to keep API transport-agnostic.
+                        // Dropping the message is acceptable; client cannot recover it anyway.
+                        if tx_json
+                            .send(serde_json::json!({
+                                "error": format!("failed to serialize outgoing message: {err}"),
+                            }))
+                            .await
+                            .is_err()
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        let processor = MessageProcessor::new_with_shared(
+            outgoing_sender,
+            self.codex_linux_sandbox_exe.clone(),
+            self.config.clone(),
+            self.auth_manager.clone(),
+            self.conversation_manager.clone(),
+        );
+        let conn = AppServerConnection { processor };
+        (conn, rx_json)
+    }
+}
+
+/// A per‑transport connection that processes JSON‑RPC messages and enqueues
+/// outgoing responses/notifications/requests on the provided channel.
+pub struct AppServerConnection {
+    processor: MessageProcessor,
+}
+
+impl AppServerConnection {
+    pub async fn process_request(&mut self, request: JSONRPCRequest) {
+        self.processor.process_request(request).await;
+    }
+    pub async fn process_notification(&self, notification: JSONRPCNotification) {
+        self.processor.process_notification(notification).await;
+    }
+    pub async fn process_response(&mut self, response: JSONRPCResponse) {
+        self.processor.process_response(response).await;
+    }
+}

--- a/codex-rs/core/src/rollout/mod.rs
+++ b/codex-rs/core/src/rollout/mod.rs
@@ -4,8 +4,11 @@ use codex_protocol::protocol::SessionSource;
 
 pub const SESSIONS_SUBDIR: &str = "sessions";
 pub const ARCHIVED_SESSIONS_SUBDIR: &str = "archived_sessions";
-pub const INTERACTIVE_SESSION_SOURCES: &[SessionSource] =
-    &[SessionSource::Cli, SessionSource::VSCode];
+pub const INTERACTIVE_SESSION_SOURCES: &[SessionSource] = &[
+    SessionSource::Cli,
+    SessionSource::VSCode,
+    SessionSource::WSRemote,
+];
 
 pub mod list;
 pub(crate) mod policy;

--- a/codex-rs/justfile
+++ b/codex-rs/justfile
@@ -42,6 +42,14 @@ install:
 test:
     cargo nextest run --no-fail-fast
 
+# Fast, targeted tests for the new WS server and in-process engine
+test-ws:
+    cargo test -p codex-app-server-ws -- --nocapture
+
+# Targeted tests for app-server (JSON-RPC) without running the whole workspace
+test-app-server:
+    cargo test -p codex-app-server -- --nocapture
+
 # Run the MCP server
 mcp-server-run *args:
     cargo run -p codex-mcp-server -- "$@"

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -959,6 +959,7 @@ pub enum SessionSource {
     Cli,
     #[default]
     VSCode,
+    WSRemote,
     Exec,
     Mcp,
     #[serde(other)]


### PR DESCRIPTION
# Why
After long desktop sessions we’d like to walk away, open an iPhone, and keep editing—dictating or finishing tasks without losing momentum. As the models mature we rely less and less on full feature code editors on desktop,  I believe that working entirely from a mobile device is finally realistic. 

 # What
This PR delivers part one of that effort: a WebSocket bridge that lets any remote client speak directly to the Codex JSON-RPC API. The AppSeerver 
<img width="372" height="338" alt="Screenshot 2025-10-15 at 00 44 23" src="https://github.com/user-attachments/assets/fb447897-c91d-4c95-80c7-54cbbdd62c8b" />

I already developed an iOS app that mirrors most TUI functionality: 
<img width="250"  alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-15 at 01 04 14" src="https://github.com/user-attachments/assets/93f13386-dc52-4151-8292-352b672bb3f2" />
<img width="250" alt="Simulator Screenshot - iPhone 16 Pro - 2025-10-15 at 01 13 44" src="https://github.com/user-attachments/assets/4d902b65-629c-45a0-a21a-48dc028cad5b" />

Part  three is to connect the TUI through the same bridge so all clients share the exact same live session. it would be as simple as add -r(--remote-access) to cli command. 


 # How
Adds the codex-app-server-ws binary, which exposes the existing JSON-RPC server over WebSocket, along with the supporting architecture and documentation (REMOTE_ACCESS.md). Remote clients reuse the in-process AppServerEngine, so sessions and auth state stay unified across desktop and mobile.

# Test
  - cargo test -p codex-app-server-ws
  - cargo test -p codex-app-server
  - cargo test --all-features

