### PR TITLE
fix(command_safety): git checkout should ask user

### DIFF
--- a/codex-rs/core/src/command_safety/is_dangerous_command.rs
+++ b/codex-rs/core/src/command_safety/is_dangerous_command.rs
@@ -22,7 +22,10 @@ fn is_dangerous_to_call_with_exec(command: &[String]) -> bool {
 
     match cmd0 {
         Some(cmd) if cmd.ends_with("git") || cmd.ends_with("/git") => {
-            matches!(command.get(1).map(String::as_str), Some("reset" | "rm" | "checkout"))
+            matches!(
+                command.get(1).map(String::as_str),
+                Some("reset" | "rm" | "checkout")
+            )
         }
 
         Some("rm") => matches!(command.get(1).map(String::as_str), Some("-f" | "-rf")),

--- a/codex-rs/core/src/command_safety/is_dangerous_command.rs
+++ b/codex-rs/core/src/command_safety/is_dangerous_command.rs
@@ -22,7 +22,7 @@ fn is_dangerous_to_call_with_exec(command: &[String]) -> bool {
 
     match cmd0 {
         Some(cmd) if cmd.ends_with("git") || cmd.ends_with("/git") => {
-            matches!(command.get(1).map(String::as_str), Some("reset" | "rm"))
+            matches!(command.get(1).map(String::as_str), Some("reset" | "rm" | "checkout"))
         }
 
         Some("rm") => matches!(command.get(1).map(String::as_str), Some("-f" | "-rf")),


### PR DESCRIPTION
Since `git checkout` can cause data loss if user hasn't checked in their current changes (e.g. `git checkout -- .`) this change adds a check to ensure we ask user for approval before running that command.