### PR TITLE
Fix rmcp client feature flag reference

### DIFF
--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -353,7 +353,7 @@ async fn run_login(config_overrides: &CliConfigOverrides, login_args: LoginArgs)
         .context("failed to load configuration")?;
 
     if !config.features.enabled(Feature::RmcpClient) {
-        bail!("OAuth login is only supported when [feature].rmcp_client is true in config.toml.");
+        bail!("OAuth login is only supported when [features].rmcp_client is true in config.toml.");
     }
 
     let LoginArgs { name, scopes } = login_args;


### PR DESCRIPTION
## Summary
- update the OAuth login error message to reference `[features].rmcp_client` in config

## Testing
- cargo test -p codex-cli

------
https://chatgpt.com/codex/tasks/task_i_69050365dc84832ca298f863c879a59a