### PR TITLE
Fixed flaky unit test

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -853,6 +853,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
+ "serial_test",
  "tempfile",
  "tokio",
  "toml",

--- a/codex-rs/app-server/Cargo.toml
+++ b/codex-rs/app-server/Cargo.toml
@@ -47,6 +47,7 @@ base64 = { workspace = true }
 core_test_support = { workspace = true }
 os_info = { workspace = true }
 pretty_assertions = { workspace = true }
+serial_test = { workspace = true }
 tempfile = { workspace = true }
 toml = { workspace = true }
 wiremock = { workspace = true }

--- a/codex-rs/app-server/tests/suite/login.rs
+++ b/codex-rs/app-server/tests/suite/login.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use std::sync::OnceLock;
 use std::time::Duration;
 
 use app_test_support::McpProcess;
@@ -14,7 +15,18 @@ use codex_app_server_protocol::LogoutChatGptResponse;
 use codex_app_server_protocol::RequestId;
 use codex_login::login_with_api_key;
 use tempfile::TempDir;
+use tokio::sync::Mutex;
+use tokio::sync::MutexGuard;
 use tokio::time::timeout;
+
+static LOGIN_TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+
+// Ensures that login tests that cause the oauth server to start do not
+// run concurrently. The server binds to a fixed port, so concurrent tests
+// would conflict.
+async fn login_test_guard() -> MutexGuard<'static, ()> {
+    LOGIN_TEST_MUTEX.get_or_init(|| Mutex::new(())).lock().await
+}
 
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
@@ -95,6 +107,7 @@ async fn logout_chatgpt_removes_auth() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn login_and_cancel_chatgpt() {
+    let _guard = login_test_guard().await;
     let codex_home = TempDir::new().unwrap_or_else(|e| panic!("create tempdir: {e}"));
     create_config_toml(codex_home.path()).unwrap_or_else(|err| panic!("write config.toml: {err}"));
 
@@ -209,6 +222,7 @@ async fn login_chatgpt_rejected_when_forced_api() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn login_chatgpt_includes_forced_workspace_query_param() {
+    let _guard = login_test_guard().await;
     let codex_home = TempDir::new().unwrap_or_else(|e| panic!("create tempdir: {e}"));
     create_config_toml_forced_workspace(codex_home.path(), "ws-forced")
         .unwrap_or_else(|err| panic!("write config.toml: {err}"));

--- a/codex-rs/app-server/tests/suite/login.rs
+++ b/codex-rs/app-server/tests/suite/login.rs
@@ -96,7 +96,7 @@ async fn logout_chatgpt_removes_auth() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 // Serialize tests that launch the login server since it binds to a fixed port.
-#[serial(login)]
+#[serial(login_port)]
 async fn login_and_cancel_chatgpt() {
     let codex_home = TempDir::new().unwrap_or_else(|e| panic!("create tempdir: {e}"));
     create_config_toml(codex_home.path()).unwrap_or_else(|err| panic!("write config.toml: {err}"));
@@ -212,7 +212,7 @@ async fn login_chatgpt_rejected_when_forced_api() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 // Serialize tests that launch the login server since it binds to a fixed port.
-#[serial(login)]
+#[serial(login_port)]
 async fn login_chatgpt_includes_forced_workspace_query_param() {
     let codex_home = TempDir::new().unwrap_or_else(|e| panic!("create tempdir: {e}"));
     create_config_toml_forced_workspace(codex_home.path(), "ws-forced")


### PR DESCRIPTION
This PR fixes a test that is sporadically failing in CI.

The problem is that two unit tests (the older `login_and_cancel_chatgpt` and a recently added `login_chatgpt_includes_forced_workspace_query_param`) exercise code paths that start the login server. The server binds to a hard-coded localhost port number, so attempts to start more than one server at the same time will fail. If these two tests happen to run concurrently, one of them will fail.

To fix this, I've added a simple mutex. We can use this same mutex for future tests that use the same pattern.