### PR TITLE
Add /resume slash command and enhance resume picker filtering

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -21,6 +21,9 @@ pub(crate) enum AppEvent {
     /// Start a new session.
     NewSession,
 
+    /// Open the resume picker to select a previous session.
+    OpenResumePicker,
+
     /// Request to exit the application gracefully.
     ExitRequest,
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1204,6 +1204,9 @@ impl ChatWidget {
             SlashCommand::New => {
                 self.app_event_tx.send(AppEvent::NewSession);
             }
+            SlashCommand::Resume => {
+                self.app_event_tx.send(AppEvent::OpenResumePicker);
+            }
             SlashCommand::Init => {
                 let init_target = self.config.cwd.join(DEFAULT_PROJECT_DOC_FILENAME);
                 if init_target.exists() {

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -418,6 +418,7 @@ async fn run_ratatui_app(
             &mut tui,
             &config.codex_home,
             &config.model_provider_id,
+            Some(config.cwd.as_path()),
         )
         .await?
         {

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -16,6 +16,7 @@ pub enum SlashCommand {
     Approvals,
     Review,
     New,
+    Resume,
     Init,
     Compact,
     Undo,
@@ -43,6 +44,7 @@ impl SlashCommand {
             SlashCommand::Quit => "exit Codex",
             SlashCommand::Diff => "show git diff (including untracked files)",
             SlashCommand::Mention => "mention a file",
+            SlashCommand::Resume => "resume a previous Codex session",
             SlashCommand::Status => "show current session configuration and token usage",
             SlashCommand::Model => "choose what model and reasoning effort to use",
             SlashCommand::Approvals => "choose what Codex can do without approval",
@@ -64,6 +66,7 @@ impl SlashCommand {
         match self {
             SlashCommand::New
             | SlashCommand::Init
+            | SlashCommand::Resume
             | SlashCommand::Compact
             | SlashCommand::Undo
             | SlashCommand::Model

--- a/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_table.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_table.snap
@@ -2,7 +2,7 @@
 source: tui/src/resume_picker.rs
 expression: snapshot
 ---
-  Created         Updated         Conversation
-  16 minutes ago  42 seconds ago  Fix resume picker timestamps
-> 1 hour ago      35 minutes ago  Investigate lazy pagination cap
-  2 hours ago     2 hours ago     Explain the codebase
+  Conversation                                                  Updated       
+  Fix resume picker timestamps                                  42 seconds ago
+> Investigate lazy pagination cap                               35 minutes ago
+  Explain the codebase                                          2 hours ago


### PR DESCRIPTION
## Summary

  - add a /resume slash command that opens the session picker through a new AppEvent::OpenResumePicker
  - enhance the picker with time-range filters, project-aware filtering via the current CWD, richer empty/
    loading states, and dynamic columns for conversation previews and relative update times
  - refactor chat widget initialization so new and resumed sessions share the same setup path, and expand
    tests to cover the new resume picker behaviors