### PR TITLE
stop capturing r when environment selection modal is open

### DIFF
--- a/codex-rs/cloud-tasks/src/ui.rs
+++ b/codex-rs/cloud-tasks/src/ui.rs
@@ -945,9 +945,7 @@ pub fn draw_env_modal(frame: &mut Frame, area: Rect, app: &mut App) {
 
     // Subheader with usage hints (dim cyan)
     let subheader = Paragraph::new(Line::from(
-        "Type to search, Enter select, Esc cancel; r refresh"
-            .cyan()
-            .dim(),
+        "Type to search, Enter select, Esc cancel".cyan().dim(),
     ))
     .wrap(Wrap { trim: true });
     frame.render_widget(subheader, rows[0]);


### PR DESCRIPTION
This fixes an issue where you can't select environments with an r in them when the selection modal is open