### PR TITLE
Add prompt cache key as a parameter when starting Codex

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -88,6 +88,7 @@ pub struct ModelClient {
     effort: Option<ReasoningEffortConfig>,
     summary: ReasoningSummaryConfig,
     session_source: SessionSource,
+    prompt_cache_key: String,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -101,6 +102,7 @@ impl ModelClient {
         summary: ReasoningSummaryConfig,
         conversation_id: ConversationId,
         session_source: SessionSource,
+        prompt_cache_key: String,
     ) -> Self {
         let client = create_client();
 
@@ -114,6 +116,7 @@ impl ModelClient {
             effort,
             summary,
             session_source,
+            prompt_cache_key,
         }
     }
 
@@ -246,7 +249,7 @@ impl ModelClient {
             store: azure_workaround,
             stream: true,
             include,
-            prompt_cache_key: Some(self.conversation_id.to_string()),
+            prompt_cache_key: Some(self.prompt_cache_key.clone()),
             text,
         };
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -629,10 +629,6 @@ impl Session {
         self.prompt_cache_key.clone()
     }
 
-    pub(crate) fn get_conversation_id(&self) -> ConversationId {
-        self.conversation_id
-    }
-
     pub(crate) fn get_tx_event(&self) -> Sender<Event> {
         self.tx_event.clone()
     }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -625,6 +625,10 @@ impl Session {
         Ok(sess)
     }
 
+    pub(crate) fn get_prompt_cache_key(&self) -> String {
+        self.prompt_cache_key.clone()
+    }
+
     pub(crate) fn get_conversation_id(&self) -> ConversationId {
         self.conversation_id
     }

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -45,6 +45,7 @@ pub(crate) async fn run_codex_conversation_interactive(
         auth_manager,
         InitialHistory::New,
         SessionSource::SubAgent(SubAgentSource::Review),
+        Some(parent_session.get_conversation_id().to_string()),
     )
     .await?;
     let codex = Arc::new(codex);

--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -45,7 +45,7 @@ pub(crate) async fn run_codex_conversation_interactive(
         auth_manager,
         InitialHistory::New,
         SessionSource::SubAgent(SubAgentSource::Review),
-        Some(parent_session.get_conversation_id().to_string()),
+        Some(parent_session.get_prompt_cache_key()),
     )
     .await?;
     let codex = Arc::new(codex);

--- a/codex-rs/core/src/conversation_manager.rs
+++ b/codex-rs/core/src/conversation_manager.rs
@@ -74,6 +74,7 @@ impl ConversationManager {
             auth_manager,
             InitialHistory::New,
             self.session_source.clone(),
+            None,
         )
         .await?;
         self.finalize_spawn(codex, conversation_id).await
@@ -150,6 +151,7 @@ impl ConversationManager {
             auth_manager,
             initial_history,
             self.session_source.clone(),
+            None,
         )
         .await?;
         self.finalize_spawn(codex, conversation_id).await
@@ -175,6 +177,7 @@ impl ConversationManager {
         nth_user_message: usize,
         config: Config,
         path: PathBuf,
+        conversation_id: ConversationId,
     ) -> CodexResult<NewConversation> {
         // Compute the prefix up to the cut point.
         let history = RolloutRecorder::get_rollout_history(&path).await?;
@@ -185,7 +188,14 @@ impl ConversationManager {
         let CodexSpawnOk {
             codex,
             conversation_id,
-        } = Codex::spawn(config, auth_manager, history, self.session_source.clone()).await?;
+        } = Codex::spawn(
+            config,
+            auth_manager,
+            history,
+            self.session_source.clone(),
+            Some(conversation_id.to_string()),
+        )
+        .await?;
 
         self.finalize_spawn(codex, conversation_id).await
     }

--- a/codex-rs/core/tests/chat_completions_payload.rs
+++ b/codex-rs/core/tests/chat_completions_payload.rs
@@ -95,6 +95,7 @@ async fn run_request(input: Vec<ResponseItem>) -> Value {
         summary,
         conversation_id,
         codex_protocol::protocol::SessionSource::Exec,
+        conversation_id.to_string(),
     );
 
     let mut prompt = Prompt::default();

--- a/codex-rs/core/tests/chat_completions_sse.rs
+++ b/codex-rs/core/tests/chat_completions_sse.rs
@@ -95,6 +95,7 @@ async fn run_stream_with_bytes(sse_body: &[u8]) -> Vec<ResponseEvent> {
         summary,
         conversation_id,
         codex_protocol::protocol::SessionSource::Exec,
+        conversation_id.to_string(),
     );
 
     let mut prompt = Prompt::default();

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -77,6 +77,7 @@ async fn responses_stream_includes_task_type_header() {
         summary,
         conversation_id,
         SessionSource::Exec,
+        conversation_id.to_string(),
     );
 
     let mut prompt = Prompt::default();

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -676,6 +676,7 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
         summary,
         conversation_id,
         codex_protocol::protocol::SessionSource::Exec,
+        conversation_id.to_string(),
     );
 
     let mut prompt = Prompt::default();

