### PR TITLE
feat: add profile support to the Codex Typescript SDK

### DIFF
--- a/sdk/typescript/src/exec.ts
+++ b/sdk/typescript/src/exec.ts
@@ -22,6 +22,8 @@ export type CodexExecArgs = {
   skipGitRepoCheck?: boolean;
   // --output-schema
   outputSchemaFile?: string;
+  // --profile
+  profile?: string;
 };
 
 const INTERNAL_ORIGINATOR_ENV = "CODEX_INTERNAL_ORIGINATOR_OVERRIDE";
@@ -54,6 +56,10 @@ export class CodexExec {
 
     if (args.outputSchemaFile) {
       commandArgs.push("--output-schema", args.outputSchemaFile);
+    }
+
+    if (args.profile) {
+      commandArgs.push("--profile", args.profile);
     }
 
     if (args.images?.length) {

--- a/sdk/typescript/src/thread.ts
+++ b/sdk/typescript/src/thread.ts
@@ -85,6 +85,7 @@ export class Thread {
       workingDirectory: options?.workingDirectory,
       skipGitRepoCheck: options?.skipGitRepoCheck,
       outputSchemaFile: schemaPath,
+      profile: turnOptions.profile,
     });
     try {
       for await (const item of generator) {

--- a/sdk/typescript/src/turnOptions.ts
+++ b/sdk/typescript/src/turnOptions.ts
@@ -1,4 +1,6 @@
 export type TurnOptions = {
   /** JSON schema describing the expected agent output. */
   outputSchema?: unknown;
+  /** Codex profile to apply for this turn. */
+  profile?: string;
 };

--- a/sdk/typescript/tests/run.test.ts
+++ b/sdk/typescript/tests/run.test.ts
@@ -279,6 +279,34 @@ describe("Codex", () => {
       await close();
     }
   });
+  it("forwards profile turn option to exec", async () => {
+    const { url, close } = await startResponsesTestProxy({
+      statusCode: 200,
+      responseBodies: [
+        sse(
+          responseStarted("response_1"),
+          assistantMessage("Profile applied", "item_1"),
+          responseCompleted("response_1"),
+        ),
+      ],
+    });
+
+    const { args: spawnArgs, restore } = codexExecSpy();
+
+    try {
+      const client = new Codex({ codexPathOverride: codexExecPath, baseUrl: url, apiKey: "test" });
+
+      const thread = client.startThread();
+      await thread.run("apply profile", { profile: "sdk-profile" });
+
+      const commandArgs = spawnArgs[0];
+      expect(commandArgs).toBeDefined();
+      expectPair(commandArgs, ["--profile", "sdk-profile"]);
+    } finally {
+      restore();
+      await close();
+    }
+  });
   it("combines structured text input segments", async () => {
     const { url, close, requests } = await startResponsesTestProxy({
       statusCode: 200,


### PR DESCRIPTION
Extends `TurnOptions` with a new `profile?: string` field.  This is then fed to the CLI through `--profile`.  It is now possible to apply a specific profile when using `run` or `runStreamed`:

```typescript
await thread.run("apply profile", { profile: "sdk-profile" });
```

Adds two new tests: one for the happy path where a profile exists, and another one for when the profile does not exist.

This brings the Typescript SDK closer to feature parity with the CLI.  Addresses #5459 .