### PR TITLE
adding messaging for stale rate limits + when no rate limits are cached

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1631,6 +1631,7 @@ impl ChatWidget {
             context_usage,
             &self.conversation_id,
             self.rate_limit_snapshot.as_ref(),
+            Local::now(),
         ));
     }
 

--- a/codex-rs/tui/src/status/rate_limits.rs
+++ b/codex-rs/tui/src/status/rate_limits.rs
@@ -2,6 +2,7 @@ use crate::chatwidget::get_limits_duration;
 
 use super::helpers::format_reset_timestamp;
 use chrono::DateTime;
+use chrono::Duration as ChronoDuration;
 use chrono::Local;
 use chrono::Utc;
 use codex_core::protocol::RateLimitSnapshot;
@@ -21,8 +22,11 @@ pub(crate) struct StatusRateLimitRow {
 #[derive(Debug, Clone)]
 pub(crate) enum StatusRateLimitData {
     Available(Vec<StatusRateLimitRow>),
+    Stale(Vec<StatusRateLimitRow>),
     Missing,
 }
+
+pub(crate) const RATE_LIMIT_STALE_THRESHOLD_MINUTES: i64 = 15;
 
 #[derive(Debug, Clone)]
 pub(crate) struct RateLimitWindowDisplay {
@@ -49,6 +53,7 @@ impl RateLimitWindowDisplay {
 
 #[derive(Debug, Clone)]
 pub(crate) struct RateLimitSnapshotDisplay {
+    pub captured_at: DateTime<Local>,
     pub primary: Option<RateLimitWindowDisplay>,
     pub secondary: Option<RateLimitWindowDisplay>,
 }
@@ -58,6 +63,7 @@ pub(crate) fn rate_limit_snapshot_display(
     captured_at: DateTime<Local>,
 ) -> RateLimitSnapshotDisplay {
     RateLimitSnapshotDisplay {
+        captured_at,
         primary: snapshot
             .primary
             .as_ref()
@@ -71,6 +77,7 @@ pub(crate) fn rate_limit_snapshot_display(
 
 pub(crate) fn compose_rate_limit_data(
     snapshot: Option<&RateLimitSnapshotDisplay>,
+    now: DateTime<Local>,
 ) -> StatusRateLimitData {
     match snapshot {
         Some(snapshot) => {
@@ -102,8 +109,13 @@ pub(crate) fn compose_rate_limit_data(
                 });
             }
 
+            let is_stale = now.signed_duration_since(snapshot.captured_at)
+                > ChronoDuration::minutes(RATE_LIMIT_STALE_THRESHOLD_MINUTES);
+
             if rows.is_empty() {
                 StatusRateLimitData::Available(vec![])
+            } else if is_stale {
+                StatusRateLimitData::Stale(rows)
             } else {
                 StatusRateLimitData::Available(rows)
             }

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
@@ -15,5 +15,5 @@ expression: sanitized
 │                                                                 │
 │  Token usage:      750 total  (500 input + 250 output)          │
 │  Context window:   100% left (750 used / 272K)                  │
-│  Limits:           send a message to load usage data            │
+│  Limits:           visit chatgpt.com/codex/settings/usage       │
 ╰─────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
@@ -1,0 +1,21 @@
+---
+source: tui/src/status/tests.rs
+expression: sanitized
+---
+/status
+
+╭─────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                           │
+│                                                                     │
+│  Model:            gpt-5-codex (reasoning none, summaries auto)     │
+│  Directory: [[workspace]]                                           │
+│  Approval:         on-request                                       │
+│  Sandbox:          read-only                                        │
+│  Agents.md:        <none>                                           │
+│                                                                     │
+│  Token usage:      1.9K total  (1K input + 900 output)              │
+│  Context window:   100% left (2.1K used / 272K)                     │
+│  5h limit:         [███████████████░░░░░] 72% used (resets 03:14)   │
+│  Weekly limit:     [████████░░░░░░░░░░░░] 40% used (resets 03:34)   │
+│  Warning:          limits may be stale - start new turn to refresh. │
+╰─────────────────────────────────────────────────────────────────────╯


### PR DESCRIPTION
Currently, users are unable to see rate limits when they first start up codex because rate limits are only fetched from the header of a call to the `responses api`. Rate limits becomes stale if a user hasn't sent a message in a while.

This PR introduces updates to the `/status` page so that 
if we have no cached rate limits, we redirect the user to [chatgpt.com/codex/settings/usage](url)
if cached rate limits are older than 15 minutes, we warn the user that rate limit data may be stale

