### PR TITLE
Re-enable SDK image forwarding test

### DIFF
--- a/sdk/typescript/samples/helpers.ts
+++ b/sdk/typescript/samples/helpers.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
 
 export function codexPathOverride() {
-  return process.env.CODEX_EXECUTABLE ??
-  path.join(process.cwd(), "..", "..", "codex-rs", "target", "debug", "codex");
+  return (
+    process.env.CODEX_EXECUTABLE ??
+    path.join(process.cwd(), "..", "..", "codex-rs", "target", "debug", "codex")
+  );
 }

--- a/sdk/typescript/src/items.ts
+++ b/sdk/typescript/src/items.ts
@@ -115,7 +115,6 @@ export type TodoListItem = {
   items: TodoItem[];
 };
 
-
 /** Canonical union of thread items and their type-specific payloads. */
 export type ThreadItem =
   | AgentMessageItem

--- a/sdk/typescript/src/outputSchemaFile.ts
+++ b/sdk/typescript/src/outputSchemaFile.ts
@@ -21,8 +21,7 @@ export async function createOutputSchemaFile(schema: unknown): Promise<OutputSch
   const cleanup = async () => {
     try {
       await fs.rm(schemaDir, { recursive: true, force: true });
-    }
-    catch  {
+    } catch {
       // suppress
     }
   };

--- a/sdk/typescript/tests/run.test.ts
+++ b/sdk/typescript/tests/run.test.ts
@@ -308,8 +308,7 @@ describe("Codex", () => {
       await close();
     }
   });
-  // TODO(pakrym): unskip the test
-  xit("forwards images to exec", async () => {
+  it("forwards images to exec", async () => {
     const { url, close } = await startResponsesTestProxy({
       statusCode: 200,
       responseBodies: [

--- a/sdk/typescript/tests/run.test.ts
+++ b/sdk/typescript/tests/run.test.ts
@@ -3,7 +3,7 @@ import os from "node:os";
 import path from "node:path";
 
 import { codexExecSpy } from "./codexExecSpy";
-import { describe, expect, it, xit } from "@jest/globals";
+import { describe, expect, it } from "@jest/globals";
 
 import { Codex } from "../src/codex";
 


### PR DESCRIPTION
## Summary
- re-enable the TypeScript SDK test that verifies local images are forwarded to `codex exec`

## Testing
- `pnpm test` *(fails: unable to download pnpm 10.8.1 because external network access is blocked in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_i_690289cb861083209fd006867e2adfb1