### PR TITLE
Fix sandbox detection for user shell commands

### DIFF
--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -89,7 +89,10 @@ impl SessionTask for UserShellCommandTask {
         let tool_call = ToolCall {
             tool_name: USER_SHELL_TOOL_NAME.to_string(),
             call_id: Uuid::new_v4().to_string(),
-            payload: ToolPayload::LocalShell { params },
+            payload: ToolPayload::LocalShell {
+                params,
+                is_user_shell_command: true,
+            },
         };
 
         let router = Arc::new(ToolRouter::from_config(&turn_context.tools_config, None));

--- a/codex-rs/core/src/tools/context.rs
+++ b/codex-rs/core/src/tools/context.rs
@@ -40,6 +40,7 @@ pub enum ToolPayload {
     },
     LocalShell {
         params: ShellToolCallParams,
+        is_user_shell_command: bool,
     },
     UnifiedExec {
         arguments: String,
@@ -56,7 +57,7 @@ impl ToolPayload {
         match self {
             ToolPayload::Function { arguments } => Cow::Borrowed(arguments),
             ToolPayload::Custom { input } => Cow::Borrowed(input),
-            ToolPayload::LocalShell { params } => Cow::Owned(params.command.join(" ")),
+            ToolPayload::LocalShell { params, .. } => Cow::Owned(params.command.join(" ")),
             ToolPayload::UnifiedExec { arguments } => Cow::Borrowed(arguments),
             ToolPayload::Mcp { raw_arguments, .. } => Cow::Borrowed(raw_arguments),
         }

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -82,7 +82,10 @@ impl ToolHandler for ShellHandler {
                 )
                 .await
             }
-            ToolPayload::LocalShell { params } => {
+            ToolPayload::LocalShell {
+                params,
+                is_user_shell_command,
+            } => {
                 let exec_params = Self::to_exec_params(params, turn.as_ref());
                 Self::run_exec_like(
                     tool_name.as_str(),
@@ -91,7 +94,7 @@ impl ToolHandler for ShellHandler {
                     turn,
                     tracker,
                     call_id,
-                    true,
+                    is_user_shell_command,
                 )
                 .await
             }

--- a/codex-rs/core/src/tools/router.rs
+++ b/codex-rs/core/src/tools/router.rs
@@ -120,7 +120,10 @@ impl ToolRouter {
                         Ok(Some(ToolCall {
                             tool_name: "local_shell".to_string(),
                             call_id,
-                            payload: ToolPayload::LocalShell { params },
+                            payload: ToolPayload::LocalShell {
+                                params,
+                                is_user_shell_command: false,
+                            },
                         }))
                     }
                 }


### PR DESCRIPTION
## Summary
- track whether `local_shell` tool calls came from bang commands
- only flag user-initiated shell commands to run outside the sandbox
- keep agent-initiated shell calls sandboxed so approval and retry logic behave as before

## Testing
- cargo test -p codex-core *(fails: unified_exec tests and long-running cases hang under sandbox)*

------
https://chatgpt.com/codex/tasks/task_i_6906733927608321a0f6c381fe77bb0e