### PR TITLE
feat: allow mentioning directories

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1154,6 +1154,7 @@ dependencies = [
  "nucleo-matcher",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/codex-rs/app-server-protocol/src/protocol.rs
+++ b/codex-rs/app-server-protocol/src/protocol.rs
@@ -731,6 +731,8 @@ pub struct FuzzyFileSearchResult {
     pub score: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indices: Option<Vec<u32>>,
+    #[serde(default)]
+    pub is_directory: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, TS)]

--- a/codex-rs/app-server/src/fuzzy_file_search.rs
+++ b/codex-rs/app-server/src/fuzzy_file_search.rs
@@ -58,17 +58,24 @@ pub(crate) async fn run_fuzzy_file_search(
             Ok(Ok((root, res))) => {
                 for m in res.matches {
                     let path = m.path;
+                    let is_directory = m.is_directory;
+                    let name_source = if is_directory {
+                        path.trim_end_matches('/')
+                    } else {
+                        path.as_str()
+                    };
                     //TODO(shijie): Move file name generation to file_search lib.
-                    let file_name = Path::new(&path)
+                    let file_name = Path::new(name_source)
                         .file_name()
                         .map(|name| name.to_string_lossy().into_owned())
-                        .unwrap_or_else(|| path.clone());
+                        .unwrap_or_else(|| name_source.to_string());
                     let result = FuzzyFileSearchResult {
                         root: root.clone(),
                         path,
                         file_name,
                         score: m.score,
                         indices: m.indices,
+                        is_directory,
                     };
                     files.push(result);
                 }

--- a/codex-rs/app-server/tests/suite/fuzzy_file_search.rs
+++ b/codex-rs/app-server/tests/suite/fuzzy_file_search.rs
@@ -70,6 +70,7 @@ async fn test_fuzzy_file_search_sorts_and_includes_indices() -> Result<()> {
                     "file_name": "abexy",
                     "score": 88,
                     "indices": [0, 1, 2],
+                    "is_directory": false,
                 },
                 {
                     "root": root_path.clone(),
@@ -77,6 +78,7 @@ async fn test_fuzzy_file_search_sorts_and_includes_indices() -> Result<()> {
                     "file_name": "abcde",
                     "score": 74,
                     "indices": [0, 1, 4],
+                    "is_directory": false,
                 },
                 {
                     "root": root_path.clone(),
@@ -84,6 +86,7 @@ async fn test_fuzzy_file_search_sorts_and_includes_indices() -> Result<()> {
                     "file_name": "abce",
                     "score": expected_score,
                     "indices": [4, 5, 7],
+                    "is_directory": false,
                 },
             ]
         })
@@ -141,6 +144,7 @@ async fn test_fuzzy_file_search_accepts_cancellation_token() -> Result<()> {
     assert_eq!(files.len(), 1);
     assert_eq!(files[0]["root"], root_path);
     assert_eq!(files[0]["path"], "alpha.txt");
+    assert_eq!(files[0]["is_directory"], false);
 
     Ok(())
 }

--- a/codex-rs/file-search/Cargo.toml
+++ b/codex-rs/file-search/Cargo.toml
@@ -19,3 +19,6 @@ nucleo-matcher = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/codex-rs/tui/src/bottom_pane/file_search_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/file_search_popup.rs
@@ -131,7 +131,7 @@ impl WidgetRef for &FileSearchPopup {
                         .map(|v| v.iter().map(|&i| i as usize).collect()),
                     is_current: false,
                     display_shortcut: None,
-                    description: None,
+                    description: m.is_directory.then_some("directory".to_string()),
                 })
                 .collect()
         };


### PR DESCRIPTION
### Description

Note: Do not want to come out as rude or disrespectful, people that developed this software probably had their reasons to filter out the folders, so please treat it as more of a suggestion/POC.

#### What

Teach the fuzzy file search system to show directories alongside files. Directory matches will have a trailing slash and an `is_directory` flag that flows through the entire stack, from the `file-search` crate through the app server protocol and into the app server bridge.

Update the TUI popup so directories are clearly labeled as such instead of looking like regular files. Also ensure the slash mention insertion logic receives the metadata it needs for future improvements.
(This UI choice is not necessarily meant to be merged.)

#### Why

Power users want to mention entire folders using `@` (for example `@src/components`) to give context or refer to groups of files.
Previously, the search ignored directories, so users had to type full paths manually.
By surfacing folders and marking them clearly, the UI can give more accurate suggestions and future tools can handle folders properly, such as opening or summarizing them.

#### How

Stop filtering out directories in the file walker. Normalize relative paths to always end with a slash, and extend `FileMatch` with an `is_directory` flag along with new tests for both files and folders.

Propagate this field through the app server protocol and types, and make the fuzzy search bridge display clean folder labels even when raw paths already end with a slash.

In the TUI file search popup, add folder annotations so users can immediately see when they are selecting a directory.

### Example
<img width="405" height="304" alt="image" src="https://github.com/user-attachments/assets/95fe913c-5669-453b-b11d-61e4a494b02f" />