### PR TITLE
Log more types of request IDs

### DIFF
--- a/codex-rs/core/src/auth.rs
+++ b/codex-rs/core/src/auth.rs
@@ -44,6 +44,8 @@ impl PartialEq for CodexAuth {
 
 impl CodexAuth {
     pub async fn refresh_token(&self) -> Result<String, std::io::Error> {
+        tracing::info!("Refreshing token");
+
         let token_data = self
             .get_current_token_data()
             .ok_or(std::io::Error::other("Token data is not available."))?;
@@ -917,7 +919,10 @@ impl AuthManager {
                 self.reload();
                 Ok(Some(token))
             }
-            Err(e) => Err(e),
+            Err(e) => {
+                tracing::error!("Failed to refresh token: {}", e);
+                Err(e)
+            }
         }
     }
 

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -301,6 +301,7 @@ impl ModelClient {
             "POST to {}: {:?}",
             self.provider.get_full_url(&auth),
             serde_json::to_string(payload_json)
+                .unwrap_or("<unable to serialize payload>".to_string())
         );
 
         let mut req_builder = self

--- a/codex-rs/core/src/default_client.rs
+++ b/codex-rs/core/src/default_client.rs
@@ -8,7 +8,6 @@ use reqwest::header::HeaderValue;
 use serde::Serialize;
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::iter::Map;
 use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::sync::OnceLock;

--- a/codex-rs/core/src/default_client.rs
+++ b/codex-rs/core/src/default_client.rs
@@ -6,7 +6,9 @@ use reqwest::Response;
 use reqwest::header::HeaderName;
 use reqwest::header::HeaderValue;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::fmt::Display;
+use std::iter::Map;
 use std::sync::LazyLock;
 use std::sync::Mutex;
 use std::sync::OnceLock;
@@ -115,20 +117,13 @@ impl CodexRequestBuilder {
     pub async fn send(self) -> Result<Response, reqwest::Error> {
         match self.builder.send().await {
             Ok(response) => {
-                let request_id = response
-                    .headers()
-                    .get("cf-ray")
-                    .map(|v| v.to_str().unwrap_or_default().to_string())
-                    .unwrap_or_default();
-
-                let version = format!("{:?}", response.version());
-
+                let request_ids = Self::extract_request_ids(&response);
                 tracing::debug!(
                     method = %self.method,
                     url = %self.url,
                     status = %response.status(),
-                    request_id = %request_id,
-                    version = %version,
+                    request_ids = ?request_ids,
+                    version = ?response.version(),
                     "Request completed"
                 );
 
@@ -146,6 +141,18 @@ impl CodexRequestBuilder {
                 Err(error)
             }
         }
+    }
+
+    fn extract_request_ids(response: &Response) -> HashMap<String, String> {
+        ["cf-ray", "x-request-id", "x-oai-request-id"]
+            .iter()
+            .filter_map(|&name| {
+                let header_name = HeaderName::from_static(name);
+                let value = response.headers().get(header_name)?;
+                let value = value.to_str().ok()?.to_owned();
+                Some((name.to_owned(), value))
+            })
+            .collect()
     }
 }
 #[derive(Debug, Clone)]

--- a/codex-rs/feedback/src/lib.rs
+++ b/codex-rs/feedback/src/lib.rs
@@ -12,7 +12,7 @@ use anyhow::anyhow;
 use codex_protocol::ConversationId;
 use tracing_subscriber::fmt::writer::MakeWriter;
 
-const DEFAULT_MAX_BYTES: usize = 2 * 1024 * 1024; // 2 MiB
+const DEFAULT_MAX_BYTES: usize = 4 * 1024 * 1024; // 4 MiB
 const SENTRY_DSN: &str =
     "https://ae32ed50620d7a7792c1ce5df38b3e3e@o33249.ingest.us.sentry.io/4510195390611458";
 const UPLOAD_TIMEOUT_SECS: u64 = 10;


### PR DESCRIPTION
Different services return different sets of IDs, log all of them to simplify debugging.
