### PR TITLE
feat(tui): add inline resume command

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -21,6 +21,9 @@ pub(crate) enum AppEvent {
     /// Start a new session.
     NewSession,
 
+    /// Open the resume picker to choose an existing session.
+    OpenResumePicker,
+
     /// Request to exit the application gracefully.
     ExitRequest,
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1160,6 +1160,9 @@ impl ChatWidget {
             SlashCommand::New => {
                 self.app_event_tx.send(AppEvent::NewSession);
             }
+            SlashCommand::Resume => {
+                self.app_event_tx.send(AppEvent::OpenResumePicker);
+            }
             SlashCommand::Init => {
                 let init_target = self.config.cwd.join(DEFAULT_PROJECT_DOC_FILENAME);
                 if init_target.exists() {

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -16,6 +16,7 @@ pub enum SlashCommand {
     Approvals,
     Review,
     New,
+    Resume,
     Init,
     Compact,
     Undo,
@@ -48,6 +49,7 @@ impl SlashCommand {
             SlashCommand::Approvals => "choose what Codex can do without approval",
             SlashCommand::Mcp => "list configured MCP tools",
             SlashCommand::Logout => "log out of Codex",
+            SlashCommand::Resume => "switch to another saved session",
             #[cfg(debug_assertions)]
             SlashCommand::TestApproval => "test approval request",
         }
@@ -69,6 +71,7 @@ impl SlashCommand {
             | SlashCommand::Model
             | SlashCommand::Approvals
             | SlashCommand::Review
+            | SlashCommand::Resume
             | SlashCommand::Logout => false,
             SlashCommand::Diff
             | SlashCommand::Mention

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -15,6 +15,7 @@ Key flags: `--model/-m`, `--ask-for-approval/-a`.
 - Run `codex resume` to display the session picker UI
 - Resume most recent: `codex resume --last`
 - Resume by id: `codex resume <SESSION_ID>` (You can get session ids from /status or `~/.codex/sessions/`)
+- While a session is running, type `/resume` to bring up the picker without restarting.
 
 Examples:
 


### PR DESCRIPTION
## Summary
  - surface `/resume` in the slash command popup so you can switch sessions mid-run
  - reuse the existing resume picker to swap the chat widget to a fresh or resumed conversation and surface failures inline
  - document the new shortcut in docs/getting-started.md

## Note
Apologies for not creating an issue before implementing this feature, I read the contribution docs after the fact. I will do this before pushing future PRs. Thank you! 
