### PR TITLE
[app-server] fix account/read response annotation

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol.rs
+++ b/codex-rs/app-server-protocol/src/protocol.rs
@@ -127,7 +127,7 @@ client_request_definitions! {
     #[ts(rename = "account/read")]
     GetAccount {
         params: #[ts(type = "undefined")] #[serde(skip_serializing_if = "Option::is_none")] Option<()>,
-        response: Option<Account>,
+        response: GetAccountResponse,
     },
 
     /// DEPRECATED APIs below
@@ -533,6 +533,12 @@ pub struct ExecOneOffCommandResponse {
 pub struct GetAccountRateLimitsResponse {
     pub rate_limits: RateLimitSnapshot,
 }
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(transparent)]
+#[ts(export)]
+#[ts(type = "Account | null")]
+pub struct GetAccountResponse(#[ts(type = "Account | null")] pub Option<Account>);
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
The API schema export is currently broken:
```
> cargo run -p codex-app-server-protocol --bin export -- --out DIR
Error: this type cannot be exported
```

This PR fixes the error message so we get more info:
```
> cargo run -p codex-app-server-protocol --bin export -- --out DIR
Error: failed to export client responses: dependency core::option::Option<codex_protocol::account::Account> cannot be exported
```

And fixes the root cause which is the `account/read` response.