### PR TITLE
chore: standardize on ParsedCommand from codex_protocol

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -856,10 +856,7 @@ impl Session {
                 call_id,
                 command: command_for_display.clone(),
                 cwd,
-                parsed_cmd: parse_command(&command_for_display)
-                    .into_iter()
-                    .map(Into::into)
-                    .collect(),
+                parsed_cmd: parse_command(&command_for_display),
             }),
         };
         let event = Event {

--- a/codex-rs/core/src/parse_command.rs
+++ b/codex-rs/core/src/parse_command.rs
@@ -1,43 +1,8 @@
 use crate::bash::try_parse_bash;
 use crate::bash::try_parse_word_only_commands_sequence;
-use serde::Deserialize;
-use serde::Serialize;
+use codex_protocol::parse_command::ParsedCommand;
 use shlex::split as shlex_split;
 use shlex::try_join as shlex_try_join;
-
-#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
-pub enum ParsedCommand {
-    Read {
-        cmd: String,
-        name: String,
-    },
-    ListFiles {
-        cmd: String,
-        path: Option<String>,
-    },
-    Search {
-        cmd: String,
-        query: Option<String>,
-        path: Option<String>,
-    },
-    Unknown {
-        cmd: String,
-    },
-}
-
-// Convert core's parsed command enum into the protocol's simplified type so
-// events can carry the canonical representation across process boundaries.
-impl From<ParsedCommand> for codex_protocol::parse_command::ParsedCommand {
-    fn from(v: ParsedCommand) -> Self {
-        use codex_protocol::parse_command::ParsedCommand as P;
-        match v {
-            ParsedCommand::Read { cmd, name } => P::Read { cmd, name },
-            ParsedCommand::ListFiles { cmd, path } => P::ListFiles { cmd, path },
-            ParsedCommand::Search { cmd, query, path } => P::Search { cmd, query, path },
-            ParsedCommand::Unknown { cmd } => P::Unknown { cmd },
-        }
-    }
-}
 
 fn shlex_join(tokens: &[String]) -> String {
     shlex_try_join(tokens.iter().map(String::as_str))

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -505,10 +505,7 @@ fn begin_exec(chat: &mut ChatWidget, call_id: &str, raw_cmd: &str) {
     // Build the full command vec and parse it using core's parser,
     // then convert to protocol variants for the event payload.
     let command = vec!["bash".to_string(), "-lc".to_string(), raw_cmd.to_string()];
-    let parsed_cmd: Vec<ParsedCommand> = codex_core::parse_command::parse_command(&command)
-        .into_iter()
-        .map(Into::into)
-        .collect();
+    let parsed_cmd: Vec<ParsedCommand> = codex_core::parse_command::parse_command(&command);
     chat.handle_codex_event(Event {
         id: call_id.to_string(),
         msg: EventMsg::ExecCommandBegin(ExecCommandBeginEvent {
@@ -1205,10 +1202,7 @@ async fn binary_size_transcript_snapshot() {
                                     call_id: e.call_id.clone(),
                                     command: e.command,
                                     cwd: e.cwd,
-                                    parsed_cmd: parsed_cmd
-                                        .into_iter()
-                                        .map(std::convert::Into::into)
-                                        .collect(),
+                                    parsed_cmd,
                                 }),
                             }
                         }
@@ -2241,17 +2235,15 @@ fn chatwidget_exec_and_status_layout_vt100_snapshot() {
             command: vec!["bash".into(), "-lc".into(), "rg \"Change Approved\"".into()],
             cwd: std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
             parsed_cmd: vec![
-                codex_core::parse_command::ParsedCommand::Search {
+                ParsedCommand::Search {
                     query: Some("Change Approved".into()),
                     path: None,
                     cmd: "rg \"Change Approved\"".into(),
-                }
-                .into(),
-                codex_core::parse_command::ParsedCommand::Read {
+                },
+                ParsedCommand::Read {
                     name: "diff_render.rs".into(),
                     cmd: "cat diff_render.rs".into(),
-                }
-                .into(),
+                },
             ],
         }),
     });


### PR DESCRIPTION
Note these two types were identical, so it seems clear to standardize on the one in `codex_protocol` and eliminate the `Into` stuff.


---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/5218).
* #5222
* __->__ #5218