### PR TITLE
fix: pin musl 1.2.5 for DNS fixes

### DIFF
--- a/.github/actions/setup-musl-1_2_5/action.yml
+++ b/.github/actions/setup-musl-1_2_5/action.yml
@@ -1,0 +1,47 @@
+name: Setup musl 1.2.5 toolchain
+description: Install musl 1.2.5 from source and configure the linker for the requested target.
+inputs:
+  target:
+    description: Cargo target triple that requires musl (e.g., x86_64-unknown-linux-musl).
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Install musl 1.2.5
+      shell: bash
+      env:
+        MUSL_VERSION: 1.2.5
+        MUSL_PREFIX: /opt/musl-1.2.5
+        DEBIAN_FRONTEND: noninteractive
+      run: |
+        set -euo pipefail
+        sudo apt-get -y update -o Acquire::Retries=3
+        sudo apt-get -y install --no-install-recommends build-essential curl pkg-config
+
+        curl -sSfL --retry 3 --retry-delay 1 "https://musl.libc.org/releases/musl-${MUSL_VERSION}.tar.gz" -o /tmp/musl.tar.gz
+        tar -xf /tmp/musl.tar.gz -C /tmp
+
+        pushd "/tmp/musl-${MUSL_VERSION}"
+        ./configure --prefix="${MUSL_PREFIX}"
+        make -j"$(nproc)"
+        sudo make install
+        popd
+
+        echo "${MUSL_PREFIX}/bin" >> "$GITHUB_PATH"
+        musl_gcc="${MUSL_PREFIX}/bin/musl-gcc"
+        "${musl_gcc}" --version
+
+        case "${{ inputs.target }}" in
+          x86_64-unknown-linux-musl)
+            echo "CC_x86_64_unknown_linux_musl=${musl_gcc}" >> "$GITHUB_ENV"
+            echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=${musl_gcc}" >> "$GITHUB_ENV"
+            ;;
+          aarch64-unknown-linux-musl)
+            echo "CC_aarch64_unknown_linux_musl=${musl_gcc}" >> "$GITHUB_ENV"
+            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=${musl_gcc}" >> "$GITHUB_ENV"
+            ;;
+          *)
+            echo "Unsupported musl target '${{ inputs.target }}'" >&2
+            exit 1
+            ;;
+        esac

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -217,38 +217,10 @@ jobs:
           key: apt-${{ matrix.runner }}-${{ matrix.target }}-v1
 
       - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl'}}
-        name: Install musl 1.2.5 toolchain
-        env:
-          DEBIAN_FRONTEND: noninteractive
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo apt-get -y update -o Acquire::Retries=3
-          sudo apt-get -y install --no-install-recommends build-essential curl pkg-config
-
-          musl_version="1.2.5"
-          musl_prefix="/opt/musl-${musl_version}"
-          curl -sSfL --retry 3 --retry-delay 1 "https://musl.libc.org/releases/musl-${musl_version}.tar.gz" -o /tmp/musl.tar.gz
-          tar -xf /tmp/musl.tar.gz -C /tmp
-
-          pushd "/tmp/musl-${musl_version}"
-          ./configure --prefix="${musl_prefix}"
-          make -j"$(nproc)"
-          sudo make install
-          popd
-
-          echo "${musl_prefix}/bin" >> "$GITHUB_PATH"
-          musl_gcc="${musl_prefix}/bin/musl-gcc"
-          "${musl_gcc}" --version
-
-          target="${{ matrix.target }}"
-          if [[ "${target}" == "x86_64-unknown-linux-musl" ]]; then
-            echo "CC_x86_64_unknown_linux_musl=${musl_gcc}" >> "$GITHUB_ENV"
-            echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=${musl_gcc}" >> "$GITHUB_ENV"
-          else
-            echo "CC_aarch64_unknown_linux_musl=${musl_gcc}" >> "$GITHUB_ENV"
-            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=${musl_gcc}" >> "$GITHUB_ENV"
-          fi
+        name: Setup musl 1.2.5 toolchain
+        uses: ./.github/actions/setup-musl-1_2_5
+        with:
+          target: ${{ matrix.target }}
 
       - name: Install cargo-chef
         if: ${{ matrix.profile == 'release' }}

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -217,14 +217,38 @@ jobs:
           key: apt-${{ matrix.runner }}-${{ matrix.target }}-v1
 
       - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl'}}
-        name: Install musl build tools
+        name: Install musl 1.2.5 toolchain
         env:
           DEBIAN_FRONTEND: noninteractive
         shell: bash
         run: |
           set -euo pipefail
           sudo apt-get -y update -o Acquire::Retries=3
