### PR TITLE
Use XDG Base Directory whenever available. CODEX_HOME still superceed…

### DIFF
--- a/codex-rs/core/src/config.rs
+++ b/codex-rs/core/src/config.rs
@@ -1451,6 +1451,15 @@ pub fn find_codex_home() -> std::io::Result<PathBuf> {
         return PathBuf::from(val).canonicalize();
     }
 
+    // Check for XDG_CONFIG_HOME to follow XDG Base Directory specification
+    if let Ok(val) = std::env::var("XDG_CONFIG_HOME")
+        && !val.is_empty()
+    {
+        let mut p = PathBuf::from(val);
+        p.push(".codex");
+        return Ok(p);
+    }
+
     let mut p = home_dir().ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::NotFound,


### PR DESCRIPTION
…s XDG_CONFIG_HOME so nothing breaks.

# External (non-OpenAI) Pull Request Requirements

Before opening this Pull Request, please read the dedicated "Contributing" markdown file or your PR may be closed:
https://github.com/openai/codex/blob/main/docs/contributing.md

If your PR conforms to our contribution guidelines, replace this text with a detailed and high quality description of your changes.
