### PR TITLE
fix: update brew auto update version check

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -20,7 +20,7 @@ use codex_exec::Cli as ExecCli;
 use codex_responses_api_proxy::Args as ResponsesApiProxyArgs;
 use codex_tui::AppExitInfo;
 use codex_tui::Cli as TuiCli;
-use codex_tui::updates::UpdateAction;
+use codex_tui::update_action::UpdateAction;
 use owo_colors::OwoColorize;
 use std::path::PathBuf;
 use supports_color::Stream;

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -13,7 +13,7 @@ use crate::render::renderable::Renderable;
 use crate::resume_picker::ResumeSelection;
 use crate::tui;
 use crate::tui::TuiEvent;
-use crate::updates::UpdateAction;
+use crate::update_action::UpdateAction;
 use codex_ansi_escape::ansi_escape_line;
 use codex_core::AuthManager;
 use codex_core::ConversationManager;
@@ -201,7 +201,7 @@ impl App {
                 tui,
                 AppEvent::InsertHistoryCell(Box::new(UpdateAvailableHistoryCell::new(
                     latest_version,
-                    crate::updates::get_update_action(),
+                    crate::update_action::get_update_action(),
                 ))),
             )
             .await?;

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -16,7 +16,7 @@ use crate::style::user_message_style;
 use crate::text_formatting::format_and_truncate_tool_result;
 use crate::text_formatting::truncate_text;
 use crate::ui_consts::LIVE_PREFIX_COLS;
-use crate::updates::UpdateAction;
+use crate::update_action::UpdateAction;
 use crate::version::CODEX_CLI_VERSION;
 use crate::wrapping::RtOptions;
 use crate::wrapping::word_wrap_line;

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -71,8 +71,9 @@ mod terminal_palette;
 mod text_formatting;
 mod tui;
 mod ui_consts;
+pub mod update_action;
 mod update_prompt;
-pub mod updates;
+mod updates;
 mod version;
 
 mod wrapping;

--- a/codex-rs/tui/src/update_action.rs
+++ b/codex-rs/tui/src/update_action.rs
@@ -41,7 +41,6 @@ impl UpdateAction {
     }
 }
 
-#[cfg(any(not(debug_assertions), test))]
 fn detect_update_action(
     is_macos: bool,
     current_exe: &std::path::Path,
@@ -49,17 +48,16 @@ fn detect_update_action(
     managed_by_bun: bool,
 ) -> Option<UpdateAction> {
     if managed_by_npm {
-        return Some(UpdateAction::NpmGlobalLatest);
-    }
-    if managed_by_bun {
-        return Some(UpdateAction::BunGlobalLatest);
-    }
-    if is_macos
+        Some(UpdateAction::NpmGlobalLatest)
+    } else if managed_by_bun {
+        Some(UpdateAction::BunGlobalLatest)
+    } else if is_macos
         && (current_exe.starts_with("/opt/homebrew") || current_exe.starts_with("/usr/local"))
     {
-        return Some(UpdateAction::BrewUpgrade);
+        Some(UpdateAction::BrewUpgrade)
+    } else {
+        None
     }
-    None
 }
 
 #[cfg(test)]

