### PR TITLE
Add current-directory filtering to codex resume

### DIFF
--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -28,6 +28,13 @@ pub struct Cli {
     #[clap(skip)]
     pub resume_session_id: Option<String>,
 
+    /// Internal: when true, resume picker and --last should limit to sessions
+    /// that were started in the current working directory. Set by the
+    /// top-level `codex resume --cwd-only` wrapper; not exposed as a public flag
+    /// on the base `codex` command.
+    #[clap(skip)]
+    pub resume_cwd_only: bool,
+
     /// Model the agent should use.
     #[arg(long, short = 'm')]
     pub model: Option<String>,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -418,6 +418,11 @@ async fn run_ratatui_app(
             &mut tui,
             &config.codex_home,
             &config.model_provider_id,
+            if cli.resume_cwd_only {
+                Some(config.cwd.clone())
+            } else {
+                None
+            },
         )
         .await?
         {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,6 +22,11 @@ Key flags: `--model/-m`, `--ask-for-approval/-a`.
 - Resume most recent: `codex resume --last`
 - Resume by id: `codex resume <SESSION_ID>` (You can get session ids from /status or `~/.codex/sessions/`)
 
+Filtering sessions by current directory
+
+- Only show sessions started in the current working directory (picker): `codex resume --cwd-only`
+- Note: `--cwd-only` is only supported in interactive resume (the picker) and conflicts with `--last`.
+
 Examples:
 
 ```shell


### PR DESCRIPTION
- Add a --cwd-only flag on codex resume and wire it through the CLI to the interactive picker.
- Filter resume picker items by the saved session cwd, including helpers to parse nested metadata plus
  unit tests.
- Document the new flag in docs/getting-started.md so users know how to limit the picker to the active
  directory.
