### PR TITLE
verify mime type of images

### DIFF
--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -374,7 +374,8 @@ async fn view_image_tool_placeholder_for_non_image_files() -> anyhow::Result<()>
         "non-image file should not produce an input_image message"
     );
 
-    let placeholder = request.inputs_of_type("message")
+    let placeholder = request
+        .inputs_of_type("message")
         .iter()
         .find_map(|item| {
             let content = item.get("content").and_then(Value::as_array)?;

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -314,6 +314,103 @@ async fn view_image_tool_errors_when_path_is_directory() -> anyhow::Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn view_image_tool_placeholder_for_non_image_files() -> anyhow::Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+
+    let TestCodex {
+        codex,
+        cwd,
+        session_configured,
+        ..
+    } = test_codex().build(&server).await?;
+
+    let rel_path = "assets/example.json";
+    let abs_path = cwd.path().join(rel_path);
+    if let Some(parent) = abs_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(&abs_path, br#"{ "message": "hello" }"#)?;
+
+    let call_id = "view-image-non-image";
+    let arguments = serde_json::json!({ "path": rel_path }).to_string();
+
+    let first_response = sse(vec![
+        ev_response_created("resp-1"),
+        ev_function_call(call_id, "view_image", &arguments),
+        ev_completed("resp-1"),
+    ]);
+    responses::mount_sse_once_match(&server, any(), first_response).await;
+
+    let second_response = sse(vec![
+        ev_assistant_message("msg-1", "done"),
+        ev_completed("resp-2"),
+    ]);
+    let mock = responses::mount_sse_once_match(&server, any(), second_response).await;
+
+    let session_model = session_configured.model.clone();
+
+    codex
+        .submit(Op::UserTurn {
+            items: vec![UserInput::Text {
+                text: "please use the view_image tool to read the json file".into(),
+            }],
+            final_output_json_schema: None,
+            cwd: cwd.path().to_path_buf(),
+            approval_policy: AskForApproval::Never,
+            sandbox_policy: SandboxPolicy::DangerFullAccess,
+            model: session_model,
+            effort: None,
+            summary: ReasoningSummary::Auto,
+        })
+        .await?;
+
+    wait_for_event(&codex, |event| matches!(event, EventMsg::TaskComplete(_))).await;
+
+    let body = mock.single_request().body_json();
+    assert!(
+        find_image_message(&body).is_none(),
+        "non-image file should not produce an input_image message"
+    );
+
+    let placeholder = body
+        .get("input")
+        .and_then(Value::as_array)
+        .and_then(|items| {
+            items.iter().find_map(|item| {
+                if item.get("type").and_then(Value::as_str) != Some("message") {
+                    return None;
+                }
+                let content = item.get("content").and_then(Value::as_array)?;
+                content.iter().find_map(|span| {
+                    if span.get("type").and_then(Value::as_str) == Some("input_text") {
+                        let text = span.get("text").and_then(Value::as_str)?;
+                        if text.contains("Codex could not read the local image at")
+                            && text.contains("unsupported MIME type `application/json`")
+                        {
+                            return Some(text);
+                        }
+                    }
+                    None
+                })
+            })
+        })
+        .expect("placeholder text found");
+
+    assert!(
+        placeholder.contains(&abs_path.display().to_string()),
+        "placeholder should mention path: {placeholder}"
+    );
+
+    let output_item = mock.single_request().function_call_output(call_id);
+    let output_text = extract_output_text(&output_item).expect("output text present");
+    assert_eq!(output_text, "attached local image path");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn view_image_tool_errors_when_file_missing() -> anyhow::Result<()> {
     skip_if_no_network!(Ok(()));
 

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -244,10 +244,20 @@ impl From<Vec<UserInput>> for ResponseInputItem {
                             } else {
                                 match std::fs::read(&path) {
                                     Ok(bytes) => {
-                                        let mime = mime_guess::from_path(&path)
-                                            .first()
-                                            .map(|m| m.essence_str().to_owned())
-                                            .unwrap_or_else(|| "image".to_string());
+                                        let Some(mime_guess) = mime_guess::from_path(&path).first()
+                                        else {
+                                            return local_image_error_placeholder(
+                                                &path,
+                                                "unsupported MIME type (unknown)",
+                                            );
+                                        };
+                                        let mime = mime_guess.essence_str().to_owned();
+                                        if !mime.starts_with("image/") {
+                                            return local_image_error_placeholder(
+                                                &path,
+                                                format!("unsupported MIME type `{mime}`"),
+                                            );
+                                        }
                                         let encoded =
                                             base64::engine::general_purpose::STANDARD.encode(bytes);
                                         ContentItem::InputImage {


### PR DESCRIPTION
solves: https://github.com/openai/codex/issues/5675

Block non-image uploads in the view_image workflow. We now confirm the file’s MIME is image/* before building the data URL; otherwise we emit a “unsupported MIME type” error to the model. This stops the agent from sending application/json blobs that the Responses API rejects with 400s.

<img width="409" height="556" alt="Screenshot 2025-10-28 at 1 15 10 PM" src="https://github.com/user-attachments/assets/a92199e8-2769-4b1d-8e33-92d9238c90fe" />
