### PR TITLE
fix: refresh expired MCP OAuth tokens

### DIFF
--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -366,9 +366,8 @@ fn load_oauth_tokens_from_file(server_name: &str, url: &str) -> Result<Option<St
             token_response.set_scopes(Some(scopes.into_iter().map(Scope::new).collect()));
         }
 
-        if let Some(expires_at) = entry.expires_at
-            && let Some(seconds) = expires_in_from_timestamp(expires_at)
-        {
+        if let Some(expires_at) = entry.expires_at {
+            let seconds = expires_in_from_timestamp(expires_at).unwrap_or(0);
             let duration = Duration::from_secs(seconds);
             token_response.set_expires_in(Some(&duration));
         }

--- a/codex-rs/rmcp-client/src/rmcp_client.rs
+++ b/codex-rs/rmcp-client/src/rmcp_client.rs
@@ -31,7 +31,6 @@ use rmcp::service::RunningService;
 use rmcp::service::{self};
 use rmcp::transport::StreamableHttpClientTransport;
 use rmcp::transport::auth::AuthClient;
-use rmcp::transport::auth::OAuthTokenResponse;
 use rmcp::transport::auth::OAuthState;
 use rmcp::transport::child_process::TokioChildProcess;
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;


### PR DESCRIPTION
Repro:

- Set up an HTTP MCP server with OAuth expiring tokens like Datadog
- Use it for a bit until the token expires
- Start a new codex session

Expected results:
- The token gets transparently refreshed and the MCP server continues to work

Actual results:
- You start getting 401s and need to do `codex mcp logout` and log back  in.
