### PR TITLE
Make file search case-insensitive

### DIFF
--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -49,7 +49,7 @@ To run Codex non-interactively, run `codex exec PROMPT` (you can also pass the p
 
 ### Use `@` for file search
 
-Typing `@` triggers a fuzzy-filename search over the workspace root. Use up/down to select among the results and Tab or Enter to replace the `@` with the selected path. You can use Esc to cancel the search.
+Typing `@` triggers a case-insensitive fuzzy-filename search over the workspace root. Use up/down to select among the results and Tab or Enter to replace the `@` with the selected path. You can use Esc to cancel the search.
 
 ### Esc–Esc to edit a previous message
 

--- a/codex-rs/file-search/src/lib.rs
+++ b/codex-rs/file-search/src/lib.rs
@@ -380,7 +380,7 @@ fn create_worker_count(num_workers: NonZero<usize>) -> WorkerCount {
 fn create_pattern(pattern: &str) -> Pattern {
     Pattern::new(
         pattern,
-        CaseMatching::Smart,
+        CaseMatching::Ignore,
         Normalization::Smart,
         AtomKind::Fuzzy,
     )
@@ -419,5 +419,15 @@ mod tests {
         ];
 
         assert_eq!(matches, expected);
+    }
+
+    #[test]
+    fn matcher_is_case_insensitive() {
+        let pattern = create_pattern("hello");
+        let mut matcher = Matcher::new(nucleo_matcher::Config::DEFAULT);
+        let mut utf32buf = Vec::<char>::new();
+        let haystack = Utf32Str::new("Sources/HelloWorld.swift", &mut utf32buf);
+
+        assert!(pattern.score(haystack, &mut matcher).is_some());
     }
 }


### PR DESCRIPTION
Addresses #3876 and #5219. Neither have a ton of conversation (the former being about a month old) but it seems like a very uncontroversial change.

Also added a test to show this behavior which will show it failing before. Test succeeeds. README was also updated to reflect this minor change. All `cargo` checks passed.

## What

Right now file search is set to be "smart" which means if you have any capitalizations anywhere else in your file search prompt you have to get perfect capitalization in your @ file search shortcut otherwise nothing is found. 

## Why

Getting capitalization right is irrelevant to file search and is contrary to how most other CLI and modern UX patterns work (Spotlight search on macOS). Currently if you type a prompt like:

> Give an overview of this project, focusing on @Contenview.swi

That will not work as you started your search with a capitalization, so unless you perfectly capitalize "ContentView.s" it will not autocomplete. Also I not realize that the initial capitalization is what broke the search until I made this PR (which speaks to the behavior being not very discoverable).

I don't think starting the search with a capital for whatever reason should make you have to capitalize everything else in the rest of the search perfectly. Again see Spotlight on Mac, or any web browser (if I type `Chatg` it will still autocomplete `chatgpt.com`)

## How

Changes Nucleo's case matching: https://docs.rs/nucleo-matcher/latest/nucleo_matcher/pattern/enum.CaseMatching.html