### PR TITLE
Add /exit alias for quit command

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1457,6 +1457,7 @@ dependencies = [
  "lazy_static",
  "libc",
  "mcp-types",
+ "once_cell",
  "opentelemetry-appender-tracing",
  "pathdiff",
  "pretty_assertions",

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -68,6 +68,7 @@ strum_macros = { workspace = true }
 supports-color = { workspace = true }
 tempfile = { workspace = true }
 textwrap = { workspace = true }
+once_cell = "1"
 tree-sitter-highlight = { workspace = true }
 tree-sitter-bash = { workspace = true }
 tokio = { workspace = true, features = [

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -36,7 +36,7 @@ use crate::bottom_pane::prompt_args::prompt_argument_names;
 use crate::bottom_pane::prompt_args::prompt_command_with_arg_placeholders;
 use crate::bottom_pane::prompt_args::prompt_has_numeric_placeholders;
 use crate::slash_command::SlashCommand;
-use crate::slash_command::built_in_slash_commands;
+use crate::slash_command::resolve_slash_command;
 use crate::style::user_message_style;
 use codex_protocol::custom_prompts::CustomPrompt;
 use codex_protocol::custom_prompts::PROMPTS_CMD_PREFIX;
@@ -932,9 +932,7 @@ impl ChatComposer {
                 let first_line = self.textarea.text().lines().next().unwrap_or("");
                 if let Some((name, rest)) = parse_slash_name(first_line)
                     && rest.is_empty()
-                    && let Some((_n, cmd)) = built_in_slash_commands()
-                        .into_iter()
-                        .find(|(n, _)| *n == name)
+                    && let Some(cmd) = resolve_slash_command(name)
                 {
                     self.textarea.set_text("");
                     return (InputResult::Command(cmd), true);
@@ -1003,9 +1001,7 @@ impl ChatComposer {
                 if let Some((name, _rest)) = parse_slash_name(&text) {
                     let treat_as_plain_text = input_starts_with_space || name.contains('/');
                     if !treat_as_plain_text {
-                        let is_builtin = built_in_slash_commands()
-                            .into_iter()
-                            .any(|(command_name, _)| command_name == name);
+                        let is_builtin = resolve_slash_command(name).is_some();
                         let prompt_prefix = format!("{PROMPTS_CMD_PREFIX}:");
                         let is_known_prompt = name
                             .strip_prefix(&prompt_prefix)

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -24,7 +24,7 @@ pub enum SlashCommand {
     Status,
     Mcp,
     Logout,
-    #[strum(serialize = "exit", serialize = "e")]
+    #[strum(serialize = "exit")]
     Quit,
     Feedback,
     Rollout,

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -24,6 +24,7 @@ pub enum SlashCommand {
     Status,
     Mcp,
     Logout,
+    #[strum(serialize = "exit", serialize = "e")]
     Quit,
     Feedback,
     Rollout,
@@ -81,6 +82,22 @@ impl SlashCommand {
         }
     }
 
+    /// Additional slash names that map to this command.
+    pub fn aliases(self) -> &'static [&'static str] {
+        match self {
+            SlashCommand::Quit => &["exit", "e"],
+            _ => &[],
+        }
+    }
+
+    /// Return true if `name` matches this command's canonical name or an alias.
+    pub fn matches_name(self, name: &str) -> bool {
+        if self.command() == name {
+            return true;
+        }
+        self.aliases().contains(&name)
+    }
+
     fn is_visible(self) -> bool {
         match self {
             SlashCommand::Rollout | SlashCommand::TestApproval => cfg!(debug_assertions),
@@ -95,4 +112,10 @@ pub fn built_in_slash_commands() -> Vec<(&'static str, SlashCommand)> {
         .filter(|command| command.is_visible())
         .map(|c| (c.command(), c))
         .collect()
+}
+
+/// Resolve a slash command name (including aliases) to the corresponding command.
+pub fn resolve_slash_command(name: &str) -> Option<SlashCommand> {
+    use std::str::FromStr;
+    SlashCommand::from_str(name).ok()
 }


### PR DESCRIPTION
- add /exit that resolve to the quit slash command
- update the command popup to filter and exclude alias names
- abstract the slash tools definition 