### PR TITLE
feat(tui): stream agent reasoning live behind config flag

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -160,6 +160,9 @@ pub struct Config {
     /// and turn completions when not focused.
     pub tui_notifications: Notifications,
 
+    /// When `true`, the TUI streams agent reasoning chunks live instead of buffering them.
+    pub stream_reasoning_live: bool,
+
     /// The directory that should be treated as the current working directory
     /// for the session. All relative paths inside the business-logic layer are
     /// resolved against this path.
@@ -1170,6 +1173,11 @@ impl Config {
                 .as_ref()
                 .map(|t| t.notifications.clone())
                 .unwrap_or_default(),
+            stream_reasoning_live: cfg
+                .tui
+                .as_ref()
+                .and_then(|t| t.stream_reasoning_live)
+                .unwrap_or(false),
             otel: {
                 let t: OtelConfigToml = cfg.otel.unwrap_or_default();
                 let log_user_prompt = t.log_user_prompt.unwrap_or(false);
@@ -2912,6 +2920,7 @@ model_verbosity = "high"
                 notices: Default::default(),
                 disable_paste_burst: false,
                 tui_notifications: Default::default(),
+                stream_reasoning_live: false,
                 otel: OtelConfig::default(),
             },
             o3_profile_config
@@ -2984,6 +2993,7 @@ model_verbosity = "high"
             notices: Default::default(),
             disable_paste_burst: false,
             tui_notifications: Default::default(),
+            stream_reasoning_live: false,
             otel: OtelConfig::default(),
         };
 
@@ -3071,6 +3081,7 @@ model_verbosity = "high"
             notices: Default::default(),
             disable_paste_burst: false,
             tui_notifications: Default::default(),
+            stream_reasoning_live: false,
             otel: OtelConfig::default(),
         };
 
@@ -3144,6 +3155,7 @@ model_verbosity = "high"
             notices: Default::default(),
             disable_paste_burst: false,
             tui_notifications: Default::default(),
+            stream_reasoning_live: false,
             otel: OtelConfig::default(),
         };
 

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -349,6 +349,10 @@ pub struct Tui {
     /// Defaults to `false`.
     #[serde(default)]
     pub notifications: Notifications,
+
+    /// When `true`, stream agent reasoning chunks live instead of buffering them.
+    #[serde(default)]
+    pub stream_reasoning_live: Option<bool>,
 }
 
 /// Settings for notices we display to users via the tui and app-server clients

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -157,32 +157,51 @@ impl ReasoningSummaryCell {
     }
 
     fn lines(&self, width: u16) -> Vec<Line<'static>> {
-        let mut lines: Vec<Line<'static>> = Vec::new();
-        append_markdown(
-            &self.content,
-            Some((width as usize).saturating_sub(2)),
-            &mut lines,
-        );
-        let summary_style = Style::default().dim().italic();
-        let summary_lines = lines
-            .into_iter()
-            .map(|mut line| {
-                line.spans = line
-                    .spans
-                    .into_iter()
-                    .map(|span| span.patch_style(summary_style))
-                    .collect();
-                line
-            })
-            .collect::<Vec<_>>();
-
-        word_wrap_lines(
-            &summary_lines,
-            RtOptions::new(width as usize)
-                .initial_indent("• ".dim().into())
-                .subsequent_indent("  ".into()),
-        )
+        format_reasoning_summary_lines(&self.content, width)
     }
