### PR TITLE
[MCP] Render full MCP errors to the model

### DIFF
--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -58,7 +58,10 @@ pub(crate) async fn handle_mcp_tool_call(
     let result = sess
         .call_tool(&server, &tool_name, arguments_value.clone())
         .await
-        .map_err(|e| format!("tool call error: {e}"));
+        .map_err(|e| format!("tool call error: {e:?}"));
+    if let Err(e) = &result {
+        tracing::warn!("MCP tool call error: {e:?}");
+    }
     let tool_call_end_event = EventMsg::McpToolCallEnd(McpToolCallEndEvent {
         call_id: call_id.clone(),
         invocation,

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -854,7 +854,12 @@ impl HistoryCell for McpToolCallCell {
                     }
                 }
                 Err(err) => {
-                    let err_line = Line::from(format!("Error: {err}").dim());
+                    let err_text = format_and_truncate_tool_result(
+                        &format!("Error: {err}"),
+                        TOOL_CALL_MAX_LINES,
+                        width as usize,
+                    );
+                    let err_line = Line::from(err_text.dim());
                     let wrapped = word_wrap_line(
                         &err_line,
                         RtOptions::new((width as usize).saturating_sub(4))


### PR DESCRIPTION
Previously, the model couldn't see why MCP tool calls failed, many of which were the model using the parameters incorrectly. A common failure is the model stringifying the json for the notion-update-page tool which it then couldn't correct.

I want to do some system prompt massaging around this as well. However, it is crucial that the model sees the error so it can fix it.

Before:
<img width="2984" height="832" alt="CleanShot 2025-10-17 at 13 02 36" src="https://github.com/user-attachments/assets/709a3d27-b71b-4d8d-87b6-9b2d7fe4e6f2" />

After:
<img width="2488" height="1550" alt="CleanShot 2025-10-17 at 13 01 18" src="https://github.com/user-attachments/assets/13a0b7dc-fdad-4996-bf2d-0772872c34fc" />

🎉 
<img width="1078" height="568" alt="CleanShot 2025-10-17 at 13 09 30" src="https://github.com/user-attachments/assets/64cde8be-9e6c-4e61-b971-c2ba22504292" />


Fixes #4707 