### PR TITLE
Add abort support to TypeScript SDK runs

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -50,6 +50,27 @@ for await (const event of events) {
 }
 ```
 
+### Aborting a turn
+
+Both `run()` and `runStreamed()` accept an `AbortSignal` via `TurnOptions.signal`. Attach a signal from an
+`AbortController` to stop an in-flight turn.
+
+```typescript
+const controller = new AbortController();
+
+const turnPromise = thread.run("Perform a health check", { signal: controller.signal });
+
+setTimeout(() => controller.abort(), 1000);
+
+try {
+  await turnPromise;
+} catch (error) {
+  if ((error as Error).name === "AbortError") {
+    console.log("Turn cancelled");
+  }
+}
+```
+
 ### Structured output
 
 The Codex agent can produce a JSON response that conforms to a specified schema. The schema can be provided for each turn as a plain JSON object.

--- a/sdk/typescript/src/thread.ts
+++ b/sdk/typescript/src/thread.ts
@@ -85,6 +85,7 @@ export class Thread {
       workingDirectory: options?.workingDirectory,
       skipGitRepoCheck: options?.skipGitRepoCheck,
       outputSchemaFile: schemaPath,
+      signal: turnOptions.signal,
     });
     try {
       for await (const item of generator) {

--- a/sdk/typescript/src/turnOptions.ts
+++ b/sdk/typescript/src/turnOptions.ts
@@ -1,4 +1,6 @@
 export type TurnOptions = {
   /** JSON schema describing the expected agent output. */
   outputSchema?: unknown;
+  /** Abort signal that cancels an in-flight turn. */
+  signal?: AbortSignal;
 };

--- a/sdk/typescript/tests/abortController.test.ts
+++ b/sdk/typescript/tests/abortController.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "@jest/globals";
+
+import type { CodexExec, CodexExecArgs } from "../src/exec";
+import type { CodexOptions } from "../src/codexOptions";
+import { Thread } from "../src/thread";
+import type { ThreadOptions } from "../src/threadOptions";
+
+class AbortAwareExec {
+  public calls: CodexExecArgs[] = [];
+
+  async *run(args: CodexExecArgs): AsyncGenerator<string> {
+    this.calls.push(args);
+    yield JSON.stringify({ type: "thread.started", thread_id: "thread_123" });
+    yield JSON.stringify({ type: "turn.started" });
+    await waitForAbort(args.signal);
+  }
+}
+
+function waitForAbort(signal?: AbortSignal): Promise<never> {
+  return new Promise((_, reject) => {
+    if (!signal) {
+      reject(new Error("Missing abort signal"));
+      return;
+    }
+    signal.addEventListener(
+      "abort",
+      () => {
+        reject(signal.reason ?? new Error("aborted"));
+      },
+      { once: true },
+    );
+  });
+}
+
+describe("Thread turn cancellation", () => {
+  const codexOptions = {} as CodexOptions;
+  const threadOptions = {} as ThreadOptions;
+
+  it("rejects run when the abort signal is triggered", async () => {
+    const exec = new AbortAwareExec();
+    const thread = new Thread(exec as unknown as CodexExec, codexOptions, threadOptions);
+    const controller = new AbortController();
+    const abortError = new Error("stop");
+
+    const promise = thread.run("Hello", { signal: controller.signal });
+    controller.abort(abortError);
+
+    await expect(promise).rejects.toBe(abortError);
+    expect(exec.calls[0]?.signal).toBe(controller.signal);
+  });
+
+  it("rejects runStreamed iterators when the abort signal is triggered", async () => {
+    const exec = new AbortAwareExec();
+    const thread = new Thread(exec as unknown as CodexExec, codexOptions, threadOptions);
+    const controller = new AbortController();
+    const abortError = new Error("stop");
+
+    const { events } = await thread.runStreamed("Hello", { signal: controller.signal });
+    await events.next();
+    await events.next();
+    const pending = events.next();
+    controller.abort(abortError);
+
+    await expect(pending).rejects.toBe(abortError);
+    expect(exec.calls[0]?.signal).toBe(controller.signal);
+  });
+});

--- a/sdk/typescript/tests/exec.test.ts
+++ b/sdk/typescript/tests/exec.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it } from "@jest/globals";
+import type { ChildProcess } from "node:child_process";
+import * as child_process from "node:child_process";
+import { EventEmitter } from "node:events";
+import { PassThrough } from "node:stream";
+
+import { CodexExec } from "../src/exec";
+
+jest.mock("node:child_process", () => {
+  const actual = jest.requireActual<typeof import("node:child_process")>("node:child_process");
+  return { ...actual, spawn: jest.fn() };
+});
+
+const actualChildProcess =
+  jest.requireActual<typeof import("node:child_process")>("node:child_process");
+const spawnMock = child_process.spawn as jest.MockedFunction<typeof actualChildProcess.spawn>;
+
+class FakeChildProcess extends EventEmitter {
+  public stdin: PassThrough | null = new PassThrough();
+  public stdout: PassThrough | null = new PassThrough();
+  public stderr: PassThrough | null = new PassThrough();
+  public killed = false;
+  public kill = jest.fn((_signal?: NodeJS.Signals | number) => {
+    this.killed = true;
+    return true;
+  });
+}
+
+describe("CodexExec", () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it("rejects pending iterations when aborted", async () => {
+    const fakeChild = new FakeChildProcess();
+    spawnMock.mockReturnValue(fakeChild as unknown as ChildProcess);
+
+    const exec = new CodexExec("/fake/path");
+    const controller = new AbortController();
+    const generator = exec.run({ input: "hello", signal: controller.signal });
+
+    const first = generator.next();
+    fakeChild.stdout?.write("{\"type\":\"turn.started\"}\n");
+    await expect(first).resolves.toEqual({
+      value: "{\"type\":\"turn.started\"}",
+      done: false,
+    });
+
+    const pending = generator.next();
+    const abortError = new Error("stop");
+    controller.abort(abortError);
+    fakeChild.stdout?.end();
+    fakeChild.emit("exit", null, "SIGTERM");
+
+    await expect(pending).rejects.toBe(abortError);
+    expect(fakeChild.kill).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- add `TurnOptions.signal` and pass AbortController signals through `run`/`runStreamed`
- update the Codex exec runner to watch abort signals, kill the CLI process, and bubble the abort reason
- document the new API surface and add unit tests covering thread- and exec-level cancellation

## Testing
- `pnpm test` *(fails: Corepack cannot download pnpm due to blocked network access)*

------
https://chatgpt.com/codex/tasks/task_i_68fa4e22ed7c83209d33b851d72c356e