### PR TITLE
feat: inject agents context prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Codex CLI supports a rich set of configuration options, with preferences stored 
   - [Example prompts](./docs/getting-started.md#example-prompts)
   - [Custom prompts](./docs/prompts.md)
   - [Memory with AGENTS.md](./docs/getting-started.md#memory-with-agentsmd)
+  - [Shared agents workspace](./docs/getting-started.md#agents-home-agents)
   - [Configuration](./docs/config.md)
 - [**Sandbox & approvals**](./docs/sandbox.md)
 - [**Authentication**](./docs/authentication.md)

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1668,6 +1668,7 @@ async fn derive_config_from_params(
         sandbox_mode,
         model_provider,
         codex_linux_sandbox_exe,
+        agents_home: None,
         base_instructions,
         include_apply_patch_tool,
         include_view_image_tool: None,

--- a/codex-rs/cli/tests/mcp_list.rs
+++ b/codex-rs/cli/tests/mcp_list.rs
@@ -159,3 +159,55 @@ async fn get_disabled_server_shows_single_line() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn list_includes_agents_home_servers() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let agents_mcp_dir = codex_home.path().join(".agents").join("mcp");
+    std::fs::create_dir_all(&agents_mcp_dir)?;
+    std::fs::write(
+        agents_mcp_dir.join("mcp.json"),
+        r#"
+{
+  "docs": {
+    "command": "docs-server",
+    "args": ["--port", "8080"],
+    "env": {"TOKEN": "secret"}
+  }
+}
+"#,
+    )?;
+
+    let mut cmd = codex_command(codex_home.path())?;
+    let output = cmd.args(["mcp", "list", "--json"]).output()?;
+    assert!(output.status.success());
+    let stdout = String::from_utf8(output.stdout)?;
+    let parsed: JsonValue = serde_json::from_str(&stdout)?;
+    assert_eq!(
+        parsed,
+        json!([
+            {
+                "name": "docs",
+                "enabled": true,
+                "transport": {
+                    "type": "stdio",
+                    "command": "docs-server",
+                    "args": [
+                        "--port",
+                        "8080"
+                    ],
+                    "env": {
+                        "TOKEN": "secret"
+                    },
+                    "env_vars": [],
+                    "cwd": null
+                },
+                "startup_timeout_sec": null,
+                "tool_timeout_sec": null,
+                "auth_status": "unsupported"
+            }
+        ])
+    );
+
+    Ok(())
+}

--- a/codex-rs/cli/tests/mcp_list.rs
+++ b/codex-rs/cli/tests/mcp_list.rs
@@ -163,7 +163,8 @@ async fn get_disabled_server_shows_single_line() -> Result<()> {
 #[test]
 fn list_includes_agents_home_servers() -> Result<()> {
     let codex_home = TempDir::new()?;
-    let agents_mcp_dir = codex_home.path().join(".agents").join("mcp");
+    let project = TempDir::new()?;
+    let agents_mcp_dir = project.path().join(".agents").join("mcp");
     std::fs::create_dir_all(&agents_mcp_dir)?;
     std::fs::write(
         agents_mcp_dir.join("mcp.json"),
@@ -179,7 +180,10 @@ fn list_includes_agents_home_servers() -> Result<()> {
     )?;
 
     let mut cmd = codex_command(codex_home.path())?;
-    let output = cmd.args(["mcp", "list", "--json"]).output()?;
+    let output = cmd
+        .current_dir(project.path())
+        .args(["mcp", "list", "--json"])
+        .output()?;
     assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout)?;
     let parsed: JsonValue = serde_json::from_str(&stdout)?;

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -81,6 +81,7 @@ tracing = { workspace = true, features = ["log"] }
 tree-sitter = { workspace = true }
 tree-sitter-bash = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v4"] }
+walkdir = { workspace = true }
 which = { workspace = true }
 wildmatch = { workspace = true }
 

--- a/codex-rs/core/src/conversation_manager.rs
+++ b/codex-rs/core/src/conversation_manager.rs
@@ -309,11 +309,17 @@ mod tests {
         let truncated = truncate_before_nth_user_message(InitialHistory::Forked(rollout_items), 1);
         let got_items = truncated.get_rollout_items();
 
-        let expected: Vec<RolloutItem> = vec![
-            RolloutItem::ResponseItem(items[0].clone()),
-            RolloutItem::ResponseItem(items[1].clone()),
-            RolloutItem::ResponseItem(items[2].clone()),
-        ];
+        let mut expected: Vec<RolloutItem> = Vec::new();
+        let mut user_count = 0;
+        for item in &items {
+            if let Some(TurnItem::UserMessage(_)) = crate::event_mapping::parse_turn_item(item) {
+                if user_count == 1 {
+                    break;
+                }
+                user_count += 1;
+            }
+            expected.push(RolloutItem::ResponseItem(item.clone()));
+        }
 
         assert_eq!(
             serde_json::to_value(&got_items).unwrap(),

--- a/codex-rs/core/src/event_mapping.rs
+++ b/codex-rs/core/src/event_mapping.rs
@@ -15,7 +15,9 @@ use tracing::warn;
 fn is_session_prefix(text: &str) -> bool {
     let trimmed = text.trim_start();
     let lowered = trimmed.to_ascii_lowercase();
-    lowered.starts_with("<environment_context>") || lowered.starts_with("<user_instructions>")
+    lowered.starts_with("<environment_context>")
+        || lowered.starts_with("<user_instructions>")
+        || lowered.starts_with("<agents_context>")
 }
 
 fn parse_user_message(message: &[ContentItem]) -> Option<UserMessageItem> {
@@ -268,5 +270,18 @@ mod tests {
             }
             other => panic!("expected TurnItem::WebSearch, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn ignores_agents_context_message() {
+        let item = ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "<agents_context>\nnotes\n</agents_context>".to_string(),
+            }],
+        };
+
+        assert!(parse_turn_item(&item).is_none());
     }
 }

--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -1,5 +1,9 @@
 #![expect(clippy::expect_used)]
 
+use std::fs;
+use std::path::Path;
+use std::path::PathBuf;
+
 use tempfile::TempDir;
 
 use codex_core::CodexConversation;
@@ -35,6 +39,40 @@ pub fn load_default_config_for_test(codex_home: &TempDir) -> Config {
         codex_home.path().to_path_buf(),
     )
     .expect("defaults for test should always succeed")
+}
+
+pub fn seed_global_agents_context(
+    codex_home: &TempDir,
+    relative: impl AsRef<Path>,
+    contents: &str,
+) -> PathBuf {
+    seed_agents_file(codex_home, "context", relative, contents)
+}
+
+pub fn seed_global_agents_tool(
+    codex_home: &TempDir,
+    relative: impl AsRef<Path>,
+    contents: &str,
+) -> PathBuf {
+    seed_agents_file(codex_home, "tools", relative, contents)
+}
+
+fn seed_agents_file(
+    codex_home: &TempDir,
+    subdir: &str,
+    relative: impl AsRef<Path>,
+    contents: &str,
+) -> PathBuf {
+    let path = codex_home
+        .path()
+        .join(".agents")
+        .join(subdir)
+        .join(relative.as_ref());
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("create agents directory");
+    }
+    fs::write(&path, contents).expect("write agents file");
+    path
 }
 
 #[cfg(target_os = "linux")]

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -174,6 +174,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         cwd: cwd.map(|p| p.canonicalize().unwrap_or(p)),
         model_provider,
         codex_linux_sandbox_exe,
+        agents_home: None,
         base_instructions: None,
         include_apply_patch_tool: None,
         include_view_image_tool: None,

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -153,6 +153,7 @@ impl CodexToolCallParam {
             sandbox_mode: sandbox.map(Into::into),
             model_provider: None,
             codex_linux_sandbox_exe,
+            agents_home: None,
             base_instructions,
             include_apply_patch_tool: None,
             include_view_image_tool: None,

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -46,6 +46,8 @@ pub const USER_INSTRUCTIONS_OPEN_TAG: &str = "<user_instructions>";
 pub const USER_INSTRUCTIONS_CLOSE_TAG: &str = "</user_instructions>";
 pub const ENVIRONMENT_CONTEXT_OPEN_TAG: &str = "<environment_context>";
 pub const ENVIRONMENT_CONTEXT_CLOSE_TAG: &str = "</environment_context>";
+pub const AGENTS_CONTEXT_OPEN_TAG: &str = "<agents_context>";
+pub const AGENTS_CONTEXT_CLOSE_TAG: &str = "</agents_context>";
 pub const USER_MESSAGE_BEGIN: &str = "## My request for Codex:";
 
 /// Submission Queue Entry - requests from user

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -143,6 +143,7 @@ pub async fn run_main(
         model_provider: model_provider_override,
         config_profile: cli.config_profile.clone(),
         codex_linux_sandbox_exe,
+        agents_home: None,
         base_instructions: None,
         include_apply_patch_tool: None,
         include_view_image_tool: None,

--- a/docs/agents_md.md
+++ b/docs/agents_md.md
@@ -11,10 +11,10 @@ Codex uses [`AGENTS.md`](https://agents.md/) files to gather helpful guidance be
 
 ## Shared Agents Workspace (`~/.agents`)
 
-Codex also creates a companion `.agents` directory alongside `.codex`. Use this space to keep durable resources that multiple projects or agents should reuse:
+Codex also creates a companion `.agents` directory alongside `.codex` (or at whatever path you set via `agents_home`/`AGENTS_HOME`). Use this space to keep durable resources that multiple projects or agents should reuse:
 
-- `context/` for structured notes, runbooks, and decision logs that complement your `AGENTS.md` guidance.
-- `tools/` for small scripts or binaries that agents can launch (for example, calculators, code generators, or health-check scripts).
+- `context/` for structured notes, runbooks, and decision logs that complement your `AGENTS.md` guidance. Codex reads UTF-8 files from this folder and emits them in an `<agents_context>` block at the start of every session (32 KiB per file, 64 KiB total). Project-level `.agents/context/` folders override conflicting files from the global store, and the CLI reports global entries with their actual absolute paths so agents never rely on the default `~/.agents` prefix.
+- `tools/` for small scripts or binaries that agents can launch (for example, calculators, code generators, or health-check scripts). Paths discovered here are listed in the same `<agents_context>` block using their true locations, so the agent knows exactly how to invoke them.
 - `mcp/` for Model Context Protocol server manifests and credential material you want available everywhere. Place one `mcp.config`, `mcp.toml`, or `mcp.json` file here (first match wins) to declare shared MCP servers.
 
 The CLI makes sure these directories exist on startup. Set `agents_home` in your config or the `AGENTS_HOME` environment variable if you want to relocate them.

--- a/docs/agents_md.md
+++ b/docs/agents_md.md
@@ -9,6 +9,16 @@ Codex uses [`AGENTS.md`](https://agents.md/) files to gather helpful guidance be
 - Only the first non-empty file is used. Other filenames, such as `instructions.md`, have no effect unless Codex is specifically instructed to use them.
 - Whatever Codex finds here stays active for the whole session, and Codex combines it with any project-specific instructions it discovers.
 
+## Shared Agents Workspace (`~/.agents`)
+
+Codex also creates a companion `.agents` directory alongside `.codex`. Use this space to keep durable resources that multiple projects or agents should reuse:
+
+- `context/` for structured notes, runbooks, and decision logs that complement your `AGENTS.md` guidance.
+- `tools/` for small scripts or binaries that agents can launch (for example, calculators, code generators, or health-check scripts).
+- `mcp/` for Model Context Protocol server manifests and credential material you want available everywhere.
+
+The CLI makes sure these directories exist on startup. Set `agents_home` in your config or the `AGENTS_HOME` environment variable if you want to relocate them.
+
 ## Project Instructions (per-repository)
 
 When you work inside a project, Codex builds on those global instructions by collecting project docs:

--- a/docs/agents_md.md
+++ b/docs/agents_md.md
@@ -15,7 +15,7 @@ Codex also creates a companion `.agents` directory alongside `.codex`. Use this 
 
 - `context/` for structured notes, runbooks, and decision logs that complement your `AGENTS.md` guidance.
 - `tools/` for small scripts or binaries that agents can launch (for example, calculators, code generators, or health-check scripts).
-- `mcp/` for Model Context Protocol server manifests and credential material you want available everywhere.
+- `mcp/` for Model Context Protocol server manifests and credential material you want available everywhere. Place a `mcp.config` (TOML or JSON) file here to declare shared MCP servers.
 
 The CLI makes sure these directories exist on startup. Set `agents_home` in your config or the `AGENTS_HOME` environment variable if you want to relocate them.
 

--- a/docs/agents_md.md
+++ b/docs/agents_md.md
@@ -15,7 +15,7 @@ Codex also creates a companion `.agents` directory alongside `.codex`. Use this 
 
 - `context/` for structured notes, runbooks, and decision logs that complement your `AGENTS.md` guidance.
 - `tools/` for small scripts or binaries that agents can launch (for example, calculators, code generators, or health-check scripts).
-- `mcp/` for Model Context Protocol server manifests and credential material you want available everywhere. Place a `mcp.config` (TOML or JSON) file here to declare shared MCP servers.
+- `mcp/` for Model Context Protocol server manifests and credential material you want available everywhere. Place one `mcp.config`, `mcp.toml`, or `mcp.json` file here (first match wins) to declare shared MCP servers.
 
 The CLI makes sure these directories exist on startup. Set `agents_home` in your config or the `AGENTS_HOME` environment variable if you want to relocate them.
 

--- a/docs/agents_md.md
+++ b/docs/agents_md.md
@@ -19,6 +19,8 @@ Codex also creates a companion `.agents` directory alongside `.codex`. Use this 
 
 The CLI makes sure these directories exist on startup. Set `agents_home` in your config or the `AGENTS_HOME` environment variable if you want to relocate them.
 
+If a repository contains its own `.agents/` folder (for example at `<repo>/.agents`), Codex will automatically merge its contents with the global workspace: project-specific entries augment or override the shared ones without requiring additional configuration.
+
 ## Project Instructions (per-repository)
 
 When you work inside a project, Codex builds on those global instructions by collecting project docs:

--- a/docs/config.md
+++ b/docs/config.md
@@ -310,6 +310,19 @@ This is reasonable to use if Codex is running in an environment that provides it
 
 Though using this option may also be necessary if you try to use Codex in environments where its native sandboxing mechanisms are unsupported, such as older Linux kernels or on Windows.
 
+### agents_home
+
+Codex keeps reusable memories, helper scripts, and MCP manifests inside a shared `.agents` directory. By default this folder lives next to `.codex` in your home directory and Codex creates the `context/`, `tools/`, and `mcp/` subdirectories automatically.
+
+Override the location if you want to place those resources somewhere else (for example on a synced drive):
+
+```toml
+# store shared artifacts under ~/.workspace/agents/
+agents_home = "~/.workspace/agents"
+```
+
+Alternatively, set the `AGENTS_HOME` environment variable before launching Codex. Relative paths are resolved against the current working directory, and leading `~` expands to your home directory.
+
 ### tools.\*
 
 Use the optional `[tools]` table to toggle built-in tools that the agent may call. Both keys default to `false` (tools stay disabled) unless you opt in:

--- a/docs/config.md
+++ b/docs/config.md
@@ -323,6 +323,29 @@ agents_home = "~/.workspace/agents"
 
 Alternatively, set the `AGENTS_HOME` environment variable before launching Codex. Relative paths are resolved against the current working directory, and leading `~` expands to your home directory.
 
+#### MCP configuration file
+
+Inside `agents_home`, Codex checks `mcp/mcp.config`, `mcp/mcp.toml`, or `mcp/mcp.json`. If present, the file is parsed (TOML or JSON) and merged with the `mcp_servers` section from `config.toml`. Entries defined in `config.toml` take precedence when the same server id appears in both places.
+
+Example `mcp.config`:
+
+```toml
+[docs]
+command = "docs-server"
+```
+
+Example `mcp.json`:
+
+```json
+{
+  "docs": {
+    "command": "docs-server"
+  }
+}
+```
+
+This lets you keep shared MCP server definitions alongside other reusable agent assets without editing `config.toml` on every machine.
+
 ### tools.\*
 
 Use the optional `[tools]` table to toggle built-in tools that the agent may call. Both keys default to `false` (tools stay disabled) unless you opt in:

--- a/docs/config.md
+++ b/docs/config.md
@@ -325,7 +325,7 @@ Alternatively, set the `AGENTS_HOME` environment variable before launching Codex
 
 #### MCP configuration file
 
-Inside `agents_home`, Codex checks `mcp/mcp.config`, `mcp/mcp.toml`, or `mcp/mcp.json`. If present, the file is parsed (TOML or JSON) and merged with the `mcp_servers` section from `config.toml`. Entries defined in `config.toml` take precedence when the same server id appears in both places.
+Inside `agents_home`, Codex checks for `mcp/mcp.config`, `mcp/mcp.toml`, or `mcp/mcp.json` (in that order) and uses the first file it finds. The contents (TOML or JSON) are merged with the `mcp_servers` section from `config.toml`; entries defined in `config.toml` still take precedence when the same server id appears in both places.
 
 Example `mcp.config`:
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -323,6 +323,8 @@ agents_home = "~/.workspace/agents"
 
 Alternatively, set the `AGENTS_HOME` environment variable before launching Codex. Relative paths are resolved against the current working directory, and leading `~` expands to your home directory.
 
+When a repository contains its own `.agents/` directory (for example `<project>/.agents`), Codex merges its `context/`, `tools/`, and `mcp/` subfolders on top of the global workspace. Project-level entries override global ones, letting each codebase define tailored memories and MCP servers without additional configuration.
+
 #### MCP configuration file
 
 Inside `agents_home`, Codex checks for `mcp/mcp.config`, `mcp/mcp.toml`, or `mcp/mcp.json` (in that order) and uses the first file it finds. The contents (TOML or JSON) are merged with the `mcp_servers` section from `config.toml`; entries defined in `config.toml` still take precedence when the same server id appears in both places.

--- a/docs/config.md
+++ b/docs/config.md
@@ -314,6 +314,8 @@ Though using this option may also be necessary if you try to use Codex in enviro
 
 Codex keeps reusable memories, helper scripts, and MCP manifests inside a shared `.agents` directory. By default this folder lives next to `.codex` in your home directory and Codex creates the `context/`, `tools/`, and `mcp/` subdirectories automatically.
 
+Files in `context/` are merged into a single `<agents_context>` block that is prepended to every session. Codex reads UTF-8 files from the global directory first and then overlays any project-level `.agents/context/` directory; files with matching relative paths are replaced by the project copy. The combined block is limited to 32 KiB per file and 64 KiB total. When a file exceeds the per-file limit Codex adds `_Content truncated to 32 KiB._` so you can split or reorganize it. Scripts dropped into `tools/` are listed in the same block with their absolute paths (derived from your configured `agents_home`), giving the agent a canonical place to discover helper binaries or small CLI utilities. Global context entries are printed with the same absolute paths so the agent never relies on the default `~/.agents` location.
+
 Override the location if you want to place those resources somewhere else (for example on a synced drive):
 
 ```toml

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,6 +68,16 @@ You can give Codex extra instructions and guidance using `AGENTS.md` files. Code
 
 For more information on how to use AGENTS.md, see the [official AGENTS.md documentation](https://agents.md/).
 
+### Agents Home (`~/.agents`)
+
+Codex also provisions a shared `.agents` directory next to your `.codex` folder. It is created automatically with a predictable layout so multiple agents and sessions can reuse the same resources:
+
+- `~/.agents/context/` – long-term notes, project briefs, and other durable context that you want every session to recall.
+- `~/.agents/tools/` – reusable helper programs (for example, a calculator script or project-specific linters) that Codex can invoke instead of reimplementing logic at runtime.
+- `~/.agents/mcp/` – Model Context Protocol server definitions and credentials that you want to keep ready for any project.
+
+You can relocate the directory with the `agents_home` config setting or the `AGENTS_HOME` environment variable if you prefer to store it somewhere else.
+
 ### Tips & shortcuts
 
 #### Use `@` for file search

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -68,15 +68,16 @@ You can give Codex extra instructions and guidance using `AGENTS.md` files. Code
 
 For more information on how to use AGENTS.md, see the [official AGENTS.md documentation](https://agents.md/).
 
-### Agents Home (`~/.agents`)
+### Agents Home (`~/.agents` by default)
 
-Codex also provisions a shared `.agents` directory next to your `.codex` folder. It is created automatically with a predictable layout so multiple agents and sessions can reuse the same resources:
+Codex also provisions a shared `.agents` directory next to your `.codex` folder (or at the path you configure via `agents_home` or `AGENTS_HOME`). It is created automatically with a predictable layout so multiple agents and sessions can reuse the same resources. When a global file is referenced in the `<agents_context>` block, Codex now prints its real absolute path so the agent can execute it without guessing at the default location.
 
-- `~/.agents/context/` – long-term notes, project briefs, and other durable context that you want every session to recall.
-- `~/.agents/tools/` – reusable helper programs (for example, a calculator script or project-specific linters) that Codex can invoke instead of reimplementing logic at runtime.
-- `~/.agents/mcp/` – Model Context Protocol server definitions and credentials that you want to keep ready for any project.
-- Drop exactly one of `mcp.config`, `mcp.toml`, or `mcp.json` into `~/.agents/mcp/` (Codex uses the first one it finds in that order) to declare shared MCP servers; Codex merges it with any `mcp_servers` defined in `~/.codex/config.toml`.
-- If your repository contains a `.agents/` folder, Codex merges its contents with the global workspace so you can keep project-specific memories and tools alongside the codebase.
+- `context/` – UTF-8 text files that Codex injects at the start of every session inside an `<agents_context>` block. Entries from project-level `.agents/context/` directories override files with the same relative path from the global store.
+- `tools/` – reusable helper programs (for example, a calculator script or project-specific linters). Codex lists these paths in the same `<agents_context>` block so the agent can call them directly via the shell.
+- `mcp/` – Model Context Protocol server definitions and credentials that you want to keep ready for any project.
+- Drop exactly one of `mcp.config`, `mcp.toml`, or `mcp.json` into the `mcp/` directory (Codex uses the first one it finds in that order) to declare shared MCP servers; Codex merges it with any `mcp_servers` defined in `~/.codex/config.toml`.
+- If your repository contains a `.agents/` folder, Codex merges its contents with the global workspace so you can keep project-specific memories and tools alongside the codebase. Project-specific entries override global ones when they share the same relative path.
+- Context is truncated to 32 KiB per file and 64 KiB total per session. Codex inserts a `_Content truncated to 32 KiB._` note next to shortened files so you can adjust the source material if needed.
 
 You can relocate the directory with the `agents_home` config setting or the `AGENTS_HOME` environment variable if you prefer to store it somewhere else.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,6 +75,7 @@ Codex also provisions a shared `.agents` directory next to your `.codex` folder.
 - `~/.agents/context/` – long-term notes, project briefs, and other durable context that you want every session to recall.
 - `~/.agents/tools/` – reusable helper programs (for example, a calculator script or project-specific linters) that Codex can invoke instead of reimplementing logic at runtime.
 - `~/.agents/mcp/` – Model Context Protocol server definitions and credentials that you want to keep ready for any project.
+- Drop a `mcp.config` (or `mcp.json`) file into `~/.agents/mcp/` to declare shared MCP servers; Codex merges it with any `mcp_servers` defined in `~/.codex/config.toml`.
 
 You can relocate the directory with the `agents_home` config setting or the `AGENTS_HOME` environment variable if you prefer to store it somewhere else.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -76,6 +76,7 @@ Codex also provisions a shared `.agents` directory next to your `.codex` folder.
 - `~/.agents/tools/` – reusable helper programs (for example, a calculator script or project-specific linters) that Codex can invoke instead of reimplementing logic at runtime.
 - `~/.agents/mcp/` – Model Context Protocol server definitions and credentials that you want to keep ready for any project.
 - Drop exactly one of `mcp.config`, `mcp.toml`, or `mcp.json` into `~/.agents/mcp/` (Codex uses the first one it finds in that order) to declare shared MCP servers; Codex merges it with any `mcp_servers` defined in `~/.codex/config.toml`.
+- If your repository contains a `.agents/` folder, Codex merges its contents with the global workspace so you can keep project-specific memories and tools alongside the codebase.
 
 You can relocate the directory with the `agents_home` config setting or the `AGENTS_HOME` environment variable if you prefer to store it somewhere else.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -75,7 +75,7 @@ Codex also provisions a shared `.agents` directory next to your `.codex` folder.
 - `~/.agents/context/` – long-term notes, project briefs, and other durable context that you want every session to recall.
 - `~/.agents/tools/` – reusable helper programs (for example, a calculator script or project-specific linters) that Codex can invoke instead of reimplementing logic at runtime.
 - `~/.agents/mcp/` – Model Context Protocol server definitions and credentials that you want to keep ready for any project.
-- Drop a `mcp.config` (or `mcp.json`) file into `~/.agents/mcp/` to declare shared MCP servers; Codex merges it with any `mcp_servers` defined in `~/.codex/config.toml`.
+- Drop exactly one of `mcp.config`, `mcp.toml`, or `mcp.json` into `~/.agents/mcp/` (Codex uses the first one it finds in that order) to declare shared MCP servers; Codex merges it with any `mcp_servers` defined in `~/.codex/config.toml`.
 
 You can relocate the directory with the `agents_home` config setting or the `AGENTS_HOME` environment variable if you prefer to store it somewhere else.
 


### PR DESCRIPTION
## Summary
- parse `.agents/context` and `.agents/tools` from the global workspace plus project overlays, truncating oversized entries
- render an `<agents_context>` block listing context files and helper tools (with real paths) ahead of the environment context for every session and turn
- expand unit/integration coverage and refresh docs so the layered `<agents_context>` behavior is stable and documented

> **Note**
> This PR is stacked on top of #5877 (`feat/agents-home`). Please review that one first; this diff will shrink once it lands.

## Testing
- just fix -p codex-core
- cargo test -p codex-core
