### PR TITLE
Add cosign signing for Linux release artifacts

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -327,6 +327,38 @@ jobs:
             zstd -T0 -19 --rm "$dest/$base"
           done
 
+      - if: ${{ contains(matrix.target, 'unknown-linux') }}
+        name: Install cosign
+        uses: sigstore/cosign-installer@v3.6.0
+
+      - if: ${{ contains(matrix.target, 'unknown-linux') }}
+        name: Sign Linux artifacts
+        shell: bash
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+          COSIGN_YES: "true"
+        run: |
+          set -euo pipefail
+
+          dest="dist/${{ matrix.target }}"
+          shopt -s nullglob
+
+          for artifact in "$dest"/*; do
+            [[ -f "$artifact" ]] || continue
+
+            case "$artifact" in
+              *.sig|*.pem)
+                continue
+                ;;
+            esac
+
+            cosign sign-blob \
+              --yes \
+              --output-signature "${artifact}.sig" \
+              --output-certificate "${artifact}.pem" \
+              "$artifact"
+          done
+
       - name: Remove signing keychain
         if: ${{ always() && matrix.runner == 'macos-15-xlarge' }}
         shell: bash


### PR DESCRIPTION
## Summary
- install cosign in Linux release matrix jobs
- sign Linux release artifacts with cosign and upload the signatures alongside the binaries

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_i_68f8fc5ac7a88326a54ae855cdc66d30