### PR TITLE
fix: ignore reasoning deltas because we send it with turn item

### DIFF
--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -10,6 +10,8 @@ use codex_protocol::protocol::Event;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::ExitedReviewModeEvent;
 use codex_protocol::protocol::ItemCompletedEvent;
+use codex_protocol::protocol::ReasoningContentDeltaEvent;
+use codex_protocol::protocol::ReasoningRawContentDeltaEvent;
 use codex_protocol::protocol::ReviewOutputEvent;
 use tokio_util::sync::CancellationToken;
 
@@ -122,7 +124,9 @@ async fn process_review_events(
                 ..
             })
             | EventMsg::AgentMessageDelta(AgentMessageDeltaEvent { .. })
-            | EventMsg::AgentMessageContentDelta(AgentMessageContentDeltaEvent { .. }) => {}
+            | EventMsg::AgentMessageContentDelta(AgentMessageContentDeltaEvent { .. })
+            | EventMsg::ReasoningContentDelta(ReasoningContentDeltaEvent { .. })
+            | EventMsg::ReasoningRawContentDelta(ReasoningRawContentDeltaEvent { .. }) => {}
             EventMsg::TaskComplete(task_complete) => {
                 // Parse review output from the last agent message (if present).
                 let out = task_complete


### PR DESCRIPTION
should fix this:

<img width="2418" height="242" alt="image" src="https://github.com/user-attachments/assets/f818d00b-ed3a-479b-94a7-e4bc5db6326e" />
