### PR TITLE
fix: enable TLS for HTTPS OpenTelemetry gRPC endpoints

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -5113,6 +5113,7 @@ version = "0.23.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2491382039b29b9b11ff08b76ff6c97cf287671dbb74f0be44bda389fffe9bd1"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
@@ -6507,8 +6508,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-native-certs",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower",
  "tower-layer",

--- a/codex-rs/otel/Cargo.toml
+++ b/codex-rs/otel/Cargo.toml
@@ -29,6 +29,8 @@ opentelemetry-otlp = { workspace = true, features = [
     "http-json",
     "reqwest",
     "reqwest-rustls",
+    "tls",
+    "tls-roots",
 ], optional = true }
 opentelemetry-semantic-conventions = { workspace = true }
 opentelemetry_sdk = { workspace = true, features = [


### PR DESCRIPTION
## fix(otel): enable TLS for HTTPS OpenTelemetry gRPC endpoints

### Context
The OpenTelemetry gRPC exporter was sending plaintext data to HTTPS endpoints because TLS was not enabled at build time and no runtime configuration existed.

### Root cause
- `opentelemetry-otlp` crate was compiled without the `tls` and `tls-roots` features  
- No call to `ClientTlsConfig` for HTTPS endpoints → fallback to cleartext transmission

### Fix
1. **Cargo.toml** — added `"tls"` and `"tls-roots"` features for `opentelemetry-otlp`
2. **otel_provider.rs** — detect `https://` endpoints and apply:
   ```rust
   let mut tls_config = ClientTlsConfig::new().with_native_roots();
   tls_config = tls_config.domain_name(domain);
   exporter_builder = exporter_builder.with_tls_config(tls_config);
   debug!("TLS enabled for HTTPS endpoint: {}", endpoint);
   ```

### Impact
- HTTPS endpoints now use encrypted TLS connections  
- Certificate validation via system root certs  


Resolves: **#6153 (OpenTelemetry HTTPS plaintext issue)**
