### PR TITLE
Kill shell tool process groups on timeout

### DIFF
--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -371,6 +371,7 @@ async fn consume_truncated_output(
                 }
                 Err(_) => {
                     // timeout
+                    kill_child_process_group(&mut child)?;
                     child.start_kill()?;
                     // Debatable whether `child.wait().await` should be called here.
                     (synthetic_exit_status(EXIT_CODE_SIGNAL_BASE + TIMEOUT_CODE), true)
@@ -378,6 +379,7 @@ async fn consume_truncated_output(
             }
         }
         _ = tokio::signal::ctrl_c() => {
+            kill_child_process_group(&mut child)?;
             child.start_kill()?;
             (synthetic_exit_status(EXIT_CODE_SIGNAL_BASE + SIGKILL_CODE), false)
         }
@@ -471,6 +473,38 @@ fn synthetic_exit_status(code: i32) -> ExitStatus {
     use std::os::windows::process::ExitStatusExt;
     #[expect(clippy::unwrap_used)]
     std::process::ExitStatus::from_raw(code.try_into().unwrap())
+}
+
+#[cfg(unix)]
+fn kill_child_process_group(child: &mut Child) -> io::Result<()> {
+    use std::io::ErrorKind;
+
+    if let Some(pid) = child.id() {
+        let pid = pid as libc::pid_t;
+        let pgid = unsafe { libc::getpgid(pid) };
+        if pgid == -1 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() != ErrorKind::NotFound {
+                return Err(err);
+            }
+            return Ok(());
+        }
+
+        let result = unsafe { libc::killpg(pgid, libc::SIGKILL) };
+        if result == -1 {
+            let err = std::io::Error::last_os_error();
+            if err.kind() != ErrorKind::NotFound {
+                return Err(err);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn kill_child_process_group(_: &mut Child) -> io::Result<()> {
+    Ok(())
 }
 
 #[cfg(test)]

--- a/codex-rs/core/src/spawn.rs
+++ b/codex-rs/core/src/spawn.rs
@@ -64,22 +64,29 @@ pub(crate) async fn spawn_child_async(
     // any child processes that were spawned as part of a `"shell"` tool call
     // to also be terminated.
 
-    // This relies on prctl(2), so it only works on Linux.
-    #[cfg(target_os = "linux")]
+    #[cfg(unix)]
     unsafe {
         cmd.pre_exec(|| {
-            // This prctl call effectively requests, "deliver SIGTERM when my
-            // current parent dies."
-            if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) == -1 {
+            if libc::setpgid(0, 0) == -1 {
                 return Err(std::io::Error::last_os_error());
             }
 
-            // Though if there was a race condition and this pre_exec() block is
-            // run _after_ the parent (i.e., the Codex process) has already
-            // exited, then the parent is the _init_ process (which will never
-            // die), so we should just terminate the child process now.
-            if libc::getppid() == 1 {
-                libc::raise(libc::SIGTERM);
+            // This relies on prctl(2), so it only works on Linux.
+            #[cfg(target_os = "linux")]
+            {
+                // This prctl call effectively requests, "deliver SIGTERM when my
+                // current parent dies."
+                if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+
+                // Though if there was a race condition and this pre_exec() block is
+                // run _after_ the parent (i.e., the Codex process) has already
+                // exited, then the parent is the _init_ process (which will never
+                // die), so we should just terminate the child process now.
+                if libc::getppid() == 1 {
+                    libc::raise(libc::SIGTERM);
+                }
             }
             Ok(())
         });

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -167,7 +167,7 @@ fn create_unified_exec_tool() -> ToolSpec {
         "timeout_ms".to_string(),
         JsonSchema::Number {
             description: Some(
-                "Maximum time in milliseconds to wait for output after writing the input."
+                "Maximum time in milliseconds to wait for output after writing the input (default: 1000)."
                     .to_string(),
             ),
         },
@@ -204,7 +204,9 @@ fn create_shell_tool() -> ToolSpec {
     properties.insert(
         "timeout_ms".to_string(),
         JsonSchema::Number {
-            description: Some("The timeout for the command in milliseconds".to_string()),
+            description: Some(
+                "The timeout for the command in milliseconds (default: 1000).".to_string(),
+            ),
         },
     );
 

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -247,7 +247,7 @@ pub struct ShellToolCallParams {
     pub command: Vec<String>,
     pub workdir: Option<String>,
 
-    /// This is the maximum time in milliseconds that the command is allowed to run.
+    /// Maximum time in milliseconds that the command is allowed to run (defaults to 1_000 ms when omitted).
     #[serde(alias = "timeout")]
     pub timeout_ms: Option<u64>,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary
- ensure shell tool launches run in a dedicated process group so Codex owns the full process tree
- on timeout or ctrl-c, send SIGKILL to the process group before terminating the tracked child
- clarify the shell/unified_exec timeout descriptions while keeping the 1s default

## Original Problem
Running `pnpm next dev --port 4001` inside Codex would hang indefinitely (even with explicit timeouts) because the timeout logic only killed the pnpm wrapper process; the spawned Next.js server continued running and held the PTY open, so the tool call never completed.
