### PR TITLE
[MCP] Allow specifying custom headers with streamable http servers

### DIFF
--- a/codex-rs/cli/tests/mcp_add_remove.rs
+++ b/codex-rs/cli/tests/mcp_add_remove.rs
@@ -112,9 +112,13 @@ async fn add_streamable_http_without_manual_token() -> Result<()> {
         McpServerTransportConfig::StreamableHttp {
             url,
             bearer_token_env_var,
+            http_headers,
+            env_http_headers,
         } => {
             assert_eq!(url, "https://example.com/mcp");
             assert!(bearer_token_env_var.is_none());
+            assert!(http_headers.is_none());
+            assert!(env_http_headers.is_none());
         }
         other => panic!("unexpected transport: {other:?}"),
     }
@@ -150,9 +154,13 @@ async fn add_streamable_http_with_custom_env_var() -> Result<()> {
         McpServerTransportConfig::StreamableHttp {
             url,
             bearer_token_env_var,
+            http_headers,
+            env_http_headers,
         } => {
             assert_eq!(url, "https://example.com/issues");
             assert_eq!(bearer_token_env_var.as_deref(), Some("GITHUB_TOKEN"));
+            assert!(http_headers.is_none());
+            assert!(env_http_headers.is_none());
         }
         other => panic!("unexpected transport: {other:?}"),
     }

