### PR TITLE
[Please ignore; not ready for review]: Add input validation to prevent exceeding the rate limits

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -542,7 +542,7 @@ impl Session {
         );
 
         // Create the mutable state for the Session.
-        let state = SessionState::new(session_configuration.clone());
+        let state = SessionState::new(session_configuration.clone(), config.model_context_window);
 
         let services = SessionServices {
             mcp_connection_manager,
@@ -876,7 +876,7 @@ impl Session {
         turn_context: &TurnContext,
         rollout_items: &[RolloutItem],
     ) -> CodexResult<Vec<ResponseItem>> {
-        let mut history = ConversationHistory::new();
+        let mut history = ConversationHistory::new(turn_context.client.get_model_context_window());
         for item in rollout_items {
             match item {
                 RolloutItem::ResponseItem(response_item) => {
@@ -1543,7 +1543,8 @@ pub(crate) async fn run_task(
     // For normal turns, continue recording to the session history as before.
     let is_review_mode = turn_context.is_review_mode;
 
-    let mut review_thread_history: ConversationHistory = ConversationHistory::new();
+    let mut review_thread_history: ConversationHistory =
+        ConversationHistory::new(turn_context.client.get_model_context_window());
     if is_review_mode {
         // Seed review threads with environment context so the model knows the working directory.
         review_thread_history
@@ -2569,7 +2570,7 @@ mod tests {
             original_config_do_not_use: Arc::clone(&config),
         };
 
-        let state = SessionState::new(session_configuration.clone());
+        let state = SessionState::new(session_configuration.clone(), config.model_context_window);
 
         let services = SessionServices {
             mcp_connection_manager: McpConnectionManager::default(),
@@ -2637,7 +2638,7 @@ mod tests {
             original_config_do_not_use: Arc::clone(&config),
         };
 
-        let state = SessionState::new(session_configuration.clone());
+        let state = SessionState::new(session_configuration.clone(), config.model_context_window);
 
         let services = SessionServices {
             mcp_connection_manager: McpConnectionManager::default(),
@@ -2860,7 +2861,8 @@ mod tests {
         turn_context: &TurnContext,
     ) -> CodexResult<(Vec<RolloutItem>, Vec<ResponseItem>)> {
         let mut rollout_items = Vec::new();
-        let mut live_history = ConversationHistory::new();
+        let mut live_history =
+            ConversationHistory::new(turn_context.client.get_model_context_window());
 
         let initial_context = session.build_initial_context(turn_context);
         for item in &initial_context {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -59,6 +59,7 @@ use crate::config::Config;
 use crate::config_types::McpServerTransportConfig;
 use crate::config_types::ShellEnvironmentPolicy;
 use crate::conversation_history::ConversationHistory;
+use crate::conversation_history::prefetch_tokenizer_in_background;
 use crate::environment_context::EnvironmentContext;
 use crate::error::CodexErr;
 use crate::error::Result as CodexResult;
@@ -159,6 +160,8 @@ impl Codex {
         conversation_history: InitialHistory,
         session_source: SessionSource,
     ) -> CodexResult<CodexSpawnOk> {
+        // Start loading the tokenizer in the background so we don't block later.
+        prefetch_tokenizer_in_background();
         let (tx_sub, rx_sub) = async_channel::bounded(SUBMISSION_CHANNEL_CAPACITY);
         let (tx_event, rx_event) = async_channel::unbounded();
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -542,7 +542,7 @@ impl Session {
         );
 
         // Create the mutable state for the Session.
-        let state = SessionState::new(session_configuration.clone(), config.model_context_window);
+        let state = SessionState::new(session_configuration.clone());
 
         let services = SessionServices {
             mcp_connection_manager,
@@ -876,7 +876,7 @@ impl Session {
         turn_context: &TurnContext,
         rollout_items: &[RolloutItem],
     ) -> CodexResult<Vec<ResponseItem>> {
-        let mut history = ConversationHistory::new(turn_context.client.get_model_context_window());
+        let mut history = ConversationHistory::new();
         for item in rollout_items {
             match item {
                 RolloutItem::ResponseItem(response_item) => {
@@ -1543,8 +1543,7 @@ pub(crate) async fn run_task(
     // For normal turns, continue recording to the session history as before.
     let is_review_mode = turn_context.is_review_mode;
 
-    let mut review_thread_history: ConversationHistory =
-        ConversationHistory::new(turn_context.client.get_model_context_window());
+    let mut review_thread_history: ConversationHistory = ConversationHistory::new();
     if is_review_mode {
         // Seed review threads with environment context so the model knows the working directory.
         review_thread_history
@@ -2570,7 +2569,7 @@ mod tests {
             original_config_do_not_use: Arc::clone(&config),
         };
 
-        let state = SessionState::new(session_configuration.clone(), config.model_context_window);
+        let state = SessionState::new(session_configuration.clone());
 
         let services = SessionServices {
             mcp_connection_manager: McpConnectionManager::default(),
@@ -2638,7 +2637,7 @@ mod tests {
             original_config_do_not_use: Arc::clone(&config),
         };
 
-        let state = SessionState::new(session_configuration.clone(), config.model_context_window);
+        let state = SessionState::new(session_configuration.clone());
 
         let services = SessionServices {
             mcp_connection_manager: McpConnectionManager::default(),
@@ -2861,8 +2860,7 @@ mod tests {
         turn_context: &TurnContext,
     ) -> CodexResult<(Vec<RolloutItem>, Vec<ResponseItem>)> {
         let mut rollout_items = Vec::new();
-        let mut live_history =
-            ConversationHistory::new(turn_context.client.get_model_context_window());
+        let mut live_history = ConversationHistory::new();
 
         let initial_context = session.build_initial_context(turn_context);
         for item in &initial_context {

--- a/codex-rs/core/src/conversation_history.rs
+++ b/codex-rs/core/src/conversation_history.rs
@@ -17,12 +17,7 @@ pub(crate) struct ConversationHistory {
 }
 
 impl ConversationHistory {
-    pub(crate) fn new(model_context_window: Option<i64>) -> Self {
-        let token_info = model_context_window.map(|context_window| TokenUsageInfo {
-            total_token_usage: TokenUsage::default(),
-            last_token_usage: TokenUsage::default(),
-            model_context_window: Some(context_window),
-        });
+    pub(crate) fn new() -> Self {
         let tokenizer = match Tokenizer::try_default() {
             Ok(tokenizer) => Some(tokenizer),
             Err(error) => {
@@ -32,7 +27,7 @@ impl ConversationHistory {
         };
         Self {
             items: Vec::new(),
-            token_info,
+            token_info: Some(TokenUsageInfo::default()),
             tokenizer,
         }
     }
@@ -408,12 +403,6 @@ impl ConversationHistory {
     }
 }
 
-impl Default for ConversationHistory {
-    fn default() -> Self {
-        Self::new(None)
-    }
-}
-
 #[inline]
 fn error_or_panic(message: String) {
     if cfg!(debug_assertions) || env!("CARGO_PKG_VERSION").contains("alpha") {
@@ -460,7 +449,7 @@ mod tests {
     }
 
     fn create_history_with_items(items: Vec<ResponseItem>) -> ConversationHistory {
-        let mut h = ConversationHistory::new(None);
+        let mut h = ConversationHistory::new();
         h.record_items(items.iter()).unwrap();
         h
     }
@@ -477,7 +466,7 @@ mod tests {
 
     #[test]
     fn filters_non_api_messages() {
-        let mut h = ConversationHistory::default();
+        let mut h = ConversationHistory::new();
         // System message is not an API message; Other is ignored.
         let system = ResponseItem::Message {
             id: None,

--- a/codex-rs/core/src/conversation_history.rs
+++ b/codex-rs/core/src/conversation_history.rs
@@ -146,7 +146,7 @@ impl ConversationHistory {
             }
         }
 
-        let prior_total = info.total_token_usage.total_tokens;
+        let prior_total = info.last_token_usage.total_tokens;
         let combined_tokens = prior_total.saturating_add(input_tokens);
         let threshold = context_window * 95 / 100;
         if combined_tokens > threshold {

--- a/codex-rs/core/src/conversation_history.rs
+++ b/codex-rs/core/src/conversation_history.rs
@@ -27,7 +27,7 @@ impl ConversationHistory {
         };
         Self {
             items: Vec::new(),
-            token_info: Some(TokenUsageInfo::default()),
+            token_info: None,
             tokenizer,
         }
     }

--- a/codex-rs/core/src/conversation_history.rs
+++ b/codex-rs/core/src/conversation_history.rs
@@ -118,6 +118,8 @@ impl ConversationHistory {
         let Some(info) = &self.token_info else {
             return Ok(());
         };
+        // this will intentionally not check the context for the first turn before getting this information.
+        // it's acceptable tradeoff.
         let Some(context_window) = info.model_context_window else {
             return Ok(());
         };

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -158,6 +158,9 @@ pub enum CodexErr {
 
     #[error("{0}")]
     EnvVar(EnvVarError),
+
+    #[error("invalid input: {0}")]
+    InvalidInput(String),
 }
 
 impl From<CancelErr> for CodexErr {

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -4,6 +4,7 @@ use codex_protocol::models::ResponseItem;
 
 use crate::codex::SessionConfiguration;
 use crate::conversation_history::ConversationHistory;
+use crate::error::CodexErr;
 use crate::protocol::RateLimitSnapshot;
 use crate::protocol::TokenUsage;
 use crate::protocol::TokenUsageInfo;
@@ -26,12 +27,13 @@ impl SessionState {
     }
 
     // History helpers
-    pub(crate) fn record_items<I>(&mut self, items: I)
+    pub(crate) fn record_items<I>(&mut self, items: I) -> Result<(), CodexErr>
     where
         I: IntoIterator,
         I::Item: std::ops::Deref<Target = ResponseItem>,
     {
-        self.history.record_items(items)
+        self.history.record_items(items)?;
+        Ok(())
     }
 
     pub(crate) fn history_snapshot(&mut self) -> Vec<ResponseItem> {

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -18,13 +18,10 @@ pub(crate) struct SessionState {
 
 impl SessionState {
     /// Create a new session state mirroring previous `State::default()` semantics.
-    pub(crate) fn new(
-        session_configuration: SessionConfiguration,
-        model_context_window: Option<i64>,
-    ) -> Self {
+    pub(crate) fn new(session_configuration: SessionConfiguration) -> Self {
         Self {
             session_configuration,
-            history: ConversationHistory::new(model_context_window),
+            history: ConversationHistory::new(),
             latest_rate_limits: None,
         }
     }

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -71,7 +71,14 @@ impl SessionState {
     pub(crate) fn token_info_and_rate_limits(
         &self,
     ) -> (Option<TokenUsageInfo>, Option<RateLimitSnapshot>) {
-        (self.token_info(), self.latest_rate_limits.clone())
+        let info = self.token_info().and_then(|info| {
+            if info.total_token_usage.is_zero() && info.last_token_usage.is_zero() {
+                None
+            } else {
+                Some(info)
+            }
+        });
+        (info, self.latest_rate_limits.clone())
     }
 
     pub(crate) fn set_token_usage_full(&mut self, context_window: i64) {

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -18,10 +18,13 @@ pub(crate) struct SessionState {
 
 impl SessionState {
     /// Create a new session state mirroring previous `State::default()` semantics.
-    pub(crate) fn new(session_configuration: SessionConfiguration) -> Self {
+    pub(crate) fn new(
+        session_configuration: SessionConfiguration,
+        model_context_window: Option<i64>,
+    ) -> Self {
         Self {
             session_configuration,
-            history: ConversationHistory::new(),
+            history: ConversationHistory::new(model_context_window),
             latest_rate_limits: None,
         }
     }

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -12,7 +12,6 @@ use crate::protocol::TokenUsageInfo;
 pub(crate) struct SessionState {
     pub(crate) session_configuration: SessionConfiguration,
     pub(crate) history: ConversationHistory,
-    pub(crate) token_info: Option<TokenUsageInfo>,
     pub(crate) latest_rate_limits: Option<RateLimitSnapshot>,
 }
 
@@ -22,7 +21,6 @@ impl SessionState {
         Self {
             session_configuration,
             history: ConversationHistory::new(),
-            token_info: None,
             latest_rate_limits: None,
         }
     }
@@ -54,11 +52,11 @@ impl SessionState {
         usage: &TokenUsage,
         model_context_window: Option<i64>,
     ) {
-        self.token_info = TokenUsageInfo::new_or_append(
-            &self.token_info,
-            &Some(usage.clone()),
-            model_context_window,
-        );
+        self.history.update_token_info(usage, model_context_window);
+    }
+
+    pub(crate) fn token_info(&self) -> Option<TokenUsageInfo> {
+        self.history.token_info()
     }
 
     pub(crate) fn set_rate_limits(&mut self, snapshot: RateLimitSnapshot) {
@@ -68,17 +66,10 @@ impl SessionState {
     pub(crate) fn token_info_and_rate_limits(
         &self,
     ) -> (Option<TokenUsageInfo>, Option<RateLimitSnapshot>) {
-        (self.token_info.clone(), self.latest_rate_limits.clone())
+        (self.token_info(), self.latest_rate_limits.clone())
     }
 
     pub(crate) fn set_token_usage_full(&mut self, context_window: i64) {
-        match &mut self.token_info {
-            Some(info) => info.fill_to_context_window(context_window),
-            None => {
-                self.token_info = Some(TokenUsageInfo::full_context_window(context_window));
-            }
-        }
+        self.history.set_token_usage_full(context_window);
     }
-
-    // Pending input/approval moved to TurnState.
 }

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -5,6 +5,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::codex::TurnContext;
 use crate::codex::compact;
+use crate::error::Result as CodexResult;
 use crate::state::TaskKind;
 use codex_protocol::user_input::UserInput;
 
@@ -26,7 +27,7 @@ impl SessionTask for CompactTask {
         ctx: Arc<TurnContext>,
         input: Vec<UserInput>,
         _cancellation_token: CancellationToken,
-    ) -> Option<String> {
+    ) -> CodexResult<Option<String>> {
         compact::run_compact_task(session.clone_session(), ctx, input).await
     }
 }

--- a/codex-rs/core/src/tasks/regular.rs
+++ b/codex-rs/core/src/tasks/regular.rs
@@ -5,6 +5,7 @@ use tokio_util::sync::CancellationToken;
 
 use crate::codex::TurnContext;
 use crate::codex::run_task;
+use crate::error::Result as CodexResult;
 use crate::state::TaskKind;
 use codex_protocol::user_input::UserInput;
 
@@ -26,7 +27,7 @@ impl SessionTask for RegularTask {
         ctx: Arc<TurnContext>,
         input: Vec<UserInput>,
         cancellation_token: CancellationToken,
-    ) -> Option<String> {
+    ) -> CodexResult<Option<String>> {
         let sess = session.clone_session();
         run_task(sess, ctx, input, TaskKind::Regular, cancellation_token).await
     }

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -6,6 +6,7 @@ use tokio_util::sync::CancellationToken;
 use crate::codex::TurnContext;
 use crate::codex::exit_review_mode;
 use crate::codex::run_task;
+use crate::error::Result as CodexResult;
 use crate::state::TaskKind;
 use codex_protocol::user_input::UserInput;
 
@@ -27,12 +28,12 @@ impl SessionTask for ReviewTask {
         ctx: Arc<TurnContext>,
         input: Vec<UserInput>,
         cancellation_token: CancellationToken,
-    ) -> Option<String> {
+    ) -> CodexResult<Option<String>> {
         let sess = session.clone_session();
         run_task(sess, ctx, input, TaskKind::Review, cancellation_token).await
     }
 
     async fn abort(&self, session: Arc<SessionTaskContext>, ctx: Arc<TurnContext>) {
-        exit_review_mode(session.clone_session(), ctx, None).await;
+        let _ = exit_review_mode(session.clone_session(), ctx, None).await;
     }
 }

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -817,7 +817,7 @@ async fn auto_compact_triggers_after_function_call_over_95_percent_usage() {
 
     let server = start_mock_server().await;
 
-    let context_window = 100;
+    let context_window = 20_000;
     let limit = context_window * 90 / 100;
     let over_limit_tokens = context_window * 95 / 100 + 1;
 

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -279,11 +279,6 @@ async fn auto_compact_runs_after_token_limit_hit() {
         ev_completed_with_tokens("r2", 330_000),
     ]);
 
-    let sse3 = sse(vec![
-        ev_assistant_message("m3", AUTO_SUMMARY_TEXT),
-        ev_completed_with_tokens("r3", 200),
-    ]);
-
     let first_matcher = |req: &wiremock::Request| {
         let body = std::str::from_utf8(&req.body).unwrap_or("");
         body.contains(FIRST_AUTO_MSG)
@@ -299,12 +294,6 @@ async fn auto_compact_runs_after_token_limit_hit() {
             && !body.contains("You have exceeded the maximum number of tokens")
     };
     mount_sse_once_match(&server, second_matcher, sse2).await;
-
-    let third_matcher = |req: &wiremock::Request| {
-        let body = std::str::from_utf8(&req.body).unwrap_or("");
-        body.contains("You have exceeded the maximum number of tokens")
-    };
-    mount_sse_once_match(&server, third_matcher, sse3).await;
 
     let model_provider = ModelProviderInfo {
         base_url: Some(format!("{}/v1", server.uri())),
@@ -342,69 +331,28 @@ async fn auto_compact_runs_after_token_limit_hit() {
         .await
         .unwrap();
 
+    let error_event = wait_for_event(&codex, |ev| matches!(ev, EventMsg::Error(_))).await;
+    let EventMsg::Error(error_event) = error_event else {
+        unreachable!("wait_for_event returned unexpected payload");
+    };
+    assert_eq!(error_event.message, "invalid input: input too large");
+
     wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
-    // wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
 
     let requests = server.received_requests().await.unwrap();
-    assert!(
-        requests.len() >= 3,
-        "auto compact should add at least a third request, got {}",
-        requests.len()
+    assert_eq!(
+        requests.len(),
+        2,
+        "auto compact should reject oversize prompts before issuing another request"
     );
-    let is_auto_compact = |req: &wiremock::Request| {
+    let saw_compact_prompt = requests.iter().any(|req| {
         std::str::from_utf8(&req.body)
             .unwrap_or("")
             .contains("You have exceeded the maximum number of tokens")
-    };
-    let auto_compact_count = requests.iter().filter(|req| is_auto_compact(req)).count();
-    assert_eq!(
-        auto_compact_count, 1,
-        "expected exactly one auto compact request"
-    );
-    let auto_compact_index = requests
-        .iter()
-        .enumerate()
-        .find_map(|(idx, req)| is_auto_compact(req).then_some(idx))
-        .expect("auto compact request missing");
-    assert_eq!(
-        auto_compact_index, 2,
-        "auto compact should add a third request"
-    );
-
-    let body_first = requests[0].body_json::<serde_json::Value>().unwrap();
-    let body3 = requests[auto_compact_index]
-        .body_json::<serde_json::Value>()
-        .unwrap();
-    let instructions = body3
-        .get("instructions")
-        .and_then(|v| v.as_str())
-        .unwrap_or_default();
-    let baseline_instructions = body_first
-        .get("instructions")
-        .and_then(|v| v.as_str())
-        .unwrap_or_default()
-        .to_string();
-    assert_eq!(
-        instructions, baseline_instructions,
-        "auto compact should keep the standard developer instructions",
-    );
-
-    let input3 = body3.get("input").and_then(|v| v.as_array()).unwrap();
-    let last3 = input3
-        .last()
-        .expect("auto compact request should append a user message");
-    assert_eq!(last3.get("type").and_then(|v| v.as_str()), Some("message"));
-    assert_eq!(last3.get("role").and_then(|v| v.as_str()), Some("user"));
-    let last_text = last3
-        .get("content")
-        .and_then(|v| v.as_array())
-        .and_then(|items| items.first())
-        .and_then(|item| item.get("text"))
-        .and_then(|text| text.as_str())
-        .unwrap_or_default();
-    assert_eq!(
-        last_text, SUMMARIZATION_PROMPT,
-        "auto compact should send the summarization prompt as a user message",
+    });
+    assert!(
+        !saw_compact_prompt,
+        "no auto compact request should be sent when the summarization prompt exceeds the limit"
     );
 }
 

--- a/codex-rs/core/tests/suite/input_validation.rs
+++ b/codex-rs/core/tests/suite/input_validation.rs
@@ -38,7 +38,7 @@ async fn interrupt_tool_records_history_entries() {
         .unwrap();
 
     // Wait for the normal turn to complete before sending the oversized input
-    let turn_timeout = Duration::from_secs(2);
+    let turn_timeout = Duration::from_secs(1);
     wait_for_event_with_timeout(
         &codex,
         |ev| matches!(ev, EventMsg::TaskComplete(_)),

--- a/codex-rs/core/tests/suite/input_validation.rs
+++ b/codex-rs/core/tests/suite/input_validation.rs
@@ -14,7 +14,7 @@ use std::time::Duration;
 use wiremock::matchers::any;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn interrupt_tool_records_history_entries() {
+async fn input_validation_should_fail_for_too_large_input() {
     let server = start_mock_server().await;
 
     let fixture = test_codex().build(&server).await.unwrap();

--- a/codex-rs/core/tests/suite/input_validation.rs
+++ b/codex-rs/core/tests/suite/input_validation.rs
@@ -1,11 +1,17 @@
 use codex_core::protocol::EventMsg;
 use codex_core::protocol::Op;
 use codex_protocol::user_input::UserInput;
+use core_test_support::responses;
+use core_test_support::responses::ev_assistant_message;
+use core_test_support::responses::ev_completed;
+use core_test_support::responses::ev_response_created;
+use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event_with_timeout;
 use std::sync::Arc;
 use std::time::Duration;
+use wiremock::matchers::any;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn interrupt_tool_records_history_entries() {
@@ -14,8 +20,34 @@ async fn interrupt_tool_records_history_entries() {
     let fixture = test_codex().build(&server).await.unwrap();
     let codex = Arc::clone(&fixture.codex);
 
-    let wait_timeout = Duration::from_millis(100);
+    // First: normal message with a mocked assistant response
+    let first_response = sse(vec![
+        ev_response_created("resp-1"),
+        ev_assistant_message("msg-1", "ok"),
+        ev_completed("resp-1"),
+    ]);
+    responses::mount_sse_once_match(&server, any(), first_response).await;
 
+    codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "hello world".into(),
+            }],
+        })
+        .await
+        .unwrap();
+
+    // Wait for the normal turn to complete before sending the oversized input
+    let turn_timeout = Duration::from_secs(2);
+    wait_for_event_with_timeout(
+        &codex,
+        |ev| matches!(ev, EventMsg::TaskComplete(_)),
+        turn_timeout,
+    )
+    .await;
+
+    // Then: 300k-token message should trigger validation error
+    let wait_timeout = Duration::from_millis(100);
     let input_300_tokens = "token ".repeat(300_000);
 
     codex

--- a/codex-rs/core/tests/suite/input_validation.rs
+++ b/codex-rs/core/tests/suite/input_validation.rs
@@ -1,0 +1,37 @@
+use codex_core::protocol::EventMsg;
+use codex_core::protocol::Op;
+use codex_protocol::user_input::UserInput;
+use core_test_support::responses::start_mock_server;
+use core_test_support::test_codex::test_codex;
+use core_test_support::wait_for_event_with_timeout;
+use std::sync::Arc;
+use std::time::Duration;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn interrupt_tool_records_history_entries() {
+    let server = start_mock_server().await;
+
+    let fixture = test_codex().build(&server).await.unwrap();
+    let codex = Arc::clone(&fixture.codex);
+
+    let wait_timeout = Duration::from_millis(100);
+
+    let input_300_tokens = "token ".repeat(300_000);
+
+    codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: input_300_tokens,
+            }],
+        })
+        .await
+        .unwrap();
+
+    let error_event =
+        wait_for_event_with_timeout(&codex, |ev| matches!(ev, EventMsg::Error(_)), wait_timeout)
+            .await;
+    let EventMsg::Error(error_event) = error_event else {
+        unreachable!("wait_for_event_with_timeout returned unexpected payload");
+    };
+    assert_eq!(error_event.message, "invalid input: input too large");
+}

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -13,6 +13,7 @@ mod compact_resume_fork;
 mod exec;
 mod fork_conversation;
 mod grep_files;
+mod input_validation;
 mod items;
 mod json_result;
 mod list_dir;

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -579,7 +579,7 @@ pub struct TokenUsage {
 pub struct TokenUsageInfo {
     /// The total token usage for the session. accumulated from all turns.
     pub total_token_usage: TokenUsage,
-    /// The token usage for the last turn. Received from the API.
+    /// The token usage for the last turn. Received from the API. It's total tokens is the whole window size.
     pub last_token_usage: TokenUsage,
     #[ts(type = "number | null")]
     pub model_context_window: Option<i64>,

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -577,7 +577,9 @@ pub struct TokenUsage {
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS)]
 pub struct TokenUsageInfo {
+    /// The total token usage for the session. accumulated from all turns.
     pub total_token_usage: TokenUsage,
+    /// The token usage for the last turn. Received from the API.
     pub last_token_usage: TokenUsage,
     #[ts(type = "number | null")]
     pub model_context_window: Option<i64>,

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -575,7 +575,7 @@ pub struct TokenUsage {
     pub total_tokens: i64,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS)]
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS, Default)]
 pub struct TokenUsageInfo {
     /// The total token usage for the session. accumulated from all turns.
     pub total_token_usage: TokenUsage,

--- a/codex-rs/utils/tokenizer/src/lib.rs
+++ b/codex-rs/utils/tokenizer/src/lib.rs
@@ -107,6 +107,12 @@ impl Tokenizer {
     }
 }
 
+impl fmt::Debug for Tokenizer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Tokenizer").finish()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
This PR introduces the idea of validating input on adding it to the history. The short term goal is to prevent large inputs from passing to fill the context window. Long term goal is to centralize input process and validation in `conversationhistory`. This can help us in truncating tool calls and mcp functions in a central way. We can also start resizing images. Basically, there is one gate that inputs can be added to the conversation history.

I am also propagating `invalidinput` error to send to the client