+
+    pub(crate) fn push_content(&mut self, content: &str) {
+        if content.is_empty() {
+            return;
+        }
+        self.content.push_str(content);
+    }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.content.trim().is_empty()
+    }
+}
+
+fn format_reasoning_summary_lines(content: &str, width: u16) -> Vec<Line<'static>> {
+    if content.trim().is_empty() {
+        return Vec::new();
+    }
+
+    let mut lines: Vec<Line<'static>> = Vec::new();
+    append_markdown(
+        content,
+        Some((width as usize).saturating_sub(2)),
+        &mut lines,
+    );
+    let summary_style = Style::default().dim().italic();
+    let summary_lines = lines
+        .into_iter()
+        .map(|mut line| {
+            line.spans = line
+                .spans
+                .into_iter()
+                .map(|span| span.patch_style(summary_style))
+                .collect();
+            line
+        })
+        .collect::<Vec<_>>();
+
+    word_wrap_lines(
+        &summary_lines,
+        RtOptions::new(width as usize)
+            .initial_indent("• ".dim().into())
+            .subsequent_indent("  ".into()),
+    )
 }
 
 impl HistoryCell for ReasoningSummaryCell {

--- a/docs/config.md
+++ b/docs/config.md
@@ -726,6 +726,20 @@ Example:
 show_raw_agent_reasoning = true  # defaults to false
 ```
 
+### tui.stream_reasoning_live
+
+Streams the agent’s reasoning output into the TUI as chunks arrive instead of
+waiting to render the entire block at the end of the reasoning phase. The final
+recorded transcript remains identical to the buffered mode, and this setting
+still respects `hide_agent_reasoning`.
+
+Example:
+
+```toml
+[tui]
+stream_reasoning_live = true  # defaults to false
+```
+
 ## Profiles and overrides
 
 ### profiles
@@ -914,6 +928,7 @@ Valid values:
 | `file_opener`                                    | `vscode` \| `vscode-insiders` \| `windsurf` \| `cursor` \| `none` | URI scheme for clickable citations (default: `vscode`).                                                                    |
 | `tui`                                            | table                                                             | TUI‑specific options.                                                                                                      |
 | `tui.notifications`                              | boolean \| array<string>                                          | Enable desktop notifications in the tui (default: false).                                                                  |
+| `tui.stream_reasoning_live`                      | boolean                                                           | Stream agent reasoning chunks live in the TUI instead of buffering (default: false).                                       |
 | `hide_agent_reasoning`                           | boolean                                                           | Hide model reasoning events.                                                                                               |
 | `show_raw_agent_reasoning`                       | boolean                                                           | Show raw reasoning (when available).                                                                                       |
 | `model_reasoning_effort`                         | `minimal` \| `low` \| `medium` \| `high`                          | Responses API reasoning effort.                                                                                            |


### PR DESCRIPTION
# ✨ TUI: Stream “thinking / reasoning” live in the CLI (opt-in via `tui.stream_reasoning_live`)

**Relates to:** #5339 (live streaming of “thinking” in CLI, like the VS Code extension)  

---

## What

This PR adds **live, incremental streaming of the agent’s reasoning (“thinking”)** to the Codex **CLI TUI**, so users see progress **as each chunk arrives** instead of waiting for the entire reasoning phase to complete.

- When enabled, reasoning text appears in the transcript **incrementally** in a **dim + italic** style, matching the existing “reasoning summary” look.  
- The **status header** continues to update as before (e.g., with the first `**bold**` subheading extracted from the block).  
- We **respect privacy**: `hide_agent_reasoning = true` still hides reasoning entirely; this feature only affects the TUI view.

**Default:** Off. Users can opt in with:

`stream_reasoning_live = true` in  ~/.codex/config.toml


---


## Why

- Addresses the user request in **#5339** to mirror the **VS Code extension’s** responsive UX, where thinking blocks stream in real time.  

## How (design & implementation)

**User-facing behavior**

- Reasoning appears **line-by-line** as chunks are received, styled **dim + italic** (same visual language as the end-of-turn summary).  
- We **throttle redraws** (~60ms) to keep the TUI snappy and avoid over-rendering.  
- On reasoning **final**, any partial line is flushed; we **avoid duplication** (we do not append a second summary if we already streamed the content live).

**Key changes (high-level)**

- **Config:**  
  - `Config.tui.stream_reasoning_live: bool` (default `false`).  
  - Plumbed into the TUI; also covered by docs.  
- **TUI (`chatwidget`):**  
  - Handle `AgentReasoningDelta` by **appending to the active reasoning cell** and scheduling a redraw (with throttling).  
  - Maintain a bit of state to know when a **live reasoning cell** is active and to finalize it on turn completion.  
- **History cells (`history_cell`):**  
  - Reuse the **existing ReasoningSummaryCell** and add small focused mutators (`push_content`, `is_empty`) so we don’t introduce a bespoke live cell; formatting stays **identical** to the summary renderer.  
- **Docs:**  
  - `docs/config.md` — add `tui.stream_reasoning_live` with a short description and example.  
- **Tests:**  
  - Unit tests verifying incremental updates, finalization equality vs buffered mode, and **respect for `hide_agent_reasoning`**.

This approach is deliberately **minimal-surface** and builds on the repo’s existing TUI streaming and reasoning work (see #5540, #5857).

## Screens / GIFs

> 1) **Before:** 

![codex-gif-buffer1](https://github.com/user-attachments/assets/c807fc97-1104-46cc-8b98-cb16145ac4f2)

 
> 2) **After (flag on):** reasoning trickles in live 


![codex-gif-streaming1](https://github.com/user-attachments/assets/51a51ba5-549a-4d0c-bf44-fc3c10ff5951)

## Backward compatibility & defaults

- **Opt-in** (`stream_reasoning_live = true`) keeps today’s default (buffered) behavior for existing users.  
- Fully compatible with `hide_agent_reasoning` (and other reasoning visibility controls mentioned across the tracker).

## Tests

- **Unit:**  
  - `live_reasoning_streams_incrementally_when_enabled` — verifies live growth and end-of-turn finalize equals last live state.  
  - `live_reasoning_respects_hide_flag` — `hide_agent_reasoning = true` → no streaming.  
  - Existing **final-only** paths remain green.  
- **Manual:**  
  1. In `~/.codex/config.toml`:  

     `stream_reasoning_live = true`

  2. Run the TUI against a task that induces multiple reasoning passes, using gpt-5-codex high.
  3. Observe incremental lines (dim + italic) and header updates.  
  4. Flip the flag off and verify legacy (buffered) behavior.
