### PR TITLE
[App Server] Allow fetching or resuming a conversation summary from the conversation id

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol.rs
+++ b/codex-rs/app-server-protocol/src/protocol.rs
@@ -340,6 +340,7 @@ pub struct ResumeConversationResponse {
     pub model: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_messages: Option<Vec<EventMsg>>,
+    pub rollout_path: PathBuf,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
@@ -498,8 +499,12 @@ pub struct LogoutAccountResponse {}
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 pub struct ResumeConversationParams {
-    /// Absolute path to the rollout JSONL file.
-    pub path: PathBuf,
+    /// Absolute path to the rollout JSONL file. If omitted, `conversationId` must be provided.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<PathBuf>,
+    /// Provide a conversation id instead of a path; the server will locate the rollout.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub conversation_id: Option<ConversationId>,
     /// Optional overrides to apply when spawning the resumed session.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub overrides: Option<NewConversationParams>,

--- a/codex-rs/app-server-protocol/src/protocol.rs
+++ b/codex-rs/app-server-protocol/src/protocol.rs
@@ -343,9 +343,20 @@ pub struct ResumeConversationResponse {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
-#[serde(rename_all = "camelCase")]
-pub struct GetConversationSummaryParams {
-    pub rollout_path: PathBuf,
+#[serde(untagged)]
+pub enum GetConversationSummaryParams {
+    /// Provide the absolute or CODEX_HOME‑relative rollout path directly.
+    RolloutPath {
+        #[serde(rename = "rolloutPath")]
+        rollout_path: PathBuf,
+    },
+    /// Provide a conversation id; the server will locate the rollout using the
+    /// same logic as `resumeConversation`. There will be extra latency compared to using the rollout path,
+    /// as the server needs to locate the rollout path first.
+    ConversationId {
+        #[serde(rename = "conversationId")]
+        conversation_id: ConversationId,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, TS)]

--- a/codex-rs/app-server-protocol/src/protocol.rs
+++ b/codex-rs/app-server-protocol/src/protocol.rs
@@ -502,7 +502,7 @@ pub struct ResumeConversationParams {
     /// Absolute path to the rollout JSONL file. If omitted, `conversationId` must be provided.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub path: Option<PathBuf>,
-    /// Provide a conversation id instead of a path; the server will locate the rollout.
+    /// If the rollout path is not known, it can be discovered via the conversation id at at the cost of extra latency.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub conversation_id: Option<ConversationId>,
     /// Optional overrides to apply when spawning the resumed session.

--- a/codex-rs/app-server/tests/suite/list_resume.rs
+++ b/codex-rs/app-server/tests/suite/list_resume.rs
@@ -171,7 +171,8 @@ async fn test_list_and_resume_conversations() -> Result<()> {
     // Now resume one of the sessions and expect a SessionConfigured notification and response.
     let resume_req_id = mcp
         .send_resume_conversation_request(ResumeConversationParams {
-            path: items[0].path.clone(),
+            path: Some(items[0].path.clone()),
+            conversation_id: None,
             overrides: Some(NewConversationParams {
                 model: Some("o3".to_string()),
                 ..Default::default()

--- a/codex-rs/file-search/src/lib.rs
+++ b/codex-rs/file-search/src/lib.rs
@@ -40,6 +40,7 @@ pub struct FileMatch {
     pub indices: Option<Vec<u32>>, // Sorted & deduplicated when present
 }
 
+#[derive(Debug)]
 pub struct FileSearchResults {
     pub matches: Vec<FileMatch>,
     pub total_match_count: usize,


### PR DESCRIPTION
This PR adds an option to app server to allow conversation summaries to be fetched from just the conversation id rather than rollout path for convenience at the cost of some latency to discover the rollout path.

This convenience is non-trivial as it allows app servers to simply maintain conversation ids rather than rollout paths and the associated platform (Windows) handling associated with storing and encoding them correctly.