### PR TITLE
fix: attempting to resume an existing conversation in ConversationManager should reuse it

### DIFF
--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -247,7 +247,11 @@ async fn resume_includes_initial_messages_and_sends_prior_items() {
         session_configured,
         ..
     } = conversation_manager
-        .resume_conversation_from_rollout(config, session_path.clone(), auth_manager)
+        .resume_conversation_from_rollout(
+            config.clone(),
+            session_path.clone(),
+            auth_manager.clone(),
+        )
         .await
         .expect("resume conversation");
 
@@ -259,6 +263,23 @@ async fn resume_includes_initial_messages_and_sends_prior_items() {
     let initial_json = serde_json::to_value(&initial_msgs).unwrap();
     let expected_initial_json = json!([]);
     assert_eq!(initial_json, expected_initial_json);
+
+    let NewConversation {
+        conversation: codex_again,
+        session_configured: session_configured_again,
+        ..
+    } = conversation_manager
+        .resume_conversation_from_rollout(
+            config.clone(),
+            session_path.clone(),
+            auth_manager.clone(),
+        )
+        .await
+        .expect("resume existing conversation");
+    assert!(Arc::ptr_eq(&codex, &codex_again));
+    let session_configured_json = serde_json::to_value(&session_configured).unwrap();
+    let session_configured_again_json = serde_json::to_value(&session_configured_again).unwrap();
+    assert_eq!(session_configured_json, session_configured_again_json);
 
     // 2) Submit new input; the request body must include the prior item followed by the new user input.
     codex


### PR DESCRIPTION
Prior to this change, `spawn_conversation()` would call `finalize_spawn()`:

https://github.com/openai/codex/blob/6af83d86ffd6176b1949f877cae76735f4584a9c/codex-rs/core/src/conversation_manager.rs#L79

which would then categorically insert the conversation into `self.conversations`:

https://github.com/openai/codex/blob/6af83d86ffd6176b1949f877cae76735f4584a9c/codex-rs/core/src/conversation_manager.rs#L102-L105

but this is potentially problematic because the resuming the same conversation could potentially be requested multiple times over the lifetime of the app server.

This updates the business logic to return the existing conversation, if appropriate.