### PR TITLE
support user_message bg color for modern Windows terminals

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1494,7 +1494,6 @@ dependencies = [
  "unicode-width 0.2.1",
  "url",
  "vt100",
- "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1480,6 +1480,7 @@ dependencies = [
  "strum_macros 0.27.2",
  "supports-color",
  "tempfile",
+ "terminal-colorsaurus",
  "textwrap 0.16.2",
  "tokio",
  "tokio-stream",
@@ -1493,6 +1494,7 @@ dependencies = [
  "unicode-width 0.2.1",
  "url",
  "vt100",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3748,14 +3750,14 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.0.4"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
+checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
  "log",
  "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -5750,9 +5752,9 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-mio"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34db1a06d485c9142248b7a054f034b349b212551f3dfd19c94d45a754a217cd"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
 dependencies = [
  "libc",
  "mio",
@@ -6133,6 +6135,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "terminal-colorsaurus"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8909f33134da34b43f69145e748790de650a6abd84faf1f82e773444dd293ec8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "memchr",
+ "mio",
+ "terminal-trx",
+ "windows-sys 0.61.1",
+ "xterm-color",
+]
+
+[[package]]
+name = "terminal-trx"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662a3cd5ca570df622e848ef18b50c151e65c9835257465417242243b0bce783"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "windows-sys 0.61.1",
 ]
 
 [[package]]
@@ -7656,6 +7684,12 @@ dependencies = [
  "libc",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "xterm-color"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4de5f056fb9dc8b7908754867544e26145767187aaac5a98495e88ad7cb8a80f"
 
 [[package]]
 name = "yansi"

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -90,10 +90,6 @@ url = { workspace = true }
 codex-windows-sandbox = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.52", features = [
-    "Win32_Foundation",
-    "Win32_System_Console",
-] }
 terminal-colorsaurus = "1"
 
 [target.'cfg(unix)'.dependencies]

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -89,6 +89,13 @@ url = { workspace = true }
 
 codex-windows-sandbox = { workspace = true }
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.52", features = [
+    "Win32_Foundation",
+    "Win32_System_Console",
+] }
+terminal-colorsaurus = "1"
+
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
 

