### PR TITLE
Fixes intermittent test failures in CI

### DIFF
--- a/codex-rs/app-server/tests/suite/archive_conversation.rs
+++ b/codex-rs/app-server/tests/suite/archive_conversation.rs
@@ -12,7 +12,7 @@ use std::path::Path;
 use tempfile::TempDir;
 use tokio::time::timeout;
 
-const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn archive_conversation_moves_rollout_into_archived_directory() -> Result<()> {


### PR DESCRIPTION
I'm seeing two tests fail intermittently in CI. This PR attempts to address (or at least mitigate) the flakiness.

* summarize_context_three_requests_and_instructions - The test snapshots server.received_requests() immediately after observing TaskComplete. Because the OpenAI /v1/responses call is streamed, the HTTP request can still be draining when that event fires, so wiremock occasionally reports only two captured requests. Fix is to wait for async activity to complete.
* archive_conversation_moves_rollout_into_archived_directory - times out on a slow CI run. Mitigation is to increase timeout value from 10s to 20s.