### PR TITLE
[MCP] Add support for specifying scopes for MCP oauth

### DIFF
--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -150,6 +150,10 @@ pub struct RemoveArgs {
 pub struct LoginArgs {
     /// Name of the MCP server to authenticate with oauth.
     pub name: String,
+
+    /// Comma-separated list of OAuth scopes to request.
+    #[arg(long, value_delimiter = ',', value_name = "SCOPE,SCOPE")]
+    pub scopes: Vec<String>,
 }
 
 #[derive(Debug, clap::Parser)]
@@ -279,6 +283,7 @@ async fn run_add(config_overrides: &CliConfigOverrides, add_args: AddArgs) -> Re
             config.mcp_oauth_credentials_store_mode,
             http_headers.clone(),
             env_http_headers.clone(),
+            &Vec::new(),
         )
         .await?;
         println!("Successfully logged in.");
@@ -327,7 +332,7 @@ async fn run_login(config_overrides: &CliConfigOverrides, login_args: LoginArgs)
         );
     }
 
-    let LoginArgs { name } = login_args;
+    let LoginArgs { name, scopes } = login_args;
 
     let Some(server) = config.mcp_servers.get(&name) else {
         bail!("No MCP server named '{name}' found.");
@@ -349,6 +354,7 @@ async fn run_login(config_overrides: &CliConfigOverrides, login_args: LoginArgs)
         config.mcp_oauth_credentials_store_mode,
         http_headers,
         env_http_headers,
+        &scopes,
     )
     .await?;
     println!("Successfully logged in to MCP server '{name}'.");

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -37,6 +37,7 @@ pub async fn perform_oauth_login(
     store_mode: OAuthCredentialsStoreMode,
     http_headers: Option<HashMap<String, String>>,
     env_http_headers: Option<HashMap<String, String>>,
+    scopes: &[String],
 ) -> Result<()> {
     let server = Arc::new(Server::http("127.0.0.1:0").map_err(|err| anyhow!(err))?);
     let guard = CallbackServerGuard {
@@ -61,8 +62,9 @@ pub async fn perform_oauth_login(
     let http_client = apply_default_headers(ClientBuilder::new(), &default_headers).build()?;
 
     let mut oauth_state = OAuthState::new(server_url, Some(http_client)).await?;
+    let scope_refs: Vec<&str> = scopes.iter().map(String::as_str).collect();
     oauth_state
-        .start_authorization(&[], &redirect_uri, Some("Codex"))
+        .start_authorization(&scope_refs, &redirect_uri, Some("Codex"))
         .await?;
     let auth_url = oauth_state.get_authorization_url().await?;
 


### PR DESCRIPTION
```
codex mcp login server_name --scopes=scope1,scope2,scope3
```

Fixes #5480