-          sudo apt-get -y install --no-install-recommends musl-tools pkg-config
+          sudo apt-get -y install --no-install-recommends build-essential curl pkg-config
+
+          musl_version="1.2.5"
+          musl_prefix="/opt/musl-${musl_version}"
+          curl -sSfL --retry 3 --retry-delay 1 "https://musl.libc.org/releases/musl-${musl_version}.tar.gz" -o /tmp/musl.tar.gz
+          tar -xf /tmp/musl.tar.gz -C /tmp
+
+          pushd "/tmp/musl-${musl_version}"
+          ./configure --prefix="${musl_prefix}"
+          make -j"$(nproc)"
+          sudo make install
+          popd
+
+          echo "${musl_prefix}/bin" >> "$GITHUB_PATH"
+          musl_gcc="${musl_prefix}/bin/musl-gcc"
+          "${musl_gcc}" --version
+
+          target="${{ matrix.target }}"
+          if [[ "${target}" == "x86_64-unknown-linux-musl" ]]; then
+            echo "CC_x86_64_unknown_linux_musl=${musl_gcc}" >> "$GITHUB_ENV"
+            echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=${musl_gcc}" >> "$GITHUB_ENV"
+          else
+            echo "CC_aarch64_unknown_linux_musl=${musl_gcc}" >> "$GITHUB_ENV"
+            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=${musl_gcc}" >> "$GITHUB_ENV"
+          fi
 
       - name: Install cargo-chef
         if: ${{ matrix.profile == 'release' }}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -92,35 +92,10 @@ jobs:
           key: cargo-${{ matrix.runner }}-${{ matrix.target }}-release-${{ hashFiles('**/Cargo.lock') }}
 
       - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl'}}
-        name: Install musl 1.2.5 toolchain
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          sudo apt-get install -y build-essential curl pkg-config
-
-          musl_version="1.2.5"
-          musl_prefix="/opt/musl-${musl_version}"
-          curl -sSfL --retry 3 --retry-delay 1 "https://musl.libc.org/releases/musl-${musl_version}.tar.gz" -o /tmp/musl.tar.gz
-          tar -xf /tmp/musl.tar.gz -C /tmp
-
-          pushd "/tmp/musl-${musl_version}"
-          ./configure --prefix="${musl_prefix}"
-          make -j"$(nproc)"
-          sudo make install
-          popd
-
-          echo "${musl_prefix}/bin" >> "$GITHUB_PATH"
-          musl_gcc="${musl_prefix}/bin/musl-gcc"
-          "${musl_gcc}" --version
-
-          target="${{ matrix.target }}"
-          if [[ "${target}" == "x86_64-unknown-linux-musl" ]]; then
-            echo "CC_x86_64_unknown_linux_musl=${musl_gcc}" >> "$GITHUB_ENV"
-            echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=${musl_gcc}" >> "$GITHUB_ENV"
-          else
-            echo "CC_aarch64_unknown_linux_musl=${musl_gcc}" >> "$GITHUB_ENV"
-            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=${musl_gcc}" >> "$GITHUB_ENV"
-          fi
+        name: Setup musl 1.2.5 toolchain
+        uses: ./.github/actions/setup-musl-1_2_5
+        with:
+          target: ${{ matrix.target }}
 
       - name: Cargo build
         run: cargo build --target ${{ matrix.target }} --release --bin codex --bin codex-responses-api-proxy

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -92,10 +92,35 @@ jobs:
           key: cargo-${{ matrix.runner }}-${{ matrix.target }}-release-${{ hashFiles('**/Cargo.lock') }}
 
       - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl'}}
-        name: Install musl build tools
+        name: Install musl 1.2.5 toolchain
         run: |
+          set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y musl-tools pkg-config
+          sudo apt-get install -y build-essential curl pkg-config
+
+          musl_version="1.2.5"
+          musl_prefix="/opt/musl-${musl_version}"
+          curl -sSfL --retry 3 --retry-delay 1 "https://musl.libc.org/releases/musl-${musl_version}.tar.gz" -o /tmp/musl.tar.gz
+          tar -xf /tmp/musl.tar.gz -C /tmp
+
+          pushd "/tmp/musl-${musl_version}"
+          ./configure --prefix="${musl_prefix}"
+          make -j"$(nproc)"
+          sudo make install
+          popd
+
+          echo "${musl_prefix}/bin" >> "$GITHUB_PATH"
+          musl_gcc="${musl_prefix}/bin/musl-gcc"
+          "${musl_gcc}" --version
+
+          target="${{ matrix.target }}"
+          if [[ "${target}" == "x86_64-unknown-linux-musl" ]]; then
+            echo "CC_x86_64_unknown_linux_musl=${musl_gcc}" >> "$GITHUB_ENV"
+            echo "CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=${musl_gcc}" >> "$GITHUB_ENV"
+          else
+            echo "CC_aarch64_unknown_linux_musl=${musl_gcc}" >> "$GITHUB_ENV"
+            echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=${musl_gcc}" >> "$GITHUB_ENV"
+          fi
 
       - name: Cargo build
         run: cargo build --target ${{ matrix.target }} --release --bin codex --bin codex-responses-api-proxy


### PR DESCRIPTION
## Summary
musl 1.2.5 includes [several fixes to DNS over TCP](https://www.openwall.com/lists/musl/2024/03/01/2), which appears to be the root cause of #6116.

This approach is a bit janky, but according to codex:
> On the Ubuntu 24.04 runners we use, apt-cache policy musl-tools shows only the distro build (1.2.4-2ubuntu2)" 

We should build with this version and confirm.

## Testing
- [ ] TODO: test and see if this fixes Azure issues