### PR TITLE
Route cloud tasks list to failing queue

### DIFF
--- a/codex-rs/cloud-tasks-client/src/http.rs
+++ b/codex-rs/cloud-tasks-client/src/http.rs
@@ -131,7 +131,9 @@ mod api {
         pub(crate) async fn list(&self, env: Option<&str>) -> Result<Vec<TaskSummary>> {
             let resp = self
                 .backend
-                .list_tasks(Some(20), Some("current"), env)
+                // Always load tasks from the failing path now that the
+                // speculative review combo flag has been removed.
+                .list_tasks(Some(20), Some("failing"), env)
                 .await
                 .map_err(|e| CloudTaskError::Http(format!("list_tasks failed: {e}")))?;
 


### PR DESCRIPTION
## Summary
- always request the failing task list in the cloud tasks client now that the speculative review combo flag is gone

## Testing
- `just fmt`
- `just fix -p codex-cloud-tasks-client`
- `cargo test -p codex-cloud-tasks-client`


------
https://chatgpt.com/codex/tasks/task_i_690144ec1eb883219da09f280dcccf7f