### PR TITLE
fix(client): add support to force forwarding Responses API's reasoning IDs

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -923,6 +923,8 @@ pub struct ConfigToml {
     /// OTEL configuration.
     pub otel: Option<crate::config_types::OtelConfigToml>,
 
+    pub force_responses_api_store: Option<bool>,
+
     /// Tracks whether the Windows onboarding screen has been acknowledged.
     pub windows_wsl_setup_acknowledged: Option<bool>,
 
@@ -2708,6 +2710,7 @@ model_verbosity = "high"
             base_url: Some("https://api.openai.com/v1".to_string()),
             env_key: Some("OPENAI_API_KEY".to_string()),
             wire_api: crate::WireApi::Chat,
+            force_responses_api_store_reasoning_ids: None,
             env_key_instructions: None,
             query_params: None,
             http_headers: None,

--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -923,8 +923,6 @@ pub struct ConfigToml {
     /// OTEL configuration.
     pub otel: Option<crate::config_types::OtelConfigToml>,
 
-    pub force_responses_api_store: Option<bool>,
-
     /// Tracks whether the Windows onboarding screen has been acknowledged.
     pub windows_wsl_setup_acknowledged: Option<bool>,
 

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -57,6 +57,10 @@ pub struct ModelProviderInfo {
     #[serde(default)]
     pub wire_api: WireApi,
 
+    // Optional flag to force the storing reasoning IDs in the response. This workaround
+    // is necessary to make codex work in some proxies like Azure and litellm.
+    pub force_responses_api_store_reasoning_ids: Option<bool>,
+
     /// Optional query parameters to append to the base URL.
     pub query_params: Option<HashMap<String, String>>,
 
@@ -275,6 +279,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
                 env_key: None,
                 env_key_instructions: None,
                 wire_api: WireApi::Responses,
+                force_responses_api_store_reasoning_ids: Some(false),
                 query_params: None,
                 http_headers: Some(
                     [("version".to_string(), env!("CARGO_PKG_VERSION").to_string())]
@@ -334,6 +339,7 @@ pub fn create_oss_provider_with_base_url(base_url: &str) -> ModelProviderInfo {
         env_key: None,
         env_key_instructions: None,
         wire_api: WireApi::Chat,
+        force_responses_api_store_reasoning_ids: None,
         query_params: None,
         http_headers: None,
         env_http_headers: None,
@@ -373,6 +379,7 @@ base_url = "http://localhost:11434/v1"
             env_key: None,
             env_key_instructions: None,
             wire_api: WireApi::Chat,
+            force_responses_api_store_reasoning_ids: None,
             query_params: None,
             http_headers: None,
             env_http_headers: None,
@@ -400,6 +407,7 @@ query_params = { api-version = "2025-04-01-preview" }
             env_key: Some("AZURE_OPENAI_API_KEY".into()),
             env_key_instructions: None,
             wire_api: WireApi::Chat,
+            force_responses_api_store_reasoning_ids: None,
             query_params: Some(maplit::hashmap! {
                 "api-version".to_string() => "2025-04-01-preview".to_string(),
             }),
@@ -430,6 +438,7 @@ env_http_headers = { "X-Example-Env-Header" = "EXAMPLE_ENV_VAR" }
             env_key: Some("API_KEY".into()),
             env_key_instructions: None,
             wire_api: WireApi::Chat,
+            force_responses_api_store_reasoning_ids: None,
             query_params: None,
             http_headers: Some(maplit::hashmap! {
                 "X-Example-Header".to_string() => "example-value".to_string(),
@@ -456,6 +465,7 @@ env_http_headers = { "X-Example-Env-Header" = "EXAMPLE_ENV_VAR" }
                 env_key: None,
                 env_key_instructions: None,
                 wire_api: WireApi::Responses,
+                force_responses_api_store_reasoning_ids: None,
                 query_params: None,
                 http_headers: None,
                 env_http_headers: None,
@@ -488,6 +498,7 @@ env_http_headers = { "X-Example-Env-Header" = "EXAMPLE_ENV_VAR" }
             env_key: None,
             env_key_instructions: None,
             wire_api: WireApi::Responses,
+            force_responses_api_store_reasoning_ids: None,
             query_params: None,
             http_headers: None,
             env_http_headers: None,

--- a/codex-rs/core/tests/chat_completions_payload.rs
+++ b/codex-rs/core/tests/chat_completions_payload.rs
@@ -51,6 +51,7 @@ async fn run_request(input: Vec<ResponseItem>) -> Value {
         env_key: None,
         env_key_instructions: None,
         wire_api: WireApi::Chat,
+        force_responses_api_store_reasoning_ids: None,
         query_params: None,
         http_headers: None,
         env_http_headers: None,

--- a/codex-rs/core/tests/chat_completions_sse.rs
+++ b/codex-rs/core/tests/chat_completions_sse.rs
@@ -50,6 +50,7 @@ async fn run_stream_with_bytes(sse_body: &[u8]) -> Vec<ResponseEvent> {
         env_key: None,
         env_key_instructions: None,
         wire_api: WireApi::Chat,
+        force_responses_api_store_reasoning_ids: None,
         query_params: None,
         http_headers: None,
         env_http_headers: None,

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -39,6 +39,7 @@ async fn responses_stream_includes_task_type_header() {
         env_key: None,
         env_key_instructions: None,
         wire_api: WireApi::Responses,
+        force_responses_api_store_reasoning_ids: None,
         query_params: None,
         http_headers: None,
         env_http_headers: None,

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -633,6 +633,7 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
         env_key: None,
         env_key_instructions: None,
         wire_api: WireApi::Responses,
+        force_responses_api_store_reasoning_ids: None,
         query_params: None,
         http_headers: None,
         env_http_headers: None,
@@ -1116,6 +1117,7 @@ async fn azure_overrides_assign_properties_used_for_responses_url() {
         )])),
         env_key_instructions: None,
         wire_api: WireApi::Responses,
+        force_responses_api_store_reasoning_ids: None,
         http_headers: Some(std::collections::HashMap::from([(
             "Custom-Header".to_string(),
             "Value".to_string(),
@@ -1193,6 +1195,7 @@ async fn env_var_overrides_loaded_auth() {
         )])),
         env_key_instructions: None,
         wire_api: WireApi::Responses,
+        force_responses_api_store_reasoning_ids: None,
         http_headers: Some(std::collections::HashMap::from([(
             "Custom-Header".to_string(),
             "Value".to_string(),

--- a/codex-rs/core/tests/suite/stream_error_allows_next_turn.rs
+++ b/codex-rs/core/tests/suite/stream_error_allows_next_turn.rs
@@ -67,6 +67,7 @@ async fn continue_after_stream_error() {
         env_key: Some("PATH".into()),
         env_key_instructions: None,
         wire_api: WireApi::Responses,
+        force_responses_api_store_reasoning_ids: None,
         query_params: None,
         http_headers: None,
         env_http_headers: None,

--- a/codex-rs/core/tests/suite/stream_no_completed.rs
+++ b/codex-rs/core/tests/suite/stream_no_completed.rs
@@ -74,6 +74,7 @@ async fn retries_on_early_close() {
         env_key: Some("PATH".into()),
         env_key_instructions: None,
         wire_api: WireApi::Responses,
+        force_responses_api_store_reasoning_ids: None,
         query_params: None,
         http_headers: None,
         env_http_headers: None,

--- a/docs/config.md
+++ b/docs/config.md
@@ -116,7 +116,20 @@ wire_api = "responses"
 
 Export your key before launching Codex: `export AZURE_OPENAI_API_KEY=…`
 
-#### Per-provider network tuning
+### Responses API's reasoning format
+Some providers/proxies like litellm require the Response API's reasoning IDs in the payload. You can force this through _force_responses_api_store_reasoning_ids_. Default is `false`.
+
+```toml
+[model_providers.custom]
+name = "custom"
+base_url = "<CUSTOM_BASE_URL>"
+env_key = "CUSTOM_API_KEY"
+wire_api = "responses"
+# this config forwards Response API's reasoning IDs
+force_responses_api_store_reasoning_ids = true
+```
+
+### Per-provider network tuning
 
 The following optional settings control retry behaviour and streaming idle timeouts **per model provider**. They must be specified inside the corresponding `[model_providers.<id>]` block in `config.toml`. (Older releases accepted top‑level keys; those are now ignored.)
 
@@ -858,7 +871,8 @@ notifications = [ "agent-turn-complete", "approval-requested" ]
 | `model_providers.<id>.name`                      | string                                                            | Display name.                                                                                                              |
 | `model_providers.<id>.base_url`                  | string                                                            | API base URL.                                                                                                              |
 | `model_providers.<id>.env_key`                   | string                                                            | Env var for API key.                                                                                                       |
-| `model_providers.<id>.wire_api`                  | `chat` \| `responses`                                             | Protocol used (default: `chat`).                                                                                           |
+| `model_providers.<id>.wire_api`                  | `chat` \| `responses`                                                 | Protocol used (default: `chat`).                                                                                           |
+| `model_providers.<id>.force_responses_api_store_reasoning_ids`   | boolean                                           | Force forwarding the Responses API's reasoning IDs. (default: `false`).                                                                                           |
 | `model_providers.<id>.query_params`              | map<string,string>                                                | Extra query params (e.g., Azure `api-version`).                                                                            |
 | `model_providers.<id>.http_headers`              | map<string,string>                                                | Additional static headers.                                                                                                 |
 | `model_providers.<id>.env_http_headers`          | map<string,string>                                                | Headers sourced from env vars.                                                                                             |

--- a/docs/config.md
+++ b/docs/config.md
@@ -116,7 +116,7 @@ wire_api = "responses"
 
 Export your key before launching Codex: `export AZURE_OPENAI_API_KEY=…`
 
-### Responses API's reasoning format
+#### Responses API's reasoning format
 Some providers/proxies like litellm require the Response API's reasoning IDs in the payload. You can force this through _force_responses_api_store_reasoning_ids_. Default is `false`.
 
 ```toml


### PR DESCRIPTION
# Summary

- fix #3451
- introduces a new configuration option `force_responses_api_store_reasoning_ids` to work around issues with certain providers (like Azure and litellm) that reject `store: false` in Responses API requests. Without this, enterprises that run litellm as a proxy cannot use Responses API models. When enabled, this preserves reasoning item IDs in the request payload. 
- Before this, the only fix, as mentioned in the issue is naming the provider as "Azure", even if the provider is not Azure.
- Documentation updated accordingly to include these changes.

# Testing

- To repro the bug, in litellm proxies, just try to use codex with any model in OpenAI using the Responses API. A similar result will show up
<img width="1910" height="709" alt="Screenshot 2025-10-15 at 12 25 37" src="https://github.com/user-attachments/assets/5cadb6e3-5810-47a5-a557-f882a8b76d98" />
- To see the fix working, just add the <code>force_responses_api_store_reasoning_ids = true</code> in the <code>[model_providers.ID]</code>