--- a/codex-rs/core/src/config_types.rs
+++ b/codex-rs/core/src/config_types.rs
@@ -49,6 +49,10 @@ impl<'de> Deserialize<'de> for McpServerConfig {
             args: Option<Vec<String>>,
             #[serde(default)]
             env: Option<HashMap<String, String>>,
+            #[serde(default)]
+            http_headers: Option<HashMap<String, String>>,
+            #[serde(default)]
+            env_http_headers: Option<HashMap<String, String>>,
 
             url: Option<String>,
             bearer_token: Option<String>,
@@ -94,6 +98,8 @@ impl<'de> Deserialize<'de> for McpServerConfig {
                 env,
                 url,
                 bearer_token_env_var,
+                http_headers,
+                env_http_headers,
                 ..
             } => {
                 throw_if_set("stdio", "url", url.as_ref())?;
@@ -102,6 +108,8 @@ impl<'de> Deserialize<'de> for McpServerConfig {
                     "bearer_token_env_var",
                     bearer_token_env_var.as_ref(),
                 )?;
+                throw_if_set("stdio", "http_headers", http_headers.as_ref())?;
+                throw_if_set("stdio", "env_http_headers", env_http_headers.as_ref())?;
                 McpServerTransportConfig::Stdio {
                     command,
                     args: args.unwrap_or_default(),
@@ -115,6 +123,8 @@ impl<'de> Deserialize<'de> for McpServerConfig {
                 command,
                 args,
                 env,
+                http_headers,
+                env_http_headers,
                 ..
             } => {
                 throw_if_set("streamable_http", "command", command.as_ref())?;
@@ -124,6 +134,8 @@ impl<'de> Deserialize<'de> for McpServerConfig {
                 McpServerTransportConfig::StreamableHttp {
                     url,
                     bearer_token_env_var,
+                    http_headers,
+                    env_http_headers,
                 }
             }
             _ => return Err(SerdeError::custom("invalid transport")),
@@ -161,6 +173,12 @@ pub enum McpServerTransportConfig {
         /// The actual secret value must be provided via the environment.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         bearer_token_env_var: Option<String>,
+        /// Additional HTTP headers to include in requests to this server.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        http_headers: Option<HashMap<String, String>>,
+        /// HTTP headers where the value is sourced from an environment variable.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        env_http_headers: Option<HashMap<String, String>>,
     },
 }
 
@@ -543,7 +561,9 @@ mod tests {
             cfg.transport,
             McpServerTransportConfig::StreamableHttp {
                 url: "https://example.com/mcp".to_string(),
-                bearer_token_env_var: None
+                bearer_token_env_var: None,
+                http_headers: None,
+                env_http_headers: None,
             }
         );
         assert!(cfg.enabled);
@@ -563,10 +583,37 @@ mod tests {
             cfg.transport,
             McpServerTransportConfig::StreamableHttp {
                 url: "https://example.com/mcp".to_string(),
-                bearer_token_env_var: Some("GITHUB_TOKEN".to_string())
+                bearer_token_env_var: Some("GITHUB_TOKEN".to_string()),
+                http_headers: None,
+                env_http_headers: None,
             }
         );
         assert!(cfg.enabled);
+    }
+
+    #[test]
+    fn deserialize_streamable_http_server_config_with_headers() {
+        let cfg: McpServerConfig = toml::from_str(
+            r#"
+            url = "https://example.com/mcp"
+            http_headers = { "X-Foo" = "bar" }
+            env_http_headers = { "X-Token" = "TOKEN_ENV" }
+        "#,
+        )
+        .expect("should deserialize http config with headers");
+
+        assert_eq!(
+            cfg.transport,
+            McpServerTransportConfig::StreamableHttp {
+                url: "https://example.com/mcp".to_string(),
+                bearer_token_env_var: None,
+                http_headers: Some(HashMap::from([("X-Foo".to_string(), "bar".to_string())])),
+                env_http_headers: Some(HashMap::from([(
+                    "X-Token".to_string(),
+                    "TOKEN_ENV".to_string()
+                )])),
+            }
+        );
     }
 
     #[test]
@@ -589,6 +636,25 @@ mod tests {
         "#,
         )
         .expect_err("should reject env for http transport");
+    }
+
+    #[test]
+    fn deserialize_rejects_headers_for_stdio() {
+        toml::from_str::<McpServerConfig>(
+            r#"
+            command = "echo"
+            http_headers = { "X-Foo" = "bar" }
+        "#,
+        )
+        .expect_err("should reject http_headers for stdio transport");
+
+        toml::from_str::<McpServerConfig>(
+            r#"
+            command = "echo"
+            env_http_headers = { "X-Foo" = "BAR_ENV" }
+        "#,
+        )
+        .expect_err("should reject env_http_headers for stdio transport");
     }
 
     #[test]

--- a/codex-rs/core/src/mcp/auth.rs
+++ b/codex-rs/core/src/mcp/auth.rs
@@ -45,11 +45,15 @@ async fn compute_auth_status(
         McpServerTransportConfig::StreamableHttp {
             url,
             bearer_token_env_var,
+            http_headers,
+            env_http_headers,
         } => {
             determine_streamable_http_auth_status(
                 server_name,
                 url,
                 bearer_token_env_var.as_deref(),
+                http_headers.clone(),
+                env_http_headers.clone(),
                 store_mode,
             )
             .await

--- a/codex-rs/core/tests/suite/rmcp_client.rs
+++ b/codex-rs/core/tests/suite/rmcp_client.rs
@@ -235,6 +235,8 @@ async fn streamable_http_tool_call_round_trip() -> anyhow::Result<()> {
                     transport: McpServerTransportConfig::StreamableHttp {
                         url: server_url,
                         bearer_token_env_var: None,
+                        http_headers: None,
+                        env_http_headers: None,
                     },
                     enabled: true,
                     startup_timeout_sec: Some(Duration::from_secs(10)),
@@ -416,6 +418,8 @@ async fn streamable_http_with_oauth_round_trip() -> anyhow::Result<()> {
                     transport: McpServerTransportConfig::StreamableHttp {
                         url: server_url,
                         bearer_token_env_var: None,
+                        http_headers: None,
+                        env_http_headers: None,
                     },
                     enabled: true,
                     startup_timeout_sec: Some(Duration::from_secs(10)),

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::string::String;
 use std::sync::Arc;
 use std::time::Duration;
@@ -5,6 +6,7 @@ use std::time::Duration;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
+use reqwest::ClientBuilder;
 use rmcp::transport::auth::OAuthState;
 use tiny_http::Response;
 use tiny_http::Server;
@@ -16,6 +18,8 @@ use crate::OAuthCredentialsStoreMode;
 use crate::StoredOAuthTokens;
 use crate::WrappedOAuthTokenResponse;
 use crate::save_oauth_tokens;
+use crate::utils::apply_default_headers;
+use crate::utils::build_default_headers;
 
 struct CallbackServerGuard {
     server: Arc<Server>,
@@ -31,6 +35,8 @@ pub async fn perform_oauth_login(
     server_name: &str,
     server_url: &str,
     store_mode: OAuthCredentialsStoreMode,
+    http_headers: Option<HashMap<String, String>>,
+    env_http_headers: Option<HashMap<String, String>>,
 ) -> Result<()> {
     let server = Arc::new(Server::http("127.0.0.1:0").map_err(|err| anyhow!(err))?);
     let guard = CallbackServerGuard {
@@ -51,7 +57,10 @@ pub async fn perform_oauth_login(
     let (tx, rx) = oneshot::channel();
     spawn_callback_server(server, tx);
 
-    let mut oauth_state = OAuthState::new(server_url, None).await?;
+    let default_headers = build_default_headers(http_headers, env_http_headers)?;
+    let http_client = apply_default_headers(ClientBuilder::new(), &default_headers).build()?;
+
+    let mut oauth_state = OAuthState::new(server_url, Some(http_client)).await?;
     oauth_state
         .start_authorization(&[], &redirect_uri, Some("Codex"))
         .await?;

--- a/codex-rs/rmcp-client/src/rmcp_client.rs
+++ b/codex-rs/rmcp-client/src/rmcp_client.rs
@@ -14,6 +14,7 @@ use mcp_types::InitializeRequestParams;
 use mcp_types::InitializeResult;
 use mcp_types::ListToolsRequestParams;
 use mcp_types::ListToolsResult;
+use reqwest::header::HeaderMap;
 use rmcp::model::CallToolRequestParam;
 use rmcp::model::InitializeRequestParam;
 use rmcp::model::PaginatedRequestParam;
@@ -38,6 +39,8 @@ use crate::logging_client_handler::LoggingClientHandler;
 use crate::oauth::OAuthCredentialsStoreMode;
 use crate::oauth::OAuthPersistor;
 use crate::oauth::StoredOAuthTokens;
+use crate::utils::apply_default_headers;
+use crate::utils::build_default_headers;
 use crate::utils::convert_call_tool_result;
 use crate::utils::convert_to_mcp;
 use crate::utils::convert_to_rmcp;
@@ -116,12 +119,17 @@ impl RmcpClient {
         })
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn new_streamable_http_client(
         server_name: &str,
         url: &str,
         bearer_token: Option<String>,
+        http_headers: Option<HashMap<String, String>>,
+        env_http_headers: Option<HashMap<String, String>>,
         store_mode: OAuthCredentialsStoreMode,
     ) -> Result<Self> {
+        let default_headers = build_default_headers(http_headers, env_http_headers)?;
+
         let initial_oauth_tokens = match bearer_token {
             Some(_) => None,
             None => match load_oauth_tokens(server_name, url, store_mode) {
@@ -132,21 +140,30 @@ impl RmcpClient {
                 }
             },
         };
+
         let transport = if let Some(initial_tokens) = initial_oauth_tokens.clone() {
-            let (transport, oauth_persistor) =
-                create_oauth_transport_and_runtime(server_name, url, initial_tokens, store_mode)
-                    .await?;
+            let (transport, oauth_persistor) = create_oauth_transport_and_runtime(
+                server_name,
+                url,
+                initial_tokens,
+                store_mode,
+                default_headers.clone(),
+            )
+            .await?;
             PendingTransport::StreamableHttpWithOAuth {
                 transport,
                 oauth_persistor,
             }
         } else {
             let mut http_config = StreamableHttpClientTransportConfig::with_uri(url.to_string());
-            if let Some(bearer_token) = bearer_token {
+            if let Some(bearer_token) = bearer_token.clone() {
                 http_config = http_config.auth_header(bearer_token);
             }
 
-            let transport = StreamableHttpClientTransport::from_config(http_config);
+            let http_client =
+                apply_default_headers(reqwest::Client::builder(), &default_headers).build()?;
+
+            let transport = StreamableHttpClientTransport::with_client(http_client, http_config);
             PendingTransport::StreamableHttp { transport }
         };
         Ok(Self {
@@ -290,11 +307,13 @@ async fn create_oauth_transport_and_runtime(
     url: &str,
     initial_tokens: StoredOAuthTokens,
     credentials_store: OAuthCredentialsStoreMode,
+    default_headers: HeaderMap,
 ) -> Result<(
     StreamableHttpClientTransport<AuthClient<reqwest::Client>>,
     OAuthPersistor,
 )> {
-    let http_client = reqwest::Client::builder().build()?;
+    let http_client =
+        apply_default_headers(reqwest::Client::builder(), &default_headers).build()?;
     let mut oauth_state = OAuthState::new(url.to_string(), Some(http_client.clone())).await?;
 
     oauth_state

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1031,8 +1031,37 @@ pub(crate) fn new_mcp_tools_output(
                     lines.push(vec!["    • Env: ".into(), env_pairs.join(" ").into()].into());
                 }
             }
-            McpServerTransportConfig::StreamableHttp { url, .. } => {
+            McpServerTransportConfig::StreamableHttp {
+                url,
+                http_headers,
+                env_http_headers,
+                ..
+            } => {
                 lines.push(vec!["    • URL: ".into(), url.clone().into()].into());
+                if let Some(headers) = http_headers.as_ref()
+                    && !headers.is_empty()
+                {
+                    let mut pairs: Vec<_> = headers.iter().collect();
+                    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+                    let display = pairs
+                        .into_iter()
+                        .map(|(name, value)| format!("{name}={value}"))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    lines.push(vec!["    • HTTP headers: ".into(), display.into()].into());
+                }
+                if let Some(headers) = env_http_headers.as_ref()
+                    && !headers.is_empty()
+                {
+                    let mut pairs: Vec<_> = headers.iter().collect();
+                    pairs.sort_by(|(a, _), (b, _)| a.cmp(b));
+                    let display = pairs
+                        .into_iter()
+                        .map(|(name, env_var)| format!("{name}={env_var}"))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    lines.push(vec!["    • Env HTTP headers: ".into(), display.into()].into());
+                }
             }
         }
 


### PR DESCRIPTION
This adds two new config fields to streamable http mcp servers:
`http_headers`: a map of key to value
`env_http_headers` a map of key to env var which will be resolved at request time

All headers will be passed to all MCP requests to that server just like authorization headers.

There is a test ensuring that headers are not passed to other servers.

Fixes #5180 