### PR TITLE
fix inheritable handles issue with piped sandbox commands.

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -326,7 +326,7 @@ mod windows_impl {
                 0,
                 PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
                 inherit_list.as_mut_ptr() as *mut _ as *mut _,
-                (std::mem::size_of::<HANDLE>() * inherit_list.len()),
+                std::mem::size_of::<HANDLE>() * inherit_list.len(),
                 ptr::null_mut(),
                 ptr::null_mut(),
             )

--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -51,8 +51,8 @@ mod windows_impl {
     use std::ptr;
     use windows_sys::Win32::Foundation::CloseHandle;
     use windows_sys::Win32::Foundation::GetLastError;
-    use windows_sys::Win32::Foundation::HANDLE;
     use windows_sys::Win32::Foundation::SetHandleInformation;
+    use windows_sys::Win32::Foundation::HANDLE;
     use windows_sys::Win32::Foundation::HANDLE_FLAG_INHERIT;
     use windows_sys::Win32::System::Pipes::CreatePipe;
     use windows_sys::Win32::System::Threading::CreateProcessAsUserW;

--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -326,7 +326,7 @@ mod windows_impl {
                 0,
                 PROC_THREAD_ATTRIBUTE_HANDLE_LIST,
                 inherit_list.as_mut_ptr() as *mut _ as *mut _,
-                (std::mem::size_of::<HANDLE>() * inherit_list.len()) as usize,
+                (std::mem::size_of::<HANDLE>() * inherit_list.len()),
                 ptr::null_mut(),
                 ptr::null_mut(),
             )


### PR DESCRIPTION
Windows Sandbox: Fix native producers in PowerShell pipelines (Access denied/STATUS_DLL_INIT_FAILED)

  - Problem
      - Native binaries (e.g., rg, where.exe) failed when used as the head of a PowerShell pipeline inside the sandbox
        (“Access is denied”).
  - Root Cause
      - The sandboxed process inherited inheritable stdio handles. When PowerShell created a piped child
        (bInheritHandles=TRUE), those extra inheritable handles were included and caused CreateProcess to fail under the
        restricted token.
  - Approach
      - Switch to STARTUPINFOEX with PROC_THREAD_ATTRIBUTE_HANDLE_LIST to inherit only the three stdio handles.
      - Create non-inheritable pipes for child stdio and pass them via the handle list (no global inheritable handles).
      - Pass the full STARTUPINFOEX memory (typed as STARTUPINFOW) to CreateProcessAsUserW and set
        EXTENDED_STARTUPINFO_PRESENT.
  - Implementation
      - windows-sandbox-rs/src/lib.rs
          - Build/attach attribute list; remove SetHandleInformation inheritance on pipe ends.
          - Use STARTUPINFOEXW + handle list; fix CreateProcessAsUserW parameter and desktop string.
