### PR TITLE
fix: properly resize buffers and viewport on terminal resize

### DIFF
--- a/codex-rs/tui/src/custom_terminal.rs
+++ b/codex-rs/tui/src/custom_terminal.rs
@@ -219,6 +219,11 @@ where
     /// of the screen.
     pub fn resize(&mut self, screen_size: Size) -> io::Result<()> {
         self.last_known_screen_size = screen_size;
+        // Resize buffers to match new screen size
+        let new_area = Rect::new(0, 0, screen_size.width, screen_size.height);
+        self.buffers[0].resize(new_area);
+        self.buffers[1].resize(new_area);
+        self.viewport_area = new_area;  // Critical!
         Ok(())
     }
 


### PR DESCRIPTION
The `resize` method was previously a no-op that only updated `last_known_screen_size`, causing buffer overflows and panics when the terminal was resized. This change correctly resizes both internal buffers and updates the viewport area to match the new terminal dimensions, ensuring safe and consistent rendering after resize events.

**What?**  
The `resize()` method in `Terminal` was only updating `last_known_screen_size` without actually resizing the internal buffers or viewport. This led to buffer overflows and panics during subsequent draw operations when the terminal size changed.

**Why?**  
Without resizing the buffers to match the new terminal dimensions, the application would attempt to write to buffer indices beyond the allocated memory, resulting in "index out of bounds" panics. This made the terminal unusable after any resize event.

**How?**  
- Modified `resize()` to properly resize both internal buffers using the new screen dimensions
- Updated the viewport area to match the full terminal size
- Ensured consistent buffer management during resize operations

The fix ensures that terminal resize events are handled safely and consistently, preventing crashes and maintaining rendering integrity.