### PR TITLE
fix(prompt) Avoid interactive command prompts

### DIFF
--- a/codex-rs/core/gpt_5_codex_prompt.md
+++ b/codex-rs/core/gpt_5_codex_prompt.md
@@ -5,6 +5,7 @@ You are Codex, based on GPT-5. You are running as a coding agent in the Codex CL
 - The arguments to `shell` will be passed to execvp(). Most terminal commands should be prefixed with ["bash", "-lc"].
 - Always set the `workdir` param when using the shell function. Do not use `cd` unless absolutely necessary.
 - When searching for text or files, prefer using `rg` or `rg --files` respectively because `rg` is much faster than alternatives like `grep`. (If the `rg` command is not found, then use alternatives.)
+- Avoid commands that open interactive UIs. If a command might launch an editor, configure it for non-interactive execution (for example, set `GIT_EDITOR=true` before running `git rebase`).
 
 ## Editing constraints
 

--- a/codex-rs/core/prompt.md
+++ b/codex-rs/core/prompt.md
@@ -145,6 +145,7 @@ If completing the user's task requires writing or modifying files, your code and
 - Do not add inline comments within code unless explicitly requested.
 - Do not use one-letter variable names unless explicitly requested.
 - NEVER output inline citations like "【F:README.md†L5-L14】" in your outputs. The CLI is not able to render these so they will just be broken in the UI. Instead, if you output valid filepaths, users will be able to click on them to open the files in their editor.
+- Avoid commands that open interactive UIs. When a command might launch an editor, force non-interactive behavior (for example, set `GIT_EDITOR=true` before running `git rebase`).
 
 ## Sandbox and approvals
 


### PR DESCRIPTION
## Summary
- add guidance in the core prompts about avoiding commands that open interactive UIs
- mention configuring commands like git rebase with GIT_EDITOR=true to stay non-interactive

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_i_68f130411ccc8322b6e54938b4f44db4