### PR TITLE
feat: Better OS Detection, starting with windows

### DIFF
--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -20,6 +20,14 @@ pub enum NetworkAccess {
     Restricted,
     Enabled,
 }
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct OperatingSystemInfo {
+    pub name: String,
+    pub version: String,
+    pub is_likely_windows_subsystem_for_linux: Option<bool>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename = "environment_context", rename_all = "snake_case")]
 pub(crate) struct EnvironmentContext {
@@ -29,6 +37,7 @@ pub(crate) struct EnvironmentContext {
     pub network_access: Option<NetworkAccess>,
     pub writable_roots: Option<Vec<PathBuf>>,
     pub shell: Option<Shell>,
+    pub operating_system: Option<OperatingSystemInfo>,
 }
 
 impl EnvironmentContext {
@@ -70,6 +79,7 @@ impl EnvironmentContext {
                 _ => None,
             },
             shell,
+            operating_system: Self::operating_system_info(),
         }
     }
 
@@ -83,6 +93,7 @@ impl EnvironmentContext {
             sandbox_mode,
             network_access,
             writable_roots,
+            operating_system,
             // should compare all fields except shell
             shell: _,
         } = other;
@@ -92,6 +103,7 @@ impl EnvironmentContext {
             && self.sandbox_mode == *sandbox_mode
             && self.network_access == *network_access
             && self.writable_roots == *writable_roots
+            && self.operating_system == *operating_system
     }
 
     pub fn diff(before: &TurnContext, after: &TurnContext) -> Self {
@@ -174,8 +186,26 @@ impl EnvironmentContext {
         {
             lines.push(format!("  <shell>{shell_name}</shell>"));
         }
+        if let Some(operating_system) = self.operating_system {
+            lines.push("  <operating_system>".to_string());
+            lines.push(format!("    <name>{}</name>", operating_system.name));
+            lines.push(format!(
+                "    <version>{}</version>",
+                operating_system.version
+            ));
+            if let Some(is_wsl) = operating_system.is_likely_windows_subsystem_for_linux {
+                lines.push(format!(
+                    "    <is_likely_windows_subsystem_for_linux>{is_wsl}</is_likely_windows_subsystem_for_linux>"
+                ));
+            }
+            lines.push("  </operating_system>".to_string());
+        }
         lines.push(ENVIRONMENT_CONTEXT_CLOSE_TAG.to_string());
         lines.join("\n")
+    }
+
+    fn operating_system_info() -> Option<OperatingSystemInfo> {
+        operating_system_info_impl()
     }
 }
 
@@ -191,6 +221,41 @@ impl From<EnvironmentContext> for ResponseItem {
     }
 }
 
