### PR TITLE
feat: auto-continue working when there is more left to do

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ Codex can access MCP servers. To configure them, refer to the [config docs](./do
 
 Codex CLI supports a rich set of configuration options, with preferences stored in `~/.codex/config.toml`. For full configuration options, see [Configuration](./docs/config.md).
 
+Prefer a quieter terminal? Run `codex --no-progress "…"` to silence interim reasoning, or `codex --progress-interval 300 "…"` to show at most one update every five minutes. When you want Codex to keep iterating hands-free, add `--auto-continue` (with optional `--auto-continue-max-turns`, `--auto-continue-max-duration`, or `--auto-continue-prompt`). If auto-continue pauses because a turn finished or you interrupted the run, the next prompt you type automatically re-arms it for the new work. In the TUI, you can also toggle it explicitly with `/auto-continue-on` and `/auto-continue-off`.
+
 ---
 
 ### Docs & FAQ

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1780,6 +1780,12 @@ async fn derive_config_from_params(
         show_raw_agent_reasoning: None,
         tools_web_search_request: None,
         experimental_sandbox_command_assessment: None,
+        progress_no_progress: None,
+        progress_interval_seconds: None,
+        auto_continue_enabled: None,
+        auto_continue_prompt: None,
+        auto_continue_max_turns: None,
+        auto_continue_max_duration_seconds: None,
         additional_writable_roots: Vec::new(),
     };
 

--- a/codex-rs/common/src/config_summary.rs
+++ b/codex-rs/common/src/config_summary.rs
@@ -1,6 +1,7 @@
 use codex_core::WireApi;
 use codex_core::config::Config;
 
+use crate::elapsed::format_duration;
 use crate::sandbox_summary::summarize_sandbox_policy;
 
 /// Build a list of key/value pairs summarizing the effective configuration.
@@ -26,6 +27,28 @@ pub fn create_config_summary_entries(config: &Config) -> Vec<(&'static str, Stri
             "reasoning summaries",
             config.model_reasoning_summary.to_string(),
         ));
+    }
+
+    if config.progress.no_progress {
+        entries.push(("progress", "disabled".to_string()));
+    } else if let Some(interval) = config.progress.interval_seconds {
+        entries.push(("progress", format!("every {}s", interval.get())));
+    }
+
+    if config.auto_continue.enabled {
+        let mut details = Vec::new();
+        if let Some(limit) = config.auto_continue.max_turns {
+            details.push(format!("max {} turn(s)", limit.get()));
+        }
+        if let Some(duration) = config.auto_continue.max_duration {
+            details.push(format!("max {}", format_duration(duration)));
+        }
+        let summary = if details.is_empty() {
+            "enabled".to_string()
+        } else {
+            format!("enabled ({})", details.join(", "))
+        };
+        entries.push(("auto-continue", summary));
     }
 
     entries

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -47,8 +47,10 @@ use similar::DiffableStr;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::io::ErrorKind;
+use std::num::NonZeroU64;
 use std::path::Path;
 use std::path::PathBuf;
+use std::time::Duration;
 
 use crate::config::profile::ConfigProfile;
 use toml::Value as TomlValue;
@@ -64,6 +66,7 @@ pub const OPENAI_DEFAULT_MODEL: &str = "gpt-5";
 pub const OPENAI_DEFAULT_MODEL: &str = "gpt-5-codex";
 const OPENAI_DEFAULT_REVIEW_MODEL: &str = "gpt-5-codex";
 pub const GPT_5_CODEX_MEDIUM_MODEL: &str = "gpt-5-codex";
+pub const MIN_PROGRESS_INTERVAL_SECONDS: u64 = 5;
 
 /// Maximum number of bytes of the documentation that will be embedded. Larger
 /// files are *silently truncated* to this size so we do not take up too much of
