### PR TITLE
ignore deltas in `codex_delegate`

### DIFF
--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -158,6 +158,11 @@ async fn forward_events(
 ) {
     while let Ok(event) = codex.next_event().await {
         match event {
+            // ignore all legacy delta events
+            Event {
+                id: _,
+                msg: EventMsg::AgentMessageDelta(_) | EventMsg::AgentReasoningDelta(_),
+            } => continue,
             Event {
                 id: _,
                 msg: EventMsg::SessionConfigured(_),

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -4,8 +4,6 @@ use async_trait::async_trait;
 use codex_protocol::items::TurnItem;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
-use codex_protocol::protocol::AgentMessageContentDeltaEvent;
-use codex_protocol::protocol::AgentMessageDeltaEvent;
 use codex_protocol::protocol::Event;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::ExitedReviewModeEvent;
@@ -120,9 +118,7 @@ async fn process_review_events(
             EventMsg::ItemCompleted(ItemCompletedEvent {
                 item: TurnItem::AgentMessage(_),
                 ..
-            })
-            | EventMsg::AgentMessageDelta(AgentMessageDeltaEvent { .. })
-            | EventMsg::AgentMessageContentDelta(AgentMessageContentDeltaEvent { .. }) => {}
+            }) => {}
             EventMsg::TaskComplete(task_complete) => {
                 // Parse review output from the last agent message (if present).
                 let out = task_complete

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -8,8 +8,6 @@ use codex_protocol::protocol::Event;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::ExitedReviewModeEvent;
 use codex_protocol::protocol::ItemCompletedEvent;
-use codex_protocol::protocol::ReasoningContentDeltaEvent;
-use codex_protocol::protocol::ReasoningRawContentDeltaEvent;
 use codex_protocol::protocol::ReviewOutputEvent;
 use tokio_util::sync::CancellationToken;
 

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -16,7 +16,7 @@ use crate::codex::TurnContext;
 use crate::codex_delegate::run_codex_conversation_one_shot;
 use crate::review_format::format_review_findings_block;
 use crate::state::TaskKind;
-use codex_protocol::user_input::UserInput;
+use codex_protocol::user_input::UserInput
 
 use super::SessionTask;
 use super::SessionTaskContext;

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -16,7 +16,7 @@ use crate::codex::TurnContext;
 use crate::codex_delegate::run_codex_conversation_one_shot;
 use crate::review_format::format_review_findings_block;
 use crate::state::TaskKind;
-use codex_protocol::user_input::UserInput
+use codex_protocol::user_input::UserInput;
 
 use super::SessionTask;
 use super::SessionTaskContext;

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -4,6 +4,8 @@ use async_trait::async_trait;
 use codex_protocol::items::TurnItem;
 use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
+use codex_protocol::protocol::AgentMessageContentDeltaEvent;
+use codex_protocol::protocol::AgentMessageDeltaEvent;
 use codex_protocol::protocol::Event;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::ExitedReviewModeEvent;
@@ -118,7 +120,9 @@ async fn process_review_events(
             EventMsg::ItemCompleted(ItemCompletedEvent {
                 item: TurnItem::AgentMessage(_),
                 ..
-            }) => {}
+            })
+            | EventMsg::AgentMessageDelta(AgentMessageDeltaEvent { .. })
+            | EventMsg::AgentMessageContentDelta(AgentMessageContentDeltaEvent { .. }) => {}
             EventMsg::TaskComplete(task_complete) => {
                 // Parse review output from the last agent message (if present).
                 let out = task_complete

--- a/codex-rs/core/tests/suite/codex_delegate.rs
+++ b/codex-rs/core/tests/suite/codex_delegate.rs
@@ -8,6 +8,8 @@ use core_test_support::responses::ev_apply_patch_function_call;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
+use core_test_support::responses::ev_reasoning_item_added;
+use core_test_support::responses::ev_reasoning_summary_text_delta;
 use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
@@ -15,6 +17,7 @@ use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
+use pretty_assertions::assert_eq;
 
 /// Delegate should surface ExecApprovalRequest from sub-agent and proceed
 /// after parent submits an approval decision.
@@ -170,4 +173,55 @@ async fn codex_delegate_forwards_patch_approval_and_proceeds_on_decision() {
     })
     .await;
     wait_for_event(&test.codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
+}
+
+/// Delegate should drop legacy delta events (AgentReasoningDelta/AgentMessageDelta)
+/// while forwarding the new delta variants.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn codex_delegate_ignores_legacy_deltas() {
+    skip_if_no_network!();
+
+    // Single response with reasoning summary deltas.
+    let sse_stream = sse(vec![
+        ev_response_created("resp-1"),
+        ev_reasoning_item_added("reason-1", &["initial"]),
+        ev_reasoning_summary_text_delta("think-1"),
+        ev_completed("resp-1"),
+    ]);
+
+    let server = start_mock_server().await;
+    mount_sse_sequence(&server, vec![sse_stream]).await;
+
+    let mut builder = test_codex();
+    let test = builder.build(&server).await.expect("build test codex");
+
+    // Kick off review (delegated).
+    test.codex
+        .submit(Op::Review {
+            review_request: ReviewRequest {
+                prompt: "Please review".to_string(),
+                user_facing_hint: "review".to_string(),
+            },
+        })
+        .await
+        .expect("submit review");
+
+    let mut saw_reasoning_delta = false;
+    let mut saw_legacy_reasoning_delta = false;
+
+    loop {
+        let ev = wait_for_event(&test.codex, |_| true).await;
+        match ev {
+            EventMsg::ReasoningContentDelta(_) => saw_reasoning_delta = true,
+            EventMsg::AgentReasoningDelta(_) => saw_legacy_reasoning_delta = true,
+            EventMsg::TaskComplete(_) => break,
+            _ => {}
+        }
+    }
+
+    assert_eq!(saw_reasoning_delta, true, "expected new reasoning delta");
+    assert_eq!(
+        saw_legacy_reasoning_delta, false,
+        "legacy reasoning deltas should be filtered by delegator"
+    );
 }

--- a/codex-rs/core/tests/suite/codex_delegate.rs
+++ b/codex-rs/core/tests/suite/codex_delegate.rs
@@ -175,8 +175,6 @@ async fn codex_delegate_forwards_patch_approval_and_proceeds_on_decision() {
     wait_for_event(&test.codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
 }
 
-/// Delegate should drop legacy delta events (AgentReasoningDelta/AgentMessageDelta)
-/// while forwarding the new delta variants.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn codex_delegate_ignores_legacy_deltas() {
     skip_if_no_network!();
@@ -219,12 +217,9 @@ async fn codex_delegate_ignores_legacy_deltas() {
         }
     }
 
-    assert_eq!(
-        reasoning_delta_count, 1,
-        "expected exactly one new reasoning delta"
-    );
+    assert_eq!(reasoning_delta_count, 1, "expected one new reasoning delta");
     assert_eq!(
         legacy_reasoning_delta_count, 1,
-        "delegator should forward at most one legacy reasoning delta (no duplicates)"
+        "expected one legacy reasoning delta"
     );
 }


### PR DESCRIPTION
ignore legacy deltas in codex-delegate to avoid this [issue](https://github.com/openai/codex/pull/6202).