--- a/codex-rs/tui/src/update_action.rs
+++ b/codex-rs/tui/src/update_action.rs
@@ -1,0 +1,71 @@
+/// Update action the CLI should perform after the TUI exits.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UpdateAction {
+    /// Update via `npm install -g @openai/codex@latest`.
+    NpmGlobalLatest,
+    /// Update via `bun install -g @openai/codex@latest`.
+    BunGlobalLatest,
+    /// Update via `brew upgrade codex`.
+    BrewUpgrade,
+}
+
+#[cfg(any(not(debug_assertions), test))]
+pub(crate) fn get_update_action() -> Option<UpdateAction> {
+    let exe = std::env::current_exe().unwrap_or_default();
+    let managed_by_npm = std::env::var_os("CODEX_MANAGED_BY_NPM").is_some();
+    let managed_by_bun = std::env::var_os("CODEX_MANAGED_BY_BUN").is_some();
+    if managed_by_npm {
+        Some(UpdateAction::NpmGlobalLatest)
+    } else if managed_by_bun {
+        Some(UpdateAction::BunGlobalLatest)
+    } else if cfg!(target_os = "macos")
+        && (exe.starts_with("/opt/homebrew") || exe.starts_with("/usr/local"))
+    {
+        Some(UpdateAction::BrewUpgrade)
+    } else {
+        None
+    }
+}
+
+impl UpdateAction {
+    /// Returns the list of command-line arguments for invoking the update.
+    pub fn command_args(self) -> (&'static str, &'static [&'static str]) {
+        match self {
+            UpdateAction::NpmGlobalLatest => ("npm", &["install", "-g", "@openai/codex@latest"]),
+            UpdateAction::BunGlobalLatest => ("bun", &["install", "-g", "@openai/codex@latest"]),
+            UpdateAction::BrewUpgrade => ("brew", &["upgrade", "codex"]),
+        }
+    }
+
+    /// Returns string representation of the command-line arguments for invoking the update.
+    pub fn command_str(self) -> String {
+        let (command, args) = self.command_args();
+        let args_str = args.join(" ");
+        format!("{command} {args_str}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_update_action() {
+        let prev = std::env::var_os("CODEX_MANAGED_BY_NPM");
+
+        // First: no npm var -> expect None (we do not run from brew in CI)
+        unsafe { std::env::remove_var("CODEX_MANAGED_BY_NPM") };
+        assert_eq!(get_update_action(), None);
+
+        // Then: with npm var -> expect NpmGlobalLatest
+        unsafe { std::env::set_var("CODEX_MANAGED_BY_NPM", "1") };
+        assert_eq!(get_update_action(), Some(UpdateAction::NpmGlobalLatest));
+
+        // Restore prior value to avoid leaking state
+        if let Some(v) = prev {
+            unsafe { std::env::set_var("CODEX_MANAGED_BY_NPM", v) };
+        } else {
+            unsafe { std::env::remove_var("CODEX_MANAGED_BY_NPM") };
+        }
+    }
+}

--- a/codex-rs/tui/src/update_prompt.rs
+++ b/codex-rs/tui/src/update_prompt.rs
@@ -10,8 +10,8 @@ use crate::selection_list::selection_option_row;
 use crate::tui::FrameRequester;
 use crate::tui::Tui;
 use crate::tui::TuiEvent;
+use crate::update_action::UpdateAction;
 use crate::updates;
-use crate::updates::UpdateAction;
 use codex_core::config::Config;
 use color_eyre::Result;
 use crossterm::event::KeyCode;
@@ -39,7 +39,7 @@ pub(crate) async fn run_update_prompt_if_needed(
     let Some(latest_version) = updates::get_upgrade_version_for_popup(config) else {
         return Ok(UpdatePromptOutcome::Continue);
     };
-    let Some(update_action) = crate::updates::get_update_action() else {
+    let Some(update_action) = crate::update_action::get_update_action() else {
         return Ok(UpdatePromptOutcome::Continue);
     };
 

--- a/codex-rs/tui/src/updates.rs
+++ b/codex-rs/tui/src/updates.rs
@@ -1,13 +1,16 @@
+#![cfg(not(debug_assertions))]
+
+use crate::update_action;
+use crate::update_action::UpdateAction;
 use chrono::DateTime;
 use chrono::Duration;
 use chrono::Utc;
+use codex_core::config::Config;
+use codex_core::default_client::create_client;
 use serde::Deserialize;
 use serde::Serialize;
 use std::path::Path;
 use std::path::PathBuf;
-
-use codex_core::config::Config;
-use codex_core::default_client::create_client;
 
 use crate::version::CODEX_CLI_VERSION;
 
@@ -68,7 +71,7 @@ fn read_version_info(version_file: &Path) -> anyhow::Result<VersionInfo> {
 }
 
 async fn check_for_update(version_file: &Path) -> anyhow::Result<()> {
-    let latest_version = match get_update_action() {
+    let latest_version = match update_action::get_update_action() {
         Some(UpdateAction::BrewUpgrade) => {
             let cask_contents = create_client()
                 .get(HOMEBREW_CASK_URL)
@@ -135,8 +138,8 @@ fn extract_version_from_latest_tag(latest_tag_name: &str) -> anyhow::Result<Stri
         .ok_or_else(|| anyhow::anyhow!("Failed to parse latest tag name '{latest_tag_name}'"))
 }
 
-/// Returns the latest version to show in a popup, if it should be shown.
-/// This respects the user's dismissal choice for the current latest version.
+// /// Returns the latest version to show in a popup, if it should be shown.
+// /// This respects the user's dismissal choice for the current latest version.
 pub fn get_upgrade_version_for_popup(config: &Config) -> Option<String> {
     let version_file = version_filepath(config);
     let latest = get_upgrade_version(config)?;
@@ -172,53 +175,6 @@ fn parse_version(v: &str) -> Option<(u64, u64, u64)> {
     let min = iter.next()?.parse::<u64>().ok()?;
     let pat = iter.next()?.parse::<u64>().ok()?;
     Some((maj, min, pat))
-}
-
-/// Update action the CLI should perform after the TUI exits.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum UpdateAction {
-    /// Update via `npm install -g @openai/codex@latest`.
-    NpmGlobalLatest,
-    /// Update via `bun install -g @openai/codex@latest`.
-    BunGlobalLatest,
-    /// Update via `brew upgrade codex`.
-    BrewUpgrade,
-}
-
-#[cfg(any(not(debug_assertions), test))]
-pub(crate) fn get_update_action() -> Option<UpdateAction> {
-    let exe = std::env::current_exe().unwrap_or_default();
-    let managed_by_npm = std::env::var_os("CODEX_MANAGED_BY_NPM").is_some();
-    let managed_by_bun = std::env::var_os("CODEX_MANAGED_BY_BUN").is_some();
-    if managed_by_npm {
-        Some(UpdateAction::NpmGlobalLatest)
-    } else if managed_by_bun {
-        Some(UpdateAction::BunGlobalLatest)
-    } else if cfg!(target_os = "macos")
-        && (exe.starts_with("/opt/homebrew") || exe.starts_with("/usr/local"))
-    {
-        Some(UpdateAction::BrewUpgrade)
-    } else {
-        None
-    }
-}
-
-impl UpdateAction {
-    /// Returns the list of command-line arguments for invoking the update.
-    pub fn command_args(self) -> (&'static str, &'static [&'static str]) {
-        match self {
-            UpdateAction::NpmGlobalLatest => ("npm", &["install", "-g", "@openai/codex@latest"]),
-            UpdateAction::BunGlobalLatest => ("bun", &["install", "-g", "@openai/codex@latest"]),
-            UpdateAction::BrewUpgrade => ("brew", &["upgrade", "codex"]),
-        }
-    }
-
-    /// Returns string representation of the command-line arguments for invoking the update.
-    pub fn command_str(self) -> String {
-        let (command, args) = self.command_args();
-        let args_str = args.join(" ");
-        format!("{command} {args_str}")
-    }
 }
 
 #[cfg(test)]
@@ -269,25 +225,5 @@ mod tests {
     fn whitespace_is_ignored() {
         assert_eq!(parse_version(" 1.2.3 \n"), Some((1, 2, 3)));
         assert_eq!(is_newer(" 1.2.3 ", "1.2.2"), Some(true));
-    }
-
-    #[test]
-    fn test_get_update_action() {
-        let prev = std::env::var_os("CODEX_MANAGED_BY_NPM");
-
-        // First: no npm var -> expect None (we do not run from brew in CI)
-        unsafe { std::env::remove_var("CODEX_MANAGED_BY_NPM") };
-        assert_eq!(get_update_action(), None);
-
-        // Then: with npm var -> expect NpmGlobalLatest
-        unsafe { std::env::set_var("CODEX_MANAGED_BY_NPM", "1") };
-        assert_eq!(get_update_action(), Some(UpdateAction::NpmGlobalLatest));
-
-        // Restore prior value to avoid leaking state
-        if let Some(v) = prev {
-            unsafe { std::env::set_var("CODEX_MANAGED_BY_NPM", v) };
-        } else {
-            unsafe { std::env::remove_var("CODEX_MANAGED_BY_NPM") };
-        }
     }
 }

--- a/codex-rs/tui/src/updates.rs
+++ b/codex-rs/tui/src/updates.rs
@@ -138,8 +138,8 @@ fn extract_version_from_latest_tag(latest_tag_name: &str) -> anyhow::Result<Stri
         .ok_or_else(|| anyhow::anyhow!("Failed to parse latest tag name '{latest_tag_name}'"))
 }
 
-// /// Returns the latest version to show in a popup, if it should be shown.
-// /// This respects the user's dismissal choice for the current latest version.
+/// Returns the latest version to show in a popup, if it should be shown.
+/// This respects the user's dismissal choice for the current latest version.
 pub fn get_upgrade_version_for_popup(config: &Config) -> Option<String> {
     let version_file = version_filepath(config);
     let latest = get_upgrade_version(config)?;

--- a/codex-rs/tui/src/updates.rs
+++ b/codex-rs/tui/src/updates.rs
@@ -51,6 +51,7 @@ struct VersionInfo {
 }
 
 const VERSION_FILENAME: &str = "version.json";
+// We use the latest version from the cask if installation is via homebrew - homebrew does not immediately pick up the latest release and can lag behind.
 const HOMEBREW_CASK_URL: &str =
     "https://raw.githubusercontent.com/Homebrew/homebrew-cask/HEAD/Casks/c/codex.rb";
 const LATEST_RELEASE_URL: &str = "https://api.github.com/repos/openai/codex/releases/latest";

--- a/codex-rs/tui/src/updates.rs
+++ b/codex-rs/tui/src/updates.rs
@@ -185,6 +185,7 @@ pub enum UpdateAction {
     BrewUpgrade,
 }
 
+#[cfg(any(not(debug_assertions), test))]
 pub(crate) fn get_update_action() -> Option<UpdateAction> {
     let exe = std::env::current_exe().unwrap_or_default();
     let managed_by_npm = std::env::var_os("CODEX_MANAGED_BY_NPM").is_some();

--- a/codex-rs/tui/src/updates.rs
+++ b/codex-rs/tui/src/updates.rs
@@ -188,7 +188,6 @@ pub enum UpdateAction {
     BrewUpgrade,
 }
 
-#[cfg(any(not(debug_assertions), test))]
 pub(crate) fn get_update_action() -> Option<UpdateAction> {
     let exe = std::env::current_exe().unwrap_or_default();
     let managed_by_npm = std::env::var_os("CODEX_MANAGED_BY_NPM").is_some();


### PR DESCRIPTION
### Summary
* Use `https://github.com/Homebrew/homebrew-cask/blob/main/Casks/c/codex.rb` to get the latest available version for brew usage. 