### PR TITLE
Strip zsh -lc wrapper from TUI command headers

### DIFF
--- a/codex-rs/tui/src/bottom_pane/approval_overlay.rs
+++ b/codex-rs/tui/src/bottom_pane/approval_overlay.rs
@@ -485,11 +485,10 @@ mod tests {
             })
             .collect();
         let expected = vec![
-            "✔ You approved codex to".to_string(),
-            "  run /bin/zsh -lc 'git add".to_string(),
-            "  tui/src/render/mod.rs tui/".to_string(),
-            "  src/render/renderable.rs'".to_string(),
-            "  this time".to_string(),
+            "✔ You approved codex to run".to_string(),
+            "  git add tui/src/render/".to_string(),
+            "  mod.rs tui/src/render/".to_string(),
+            "  renderable.rs this time".to_string(),
         ];
         assert_eq!(rendered, expected);
     }


### PR DESCRIPTION
Extends shell wrapper stripping in TUI to handle `zsh -lc` in addition to `bash -lc`.

Currently, Linux users (and macOS users with zsh profiles) see cluttered command headers like `• Ran zsh -lc "echo hello"` instead of `• Ran echo hello`. This happens because `codex-rs/tui/src/exec_command.rs` only checks for literal `"bash"`, ignoring `zsh` and absolute paths like `/usr/bin/zsh`.

**Changes:**
- Added `is_login_shell_with_lc` helper that extracts shell basename and matches against `bash` or `zsh`
- Updated pattern matching to use the helper instead of hardcoded check
- Added test coverage for zsh and absolute paths (`/usr/bin/zsh`, `/bin/bash`)

**Testing:**
```bash
cd codex-rs
cargo test strip_bash_lc_and_escape -p codex-tui
```

All 4 test cases pass (bash, zsh, and absolute paths for both).

Closes #4201
