### PR TITLE
Execute user-issued bang commands without sandboxing

### DIFF
--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -89,7 +89,10 @@ impl SessionTask for UserShellCommandTask {
         let tool_call = ToolCall {
             tool_name: USER_SHELL_TOOL_NAME.to_string(),
             call_id: Uuid::new_v4().to_string(),
-            payload: ToolPayload::LocalShell { params },
+            payload: ToolPayload::LocalShell {
+                params,
+                is_user_shell_command: true,
+            },
         };
 
         let router = Arc::new(ToolRouter::from_config(&turn_context.tools_config, None));

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -82,8 +82,8 @@ impl SessionTask for UserShellCommandTask {
             command: shell_invocation,
             workdir: None,
             timeout_ms: None,
-            with_escalated_permissions: None,
-            justification: None,
+            with_escalated_permissions: Some(true),
+            justification: Some("user-requested shell command".to_string()),
         };
 
         let tool_call = ToolCall {

--- a/codex-rs/core/src/tools/context.rs
+++ b/codex-rs/core/src/tools/context.rs
@@ -40,6 +40,7 @@ pub enum ToolPayload {
     },
     LocalShell {
         params: ShellToolCallParams,
+        is_user_shell_command: bool,
     },
     UnifiedExec {
         arguments: String,
@@ -56,7 +57,7 @@ impl ToolPayload {
         match self {
             ToolPayload::Function { arguments } => Cow::Borrowed(arguments),
             ToolPayload::Custom { input } => Cow::Borrowed(input),
-            ToolPayload::LocalShell { params } => Cow::Owned(params.command.join(" ")),
+            ToolPayload::LocalShell { params, .. } => Cow::Owned(params.command.join(" ")),
             ToolPayload::UnifiedExec { arguments } => Cow::Borrowed(arguments),
             ToolPayload::Mcp { raw_arguments, .. } => Cow::Borrowed(raw_arguments),
         }

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -219,6 +219,7 @@ impl ShellHandler {
             env: exec_params.env.clone(),
             with_escalated_permissions: exec_params.with_escalated_permissions,
             justification: exec_params.justification.clone(),
+            is_user_shell_command,
         };
         let mut orchestrator = ToolOrchestrator::new();
         let mut runtime = ShellRuntime::new();

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -82,7 +82,10 @@ impl ToolHandler for ShellHandler {
                 )
                 .await
             }
-            ToolPayload::LocalShell { params } => {
+            ToolPayload::LocalShell {
+                params,
+                is_user_shell_command,
+            } => {
                 let exec_params = Self::to_exec_params(params, turn.as_ref());
                 Self::run_exec_like(
                     tool_name.as_str(),
@@ -91,7 +94,7 @@ impl ToolHandler for ShellHandler {
                     turn,
                     tracker,
                     call_id,
-                    true,
+                    is_user_shell_command,
                 )
                 .await
             }

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -114,6 +114,7 @@ impl ShellHandler {
     ) -> Result<ToolOutput, FunctionCallError> {
         // Approval policy guard for explicit escalation in non-OnRequest modes.
         if exec_params.with_escalated_permissions.unwrap_or(false)
+            && !is_user_shell_command
             && !matches!(
                 turn.approval_policy,
                 codex_protocol::protocol::AskForApproval::OnRequest

--- a/codex-rs/core/src/tools/router.rs
+++ b/codex-rs/core/src/tools/router.rs
@@ -120,7 +120,10 @@ impl ToolRouter {
                         Ok(Some(ToolCall {
                             tool_name: "local_shell".to_string(),
                             call_id,
-                            payload: ToolPayload::LocalShell { params },
+                            payload: ToolPayload::LocalShell {
+                                params,
+                                is_user_shell_command: false,
+                            },
                         }))
                     }
                 }

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -34,6 +34,7 @@ pub struct ShellRequest {
     pub env: std::collections::HashMap<String, String>,
     pub with_escalated_permissions: Option<bool>,
     pub justification: Option<String>,
+    pub is_user_shell_command: bool,
 }
 
 impl ProvidesSandboxRetryData for ShellRequest {
@@ -121,6 +122,9 @@ impl Approvable<ShellRequest> for ShellRuntime {
         policy: AskForApproval,
         sandbox_policy: &SandboxPolicy,
     ) -> bool {
+        if req.is_user_shell_command {
+            return false;
+        }
         if is_known_safe_command(&req.command) {
             return false;
         }


### PR DESCRIPTION
Current version of CLI fails to execute shell commands issued by user in a sandboxed environment (partially redacted example here). This makes the experience not as streamlined as doing many of those requires switching to a different terminal session to execute
```
Ran git commit -m "Test committing"
  └ /opt/homebrew/Library/Homebrew/cmd/shellenv.sh: line 18: /bin/ps: Operation not permitted
    fatal: Unable to create '/Users/andriinikolin/Git/****/.git/index.lock': Operation not permitted
```

Proposed change elevates bang-commands to skip sandboxing, so commands issued by user can be executed with full privileges

Used CLI itself while working on this, have basic knowledge of Rust fundamentals