### PR TITLE
Moving `token_info` to `ConversationHistory`

### DIFF
--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -12,7 +12,6 @@ use crate::protocol::TokenUsageInfo;
 pub(crate) struct SessionState {
     pub(crate) session_configuration: SessionConfiguration,
     pub(crate) history: ConversationHistory,
-    pub(crate) token_info: Option<TokenUsageInfo>,
     pub(crate) latest_rate_limits: Option<RateLimitSnapshot>,
 }
 
@@ -22,7 +21,6 @@ impl SessionState {
         Self {
             session_configuration,
             history: ConversationHistory::new(),
-            token_info: None,
             latest_rate_limits: None,
         }
     }
@@ -54,11 +52,11 @@ impl SessionState {
         usage: &TokenUsage,
         model_context_window: Option<i64>,
     ) {
-        self.token_info = TokenUsageInfo::new_or_append(
-            &self.token_info,
-            &Some(usage.clone()),
-            model_context_window,
-        );
+        self.history.update_token_info(usage, model_context_window);
+    }
+
+    pub(crate) fn token_info(&self) -> Option<TokenUsageInfo> {
+        self.history.token_info()
     }
 
     pub(crate) fn set_rate_limits(&mut self, snapshot: RateLimitSnapshot) {
@@ -68,17 +66,10 @@ impl SessionState {
     pub(crate) fn token_info_and_rate_limits(
         &self,
     ) -> (Option<TokenUsageInfo>, Option<RateLimitSnapshot>) {
-        (self.token_info.clone(), self.latest_rate_limits.clone())
+        (self.token_info(), self.latest_rate_limits.clone())
     }
 
     pub(crate) fn set_token_usage_full(&mut self, context_window: i64) {
-        match &mut self.token_info {
-            Some(info) => info.fill_to_context_window(context_window),
-            None => {
-                self.token_info = Some(TokenUsageInfo::full_context_window(context_window));
-            }
-        }
+        self.history.set_token_usage_full(context_window);
     }
-
-    // Pending input/approval moved to TurnState.
 }


### PR DESCRIPTION
I want to centralize input processing and management to `ConversationHistory`. This would need `ConversationHistory` to have access to `token_info` (i.e. preventing adding a big input to the history). Besides, it makes more sense to have it on `ConversationHistory` than `state`.