### PR TITLE
Exposes `final_output_json_schema` through the app-server protocol

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1015,6 +1015,7 @@ impl CodexMessageProcessor {
             model,
             effort,
             summary,
+            final_output_json_schema,
         } = params;
 
         let Ok(conversation) = self
@@ -1049,7 +1050,7 @@ impl CodexMessageProcessor {
                 model,
                 effort,
                 summary,
-                final_output_json_schema: None,
+                final_output_json_schema,
             })
             .await;
 

--- a/codex-rs/app-server/tests/suite/codex_message_processor_flow.rs
+++ b/codex-rs/app-server/tests/suite/codex_message_processor_flow.rs
@@ -345,6 +345,7 @@ async fn test_send_user_turn_changes_approval_policy_behavior() {
             model: "mock-model".to_string(),
             effort: Some(ReasoningEffort::Medium),
             summary: ReasoningSummary::Auto,
+            final_output_json_schema: None,
         })
         .await
         .expect("send sendUserTurn");
@@ -483,6 +484,7 @@ async fn test_send_user_turn_updates_sandbox_and_cwd_between_turns() {
             model: model.clone(),
             effort: Some(ReasoningEffort::Medium),
             summary: ReasoningSummary::Auto,
+            final_output_json_schema: None,
         })
         .await
         .expect("send first sendUserTurn");
@@ -513,6 +515,7 @@ async fn test_send_user_turn_updates_sandbox_and_cwd_between_turns() {
             model: model.clone(),
             effort: Some(ReasoningEffort::Medium),
             summary: ReasoningSummary::Auto,
+            final_output_json_schema: None,
         })
         .await
         .expect("send second sendUserTurn");


### PR DESCRIPTION
Changes

  - Added the optional final_output_json_schema field to the app-server protocol’s user-turn payload so callers can supply
    a JSON schema with each turn (app-server-protocol/src/protocol.rs:543).
  - Plumbed the new field through the app server so the conversation submission passes the schema down to core when
    present (app-server/src/codex_message_processor.rs:1008).
  - Expanded the send-user-turn flow tests to populate the new field explicitly, keeping existing behavioural
    assertions intact (app-server/tests/suite/codex_message_processor_flow.rs:337, app-server/tests/suite/
    codex_message_processor_flow.rs:470, app-server/tests/suite/codex_message_processor_flow.rs:506).
  - Added focused protocol serialization tests that confirm the schema is emitted only when provided (app-server-protocol/
    src/protocol.rs:935, app-server-protocol/src/protocol.rs:965).