--- a/codex-rs/tui/src/exec_cell/render.rs
+++ b/codex-rs/tui/src/exec_cell/render.rs
@@ -140,8 +140,7 @@ pub(crate) fn output_lines(
 
 pub(crate) fn spinner(start_time: Option<Instant>) -> Span<'static> {
     let elapsed = start_time.map(|st| st.elapsed()).unwrap_or_default();
-    if crate::terminal_palette::stdout_supports_truecolor()
-    {
+    if crate::terminal_palette::stdout_supports_truecolor() {
         shimmer_spans("•")[0].clone()
     } else {
         let blink_on = (elapsed.as_millis() / 600).is_multiple_of(2);

--- a/codex-rs/tui/src/exec_cell/render.rs
+++ b/codex-rs/tui/src/exec_cell/render.rs
@@ -140,9 +140,7 @@ pub(crate) fn output_lines(
 
 pub(crate) fn spinner(start_time: Option<Instant>) -> Span<'static> {
     let elapsed = start_time.map(|st| st.elapsed()).unwrap_or_default();
-    if supports_color::on_cached(supports_color::Stream::Stdout)
-        .map(|level| level.has_16m)
-        .unwrap_or(false)
+    if crate::terminal_palette::stdout_supports_truecolor()
     {
         shimmer_spans("•")[0].clone()
     } else {

--- a/codex-rs/tui/src/shimmer.rs
+++ b/codex-rs/tui/src/shimmer.rs
@@ -30,9 +30,7 @@ pub(crate) fn shimmer_spans(text: &str) -> Vec<Span<'static>> {
     let pos_f =
         (elapsed_since_start().as_secs_f32() % sweep_seconds) / sweep_seconds * (period as f32);
     let pos = pos_f as usize;
-    let has_true_color = supports_color::on_cached(supports_color::Stream::Stdout)
-        .map(|level| level.has_16m)
-        .unwrap_or(false);
+    let has_true_color = crate::terminal_palette::stdout_supports_truecolor();
     let band_half_width = 5.0;
 
     let mut spans: Vec<Span<'static>> = Vec::with_capacity(chars.len());

--- a/codex-rs/tui/src/terminal_palette.rs
+++ b/codex-rs/tui/src/terminal_palette.rs
@@ -25,7 +25,6 @@ pub fn best_color(target: (u8, u8, u8)) -> Color {
     }
 }
 
-
 #[cfg(not(windows))]
 fn stdout_has_truecolor(level: &supports_color::ColorLevel) -> bool {
     level.has_16m
@@ -54,11 +53,11 @@ fn stdout_has_truecolor(level: &supports_color::ColorLevel) -> bool {
 #[cfg(windows)]
 fn enable_vt_stdout() -> std::io::Result<()> {
     use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+    use windows_sys::Win32::System::Console::ENABLE_VIRTUAL_TERMINAL_PROCESSING;
     use windows_sys::Win32::System::Console::GetConsoleMode;
     use windows_sys::Win32::System::Console::GetStdHandle;
-    use windows_sys::Win32::System::Console::SetConsoleMode;
-    use windows_sys::Win32::System::Console::ENABLE_VIRTUAL_TERMINAL_PROCESSING;
     use windows_sys::Win32::System::Console::STD_OUTPUT_HANDLE;
+    use windows_sys::Win32::System::Console::SetConsoleMode;
 
     unsafe {
         let handle = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -235,7 +234,10 @@ mod imp {
             Ok(p) => {
                 let (fr, fg, fb) = p.foreground.scale_to_8bit();
                 let (br, bg, bb) = p.background.scale_to_8bit();
-                Ok(Some(DefaultColors { fg: (fr, fg, fb), bg: (br, bg, bb) }))
+                Ok(Some(DefaultColors {
+                    fg: (fr, fg, fb),
+                    bg: (br, bg, bb),
+                }))
             }
             Err(_) => Ok(None),
         }
@@ -245,7 +247,9 @@ mod imp {
 #[cfg(not(any(all(unix, not(test)), all(windows, not(test)))))]
 mod imp {
     use super::DefaultColors;
-    pub(super) fn default_colors() -> Option<DefaultColors> { None }
+    pub(super) fn default_colors() -> Option<DefaultColors> {
+        None
+    }
 
     pub(super) fn requery_default_colors() {}
 }

--- a/codex-rs/tui/src/terminal_palette.rs
+++ b/codex-rs/tui/src/terminal_palette.rs
@@ -1,9 +1,9 @@
 use crate::color::perceptual_distance;
 use ratatui::style::Color;
 use std::sync::LazyLock;
+use std::sync::Mutex;
 #[cfg(windows)]
 use std::sync::OnceLock;
-use std::sync::Mutex;
 
 /// Returns the closest color to the target color that the terminal can display.
 pub fn best_color(target: (u8, u8, u8)) -> Color {
@@ -75,8 +75,8 @@ fn enable_vt_stdout() -> std::io::Result<()> {
     use std::io;
     use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
     use windows_sys::Win32::System::Console::{
-        GetConsoleMode, SetConsoleMode, GetStdHandle, ENABLE_VIRTUAL_TERMINAL_PROCESSING,
-        STD_OUTPUT_HANDLE,
+        ENABLE_VIRTUAL_TERMINAL_PROCESSING, GetConsoleMode, GetStdHandle, STD_OUTPUT_HANDLE,
+        SetConsoleMode,
     };
 
     unsafe {

--- a/codex-rs/tui/src/terminal_palette.rs
+++ b/codex-rs/tui/src/terminal_palette.rs
@@ -1,6 +1,8 @@
 use crate::color::perceptual_distance;
 use ratatui::style::Color;
+#[cfg(not(test))]
 use std::sync::LazyLock;
+#[cfg(not(test))]
 use std::sync::Mutex;
 #[cfg(windows)]
 use std::sync::OnceLock;
@@ -74,10 +76,11 @@ pub fn stdout_supports_truecolor() -> bool {
 fn enable_vt_stdout() -> std::io::Result<()> {
     use std::io;
     use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
-    use windows_sys::Win32::System::Console::{
-        ENABLE_VIRTUAL_TERMINAL_PROCESSING, GetConsoleMode, GetStdHandle, STD_OUTPUT_HANDLE,
-        SetConsoleMode,
-    };
+    use windows_sys::Win32::System::Console::ENABLE_VIRTUAL_TERMINAL_PROCESSING;
+    use windows_sys::Win32::System::Console::GetConsoleMode;
+    use windows_sys::Win32::System::Console::GetStdHandle;
+    use windows_sys::Win32::System::Console::STD_OUTPUT_HANDLE;
+    use windows_sys::Win32::System::Console::SetConsoleMode;
 
     unsafe {
         let handle = GetStdHandle(STD_OUTPUT_HANDLE);
@@ -131,11 +134,13 @@ pub fn default_bg() -> Option<(u8, u8, u8)> {
 /// `get_or_init_with` for the first successful query and `refresh_with` for a manual re-query.
 /// If a first query fails, we remember the failure to avoid repeated failed probes, unless
 /// a subsequent explicit refresh is performed.
+#[cfg(not(test))]
 struct Cache<T> {
     attempted: bool,
     value: Option<T>,
 }
 
+#[cfg(not(test))]
 impl<T> Default for Cache<T> {
     fn default() -> Self {
         Self {
@@ -145,6 +150,7 @@ impl<T> Default for Cache<T> {
     }
 }
 
+#[cfg(not(test))]
 impl<T: Copy> Cache<T> {
     /// Returns the cached value if available; otherwise runs `init` once and caches its result.
     fn get_or_init_with(&mut self, mut init: impl FnMut() -> Option<T>) -> Option<T> {
@@ -163,6 +169,7 @@ impl<T: Copy> Cache<T> {
     }
 }
 
+#[cfg(not(test))]
 fn default_terminal_colors_cache() -> &'static Mutex<Cache<DefaultColors>> {
     // LazyLock creates the single cache instance; the Mutex guards concurrent refreshes/reads.
     static CACHE: LazyLock<Mutex<Cache<DefaultColors>>> =

--- a/codex-rs/tui/src/terminal_palette.rs
+++ b/codex-rs/tui/src/terminal_palette.rs
@@ -1,6 +1,7 @@
 use crate::color::perceptual_distance;
 use ratatui::style::Color;
 use std::sync::LazyLock;
+#[cfg(windows)]
 use std::sync::OnceLock;
 use std::sync::Mutex;
 


### PR DESCRIPTION
Implements the "user message background" shading for modern Windows Terminals.

Windows Terminal does not make it easy to
- detect truecolor (supports-color basically is non-functional for Windows)
- detect the actual background color of the current shell.

This PR
- applies a heuristic to detect modern Windows Terminals by looking for the WT_SESSION env variable, and ensuring that ENABLE_VIRTUAL_TERMINAL_PROCESSING can be set on the terminal
- introduces the [terminal_colorsaurus](https://docs.rs/terminal-colorsaurus/latest/terminal_colorsaurus/) crate, which abstracts away the details of actual determining the terminal color on Windows, which is non-trivial

examples:
<img width="932" height="379" alt="image" src="https://github.com/user-attachments/assets/4ec04f60-df5a-429f-bc26-a91bb62dc68b" />
<img width="985" height="419" alt="image" src="https://github.com/user-attachments/assets/9b2dcb2d-d73a-4a9c-83d9-30c927b82689" />
<img width="946" height="408" alt="image" src="https://github.com/user-attachments/assets/29a2e54f-b8f5-4a03-a0aa-a9874d55dc60" />
<img width="938" height="394" alt="image" src="https://github.com/user-attachments/assets/78683bd2-7824-4aba-a38a-991b491ec9ff" />

