### PR TITLE
feat: add options to responses-api-proxy to support Azure

### DIFF
--- a/codex-rs/responses-api-proxy/src/read_api_key.rs
+++ b/codex-rs/responses-api-proxy/src/read_api_key.rs
@@ -121,7 +121,7 @@ where
     if total_read == capacity && !saw_newline && !saw_eof {
         buf.zeroize();
         return Err(anyhow!(
-            "OPENAI_API_KEY is too large to fit in the 512-byte buffer"
+            "API key is too large to fit in the {BUFFER_SIZE}-byte buffer"
         ));
     }
 
@@ -133,7 +133,7 @@ where
     if total == AUTH_HEADER_PREFIX.len() {
         buf.zeroize();
         return Err(anyhow!(
-            "OPENAI_API_KEY must be provided via stdin (e.g. printenv OPENAI_API_KEY | codex responses-api-proxy)"
+            "API key must be provided via stdin (e.g. printenv OPENAI_API_KEY | codex responses-api-proxy)"
         ));
     }
 
@@ -214,7 +214,7 @@ fn validate_auth_header_bytes(key_bytes: &[u8]) -> Result<()> {
     }
 
     Err(anyhow!(
-        "OPENAI_API_KEY may only contain ASCII letters, numbers, '-' or '_'"
+        "API key may only contain ASCII letters, numbers, '-' or '_'"
     ))
 }
 
@@ -290,7 +290,9 @@ mod tests {
         })
         .unwrap_err();
         let message = format!("{err:#}");
-        assert!(message.contains("OPENAI_API_KEY is too large to fit in the 512-byte buffer"));
+        let expected_error =
+            format!("API key is too large to fit in the {BUFFER_SIZE}-byte buffer");
+        assert!(message.contains(&expected_error));
     }
 
     #[test]
@@ -317,9 +319,7 @@ mod tests {
         .unwrap_err();
 
         let message = format!("{err:#}");
-        assert!(
-            message.contains("OPENAI_API_KEY may only contain ASCII letters, numbers, '-' or '_'")
-        );
+        assert!(message.contains("API key may only contain ASCII letters, numbers, '-' or '_'"));
     }
 
     #[test]
@@ -337,8 +337,6 @@ mod tests {
         .unwrap_err();
 
         let message = format!("{err:#}");
-        assert!(
-            message.contains("OPENAI_API_KEY may only contain ASCII letters, numbers, '-' or '_'")
-        );
+        assert!(message.contains("API key may only contain ASCII letters, numbers, '-' or '_'"));
     }
 }


### PR DESCRIPTION
This PR introduces an `--upstream-url` option to the proxy CLI that determines the URL that Responses API requests should be forwarded to. To preserve existing behavior, the default value is `"https://api.openai.com/v1/responses"`.

The motivation for this change is that the [Codex GitHub Action](https://github.com/openai/codex-action) should support those who use the OpenAI Responses API via Azure. Relevant issues:

- https://github.com/openai/codex-action/issues/28
- https://github.com/openai/codex-action/issues/38
- https://github.com/openai/codex-action/pull/44

Though rather than introduce a bunch of new Azure-specific logic in the action as https://github.com/openai/codex-action/pull/44 proposes, we should leverage our Responses API proxy to get the _hardening_ benefits it provides:

https://github.com/openai/codex/blob/d5853d9c47b1badad183f62622745cf47e6ff0f4/codex-rs/responses-api-proxy/README.md#hardening-details

This PR should make this straightforward to incorporate in the action. To see how the updated version of the action would consume these new options, see https://github.com/openai/codex-action/pull/47.