### PR TITLE
[app-server] feat: export.rs supports a v2 namespace, initial v2 notifications

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -871,6 +871,7 @@ dependencies = [
  "anyhow",
  "clap",
  "codex-protocol",
+ "mcp-types",
  "paste",
  "pretty_assertions",
  "schemars 0.8.22",

--- a/codex-rs/app-server-protocol/Cargo.toml
+++ b/codex-rs/app-server-protocol/Cargo.toml
@@ -14,6 +14,7 @@ workspace = true
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
 codex-protocol = { workspace = true }
+mcp-types = { workspace = true }
 paste = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/codex-rs/app-server-protocol/src/export.rs
+++ b/codex-rs/app-server-protocol/src/export.rs
@@ -13,6 +13,10 @@ use crate::export_server_responses;
 use anyhow::Context;
 use anyhow::Result;
 use anyhow::anyhow;
+use codex_protocol::parse_command::ParsedCommand;
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::FileChange;
+use codex_protocol::protocol::SandboxPolicy;
 use schemars::JsonSchema;
 use schemars::schema_for;
 use serde::Serialize;
@@ -113,6 +117,11 @@ pub fn generate_json(out_dir: &Path) -> Result<()> {
         |d| write_json_schema_with_return::<crate::ServerRequest>(d, "ServerRequest"),
         |d| write_json_schema_with_return::<crate::ClientNotification>(d, "ClientNotification"),
         |d| write_json_schema_with_return::<crate::ServerNotification>(d, "ServerNotification"),
+        |d| write_json_schema_with_return::<EventMsg>(d, "EventMsg"),
+        |d| write_json_schema_with_return::<FileChange>(d, "FileChange"),
+        |d| write_json_schema_with_return::<crate::protocol::v1::InputItem>(d, "InputItem"),
+        |d| write_json_schema_with_return::<ParsedCommand>(d, "ParsedCommand"),
+        |d| write_json_schema_with_return::<SandboxPolicy>(d, "SandboxPolicy"),
     ];
 
     let mut schemas: Vec<GeneratedSchema> = Vec::new();

--- a/codex-rs/app-server-protocol/src/export.rs
+++ b/codex-rs/app-server-protocol/src/export.rs
@@ -2,8 +2,12 @@ use crate::ClientNotification;
 use crate::ClientRequest;
 use crate::ServerNotification;
 use crate::ServerRequest;
+use crate::export_client_notification_schemas;
+use crate::export_client_param_schemas;
 use crate::export_client_response_schemas;
 use crate::export_client_responses;
+use crate::export_server_notification_schemas;
+use crate::export_server_param_schemas;
 use crate::export_server_response_schemas;
 use crate::export_server_responses;
 use anyhow::Context;
@@ -16,6 +20,7 @@ use serde::Serialize;
 use serde_json::Map;
 use serde_json::Value;
 use std::collections::BTreeMap;
+use std::collections::HashMap;
 use std::collections::HashSet;
 use std::ffi::OsStr;
 use std::fs;
@@ -28,84 +33,7 @@ use ts_rs::TS;
 
 const HEADER: &str = "// GENERATED CODE! DO NOT MODIFY BY HAND!\n\n";
 
-macro_rules! for_each_schema_type {
-    ($macro:ident) => {
-        $macro!(crate::RequestId);
-        $macro!(crate::JSONRPCMessage);
-        $macro!(crate::JSONRPCRequest);
-        $macro!(crate::JSONRPCNotification);
-        $macro!(crate::JSONRPCResponse);
-        $macro!(crate::JSONRPCError);
-        $macro!(crate::JSONRPCErrorError);
-        $macro!(crate::AddConversationListenerParams);
-        $macro!(crate::AddConversationSubscriptionResponse);
-        $macro!(crate::ApplyPatchApprovalParams);
-        $macro!(crate::ApplyPatchApprovalResponse);
-        $macro!(crate::ArchiveConversationParams);
-        $macro!(crate::ArchiveConversationResponse);
-        $macro!(crate::AuthMode);
-        $macro!(crate::AccountUpdatedNotification);
-        $macro!(crate::AuthStatusChangeNotification);
-        $macro!(crate::CancelLoginChatGptParams);
-        $macro!(crate::CancelLoginChatGptResponse);
-        $macro!(crate::ClientInfo);
-        $macro!(crate::ClientNotification);
-        $macro!(crate::ClientRequest);
-        $macro!(crate::ConversationSummary);
-        $macro!(crate::ExecCommandApprovalParams);
-        $macro!(crate::ExecCommandApprovalResponse);
-        $macro!(crate::ExecOneOffCommandParams);
-        $macro!(crate::ExecOneOffCommandResponse);
-        $macro!(crate::FuzzyFileSearchParams);
-        $macro!(crate::FuzzyFileSearchResponse);
-        $macro!(crate::FuzzyFileSearchResult);
-        $macro!(crate::GetAuthStatusParams);
-        $macro!(crate::GetAuthStatusResponse);
-        $macro!(crate::GetUserAgentResponse);
-        $macro!(crate::GetUserSavedConfigResponse);
-        $macro!(crate::GitDiffToRemoteParams);
-        $macro!(crate::GitDiffToRemoteResponse);
-        $macro!(crate::GitSha);
-        $macro!(crate::InitializeParams);
-        $macro!(crate::InitializeResponse);
-        $macro!(crate::InputItem);
-        $macro!(crate::InterruptConversationParams);
-        $macro!(crate::InterruptConversationResponse);
-        $macro!(crate::ListConversationsParams);
-        $macro!(crate::ListConversationsResponse);
-        $macro!(crate::LoginApiKeyParams);
-        $macro!(crate::LoginApiKeyResponse);
-        $macro!(crate::LoginChatGptCompleteNotification);
-        $macro!(crate::LoginChatGptResponse);
-        $macro!(crate::LogoutChatGptParams);
-        $macro!(crate::LogoutChatGptResponse);
-        $macro!(crate::NewConversationParams);
-        $macro!(crate::NewConversationResponse);
-        $macro!(crate::Profile);
-        $macro!(crate::RemoveConversationListenerParams);
-        $macro!(crate::RemoveConversationSubscriptionResponse);
-        $macro!(crate::ResumeConversationParams);
-        $macro!(crate::ResumeConversationResponse);
-        $macro!(crate::SandboxSettings);
-        $macro!(crate::SendUserMessageParams);
-        $macro!(crate::SendUserMessageResponse);
-        $macro!(crate::SendUserTurnParams);
-        $macro!(crate::SendUserTurnResponse);
-        $macro!(crate::ServerNotification);
-        $macro!(crate::ServerRequest);
-        $macro!(crate::SessionConfiguredNotification);
-        $macro!(crate::SetDefaultModelParams);
-        $macro!(crate::SetDefaultModelResponse);
-        $macro!(crate::Tools);
-        $macro!(crate::UserInfoResponse);
-        $macro!(crate::UserSavedConfig);
-        $macro!(codex_protocol::protocol::EventMsg);
-        $macro!(codex_protocol::protocol::FileChange);
-        $macro!(codex_protocol::parse_command::ParsedCommand);
-        $macro!(codex_protocol::protocol::SandboxPolicy);
-    };
-}
-
+type JsonSchemaEmitter = fn(&Path) -> Result<RootSchema>;
 pub fn generate_types(out_dir: &Path, prettier: Option<&Path>) -> Result<()> {
     generate_ts(out_dir, prettier)?;
     generate_json(out_dir)?;
@@ -113,7 +41,9 @@ pub fn generate_types(out_dir: &Path, prettier: Option<&Path>) -> Result<()> {
 }
 
 pub fn generate_ts(out_dir: &Path, prettier: Option<&Path>) -> Result<()> {
+    let v2_out_dir = out_dir.join("v2");
     ensure_dir(out_dir)?;
+    ensure_dir(&v2_out_dir)?;
 
     ClientRequest::export_all_to(out_dir)?;
     export_client_responses(out_dir)?;
@@ -124,12 +54,15 @@ pub fn generate_ts(out_dir: &Path, prettier: Option<&Path>) -> Result<()> {
     ServerNotification::export_all_to(out_dir)?;
 
     generate_index_ts(out_dir)?;
+    generate_index_ts(&v2_out_dir)?;
 
-    let ts_files = ts_files_in(out_dir)?;
+    // Ensure our header is present on all TS files (root + subdirs like v2/).
+    let ts_files = ts_files_in_recursive(out_dir)?;
     for file in &ts_files {
         prepend_header_if_missing(file)?;
     }
 
+    // Optionally run Prettier on all generated TS files.
     if let Some(prettier_bin) = prettier
         && !ts_files.is_empty()
     {
@@ -148,20 +81,57 @@ pub fn generate_ts(out_dir: &Path, prettier: Option<&Path>) -> Result<()> {
 
 pub fn generate_json(out_dir: &Path) -> Result<()> {
     ensure_dir(out_dir)?;
+    // Emit schemas for core envelope/wire types that may not be referenced
+    // by params/responses but are useful as standalone:
     let mut bundle: BTreeMap<String, RootSchema> = BTreeMap::new();
 
-    macro_rules! add_schema {
-        ($ty:path) => {{
-            let name = type_basename(stringify!($ty));
-            let schema = write_json_schema_with_return::<$ty>(out_dir, &name)?;
-            bundle.insert(name, schema);
-        }};
+    let envelope_emitters: &[(&str, JsonSchemaEmitter)] = &[
+        ("RequestId", |d| {
+            write_json_schema_with_return::<crate::RequestId>(d, "RequestId")
+        }),
+        ("JSONRPCMessage", |d| {
+            write_json_schema_with_return::<crate::JSONRPCMessage>(d, "JSONRPCMessage")
+        }),
+        ("JSONRPCRequest", |d| {
+            write_json_schema_with_return::<crate::JSONRPCRequest>(d, "JSONRPCRequest")
+        }),
+        ("JSONRPCNotification", |d| {
+            write_json_schema_with_return::<crate::JSONRPCNotification>(d, "JSONRPCNotification")
+        }),
+        ("JSONRPCResponse", |d| {
+            write_json_schema_with_return::<crate::JSONRPCResponse>(d, "JSONRPCResponse")
+        }),
+        ("JSONRPCError", |d| {
+            write_json_schema_with_return::<crate::JSONRPCError>(d, "JSONRPCError")
+        }),
+        ("JSONRPCErrorError", |d| {
+            write_json_schema_with_return::<crate::JSONRPCErrorError>(d, "JSONRPCErrorError")
+        }),
+        ("ClientRequest", |d| {
+            write_json_schema_with_return::<crate::ClientRequest>(d, "ClientRequest")
+        }),
+        ("ServerRequest", |d| {
+            write_json_schema_with_return::<crate::ServerRequest>(d, "ServerRequest")
+        }),
+        ("ClientNotification", |d| {
+            write_json_schema_with_return::<crate::ClientNotification>(d, "ClientNotification")
+        }),
+        ("ServerNotification", |d| {
+            write_json_schema_with_return::<crate::ServerNotification>(d, "ServerNotification")
+        }),
+    ];
+    for (name, emit) in envelope_emitters {
+        let schema = emit(out_dir)?;
+        bundle.insert((*name).to_string(), schema);
     }
 
-    for_each_schema_type!(add_schema);
-
+    // Have the macros generate per-type JSON for params, responses, and notifications.
+    export_client_param_schemas(out_dir)?;
     export_client_response_schemas(out_dir)?;
+    export_server_param_schemas(out_dir)?;
     export_server_response_schemas(out_dir)?;
+    export_client_notification_schemas(out_dir)?;
+    export_server_notification_schemas(out_dir)?;
 
     let mut definitions = Map::new();
 
@@ -177,10 +147,51 @@ pub fn generate_json(out_dir: &Path) -> Result<()> {
         "ServerRequest",
     ];
 
-    for (name, schema) in bundle {
-        let mut schema_value = serde_json::to_value(schema)?;
-        annotate_schema(&mut schema_value, Some(name.as_str()));
+    // Merge all generated per-type JSON files (including the envelopes above)
+    // into a single definitions bundle. Also recognize a v2 namespace so that
+    // types like RateLimitSnapshot can co-exist between legacy and v2.
+    let json_files = json_files_in_recursive(out_dir)?;
+    let namespaced_types = collect_namespaced_types(&json_files)?;
+    for path in json_files {
+        // Skip the bundle we’re about to (re)generate.
+        if path.file_name().and_then(OsStr::to_str)
+            == Some("codex_app_server_protocol.schemas.json")
+        {
+            continue;
+        }
 
+        let file_stem = path
+            .file_stem()
+            .and_then(OsStr::to_str)
+            .ok_or_else(|| anyhow!(format!("Invalid schema file name {}", path.display())))?;
+
+        // Determine namespace and logical type name from either the stem
+        // (e.g., "v2::Type") or the directory layout (e.g., ".../v2/Type.json").
+        let (ns_opt, logical_name) = detect_namespace(&path, file_stem);
+        let in_v1_dir = path
+            .parent()
+            .and_then(Path::file_name)
+            .and_then(OsStr::to_str)
+            == Some("v1");
+
+        let mut schema_value: Value = serde_json::from_str(
+            &fs::read_to_string(&path)
+                .with_context(|| format!("Failed to read {}", path.display()))?,
+        )
+        .with_context(|| format!("Failed to parse JSON from {}", path.display()))?;
+
+        // Normalize; use the original stem as the base so existing naming rules apply.
+        annotate_schema(&mut schema_value, Some(file_stem));
+
+        if let Some(ref ns) = ns_opt {
+            // Rewrite internal $ref targets to point to the namespaced location
+            // under the bundle's definitions.
+            rewrite_refs_to_namespace(&mut schema_value, ns);
+        }
+
+        // Pull embedded definitions out and insert into our bundle map at the
+        // appropriate namespace.
+        let mut forced_namespace_refs: Vec<(String, String)> = Vec::new();
         if let Value::Object(ref mut obj) = schema_value
             && let Some(defs) = obj.remove("definitions")
             && let Value::Object(defs_obj) = defs
@@ -188,11 +199,61 @@ pub fn generate_json(out_dir: &Path) -> Result<()> {
             for (def_name, mut def_schema) in defs_obj {
                 if !SPECIAL_DEFINITIONS.contains(&def_name.as_str()) {
                     annotate_schema(&mut def_schema, Some(def_name.as_str()));
-                    definitions.insert(def_name, def_schema);
+                    let target_ns = match ns_opt.clone() {
+                        Some(ns) => Some(ns),
+                        None => {
+                            namespace_for_definition(&def_name, &namespaced_types).and_then(|ns| {
+                                if in_v1_dir {
+                                    None
+                                } else {
+                                    Some(ns.to_string())
+                                }
+                            })
+                        }
+                    };
+                    if let Some(ref ns) = target_ns {
+                        if ns_opt.as_deref() == Some(ns.as_str()) {
+                            rewrite_refs_to_namespace(&mut def_schema, ns);
+                            definitions
+                                .entry(ns.clone())
+                                .or_insert_with(|| Value::Object(Map::new()));
+                            if let Value::Object(defs_ns) = definitions
+                                .get_mut(ns)
+                                .ok_or_else(|| anyhow!("just inserted {ns} namespace"))?
+                            {
+                                defs_ns.insert(def_name, def_schema);
+                            }
+                        } else if !forced_namespace_refs
+                            .iter()
+                            .any(|(name, existing_ns)| name == &def_name && existing_ns == ns)
+                        {
+                            forced_namespace_refs.push((def_name.clone(), ns.clone()));
+                        }
+                    } else {
+                        definitions.insert(def_name, def_schema);
+                    }
                 }
             }
         }
-        definitions.insert(name, schema_value);
+
+        for (name, ns) in forced_namespace_refs {
+            rewrite_named_ref_to_namespace(&mut schema_value, &ns, &name);
+        }
+
+        // Insert the schema root itself into the bundle under the namespace.
+        if let Some(ref ns) = ns_opt {
+            definitions
+                .entry(ns.to_string())
+                .or_insert_with(|| Value::Object(Map::new()));
+            if let Value::Object(defs_ns) = definitions
+                .get_mut(ns)
+                .ok_or_else(|| anyhow!("just inserted v2 namespace"))?
+            {
+                defs_ns.insert(logical_name.to_string(), schema_value);
+            }
+        } else {
+            definitions.insert(logical_name.to_string(), schema_value);
+        }
     }
 
     let mut root = Map::new();
@@ -223,7 +284,19 @@ where
     let schema = schema_for!(T);
     let mut schema_value = serde_json::to_value(schema)?;
     annotate_schema(&mut schema_value, Some(file_stem));
-    write_pretty_json(out_dir.join(format!("{file_stem}.json")), &schema_value)
+    // If the name looks like a namespaced path (e.g., "v2::Type"), mirror
+    // the TypeScript layout and write to out_dir/v2/Type.json. Otherwise
+    // write alongside the legacy files.
+    let (ns_opt, logical_name) = split_namespace(file_stem);
+    let out_path = if let Some(ns) = ns_opt {
+        let dir = out_dir.join(ns);
+        ensure_dir(&dir)?;
+        dir.join(format!("{logical_name}.json"))
+    } else {
+        out_dir.join(format!("{file_stem}.json"))
+    };
+
+    write_pretty_json(out_path, &schema_value)
         .with_context(|| format!("Failed to write JSON schema for {file_stem}"))?;
     let annotated_schema = serde_json::from_value(schema_value)?;
     Ok(annotated_schema)
@@ -242,13 +315,124 @@ fn write_pretty_json(path: PathBuf, value: &impl Serialize) -> Result<()> {
     fs::write(&path, json).with_context(|| format!("Failed to write {}", path.display()))?;
     Ok(())
 }
-fn type_basename(type_path: &str) -> String {
-    type_path
-        .rsplit_once("::")
-        .map(|(_, name)| name)
-        .unwrap_or(type_path)
-        .trim()
-        .to_string()
+
+/// Detect a namespace from a schema file path and stem.
+/// Supports both legacy on-disk names like "v2::Type.json" and the new
+/// directory layout ".../v2/Type.json".
+fn detect_namespace(path: &Path, stem: &str) -> (Option<String>, String) {
+    // Prefer directory-based detection.
+    if let Some(parent) = path.parent()
+        && parent.file_name().and_then(OsStr::to_str) == Some("v2")
+    {
+        return (Some("v2".to_string()), stem.to_string());
+    }
+    split_namespace(stem)
+}
+
+/// Split a "ns::Type" name into (Some(ns), Type). Returns (None, name) if no ns.
+fn split_namespace(name: &str) -> (Option<String>, String) {
+    if let Some(idx) = name.find("::") {
+        let (ns, rest) = name.split_at(idx);
+        // rest starts with "::"
+        let typ = &rest[2..];
+        return (Some(ns.to_string()), typ.to_string());
+    }
+    (None, name.to_string())
+}
+
+/// Recursively rewrite $ref values that point at "#/definitions/..." so that
+/// they point to a namespaced location under the bundle.
+fn rewrite_refs_to_namespace(value: &mut Value, ns: &str) {
+    match value {
+        Value::Object(obj) => {
+            if let Some(Value::String(r)) = obj.get_mut("$ref")
+                && let Some(suffix) = r.strip_prefix("#/definitions/")
+            {
+                let prefix = format!("{ns}/");
+                if !suffix.starts_with(&prefix) {
+                    *r = format!("#/definitions/{ns}/{suffix}");
+                }
+            }
+            for v in obj.values_mut() {
+                rewrite_refs_to_namespace(v, ns);
+            }
+        }
+        Value::Array(items) => {
+            for v in items.iter_mut() {
+                rewrite_refs_to_namespace(v, ns);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn json_files_in_recursive(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        for entry in
+            fs::read_dir(&d).with_context(|| format!("Failed to read dir {}", d.display()))?
+        {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                // Skip known non-protocol directories.
+                if path.file_name().and_then(OsStr::to_str) == Some("serde_json") {
+                    continue;
+                }
+                stack.push(path);
+            } else if path.is_file() && path.extension() == Some(OsStr::new("json")) {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
+fn collect_namespaced_types(paths: &[PathBuf]) -> Result<HashMap<String, String>> {
+    let mut types = HashMap::new();
+    for path in paths {
+        let file_stem = path
+            .file_stem()
+            .and_then(OsStr::to_str)
+            .ok_or_else(|| anyhow!(format!("Invalid schema file name {}", path.display())))?;
+        let (ns_opt, logical_name) = detect_namespace(path, file_stem);
+        if let Some(ns) = ns_opt {
+            types
+                .entry(logical_name.to_string())
+                .or_insert_with(|| ns.clone());
+            let raw = fs::read_to_string(path)
+                .with_context(|| format!("Failed to read {}", path.display()))?;
+            let parsed: Value = serde_json::from_str(&raw)
+                .with_context(|| format!("Failed to parse JSON from {}", path.display()))?;
+            if let Some(Value::Object(defs)) = parsed.get("definitions") {
+                for key in defs.keys() {
+                    types.entry(key.clone()).or_insert_with(|| ns.clone());
+                }
+            }
+            if let Some(Value::Object(defs)) = parsed.get("$defs") {
+                for key in defs.keys() {
+                    types.entry(key.clone()).or_insert_with(|| ns.clone());
+                }
+            }
+        }
+    }
+    Ok(types)
+}
+
+fn namespace_for_definition<'a>(
+    name: &str,
+    types: &'a HashMap<String, String>,
+) -> Option<&'a String> {
+    if let Some(ns) = types.get(name) {
+        return Some(ns);
+    }
+    let trimmed = name.trim_end_matches(|c: char| c.is_ascii_digit());
+    if trimmed != name {
+        return types.get(trimmed);
+    }
+    None
 }
 
 fn variant_definition_name(base: &str, variant: &Value) -> Option<String> {
@@ -468,6 +652,33 @@ fn ensure_dir(dir: &Path) -> Result<()> {
         .with_context(|| format!("Failed to create output directory {}", dir.display()))
 }
 
+fn rewrite_named_ref_to_namespace(value: &mut Value, ns: &str, name: &str) {
+    let direct = format!("#/definitions/{name}");
+    let prefixed = format!("{direct}/");
+    let replacement = format!("#/definitions/{ns}/{name}");
+    let replacement_prefixed = format!("{replacement}/");
+    match value {
+        Value::Object(obj) => {
+            if let Some(Value::String(reference)) = obj.get_mut("$ref") {
+                if reference == &direct {
+                    *reference = replacement;
+                } else if let Some(rest) = reference.strip_prefix(&prefixed) {
+                    *reference = format!("{replacement_prefixed}{rest}");
+                }
+            }
+            for child in obj.values_mut() {
+                rewrite_named_ref_to_namespace(child, ns, name);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                rewrite_named_ref_to_namespace(child, ns, name);
+            }
+        }
+        _ => {}
+    }
+}
+
 fn prepend_header_if_missing(path: &Path) -> Result<()> {
     let mut content = String::new();
     {
@@ -505,6 +716,26 @@ fn ts_files_in(dir: &Path) -> Result<Vec<PathBuf>> {
     Ok(files)
 }
 
+fn ts_files_in_recursive(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut files = Vec::new();
+    let mut stack = vec![dir.to_path_buf()];
+    while let Some(d) = stack.pop() {
+        for entry in
+            fs::read_dir(&d).with_context(|| format!("Failed to read dir {}", d.display()))?
+        {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                stack.push(path);
+            } else if path.is_file() && path.extension() == Some(OsStr::new("ts")) {
+                files.push(path);
+            }
+        }
+    }
+    files.sort();
+    Ok(files)
+}
+
 fn generate_index_ts(out_dir: &Path) -> Result<PathBuf> {
     let mut entries: Vec<String> = Vec::new();
     let mut stems: Vec<String> = ts_files_in(out_dir)?
@@ -519,6 +750,14 @@ fn generate_index_ts(out_dir: &Path) -> Result<PathBuf> {
 
     for name in stems {
         entries.push(format!("export type {{ {name} }} from \"./{name}\";\n"));
+    }
+
+    // If this is the root out_dir and a ./v2 folder exists with TS files,
+    // expose it as a namespace to avoid symbol collisions at the root.
+    let v2_dir = out_dir.join("v2");
+    let has_v2_ts = ts_files_in(&v2_dir).map(|v| !v.is_empty()).unwrap_or(false);
+    if has_v2_ts {
+        entries.push("export * as v2 from \"./v2\";\n".to_string());
     }
 
     let mut content =
@@ -547,6 +786,7 @@ mod tests {
 
     #[test]
     fn generated_ts_has_no_optional_nullable_fields() -> Result<()> {
+        // Assert that there are no types of the form "?: T | null" in the generated TS files.
         let output_dir = std::env::temp_dir().join(format!("codex_ts_types_{}", Uuid::now_v7()));
         fs::create_dir(&output_dir)?;
 

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -9,7 +9,6 @@ use crate::protocol::v2;
 use codex_protocol::ConversationId;
 use codex_protocol::parse_command::ParsedCommand;
 use codex_protocol::protocol::FileChange;
-use codex_protocol::protocol::RateLimitSnapshot;
 use codex_protocol::protocol::ReviewDecision;
 use codex_protocol::protocol::SandboxCommandAssessment;
 use paste::paste;
@@ -79,6 +78,15 @@ macro_rules! client_request_definitions {
         ) -> ::anyhow::Result<()> {
             $(
                 crate::export::write_json_schema::<$response>(out_dir, stringify!($response))?;
+            )*
+            Ok(())
+        }
+
+        pub fn export_client_param_schemas(
+            out_dir: &::std::path::Path,
+        ) -> ::anyhow::Result<()> {
+            $(
+                crate::export::write_json_schema::<$params>(out_dir, stringify!($params))?;
             )*
             Ok(())
         }
@@ -284,6 +292,87 @@ macro_rules! server_request_definitions {
             }
             Ok(())
         }
+
+        pub fn export_server_param_schemas(
+            out_dir: &::std::path::Path,
+        ) -> ::anyhow::Result<()> {
+            paste! {
+                $(crate::export::write_json_schema::<[<$variant Params>]>(out_dir, stringify!([<$variant Params>]))?;)*
+            }
+            Ok(())
+        }
+    };
+}
+
+/// Generates `ServerNotification` enum and helpers, including a JSON Schema
+/// exporter for each notification.
+macro_rules! server_notification_definitions {
+    (
+        $(
+            $(#[$variant_meta:meta])*
+            $variant:ident ( $payload:ty )
+        ),* $(,)?
+    ) => {
+        /// Notification sent from the server to the client.
+        #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, TS, Display)]
+        #[serde(tag = "method", content = "params", rename_all = "camelCase")]
+        #[strum(serialize_all = "camelCase")]
+        pub enum ServerNotification {
+            $(
+                $(#[$variant_meta])*
+                $variant($payload),
+            )*
+        }
+
+        impl ServerNotification {
+            pub fn to_params(self) -> Result<serde_json::Value, serde_json::Error> {
+                match self {
+                    $(Self::$variant(params) => serde_json::to_value(params),)*
+                }
+            }
+        }
+
+        impl TryFrom<JSONRPCNotification> for ServerNotification {
+            type Error = serde_json::Error;
+
+            fn try_from(value: JSONRPCNotification) -> Result<Self, Self::Error> {
+                serde_json::from_value(serde_json::to_value(value)?)
+            }
+        }
+
+        pub fn export_server_notification_schemas(
+            out_dir: &::std::path::Path,
+        ) -> ::anyhow::Result<()> {
+            $(crate::export::write_json_schema::<$payload>(out_dir, stringify!($payload))?;)*
+            Ok(())
+        }
+    };
+}
+
+/// Notifications sent from the client to the server.
+macro_rules! client_notification_definitions {
+    (
+        $(
+            $(#[$variant_meta:meta])*
+            $variant:ident $( ( $payload:ty ) )?
+        ),* $(,)?
+    ) => {
+        #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, TS, Display)]
+        #[serde(tag = "method", content = "params", rename_all = "camelCase")]
+        #[strum(serialize_all = "camelCase")]
+        pub enum ClientNotification {
+            $(
+                $(#[$variant_meta])*
+                $variant $( ( $payload ) )?,
+            )*
+        }
+
+        pub fn export_client_notification_schemas(
+            _out_dir: &::std::path::Path,
+        ) -> ::anyhow::Result<()> {
+            $( $(crate::export::write_json_schema::<$payload>(_out_dir, stringify!($payload))?;)? )*
+            Ok(())
+        }
     };
 }
 
@@ -366,12 +455,48 @@ pub struct FuzzyFileSearchResponse {
     pub files: Vec<FuzzyFileSearchResult>,
 }
 
-/// Notification sent from the server to the client.
-#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, TS, Display)]
-#[serde(tag = "method", content = "params", rename_all = "camelCase")]
-#[strum(serialize_all = "camelCase")]
-pub enum ServerNotification {
+server_notification_definitions! {
     /// NEW NOTIFICATIONS
+    #[serde(rename = "thread/started")]
+    #[ts(rename = "thread/started")]
+    #[strum(serialize = "thread/started")]
+    ThreadStarted(v2::ThreadStartedNotification),
+
+    #[serde(rename = "turn/started")]
+    #[ts(rename = "turn/started")]
+    #[strum(serialize = "turn/started")]
+    TurnStarted(v2::TurnStartedNotification),
+
+    #[serde(rename = "turn/completed")]
+    #[ts(rename = "turn/completed")]
+    #[strum(serialize = "turn/completed")]
+    TurnCompleted(v2::TurnCompletedNotification),
+
+    #[serde(rename = "item/started")]
+    #[ts(rename = "item/started")]
+    #[strum(serialize = "item/started")]
+    ItemStarted(v2::ItemStartedNotification),
+
+    #[serde(rename = "item/completed")]
+    #[ts(rename = "item/completed")]
+    #[strum(serialize = "item/completed")]
+    ItemCompleted(v2::ItemCompletedNotification),
+
+    #[serde(rename = "item/agentMessage/delta")]
+    #[ts(rename = "item/agentMessage/delta")]
+    #[strum(serialize = "item/agentMessage/delta")]
+    AgentMessageDelta(v2::AgentMessageDeltaNotification),
+
+    #[serde(rename = "item/commandExecution/outputDelta")]
+    #[ts(rename = "item/commandExecution/outputDelta")]
+    #[strum(serialize = "item/commandExecution/outputDelta")]
+    CommandExecutionOutputDelta(v2::CommandExecutionOutputDeltaNotification),
+
+    #[serde(rename = "item/mcpToolCall/progress")]
+    #[ts(rename = "item/mcpToolCall/progress")]
+    #[strum(serialize = "item/mcpToolCall/progress")]
+    McpToolCallProgress(v2::McpToolCallProgressNotification),
+
     #[serde(rename = "account/updated")]
     #[ts(rename = "account/updated")]
     #[strum(serialize = "account/updated")]
@@ -380,44 +505,15 @@ pub enum ServerNotification {
     #[serde(rename = "account/rateLimits/updated")]
     #[ts(rename = "account/rateLimits/updated")]
     #[strum(serialize = "account/rateLimits/updated")]
-    AccountRateLimitsUpdated(RateLimitSnapshot),
+    AccountRateLimitsUpdated(v2::AccountRateLimitsUpdatedNotification),
 
     /// DEPRECATED NOTIFICATIONS below
-    /// Authentication status changed
     AuthStatusChange(v1::AuthStatusChangeNotification),
-
-    /// ChatGPT login flow completed
     LoginChatGptComplete(v1::LoginChatGptCompleteNotification),
-
-    /// The special session configured event for a new or resumed conversation.
     SessionConfigured(v1::SessionConfiguredNotification),
 }
 
-impl ServerNotification {
-    pub fn to_params(self) -> Result<serde_json::Value, serde_json::Error> {
-        match self {
-            ServerNotification::AccountUpdated(params) => serde_json::to_value(params),
-            ServerNotification::AccountRateLimitsUpdated(params) => serde_json::to_value(params),
-            ServerNotification::AuthStatusChange(params) => serde_json::to_value(params),
-            ServerNotification::LoginChatGptComplete(params) => serde_json::to_value(params),
-            ServerNotification::SessionConfigured(params) => serde_json::to_value(params),
-        }
-    }
-}
-
-impl TryFrom<JSONRPCNotification> for ServerNotification {
-    type Error = serde_json::Error;
-
-    fn try_from(value: JSONRPCNotification) -> Result<Self, Self::Error> {
-        serde_json::from_value(serde_json::to_value(value)?)
-    }
-}
-
-/// Notification sent from the client to the server.
-#[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, TS, Display)]
-#[serde(tag = "method", content = "params", rename_all = "camelCase")]
-#[strum(serialize_all = "camelCase")]
-pub enum ClientNotification {
+client_notification_definitions! {
     Initialized,
 }
 

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -4,6 +4,8 @@ use std::path::PathBuf;
 use crate::JSONRPCNotification;
 use crate::JSONRPCRequest;
 use crate::RequestId;
+use crate::export::GeneratedSchema;
+use crate::export::write_json_schema;
 use crate::protocol::v1;
 use crate::protocol::v2;
 use codex_protocol::ConversationId;
@@ -73,22 +75,26 @@ macro_rules! client_request_definitions {
             Ok(())
         }
 
+        #[allow(clippy::vec_init_then_push)]
         pub fn export_client_response_schemas(
             out_dir: &::std::path::Path,
-        ) -> ::anyhow::Result<()> {
+        ) -> ::anyhow::Result<Vec<GeneratedSchema>> {
+            let mut schemas = Vec::new();
             $(
-                crate::export::write_json_schema::<$response>(out_dir, stringify!($response))?;
+                schemas.push(write_json_schema::<$response>(out_dir, stringify!($response))?);
             )*
-            Ok(())
+            Ok(schemas)
         }
 
+        #[allow(clippy::vec_init_then_push)]
         pub fn export_client_param_schemas(
             out_dir: &::std::path::Path,
-        ) -> ::anyhow::Result<()> {
+        ) -> ::anyhow::Result<Vec<GeneratedSchema>> {
+            let mut schemas = Vec::new();
             $(
-                crate::export::write_json_schema::<$params>(out_dir, stringify!($params))?;
+                schemas.push(write_json_schema::<$params>(out_dir, stringify!($params))?);
             )*
-            Ok(())
+            Ok(schemas)
         }
     };
 }
@@ -284,22 +290,26 @@ macro_rules! server_request_definitions {
             Ok(())
         }
 
+        #[allow(clippy::vec_init_then_push)]
         pub fn export_server_response_schemas(
             out_dir: &::std::path::Path,
-        ) -> ::anyhow::Result<()> {
+        ) -> ::anyhow::Result<Vec<GeneratedSchema>> {
+            let mut schemas = Vec::new();
             paste! {
-                $(crate::export::write_json_schema::<[<$variant Response>]>(out_dir, stringify!([<$variant Response>]))?;)*
+                $(schemas.push(crate::export::write_json_schema::<[<$variant Response>]>(out_dir, stringify!([<$variant Response>]))?);)*
             }
-            Ok(())
+            Ok(schemas)
         }
 
+        #[allow(clippy::vec_init_then_push)]
         pub fn export_server_param_schemas(
             out_dir: &::std::path::Path,
-        ) -> ::anyhow::Result<()> {
+        ) -> ::anyhow::Result<Vec<GeneratedSchema>> {
+            let mut schemas = Vec::new();
             paste! {
-                $(crate::export::write_json_schema::<[<$variant Params>]>(out_dir, stringify!([<$variant Params>]))?;)*
+                $(schemas.push(crate::export::write_json_schema::<[<$variant Params>]>(out_dir, stringify!([<$variant Params>]))?);)*
             }
-            Ok(())
+            Ok(schemas)
         }
     };
 }
@@ -340,11 +350,13 @@ macro_rules! server_notification_definitions {
             }
         }
 
+        #[allow(clippy::vec_init_then_push)]
         pub fn export_server_notification_schemas(
             out_dir: &::std::path::Path,
-        ) -> ::anyhow::Result<()> {
-            $(crate::export::write_json_schema::<$payload>(out_dir, stringify!($payload))?;)*
-            Ok(())
+        ) -> ::anyhow::Result<Vec<GeneratedSchema>> {
+            let mut schemas = Vec::new();
+            $(schemas.push(crate::export::write_json_schema::<$payload>(out_dir, stringify!($payload))?);)*
+            Ok(schemas)
         }
     };
 }
@@ -369,9 +381,10 @@ macro_rules! client_notification_definitions {
 
         pub fn export_client_notification_schemas(
             _out_dir: &::std::path::Path,
-        ) -> ::anyhow::Result<()> {
-            $( $(crate::export::write_json_schema::<$payload>(_out_dir, stringify!($payload))?;)? )*
-            Ok(())
+        ) -> ::anyhow::Result<Vec<GeneratedSchema>> {
+            let schemas = Vec::new();
+            $( $(schemas.push(crate::export::write_json_schema::<$payload>(_out_dir, stringify!($payload))?);)? )*
+            Ok(schemas)
         }
     };
 }

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -320,7 +320,7 @@ macro_rules! server_notification_definitions {
     (
         $(
             $(#[$variant_meta:meta])*
-            $variant:ident ( $payload:ty )
+            $variant:ident $(=> $wire:literal)? ( $payload:ty )
         ),* $(,)?
     ) => {
         /// Notification sent from the server to the client.
@@ -330,6 +330,7 @@ macro_rules! server_notification_definitions {
         pub enum ServerNotification {
             $(
                 $(#[$variant_meta])*
+                $(#[serde(rename = $wire)] #[ts(rename = $wire)] #[strum(serialize = $wire)])?
                 $variant($payload),
             )*
         }
@@ -360,7 +361,6 @@ macro_rules! server_notification_definitions {
         }
     };
 }
-
 /// Notifications sent from the client to the server.
 macro_rules! client_notification_definitions {
     (
@@ -470,55 +470,16 @@ pub struct FuzzyFileSearchResponse {
 
 server_notification_definitions! {
     /// NEW NOTIFICATIONS
-    #[serde(rename = "thread/started")]
-    #[ts(rename = "thread/started")]
-    #[strum(serialize = "thread/started")]
-    ThreadStarted(v2::ThreadStartedNotification),
-
-    #[serde(rename = "turn/started")]
-    #[ts(rename = "turn/started")]
-    #[strum(serialize = "turn/started")]
-    TurnStarted(v2::TurnStartedNotification),
-
-    #[serde(rename = "turn/completed")]
-    #[ts(rename = "turn/completed")]
-    #[strum(serialize = "turn/completed")]
-    TurnCompleted(v2::TurnCompletedNotification),
-
-    #[serde(rename = "item/started")]
-    #[ts(rename = "item/started")]
-    #[strum(serialize = "item/started")]
-    ItemStarted(v2::ItemStartedNotification),
-
-    #[serde(rename = "item/completed")]
-    #[ts(rename = "item/completed")]
-    #[strum(serialize = "item/completed")]
-    ItemCompleted(v2::ItemCompletedNotification),
-
-    #[serde(rename = "item/agentMessage/delta")]
-    #[ts(rename = "item/agentMessage/delta")]
-    #[strum(serialize = "item/agentMessage/delta")]
-    AgentMessageDelta(v2::AgentMessageDeltaNotification),
-
-    #[serde(rename = "item/commandExecution/outputDelta")]
-    #[ts(rename = "item/commandExecution/outputDelta")]
-    #[strum(serialize = "item/commandExecution/outputDelta")]
-    CommandExecutionOutputDelta(v2::CommandExecutionOutputDeltaNotification),
-
-    #[serde(rename = "item/mcpToolCall/progress")]
-    #[ts(rename = "item/mcpToolCall/progress")]
-    #[strum(serialize = "item/mcpToolCall/progress")]
-    McpToolCallProgress(v2::McpToolCallProgressNotification),
-
-    #[serde(rename = "account/updated")]
-    #[ts(rename = "account/updated")]
-    #[strum(serialize = "account/updated")]
-    AccountUpdated(v2::AccountUpdatedNotification),
-
-    #[serde(rename = "account/rateLimits/updated")]
-    #[ts(rename = "account/rateLimits/updated")]
-    #[strum(serialize = "account/rateLimits/updated")]
-    AccountRateLimitsUpdated(v2::AccountRateLimitsUpdatedNotification),
+    ThreadStarted => "thread/started" (v2::ThreadStartedNotification),
+    TurnStarted => "turn/started" (v2::TurnStartedNotification),
+    TurnCompleted => "turn/completed" (v2::TurnCompletedNotification),
+    ItemStarted => "item/started" (v2::ItemStartedNotification),
+    ItemCompleted => "item/completed" (v2::ItemCompletedNotification),
+    AgentMessageDelta => "item/agentMessage/delta" (v2::AgentMessageDeltaNotification),
+    CommandExecutionOutputDelta => "item/commandExecution/outputDelta" (v2::CommandExecutionOutputDeltaNotification),
+    McpToolCallProgress => "item/mcpToolCall/progress" (v2::McpToolCallProgressNotification),
+    AccountUpdated => "account/updated" (v2::AccountUpdatedNotification),
+    AccountRateLimitsUpdated => "account/rateLimits/updated" (v2::AccountRateLimitsUpdatedNotification),
 
     /// DEPRECATED NOTIFICATIONS below
     AuthStatusChange(v1::AuthStatusChangeNotification),

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -16,6 +16,7 @@ use uuid::Uuid;
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(tag = "type", rename_all = "camelCase")]
 #[ts(tag = "type")]
+#[ts(export_to = "v2/")]
 pub enum Account {
     #[serde(rename = "apiKey", rename_all = "camelCase")]
     #[ts(rename = "apiKey", rename_all = "camelCase")]
@@ -32,6 +33,7 @@ pub enum Account {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(tag = "type")]
 #[ts(tag = "type")]
+#[ts(export_to = "v2/")]
 pub enum LoginAccountParams {
     #[serde(rename = "apiKey")]
     #[ts(rename = "apiKey")]
@@ -47,6 +49,7 @@ pub enum LoginAccountParams {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct LoginAccountResponse {
     /// Only set if the login method is ChatGPT.
     #[schemars(with = "String")]
@@ -59,22 +62,26 @@ pub struct LoginAccountResponse {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct LogoutAccountResponse {}
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct GetAccountRateLimitsResponse {
     pub rate_limits: RateLimitSnapshot,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct GetAccountResponse {
     pub account: Account,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct ListModelsParams {
     /// Optional page size; defaults to a reasonable server-side value.
     pub page_size: Option<usize>,
@@ -84,6 +91,7 @@ pub struct ListModelsParams {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct Model {
     pub id: String,
     pub model: String,
@@ -97,6 +105,7 @@ pub struct Model {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct ReasoningEffortOption {
     pub reasoning_effort: ReasoningEffort,
     pub description: String,
@@ -104,6 +113,7 @@ pub struct ReasoningEffortOption {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct ListModelsResponse {
     pub items: Vec<Model>,
     /// Opaque cursor to pass to the next call to continue after the last item.
@@ -113,6 +123,7 @@ pub struct ListModelsResponse {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct UploadFeedbackParams {
     pub classification: String,
     pub reason: Option<String>,
@@ -122,24 +133,28 @@ pub struct UploadFeedbackParams {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct UploadFeedbackResponse {
     pub thread_id: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct AccountUpdatedNotification {
     pub auth_method: Option<AuthMode>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct Thread {
     pub id: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct Turn {
     pub id: String,
     pub items: Vec<ThreadItem>,
@@ -149,6 +164,7 @@ pub struct Turn {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub enum TurnStatus {
     Completed,
     Interrupted,
@@ -158,12 +174,14 @@ pub enum TurnStatus {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct TurnError {
     pub message: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(tag = "type", rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub enum UserInput {
     Text { text: String },
     Image { url: String },
@@ -172,6 +190,7 @@ pub enum UserInput {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(tag = "type", rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub enum ThreadItem {
     UserMessage {
         id: String,
@@ -227,6 +246,7 @@ pub enum ThreadItem {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub enum CommandExecutionStatus {
     InProgress,
     Completed,
@@ -235,6 +255,7 @@ pub enum CommandExecutionStatus {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct FileUpdateChange {
     pub path: String,
     pub kind: PatchChangeKind,
@@ -243,6 +264,7 @@ pub struct FileUpdateChange {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub enum PatchChangeKind {
     Add,
     Delete,
@@ -251,6 +273,7 @@ pub enum PatchChangeKind {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub enum PatchApplyStatus {
     Completed,
     Failed,
@@ -258,6 +281,7 @@ pub enum PatchApplyStatus {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub enum McpToolCallStatus {
     InProgress,
     Completed,
@@ -266,6 +290,7 @@ pub enum McpToolCallStatus {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct McpToolCallResult {
     pub content: Vec<McpContentBlock>,
     pub structured_content: JsonValue,
@@ -273,12 +298,14 @@ pub struct McpToolCallResult {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct McpToolCallError {
     pub message: String,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct TodoItem {
     pub id: String,
     pub text: String,
@@ -289,18 +316,21 @@ pub struct TodoItem {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct ThreadStartedNotification {
     pub thread: Thread,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct TurnStartedNotification {
     pub turn: Turn,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct Usage {
     pub input_tokens: i32,
     pub cached_input_tokens: i32,
@@ -309,6 +339,7 @@ pub struct Usage {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct TurnCompletedNotification {
     pub turn: Turn,
     pub usage: Usage,
@@ -316,18 +347,21 @@ pub struct TurnCompletedNotification {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct ItemStartedNotification {
     pub item: ThreadItem,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct ItemCompletedNotification {
     pub item: ThreadItem,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct AgentMessageDeltaNotification {
     pub item_id: String,
     pub delta: String,
@@ -335,6 +369,7 @@ pub struct AgentMessageDeltaNotification {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct CommandExecutionOutputDeltaNotification {
     pub item_id: String,
     pub delta: String,
@@ -342,6 +377,7 @@ pub struct CommandExecutionOutputDeltaNotification {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct McpToolCallProgressNotification {
     pub item_id: String,
     pub message: String,
@@ -349,12 +385,14 @@ pub struct McpToolCallProgressNotification {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct AccountRateLimitsUpdatedNotification {
     pub rate_limits: RateLimitSnapshot,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct RateLimitSnapshot {
     pub primary: Option<RateLimitWindow>,
     pub secondary: Option<RateLimitWindow>,
@@ -371,6 +409,7 @@ impl From<CoreRateLimitSnapshot> for RateLimitSnapshot {
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct RateLimitWindow {
     pub used_percent: i32,
     pub window_duration_mins: Option<i64>,

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -4,6 +4,7 @@ use crate::fuzzy_file_search::run_fuzzy_file_search;
 use crate::models::supported_models;
 use crate::outgoing_message::OutgoingMessageSender;
 use crate::outgoing_message::OutgoingNotification;
+use codex_app_server_protocol::AccountRateLimitsUpdatedNotification;
 use codex_app_server_protocol::AccountUpdatedNotification;
 use codex_app_server_protocol::AddConversationListenerParams;
 use codex_app_server_protocol::AddConversationSubscriptionResponse;
@@ -625,7 +626,9 @@ impl CodexMessageProcessor {
     async fn get_account_rate_limits(&self, request_id: RequestId) {
         match self.fetch_account_rate_limits().await {
             Ok(rate_limits) => {
-                let response = GetAccountRateLimitsResponse { rate_limits };
+                let response = GetAccountRateLimitsResponse {
+                    rate_limits: rate_limits.into(),
+                };
                 self.outgoing.send_response(request_id, response).await;
             }
             Err(error) => {
@@ -1766,7 +1769,9 @@ async fn apply_bespoke_event_handling(
             if let Some(rate_limits) = token_count_event.rate_limits {
                 outgoing
                     .send_server_notification(ServerNotification::AccountRateLimitsUpdated(
-                        rate_limits,
+                        AccountRateLimitsUpdatedNotification {
+                            rate_limits: rate_limits.into(),
+                        },
                     ))
                     .await;
             }

--- a/codex-rs/app-server/src/outgoing_message.rs
+++ b/codex-rs/app-server/src/outgoing_message.rs
@@ -199,8 +199,8 @@ mod tests {
                 "params": {
                     "rateLimits": {
                         "primary": {
-                            "usedPercent": 25.0,
-                            "windowMinutes": 15,
+                            "usedPercent": 25,
+                            "windowDurationMins": 15,
                             "resetsAt": 123
                         },
                         "secondary": null

--- a/codex-rs/app-server/src/outgoing_message.rs
+++ b/codex-rs/app-server/src/outgoing_message.rs
@@ -183,7 +183,7 @@ mod tests {
             codex_app_server_protocol::AccountRateLimitsUpdatedNotification {
                 rate_limits: RateLimitSnapshot {
                     primary: Some(RateLimitWindow {
-                        used_percent: 25.0,
+                        used_percent: 25,
                         window_duration_mins: Some(15),
                         resets_at: Some(123),
                     }),

--- a/codex-rs/app-server/src/outgoing_message.rs
+++ b/codex-rs/app-server/src/outgoing_message.rs
@@ -141,6 +141,7 @@ pub(crate) struct OutgoingError {
 
 #[cfg(test)]
 mod tests {
+    use codex_app_server_protocol::AccountRateLimitsUpdatedNotification;
     use codex_app_server_protocol::AccountUpdatedNotification;
     use codex_app_server_protocol::AuthMode;
     use codex_app_server_protocol::LoginChatGptCompleteNotification;
@@ -179,8 +180,8 @@ mod tests {
 
     #[test]
     fn verify_account_rate_limits_notification_serialization() {
-        let notification = ServerNotification::AccountRateLimitsUpdated(
-            codex_app_server_protocol::AccountRateLimitsUpdatedNotification {
+        let notification =
+            ServerNotification::AccountRateLimitsUpdated(AccountRateLimitsUpdatedNotification {
                 rate_limits: RateLimitSnapshot {
                     primary: Some(RateLimitWindow {
                         used_percent: 25,
@@ -189,8 +190,7 @@ mod tests {
                     }),
                     secondary: None,
                 },
-            },
-        );
+            });
 
         let jsonrpc_notification = OutgoingMessage::AppServerNotification(notification);
         assert_eq!(

--- a/codex-rs/app-server/src/outgoing_message.rs
+++ b/codex-rs/app-server/src/outgoing_message.rs
@@ -144,8 +144,8 @@ mod tests {
     use codex_app_server_protocol::AccountUpdatedNotification;
     use codex_app_server_protocol::AuthMode;
     use codex_app_server_protocol::LoginChatGptCompleteNotification;
-    use codex_protocol::protocol::RateLimitSnapshot;
-    use codex_protocol::protocol::RateLimitWindow;
+    use codex_app_server_protocol::RateLimitSnapshot;
+    use codex_app_server_protocol::RateLimitWindow;
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use uuid::Uuid;
@@ -179,26 +179,32 @@ mod tests {
 
     #[test]
     fn verify_account_rate_limits_notification_serialization() {
-        let notification = ServerNotification::AccountRateLimitsUpdated(RateLimitSnapshot {
-            primary: Some(RateLimitWindow {
-                used_percent: 25.0,
-                window_minutes: Some(15),
-                resets_at: Some(123),
-            }),
-            secondary: None,
-        });
+        let notification = ServerNotification::AccountRateLimitsUpdated(
+            codex_app_server_protocol::AccountRateLimitsUpdatedNotification {
+                rate_limits: RateLimitSnapshot {
+                    primary: Some(RateLimitWindow {
+                        used_percent: 25.0,
+                        window_duration_mins: Some(15),
+                        resets_at: Some(123),
+                    }),
+                    secondary: None,
+                },
+            },
+        );
 
         let jsonrpc_notification = OutgoingMessage::AppServerNotification(notification);
         assert_eq!(
             json!({
                 "method": "account/rateLimits/updated",
                 "params": {
-                    "primary": {
-                        "used_percent": 25.0,
-                        "window_minutes": 15,
-                        "resets_at": 123,
-                    },
-                    "secondary": null,
+                    "rateLimits": {
+                        "primary": {
+                            "usedPercent": 25.0,
+                            "windowMinutes": 15,
+                            "resetsAt": 123
+                        },
+                        "secondary": null
+                    }
                 },
             }),
             serde_json::to_value(jsonrpc_notification)

--- a/codex-rs/app-server/tests/suite/rate_limits.rs
+++ b/codex-rs/app-server/tests/suite/rate_limits.rs
@@ -7,10 +7,10 @@ use codex_app_server_protocol::GetAccountRateLimitsResponse;
 use codex_app_server_protocol::JSONRPCError;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::LoginApiKeyParams;
+use codex_app_server_protocol::RateLimitSnapshot;
+use codex_app_server_protocol::RateLimitWindow;
 use codex_app_server_protocol::RequestId;
 use codex_core::auth::AuthCredentialsStoreMode;
-use codex_protocol::protocol::RateLimitSnapshot;
-use codex_protocol::protocol::RateLimitWindow;
 use pretty_assertions::assert_eq;
 use serde_json::json;
 use std::path::Path;
@@ -143,13 +143,13 @@ async fn get_account_rate_limits_returns_snapshot() -> Result<()> {
     let expected = GetAccountRateLimitsResponse {
         rate_limits: RateLimitSnapshot {
             primary: Some(RateLimitWindow {
-                used_percent: 42.0,
-                window_minutes: Some(60),
+                used_percent: 42,
+                window_duration_mins: Some(60),
                 resets_at: Some(primary_reset_timestamp),
             }),
             secondary: Some(RateLimitWindow {
-                used_percent: 5.0,
-                window_minutes: Some(1440),
+                used_percent: 5,
+                window_duration_mins: Some(1440),
                 resets_at: Some(secondary_reset_timestamp),
             }),
         },


### PR DESCRIPTION
**Typescript and JSON schema exports**
While working on Thread/Turn/Items type definitions, I realize we will run into name conflicts between v1 and v2 APIs (e.g. `RateLimitWindow` which won't be reusable since v1 uses `RateLimitWindow` from `protocol/` which uses snake_case, but we want to expose camelCase everywhere, so we'll define a V2 version of that struct that serializes as camelCase).

To set us up for a clean and isolated v2 API, generate types into a `v2/` namespace for both typescript and JSON schema.
- TypeScript: v2 types emit under `out_dir/v2/*.ts`, and root index.ts now re-exports them via `export * as v2 from "./v2"`;.
- JSON Schemas: v2 definitions bundle under `#/definitions/v2/*` rather than the root.

The location for the original types (v1 and types pulled from `protocol/` and other core crates) haven't changed and are still at the root. This is for backwards compatibility: no breaking changes to existing usages of v1 APIs and types.

**Notifications**
While working on export.rs, I:
- refactored server/client notifications with macros (like we already do for methods) so they also get exported (I noticed they weren't being exported at all).
- removed the hardcoded list of types to export as JSON schema by leveraging the existing macros instead
- and took a stab at API V2 notifications. These aren't wired up yet, and I expect to iterate on these this week.