### PR TITLE
Add sandbox mode to config profiles

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol.rs
+++ b/codex-rs/app-server-protocol/src/protocol.rs
@@ -507,6 +507,7 @@ pub struct Profile {
     pub model_reasoning_summary: Option<ReasoningSummary>,
     pub model_verbosity: Option<Verbosity>,
     pub chatgpt_base_url: Option<String>,
+    pub sandbox_mode: Option<SandboxMode>,
 }
 /// MCP representation of a [`codex_core::config::ToolsToml`].
 #[derive(Deserialize, Debug, Clone, PartialEq, Serialize, TS)]

--- a/codex-rs/app-server/tests/suite/config.rs
+++ b/codex-rs/app-server/tests/suite/config.rs
@@ -52,6 +52,7 @@ model_reasoning_summary = "detailed"
 model_verbosity = "medium"
 model_provider = "openai"
 chatgpt_base_url = "https://api.chatgpt.com"
+sandbox_mode = "danger-full-access"
 "#,
     )
 }
@@ -111,6 +112,7 @@ async fn get_config_toml_parses_all_fields() {
                     model_verbosity: Some(Verbosity::Medium),
                     model_provider: Some("openai".into()),
                     chatgpt_base_url: Some("https://api.chatgpt.com".into()),
+                    sandbox_mode: Some(SandboxMode::DangerFullAccess),
                 },
             )]),
         },

--- a/codex-rs/core/src/config_profile.rs
+++ b/codex-rs/core/src/config_profile.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use crate::protocol::AskForApproval;
 use codex_protocol::config_types::ReasoningEffort;
 use codex_protocol::config_types::ReasoningSummary;
+use codex_protocol::config_types::SandboxMode;
 use codex_protocol::config_types::Verbosity;
 
 /// Collection of common configuration options that a user can define as a unit
@@ -19,6 +20,7 @@ pub struct ConfigProfile {
     pub model_reasoning_summary: Option<ReasoningSummary>,
     pub model_verbosity: Option<Verbosity>,
     pub chatgpt_base_url: Option<String>,
+    pub sandbox_mode: Option<SandboxMode>,
     pub experimental_instructions_file: Option<PathBuf>,
     pub include_plan_tool: Option<bool>,
     pub include_apply_patch_tool: Option<bool>,
@@ -44,6 +46,7 @@ impl From<ConfigProfile> for codex_app_server_protocol::Profile {
             model_reasoning_summary: config_profile.model_reasoning_summary,
             model_verbosity: config_profile.model_verbosity,
             chatgpt_base_url: config_profile.chatgpt_base_url,
+            sandbox_mode: config_profile.sandbox_mode,
         }
     }
 }


### PR DESCRIPTION
## Summary
- allow config profiles to declare a sandbox_mode and include it in the MCP protocol surface
- honor profile-specific sandbox_mode when deriving the effective sandbox policy
- add coverage ensuring profile sandbox configuration is surfaced over MCP and overrides base config

## Testing
- cargo test -p codex-core config::tests::profile_sandbox_mode_overrides_base_config -- --nocapture
- cargo test -p codex-app-server-protocol


------
https://chatgpt.com/codex/tasks/task_i_68f130640c1083229b9e6db3e68c0cf2