### PR TITLE
Update Homebrew install instructions to use cask

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><code>npm i -g @openai/codex</code><br />or <code>brew install codex</code></p>
+<p align="center"><code>npm i -g @openai/codex</code><br />or <code>brew install --cask codex</code></p>
 
 <p align="center"><strong>Codex CLI</strong> is a coding agent from OpenAI that runs locally on your computer.
 </br>
@@ -24,7 +24,7 @@ npm install -g @openai/codex
 Alternatively, if you use Homebrew:
 
 ```shell
-brew install codex
+brew install --cask codex
 ```
 
 Then simply run `codex` to get started:

--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -11,7 +11,7 @@ npm i -g @openai/codex
 codex
 ```
 
-You can also install via Homebrew (`brew install codex`) or download a platform-specific release directly from our [GitHub Releases](https://github.com/openai/codex/releases).
+You can also install via Homebrew (`brew install --cask codex`) or download a platform-specific release directly from our [GitHub Releases](https://github.com/openai/codex/releases).
 
 ## Documentation quickstart
 

--- a/docs/release_management.md
+++ b/docs/release_management.md
@@ -4,7 +4,7 @@ Currently, we made Codex binaries available in three places:
 
 - GitHub Releases https://github.com/openai/codex/releases/
 - `@openai/codex` on npm: https://www.npmjs.com/package/@openai/codex
-- `codex` on Homebrew: https://formulae.brew.sh/formula/codex
+- `codex` on Homebrew Cask: https://formulae.brew.sh/cask/codex
 
 # Cutting a Release
 
@@ -34,14 +34,14 @@ The GitHub Action is responsible for publishing to npm.
 
 ## Publishing to Homebrew
 
-For Homebrew, we are properly set up with their automation system, so every few hours or so it will check our GitHub repo to see if there is a new release. When it finds one, it will put up a PR to create the equivalent Homebrew release, which entails building Codex CLI from source on various versions of macOS.
+For Homebrew, we ship Codex as a cask. Homebrew's automation system checks our GitHub repo every few hours for a new release and will open a PR to update the cask with the latest binary.
 
 Inevitably, you just have to refresh this page periodically to see if the release has been picked up by their automation system:
 
-https://github.com/Homebrew/homebrew-core/pulls?q=%3Apr+codex
+https://github.com/Homebrew/homebrew-cask/pulls?q=%3Apr+codex
 
 Once everything builds, a Homebrew admin has to approve the PR. Again, the whole process takes several hours and we don't have total control over it, but it seems to work pretty well.
 
-For reference, our Homebrew formula lives at:
+For reference, our Homebrew cask lives at:
 
-https://github.com/Homebrew/homebrew-core/blob/main/Formula/c/codex.rb
+https://github.com/Homebrew/homebrew-cask/blob/main/Casks/c/codex.rb


### PR DESCRIPTION
## Summary
- update the README install snippets to use `brew install --cask codex`
- mirror the same change in the Rust CLI README

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_i_68f65682543083269254cd64d290df28