### PR TITLE
Fix sandbox configuration race in executor

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -980,6 +980,7 @@ impl Session {
         turn_diff_tracker: SharedTurnDiffTracker,
         prepared: PreparedExec,
         approval_policy: AskForApproval,
+        config: ExecutorConfig,
     ) -> Result<ExecToolCallOutput, ExecError> {
         let PreparedExec { context, request } = prepared;
         let is_apply_patch = context.apply_patch.is_some();
@@ -992,13 +993,20 @@ impl Session {
         let result = self
             .services
             .executor
-            .run(request, self, approval_policy, &context, move || {
-                let turn_diff = begin_turn_diff.clone();
-                let ctx = begin_context.clone();
-                async move {
-                    session.on_exec_command_begin(turn_diff, ctx).await;
-                }
-            })
+            .run(
+                request,
+                self,
+                approval_policy,
+                &context,
+                config,
+                move || {
+                    let turn_diff = begin_turn_diff.clone();
+                    let ctx = begin_context.clone();
+                    async move {
+                        session.on_exec_command_begin(turn_diff, ctx).await;
+                    }
+                },
+            )
             .await;
 
         if matches!(

--- a/codex-rs/core/src/tools/mod.rs
+++ b/codex-rs/core/src/tools/mod.rs
@@ -129,7 +129,7 @@ pub(crate) async fn handle_container_exec_with_params(
         None => ExecutionMode::Shell,
     };
 
-    sess.services.executor.update_environment(
+    let executor_config = sess.services.executor.update_environment(
         turn_context.sandbox_policy.clone(),
         turn_context.cwd.clone(),
     );
@@ -152,6 +152,7 @@ pub(crate) async fn handle_container_exec_with_params(
             turn_diff_tracker.clone(),
             prepared_exec,
             turn_context.approval_policy,
+            executor_config,
         )
         .await;
 


### PR DESCRIPTION
## Summary
- snapshot the executor sandbox policy and cwd per run instead of reading from shared mutable state
- thread the captured executor configuration through exec handling so concurrent calls cannot clobber each other

## Testing
- cargo fmt --all
- cargo clippy --fix --all-features --tests --allow-dirty -p codex-core
- cargo test -p codex-core *(fails: integration suite requires external services in this environment)*

------
https://chatgpt.com/codex/tasks/task_i_68f2c8c779688321b842553588118c6e