### PR TITLE
Make it possible to configure `reasoning_key` in providers.

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -972,6 +972,7 @@ fn is_context_window_error(error: &Error) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model_provider_info::DEFAULT_REASONING_KEY;
     use assert_matches::assert_matches;
     use serde_json::json;
     use tokio::sync::mpsc;
@@ -1110,6 +1111,7 @@ mod tests {
             stream_max_retries: Some(0),
             stream_idle_timeout_ms: Some(1000),
             requires_openai_auth: false,
+            reasoning_key: DEFAULT_REASONING_KEY.to_string(),
         };
 
         let otel_event_manager = otel_event_manager();
@@ -1174,6 +1176,7 @@ mod tests {
             stream_max_retries: Some(0),
             stream_idle_timeout_ms: Some(1000),
             requires_openai_auth: false,
+            reasoning_key: DEFAULT_REASONING_KEY.to_string(),
         };
 
         let otel_event_manager = otel_event_manager();
@@ -1211,6 +1214,7 @@ mod tests {
             stream_max_retries: Some(0),
             stream_idle_timeout_ms: Some(1000),
             requires_openai_auth: false,
+            reasoning_key: DEFAULT_REASONING_KEY.to_string(),
         };
 
         let otel_event_manager = otel_event_manager();
@@ -1250,6 +1254,7 @@ mod tests {
             stream_max_retries: Some(0),
             stream_idle_timeout_ms: Some(1000),
             requires_openai_auth: false,
+            reasoning_key: DEFAULT_REASONING_KEY.to_string(),
         };
 
         let otel_event_manager = otel_event_manager();
@@ -1285,6 +1290,7 @@ mod tests {
             stream_max_retries: Some(0),
             stream_idle_timeout_ms: Some(1000),
             requires_openai_auth: false,
+            reasoning_key: DEFAULT_REASONING_KEY.to_string(),
         };
 
         let otel_event_manager = otel_event_manager();
@@ -1389,6 +1395,7 @@ mod tests {
                 stream_max_retries: Some(0),
                 stream_idle_timeout_ms: Some(1000),
                 requires_openai_auth: false,
+                reasoning_key: DEFAULT_REASONING_KEY.to_string(),
             };
 
             let otel_event_manager = otel_event_manager();

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1290,6 +1290,7 @@ mod tests {
     use crate::features::Feature;
 
     use super::*;
+    use crate::model_provider_info::DEFAULT_REASONING_KEY;
     use pretty_assertions::assert_eq;
 
     use std::time::Duration;
@@ -1325,6 +1326,36 @@ persistence = "none"
             }),
             history_no_persistence_cfg.history
         );
+    }
+
+    #[test]
+    fn model_provider_reasoning_key_config() {
+        let without_override = r#"
+[model_providers.default]
+name = "Default"
+base_url = "https://example.com"
+"#;
+        let cfg = toml::from_str::<ConfigToml>(without_override)
+            .expect("TOML deserialization should succeed");
+        let provider = cfg
+            .model_providers
+            .get("default")
+            .expect("provider to be present");
+        assert_eq!(provider.reasoning_key, DEFAULT_REASONING_KEY);
+
+        let with_override = r#"
+[model_providers.custom]
+name = "Custom"
+base_url = "https://example.com"
+reasoning_key = "reasoning_content"
+"#;
+        let cfg = toml::from_str::<ConfigToml>(with_override)
+            .expect("TOML deserialization should succeed");
+        let provider = cfg
+            .model_providers
+            .get("custom")
+            .expect("provider to be present");
+        assert_eq!(provider.reasoning_key, "reasoning_content");
     }
 
     #[test]
@@ -2809,6 +2840,7 @@ model_verbosity = "high"
             stream_max_retries: Some(10),
             stream_idle_timeout_ms: Some(300_000),
             requires_openai_auth: false,
+            reasoning_key: DEFAULT_REASONING_KEY.to_string(),
         };
         let model_provider_map = {
             let mut model_provider_map = built_in_model_providers();

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -93,6 +93,16 @@ pub struct ModelProviderInfo {
     /// and API key (if needed) comes from the "env_key" environment variable.
     #[serde(default)]
     pub requires_openai_auth: bool,
+
+    /// JSON key used by this provider for transmitting reasoning content.
+    #[serde(default = "default_reasoning_key")]
+    pub reasoning_key: String,
+}
+
+pub const DEFAULT_REASONING_KEY: &str = "reasoning";
+
+fn default_reasoning_key() -> String {
+    DEFAULT_REASONING_KEY.to_string()
 }
 
 impl ModelProviderInfo {
@@ -309,6 +319,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
                 stream_max_retries: None,
                 stream_idle_timeout_ms: None,
                 requires_openai_auth: true,
+                reasoning_key: default_reasoning_key(),
             },
         ),
         (BUILT_IN_OSS_MODEL_PROVIDER_ID, create_oss_provider()),
@@ -354,6 +365,7 @@ pub fn create_oss_provider_with_base_url(base_url: &str) -> ModelProviderInfo {
         stream_max_retries: None,
         stream_idle_timeout_ms: None,
         requires_openai_auth: false,
+        reasoning_key: default_reasoning_key(),
     }
 }
 
@@ -394,6 +406,7 @@ base_url = "http://localhost:11434/v1"
             stream_max_retries: None,
             stream_idle_timeout_ms: None,
             requires_openai_auth: false,
