### PR TITLE
Improve resume picker grouping and folder filtering

### DIFF
--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -407,7 +407,13 @@ async fn run_ratatui_app(
             Err(_) => resume_picker::ResumeSelection::StartFresh,
         }
     } else if cli.resume_picker {
-        match resume_picker::run_resume_picker(&mut tui, &config.codex_home).await? {
+        match resume_picker::run_resume_picker(
+            &mut tui,
+            &config.codex_home,
+            Some(config.cwd.clone()),
+        )
+        .await?
+        {
             resume_picker::ResumeSelection::Exit => {
                 restore();
                 session_log::log_session_end();

--- a/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_table.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_table.snap
@@ -1,8 +1,11 @@
 ---
 source: tui/src/resume_picker.rs
+assertion_line: 1593
 expression: snapshot
 ---
   Created         Updated         Conversation
+--- Today ---
   16 minutes ago  42 seconds ago  Fix resume picker timestamps
 > 1 hour ago      35 minutes ago  Investigate lazy pagination cap
+--- Yesterday ---
   2 hours ago     2 hours ago     Explain the codebase


### PR DESCRIPTION
  - Extend the resume picker so callers pass the active working directory, enabling a new “This Folder” tab that filters sessions to the current project.
  - Redesign the picker list with Created/Updated columns, time-bucket dividers (Today / Yesterday / n weeks ago), richer empty states, and viewport-aware PageUp/PageDown navigation.
  - Rework pagination and search to keep scanning until matches appear, coalescing scroll- and search-triggered loads and guarding against duplicate rows.
  - Add comprehensive unit coverage for search iteration, tab switching, pagination, and timestamp helpers, plus refresh the snapshot to capture the grouped table layout.

  ## Testing

- just fmt
- cargo test -p codex-tui
- just fix -p codex-tui
- cargo build