### PR TITLE
Add user-triggered /command execution pathway

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -313,6 +313,15 @@ impl App {
                 ));
                 tui.frame_requester().schedule_frame();
             }
+            AppEvent::UserCommandOutput {
+                command,
+                exit_code,
+                stdout,
+                stderr,
+            } => {
+                self.chat_widget
+                    .handle_user_command_output(command, exit_code, stdout, stderr);
+            }
             AppEvent::StartFileSearch(query) => {
                 if !query.is_empty() {
                     self.file_search.on_user_query(query);

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -87,4 +87,12 @@ pub(crate) enum AppEvent {
 
     /// Open the approval popup.
     FullScreenApprovalRequest(ApprovalRequest),
+
+    /// Result of a `/command` executed directly by the user.
+    UserCommandOutput {
+        command: Vec<String>,
+        exit_code: i32,
+        stdout: String,
+        stderr: String,
+    },
 }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -40,6 +40,7 @@ pub(crate) enum CancellationEvent {
 }
 
 pub(crate) use chat_composer::ChatComposer;
+pub(crate) use chat_composer::CommandInvocation;
 pub(crate) use chat_composer::InputResult;
 use codex_protocol::custom_prompts::CustomPrompt;
 

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -18,6 +18,7 @@ pub enum SlashCommand {
     New,
     Init,
     Compact,
+    Command,
     Undo,
     Diff,
     Mention,
@@ -37,6 +38,7 @@ impl SlashCommand {
             SlashCommand::Init => "create an AGENTS.md file with instructions for Codex",
             SlashCommand::Compact => "summarize conversation to prevent hitting the context limit",
             SlashCommand::Review => "review my current changes and find issues",
+            SlashCommand::Command => "run a shell command immediately",
             SlashCommand::Undo => "restore the workspace to the last Codex snapshot",
             SlashCommand::Quit => "exit Codex",
             SlashCommand::Diff => "show git diff (including untracked files)",
@@ -69,6 +71,7 @@ impl SlashCommand {
             | SlashCommand::Review
             | SlashCommand::Logout => false,
             SlashCommand::Diff
+            | SlashCommand::Command
             | SlashCommand::Mention
             | SlashCommand::Status
             | SlashCommand::Mcp
@@ -77,6 +80,14 @@ impl SlashCommand {
             #[cfg(debug_assertions)]
             SlashCommand::TestApproval => true,
         }
+    }
+
+    pub fn accepts_arguments(self) -> bool {
+        matches!(self, SlashCommand::Command)
+    }
+
+    pub fn requires_arguments(self) -> bool {
+        matches!(self, SlashCommand::Command)
     }
 }
 


### PR DESCRIPTION
/command < command />

Get the result without switching terminals.