### PR TITLE
feat: include cwd in notify payload

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1705,6 +1705,7 @@ pub(crate) async fn run_task(
                         .notify(&UserNotification::AgentTurnComplete {
                             thread_id: sess.conversation_id.to_string(),
                             turn_id: sub_id.clone(),
+                            cwd: turn_context.cwd.display().to_string(),
                             input_messages: turn_input_messages,
                             last_assistant_message: last_agent_message.clone(),
                         });

--- a/codex-rs/core/src/user_notification.rs
+++ b/codex-rs/core/src/user_notification.rs
@@ -51,6 +51,8 @@ pub(crate) enum UserNotification {
     AgentTurnComplete {
         thread_id: String,
         turn_id: String,
+        /// Canonical working directory for the Codex session.
+        cwd: String,
 
         /// Messages that the user sent to the agent to initiate the turn.
         input_messages: Vec<String>,
@@ -70,6 +72,7 @@ mod tests {
         let notification = UserNotification::AgentTurnComplete {
             thread_id: "b5f6c1c2-1111-2222-3333-444455556666".to_string(),
             turn_id: "12345".to_string(),
+            cwd: "/Users/example/project".to_string(),
             input_messages: vec!["Rename `foo` to `bar` and update the callsites.".to_string()],
             last_assistant_message: Some(
                 "Rename complete and verified `cargo build` succeeds.".to_string(),
@@ -78,7 +81,7 @@ mod tests {
         let serialized = serde_json::to_string(&notification)?;
         assert_eq!(
             serialized,
-            r#"{"type":"agent-turn-complete","thread-id":"b5f6c1c2-1111-2222-3333-444455556666","turn-id":"12345","input-messages":["Rename `foo` to `bar` and update the callsites."],"last-assistant-message":"Rename complete and verified `cargo build` succeeds."}"#
+            r#"{"type":"agent-turn-complete","thread-id":"b5f6c1c2-1111-2222-3333-444455556666","turn-id":"12345","cwd":"/Users/example/project","input-messages":["Rename `foo` to `bar` and update the callsites."],"last-assistant-message":"Rename complete and verified `cargo build` succeeds."}"#
         );
         Ok(())
     }

--- a/codex-rs/core/src/user_notification.rs
+++ b/codex-rs/core/src/user_notification.rs
@@ -51,7 +51,6 @@ pub(crate) enum UserNotification {
     AgentTurnComplete {
         thread_id: String,
         turn_id: String,
-        /// Canonical working directory for the Codex session.
         cwd: String,
 
         /// Messages that the user sent to the agent to initiate the turn.

--- a/docs/config.md
+++ b/docs/config.md
@@ -620,6 +620,7 @@ Specify a program that will be executed to get notified about events generated b
   "type": "agent-turn-complete",
   "thread-id": "b5f6c1c2-1111-2222-3333-444455556666",
   "turn-id": "12345",
+  "cwd": "/Users/alice/projects/example",
   "input-messages": ["Rename `foo` to `bar` and update the callsites."],
   "last-assistant-message": "Rename complete and verified `cargo build` succeeds."
 }
@@ -628,6 +629,8 @@ Specify a program that will be executed to get notified about events generated b
 The `"type"` property will always be set. Currently, `"agent-turn-complete"` is the only notification type that is supported.
 
 `"thread-id"` contains a string that identifies the Codex session that produced the notification; you can use it to correlate multiple turns that belong to the same task.
+
+`"cwd"` reports the absolute working directory for the session so scripts can disambiguate which project triggered the notification.
 
 As an example, here is a Python script that parses the JSON and decides whether to show a desktop push notification using [terminal-notifier](https://github.com/julienXX/terminal-notifier) on macOS:
 


### PR DESCRIPTION
Expose the session cwd in the notify payload and update docs so scripts and extensions receive the real project path; users get accurate project-aware notifications in CLI and VS Code.

Fixes #5387