### PR TITLE
Fix link to MCP Servers config section

### DIFF
--- a/codex-rs/config.md
+++ b/codex-rs/config.md
@@ -3,4 +3,4 @@
 This file has moved. Please see the latest configuration documentation here:
 
 - Full config docs: [docs/config.md](../docs/config.md)
-- MCP servers section: [docs/config.md#mcp_servers](../docs/config.md#mcp_servers) 
+- MCP servers section: [docs/config.md#connecting-to-mcp-servers](../docs/config.md#connecting-to-mcp-servers)


### PR DESCRIPTION
fix a broken link in https://github.com/openai/codex/blob/main/codex-rs/config.md to point to the anchor for configuring MCPs: https://github.com/openai/codex/blob/main/docs/config.md#connecting-to-mcp-servers