### PR TITLE
Fix incorrect "deprecated" message about experimental config key

### DIFF
--- a/codex-rs/core/src/features/legacy.rs
+++ b/codex-rs/core/src/features/legacy.rs
@@ -123,7 +123,7 @@ fn set_if_some(
     if let Some(enabled) = maybe_value {
         set_feature(features, feature, enabled);
         log_alias(alias_key, feature);
-        features.record_legacy_usage_force(alias_key, feature);
+        features.record_legacy_usage(alias_key, feature);
     }
 }
 


### PR DESCRIPTION
When I enable `experimental_sandbox_command_assessment`, I get an incorrect deprecation warning: "experimental_sandbox_command_assessment is deprecated. Use experimental_sandbox_command_assessment instead."

This PR fixes this error.
