### PR TITLE
Add codex setup-token command

### DIFF
--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -187,7 +187,7 @@ pub async fn run_logout(cli_config_overrides: CliConfigOverrides) -> ! {
     }
 }
 
-async fn load_config_or_exit(cli_config_overrides: CliConfigOverrides) -> Config {
+pub(crate) async fn load_config_or_exit(cli_config_overrides: CliConfigOverrides) -> Config {
     let cli_overrides = match cli_config_overrides.parse_overrides() {
         Ok(v) => v,
         Err(e) => {

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -25,8 +25,10 @@ use std::path::PathBuf;
 use supports_color::Stream;
 
 mod mcp_cmd;
+mod setup_token;
 
 use crate::mcp_cmd::McpCli;
+use crate::setup_token::run_setup_token;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
 
@@ -70,6 +72,10 @@ enum Subcommand {
 
     /// Remove stored authentication credentials.
     Logout(LogoutCommand),
+
+    /// Ensure credentials exist and print the contents of auth.json.
+    #[clap(name = "setup-token")]
+    SetupToken(SetupTokenCommand),
 
     /// [experimental] Run Codex as an MCP server and manage MCP servers.
     Mcp(McpCli),
@@ -195,6 +201,12 @@ enum LoginSubcommand {
 
 #[derive(Debug, Parser)]
 struct LogoutCommand {
+    #[clap(skip)]
+    config_overrides: CliConfigOverrides,
+}
+
+#[derive(Debug, Parser)]
+struct SetupTokenCommand {
     #[clap(skip)]
     config_overrides: CliConfigOverrides,
 }
@@ -428,6 +440,13 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
                 root_config_overrides.clone(),
             );
             run_logout(logout_cli.config_overrides).await;
+        }
+        Some(Subcommand::SetupToken(mut setup_token_cli)) => {
+            prepend_config_flags(
+                &mut setup_token_cli.config_overrides,
+                root_config_overrides.clone(),
+            );
+            run_setup_token(setup_token_cli.config_overrides).await;
         }
         Some(Subcommand::Completion(completion_cli)) => {
             print_completion(completion_cli);

--- a/codex-rs/cli/src/setup_token.rs
+++ b/codex-rs/cli/src/setup_token.rs
@@ -1,0 +1,64 @@
+use std::io::ErrorKind;
+use std::path::Path;
+
+use codex_common::CliConfigOverrides;
+use codex_core::CodexAuth;
+
+use crate::login::load_config_or_exit;
+use crate::login::login_with_chatgpt;
+
+pub async fn run_setup_token(cli_config_overrides: CliConfigOverrides) -> ! {
+    let config = load_config_or_exit(cli_config_overrides).await;
+    let auth_path = codex_core::auth::get_auth_file(&config.codex_home);
+
+    match has_login(&config.codex_home) {
+        Ok(true) => {
+            if let Err(err) = print_auth_json(&auth_path) {
+                eprintln!(
+                    "Failed to read existing auth.json at {}: {err}",
+                    auth_path.display()
+                );
+                std::process::exit(1);
+            }
+            std::process::exit(0);
+        }
+        Ok(false) => {}
+        Err(err) => {
+            eprintln!(
+                "Failed to inspect auth.json at {}: {err}",
+                auth_path.display()
+            );
+            std::process::exit(1);
+        }
+    }
+
+    if let Err(err) = login_with_chatgpt(config.codex_home.clone()).await {
+        eprintln!("Error during login: {err}");
+        std::process::exit(1);
+    }
+
+    if let Err(err) = print_auth_json(&auth_path) {
+        eprintln!(
+            "Failed to read auth.json after login at {}: {err}",
+            auth_path.display()
+        );
+        std::process::exit(1);
+    }
+
+    std::process::exit(0);
+}
+
+fn has_login(codex_home: &Path) -> std::io::Result<bool> {
+    match CodexAuth::from_codex_home(codex_home) {
+        Ok(Some(_)) => Ok(true),
+        Ok(None) => Ok(false),
+        Err(err) if err.kind() == ErrorKind::NotFound => Ok(false),
+        Err(err) => Err(err),
+    }
+}
+
+fn print_auth_json(auth_path: &Path) -> std::io::Result<()> {
+    let contents = std::fs::read_to_string(auth_path)?;
+    print!("{contents}");
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `codex setup-token` command that checks login and prints auth.json
- reuse existing config loader and login helper

## Testing
- just fmt
- cargo test -p codex-cli _(fails: No space left on device)_
- just fix -p codex-cli _(not run: waiting on additional disk space)_