### PR TITLE
Improved token refresh handling to address "Re-connecting" behavior

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -70,7 +70,6 @@ use codex_core::NewConversation;
 use codex_core::RolloutRecorder;
 use codex_core::SessionMeta;
 use codex_core::auth::CLIENT_ID;
-use codex_core::auth::RefreshTokenError;
 use codex_core::auth::login_with_api_key;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
@@ -570,24 +569,8 @@ impl CodexMessageProcessor {
         let include_token = params.include_token.unwrap_or(false);
         let do_refresh = params.refresh_token.unwrap_or(false);
 
-        // Attempt token refresh if requested. This may cause the auth state to change
-        // if token refresh fails in a permanent (non-transient) manner.
         if do_refresh && let Err(err) = self.auth_manager.refresh_token().await {
-            match err {
-                RefreshTokenError::Permanent(failed) => {
-                    tracing::warn!(
-                        reason = ?failed.reason,
-                        "failed to refresh token while getting auth status: {}; logging out",
-                        failed
-                    );
-                }
-                RefreshTokenError::Transient(other) => {
-                    tracing::warn!(
-                        "failed to refresh token while getting auth status: {}",
-                        other
-                    );
-                }
-            }
+            tracing::warn!("failed to refresh token while getting auth status: {err}");
         }
 
         // Determine whether auth is required based on the active model provider.

--- a/codex-rs/core/src/auth.rs
+++ b/codex-rs/core/src/auth.rs
@@ -57,6 +57,8 @@ const REFRESH_TOKEN_REUSED_MESSAGE: &str = "Your access token could not be refre
 const REFRESH_TOKEN_INVALIDATED_MESSAGE: &str = "Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.";
 const REFRESH_TOKEN_UNKNOWN_MESSAGE: &str =
     "Your access token could not be refreshed. Please log out and sign in again.";
+const REFRESH_TOKEN_URL: &str = "https://auth.openai.com/oauth/token";
+pub const REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR: &str = "CODEX_REFRESH_TOKEN_URL_OVERRIDE";
 
 #[derive(Debug, Error)]
 pub enum RefreshTokenError {
@@ -480,9 +482,11 @@ async fn try_refresh_token(
         scope: "openid profile email",
     };
 
+    let endpoint = refresh_token_endpoint();
+
     // Use shared client factory to include standard headers
     let response = client
-        .post("https://auth.openai.com/oauth/token")
+        .post(endpoint.as_str())
         .header("Content-Type", "application/json")
         .json(&refresh_request)
         .send()
@@ -582,6 +586,11 @@ struct RefreshResponse {
 
 // Shared constant for token refresh (client id used for oauth token refresh flow)
 pub const CLIENT_ID: &str = "app_EMoamEEZ73f0CkXaXp7hrann";
+
+fn refresh_token_endpoint() -> String {
+    std::env::var(REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR)
+        .unwrap_or_else(|_| REFRESH_TOKEN_URL.to_string())
+}
 
 use std::sync::RwLock;
 

--- a/codex-rs/core/src/auth.rs
+++ b/codex-rs/core/src/auth.rs
@@ -52,13 +52,11 @@ impl PartialEq for CodexAuth {
 // TODO(pakrym): use token exp field to check for expiration instead
 const TOKEN_REFRESH_INTERVAL: i64 = 8;
 
-const REFRESH_TOKEN_EXPIRED_MESSAGE: &str =
-    "Could not refresh token has expired. Please sign in again.";
-const REFRESH_TOKEN_REUSED_MESSAGE: &str = "Your refresh token has already been used to generate a new access token. Please sign in again.";
-const REFRESH_TOKEN_INVALIDATED_MESSAGE: &str =
-    "Your refresh token has been invalidated. Please sign in again.";
+const REFRESH_TOKEN_EXPIRED_MESSAGE: &str = "Your access token could not be refreshed because your refresh token has expired. Please log out and sign in again.";
+const REFRESH_TOKEN_REUSED_MESSAGE: &str = "Your access token could not be refreshed because your refresh token was already used. Please log out and sign in again.";
+const REFRESH_TOKEN_INVALIDATED_MESSAGE: &str = "Your access token could not be refreshed because your refresh token was revoked. Please log out and sign in again.";
 const REFRESH_TOKEN_UNKNOWN_MESSAGE: &str =
-    "We couldn't refresh your session. Please sign in again.";
+    "Your access token could not be refreshed. Please log out and sign in again.";
 
 #[derive(Debug, Error)]
 pub enum RefreshTokenError {
@@ -1094,12 +1092,6 @@ impl AuthManager {
                             "Failed to refresh token: {}",
                             failed
                         );
-                        if let Err(logout_err) = self.logout() {
-                            tracing::error!(
-                                "failed to clear auth after fatal refresh error: {}",
-                                logout_err
-                            );
-                        }
                     }
                     RefreshTokenError::Transient(other) => {
                         tracing::error!("Failed to refresh token: {}", other);

--- a/codex-rs/core/src/auth.rs
+++ b/codex-rs/core/src/auth.rs
@@ -1084,20 +1084,9 @@ impl AuthManager {
                 self.reload();
                 Ok(Some(token))
             }
-            Err(err) => {
-                match &err {
-                    RefreshTokenError::Permanent(failed) => {
-                        tracing::error!(
-                            reason = ?failed.reason,
-                            "Failed to refresh token: {}",
-                            failed
-                        );
-                    }
-                    RefreshTokenError::Transient(other) => {
-                        tracing::error!("Failed to refresh token: {}", other);
-                    }
-                }
-                Err(err)
+            Err(e) => {
+                tracing::error!("Failed to refresh token: {}", e);
+                Err(e)
             }
         }
     }

--- a/codex-rs/core/src/auth.rs
+++ b/codex-rs/core/src/auth.rs
@@ -1,12 +1,14 @@
 mod storage;
 
 use chrono::Utc;
+use reqwest::StatusCode;
 use serde::Deserialize;
 use serde::Serialize;
 #[cfg(test)]
 use serial_test::serial;
 use std::env;
 use std::fmt::Debug;
+use std::io::ErrorKind;
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -22,10 +24,14 @@ use crate::auth::storage::AuthStorageBackend;
 use crate::auth::storage::create_auth_storage;
 use crate::config::Config;
 use crate::default_client::CodexHttpClient;
+use crate::error::RefreshTokenFailedError;
+use crate::error::RefreshTokenFailedReason;
 use crate::token_data::PlanType;
 use crate::token_data::TokenData;
 use crate::token_data::parse_id_token;
 use crate::util::try_parse_error_message;
+use serde_json::Value;
+use thiserror::Error;
 
 #[derive(Debug, Clone)]
 pub struct CodexAuth {
@@ -46,18 +52,52 @@ impl PartialEq for CodexAuth {
 // TODO(pakrym): use token exp field to check for expiration instead
 const TOKEN_REFRESH_INTERVAL: i64 = 8;
 
+const REFRESH_TOKEN_EXPIRED_MESSAGE: &str =
+    "Could not refresh token has expired. Please sign in again.";
+const REFRESH_TOKEN_REUSED_MESSAGE: &str = "Your refresh token has already been used to generate a new access token. Please sign in again.";
+const REFRESH_TOKEN_INVALIDATED_MESSAGE: &str =
+    "Your refresh token has been invalidated. Please sign in again.";
+const REFRESH_TOKEN_UNKNOWN_MESSAGE: &str =
+    "We couldn't refresh your session. Please sign in again.";
+
+#[derive(Debug, Error)]
+pub enum RefreshTokenError {
+    #[error("{0}")]
+    Permanent(#[from] RefreshTokenFailedError),
+    #[error(transparent)]
+    Transient(#[from] std::io::Error),
+}
+
+impl RefreshTokenError {
+    pub fn failed_reason(&self) -> Option<RefreshTokenFailedReason> {
+        match self {
+            Self::Permanent(error) => Some(error.reason),
+            Self::Transient(_) => None,
+        }
+    }
+
+    fn other_with_message(message: impl Into<String>) -> Self {
+        Self::Transient(std::io::Error::other(message.into()))
+    }
+}
+
+fn refresh_token_error_to_io(err: RefreshTokenError) -> std::io::Error {
+    match err {
+        RefreshTokenError::Permanent(failed) => std::io::Error::other(failed),
+        RefreshTokenError::Transient(inner) => inner,
+    }
+}
+
 impl CodexAuth {
-    pub async fn refresh_token(&self) -> Result<String, std::io::Error> {
+    pub async fn refresh_token(&self) -> Result<String, RefreshTokenError> {
         tracing::info!("Refreshing token");
 
-        let token_data = self
-            .get_current_token_data()
-            .ok_or(std::io::Error::other("Token data is not available."))?;
+        let token_data = self.get_current_token_data().ok_or_else(|| {
+            RefreshTokenError::Transient(std::io::Error::other("Token data is not available."))
+        })?;
         let token = token_data.refresh_token;
 
-        let refresh_response = try_refresh_token(token, &self.client)
-            .await
-            .map_err(std::io::Error::other)?;
+        let refresh_response = try_refresh_token(token, &self.client).await?;
 
         let updated = update_tokens(
             &self.storage,
@@ -65,7 +105,8 @@ impl CodexAuth {
             refresh_response.access_token,
             refresh_response.refresh_token,
         )
-        .await?;
+        .await
+        .map_err(RefreshTokenError::from)?;
 
         if let Ok(mut auth_lock) = self.auth_dot_json.lock() {
             *auth_lock = Some(updated.clone());
@@ -74,7 +115,7 @@ impl CodexAuth {
         let access = match updated.tokens {
             Some(t) => t.access_token,
             None => {
-                return Err(std::io::Error::other(
+                return Err(RefreshTokenError::other_with_message(
                     "Token data is not available after refresh.",
                 ));
             }
@@ -99,15 +140,21 @@ impl CodexAuth {
                 ..
             }) => {
                 if last_refresh < Utc::now() - chrono::Duration::days(TOKEN_REFRESH_INTERVAL) {
-                    let refresh_response = tokio::time::timeout(
+                    let refresh_result = tokio::time::timeout(
                         Duration::from_secs(60),
                         try_refresh_token(tokens.refresh_token.clone(), &self.client),
                     )
-                    .await
-                    .map_err(|_| {
-                        std::io::Error::other("timed out while refreshing OpenAI API key")
-                    })?
-                    .map_err(std::io::Error::other)?;
+                    .await;
+                    let refresh_response = match refresh_result {
+                        Ok(Ok(response)) => response,
+                        Ok(Err(err)) => return Err(refresh_token_error_to_io(err)),
+                        Err(_) => {
+                            return Err(std::io::Error::new(
+                                ErrorKind::TimedOut,
+                                "timed out while refreshing OpenAI API key",
+                            ));
+                        }
+                    };
 
                     let updated_auth_dot_json = update_tokens(
                         &self.storage,
@@ -425,7 +472,7 @@ async fn update_tokens(
 async fn try_refresh_token(
     refresh_token: String,
     client: &CodexHttpClient,
-) -> std::io::Result<RefreshResponse> {
+) -> Result<RefreshResponse, RefreshTokenError> {
     let refresh_request = RefreshRequest {
         client_id: CLIENT_ID,
         grant_type: "refresh_token",
@@ -440,21 +487,82 @@ async fn try_refresh_token(
         .json(&refresh_request)
         .send()
         .await
-        .map_err(std::io::Error::other)?;
+        .map_err(|err| RefreshTokenError::Transient(std::io::Error::other(err)))?;
 
-    if response.status().is_success() {
+    let status = response.status();
+    if status.is_success() {
         let refresh_response = response
             .json::<RefreshResponse>()
             .await
-            .map_err(std::io::Error::other)?;
+            .map_err(|err| RefreshTokenError::Transient(std::io::Error::other(err)))?;
         Ok(refresh_response)
     } else {
-        Err(std::io::Error::other(format!(
-            "Failed to refresh token: {}: {}",
-            response.status(),
-            try_parse_error_message(&response.text().await.unwrap_or_default()),
-        )))
+        let body = response.text().await.unwrap_or_default();
+        if status == StatusCode::UNAUTHORIZED {
+            let failed = classify_refresh_token_failure(&body);
+            Err(RefreshTokenError::Permanent(failed))
+        } else {
+            let message = try_parse_error_message(&body);
+            Err(RefreshTokenError::Transient(std::io::Error::other(
+                format!("Failed to refresh token: {status}: {message}"),
+            )))
+        }
     }
+}
+
+fn classify_refresh_token_failure(body: &str) -> RefreshTokenFailedError {
+    let code = extract_refresh_token_error_code(body);
+
+    let normalized_code = code.as_deref().map(str::to_ascii_lowercase);
+    let reason = match normalized_code.as_deref() {
+        Some("refresh_token_expired") => RefreshTokenFailedReason::Expired,
+        Some("refresh_token_reused") => RefreshTokenFailedReason::Exhausted,
+        Some("refresh_token_invalidated") => RefreshTokenFailedReason::Revoked,
+        _ => RefreshTokenFailedReason::Other,
+    };
+
+    if reason == RefreshTokenFailedReason::Other {
+        tracing::warn!(
+            backend_code = normalized_code.as_deref(),
+            backend_body = body,
+            "Encountered unknown 401 response while refreshing token"
+        );
+    }
+
+    let message = match reason {
+        RefreshTokenFailedReason::Expired => REFRESH_TOKEN_EXPIRED_MESSAGE.to_string(),
+        RefreshTokenFailedReason::Exhausted => REFRESH_TOKEN_REUSED_MESSAGE.to_string(),
+        RefreshTokenFailedReason::Revoked => REFRESH_TOKEN_INVALIDATED_MESSAGE.to_string(),
+        RefreshTokenFailedReason::Other => REFRESH_TOKEN_UNKNOWN_MESSAGE.to_string(),
+    };
+
+    RefreshTokenFailedError::new(reason, message)
+}
+
+fn extract_refresh_token_error_code(body: &str) -> Option<String> {
+    if body.trim().is_empty() {
+        return None;
+    }
+
+    let Value::Object(map) = serde_json::from_str::<Value>(body).ok()? else {
+        return None;
+    };
+
+    if let Some(error_value) = map.get("error") {
+        match error_value {
+            Value::Object(obj) => {
+                if let Some(code) = obj.get("code").and_then(Value::as_str) {
+                    return Some(code.to_string());
+                }
+            }
+            Value::String(code) => {
+                return Some(code.to_string());
+            }
+            _ => {}
+        }
+    }
+
+    map.get("code").and_then(Value::as_str).map(str::to_string)
 }
 
 #[derive(Serialize)]
@@ -965,7 +1073,9 @@ impl AuthManager {
 
     /// Attempt to refresh the current auth token (if any). On success, reload
     /// the auth state from disk so other components observe refreshed token.
-    pub async fn refresh_token(&self) -> std::io::Result<Option<String>> {
+    /// If the token refresh fails in a permanent (non‑transient) way, logs out
+    /// to clear invalid auth state.
+    pub async fn refresh_token(&self) -> Result<Option<String>, RefreshTokenError> {
         let auth = match self.auth() {
             Some(a) => a,
             None => return Ok(None),
@@ -976,9 +1086,26 @@ impl AuthManager {
                 self.reload();
                 Ok(Some(token))
             }
-            Err(e) => {
-                tracing::error!("Failed to refresh token: {}", e);
-                Err(e)
+            Err(err) => {
+                match &err {
+                    RefreshTokenError::Permanent(failed) => {
+                        tracing::error!(
+                            reason = ?failed.reason,
+                            "Failed to refresh token: {}",
+                            failed
+                        );
+                        if let Err(logout_err) = self.logout() {
+                            tracing::error!(
+                                "failed to clear auth after fatal refresh error: {}",
+                                logout_err
+                            );
+                        }
+                    }
+                    RefreshTokenError::Transient(other) => {
+                        tracing::error!("Failed to refresh token: {}", other);
+                    }
+                }
+                Err(err)
             }
         }
     }

--- a/codex-rs/core/src/auth.rs
+++ b/codex-rs/core/src/auth.rs
@@ -79,10 +79,12 @@ impl RefreshTokenError {
     }
 }
 
-fn refresh_token_error_to_io(err: RefreshTokenError) -> std::io::Error {
-    match err {
-        RefreshTokenError::Permanent(failed) => std::io::Error::other(failed),
-        RefreshTokenError::Transient(inner) => inner,
+impl From<RefreshTokenError> for std::io::Error {
+    fn from(err: RefreshTokenError) -> Self {
+        match err {
+            RefreshTokenError::Permanent(failed) => std::io::Error::other(failed),
+            RefreshTokenError::Transient(inner) => inner,
+        }
     }
 }
 
@@ -145,7 +147,7 @@ impl CodexAuth {
                     .await;
                     let refresh_response = match refresh_result {
                         Ok(Ok(response)) => response,
-                        Ok(Err(err)) => return Err(refresh_token_error_to_io(err)),
+                        Ok(Err(err)) => return Err(err.into()),
                         Err(_) => {
                             return Err(std::io::Error::new(
                                 ErrorKind::TimedOut,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1928,6 +1928,7 @@ async fn run_turn(
                 return Err(CodexErr::UsageLimitReached(e));
             }
             Err(CodexErr::UsageNotIncluded) => return Err(CodexErr::UsageNotIncluded),
+            Err(e @ CodexErr::RefreshTokenFailed(_)) => return Err(e),
             Err(e) => {
                 // Use the configured provider-specific stream retry budget.
                 let max_retries = turn_context.client.get_provider().stream_max_retries();
@@ -1946,7 +1947,7 @@ async fn run_turn(
                     // at a seemingly frozen screen.
                     sess.notify_stream_error(
                         &turn_context,
-                        format!("Re-connecting... {retries}/{max_retries}"),
+                        format!("Reconnecting... {retries}/{max_retries}"),
                     )
                     .await;
 

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -135,6 +135,9 @@ pub enum CodexErr {
     #[error("unsupported operation: {0}")]
     UnsupportedOperation(String),
 
+    #[error("{0}")]
+    RefreshTokenFailed(RefreshTokenFailedError),
+
     #[error("Fatal error: {0}")]
     Fatal(String),
 
@@ -199,6 +202,30 @@ impl std::fmt::Display for ResponseStreamFailed {
                 .unwrap_or_default()
         )
     }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+#[error("{message}")]
+pub struct RefreshTokenFailedError {
+    pub reason: RefreshTokenFailedReason,
+    pub message: String,
+}
+
+impl RefreshTokenFailedError {
+    pub fn new(reason: RefreshTokenFailedReason, message: impl Into<String>) -> Self {
+        Self {
+            reason,
+            message: message.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RefreshTokenFailedReason {
+    Expired,
+    Exhausted,
+    Revoked,
+    Other,
 }
 
 #[derive(Debug)]

--- a/codex-rs/core/tests/suite/auth_refresh.rs
+++ b/codex-rs/core/tests/suite/auth_refresh.rs
@@ -1,0 +1,244 @@
+use anyhow::Result;
+use base64::Engine;
+use chrono::Duration;
+use chrono::Utc;
+use codex_core::CodexAuth;
+use codex_core::auth::AuthCredentialsStoreMode;
+use codex_core::auth::AuthDotJson;
+use codex_core::auth::REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR;
+use codex_core::auth::RefreshTokenError;
+use codex_core::auth::load_auth_dot_json;
+use codex_core::auth::save_auth;
+use codex_core::error::RefreshTokenFailedReason;
+use codex_core::token_data::IdTokenInfo;
+use codex_core::token_data::TokenData;
+use core_test_support::skip_if_no_network;
+use pretty_assertions::assert_eq;
+use serde::Serialize;
+use serde_json::json;
+use std::ffi::OsString;
+use tempfile::TempDir;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+
+const INITIAL_ACCESS_TOKEN: &str = "initial-access-token";
+const INITIAL_REFRESH_TOKEN: &str = "initial-refresh-token";
+
+#[tokio::test]
+async fn refresh_token_succeeds_updates_storage() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let ctx = RefreshTokenTestContext::new(&server)?;
+    let auth = ctx.auth.clone();
+
+    let access = auth.refresh_token().await.expect("refresh should succeed");
+    assert_eq!(access, "new-access-token");
+
+    let stored = ctx.load_auth();
+    let tokens = stored.tokens.expect("tokens should exist");
+    assert_eq!(tokens.access_token, "new-access-token");
+    assert_eq!(tokens.refresh_token, "new-refresh-token");
+    let refreshed_at = stored
+        .last_refresh
+        .expect("last_refresh should be recorded");
+    assert!(
+        refreshed_at >= ctx.initial_last_refresh,
+        "last_refresh should advance"
+    );
+
+    let cached = auth
+        .get_token_data()
+        .await
+        .expect("token data should be cached");
+    assert_eq!(cached.access_token, "new-access-token");
+
+    server.verify().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn refresh_token_returns_permanent_error_for_expired_refresh_token() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(401).set_body_json(json!({
+            "error": {
+                "code": "refresh_token_expired"
+            }
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let ctx = RefreshTokenTestContext::new(&server)?;
+    let auth = ctx.auth.clone();
+
+    let err = auth.refresh_token().await.expect_err("refresh should fail");
+    assert_eq!(err.failed_reason(), Some(RefreshTokenFailedReason::Expired));
+
+    let stored = ctx.load_auth();
+    let tokens = stored.tokens.expect("tokens should remain");
+    assert_eq!(tokens.access_token, INITIAL_ACCESS_TOKEN);
+    assert_eq!(tokens.refresh_token, INITIAL_REFRESH_TOKEN);
+    assert_eq!(
+        stored
+            .last_refresh
+            .expect("last_refresh should remain unchanged"),
+        ctx.initial_last_refresh
+    );
+
+    server.verify().await;
+    Ok(())
+}
+
+#[tokio::test]
+async fn refresh_token_returns_transient_error_on_server_failure() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(500).set_body_json(json!({
+            "error": "temporary-failure"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let ctx = RefreshTokenTestContext::new(&server)?;
+    let auth = ctx.auth.clone();
+
+    let err = auth.refresh_token().await.expect_err("refresh should fail");
+    assert!(matches!(err, RefreshTokenError::Transient(_)));
+    assert_eq!(err.failed_reason(), None);
+
+    let stored = ctx.load_auth();
+    let tokens = stored.tokens.expect("tokens should remain");
+    assert_eq!(tokens.access_token, INITIAL_ACCESS_TOKEN);
+    assert_eq!(tokens.refresh_token, INITIAL_REFRESH_TOKEN);
+    assert_eq!(
+        stored
+            .last_refresh
+            .expect("last_refresh should remain unchanged"),
+        ctx.initial_last_refresh
+    );
+
+    server.verify().await;
+    Ok(())
+}
+
+struct RefreshTokenTestContext {
+    codex_home: TempDir,
+    auth: CodexAuth,
+    initial_last_refresh: chrono::DateTime<Utc>,
+    _env_guard: EnvGuard,
+}
+
+impl RefreshTokenTestContext {
+    fn new(server: &MockServer) -> Result<Self> {
+        let codex_home = TempDir::new()?;
+        let initial_last_refresh = Utc::now() - Duration::days(1);
+        let mut id_token = IdTokenInfo::default();
+        id_token.raw_jwt = minimal_jwt();
+        let tokens = TokenData {
+            id_token,
+            access_token: INITIAL_ACCESS_TOKEN.to_string(),
+            refresh_token: INITIAL_REFRESH_TOKEN.to_string(),
+            account_id: Some("account-id".to_string()),
+        };
+        let auth_dot_json = AuthDotJson {
+            openai_api_key: None,
+            tokens: Some(tokens),
+            last_refresh: Some(initial_last_refresh),
+        };
+        save_auth(
+            codex_home.path(),
+            &auth_dot_json,
+            AuthCredentialsStoreMode::File,
+        )?;
+
+        let endpoint = format!("{}/oauth/token", server.uri());
+        let env_guard = EnvGuard::set(REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR, endpoint);
+
+        let auth = CodexAuth::from_auth_storage(codex_home.path(), AuthCredentialsStoreMode::File)?
+            .expect("auth should load from storage");
+
+        Ok(Self {
+            codex_home,
+            auth,
+            initial_last_refresh,
+            _env_guard: env_guard,
+        })
+    }
+
+    fn load_auth(&self) -> AuthDotJson {
+        load_auth_dot_json(self.codex_home.path(), AuthCredentialsStoreMode::File)
+            .expect("load auth.json")
+            .expect("auth.json should exist")
+    }
+}
+
+struct EnvGuard {
+    key: &'static str,
+    original: Option<OsString>,
+}
+
+impl EnvGuard {
+    fn set(key: &'static str, value: String) -> Self {
+        let original = std::env::var_os(key);
+        unsafe {
+            std::env::set_var(key, &value);
+        }
+        Self { key, original }
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        unsafe {
+            match &self.original {
+                Some(value) => std::env::set_var(self.key, value),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+}
+
+fn minimal_jwt() -> String {
+    #[derive(Serialize)]
+    struct Header {
+        alg: &'static str,
+        typ: &'static str,
+    }
+
+    let header = Header {
+        alg: "none",
+        typ: "JWT",
+    };
+    let payload = json!({ "sub": "user-123" });
+
+    fn b64(data: &[u8]) -> String {
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(data)
+    }
+
+    let header_b64 = b64(&serde_json::to_vec(&header).expect("serialize header"));
+    let payload_b64 = b64(&serde_json::to_vec(&payload).expect("serialize payload"));
+    let signature_b64 = b64(b"sig");
+    format!("{header_b64}.{payload_b64}.{signature_b64}")
+}

--- a/codex-rs/core/tests/suite/auth_refresh.rs
+++ b/codex-rs/core/tests/suite/auth_refresh.rs
@@ -27,6 +27,7 @@ use wiremock::matchers::path;
 const INITIAL_ACCESS_TOKEN: &str = "initial-access-token";
 const INITIAL_REFRESH_TOKEN: &str = "initial-refresh-token";
 
+#[serial_test::serial(auth_refresh)]
 #[tokio::test]
 async fn refresh_token_succeeds_updates_storage() -> Result<()> {
     skip_if_no_network!(Ok(()));
@@ -70,6 +71,7 @@ async fn refresh_token_succeeds_updates_storage() -> Result<()> {
     Ok(())
 }
 
+#[serial_test::serial(auth_refresh)]
 #[tokio::test]
 async fn refresh_token_returns_permanent_error_for_expired_refresh_token() -> Result<()> {
     skip_if_no_network!(Ok(()));
@@ -107,6 +109,7 @@ async fn refresh_token_returns_permanent_error_for_expired_refresh_token() -> Re
     Ok(())
 }
 
+#[serial_test::serial(auth_refresh)]
 #[tokio::test]
 async fn refresh_token_returns_transient_error_on_server_failure() -> Result<()> {
     skip_if_no_network!(Ok(()));

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -8,6 +8,7 @@ mod apply_patch_cli;
 mod apply_patch_freeform;
 #[cfg(not(target_os = "windows"))]
 mod approvals;
+mod auth_refresh;
 mod cli_stream;
 mod client;
 mod codex_delegate;


### PR DESCRIPTION
Currently, when the access token expires, we attempt to use the refresh token to acquire a new access token. This works most of the time. However, there are situations where the refresh token is expired, exhausted (already used to perform a refresh), or revoked. In those cases, the current logic treats the error as transient and attempts to retry it repeatedly.

This PR changes the token refresh logic to differentiate between permanent and transient errors. It also changes callers to treat the permanent errors as fatal rather than retrying them. And it provides better error messages to users so they understand how to address the problem. These error messages should also help us further understand why we're seeing examples of refresh token exhaustion.

Here is the error message in the CLI. The same text appears within the extension.

<img width="863" height="38" alt="image" src="https://github.com/user-attachments/assets/7ffc0d08-ebf0-4900-b9a9-265064202f4f" />

I also correct the spelling of "Re-connecting", which shouldn't have a hyphen in it.

Testing: I manually tested these code paths by adding temporary code to programmatically cause my refresh token to be exhausted (by calling the token refresh endpoint in a tight loop more than 50 times). I then simulated an access token expiration, which caused the token refresh logic to be invoked. I confirmed that the updated logic properly handled the error condition.

Note: We earlier discussed the idea of forcefully logging out the user at the point where token refresh failed. I made several attempts to do this, and all of them resulted in a bad UX. It's important to surface this error to users in a way that explains the problem and tells them that they need to log in again. We also previously discussed deleting the auth.json file when this condition is detected. That also creates problems because it effectively changes the auth status from logged in to logged out, and this causes odd failures and inconsistent UX. I think it's therefore better not to delete auth.json in this case. If the user closes the CLI or VSCE and starts it again, we properly detect that the access token is expired and the refresh token is "dead", and we force the user to go through the login flow at that time.

This should address aspects of #6191, #5679, and #5505