### PR TITLE
fix: improve usage URLs in status card and snapshots

### DIFF
--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -255,7 +255,7 @@ impl std::fmt::Display for UsageLimitReachedError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let message = match self.plan_type.as_ref() {
             Some(PlanType::Known(KnownPlan::Plus)) => format!(
-                "You've hit your usage limit. Upgrade to Pro (https://openai.com/chatgpt/pricing), visit chatgpt.com/codex/settings/usage to purchase more credits{}",
+                "You've hit your usage limit. Upgrade to Pro (https://openai.com/chatgpt/pricing), visit https://chatgpt.com/codex/settings/usage to purchase more credits{}",
                 retry_suffix_after_or(self.resets_at.as_ref())
             ),
             Some(PlanType::Known(KnownPlan::Team)) | Some(PlanType::Known(KnownPlan::Business)) => {
@@ -269,7 +269,7 @@ impl std::fmt::Display for UsageLimitReachedError {
                     .to_string()
             }
             Some(PlanType::Known(KnownPlan::Pro)) => format!(
-                "You've hit your usage limit. Visit chatgpt.com/codex/settings/usage to purchase more credits{}",
+                "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits{}",
                 retry_suffix_after_or(self.resets_at.as_ref())
             ),
             Some(PlanType::Known(KnownPlan::Enterprise))
@@ -460,7 +460,7 @@ mod tests {
         };
         assert_eq!(
             err.to_string(),
-            "You've hit your usage limit. Upgrade to Pro (https://openai.com/chatgpt/pricing), visit chatgpt.com/codex/settings/usage to purchase more credits or try again later."
+            "You've hit your usage limit. Upgrade to Pro (https://openai.com/chatgpt/pricing), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again later."
         );
     }
 
@@ -613,7 +613,7 @@ mod tests {
                 rate_limits: Some(rate_limit_snapshot()),
             };
             let expected = format!(
-                "You've hit your usage limit. Visit chatgpt.com/codex/settings/usage to purchase more credits or try again at {expected_time}."
+                "You've hit your usage limit. Visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at {expected_time}."
             );
             assert_eq!(err.to_string(), expected);
         });
@@ -647,7 +647,7 @@ mod tests {
                 rate_limits: Some(rate_limit_snapshot()),
             };
             let expected = format!(
-                "You've hit your usage limit. Upgrade to Pro (https://openai.com/chatgpt/pricing), visit chatgpt.com/codex/settings/usage to purchase more credits or try again at {expected_time}."
+                "You've hit your usage limit. Upgrade to Pro (https://openai.com/chatgpt/pricing), visit https://chatgpt.com/codex/settings/usage to purchase more credits or try again at {expected_time}."
             );
             assert_eq!(err.to_string(), expected);
         });

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -313,7 +313,9 @@ impl HistoryCell for StatusHistoryCell {
 
         let note_first_line = Line::from(vec![
             Span::from("Visit ").cyan(),
-            "https://chatgpt.com/codex/settings/usage".cyan().underlined(),
+            "https://chatgpt.com/codex/settings/usage"
+                .cyan()
+                .underlined(),
             Span::from(" for up-to-date").cyan(),
         ]);
         let note_second_line = Line::from(vec![

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -313,7 +313,7 @@ impl HistoryCell for StatusHistoryCell {
 
         let note_first_line = Line::from(vec![
             Span::from("Visit ").cyan(),
-            "chatgpt.com/codex/settings/usage".cyan().underlined(),
+            "https://chatgpt.com/codex/settings/usage".cyan().underlined(),
             Span::from(" for up-to-date").cyan(),
         ]);
         let note_second_line = Line::from(vec![

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
@@ -7,7 +7,7 @@ expression: sanitized
 ╭────────────────────────────────────────────────────────────────────────────╮
 │  >_ OpenAI Codex (v0.0.0)                                                  │
 │                                                                            │
-│ Visit chatgpt.com/codex/settings/usage for up-to-date                      │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date              │
 │ information on rate limits and credits                                     │
 │                                                                            │
 │  Model:            gpt-5-codex (reasoning none, summaries auto)            │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
@@ -7,7 +7,7 @@ expression: sanitized
 ╭─────────────────────────────────────────────────────────────────────╮
 │  >_ OpenAI Codex (v0.0.0)                                           │
 │                                                                     │
-│ Visit chatgpt.com/codex/settings/usage for up-to-date               │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date       │
 │ information on rate limits and credits                              │
 │                                                                     │
 │  Model:            gpt-5-codex (reasoning high, summaries detailed) │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_empty_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_empty_limits_message.snap
@@ -7,7 +7,7 @@ expression: sanitized
 ╭─────────────────────────────────────────────────────────────────╮
 │  >_ OpenAI Codex (v0.0.0)                                       │
 │                                                                 │
-│ Visit chatgpt.com/codex/settings/usage for up-to-date           │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date   │
 │ information on rate limits and credits                          │
 │                                                                 │
 │  Model:            gpt-5-codex (reasoning none, summaries auto) │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_missing_limits_message.snap
@@ -7,7 +7,7 @@ expression: sanitized
 ╭─────────────────────────────────────────────────────────────────╮
 │  >_ OpenAI Codex (v0.0.0)                                       │
 │                                                                 │
-│ Visit chatgpt.com/codex/settings/usage for up-to-date           │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date   │
 │ information on rate limits and credits                          │
 │                                                                 │
 │  Model:            gpt-5-codex (reasoning none, summaries auto) │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
@@ -7,7 +7,7 @@ expression: sanitized
 ╭─────────────────────────────────────────────────────────────────────╮
 │  >_ OpenAI Codex (v0.0.0)                                           │
 │                                                                     │
-│ Visit chatgpt.com/codex/settings/usage for up-to-date               │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date       │
 │ information on rate limits and credits                              │
 │                                                                     │
 │  Model:            gpt-5-codex (reasoning none, summaries auto)     │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/src/status/tests.rs
+assertion_line: 257
 expression: sanitized
 ---
 /status
@@ -7,8 +8,8 @@ expression: sanitized
 ╭────────────────────────────────────────────╮
 │  >_ OpenAI Codex (v0.0.0)                  │
 │                                            │
-│ Visit chatgpt.com/codex/settings/usage for │
-│ up-to-date                                 │
+│ Visit https://chatgpt.com/codex/settings/  │
+│ usage for up-to-date                       │
 │ information on rate limits and credits     │
 │                                            │
 │  Model:            gpt-5-codex (reasoning  │


### PR DESCRIPTION
Hi OpenAI Codex team, currently "Visit chatgpt.com/codex/settings/usage for up-to-date information on rate limits and credits" message in status card and error messages. For now, without the "https://" prefix, the link cannot be clicked directly from most terminals or chat interfaces.

<img width="636" height="127" alt="Screenshot 2025-11-02 at 22 47 06" src="https://github.com/user-attachments/assets/5ea11e8b-fb74-451c-85dc-f4d492b2678b" />

---

The fix is intent to improve this issue:

- It makes the link clickable in terminals that support it, hence better accessibility
- It follows standard URL formatting practices
- It maintains consistency with other links in the application (like the existing "https://openai.com/chatgpt/pricing" links)

Thank you!