### PR TITLE
[draft] fixing terminal rendering

### DIFF
--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -143,9 +143,11 @@ impl App {
     pub(crate) fn render_transcript_once(&mut self, tui: &mut tui::Tui) {
         if !self.transcript_cells.is_empty() {
             let width = tui.terminal.last_known_screen_size.width;
-            for cell in &self.transcript_cells {
-                tui.insert_history_lines(cell.display_lines(width));
+            let (lines, has_visible_output) = self.transcript_lines_for_width(width);
+            if !lines.is_empty() {
+                tui.insert_history_lines(lines);
             }
+            self.update_transcript_layout_state(width, has_visible_output);
         }
     }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -757,9 +757,7 @@ impl ChatWidget {
                 self.add_to_history(history_cell::FinalMessageSeparator::new(elapsed_seconds));
                 self.needs_final_message_separator = false;
             }
-            self.stream_controller = Some(StreamController::new(
-                self.last_rendered_width.get().map(|w| w.saturating_sub(2)),
-            ));
+            self.stream_controller = Some(StreamController::new(None));
         }
         if let Some(controller) = self.stream_controller.as_mut()
             && controller.push(&delta)

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -220,4 +220,22 @@ mod tests {
             "expected exact rendered lines for loose/tight section"
         );
     }
+
+    #[tokio::test]
+    async fn streaming_cells_reflow_when_width_changes() {
+        let mut ctrl = StreamController::new(None);
+        ctrl.push(
+            "This is a long streamed line that should collapse when the terminal grows wider.",
+        );
+        let cell = ctrl
+            .finalize()
+            .expect("finalize should return a history cell for streamed content");
+
+        let narrow = cell.display_lines(10);
+        let wide = cell.display_lines(80);
+        assert!(
+            narrow.len() > wide.len(),
+            "expected rewrapping to reduce the number of lines when width increases"
+        );
+    }
 }

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -485,6 +485,17 @@ impl Tui {
         self.frame_requester().schedule_frame();
     }
 
+    pub fn clear_history(&mut self) -> Result<()> {
+        let size = self.terminal.size()?;
+        let original_viewport = self.terminal.viewport_area;
+        let full = ratatui::layout::Rect::new(0, 0, size.width, size.height);
+        self.terminal.set_viewport_area(full);
+        self.terminal.clear()?;
+        self.terminal.set_viewport_area(original_viewport);
+        self.pending_history_lines.clear();
+        Ok(())
+    }
+
     pub fn draw(
         &mut self,
         height: u16,

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -486,12 +486,22 @@ impl Tui {
     }
 
     pub fn clear_history(&mut self) -> Result<()> {
+        {
+            let backend = self.terminal.backend_mut();
+            std::io::Write::write_all(backend, b"\x1b[3J")?;
+            std::io::Write::write_all(backend, b"\x1b[2J")?;
+            std::io::Write::write_all(backend, b"\x1b[H")?;
+            std::io::Write::flush(backend)?;
+        }
+
         let size = self.terminal.size()?;
         let original_viewport = self.terminal.viewport_area;
         let full = ratatui::layout::Rect::new(0, 0, size.width, size.height);
         self.terminal.set_viewport_area(full);
         self.terminal.clear()?;
         self.terminal.set_viewport_area(original_viewport);
+        self.terminal
+            .set_cursor_position(original_viewport.as_position())?;
         self.pending_history_lines.clear();
         Ok(())
     }


### PR DESCRIPTION
refactored the chat transcript logic on terminal resize by clearing scrollback and re-rendering history at the new width. 

added regression tests to cover the new behavior