### PR TITLE
Fixed notify handler so it passes correct `input_messages` details

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -125,7 +125,6 @@ use codex_protocol::models::FunctionCallOutputPayload;
 use codex_protocol::models::ResponseInputItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::InitialHistory;
-// use codex_protocol::protocol::USER_MESSAGE_BEGIN;
 use codex_protocol::user_input::UserInput;
 use codex_utils_readiness::Readiness;
 use codex_utils_readiness::ReadinessFlag;


### PR DESCRIPTION
This fixes bug #6121. 

The `input_messages` field passed to the notify handler is currently empty because the logic is incorrectly including the OutputText rather than InputText. I've fixed that and added proper filtering to remove messages associated with AGENTS.md and other context injected by the harness.

Testing: I wrote a notify handler and verified that the user prompt is correctly passed through to the handler.