### PR TITLE
fix: move account struct to app-server-protocol and use camelCase

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol.rs
+++ b/codex-rs/app-server-protocol/src/protocol.rs
@@ -5,7 +5,7 @@ use crate::JSONRPCNotification;
 use crate::JSONRPCRequest;
 use crate::RequestId;
 use codex_protocol::ConversationId;
-use codex_protocol::account::Account;
+use codex_protocol::account::PlanType;
 use codex_protocol::config_types::ForcedLoginMethod;
 use codex_protocol::config_types::ReasoningEffort;
 use codex_protocol::config_types::ReasoningSummary;
@@ -233,6 +233,21 @@ client_request_definitions! {
     ExecOneOffCommand {
         params: ExecOneOffCommandParams,
         response: ExecOneOffCommandResponse,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema, TS)]
+#[serde(tag = "type", rename_all = "camelCase")]
+#[ts(tag = "type")]
+pub enum Account {
+    #[serde(rename = "apiKey")]
+    #[ts(rename = "apiKey")]
+    ApiKey { api_key: String },
+    #[serde(rename = "chatgpt")]
+    #[ts(rename = "chatgpt")]
+    ChatGpt {
+        email: Option<String>,
+        plan_type: PlanType,
     },
 }
 

--- a/codex-rs/app-server-protocol/src/protocol.rs
+++ b/codex-rs/app-server-protocol/src/protocol.rs
@@ -240,11 +240,12 @@ client_request_definitions! {
 #[serde(tag = "type", rename_all = "camelCase")]
 #[ts(tag = "type")]
 pub enum Account {
-    #[serde(rename = "apiKey")]
-    #[ts(rename = "apiKey")]
+    #[serde(rename = "apiKey", rename_all = "camelCase")]
+    #[ts(rename = "apiKey", rename_all = "camelCase")]
     ApiKey { api_key: String },
-    #[serde(rename = "chatgpt")]
-    #[ts(rename = "chatgpt")]
+
+    #[serde(rename = "chatgpt", rename_all = "camelCase")]
+    #[ts(rename = "chatgpt", rename_all = "camelCase")]
     ChatGpt {
         email: Option<String>,
         plan_type: PlanType,
@@ -1258,6 +1259,35 @@ mod tests {
             }),
             serde_json::to_value(&request)?,
         );
+        Ok(())
+    }
+
+    #[test]
+    fn account_serializes_fields_in_camel_case() -> Result<()> {
+        let api_key = Account::ApiKey {
+            api_key: "secret".to_string(),
+        };
+        assert_eq!(
+            json!({
+                "type": "apiKey",
+                "apiKey": "secret",
+            }),
+            serde_json::to_value(&api_key)?,
+        );
+
+        let chatgpt = Account::ChatGpt {
+            email: Some("user@example.com".to_string()),
+            plan_type: PlanType::Plus,
+        };
+        assert_eq!(
+            json!({
+                "type": "chatgpt",
+                "email": "user@example.com",
+                "planType": "plus",
+            }),
+            serde_json::to_value(&chatgpt)?,
+        );
+
         Ok(())
     }
 

--- a/codex-rs/protocol/src/account.rs
+++ b/codex-rs/protocol/src/account.rs
@@ -18,18 +18,3 @@ pub enum PlanType {
     #[serde(other)]
     Unknown,
 }
-
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema, TS)]
-#[serde(tag = "type")]
-#[ts(tag = "type")]
-pub enum Account {
-    ApiKey {
-        api_key: String,
-    },
-    #[serde(rename = "chatgpt")]
-    #[ts(rename = "chatgpt")]
-    ChatGpt {
-        email: Option<String>,
-        plan_type: PlanType,
-    },
-}


### PR DESCRIPTION
Makes sense to move this struct to `app-server-protocol/` since we want to serialize as camelCase, but we don't for structs defined in `protocol/`

It was:
```
export type Account = { "type": "ApiKey", api_key: string, } | { "type": "chatgpt", email: string | null, plan_type: PlanType, };
```

But we want:
```
export type Account = { "type": "apiKey", apiKey: string, } | { "type": "chatgpt", email: string | null, planType: PlanType, };
```