### PR TITLE
fix: web search doesn't get recorded in next rounds

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -26,7 +26,6 @@ use tokio::sync::mpsc;
 use tokio::time::timeout;
 use tokio_util::io::ReaderStream;
 use tracing::debug;
-use tracing::error;
 use tracing::trace;
 use tracing::warn;
 
@@ -252,7 +251,6 @@ impl ModelClient {
             prompt_cache_key: Some(self.conversation_id.to_string()),
             text,
         };
-        error!("payload: {:?}", payload);
 
         let mut payload_json = serde_json::to_value(&payload)?;
         if azure_workaround {

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -26,6 +26,7 @@ use tokio::sync::mpsc;
 use tokio::time::timeout;
 use tokio_util::io::ReaderStream;
 use tracing::debug;
+use tracing::error;
 use tracing::trace;
 use tracing::warn;
 
@@ -251,6 +252,7 @@ impl ModelClient {
             prompt_cache_key: Some(self.conversation_id.to_string()),
             text,
         };
+        error!("payload: {:?}", payload);
 
         let mut payload_json = serde_json::to_value(&payload)?;
         if azure_workaround {

--- a/codex-rs/core/src/response_processing.rs
+++ b/codex-rs/core/src/response_processing.rs
@@ -3,6 +3,7 @@ use crate::codex::TurnContext;
 use codex_protocol::models::FunctionCallOutputPayload;
 use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
+use tracing::error;
 use tracing::warn;
 
 /// Process streamed `ResponseItem`s from the model into the pair of:
@@ -85,6 +86,10 @@ pub(crate) async fn process_items(
                     content: content.clone(),
                     encrypted_content: encrypted_content.clone(),
                 });
+            }
+            (ResponseItem::WebSearchCall { .. }, None) => {
+                items_to_record_in_conversation_history.push(item.clone());
+                error!("WebSearchCall: {item:?}");
             }
             _ => {
                 warn!("Unexpected response item: {item:?} with response: {response:?}");

--- a/codex-rs/core/src/response_processing.rs
+++ b/codex-rs/core/src/response_processing.rs
@@ -3,7 +3,6 @@ use crate::codex::TurnContext;
 use codex_protocol::models::FunctionCallOutputPayload;
 use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
-use tracing::error;
 use tracing::warn;
 
 /// Process streamed `ResponseItem`s from the model into the pair of:
@@ -89,7 +88,6 @@ pub(crate) async fn process_items(
             }
             (ResponseItem::WebSearchCall { .. }, None) => {
                 items_to_record_in_conversation_history.push(item.clone());
-                error!("WebSearchCall: {item:?}");
             }
             _ => {
                 warn!("Unexpected response item: {item:?} with response: {response:?}");

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -120,8 +120,6 @@ pub enum ResponseItem {
     //   "action": {"type":"search","query":"weather: San Francisco, CA"}
     // }
     WebSearchCall {
-        #[serde(default, skip_serializing)]
-        #[ts(skip)]
         id: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         #[ts(optional)]


### PR DESCRIPTION
In order to fix that, we need to record the `web_search` to the history and keep its id because the results live on the server side.