### PR TITLE
fix: override verbosity for gpt-5-codex

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -225,11 +225,7 @@ impl ModelClient {
         };
 
         // gpt-5-codex does not support `low` verbosity; omit it to avoid errors.
-        if self.config.model_family.family.starts_with("gpt-5-codex") {
-            warn!(
-                "Overriding unsupported 'low' verbosity for {} by omitting it",
-                self.config.model_family.family
-            );
+        if self.config.model.starts_with("gpt-5-codex") {
             verbosity = None;
         }
 

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -12,7 +12,6 @@ use codex_otel::otel_event_manager::OtelEventManager;
 use codex_protocol::ConversationId;
 use codex_protocol::config_types::ReasoningEffort as ReasoningEffortConfig;
 use codex_protocol::config_types::ReasoningSummary as ReasoningSummaryConfig;
-use codex_protocol::config_types::Verbosity as VerbosityConfig;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::SessionSource;
 use eventsource_stream::Eventsource;
@@ -214,7 +213,7 @@ impl ModelClient {
 
         let input_with_instructions = prompt.get_formatted_input();
 
-        let mut verbosity = if self.config.model_family.support_verbosity {
+        let verbosity = if self.config.model_family.support_verbosity {
             self.config.model_verbosity
         } else {
             warn!(
@@ -224,17 +223,8 @@ impl ModelClient {
             None
         };
 
-        // gpt-5-codex doesn't have different verbosity levels; omit it to avoid errors.
-        if self.config.model.starts_with("gpt-5-codex") {
-            verbosity = None;
-        }
-
         // Only include `text.verbosity` for GPT-5 family models
-        let text = create_text_param_for_request(
-            self.config.model.clone(),
-            verbosity,
-            &prompt.output_schema,
-        );
+        let text = create_text_param_for_request(verbosity, &prompt.output_schema);
 
         // In general, we want to explicitly send `store: false` when using the Responses API,
         // but in practice, the Azure Responses API rejects `store: false`:

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -216,10 +216,12 @@ impl ModelClient {
         let verbosity = if self.config.model_family.support_verbosity {
             self.config.model_verbosity
         } else {
-            warn!(
-                "model_verbosity is set but ignored as the model does not support verbosity: {}",
-                self.config.model_family.family
-            );
+            if verbosity.is_some() {
+                warn!(
+                    "model_verbosity is set but ignored as the model does not support verbosity: {}",
+                    self.config.model_family.family
+                );
+            }
             None
         };
 

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -216,7 +216,7 @@ impl ModelClient {
         let verbosity = if self.config.model_family.support_verbosity {
             self.config.model_verbosity
         } else {
-            if verbosity.is_some() {
+            if self.config.model_verbosity.is_some() {
                 warn!(
                     "model_verbosity is set but ignored as the model does not support verbosity: {}",
                     self.config.model_family.family

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -225,9 +225,7 @@ impl ModelClient {
         };
 
         // gpt-5-codex does not support `low` verbosity; omit it to avoid errors.
-        if self.config.model_family.family.starts_with("gpt-5-codex")
-            && matches!(verbosity, Some(VerbosityConfig::Low))
-        {
+        if self.config.model_family.family.starts_with("gpt-5-codex") {
             warn!(
                 "Overriding unsupported 'low' verbosity for {} by omitting it",
                 self.config.model_family.family

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -12,6 +12,7 @@ use codex_otel::otel_event_manager::OtelEventManager;
 use codex_protocol::ConversationId;
 use codex_protocol::config_types::ReasoningEffort as ReasoningEffortConfig;
 use codex_protocol::config_types::ReasoningSummary as ReasoningSummaryConfig;
+use codex_protocol::config_types::Verbosity as VerbosityConfig;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::SessionSource;
 use eventsource_stream::Eventsource;
@@ -213,7 +214,7 @@ impl ModelClient {
 
         let input_with_instructions = prompt.get_formatted_input();
 
-        let verbosity = if self.config.model_family.support_verbosity {
+        let mut verbosity = if self.config.model_family.support_verbosity {
             self.config.model_verbosity
         } else {
             warn!(
@@ -223,8 +224,23 @@ impl ModelClient {
             None
         };
 
+        // gpt-5-codex does not support `low` verbosity; omit it to avoid errors.
+        if self.config.model_family.family.starts_with("gpt-5-codex")
+            && matches!(verbosity, Some(VerbosityConfig::Low))
+        {
+            warn!(
+                "Overriding unsupported 'low' verbosity for {} by omitting it",
+                self.config.model_family.family
+            );
+            verbosity = None;
+        }
+
         // Only include `text.verbosity` for GPT-5 family models
-        let text = create_text_param_for_request(verbosity, &prompt.output_schema);
+        let text = create_text_param_for_request(
+            self.config.model.clone(),
+            verbosity,
+            &prompt.output_schema,
+        );
 
         // In general, we want to explicitly send `store: false` when using the Responses API,
         // but in practice, the Azure Responses API rejects `store: false`:

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -224,7 +224,7 @@ impl ModelClient {
             None
         };
 
-        // gpt-5-codex does not support `low` verbosity; omit it to avoid errors.
+        // gpt-5-codex doesn't have different verbosity levels; omit it to avoid errors.
         if self.config.model.starts_with("gpt-5-codex") {
             verbosity = None;
         }

--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -358,15 +358,23 @@ pub(crate) fn create_reasoning_param_for_request(
 }
 
 pub(crate) fn create_text_param_for_request(
+    model: String,
     verbosity: Option<VerbosityConfig>,
     output_schema: &Option<Value>,
 ) -> Option<TextControls> {
     if verbosity.is_none() && output_schema.is_none() {
         return None;
     }
-
+    let adjusted = if model.starts_with("gpt-5-codex") {
+        match verbosity {
+            Some(VerbosityConfig::Low) => None,
+            other => other,
+        }
+    } else {
+        verbosity
+    };
     Some(TextControls {
-        verbosity: verbosity.map(std::convert::Into::into),
+        verbosity: adjusted.map(std::convert::Into::into),
         format: output_schema.as_ref().map(|schema| TextFormat {
             r#type: TextFormatType::JsonSchema,
             strict: true,
@@ -494,7 +502,8 @@ mod tests {
             "required": ["answer"],
         });
         let text_controls =
-            create_text_param_for_request(None, &Some(schema.clone())).expect("text controls");
+            create_text_param_for_request("gpt-5".to_string(), None, &Some(schema.clone()))
+                .expect("text controls");
 
         let req = ResponsesApiRequest {
             model: "gpt-5",
@@ -549,5 +558,37 @@ mod tests {
 
         let v = serde_json::to_value(&req).expect("json");
         assert!(v.get("text").is_none());
+    }
+
+    #[test]
+    fn gpt5_codex_omits_low_verbosity() {
+        let input: Vec<ResponseItem> = vec![];
+        let tools: Vec<serde_json::Value> = vec![];
+
+        let text_controls = create_text_param_for_request(
+            "gpt-5-codex".to_string(),
+            Some(VerbosityConfig::Low),
+            &None,
+        )
+        .expect("text controls present");
+
+        let req = ResponsesApiRequest {
+            model: "gpt-5-codex",
+            instructions: "i",
+            input: &input,
+            tools: &tools,
+            tool_choice: "auto",
+            parallel_tool_calls: true,
+            reasoning: None,
+            store: false,
+            stream: true,
+            include: vec![],
+            prompt_cache_key: None,
+            text: Some(text_controls),
+        };
+
+        let v = serde_json::to_value(&req).expect("json");
+        let text = v.get("text").expect("text field exists");
+        assert!(text.get("verbosity").is_none());
     }
 }

--- a/codex-rs/core/src/model_family.rs
+++ b/codex-rs/core/src/model_family.rs
@@ -160,7 +160,7 @@ pub fn find_family_for_model(slug: &str) -> Option<ModelFamily> {
             reasoning_summary_format: ReasoningSummaryFormat::Experimental,
             base_instructions: GPT_5_CODEX_INSTRUCTIONS.to_string(),
             apply_patch_tool_type: Some(ApplyPatchToolType::Freeform),
-            support_verbosity: true,
+            support_verbosity: false,
         )
     } else if slug.starts_with("gpt-5") {
         model_family!(


### PR DESCRIPTION
we are seeing [reports](https://github.com/openai/codex/issues/6004) of users having verbosity in their config.toml and facing issues. gpt-5-codex doesn't accept other values rather than medium for verbosity.