@@ -199,6 +202,12 @@ pub struct Config {
     /// Settings that govern if and what will be written to `~/.codex/history.jsonl`.
     pub history: History,
 
+    /// Controls how model progress updates should be surfaced to front-ends.
+    pub progress: ProgressConfig,
+
+    /// Controls whether Codex should autonomously continue turns after completions.
+    pub auto_continue: AutoContinueConfig,
+
     /// Optional URI-based file opener. If set, citations to files in the model
     /// output will be hyperlinked using the specified URI scheme.
     pub file_opener: UriBasedFileOpener,
@@ -273,6 +282,34 @@ pub struct Config {
 
     /// OTEL configuration (exporter type, endpoint, headers, etc.).
     pub otel: crate::config::types::OtelConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct ProgressConfig {
+    pub no_progress: bool,
+    pub interval_seconds: Option<NonZeroU64>,
+}
+
+pub const DEFAULT_AUTO_CONTINUE_PROMPT: &str = "continue";
+pub const MAX_AUTO_CONTINUE_PROMPT_LEN: usize = 400;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct AutoContinueConfig {
+    pub enabled: bool,
+    pub prompt: String,
+    pub max_turns: Option<NonZeroU64>,
+    pub max_duration: Option<Duration>,
+}
+
+impl Default for AutoContinueConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            prompt: DEFAULT_AUTO_CONTINUE_PROMPT.to_string(),
+            max_turns: None,
+            max_duration: None,
+        }
+    }
 }
 
 impl Config {
@@ -506,7 +543,27 @@ fn apply_toml_override(root: &mut TomlValue, path: &str, value: TomlValue) {
 }
 
 /// Base config deserialized from ~/.codex/config.toml.
-#[derive(Deserialize, Debug, Clone, Default, PartialEq)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Deserialize)]
+pub struct ProgressToml {
+    #[serde(default)]
+    pub no_progress: Option<bool>,
+    #[serde(default)]
+    pub interval_seconds: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
+pub struct AutoContinueToml {
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub prompt: Option<String>,
+    #[serde(default)]
+    pub max_turns: Option<u64>,
+    #[serde(default)]
+    pub max_duration_seconds: Option<u64>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Deserialize)]
 pub struct ConfigToml {
     /// Optional override of model selection.
     pub model: Option<String>,
@@ -598,6 +655,14 @@ pub struct ConfigToml {
     /// Settings that govern if and what will be written to `~/.codex/history.jsonl`.
     #[serde(default)]
     pub history: Option<History>,
+
+    /// Controls how model progress updates should be surfaced to front-ends.
+    #[serde(default)]
+    pub progress: Option<ProgressToml>,
+
+    /// Controls whether Codex should automatically continue turns.
+    #[serde(default)]
+    pub auto_continue: Option<AutoContinueToml>,
 
     /// Optional URI-based file opener. If set, citations to files in the model
     /// output will be hyperlinked using the specified URI scheme.
@@ -843,6 +908,12 @@ pub struct ConfigOverrides {
     pub show_raw_agent_reasoning: Option<bool>,
     pub tools_web_search_request: Option<bool>,
     pub experimental_sandbox_command_assessment: Option<bool>,
+    pub progress_no_progress: Option<bool>,
+    pub progress_interval_seconds: Option<u64>,
+    pub auto_continue_enabled: Option<bool>,
+    pub auto_continue_prompt: Option<String>,
+    pub auto_continue_max_turns: Option<u64>,
+    pub auto_continue_max_duration_seconds: Option<u64>,
     /// Additional directories that should be treated as writable roots for this session.
     pub additional_writable_roots: Vec<PathBuf>,
 }
@@ -874,6 +945,12 @@ impl Config {
             show_raw_agent_reasoning,
             tools_web_search_request: override_tools_web_search_request,
             experimental_sandbox_command_assessment: sandbox_command_assessment_override,
+            progress_no_progress,
+            progress_interval_seconds,
+            auto_continue_enabled,
+            auto_continue_prompt,
+            auto_continue_max_turns,
+            auto_continue_max_duration_seconds,
             additional_writable_roots,
         } = overrides;
 
@@ -882,16 +959,24 @@ impl Config {
             .or(cfg.profile.as_ref())
             .cloned();
         let config_profile = match active_profile_name.as_ref() {
-            Some(key) => cfg
-                .profiles
-                .get(key)
-                .ok_or_else(|| {
-                    std::io::Error::new(
-                        std::io::ErrorKind::NotFound,
-                        format!("config profile `{key}` not found"),
-                    )
-                })?
-                .clone(),
+            Some(key) => {
+                if key == "deepwork" {
+                    cfg.profiles
+                        .get(key)
+                        .cloned()
+                        .unwrap_or_else(ConfigProfile::deepwork)
+                } else {
+                    cfg.profiles
+                        .get(key)
+                        .ok_or_else(|| {
+                            std::io::Error::new(
+                                std::io::ErrorKind::NotFound,
+                                format!("config profile `{key}` not found"),
+                            )
+                        })?
+                        .clone()
+                }
+            }
             None => ConfigProfile::default(),
         };
 
@@ -996,6 +1081,24 @@ impl Config {
         let shell_environment_policy = cfg.shell_environment_policy.into();
 
         let history = cfg.history.unwrap_or_default();
+
+        let progress = resolve_progress_config(
+            cfg.progress.as_ref(),
+            config_profile.progress.as_ref(),
+            progress_no_progress,
+            progress_interval_seconds,
+            active_profile_name.as_deref(),
+        )?;
+        let auto_continue = resolve_auto_continue_config(
+            cfg.auto_continue.as_ref(),
+            config_profile.auto_continue.as_ref(),
+            auto_continue_enabled,
+            auto_continue_prompt,
+            auto_continue_max_turns,
+            auto_continue_max_duration_seconds,
+        )?;
+        let hide_agent_reasoning =
+            cfg.hide_agent_reasoning.unwrap_or(false) || progress.no_progress;
 
         let include_apply_patch_tool_flag = features.enabled(Feature::ApplyPatchFreeform);
         let tools_web_search_request = features.enabled(Feature::WebSearchRequest);
@@ -1131,10 +1234,12 @@ impl Config {
                 .collect(),
             codex_home,
             history,
+            progress,
+            auto_continue,
             file_opener: cfg.file_opener.unwrap_or(UriBasedFileOpener::VsCode),
             codex_linux_sandbox_exe,
 
-            hide_agent_reasoning: cfg.hide_agent_reasoning.unwrap_or(false),
+            hide_agent_reasoning,
             show_raw_agent_reasoning: cfg
                 .show_raw_agent_reasoning
                 .or(show_raw_agent_reasoning)
@@ -1234,6 +1339,193 @@ impl Config {
             Ok(Some(s))
         }
     }
+}
+
+fn resolve_progress_config(
+    base: Option<&ProgressToml>,
+    profile: Option<&ProgressToml>,
+    override_no_progress: Option<bool>,
+    override_interval_seconds: Option<u64>,
+    active_profile_name: Option<&str>,
+) -> std::io::Result<ProgressConfig> {
+    let mut resolved = ProgressConfig::default();
+
+    if let Some(progress) = base {
+        if let Some(value) = progress.no_progress {
+            resolved.no_progress = value;
+        }
+        if progress.interval_seconds.is_some() {
+            resolved.interval_seconds =
+                sanitize_progress_interval(progress.interval_seconds, "progress.interval_seconds")?;
+        }
+    }
+
+    if let Some(progress) = profile {
+        if let Some(value) = progress.no_progress {
+            resolved.no_progress = value;
+        }
+        if progress.interval_seconds.is_some() {
+            let label = active_profile_name
+                .map(|name| format!("profile `{name}` progress.interval_seconds"))
+                .unwrap_or_else(|| "profile progress.interval_seconds".to_string());
+            resolved.interval_seconds =
+                sanitize_progress_interval(progress.interval_seconds, &label)?;
+        }
+    }
+
+    if let Some(value) = override_no_progress {
+        resolved.no_progress = value;
+    }
+
+    if let Some(value) = override_interval_seconds {
+        resolved.interval_seconds =
+            sanitize_progress_interval(Some(value), "CLI flag --progress-interval")?;
+    }
+
+    Ok(resolved)
+}
+
+fn sanitize_progress_interval(
+    raw: Option<u64>,
+    source: &str,
+) -> std::io::Result<Option<NonZeroU64>> {
+    let Some(value) = raw else {
+        return Ok(None);
+    };
+
+    if value == 0 {
+        return Ok(None);
+    }
+
+    if value < MIN_PROGRESS_INTERVAL_SECONDS {
+        return Err(std::io::Error::new(
+            ErrorKind::InvalidInput,
+            format!(
+                "{source} must be at least {MIN_PROGRESS_INTERVAL_SECONDS} seconds when set (got {value})"
+            ),
+        ));
+    }
+
+    Ok(NonZeroU64::new(value))
+}
+
+fn resolve_auto_continue_config(
+    base: Option<&AutoContinueToml>,
+    profile: Option<&AutoContinueToml>,
+    override_enabled: Option<bool>,
+    override_prompt: Option<String>,
+    override_max_turns: Option<u64>,
+    override_max_duration_seconds: Option<u64>,
+) -> std::io::Result<AutoContinueConfig> {
+    let mut resolved = AutoContinueConfig::default();
+
+    apply_auto_continue_table(&mut resolved, base, "auto_continue")?;
+    apply_auto_continue_table(&mut resolved, profile, "profile auto_continue")?;
+
+    if let Some(enabled) = override_enabled {
+        resolved.enabled = enabled;
+    }
+
+    if let Some(prompt) = override_prompt {
+        resolved.prompt =
+            sanitize_auto_continue_prompt(&prompt, "CLI flag --auto-continue-prompt")?;
+    }
+
+    if let Some(max_turns) = override_max_turns {
+        resolved.max_turns =
+            sanitize_auto_continue_turns(Some(max_turns), "CLI flag --auto-continue-max-turns")?;
+    }
+
+    if let Some(seconds) = override_max_duration_seconds {
+        resolved.max_duration = sanitize_auto_continue_duration(
+            Some(seconds),
+            "CLI flag --auto-continue-max-duration",
+        )?;
+    }
+
+    Ok(resolved)
+}
+
+fn apply_auto_continue_table(
+    resolved: &mut AutoContinueConfig,
+    table: Option<&AutoContinueToml>,
+    source: &str,
+) -> std::io::Result<()> {
+    let Some(table) = table else {
+        return Ok(());
+    };
+
+    if let Some(enabled) = table.enabled {
+        resolved.enabled = enabled;
+    }
+    if let Some(ref prompt) = table.prompt {
+        resolved.prompt = sanitize_auto_continue_prompt(prompt, source)?;
+    }
+    if table.max_turns.is_some() {
+        resolved.max_turns = sanitize_auto_continue_turns(table.max_turns, source)?;
+    }
+    if table.max_duration_seconds.is_some() {
+        resolved.max_duration =
+            sanitize_auto_continue_duration(table.max_duration_seconds, source)?;
+    }
+    Ok(())
+}
+
+fn sanitize_auto_continue_prompt(prompt: &str, source: &str) -> std::io::Result<String> {
+    let trimmed = prompt.trim();
+    if trimmed.is_empty() {
+        return Err(std::io::Error::new(
+            ErrorKind::InvalidInput,
+            format!("{source} prompt must be non-empty when set"),
+        ));
+    }
+    if trimmed.len() > MAX_AUTO_CONTINUE_PROMPT_LEN {
+        return Err(std::io::Error::new(
+            ErrorKind::InvalidInput,
+            format!(
+                "{source} prompt must be at most {MAX_AUTO_CONTINUE_PROMPT_LEN} characters (got {})",
+                trimmed.len()
+            ),
+        ));
+    }
+    Ok(trimmed.to_string())
+}
+
+fn sanitize_auto_continue_turns(
+    raw: Option<u64>,
+    source: &str,
+) -> std::io::Result<Option<NonZeroU64>> {
+    let Some(value) = raw else {
+        return Ok(None);
+    };
+
+    if value == 0 {
+        return Ok(None);
+    }
+
+    NonZeroU64::new(value)
+        .ok_or_else(|| {
+            std::io::Error::new(
+                ErrorKind::InvalidInput,
+                format!("{source} max_turns must be greater than zero when set"),
+            )
+        })
+        .map(Some)
+}
+
+fn sanitize_auto_continue_duration(
+    raw: Option<u64>,
+    _source: &str,
+) -> std::io::Result<Option<Duration>> {
+    let Some(seconds) = raw else {
+        return Ok(None);
+    };
+
+    if seconds == 0 {
+        return Ok(None);
+    }
+
+    Ok(Some(Duration::from_secs(seconds)))
 }
 
 fn default_model() -> String {
@@ -1685,6 +1977,109 @@ trust_level = "trusted"
             ));
             assert!(!config.forced_auto_mode_downgraded_on_windows);
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn progress_defaults_disabled() -> std::io::Result<()> {
+        let codex_home = TempDir::new()?;
+        let config = Config::load_from_base_config_with_overrides(
+            ConfigToml::default(),
+            ConfigOverrides::default(),
+            codex_home.path().to_path_buf(),
+        )?;
+
+        assert!(!config.progress.no_progress);
+        assert!(config.progress.interval_seconds.is_none());
+
+        Ok(())
+    }
+
+    #[test]
+    fn progress_merges_sources_with_cli_override() -> std::io::Result<()> {
+        let codex_home = TempDir::new()?;
+        let mut profiles = HashMap::new();
+        profiles.insert(
+            "focus".to_string(),
+            ConfigProfile {
+                progress: Some(ProgressToml {
+                    no_progress: Some(true),
+                    interval_seconds: Some(MIN_PROGRESS_INTERVAL_SECONDS + 5),
+                }),
+                ..Default::default()
+            },
+        );
+
+        let cfg = ConfigToml {
+            progress: Some(ProgressToml {
+                no_progress: Some(false),
+                interval_seconds: Some(MIN_PROGRESS_INTERVAL_SECONDS + 10),
+            }),
+            profiles,
+            profile: Some("focus".to_string()),
+            ..Default::default()
+        };
+
+        let overrides = ConfigOverrides {
+            progress_no_progress: Some(false),
+            progress_interval_seconds: Some(MIN_PROGRESS_INTERVAL_SECONDS + 15),
+            ..Default::default()
+        };
+
+        let config = Config::load_from_base_config_with_overrides(
+            cfg,
+            overrides,
+            codex_home.path().to_path_buf(),
+        )?;
+
+        assert!(!config.progress.no_progress);
+        assert_eq!(
+            config.progress.interval_seconds,
+            NonZeroU64::new(MIN_PROGRESS_INTERVAL_SECONDS + 15)
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn progress_interval_validation_rejects_small_values() {
+        let codex_home = TempDir::new().expect("create temp dir");
+        let cfg = ConfigToml {
+            progress: Some(ProgressToml {
+                interval_seconds: Some(MIN_PROGRESS_INTERVAL_SECONDS - 1),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let err = Config::load_from_base_config_with_overrides(
+            cfg,
+            ConfigOverrides::default(),
+            codex_home.path().to_path_buf(),
+        )
+        .unwrap_err();
+
+        assert_eq!(err.kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[test]
+    fn deepwork_profile_defaults_to_no_progress() -> std::io::Result<()> {
+        let codex_home = TempDir::new()?;
+        let cfg = ConfigToml {
+            profile: Some("deepwork".to_string()),
+            ..Default::default()
+        };
+
+        let config = Config::load_from_base_config_with_overrides(
+            cfg,
+            ConfigOverrides::default(),
+            codex_home.path().to_path_buf(),
+        )?;
+
+        assert!(matches!(config.approval_policy, AskForApproval::OnFailure));
+        assert!(config.progress.no_progress);
+        assert!(config.progress.interval_seconds.is_none());
 
         Ok(())
     }
@@ -2886,6 +3281,8 @@ model_verbosity = "high"
                 project_doc_fallback_filenames: Vec::new(),
                 codex_home: fixture.codex_home(),
                 history: History::default(),
+                progress: ProgressConfig::default(),
+                auto_continue: AutoContinueConfig::default(),
                 file_opener: UriBasedFileOpener::VsCode,
                 codex_linux_sandbox_exe: None,
                 hide_agent_reasoning: false,
@@ -2958,6 +3355,8 @@ model_verbosity = "high"
             project_doc_fallback_filenames: Vec::new(),
             codex_home: fixture.codex_home(),
             history: History::default(),
+            progress: ProgressConfig::default(),
+            auto_continue: AutoContinueConfig::default(),
             file_opener: UriBasedFileOpener::VsCode,
             codex_linux_sandbox_exe: None,
             hide_agent_reasoning: false,
@@ -3045,6 +3444,8 @@ model_verbosity = "high"
             project_doc_fallback_filenames: Vec::new(),
             codex_home: fixture.codex_home(),
             history: History::default(),
+            progress: ProgressConfig::default(),
+            auto_continue: AutoContinueConfig::default(),
             file_opener: UriBasedFileOpener::VsCode,
             codex_linux_sandbox_exe: None,
             hide_agent_reasoning: false,
@@ -3118,6 +3519,8 @@ model_verbosity = "high"
             project_doc_fallback_filenames: Vec::new(),
             codex_home: fixture.codex_home(),
             history: History::default(),
+            progress: ProgressConfig::default(),
+            auto_continue: AutoContinueConfig::default(),
             file_opener: UriBasedFileOpener::VsCode,
             codex_linux_sandbox_exe: None,
             hide_agent_reasoning: false,

--- a/codex-rs/core/src/config/profile.rs
+++ b/codex-rs/core/src/config/profile.rs
@@ -1,6 +1,8 @@
 use serde::Deserialize;
 use std::path::PathBuf;
 
+use super::AutoContinueToml;
+use super::ProgressToml;
 use crate::protocol::AskForApproval;
 use codex_protocol::config_types::ReasoningEffort;
 use codex_protocol::config_types::ReasoningSummary;
@@ -34,6 +36,10 @@ pub struct ConfigProfile {
     /// Optional feature toggles scoped to this profile.
     #[serde(default)]
     pub features: Option<crate::features::FeaturesToml>,
+    #[serde(default)]
+    pub progress: Option<ProgressToml>,
+    #[serde(default)]
+    pub auto_continue: Option<AutoContinueToml>,
 }
 
 impl From<ConfigProfile> for codex_app_server_protocol::Profile {
@@ -46,6 +52,25 @@ impl From<ConfigProfile> for codex_app_server_protocol::Profile {
             model_reasoning_summary: config_profile.model_reasoning_summary,
             model_verbosity: config_profile.model_verbosity,
             chatgpt_base_url: config_profile.chatgpt_base_url,
+        }
+    }
+}
+
+impl ConfigProfile {
+    pub fn deepwork() -> Self {
+        Self {
+            approval_policy: Some(AskForApproval::OnFailure),
+            progress: Some(ProgressToml {
+                no_progress: Some(true),
+                interval_seconds: None,
+            }),
+            auto_continue: Some(AutoContinueToml {
+                enabled: Some(true),
+                prompt: None,
+                max_turns: None,
+                max_duration_seconds: None,
+            }),
+            ..Self::default()
         }
     }
 }

--- a/codex-rs/core/src/conversation_manager.rs
+++ b/codex-rs/core/src/conversation_manager.rs
@@ -309,7 +309,7 @@ mod tests {
 
     #[test]
     fn ignores_session_prefix_messages_when_truncating() {
-        let (session, turn_context) = make_session_and_context();
+        let (session, turn_context, _rx_submission) = make_session_and_context();
         let mut items = session.build_initial_context(&turn_context);
         items.push(user_msg("feature request"));
         items.push(assistant_msg("ack"));

--- a/codex-rs/core/src/state/mod.rs
+++ b/codex-rs/core/src/state/mod.rs
@@ -3,6 +3,8 @@ mod session;
 mod turn;
 
 pub(crate) use service::SessionServices;
+pub(crate) use session::AutoContinueDecision;
+pub(crate) use session::AutoContinueStopReason;
 pub(crate) use session::SessionState;
 pub(crate) use turn::ActiveTurn;
 pub(crate) use turn::RunningTask;

--- a/codex-rs/core/src/state/service.rs
+++ b/codex-rs/core/src/state/service.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::AuthManager;
 use crate::RolloutRecorder;
+use crate::config::ProgressConfig;
 use crate::mcp_connection_manager::McpConnectionManager;
 use crate::tools::sandboxing::ApprovalStore;
 use crate::unified_exec::UnifiedExecSessionManager;
@@ -16,6 +17,7 @@ pub(crate) struct SessionServices {
     pub(crate) rollout: Mutex<Option<RolloutRecorder>>,
     pub(crate) user_shell: crate::shell::Shell,
     pub(crate) show_raw_agent_reasoning: bool,
+    pub(crate) progress: ProgressConfig,
     pub(crate) auth_manager: Arc<AuthManager>,
     pub(crate) otel_event_manager: OtelEventManager,
     pub(crate) tool_approvals: Mutex<ApprovalStore>,

--- a/codex-rs/core/src/unified_exec/mod.rs
+++ b/codex-rs/core/src/unified_exec/mod.rs
@@ -174,7 +174,7 @@ mod tests {
     use super::session::OutputBufferState;
 
     fn test_session_and_turn() -> (Arc<Session>, Arc<TurnContext>) {
-        let (session, mut turn) = make_session_and_context();
+        let (session, mut turn, _rx_submission) = make_session_and_context();
         turn.approval_policy = AskForApproval::Never;
         turn.sandbox_policy = SandboxPolicy::DangerFullAccess;
         (Arc::new(session), Arc::new(turn))

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -56,6 +56,44 @@ pub struct Cli {
     #[arg(long = "output-schema", value_name = "FILE")]
     pub output_schema: Option<PathBuf>,
 
+    /// Suppress model progress updates and preambles in the terminal.
+    #[arg(
+        long = "no-progress",
+        alias = "silent-progress",
+        value_name = "BOOL",
+        num_args = 0..=1,
+        default_missing_value = "true",
+        value_parser = clap::value_parser!(bool)
+    )]
+    pub no_progress: Option<bool>,
+
+    /// Minimum number of seconds between progress updates (0 disables throttling).
+    #[arg(long = "progress-interval", value_name = "SECONDS")]
+    pub progress_interval: Option<u64>,
+
+    /// Automatically submit follow-up prompts after each completed turn.
+    #[arg(
+        long = "auto-continue",
+        alias = "autoc",
+        value_name = "BOOL",
+        num_args = 0..=1,
+        default_missing_value = "true",
+        value_parser = clap::value_parser!(bool)
+    )]
+    pub auto_continue: Option<bool>,
+
+    /// Maximum number of auto-continued turns (0 disables the limit).
+    #[arg(long = "auto-continue-max-turns", value_name = "N")]
+    pub auto_continue_max_turns: Option<u64>,
+
+    /// Maximum number of seconds to auto-continue before stopping (0 disables the limit).
+    #[arg(long = "auto-continue-max-duration", value_name = "SECONDS")]
+    pub auto_continue_max_duration: Option<u64>,
+
+    /// Prompt to send for each auto-continued turn (defaults to "continue").
+    #[arg(long = "auto-continue-prompt", value_name = "TEXT")]
+    pub auto_continue_prompt: Option<String>,
+
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,
 

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -170,6 +170,12 @@ impl CodexToolCallParam {
             show_raw_agent_reasoning: None,
             tools_web_search_request: None,
             experimental_sandbox_command_assessment: None,
+            progress_no_progress: None,
+            progress_interval_seconds: None,
+            auto_continue_enabled: None,
+            auto_continue_prompt: None,
+            auto_continue_max_turns: None,
+            auto_continue_max_duration_seconds: None,
             additional_writable_roots: Vec::new(),
         };
 

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -196,6 +196,9 @@ pub enum Op {
         /// The raw command string after '!'
         command: String,
     },
+
+    /// Enable or disable auto-continue for the active session.
+    SetAutoContinue { enabled: bool },
 }
 
 /// Determines the conditions under which the user is consulted to approve

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1229,6 +1229,16 @@ impl ChatWidget {
             SlashCommand::Approvals => {
                 self.open_approvals_popup();
             }
+            SlashCommand::AutoContinueOn => {
+                self.app_event_tx
+                    .send(AppEvent::CodexOp(Op::SetAutoContinue { enabled: true }));
+                self.add_info_message("Auto-continue enabled.".to_string(), None);
+            }
+            SlashCommand::AutoContinueOff => {
+                self.app_event_tx
+                    .send(AppEvent::CodexOp(Op::SetAutoContinue { enabled: false }));
+                self.add_info_message("Auto-continue disabled.".to_string(), None);
+            }
             SlashCommand::Quit | SlashCommand::Exit => {
                 self.request_exit();
             }

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -73,6 +73,44 @@ pub struct Cli {
     #[arg(long = "search", default_value_t = false)]
     pub web_search: bool,
 
+    /// Suppress model progress updates and preambles in the terminal.
+    #[arg(
+        long = "no-progress",
+        alias = "silent-progress",
+        value_name = "BOOL",
+        num_args = 0..=1,
+        default_missing_value = "true",
+        value_parser = clap::value_parser!(bool)
+    )]
+    pub no_progress: Option<bool>,
+
+    /// Minimum number of seconds between progress updates (0 disables throttling).
+    #[arg(long = "progress-interval", value_name = "SECONDS")]
+    pub progress_interval: Option<u64>,
+
+    /// Automatically submit follow-up prompts after each completed turn.
+    #[arg(
+        long = "auto-continue",
+        alias = "autoc",
+        value_name = "BOOL",
+        num_args = 0..=1,
+        default_missing_value = "true",
+        value_parser = clap::value_parser!(bool)
+    )]
+    pub auto_continue: Option<bool>,
+
+    /// Maximum number of auto-continued turns (0 disables the limit).
+    #[arg(long = "auto-continue-max-turns", value_name = "N")]
+    pub auto_continue_max_turns: Option<u64>,
+
+    /// Maximum number of seconds to auto-continue before stopping (0 disables the limit).
+    #[arg(long = "auto-continue-max-duration", value_name = "SECONDS")]
+    pub auto_continue_max_duration: Option<u64>,
+
+    /// Prompt to send for each auto-continued turn (defaults to "continue").
+    #[arg(long = "auto-continue-prompt", value_name = "TEXT")]
+    pub auto_continue_prompt: Option<String>,
+
     /// Additional directories that should be writable alongside the primary workspace.
     #[arg(long = "add-dir", value_name = "DIR", value_hint = ValueHint::DirPath)]
     pub add_dir: Vec<PathBuf>,

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -14,6 +14,8 @@ pub enum SlashCommand {
     // more frequently used commands should be listed first.
     Model,
     Approvals,
+    AutoContinueOn,
+    AutoContinueOff,
     Review,
     New,
     Init,
@@ -47,6 +49,8 @@ impl SlashCommand {
             SlashCommand::Status => "show current session configuration and token usage",
             SlashCommand::Model => "choose what model and reasoning effort to use",
             SlashCommand::Approvals => "choose what Codex can do without approval",
+            SlashCommand::AutoContinueOn => "enable auto-continue for this session",
+            SlashCommand::AutoContinueOff => "disable auto-continue for this session",
             SlashCommand::Mcp => "list configured MCP tools",
             SlashCommand::Logout => "log out of Codex",
             SlashCommand::Rollout => "print the rollout file path",
@@ -69,6 +73,8 @@ impl SlashCommand {
             | SlashCommand::Undo
             | SlashCommand::Model
             | SlashCommand::Approvals
+            | SlashCommand::AutoContinueOn
+            | SlashCommand::AutoContinueOff
             | SlashCommand::Review
             | SlashCommand::Logout => false,
             SlashCommand::Diff

--- a/docs/config.md
+++ b/docs/config.md
@@ -500,6 +500,50 @@ Some of the most common MCPs we've seen are:
 - [Sentry](https://docs.sentry.io/product/sentry-mcp/#codex) — access to your Sentry logs
 - [GitHub](https://github.com/github/github-mcp-server) — Control over your GitHub account beyond what git allows (like controlling PRs, issues, etc.)
 
+## Progress updates
+
+Codex streams short reasoning updates while the model works so you can follow along. When you prefer a quieter terminal, opt out or throttle those updates.
+
+- `--no-progress` (alias `--silent-progress`) disables model progress messages for the current run.
+- `--progress-interval <seconds>` ensures progress is emitted at most once per interval. Use `0` (the default) to disable throttling. Any non-zero value must be at least 5 seconds.
+
+To persist the same behaviour, add a `[progress]` table to `config.toml`:
+
+```toml
+[progress]
+# Skip progress updates unless tools produce their own output.
+no_progress = true
+
+# Emit at most one update every two minutes.
+interval_seconds = 120
+```
+
+CLI arguments override profiles, which in turn override the base configuration. The built-in `deepwork` profile combines `no_progress = true` with `ask_for_approval = "on-failure"` for a distraction-free workflow: `codex -p deepwork "…"`.
+
+### Auto-continue
+
+Pair quiet progress with unattended execution by enabling auto-continue. Codex will automatically send a follow-up prompt (defaulting to `"continue"`) whenever a turn finishes, stopping when limits are reached or the run concludes.
+
+- `--auto-continue` (alias `--autoc`) switches the behaviour on for the current run.
+- `--auto-continue-max-turns <n>` caps the number of auto-submitted turns. Use `0` (default) to disable the limit.
+- `--auto-continue-max-duration <seconds>` stops once that many seconds have elapsed. `0` disables the limit.
+- `--auto-continue-prompt <text>` customises the follow-up message Codex sends each cycle.
+
+If auto-continue pauses because a turn ended without new next steps—or you interrupted a turn—your next manual prompt automatically re-enables it for the remainder of the session. In the TUI, you can explicitly toggle it with `/auto-continue-on` and `/auto-continue-off`.
+
+Persist the same defaults in `config.toml`:
+
+```toml
+[auto_continue]
+enabled = true
+prompt = "continue"
+# Turn off after 6 hours (21600 seconds) or 40 turns, whichever comes first.
+max_duration_seconds = 21600
+max_turns = 40
+```
+
+Like other settings, CLI flags override profiles which override the base configuration. The default `deepwork` profile enables auto-continue so `codex -p deepwork` runs hands-free unless you interrupt it.
+
 ## Observability and telemetry
 
 ### otel

--- a/docs/exec.md
+++ b/docs/exec.md
@@ -16,6 +16,8 @@ By default, Codex streams its activity to stderr and only writes the final messa
 
 To write the output of `codex exec` to a file, in addition to using a shell redirect like `>`, there is also a dedicated flag to specify an output file: `-o`/`--output-last-message`.
 
+Prefer less chatter? Add `--no-progress` to silence interim reasoning entirely, or `--progress-interval 300` to emit at most one update every five minutes. To keep Codex moving without further input, pair those flags with `--auto-continue` (optionally tuning `--auto-continue-max-turns`, `--auto-continue-max-duration`, or `--auto-continue-prompt`). Once a run temporarily pauses itself, typing the next prompt re-arms auto-continue for the new work.
+
 ### JSON output mode
 
 `codex exec` supports a `--json` mode that streams events to stdout as JSON Lines (JSONL) while the agent runs.


### PR DESCRIPTION
# Summary

Codex would often stop to provide minor progress updates, even if there is plenty to do and the overall task is not complete. Often this would happen after less than 10 minutes of processing. Useful for incremental updates, not so useful for a more complex task.

## Auto Continue

  - Added a session-scoped auto-continue engine (codex-rs/core/src/state/session.rs, codex-rs/core/src/codex.rs, codex-rs/core/src/tasks/mod.rs) that tracks runtime limits, detects stop phrases or repeated answers, pauses on interrupts, and automatically enqueues follow-up prompts while meaningful next steps remain, emitting background notifications when it stops itself.
  - Introduced end-to-end controls for the feature: new Op::SetAutoContinue protocol message, CLI/exec flags (--auto-continue, max turns/duration, custom prompt), TUI slash commands (/auto-continue-on|off), and session rearming logic so manual input resumes automation after a pause.
  - Expanded configuration and documentation (codex-rs/core/src/config/mod.rs, codex-rs/core/src/config/profile.rs, codex-rs/common/src/config_summary.rs, docs/config.md, docs/exec.md) to cover the [auto_continue] table, surface the setting in summaries, and enable the deepwork profile to run hands-free by default while app-server and MCP clients now forward the associated overrides.

## Additional Detail

  - Session runtime keeps AutoContinueRuntimeState with configurable prompt, turn cap, and duration cap; it normalizes messages to catch repetitions, inspects “next step” vs “we’re done” vocabulary, and emits contextual pause messages (e.g., “Auto-continue paused after the assistant repeated the same response”).
  - The loop that handles turn completion now feeds the last assistant reply into maybe_auto_continue; if automation stays active it queues a synthetic UserInput submission, otherwise it records why it stopped. Manual turns call rearm_auto_continue_if_allowed so typing resets the stopwatch unless the user explicitly disabled the feature.
  - Interrupts and task aborts call pause_auto_continue_after_interrupt, ensuring /interrupt or approval denials halt automation until the user resumes work.
  - CLI/TUI wiring propagates the new flags through ConfigOverrides, SessionConfiguration, and the status slash command summaries so every frontend reports whether hands-free mode is active and what limits apply.


