### PR TITLE
[App-server] v2 for account/updated and account/logout

### DIFF
--- a/codex-rs/app-server-protocol/src/export.rs
+++ b/codex-rs/app-server-protocol/src/export.rs
@@ -44,6 +44,7 @@ macro_rules! for_each_schema_type {
         $macro!(crate::ArchiveConversationParams);
         $macro!(crate::ArchiveConversationResponse);
         $macro!(crate::AuthMode);
+        $macro!(crate::AccountUpdatedNotification);
         $macro!(crate::AuthStatusChangeNotification);
         $macro!(crate::CancelLoginChatGptParams);
         $macro!(crate::CancelLoginChatGptResponse);

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -372,6 +372,11 @@ pub struct FuzzyFileSearchResponse {
 #[strum(serialize_all = "camelCase")]
 pub enum ServerNotification {
     /// NEW NOTIFICATIONS
+    #[serde(rename = "account/updated")]
+    #[ts(rename = "account/updated")]
+    #[strum(serialize = "account/updated")]
+    AccountUpdated(v2::AccountUpdatedNotification),
+
     #[serde(rename = "account/rateLimits/updated")]
     #[ts(rename = "account/rateLimits/updated")]
     #[strum(serialize = "account/rateLimits/updated")]
@@ -391,6 +396,7 @@ pub enum ServerNotification {
 impl ServerNotification {
     pub fn to_params(self) -> Result<serde_json::Value, serde_json::Error> {
         match self {
+            ServerNotification::AccountUpdated(params) => serde_json::to_value(params),
             ServerNotification::AccountRateLimitsUpdated(params) => serde_json::to_value(params),
             ServerNotification::AuthStatusChange(params) => serde_json::to_value(params),
             ServerNotification::LoginChatGptComplete(params) => serde_json::to_value(params),

--- a/codex-rs/app-server-protocol/src/protocol/v1.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v1.rs
@@ -400,6 +400,7 @@ pub struct SessionConfiguredNotification {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+/// Deprecated notification. Use AccountUpdatedNotification instead.
 pub struct AuthStatusChangeNotification {
     pub auth_method: Option<AuthMode>,
 }

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -125,6 +125,5 @@ pub struct UploadFeedbackResponse {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 pub struct AccountUpdatedNotification {
-    /// Mirrors the deprecated v1 AuthStatusChangeNotification payload but on a new endpoint.
     pub auth_method: Option<AuthMode>,
 }

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1,3 +1,4 @@
+use crate::protocol::common::AuthMode;
 use codex_protocol::ConversationId;
 use codex_protocol::account::PlanType;
 use codex_protocol::config_types::ReasoningEffort;
@@ -119,4 +120,11 @@ pub struct UploadFeedbackParams {
 #[serde(rename_all = "camelCase")]
 pub struct UploadFeedbackResponse {
     pub thread_id: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+pub struct AccountUpdatedNotification {
+    /// Mirrors the deprecated v1 AuthStatusChangeNotification payload but on a new endpoint.
+    pub auth_method: Option<AuthMode>,
 }

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -518,7 +518,6 @@ impl CodexMessageProcessor {
     async fn logout_v1(&mut self, request_id: RequestId) {
         match self.logout_common().await {
             Ok(current_auth_method) => {
-                // v1 response shape
                 self.outgoing
                     .send_response(
                         request_id,
@@ -526,7 +525,6 @@ impl CodexMessageProcessor {
                     )
                     .await;
 
-                // v1 notification: AuthStatusChange only
                 let payload = AuthStatusChangeNotification {
                     auth_method: current_auth_method,
                 };
@@ -543,7 +541,6 @@ impl CodexMessageProcessor {
     async fn logout_v2(&mut self, request_id: RequestId) {
         match self.logout_common().await {
             Ok(current_auth_method) => {
-                // v2 response shape
                 self.outgoing
                     .send_response(
                         request_id,
@@ -551,7 +548,6 @@ impl CodexMessageProcessor {
                     )
                     .await;
 
-                // v2 notification: AccountUpdated only
                 let payload_v2 = AccountUpdatedNotification {
                     auth_method: current_auth_method,
                 };

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -342,10 +342,6 @@ impl CodexMessageProcessor {
                     .send_server_notification(ServerNotification::AuthStatusChange(payload))
                     .await;
 
-                // Also emit the v2 account/updated notification mirroring the same payload.
-                let payload_v2 = AccountUpdatedNotification {
-                    auth_method: self.auth_manager.auth().map(|auth| auth.mode),
-                };
                 self.outgoing
                     .send_server_notification(ServerNotification::AccountUpdated(payload_v2))
                     .await;
@@ -451,16 +447,6 @@ impl CodexMessageProcessor {
                         };
                         outgoing_clone
                             .send_server_notification(ServerNotification::AuthStatusChange(payload))
-                            .await;
-
-                        // Also send the v2 account/updated notification.
-                        let payload_v2 = AccountUpdatedNotification {
-                            auth_method: current_auth_method,
-                        };
-                        outgoing_clone
-                            .send_server_notification(ServerNotification::AccountUpdated(
-                                payload_v2,
-                            ))
                             .await;
                     }
 

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -341,10 +341,6 @@ impl CodexMessageProcessor {
                 self.outgoing
                     .send_server_notification(ServerNotification::AuthStatusChange(payload))
                     .await;
-
-                self.outgoing
-                    .send_server_notification(ServerNotification::AccountUpdated(payload_v2))
-                    .await;
             }
             Err(err) => {
                 let error = JSONRPCErrorError {

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -201,8 +201,7 @@ impl CodexMessageProcessor {
                 request_id,
                 params: _,
             } => {
-                self.send_unimplemented_error(request_id, "account/logout")
-                    .await;
+                self.logout_v2(request_id).await;
             }
             ClientRequest::GetAccount {
                 request_id,
@@ -251,7 +250,7 @@ impl CodexMessageProcessor {
                 request_id,
                 params: _,
             } => {
-                self.logout_chatgpt(request_id).await;
+                self.logout_v1(request_id).await;
             }
             ClientRequest::GetAuthStatus { request_id, params } => {
                 self.get_auth_status(request_id, params).await;
@@ -513,9 +512,9 @@ impl CodexMessageProcessor {
         }
     }
 
-    async fn logout_chatgpt(&mut self, request_id: RequestId) {
+    async fn logout_common(&mut self) -> std::result::Result<Option<AuthMode>, JSONRPCErrorError> {
+        // Cancel any active login attempt.
         {
-            // Cancel any active login attempt.
             let mut guard = self.active_login.lock().await;
             if let Some(active) = guard.take() {
                 active.drop();
@@ -523,39 +522,65 @@ impl CodexMessageProcessor {
         }
 
         if let Err(err) = self.auth_manager.logout() {
-            let error = JSONRPCErrorError {
+            return Err(JSONRPCErrorError {
                 code: INTERNAL_ERROR_CODE,
                 message: format!("logout failed: {err}"),
                 data: None,
-            };
-            self.outgoing.send_error(request_id, error).await;
-            return;
+            });
         }
 
-        self.outgoing
-            .send_response(
-                request_id,
-                codex_app_server_protocol::LogoutChatGptResponse {},
-            )
-            .await;
+        // Reflect the current auth method after logout (likely None).
+        Ok(self.auth_manager.auth().map(|auth| auth.mode))
+    }
 
-        // Send auth status change notification reflecting the current auth mode
-        // after logout.
-        let current_auth_method = self.auth_manager.auth().map(|auth| auth.mode);
-        let payload = AuthStatusChangeNotification {
-            auth_method: current_auth_method,
-        };
-        self.outgoing
-            .send_server_notification(ServerNotification::AuthStatusChange(payload))
-            .await;
+    async fn logout_v1(&mut self, request_id: RequestId) {
+        match self.logout_common().await {
+            Ok(current_auth_method) => {
+                // v1 response shape
+                self.outgoing
+                    .send_response(
+                        request_id,
+                        codex_app_server_protocol::LogoutChatGptResponse {},
+                    )
+                    .await;
 
-        // Also emit the v2 account/updated notification.
-        let payload_v2 = AccountUpdatedNotification {
-            auth_method: current_auth_method,
-        };
-        self.outgoing
-            .send_server_notification(ServerNotification::AccountUpdated(payload_v2))
-            .await;
+                // v1 notification: AuthStatusChange only
+                let payload = AuthStatusChangeNotification {
+                    auth_method: current_auth_method,
+                };
+                self.outgoing
+                    .send_server_notification(ServerNotification::AuthStatusChange(payload))
+                    .await;
+            }
+            Err(error) => {
+                self.outgoing.send_error(request_id, error).await;
+            }
+        }
+    }
+
+    async fn logout_v2(&mut self, request_id: RequestId) {
+        match self.logout_common().await {
+            Ok(current_auth_method) => {
+                // v2 response shape
+                self.outgoing
+                    .send_response(
+                        request_id,
+                        codex_app_server_protocol::LogoutAccountResponse {},
+                    )
+                    .await;
+
+                // v2 notification: AccountUpdated only
+                let payload_v2 = AccountUpdatedNotification {
+                    auth_method: current_auth_method,
+                };
+                self.outgoing
+                    .send_server_notification(ServerNotification::AccountUpdated(payload_v2))
+                    .await;
+            }
+            Err(error) => {
+                self.outgoing.send_error(request_id, error).await;
+            }
+        }
     }
 
     async fn get_auth_status(

--- a/codex-rs/app-server/src/outgoing_message.rs
+++ b/codex-rs/app-server/src/outgoing_message.rs
@@ -141,6 +141,8 @@ pub(crate) struct OutgoingError {
 
 #[cfg(test)]
 mod tests {
+    use codex_app_server_protocol::AccountUpdatedNotification;
+    use codex_app_server_protocol::AuthMode;
     use codex_app_server_protocol::LoginChatGptCompleteNotification;
     use codex_protocol::protocol::RateLimitSnapshot;
     use codex_protocol::protocol::RateLimitWindow;
@@ -197,6 +199,26 @@ mod tests {
                         "resets_at": 123,
                     },
                     "secondary": null,
+                },
+            }),
+            serde_json::to_value(jsonrpc_notification)
+                .expect("ensure the notification serializes correctly"),
+            "ensure the notification serializes correctly"
+        );
+    }
+
+    #[test]
+    fn verify_account_updated_notification_serialization() {
+        let notification = ServerNotification::AccountUpdated(AccountUpdatedNotification {
+            auth_method: Some(AuthMode::ApiKey),
+        });
+
+        let jsonrpc_notification = OutgoingMessage::AppServerNotification(notification);
+        assert_eq!(
+            json!({
+                "method": "account/updated",
+                "params": {
+                    "authMethod": "apikey"
                 },
             }),
             serde_json::to_value(jsonrpc_notification)

--- a/codex-rs/app-server/tests/common/mcp_process.rs
+++ b/codex-rs/app-server/tests/common/mcp_process.rs
@@ -321,6 +321,11 @@ impl McpProcess {
         self.send_request("logoutChatGpt", None).await
     }
 
+    /// Send an `account/logout` JSON-RPC request.
+    pub async fn send_logout_account_request(&mut self) -> anyhow::Result<i64> {
+        self.send_request("account/logout", None).await
+    }
+
     /// Send a `fuzzyFileSearch` JSON-RPC request.
     pub async fn send_fuzzy_file_search_request(
         &mut self,

--- a/codex-rs/app-server/tests/suite/account.rs
+++ b/codex-rs/app-server/tests/suite/account.rs
@@ -1,0 +1,89 @@
+use anyhow::Result;
+use anyhow::bail;
+use app_test_support::McpProcess;
+use app_test_support::to_response;
+use codex_app_server_protocol::GetAuthStatusParams;
+use codex_app_server_protocol::GetAuthStatusResponse;
+use codex_app_server_protocol::JSONRPCResponse;
+use codex_app_server_protocol::LogoutAccountResponse;
+use codex_app_server_protocol::RequestId;
+use codex_app_server_protocol::ServerNotification;
+use codex_core::auth::AuthCredentialsStoreMode;
+use codex_login::login_with_api_key;
+use pretty_assertions::assert_eq;
+use tempfile::TempDir;
+use tokio::time::timeout;
+
+const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+// Helper to create a minimal config.toml for the app server
+fn create_config_toml(codex_home: &std::path::Path) -> std::io::Result<()> {
+    let config_toml = codex_home.join("config.toml");
+    std::fs::write(
+        config_toml,
+        r#"
+model = "mock-model"
+approval_policy = "never"
+sandbox_mode = "danger-full-access"
+"#,
+    )
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn logout_account_removes_auth_and_notifies() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path())?;
+
+    login_with_api_key(
+        codex_home.path(),
+        "sk-test-key",
+        AuthCredentialsStoreMode::File,
+    )?;
+    assert!(codex_home.path().join("auth.json").exists());
+
+    let mut mcp = McpProcess::new_with_env(codex_home.path(), &[("OPENAI_API_KEY", None)]).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let id = mcp.send_logout_account_request().await?;
+    let resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(id)),
+    )
+    .await??;
+    let _ok: LogoutAccountResponse = to_response(resp)?;
+
+    let note = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_notification_message("account/updated"),
+    )
+    .await??;
+    let parsed: ServerNotification = note.try_into()?;
+    let ServerNotification::AccountUpdated(payload) = parsed else {
+        bail!("unexpected notification: {:?}", parsed);
+    };
+    assert!(
+        payload.auth_method.is_none(),
+        "auth_method should be None after logout"
+    );
+
+    assert!(
+        !codex_home.path().join("auth.json").exists(),
+        "auth.json should be deleted"
+    );
+
+    let status_id = mcp
+        .send_get_auth_status_request(GetAuthStatusParams {
+            include_token: Some(true),
+            refresh_token: Some(false),
+        })
+        .await?;
+    let status_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(status_id)),
+    )
+    .await??;
+    let status: GetAuthStatusResponse = to_response(status_resp)?;
+    assert_eq!(status.auth_method, None);
+    assert_eq!(status.auth_token, None);
+    Ok(())
+}

--- a/codex-rs/app-server/tests/suite/mod.rs
+++ b/codex-rs/app-server/tests/suite/mod.rs
@@ -1,4 +1,3 @@
-mod account;
 mod archive_conversation;
 mod auth;
 mod codex_message_processor_flow;
@@ -14,3 +13,4 @@ mod send_message;
 mod set_default_model;
 mod user_agent;
 mod user_info;
+mod v2;

--- a/codex-rs/app-server/tests/suite/mod.rs
+++ b/codex-rs/app-server/tests/suite/mod.rs
@@ -1,3 +1,4 @@
+mod account;
 mod archive_conversation;
 mod auth;
 mod codex_message_processor_flow;

--- a/codex-rs/app-server/tests/suite/v2/account.rs
+++ b/codex-rs/app-server/tests/suite/v2/account.rs
@@ -39,7 +39,7 @@ stream_max_retries = 0
     )
 }
 
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[tokio::test]
 async fn logout_account_removes_auth_and_notifies() -> Result<()> {
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path())?;

--- a/codex-rs/app-server/tests/suite/v2/mod.rs
+++ b/codex-rs/app-server/tests/suite/v2/mod.rs
@@ -1,0 +1,2 @@
+// v2 test suite modules
+mod account;

--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -244,7 +244,7 @@ pub mod fs_wait {
         if path.exists() {
             Ok(path)
         } else {
-            Err(anyhow!("timed out waiting for {:?}", path))
+            Err(anyhow!("timed out waiting for {path:?}"))
         }
     }
 
@@ -284,7 +284,7 @@ pub mod fs_wait {
         if let Some(found) = scan_for_match(&root, predicate) {
             Ok(found)
         } else {
-            Err(anyhow!("timed out waiting for matching file in {:?}", root))
+            Err(anyhow!("timed out waiting for matching file in {root:?}"))
         }
     }
 


### PR DESCRIPTION
V2 for `account/updated` and `account/logout` for app server. correspond to old `authStatusChange` and `LogoutChatGpt` respectively. Followup PRs will make other v2 endpoints call `account/updated` instead of `authStatusChange` too.