--- a/codex-rs/core/tests/suite/fork_conversation.rs
+++ b/codex-rs/core/tests/suite/fork_conversation.rs
@@ -58,6 +58,7 @@ async fn fork_conversation_twice_drops_to_first_message() {
     let conversation_manager = ConversationManager::with_auth(CodexAuth::from_api_key("dummy"));
     let NewConversation {
         conversation: codex,
+        conversation_id,
         ..
     } = conversation_manager
         .new_conversation(config)
@@ -129,7 +130,12 @@ async fn fork_conversation_twice_drops_to_first_message() {
         conversation: codex_fork1,
         ..
     } = conversation_manager
-        .fork_conversation(1, config_for_fork.clone(), base_path.clone())
+        .fork_conversation(
+            1,
+            config_for_fork.clone(),
+            base_path.clone(),
+            conversation_id,
+        )
         .await
         .expect("fork 1");
 
@@ -147,7 +153,12 @@ async fn fork_conversation_twice_drops_to_first_message() {
         conversation: codex_fork2,
         ..
     } = conversation_manager
-        .fork_conversation(0, config_for_fork.clone(), fork1_path.clone())
+        .fork_conversation(
+            0,
+            config_for_fork.clone(),
+            fork1_path.clone(),
+            conversation_id,
+        )
         .await
         .expect("fork 2");
 

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -305,7 +305,12 @@ impl App {
         let cfg = self.chat_widget.config_ref().clone();
         // Perform the fork via a thin wrapper for clarity/testability.
         let result = self
-            .perform_fork(ev.path.clone(), nth_user_message, cfg.clone())
+            .perform_fork(
+                ev.path.clone(),
+                nth_user_message,
+                cfg.clone(),
+                ev.conversation_id,
+            )
             .await;
         match result {
             Ok(new_conv) => {
@@ -321,9 +326,10 @@ impl App {
         path: PathBuf,
         nth_user_message: usize,
         cfg: codex_core::config::Config,
+        conversation_id: ConversationId,
     ) -> codex_core::error::Result<codex_core::NewConversation> {
         self.server
-            .fork_conversation(nth_user_message, cfg, path)
+            .fork_conversation(nth_user_message, cfg, path, conversation_id)
             .await
     }
 


### PR DESCRIPTION
This will help us keep cache when delegating to Codex using the same history. i.e. in compact tasks

It also helps us associating forked task to the same prompt cache key

The change basically adds `prompt_cache_key` as an optional parameter on `Codex::Spawn`. Then, we pass it to `Session::new`. We add the parameter as a member of `Session` struct (source of truth). Then, we add it on `client` to propagate it to the API. `client` is constructed every turn from `Session`