### PR TITLE
Use int timestamps for rate limit reset_at

### DIFF
--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -421,16 +421,24 @@ mod tests {
     use pretty_assertions::assert_eq;
 
     fn rate_limit_snapshot() -> RateLimitSnapshot {
+        let primary_reset_at = Utc
+            .with_ymd_and_hms(2024, 1, 1, 1, 0, 0)
+            .unwrap()
+            .timestamp();
+        let secondary_reset_at = Utc
+            .with_ymd_and_hms(2024, 1, 1, 2, 0, 0)
+            .unwrap()
+            .timestamp();
         RateLimitSnapshot {
             primary: Some(RateLimitWindow {
                 used_percent: 50.0,
                 window_minutes: Some(60),
-                resets_at: Some("2024-01-01T01:00:00Z".to_string()),
+                resets_at: Some(primary_reset_at),
             }),
             secondary: Some(RateLimitWindow {
                 used_percent: 30.0,
                 window_minutes: Some(120),
-                resets_at: Some("2024-01-01T02:00:00Z".to_string()),
+                resets_at: Some(secondary_reset_at),
             }),
         }
     }

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -768,8 +768,8 @@ async fn token_count_includes_rate_limits_snapshot() {
         .insert_header("x-codex-secondary-used-percent", "40.0")
         .insert_header("x-codex-primary-window-minutes", "10")
         .insert_header("x-codex-secondary-window-minutes", "60")
-        .insert_header("x-codex-primary-reset-at", "2024-01-01T00:30:00Z")
-        .insert_header("x-codex-secondary-reset-at", "2024-01-01T02:00:00Z")
+        .insert_header("x-codex-primary-reset-at", "1704069000")
+        .insert_header("x-codex-secondary-reset-at", "1704074400")
         .set_body_raw(sse_body, "text/event-stream");
 
     Mock::given(method("POST"))
@@ -818,12 +818,12 @@ async fn token_count_includes_rate_limits_snapshot() {
                 "primary": {
                     "used_percent": 12.5,
                     "window_minutes": 10,
-                    "resets_at": "2024-01-01T00:30:00Z"
+                    "resets_at": 1704069000
                 },
                 "secondary": {
                     "used_percent": 40.0,
                     "window_minutes": 60,
-                    "resets_at": "2024-01-01T02:00:00Z"
+                    "resets_at": 1704074400
                 }
             }
         })
@@ -865,12 +865,12 @@ async fn token_count_includes_rate_limits_snapshot() {
                 "primary": {
                     "used_percent": 12.5,
                     "window_minutes": 10,
-                    "resets_at": "2024-01-01T00:30:00Z"
+                    "resets_at": 1704069000
                 },
                 "secondary": {
                     "used_percent": 40.0,
                     "window_minutes": 60,
-                    "resets_at": "2024-01-01T02:00:00Z"
+                    "resets_at": 1704074400
                 }
             }
         })
@@ -893,8 +893,8 @@ async fn token_count_includes_rate_limits_snapshot() {
         final_snapshot
             .primary
             .as_ref()
-            .and_then(|window| window.resets_at.as_deref()),
-        Some("2024-01-01T00:30:00Z")
+            .and_then(|window| window.resets_at),
+        Some(1704069000)
     );
 
     wait_for_event(&codex, |msg| matches!(msg, EventMsg::TaskComplete(_))).await;
@@ -915,7 +915,7 @@ async fn usage_limit_error_emits_rate_limit_event() -> anyhow::Result<()> {
             "error": {
                 "type": "usage_limit_reached",
                 "message": "limit reached",
-                "resets_at": "2024-01-01T00:00:42Z",
+                "resets_at": 1704067242,
                 "plan_type": "pro"
             }
         }));

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -644,9 +644,9 @@ pub struct RateLimitWindow {
     /// Rolling window duration, in minutes.
     #[ts(type = "number | null")]
     pub window_minutes: Option<i64>,
-    /// Timestamp (RFC3339) when the window resets.
-    #[ts(type = "string | null")]
-    pub resets_at: Option<String>,
+    /// Unix timestamp (seconds since epoch) when the window resets.
+    #[ts(type = "number | null")]
+    pub resets_at: Option<i64>,
 }
 
 // Includes prompts, tools and space to call compact.

--- a/codex-rs/tui/src/status/rate_limits.rs
+++ b/codex-rs/tui/src/status/rate_limits.rs
@@ -3,6 +3,7 @@ use crate::chatwidget::get_limits_duration;
 use super::helpers::format_reset_timestamp;
 use chrono::DateTime;
 use chrono::Local;
+use chrono::Utc;
 use codex_core::protocol::RateLimitSnapshot;
 use codex_core::protocol::RateLimitWindow;
 
@@ -34,8 +35,7 @@ impl RateLimitWindowDisplay {
     fn from_window(window: &RateLimitWindow, captured_at: DateTime<Local>) -> Self {
         let resets_at = window
             .resets_at
-            .as_deref()
-            .and_then(|value| DateTime::parse_from_rfc3339(value).ok())
+            .and_then(|seconds| DateTime::<Utc>::from_timestamp(seconds, 0))
             .map(|dt| dt.with_timezone(&Local))
             .map(|dt| format_reset_timestamp(dt, captured_at));
 

--- a/codex-rs/tui/src/status/tests.rs
+++ b/codex-rs/tui/src/status/tests.rs
@@ -62,10 +62,10 @@ fn sanitize_directory(lines: Vec<String>) -> Vec<String> {
         .collect()
 }
 
-fn reset_at_from(captured_at: &chrono::DateTime<chrono::Local>, seconds: i64) -> String {
+fn reset_at_from(captured_at: &chrono::DateTime<chrono::Local>, seconds: i64) -> i64 {
     (*captured_at + ChronoDuration::seconds(seconds))
         .with_timezone(&Utc)
-        .to_rfc3339()
+        .timestamp()
 }
 
 #[test]


### PR DESCRIPTION
The backend will be returning unix timestamps (seconds since epoch) instead of RFC 3339 strings. This will make it more ergonomic for developers to integrate against - no string parsing.