### PR TITLE
Treat `zsh -lc` like `bash -lc`

### DIFF
--- a/codex-rs/core/src/bash.rs
+++ b/codex-rs/core/src/bash.rs
@@ -5,13 +5,13 @@ use tree_sitter_bash::LANGUAGE as BASH;
 
 /// Parse the provided bash source using tree-sitter-bash, returning a Tree on
 /// success or None if parsing failed.
-pub fn try_parse_bash(bash_lc_arg: &str) -> Option<Tree> {
+pub fn try_parse_shell(shell_lc_arg: &str) -> Option<Tree> {
     let lang = BASH.into();
     let mut parser = Parser::new();
     #[expect(clippy::expect_used)]
     parser.set_language(&lang).expect("load bash grammar");
     let old_tree: Option<&Tree> = None;
-    parser.parse(bash_lc_arg, old_tree)
+    parser.parse(shell_lc_arg, old_tree)
 }
 
 /// Parse a script which may contain multiple simple commands joined only by
@@ -88,18 +88,19 @@ pub fn try_parse_word_only_commands_sequence(tree: &Tree, src: &str) -> Option<V
     Some(commands)
 }
 
-/// Returns the sequence of plain commands within a `bash -lc "..."` invocation
-/// when the script only contains word-only commands joined by safe operators.
-pub fn parse_bash_lc_plain_commands(command: &[String]) -> Option<Vec<Vec<String>>> {
-    let [bash, flag, script] = command else {
+/// Returns the sequence of plain commands within a `bash -lc "..."` or
+/// `zsh -lc "..."` invocation when the script only contains word-only commands
+/// joined by safe operators.
+pub fn parse_shell_lc_plain_commands(command: &[String]) -> Option<Vec<Vec<String>>> {
+    let [shell, flag, script] = command else {
         return None;
     };
 
-    if bash != "bash" || flag != "-lc" {
+    if flag != "-lc" || !(shell == "bash" || shell == "zsh") {
         return None;
     }
 
-    let tree = try_parse_bash(script)?;
+    let tree = try_parse_shell(script)?;
     try_parse_word_only_commands_sequence(&tree, script)
 }
 
@@ -154,7 +155,7 @@ mod tests {
     use super::*;
 
     fn parse_seq(src: &str) -> Option<Vec<Vec<String>>> {
-        let tree = try_parse_bash(src)?;
+        let tree = try_parse_shell(src)?;
         try_parse_word_only_commands_sequence(&tree, src)
     }
 
@@ -233,5 +234,12 @@ mod tests {
     #[test]
     fn rejects_trailing_operator_parse_error() {
         assert!(parse_seq("ls &&").is_none());
+    }
+
+    #[test]
+    fn parse_zsh_lc_plain_commands() {
+        let command = vec!["zsh".to_string(), "-lc".to_string(), "ls".to_string()];
+        let parsed = parse_shell_lc_plain_commands(&command).unwrap();
+        assert_eq!(parsed, vec![vec!["ls".to_string()]]);
     }
 }

--- a/codex-rs/core/src/command_safety/is_dangerous_command.rs
+++ b/codex-rs/core/src/command_safety/is_dangerous_command.rs
@@ -1,4 +1,4 @@
-use crate::bash::parse_bash_lc_plain_commands;
+use crate::bash::parse_shell_lc_plain_commands;
 
 pub fn command_might_be_dangerous(command: &[String]) -> bool {
     if is_dangerous_to_call_with_exec(command) {
@@ -6,7 +6,7 @@ pub fn command_might_be_dangerous(command: &[String]) -> bool {
     }
 
     // Support `bash -lc "<script>"` where the any part of the script might contain a dangerous command.
-    if let Some(all_commands) = parse_bash_lc_plain_commands(command)
+    if let Some(all_commands) = parse_shell_lc_plain_commands(command)
         && all_commands
             .iter()
             .any(|cmd| is_dangerous_to_call_with_exec(cmd))
@@ -52,6 +52,15 @@ mod tests {
     fn bash_git_reset_is_dangerous() {
         assert!(command_might_be_dangerous(&vec_str(&[
             "bash",
+            "-lc",
+            "git reset --hard"
+        ])));
+    }
+
+    #[test]
+    fn zsh_git_reset_is_dangerous() {
+        assert!(command_might_be_dangerous(&vec_str(&[
+            "zsh",
             "-lc",
             "git reset --hard"
         ])));

--- a/codex-rs/core/src/command_safety/is_safe_command.rs
+++ b/codex-rs/core/src/command_safety/is_safe_command.rs
@@ -1,4 +1,4 @@
-use crate::bash::parse_bash_lc_plain_commands;
+use crate::bash::parse_shell_lc_plain_commands;
 
 pub fn is_known_safe_command(command: &[String]) -> bool {
     let command: Vec<String> = command
@@ -29,7 +29,7 @@ pub fn is_known_safe_command(command: &[String]) -> bool {
     // introduce side effects ( "&&", "||", ";", and "|" ). If every
     // individual command in the script is itself a known‑safe command, then
     // the composite expression is considered safe.
-    if let Some(all_commands) = parse_bash_lc_plain_commands(&command)
+    if let Some(all_commands) = parse_shell_lc_plain_commands(&command)
         && !all_commands.is_empty()
         && all_commands
             .iter()
@@ -199,6 +199,11 @@ mod tests {
         assert!(is_safe_to_call_with_exec(&vec_str(&[
             "find", ".", "-name", "file.txt"
         ])));
+    }
+
+    #[test]
+    fn zsh_lc_safe_command_sequence() {
+        assert!(is_known_safe_command(&vec_str(&["zsh", "-lc", "ls"])));
     }
 
     #[test]


### PR DESCRIPTION
Without proper `zsh -lc` parsing, we lose some things like proper command parsing, turn diff tracking, safe command checks, and other things we expect from raw or `bash -lc` commands.