### PR TITLE
[app-server] add new account method API stubs

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -176,6 +176,27 @@ impl CodexMessageProcessor {
             ClientRequest::ListModels { request_id, params } => {
                 self.list_models(request_id, params).await;
             }
+            ClientRequest::LoginAccount {
+                request_id,
+                params: _,
+            } => {
+                self.send_unimplemented_error(request_id, "account/login")
+                    .await;
+            }
+            ClientRequest::LogoutAccount {
+                request_id,
+                params: _,
+            } => {
+                self.send_unimplemented_error(request_id, "account/logout")
+                    .await;
+            }
+            ClientRequest::GetAccount {
+                request_id,
+                params: _,
+            } => {
+                self.send_unimplemented_error(request_id, "account/read")
+                    .await;
+            }
             ClientRequest::ResumeConversation { request_id, params } => {
                 self.handle_resume_conversation(request_id, params).await;
             }
@@ -255,6 +276,15 @@ impl CodexMessageProcessor {
                 self.get_account_rate_limits(request_id).await;
             }
         }
+    }
+
+    async fn send_unimplemented_error(&self, request_id: RequestId, method: &str) {
+        let error = JSONRPCErrorError {
+            code: INTERNAL_ERROR_CODE,
+            message: format!("{method} is not implemented yet"),
+            data: None,
+        };
+        self.outgoing.send_error(request_id, error).await;
     }
 
     async fn login_api_key(&mut self, request_id: RequestId, params: LoginApiKeyParams) {

--- a/codex-rs/protocol/src/account.rs
+++ b/codex-rs/protocol/src/account.rs
@@ -1,0 +1,35 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use ts_rs::TS;
+
+#[derive(Serialize, Deserialize, Copy, Clone, Debug, PartialEq, Eq, JsonSchema, TS, Default)]
+#[serde(rename_all = "lowercase")]
+#[ts(rename_all = "lowercase")]
+pub enum PlanType {
+    #[default]
+    Free,
+    Plus,
+    Pro,
+    Team,
+    Business,
+    Enterprise,
+    Edu,
+    #[serde(other)]
+    Unknown,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema, TS)]
+#[serde(tag = "type")]
+#[ts(tag = "type")]
+pub enum Account {
+    ApiKey {
+        api_key: String,
+    },
+    #[serde(rename = "chatgpt")]
+    #[ts(rename = "chatgpt")]
+    ChatGpt {
+        email: Option<String>,
+        plan_type: PlanType,
+    },
+}

--- a/codex-rs/protocol/src/lib.rs
+++ b/codex-rs/protocol/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod account;
 mod conversation_id;
 pub use conversation_id::ConversationId;
 pub mod config_types;


### PR DESCRIPTION
These are the schema definitions for the new JSON-RPC APIs associated with accounts. These are not wired up to business logic yet and will currently throw an internal error indicating these are unimplemented.