### PR TITLE
Fix "archive conversation" on Windows

### DIFF
--- a/codex-rs/core/src/rollout/recorder.rs
+++ b/codex-rs/core/src/rollout/recorder.rs
@@ -5,6 +5,7 @@ use std::fs::{self};
 use std::io::Error as IoError;
 use std::path::Path;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use codex_protocol::ConversationId;
 use serde_json::Value;
@@ -12,9 +13,11 @@ use time::OffsetDateTime;
 use time::format_description::FormatItem;
 use time::macros::format_description;
 use tokio::io::AsyncWriteExt;
+use tokio::sync::Mutex;
 use tokio::sync::mpsc::Sender;
 use tokio::sync::mpsc::{self};
 use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
 use tracing::info;
 use tracing::warn;
 
@@ -43,10 +46,20 @@ use codex_protocol::protocol::SessionSource;
 /// $ jq -C . ~/.codex/sessions/rollout-2025-05-07T17-24-21-5973b6c0-94b8-487b-a530-2aeb6098ae0e.jsonl
 /// $ fx ~/.codex/sessions/rollout-2025-05-07T17-24-21-5973b6c0-94b8-487b-a530-2aeb6098ae0e.jsonl
 /// ```
-#[derive(Clone)]
 pub struct RolloutRecorder {
     tx: Sender<RolloutCmd>,
     pub(crate) rollout_path: PathBuf,
+    writer_task: Arc<Mutex<Option<JoinHandle<std::io::Result<()>>>>>,
+}
+
+impl Clone for RolloutRecorder {
+    fn clone(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+            rollout_path: self.rollout_path.clone(),
+            writer_task: Arc::clone(&self.writer_task),
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -172,9 +185,14 @@ impl RolloutRecorder {
         // Spawn a Tokio task that owns the file handle and performs async
         // writes. Using `tokio::fs::File` keeps everything on the async I/O
         // driver instead of blocking the runtime.
-        tokio::task::spawn(rollout_writer(file, rx, meta, cwd));
+        let writer_task =
+            tokio::task::spawn(async move { rollout_writer(file, rx, meta, cwd).await });
 
-        Ok(Self { tx, rollout_path })
+        Ok(Self {
+            tx,
+            rollout_path,
+            writer_task: Arc::new(Mutex::new(Some(writer_task))),
+        })
     }
 
     pub(crate) async fn record_items(&self, items: &[RolloutItem]) -> std::io::Result<()> {
@@ -280,16 +298,27 @@ impl RolloutRecorder {
 
     pub async fn shutdown(&self) -> std::io::Result<()> {
         let (tx_done, rx_done) = oneshot::channel();
-        match self.tx.send(RolloutCmd::Shutdown { ack: tx_done }).await {
-            Ok(_) => rx_done
-                .await
-                .map_err(|e| IoError::other(format!("failed waiting for rollout shutdown: {e}"))),
-            Err(e) => {
-                warn!("failed to send rollout shutdown command: {e}");
-                Err(IoError::other(format!(
-                    "failed to send rollout shutdown command: {e}"
-                )))
+        if let Err(e) = self.tx.send(RolloutCmd::Shutdown { ack: tx_done }).await {
+            warn!("failed to send rollout shutdown command: {e}");
+            return Err(IoError::other(format!(
+                "failed to send rollout shutdown command: {e}"
+            )));
+        }
+
+        rx_done
+            .await
+            .map_err(|e| IoError::other(format!("failed waiting for rollout shutdown: {e}")))?;
+
+        let mut guard = self.writer_task.lock().await;
+        if let Some(handle) = guard.take() {
+            match handle.await {
+                Ok(result) => result,
+                Err(join_err) => Err(IoError::other(format!(
+                    "failed joining rollout writer task: {join_err}"
+                ))),
             }
+        } else {
+            Ok(())
         }
     }
 }
@@ -387,7 +416,9 @@ async fn rollout_writer(
                 let _ = ack.send(());
             }
             RolloutCmd::Shutdown { ack } => {
+                let result = writer.shutdown().await;
                 let _ = ack.send(());
+                return result;
             }
         }
     }
@@ -420,5 +451,9 @@ impl JsonlWriter {
         self.file.write_all(json.as_bytes()).await?;
         self.file.flush().await?;
         Ok(())
+    }
+
+    async fn shutdown(mut self) -> std::io::Result<()> {
+        self.file.flush().await
     }
 }


### PR DESCRIPTION
Addresses issue https://github.com/openai/codex/issues/3582 where an "archive conversation" command in the extension fails on Windows.

The problem is that the `archive_conversation` api server call is not canonicalizing the path to the rollout path when performing its check to verify that the rollout path is in the sessions directory. This causes it to fail 100% of the time on Windows.

Testing: I was able to repro the error on Windows 100% prior to this change. After the change, I'm no longer able to repro.