### PR TITLE
Fix typo in error message for OAuth login

### DIFF
--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -353,7 +353,7 @@ async fn run_login(config_overrides: &CliConfigOverrides, login_args: LoginArgs)
         .context("failed to load configuration")?;
 
     if !config.features.enabled(Feature::RmcpClient) {
-        bail!("OAuth login is only supported when [feature].rmcp_client is true in config.toml.");
+        bail!("OAuth login is only supported when [features].rmcp_client is true in config.toml.");
     }
 
     let LoginArgs { name, scopes } = login_args;


### PR DESCRIPTION
Error message for attempting to OAuth with a remote RCP is incorrect and misleading. The correct config is

```
[features]
rmcp_client = true
```