+            reasoning_key: default_reasoning_key(),
         };
 
         let provider: ModelProviderInfo = toml::from_str(azure_provider_toml).unwrap();
@@ -424,6 +437,7 @@ query_params = { api-version = "2025-04-01-preview" }
             stream_max_retries: None,
             stream_idle_timeout_ms: None,
             requires_openai_auth: false,
+            reasoning_key: default_reasoning_key(),
         };
 
         let provider: ModelProviderInfo = toml::from_str(azure_provider_toml).unwrap();
@@ -457,6 +471,7 @@ env_http_headers = { "X-Example-Env-Header" = "EXAMPLE_ENV_VAR" }
             stream_max_retries: None,
             stream_idle_timeout_ms: None,
             requires_openai_auth: false,
+            reasoning_key: default_reasoning_key(),
         };
 
         let provider: ModelProviderInfo = toml::from_str(azure_provider_toml).unwrap();
@@ -480,6 +495,7 @@ env_http_headers = { "X-Example-Env-Header" = "EXAMPLE_ENV_VAR" }
                 stream_max_retries: None,
                 stream_idle_timeout_ms: None,
                 requires_openai_auth: false,
+                reasoning_key: default_reasoning_key(),
             }
         }
 
@@ -513,6 +529,7 @@ env_http_headers = { "X-Example-Env-Header" = "EXAMPLE_ENV_VAR" }
             stream_max_retries: None,
             stream_idle_timeout_ms: None,
             requires_openai_auth: false,
+            reasoning_key: default_reasoning_key(),
         };
         assert!(named_provider.is_azure_responses_endpoint());
 

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -48,6 +48,7 @@ async fn responses_stream_includes_subagent_header_on_review() {
         stream_max_retries: Some(0),
         stream_idle_timeout_ms: Some(5_000),
         requires_openai_auth: false,
+        reasoning_key: "reasoning".into(),
     };
 
     let codex_home = TempDir::new().expect("failed to create TempDir");
@@ -136,6 +137,7 @@ async fn responses_stream_includes_subagent_header_on_other() {
         stream_max_retries: Some(0),
         stream_idle_timeout_ms: Some(5_000),
         requires_openai_auth: false,
+        reasoning_key: "reasoning".into(),
     };
 
     let codex_home = TempDir::new().expect("failed to create TempDir");

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -724,6 +724,7 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
         stream_max_retries: Some(0),
         stream_idle_timeout_ms: Some(5_000),
         requires_openai_auth: false,
+        reasoning_key: "reasoning".into(),
     };
 
     let codex_home = TempDir::new().unwrap();
@@ -1216,6 +1217,7 @@ async fn azure_overrides_assign_properties_used_for_responses_url() {
         stream_max_retries: None,
         stream_idle_timeout_ms: None,
         requires_openai_auth: false,
+        reasoning_key: "reasoning".into(),
     };
 
     // Init session
@@ -1294,6 +1296,7 @@ async fn env_var_overrides_loaded_auth() {
         stream_max_retries: None,
         stream_idle_timeout_ms: None,
         requires_openai_auth: false,
+        reasoning_key: "reasoning".into(),
     };
 
     // Init session

--- a/codex-rs/core/tests/suite/stream_error_allows_next_turn.rs
+++ b/codex-rs/core/tests/suite/stream_error_allows_next_turn.rs
@@ -75,6 +75,7 @@ async fn continue_after_stream_error() {
         stream_max_retries: Some(1),
         stream_idle_timeout_ms: Some(2_000),
         requires_openai_auth: false,
+        reasoning_key: "reasoning".into(),
     };
 
     let TestCodex { codex, .. } = test_codex()

--- a/codex-rs/core/tests/suite/stream_no_completed.rs
+++ b/codex-rs/core/tests/suite/stream_no_completed.rs
@@ -83,6 +83,7 @@ async fn retries_on_early_close() {
         stream_max_retries: Some(1),
         stream_idle_timeout_ms: Some(2000),
         requires_openai_auth: false,
+        reasoning_key: "reasoning".into(),
     };
 
     let TestCodex { codex, .. } = test_codex()

--- a/docs/config.md
+++ b/docs/config.md
@@ -100,6 +100,15 @@ http_headers = { "X-Example-Header" = "example-value" }
 env_http_headers = { "X-Example-Features" = "EXAMPLE_FEATURES" }
 ```
 
+If a provider exposes its reasoning output under a different JSON key, set `reasoning_key` to match the API. Codex defaults to the OpenAI-compatible `"reasoning"` field, but implementations such as llama.cpp expect `"reasoning_content"`.
+
+```toml
+[model_providers.llama_cpp]
+name = "llama.cpp"
+base_url = "http://localhost:8080/v1"
+reasoning_key = "reasoning_content"
+```
+
 #### Azure model provider example
 
 Note that Azure requires `api-version` to be passed as a query parameter, so be sure to specify it as part of `query_params` when defining the Azure provider:


### PR DESCRIPTION
- Introduce `reasoning_key` field in `ModelProviderInfo` with default value of "reasoning".
- Propagate the key through chat completion streaming logic.

This is useful when using GPT-OSS with inference engines that don't use "reasoning_content" to pass reasoning to the client, so I removed the hardcoded values and made it configurable with a default.

