### PR TITLE
fix: switch rate limit reset handling to timestamps

### DIFF
--- a/codex-rs/clippy.toml
+++ b/codex-rs/clippy.toml
@@ -1,6 +1,5 @@
 allow-expect-in-tests = true
 allow-unwrap-in-tests = true
-result_large_err_threshold = 256
 disallowed-methods = [
     { path = "ratatui::style::Color::Rgb", reason = "Use ANSI colors, which work better in various terminal themes." },
     { path = "ratatui::style::Color::Indexed", reason = "Use ANSI colors, which work better in various terminal themes." },
@@ -8,3 +7,7 @@ disallowed-methods = [
     { path = "ratatui::style::Stylize::black", reason = "Avoid hardcoding black; prefer default fg or dim/bold. Exception: Disable this rule if rendering over a hardcoded ANSI background." },
     { path = "ratatui::style::Stylize::yellow", reason = "Avoid yellow; prefer other colors in `tui/styles.md`." },
 ]
+
+# Increase the size threshold for result_large_err to accommodate
+# richer error variants.
+large-error-threshold = 256

--- a/codex-rs/clippy.toml
+++ b/codex-rs/clippy.toml
@@ -1,5 +1,6 @@
 allow-expect-in-tests = true
 allow-unwrap-in-tests = true
+result_large_err_threshold = 256
 disallowed-methods = [
     { path = "ratatui::style::Color::Rgb", reason = "Use ANSI colors, which work better in various terminal themes." },
     { path = "ratatui::style::Color::Indexed", reason = "Use ANSI colors, which work better in various terminal themes." },

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -2,6 +2,8 @@ use crate::exec::ExecToolCallOutput;
 use crate::token_data::KnownPlan;
 use crate::token_data::PlanType;
 use crate::truncate::truncate_middle;
+use chrono::DateTime;
+use chrono::Utc;
 use codex_async_utils::CancelErr;
 use codex_protocol::ConversationId;
 use codex_protocol::protocol::RateLimitSnapshot;
@@ -237,7 +239,7 @@ impl std::fmt::Display for RetryLimitReachedError {
 #[derive(Debug)]
 pub struct UsageLimitReachedError {
     pub(crate) plan_type: Option<PlanType>,
-    pub(crate) resets_in_seconds: Option<u64>,
+    pub(crate) resets_at: Option<DateTime<Utc>>,
     pub(crate) rate_limits: Option<RateLimitSnapshot>,
 }
 
@@ -246,12 +248,12 @@ impl std::fmt::Display for UsageLimitReachedError {
         let message = match self.plan_type.as_ref() {
             Some(PlanType::Known(KnownPlan::Plus)) => format!(
                 "You've hit your usage limit. Upgrade to Pro (https://openai.com/chatgpt/pricing){}",
-                retry_suffix_after_or(self.resets_in_seconds)
+                retry_suffix_after_or(self.resets_at.as_ref())
             ),
             Some(PlanType::Known(KnownPlan::Team)) | Some(PlanType::Known(KnownPlan::Business)) => {
                 format!(
                     "You've hit your usage limit. To get more access now, send a request to your admin{}",
-                    retry_suffix_after_or(self.resets_in_seconds)
+                    retry_suffix_after_or(self.resets_at.as_ref())
                 )
             }
             Some(PlanType::Known(KnownPlan::Free)) => {
@@ -262,11 +264,11 @@ impl std::fmt::Display for UsageLimitReachedError {
             | Some(PlanType::Known(KnownPlan::Enterprise))
             | Some(PlanType::Known(KnownPlan::Edu)) => format!(
                 "You've hit your usage limit.{}",
-                retry_suffix(self.resets_in_seconds)
+                retry_suffix(self.resets_at.as_ref())
             ),
             Some(PlanType::Unknown(_)) | None => format!(
                 "You've hit your usage limit.{}",
-                retry_suffix(self.resets_in_seconds)
+                retry_suffix(self.resets_at.as_ref())
             ),
         };
 
@@ -274,8 +276,8 @@ impl std::fmt::Display for UsageLimitReachedError {
     }
 }
 
-fn retry_suffix(resets_in_seconds: Option<u64>) -> String {
-    if let Some(secs) = resets_in_seconds {
+fn retry_suffix(resets_at: Option<&DateTime<Utc>>) -> String {
+    if let Some(secs) = remaining_seconds(resets_at) {
         let reset_duration = format_reset_duration(secs);
         format!(" Try again in {reset_duration}.")
     } else {
@@ -283,13 +285,36 @@ fn retry_suffix(resets_in_seconds: Option<u64>) -> String {
     }
 }
 
-fn retry_suffix_after_or(resets_in_seconds: Option<u64>) -> String {
-    if let Some(secs) = resets_in_seconds {
+fn retry_suffix_after_or(resets_at: Option<&DateTime<Utc>>) -> String {
+    if let Some(secs) = remaining_seconds(resets_at) {
         let reset_duration = format_reset_duration(secs);
         format!(" or try again in {reset_duration}.")
     } else {
         " or try again later.".to_string()
     }
+}
+
+fn remaining_seconds(resets_at: Option<&DateTime<Utc>>) -> Option<u64> {
+    let resets_at = resets_at.cloned()?;
+    let now = now_for_retry();
+    let secs = resets_at.signed_duration_since(now).num_seconds();
+    Some(if secs <= 0 { 0 } else { secs as u64 })
+}
+
+#[cfg(test)]
+thread_local! {
+    static NOW_OVERRIDE: std::cell::RefCell<Option<DateTime<Utc>>> =
+        const { std::cell::RefCell::new(None) };
+}
+
+fn now_for_retry() -> DateTime<Utc> {
+    #[cfg(test)]
+    {
+        if let Some(now) = NOW_OVERRIDE.with(|cell| *cell.borrow()) {
+            return now;
+        }
+    }
+    Utc::now()
 }
 
 fn format_reset_duration(total_secs: u64) -> String {
@@ -388,6 +413,10 @@ pub fn get_error_message_ui(e: &CodexErr) -> String {
 mod tests {
     use super::*;
     use crate::exec::StreamOutput;
+    use chrono::DateTime;
+    use chrono::Duration as ChronoDuration;
+    use chrono::TimeZone;
+    use chrono::Utc;
     use codex_protocol::protocol::RateLimitWindow;
     use pretty_assertions::assert_eq;
 
@@ -396,21 +425,30 @@ mod tests {
             primary: Some(RateLimitWindow {
                 used_percent: 50.0,
                 window_minutes: Some(60),
-                resets_in_seconds: Some(3600),
+                resets_at: Some("2024-01-01T01:00:00Z".to_string()),
             }),
             secondary: Some(RateLimitWindow {
                 used_percent: 30.0,
                 window_minutes: Some(120),
-                resets_in_seconds: Some(7200),
+                resets_at: Some("2024-01-01T02:00:00Z".to_string()),
             }),
         }
+    }
+
+    fn with_now_override<T>(now: DateTime<Utc>, f: impl FnOnce() -> T) -> T {
+        NOW_OVERRIDE.with(|cell| {
+            *cell.borrow_mut() = Some(now);
+            let result = f();
+            *cell.borrow_mut() = None;
+            result
+        })
     }
 
     #[test]
     fn usage_limit_reached_error_formats_plus_plan() {
         let err = UsageLimitReachedError {
             plan_type: Some(PlanType::Known(KnownPlan::Plus)),
-            resets_in_seconds: None,
+            resets_at: None,
             rate_limits: Some(rate_limit_snapshot()),
         };
         assert_eq!(
@@ -490,7 +528,7 @@ mod tests {
     fn usage_limit_reached_error_formats_free_plan() {
         let err = UsageLimitReachedError {
             plan_type: Some(PlanType::Known(KnownPlan::Free)),
-            resets_in_seconds: Some(3600),
+            resets_at: None,
             rate_limits: Some(rate_limit_snapshot()),
         };
         assert_eq!(
@@ -503,7 +541,7 @@ mod tests {
     fn usage_limit_reached_error_formats_default_when_none() {
         let err = UsageLimitReachedError {
             plan_type: None,
-            resets_in_seconds: None,
+            resets_at: None,
             rate_limits: Some(rate_limit_snapshot()),
         };
         assert_eq!(
@@ -514,22 +552,26 @@ mod tests {
 
     #[test]
     fn usage_limit_reached_error_formats_team_plan() {
-        let err = UsageLimitReachedError {
-            plan_type: Some(PlanType::Known(KnownPlan::Team)),
-            resets_in_seconds: Some(3600),
-            rate_limits: Some(rate_limit_snapshot()),
-        };
-        assert_eq!(
-            err.to_string(),
-            "You've hit your usage limit. To get more access now, send a request to your admin or try again in 1 hour."
-        );
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let resets_at = base + ChronoDuration::hours(1);
+        with_now_override(base, move || {
+            let err = UsageLimitReachedError {
+                plan_type: Some(PlanType::Known(KnownPlan::Team)),
+                resets_at: Some(resets_at),
+                rate_limits: Some(rate_limit_snapshot()),
+            };
+            assert_eq!(
+                err.to_string(),
+                "You've hit your usage limit. To get more access now, send a request to your admin or try again in 1 hour."
+            );
+        });
     }
 
     #[test]
     fn usage_limit_reached_error_formats_business_plan_without_reset() {
         let err = UsageLimitReachedError {
             plan_type: Some(PlanType::Known(KnownPlan::Business)),
-            resets_in_seconds: None,
+            resets_at: None,
             rate_limits: Some(rate_limit_snapshot()),
         };
         assert_eq!(
@@ -542,7 +584,7 @@ mod tests {
     fn usage_limit_reached_error_formats_default_for_other_plans() {
         let err = UsageLimitReachedError {
             plan_type: Some(PlanType::Known(KnownPlan::Pro)),
-            resets_in_seconds: None,
+            resets_at: None,
             rate_limits: Some(rate_limit_snapshot()),
         };
         assert_eq!(
@@ -553,53 +595,70 @@ mod tests {
 
     #[test]
     fn usage_limit_reached_includes_minutes_when_available() {
-        let err = UsageLimitReachedError {
-            plan_type: None,
-            resets_in_seconds: Some(5 * 60),
-            rate_limits: Some(rate_limit_snapshot()),
-        };
-        assert_eq!(
-            err.to_string(),
-            "You've hit your usage limit. Try again in 5 minutes."
-        );
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let resets_at = base + ChronoDuration::minutes(5);
+        with_now_override(base, move || {
+            let err = UsageLimitReachedError {
+                plan_type: None,
+                resets_at: Some(resets_at),
+                rate_limits: Some(rate_limit_snapshot()),
+            };
+            assert_eq!(
+                err.to_string(),
+                "You've hit your usage limit. Try again in 5 minutes."
+            );
+        });
     }
 
     #[test]
     fn usage_limit_reached_includes_hours_and_minutes() {
-        let err = UsageLimitReachedError {
-            plan_type: Some(PlanType::Known(KnownPlan::Plus)),
-            resets_in_seconds: Some(3 * 3600 + 32 * 60),
-            rate_limits: Some(rate_limit_snapshot()),
-        };
-        assert_eq!(
-            err.to_string(),
-            "You've hit your usage limit. Upgrade to Pro (https://openai.com/chatgpt/pricing) or try again in 3 hours 32 minutes."
-        );
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let resets_at = base + ChronoDuration::hours(3) + ChronoDuration::minutes(32);
+        with_now_override(base, move || {
+            let err = UsageLimitReachedError {
+                plan_type: Some(PlanType::Known(KnownPlan::Plus)),
+                resets_at: Some(resets_at),
+                rate_limits: Some(rate_limit_snapshot()),
+            };
+            assert_eq!(
+                err.to_string(),
+                "You've hit your usage limit. Upgrade to Pro (https://openai.com/chatgpt/pricing) or try again in 3 hours 32 minutes."
+            );
+        });
     }
 
     #[test]
     fn usage_limit_reached_includes_days_hours_minutes() {
-        let err = UsageLimitReachedError {
-            plan_type: None,
-            resets_in_seconds: Some(2 * 86_400 + 3 * 3600 + 5 * 60),
-            rate_limits: Some(rate_limit_snapshot()),
-        };
-        assert_eq!(
-            err.to_string(),
-            "You've hit your usage limit. Try again in 2 days 3 hours 5 minutes."
-        );
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let resets_at =
+            base + ChronoDuration::days(2) + ChronoDuration::hours(3) + ChronoDuration::minutes(5);
+        with_now_override(base, move || {
+            let err = UsageLimitReachedError {
+                plan_type: None,
+                resets_at: Some(resets_at),
+                rate_limits: Some(rate_limit_snapshot()),
+            };
+            assert_eq!(
+                err.to_string(),
+                "You've hit your usage limit. Try again in 2 days 3 hours 5 minutes."
+            );
+        });
     }
 
     #[test]
     fn usage_limit_reached_less_than_minute() {
-        let err = UsageLimitReachedError {
-            plan_type: None,
-            resets_in_seconds: Some(30),
-            rate_limits: Some(rate_limit_snapshot()),
-        };
-        assert_eq!(
-            err.to_string(),
-            "You've hit your usage limit. Try again in less than a minute."
-        );
+        let base = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let resets_at = base + ChronoDuration::seconds(30);
+        with_now_override(base, move || {
+            let err = UsageLimitReachedError {
+                plan_type: None,
+                resets_at: Some(resets_at),
+                rate_limits: Some(rate_limit_snapshot()),
+            };
+            assert_eq!(
+                err.to_string(),
+                "You've hit your usage limit. Try again in less than a minute."
+            );
+        });
     }
 }

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -768,8 +768,8 @@ async fn token_count_includes_rate_limits_snapshot() {
         .insert_header("x-codex-secondary-used-percent", "40.0")
         .insert_header("x-codex-primary-window-minutes", "10")
         .insert_header("x-codex-secondary-window-minutes", "60")
-        .insert_header("x-codex-primary-reset-after-seconds", "1800")
-        .insert_header("x-codex-secondary-reset-after-seconds", "7200")
+        .insert_header("x-codex-primary-reset-at", "2024-01-01T00:30:00Z")
+        .insert_header("x-codex-secondary-reset-at", "2024-01-01T02:00:00Z")
         .set_body_raw(sse_body, "text/event-stream");
 
     Mock::given(method("POST"))
@@ -818,12 +818,12 @@ async fn token_count_includes_rate_limits_snapshot() {
                 "primary": {
                     "used_percent": 12.5,
                     "window_minutes": 10,
-                    "resets_in_seconds": 1800
+                    "resets_at": "2024-01-01T00:30:00Z"
                 },
                 "secondary": {
                     "used_percent": 40.0,
                     "window_minutes": 60,
-                    "resets_in_seconds": 7200
+                    "resets_at": "2024-01-01T02:00:00Z"
                 }
             }
         })
@@ -865,12 +865,12 @@ async fn token_count_includes_rate_limits_snapshot() {
                 "primary": {
                     "used_percent": 12.5,
                     "window_minutes": 10,
-                    "resets_in_seconds": 1800
+                    "resets_at": "2024-01-01T00:30:00Z"
                 },
                 "secondary": {
                     "used_percent": 40.0,
                     "window_minutes": 60,
-                    "resets_in_seconds": 7200
+                    "resets_at": "2024-01-01T02:00:00Z"
                 }
             }
         })
@@ -893,8 +893,8 @@ async fn token_count_includes_rate_limits_snapshot() {
         final_snapshot
             .primary
             .as_ref()
-            .and_then(|window| window.resets_in_seconds),
-        Some(1800)
+            .and_then(|window| window.resets_at.as_deref()),
+        Some("2024-01-01T00:30:00Z")
     );
 
     wait_for_event(&codex, |msg| matches!(msg, EventMsg::TaskComplete(_))).await;
@@ -915,7 +915,7 @@ async fn usage_limit_error_emits_rate_limit_event() -> anyhow::Result<()> {
             "error": {
                 "type": "usage_limit_reached",
                 "message": "limit reached",
-                "resets_in_seconds": 42,
+                "resets_at": "2024-01-01T00:00:42Z",
                 "plan_type": "pro"
             }
         }));
@@ -935,12 +935,12 @@ async fn usage_limit_error_emits_rate_limit_event() -> anyhow::Result<()> {
         "primary": {
             "used_percent": 100.0,
             "window_minutes": 15,
-            "resets_in_seconds": null
+            "resets_at": null
         },
         "secondary": {
             "used_percent": 87.5,
             "window_minutes": 60,
-            "resets_in_seconds": null
+            "resets_at": null
         }
     });
 

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -644,9 +644,9 @@ pub struct RateLimitWindow {
     /// Rolling window duration, in minutes.
     #[ts(type = "number | null")]
     pub window_minutes: Option<u64>,
-    /// Seconds until the window resets.
-    #[ts(type = "number | null")]
-    pub resets_in_seconds: Option<u64>,
+    /// Timestamp (RFC3339) when the window resets.
+    #[ts(type = "string | null")]
+    pub resets_at: Option<String>,
 }
 
 // Includes prompts, tools and space to call compact.

--- a/codex-rs/tui/src/status/rate_limits.rs
+++ b/codex-rs/tui/src/status/rate_limits.rs
@@ -2,11 +2,9 @@ use crate::chatwidget::get_limits_duration;
 
 use super::helpers::format_reset_timestamp;
 use chrono::DateTime;
-use chrono::Duration as ChronoDuration;
 use chrono::Local;
 use codex_core::protocol::RateLimitSnapshot;
 use codex_core::protocol::RateLimitWindow;
-use std::convert::TryFrom;
 
 const STATUS_LIMIT_BAR_SEGMENTS: usize = 20;
 const STATUS_LIMIT_BAR_FILLED: &str = "█";
@@ -35,9 +33,10 @@ pub(crate) struct RateLimitWindowDisplay {
 impl RateLimitWindowDisplay {
     fn from_window(window: &RateLimitWindow, captured_at: DateTime<Local>) -> Self {
         let resets_at = window
-            .resets_in_seconds
-            .and_then(|seconds| i64::try_from(seconds).ok())
-            .and_then(|secs| captured_at.checked_add_signed(ChronoDuration::seconds(secs)))
+            .resets_at
+            .as_deref()
+            .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+            .map(|dt| dt.with_timezone(&Local))
             .map(|dt| format_reset_timestamp(dt, captured_at));
 
         Self {

--- a/codex-rs/tui/src/status/tests.rs
+++ b/codex-rs/tui/src/status/tests.rs
@@ -1,7 +1,9 @@
 use super::new_status_output;
 use super::rate_limit_snapshot_display;
 use crate::history_cell::HistoryCell;
+use chrono::Duration as ChronoDuration;
 use chrono::TimeZone;
+use chrono::Utc;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
 use codex_core::config::ConfigToml;
@@ -60,6 +62,12 @@ fn sanitize_directory(lines: Vec<String>) -> Vec<String> {
         .collect()
 }
 
+fn reset_at_from(captured_at: &chrono::DateTime<chrono::Local>, seconds: i64) -> String {
+    (*captured_at + ChronoDuration::seconds(seconds))
+        .with_timezone(&Utc)
+        .to_rfc3339()
+}
+
 #[test]
 fn status_snapshot_includes_reasoning_details() {
     let temp_home = TempDir::new().expect("temp home");
@@ -85,22 +93,22 @@ fn status_snapshot_includes_reasoning_details() {
         total_tokens: 2_250,
     };
 
-    let snapshot = RateLimitSnapshot {
-        primary: Some(RateLimitWindow {
-            used_percent: 72.5,
-            window_minutes: Some(300),
-            resets_in_seconds: Some(600),
-        }),
-        secondary: Some(RateLimitWindow {
-            used_percent: 45.0,
-            window_minutes: Some(10080),
-            resets_in_seconds: Some(1_200),
-        }),
-    };
     let captured_at = chrono::Local
         .with_ymd_and_hms(2024, 1, 2, 3, 4, 5)
         .single()
         .expect("timestamp");
+    let snapshot = RateLimitSnapshot {
+        primary: Some(RateLimitWindow {
+            used_percent: 72.5,
+            window_minutes: Some(300),
+            resets_at: Some(reset_at_from(&captured_at, 600)),
+        }),
+        secondary: Some(RateLimitWindow {
+            used_percent: 45.0,
+            window_minutes: Some(10080),
+            resets_at: Some(reset_at_from(&captured_at, 1_200)),
+        }),
+    };
     let rate_display = rate_limit_snapshot_display(&snapshot, captured_at);
 
     let composite = new_status_output(&config, &usage, Some(&usage), &None, Some(&rate_display));
@@ -130,18 +138,18 @@ fn status_snapshot_includes_monthly_limit() {
         total_tokens: 1_200,
     };
 
-    let snapshot = RateLimitSnapshot {
-        primary: Some(RateLimitWindow {
-            used_percent: 12.0,
-            window_minutes: Some(43_200),
-            resets_in_seconds: Some(86_400),
-        }),
-        secondary: None,
-    };
     let captured_at = chrono::Local
         .with_ymd_and_hms(2024, 5, 6, 7, 8, 9)
         .single()
         .expect("timestamp");
+    let snapshot = RateLimitSnapshot {
+        primary: Some(RateLimitWindow {
+            used_percent: 12.0,
+            window_minutes: Some(43_200),
+            resets_at: Some(reset_at_from(&captured_at, 86_400)),
+        }),
+        secondary: None,
+    };
     let rate_display = rate_limit_snapshot_display(&snapshot, captured_at);
 
     let composite = new_status_output(&config, &usage, Some(&usage), &None, Some(&rate_display));
@@ -197,18 +205,18 @@ fn status_snapshot_truncates_in_narrow_terminal() {
         total_tokens: 2_250,
     };
 
-    let snapshot = RateLimitSnapshot {
-        primary: Some(RateLimitWindow {
-            used_percent: 72.5,
-            window_minutes: Some(300),
-            resets_in_seconds: Some(600),
-        }),
-        secondary: None,
-    };
     let captured_at = chrono::Local
         .with_ymd_and_hms(2024, 1, 2, 3, 4, 5)
         .single()
         .expect("timestamp");
+    let snapshot = RateLimitSnapshot {
+        primary: Some(RateLimitWindow {
+            used_percent: 72.5,
+            window_minutes: Some(300),
+            resets_at: Some(reset_at_from(&captured_at, 600)),
+        }),
+        secondary: None,
+    };
     let rate_display = rate_limit_snapshot_display(&snapshot, captured_at);
 
     let composite = new_status_output(&config, &usage, Some(&usage), &None, Some(&rate_display));


### PR DESCRIPTION
This change ensures that we store the absolute time instead of relative offsets of when the primary and secondary rate limits will reset. Previously these got recalculated relative to current time, which leads to the displayed reset times to change over time, including after doing a codex resume.

For previously changed sessions, this will cause the reset times to not show due to this being a breaking change:
<img width="524" height="55" alt="Screenshot 2025-10-17 at 5 14 18 PM" src="https://github.com/user-attachments/assets/53ebd43e-da25-4fef-9c47-94a529d40265" />

Fixes https://github.com/openai/codex/issues/4761
