### PR TITLE
Made token refresh code resilient to missing `id_token`

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -387,17 +387,16 @@ impl ModelClient {
                     .and_then(|s| s.parse::<u64>().ok());
                 let retry_after = retry_after_secs.map(|s| Duration::from_millis(s * 1_000));
 
-                if status == StatusCode::UNAUTHORIZED {
-                    if let Some(manager) = auth_manager.as_ref()
-                        && let Some(auth) = auth.as_ref()
-                        && auth.mode == AuthMode::ChatGPT
-                    {
-                        manager.refresh_token().await.map_err(|err| {
-                            StreamAttemptError::Fatal(CodexErr::Fatal(format!(
-                                "Failed to refresh ChatGPT credentials: {err}"
-                            )))
-                        })?;
-                    }
+                if status == StatusCode::UNAUTHORIZED
+                    && let Some(manager) = auth_manager.as_ref()
+                    && let Some(auth) = auth.as_ref()
+                    && auth.mode == AuthMode::ChatGPT
+                {
+                    manager.refresh_token().await.map_err(|err| {
+                        StreamAttemptError::Fatal(CodexErr::Fatal(format!(
+                            "Failed to refresh ChatGPT credentials: {err}"
+                        )))
+                    })?;
                 }
 
                 // The OpenAI Responses endpoint returns structured JSON bodies even for 4xx/5xx

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -387,14 +387,17 @@ impl ModelClient {
                     .and_then(|s| s.parse::<u64>().ok());
                 let retry_after = retry_after_secs.map(|s| Duration::from_millis(s * 1_000));
 
-                if status == StatusCode::UNAUTHORIZED
-                    && let Some(manager) = auth_manager.as_ref()
-                    && manager.auth().is_some()
-                {
-                    manager
-                        .refresh_token()
-                        .await
-                        .map_err(|err| StreamAttemptError::Fatal(err.into()))?;
+                if status == StatusCode::UNAUTHORIZED {
+                    if let Some(manager) = auth_manager.as_ref()
+                        && let Some(auth) = auth.as_ref()
+                        && auth.mode == AuthMode::ChatGPT
+                    {
+                        manager.refresh_token().await.map_err(|err| {
+                            StreamAttemptError::Fatal(CodexErr::Fatal(format!(
+                                "Failed to refresh ChatGPT credentials: {err}"
+                            )))
+                        })?;
+                    }
                 }
 
                 // The OpenAI Responses endpoint returns structured JSON bodies even for 4xx/5xx

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -391,7 +391,10 @@ impl ModelClient {
                     && let Some(manager) = auth_manager.as_ref()
                     && manager.auth().is_some()
                 {
-                    let _ = manager.refresh_token().await;
+                    manager
+                        .refresh_token()
+                        .await
+                        .map_err(|err| StreamAttemptError::Fatal(err.into()))?;
                 }
 
                 // The OpenAI Responses endpoint returns structured JSON bodies even for 4xx/5xx

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1855,7 +1855,7 @@ async fn run_turn(
                     // at a seemingly frozen screen.
                     sess.notify_stream_error(
                         turn_context.as_ref(),
-                        format!("Re-connecting... {retries}/{max_retries}"),
+                        format!("Reconnecting... {retries}/{max_retries}"),
                     )
                     .await;
 

--- a/codex-rs/core/src/codex/compact.rs
+++ b/codex-rs/core/src/codex/compact.rs
@@ -132,7 +132,7 @@ async fn run_compact_task_inner(
                     let delay = backoff(retries);
                     sess.notify_stream_error(
                         turn_context.as_ref(),
-                        format!("Re-connecting... {retries}/{max_retries}"),
+                        format!("Reconnecting... {retries}/{max_retries}"),
                     )
                     .await;
                     tokio::time::sleep(delay).await;

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -2222,7 +2222,7 @@ fn plan_update_renders_history_cell() {
 fn stream_error_updates_status_indicator() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual();
     chat.bottom_pane.set_task_running(true);
-    let msg = "Re-connecting... 2/5";
+    let msg = "Reconnecting... 2/5";
     chat.handle_codex_event(Event {
         id: "sub-1".into(),
         msg: EventMsg::StreamError(StreamErrorEvent {


### PR DESCRIPTION
This PR does the following:
1. Changes `try_refresh_token` to handle the case where the endpoint returns a response without an `id_token`. The OpenID spec indicates that this field is optional and clients should not assume it's present.
2. Changes the `attempt_stream_responses` to propagate token refresh errors rather than silently ignoring them.
3. Fixes a typo in a couple of error messages (unrelated to the above, but something I noticed in passing) - "reconnect" should be spelled without a hyphen.

This PR does not implement the additional suggestion from @pakrym-oai that we should sign out when receiving `refresh_token_expired` from the refresh endpoint. Leaving this as a follow-on because I'm undecided on whether this should be implemented in `try_refresh_token` or its callers.