### PR TITLE
Add a wrapper around raw response items

### DIFF
--- a/codex-rs/app-server/tests/suite/send_message.rs
+++ b/codex-rs/app-server/tests/suite/send_message.rs
@@ -16,6 +16,7 @@ use codex_app_server_protocol::SendUserMessageResponse;
 use codex_protocol::ConversationId;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
+use codex_protocol::protocol::RawResponseItemEvent;
 use pretty_assertions::assert_eq;
 use std::path::Path;
 use tempfile::TempDir;
@@ -294,7 +295,9 @@ async fn read_raw_response_item(
         .cloned()
         .expect("raw response item should include msg payload");
 
-    serde_json::from_value(msg_value).expect("deserialize raw response item")
+    let event: RawResponseItemEvent =
+        serde_json::from_value(msg_value).expect("deserialize raw response item");
+    event.item
 }
 
 fn assert_instructions_message(item: &ResponseItem) {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -23,6 +23,7 @@ use codex_protocol::items::TurnItem;
 use codex_protocol::protocol::ExitedReviewModeEvent;
 use codex_protocol::protocol::ItemCompletedEvent;
 use codex_protocol::protocol::ItemStartedEvent;
+use codex_protocol::protocol::RawResponseItemEvent;
 use codex_protocol::protocol::ReviewRequest;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::SessionSource;
@@ -987,8 +988,11 @@ impl Session {
 
     async fn send_raw_response_items(&self, turn_context: &TurnContext, items: &[ResponseItem]) {
         for item in items {
-            self.send_event(turn_context, EventMsg::RawResponseItem(item.clone()))
-                .await;
+            self.send_event(
+                turn_context,
+                EventMsg::RawResponseItem(RawResponseItemEvent { item: item.clone() }),
+            )
+            .await;
         }
     }
 

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -542,10 +542,15 @@ pub enum EventMsg {
     /// Exited review mode with an optional final result to apply.
     ExitedReviewMode(ExitedReviewModeEvent),
 
-    RawResponseItem(ResponseItem),
+    RawResponseItem(RawResponseItemEvent),
 
     ItemStarted(ItemStartedEvent),
     ItemCompleted(ItemCompletedEvent),
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema)]
+pub struct RawResponseItemEvent {
+    pub item: ResponseItem,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema)]


### PR DESCRIPTION
We currently have nested enums when sending raw response items in the app-server protocol. This makes downstream schemas confusing because we need to embed `type`-discriminated enums within each other.

This PR adds a small wrapper around the response item so we can keep the schemas separate