### PR TITLE
[app-server] Add cancellation registry and $/cancelRequest

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -413,6 +413,18 @@ impl TryFrom<JSONRPCNotification> for ServerNotification {
 #[strum(serialize_all = "camelCase")]
 pub enum ClientNotification {
     Initialized,
+    /// LSP-style cancellation of an in-flight JSON-RPC request.
+    /// Shape: { "method": "$/cancelRequest", "params": { "id": <request-id> } }
+    #[serde(rename = "$/cancelRequest")]
+    #[ts(rename = "$/cancelRequest")]
+    #[strum(serialize = "$/cancelRequest")]
+    CancelRequest(CancelRequestParams),
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct CancelRequestParams {
+    pub id: RequestId,
 }
 
 #[cfg(test)]
@@ -493,6 +505,22 @@ mod tests {
         assert_eq!(
             json!({
                 "method": "initialized",
+            }),
+            serde_json::to_value(&notification)?,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn serialize_cancel_request_notification() -> Result<()> {
+        let notification = ClientNotification::CancelRequest(CancelRequestParams {
+            id: RequestId::Integer(7),
+        });
+
+        assert_eq!(
+            json!({
+                "method": "$/cancelRequest",
+                "params": { "id": 7 }
             }),
             serde_json::to_value(&notification)?,
         );

--- a/codex-rs/app-server/src/cancellation_registry.rs
+++ b/codex-rs/app-server/src/cancellation_registry.rs
@@ -1,0 +1,56 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex as StdMutex;
+use std::sync::PoisonError;
+
+use codex_app_server_protocol::RequestId;
+
+trait Cancellable: Send {
+    fn cancel(&self);
+}
+
+impl<F> Cancellable for F
+where
+    F: Fn() + Send,
+{
+    fn cancel(&self) {
+        (self)();
+    }
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct CancellationRegistry {
+    inner: Arc<StdMutex<HashMap<RequestId, Box<dyn Cancellable + Send>>>>,
+}
+
+impl CancellationRegistry {
+    pub(crate) fn insert<F>(&self, id: RequestId, f: F)
+    where
+        F: Fn() + Send + 'static,
+    {
+        self.inner
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .insert(id, Box::new(f));
+    }
+
+    pub(crate) fn cancel(&self, id: &RequestId) -> bool {
+        // Remove the callback while holding the lock, but invoke it only after
+        // releasing the lock to avoid deadlocks or long critical sections.
+        let callback = {
+            let mut guard = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+            guard.remove(id)
+        };
+        if let Some(c) = callback {
+            c.cancel();
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(crate) fn remove(&self, id: &RequestId) {
+        let mut guard = self.inner.lock().unwrap_or_else(PoisonError::into_inner);
+        guard.remove(id);
+    }
+}

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -470,6 +470,11 @@ impl CodexMessageProcessor {
         }
     }
 
+    /// Handle a generic JSON-RPC cancellation for a previously started operation.
+    /// This is a fire-and-forget path; no response.
+    pub async fn cancel_request(&self, id: RequestId) {}
+
+    // Legacy endpoint for cancelling a LoginChatGpt request. Please use $/cancelRequest instead.
     async fn cancel_login_chatgpt(&mut self, request_id: RequestId, login_id: Uuid) {
         let mut guard = self.active_login.lock().await;
         if guard.as_ref().map(|l| l.login_id) == Some(login_id) {

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -28,6 +28,7 @@ use tracing_subscriber::filter::Targets;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::util::SubscriberInitExt;
 
+mod cancellation_registry;
 mod codex_message_processor;
 mod error_code;
 mod fuzzy_file_search;

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -134,7 +134,6 @@ impl MessageProcessor {
         {
             match typed {
                 ClientNotification::CancelRequest(CancelRequestParams { id }) => {
-                    // Map $/cancelRequest to a cancellation inside Codex.
                     self.codex_message_processor.cancel_request(id).await;
                 }
                 ClientNotification::Initialized => {
@@ -142,7 +141,6 @@ impl MessageProcessor {
                 }
             }
         }
-        // Unknown or untyped notification: nothing to do.
     }
 
     /// Handle a standalone JSON-RPC response originating from the peer.


### PR DESCRIPTION
Add cancellation registry and `$/cancelRequest`, so that long-running Json-RPC endpoints can orchestrate their own cancellation logic. This is in line with the LSP protocol ([doc](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#cancelRequest)). Registered cancellation for `login_chatgpt`, so `$/cancelRequest` performs the same as the legacy `cancelLoginGpt` endpoint.