+// Restrict Operating System Info to Windows and Linux inside WSL for now
+#[cfg(target_os = "windows")]
+fn operating_system_info_impl() -> Option<OperatingSystemInfo> {
+    let os_info = os_info::get();
+    Some(OperatingSystemInfo {
+        name: os_info.os_type().to_string(),
+        version: os_info.version().to_string(),
+        is_likely_windows_subsystem_for_linux: Some(has_wsl_env_markers()),
+    })
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn operating_system_info_impl() -> Option<OperatingSystemInfo> {
+    match has_wsl_env_markers() {
+        true => Some(OperatingSystemInfo {
+            name: "Windows Subsystem for Linux".to_string(),
+            version: "".to_string(),
+            is_likely_windows_subsystem_for_linux: Some(true),
+        }),
+        false => None,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn operating_system_info_impl() -> Option<OperatingSystemInfo> {
+    None
+}
+
+#[cfg(not(target_os = "macos"))]
+fn has_wsl_env_markers() -> bool {
+    std::env::var_os("WSL_INTEROP").is_some()
+        || std::env::var_os("WSLENV").is_some()
+        || std::env::var_os("WSL_DISTRO_NAME").is_some()
+}
+
 #[cfg(test)]
 mod tests {
     use crate::shell::BashShell;
@@ -198,6 +263,57 @@ mod tests {
 
     use super::*;
     use pretty_assertions::assert_eq;
+    fn expected_environment_context(mut body_lines: Vec<String>) -> String {
+        let mut lines = vec!["<environment_context>".to_string()];
+        lines.append(&mut body_lines);
+        if let Some(os) = EnvironmentContext::operating_system_info() {
+            lines.push("  <operating_system>".to_string());
+            lines.push(format!("    <name>{}</name>", os.name));
+            lines.push(format!("    <version>{}</version>", os.version));
+            if let Some(is_wsl) = os.is_likely_windows_subsystem_for_linux {
+                lines.push(format!(
+                    "    <is_likely_windows_subsystem_for_linux>{is_wsl}</is_likely_windows_subsystem_for_linux>"
+                ));
+            }
+            lines.push("  </operating_system>".to_string());
+        }
+        lines.push("</environment_context>".to_string());
+        lines.join("\n")
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn operating_system_info_on_windows_includes_os_details() {
+        let info = operating_system_info_impl().expect("expected Windows operating system info");
+        let os_details = os_info::get();
+
+        assert_eq!(info.name, os_details.os_type().to_string());
+        assert_eq!(info.version, os_details.version().to_string());
+        assert_eq!(
+            info.is_likely_windows_subsystem_for_linux,
+            Some(has_wsl_env_markers())
+        );
+    }
+
+    #[cfg(all(unix, not(target_os = "macos")))]
+    #[test]
+    fn operating_system_info_matches_wsl_detection_on_unix() {
+        let info = operating_system_info_impl();
+        if has_wsl_env_markers() {
+            let info = info.expect("expected WSL operating system info");
+            assert_eq!(info.name, "Windows Subsystem for Linux");
+            assert_eq!(info.version, "");
+            assert_eq!(info.is_likely_windows_subsystem_for_linux, Some(true));
+        } else {
+            assert_eq!(info, None);
+        }
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn operating_system_info_is_none_on_macos() {
+        assert_eq!(operating_system_info_impl(), None);
+    }
 
     fn workspace_write_policy(writable_roots: Vec<&str>, network_access: bool) -> SandboxPolicy {
         SandboxPolicy::WorkspaceWrite {
@@ -217,16 +333,16 @@ mod tests {
             None,
         );
 
-        let expected = r#"<environment_context>
-  <cwd>/repo</cwd>
-  <approval_policy>on-request</approval_policy>
-  <sandbox_mode>workspace-write</sandbox_mode>
-  <network_access>restricted</network_access>
-  <writable_roots>
-    <root>/repo</root>
-    <root>/tmp</root>
-  </writable_roots>
-</environment_context>"#;
+        let expected = expected_environment_context(vec![
+            "  <cwd>/repo</cwd>".to_string(),
+            "  <approval_policy>on-request</approval_policy>".to_string(),
+            "  <sandbox_mode>workspace-write</sandbox_mode>".to_string(),
+            "  <network_access>restricted</network_access>".to_string(),
+            "  <writable_roots>".to_string(),
+            "    <root>/repo</root>".to_string(),
+            "    <root>/tmp</root>".to_string(),
+            "  </writable_roots>".to_string(),
+        ]);
 
         assert_eq!(context.serialize_to_xml(), expected);
     }
@@ -240,11 +356,11 @@ mod tests {
             None,
         );
 
-        let expected = r#"<environment_context>
-  <approval_policy>never</approval_policy>
-  <sandbox_mode>read-only</sandbox_mode>
-  <network_access>restricted</network_access>
-</environment_context>"#;
+        let expected = expected_environment_context(vec![
+            "  <approval_policy>never</approval_policy>".to_string(),
+            "  <sandbox_mode>read-only</sandbox_mode>".to_string(),
+            "  <network_access>restricted</network_access>".to_string(),
+        ]);
 
         assert_eq!(context.serialize_to_xml(), expected);
     }
@@ -258,11 +374,11 @@ mod tests {
             None,
         );
 
-        let expected = r#"<environment_context>
-  <approval_policy>on-failure</approval_policy>
-  <sandbox_mode>danger-full-access</sandbox_mode>
-  <network_access>enabled</network_access>
-</environment_context>"#;
+        let expected = expected_environment_context(vec![
+            "  <approval_policy>on-failure</approval_policy>".to_string(),
+            "  <sandbox_mode>danger-full-access</sandbox_mode>".to_string(),
+            "  <network_access>enabled</network_access>".to_string(),
+        ]);
 
         assert_eq!(context.serialize_to_xml(), expected);
     }

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -256,9 +256,14 @@ fn operating_system_info_impl() -> Option<OperatingSystemInfo> {
 
 #[cfg(not(target_os = "macos"))]
 fn has_wsl_env_markers() -> bool {
-    std::env::var_os("WSL_INTEROP").is_some()
-        || std::env::var_os("WSLENV").is_some()
-        || std::env::var_os("WSL_DISTRO_NAME").is_some()
+    // Cache detection result since env vars are stable across process lifetime
+    // and this function may be called multiple times.
+    static CACHE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
+    *CACHE.get_or_init(|| {
+        std::env::var_os("WSL_INTEROP").is_some()
+            || std::env::var_os("WSLENV").is_some()
+            || std::env::var_os("WSL_DISTRO_NAME").is_some()
+    })
 }
 
 #[cfg(test)]

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -158,10 +158,11 @@ impl EnvironmentContext {
     ///   <shell>...</shell>
     /// </environment_context>
     /// ```
-    pub fn serialize_to_xml(self) -> String {
+    pub fn serialize_to_xml(&self) -> String {
         let mut lines = vec![ENVIRONMENT_CONTEXT_OPEN_TAG.to_string()];
-        if let Some(cwd) = self.cwd {
-            lines.push(format!("  <cwd>{}</cwd>", cwd.to_string_lossy()));
+        if let Some(cwd) = self.cwd.as_ref() {
+            let cwd = cwd.to_string_lossy();
+            lines.push(format!("  <cwd>{cwd}</cwd>"));
         }
         if let Some(approval_policy) = self.approval_policy {
             lines.push(format!(
@@ -171,33 +172,30 @@ impl EnvironmentContext {
         if let Some(sandbox_mode) = self.sandbox_mode {
             lines.push(format!("  <sandbox_mode>{sandbox_mode}</sandbox_mode>"));
         }
-        if let Some(network_access) = self.network_access {
+        if let Some(network_access) = self.network_access.as_ref() {
             lines.push(format!(
                 "  <network_access>{network_access}</network_access>"
             ));
         }
-        if let Some(writable_roots) = self.writable_roots {
+        if let Some(writable_roots) = self.writable_roots.as_ref() {
             lines.push("  <writable_roots>".to_string());
             for writable_root in writable_roots {
-                lines.push(format!(
-                    "    <root>{}</root>",
-                    writable_root.to_string_lossy()
-                ));
+                let writable_root = writable_root.to_string_lossy();
+                lines.push(format!("    <root>{writable_root}</root>"));
             }
             lines.push("  </writable_roots>".to_string());
         }
-        if let Some(shell) = self.shell
+        if let Some(shell) = self.shell.as_ref()
             && let Some(shell_name) = shell.name()
         {
             lines.push(format!("  <shell>{shell_name}</shell>"));
         }
-        if let Some(operating_system) = self.operating_system {
+        if let Some(operating_system) = self.operating_system.as_ref() {
             lines.push("  <operating_system>".to_string());
-            lines.push(format!("    <name>{}</name>", operating_system.name));
-            lines.push(format!(
-                "    <version>{}</version>",
-                operating_system.version
-            ));
+            let name = operating_system.name.as_str();
+            lines.push(format!("    <name>{name}</name>"));
+            let version = operating_system.version.as_str();
+            lines.push(format!("    <version>{version}</version>"));
             if let Some(is_wsl) = operating_system.is_likely_windows_subsystem_for_linux {
                 lines.push(format!(
                     "    <is_likely_windows_subsystem_for_linux>{is_wsl}</is_likely_windows_subsystem_for_linux>"

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -122,7 +122,12 @@ impl EnvironmentContext {
         } else {
             None
         };
-        EnvironmentContext::new(cwd, approval_policy, sandbox_policy, None)
+        // Diff messages should only include fields that changed between turns.
+        // Operating system is a static property of the host and should not be
+        // emitted as part of a per-turn diff.
+        let mut ec = EnvironmentContext::new(cwd, approval_policy, sandbox_policy, None);
+        ec.operating_system = None;
+        ec
     }
 }
 

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -227,20 +227,21 @@ impl From<EnvironmentContext> for ResponseItem {
 // Restrict Operating System Info to Windows and Linux inside WSL for now
 #[cfg(target_os = "windows")]
 fn operating_system_info_impl() -> Option<OperatingSystemInfo> {
-    let os_info = os_info::get();
+    let info = os_info::get();
     Some(OperatingSystemInfo {
-        name: os_info.os_type().to_string(),
-        version: os_info.version().to_string(),
+        name: info.os_type().to_string(),
+        version: info.version().to_string(),
         is_likely_windows_subsystem_for_linux: Some(has_wsl_env_markers()),
     })
 }
 
 #[cfg(all(unix, not(target_os = "macos")))]
 fn operating_system_info_impl() -> Option<OperatingSystemInfo> {
+    let info = os_info::get();
     match has_wsl_env_markers() {
         true => Some(OperatingSystemInfo {
-            name: "Windows Subsystem for Linux".to_string(),
-            version: "".to_string(),
+            name: info.os_type().to_string(),
+            version: info.version().to_string(),
             is_likely_windows_subsystem_for_linux: Some(true),
         }),
         false => None,
@@ -307,10 +308,11 @@ mod tests {
     #[test]
     fn operating_system_info_matches_wsl_detection_on_unix() {
         let info = operating_system_info_impl();
+        let os_details = os_info::get();
         if has_wsl_env_markers() {
             let info = info.expect("expected WSL operating system info");
-            assert_eq!(info.name, "Windows Subsystem for Linux");
-            assert_eq!(info.version, "");
+            assert_eq!(info.name, os_details.os_type().to_string());
+            assert_eq!(info.version, os_details.version().to_string());
             assert_eq!(info.is_likely_windows_subsystem_for_linux, Some(true));
         } else {
             assert_eq!(info, None);

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -77,12 +77,11 @@ fn default_env_context_str(cwd: &str, shell: &Shell) -> String {
     let os_block = operating_system_context_block();
     format!(
         r#"<environment_context>
-  <cwd>{}</cwd>
+  <cwd>{cwd}</cwd>
   <approval_policy>on-request</approval_policy>
   <sandbox_mode>read-only</sandbox_mode>
   <network_access>restricted</network_access>
-{}{}</environment_context>"#,
-        cwd, shell_line, os_block
+{shell_line}{os_block}</environment_context>"#
     )
 }
 


### PR DESCRIPTION
## Summary
Adds more information to `<environment_context>` on Windows platforms and when WSL env vars are set. I think we're almost certainly add this to env context for all sessions, but want to test those cases further.

## Testing
- [x] Added unit tests