### PR TITLE
feat(cli): teach completion scripts to surface config profiles

### DIFF
--- a/codex-rs/cli/tests/profiles.rs
+++ b/codex-rs/cli/tests/profiles.rs
@@ -1,0 +1,97 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::Result;
+use assert_cmd::Command;
+use predicates::str::contains;
+use tempfile::TempDir;
+
+fn codex_command(codex_home: &Path) -> Result<Command> {
+    let mut cmd = Command::cargo_bin("codex")?;
+    cmd.env("CODEX_HOME", codex_home);
+    Ok(cmd)
+}
+
+#[test]
+fn profiles_list_outputs_sorted_names() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    fs::write(
+        codex_home.path().join("config.toml"),
+        r#"
+[profiles.zeta]
+model = "gpt-5"
+
+[profiles.alpha]
+model = "gpt-5"
+
+[profiles.mid]
+model = "gpt-5"
+"#,
+    )?;
+
+    let mut cmd = codex_command(codex_home.path())?;
+    let output = cmd.args(["profiles", "list"]).output()?;
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8(output.stdout)?;
+    let lines: Vec<_> = stdout.lines().collect();
+    assert_eq!(lines, vec!["alpha", "mid", "zeta"]);
+
+    Ok(())
+}
+
+#[test]
+fn profiles_list_respects_invalid_flag() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    fs::write(
+        codex_home.path().join("config.toml"),
+        r#"
+[profiles.alpha]
+model = "gpt-5"
+"#,
+    )?;
+
+    let mut cmd = codex_command(codex_home.path())?;
+    cmd.args(["--profile", "missing", "profiles", "list"])
+        .assert()
+        .failure()
+        .stderr(contains("config profile `missing` not found"));
+
+    Ok(())
+}
+
+#[test]
+fn fish_completion_uses_profiles_helper() -> Result<()> {
+    let output = Command::cargo_bin("codex")?
+        .args(["completion", "fish"])
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("function __fish_codex_profile_list"));
+    assert!(stdout.contains("codex profiles list"));
+    Ok(())
+}
+
+#[test]
+fn bash_completion_uses_profiles_helper() -> Result<()> {
+    let output = Command::cargo_bin("codex")?
+        .args(["completion", "bash"])
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("__codex_bash_complete_profiles()"));
+    assert!(stdout.contains("__codex_bash_complete_profiles \"${cur}\""));
+    Ok(())
+}
+
+#[test]
+fn zsh_completion_uses_profiles_helper() -> Result<()> {
+    let output = Command::cargo_bin("codex")?
+        .args(["completion", "zsh"])
+        .output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    assert!(stdout.contains("__codex_zsh_complete_profiles()"));
+    assert!(stdout.contains(":CONFIG_PROFILE:__codex_zsh_complete_profiles"));
+    Ok(())
+}

--- a/docs/config.md
+++ b/docs/config.md
@@ -773,6 +773,12 @@ Users can specify config values at multiple levels. Order of precedence is as fo
 3. as an entry in `config.toml`, e.g., `model = "o3"`
 4. the default value that comes with Codex CLI (i.e., Codex CLI defaults to `gpt-5-codex`)
 
+To see which profiles are available in your current configuration, run:
+
+```shell
+codex profiles list
+```
+
 ### history
 
 By default, Codex CLI records messages sent to the model in `$CODEX_HOME/history.jsonl`. Note that on UNIX, the file permissions are set to `o600`, so it should only be readable and writable by the owner.


### PR DESCRIPTION
## Background

This small PR was written to solve a pain point I was experiencing. In trying to use the profiles feature extensively with local LLMs including `gpt-oss-20b` and `gpt-oss-120b`, I wanted to be able to more quickly type out the names, and I wanted to avoid the need to reference the `config.toml` file to remember names, so I added tab completion. Originally developed for `fish`, but I added support for `bash` and `zsh` as well.

## Description

Generates dynamic `--profile` suggestions for fish, bash, and zsh by appending small helpers that call `codex profiles list`. Each script now delegates profile name discovery to the CLI instead of guessing from the filesystem, so completions stay accurate as users edit `config.toml`.

Adds a lightweight `codex profiles list` subcommand to feed those helpers and writes integration tests that assert the command output is wired into every supported shell. Updates the configuration docs to mention the inspection command for users who prefer to check profiles manually.

(I wish there were a more elegant way to support dynamic completions in `clap`, but modifying your own custom completions into the output _is_ the most elegant way that appears to be available. `clap` still does most of the work.)