### PR TITLE
Windows Sandbox: Show Everyone-writable directory warning

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1452,6 +1452,7 @@ dependencies = [
  "codex-login",
  "codex-ollama",
  "codex-protocol",
+ "codex-windows-sandbox",
  "color-eyre",
  "crossterm",
  "diffy",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -87,7 +87,7 @@ codex-utils-pty = { path = "utils/pty" }
 codex-utils-readiness = { path = "utils/readiness" }
 codex-utils-string = { path = "utils/string" }
 codex-utils-tokenizer = { path = "utils/tokenizer" }
-codex-windows-sandbox = { path = "windows-sandbox" }
+codex-windows-sandbox = { path = "windows-sandbox-rs" }
 core_test_support = { path = "core/tests/common" }
 mcp-types = { path = "mcp-types" }
 mcp_test_support = { path = "mcp-server/tests/common" }

--- a/codex-rs/core/src/config/edit.rs
+++ b/codex-rs/core/src/config/edit.rs
@@ -23,6 +23,8 @@ pub enum ConfigEdit {
     },
     /// Toggle the acknowledgement flag under `[notice]`.
     SetNoticeHideFullAccessWarning(bool),
+    /// Toggle the Windows world-writable directories warning acknowledgement flag.
+    SetNoticeHideWorldWritableWarning(bool),
     /// Toggle the Windows onboarding acknowledgement flag.
     SetWindowsWslSetupAcknowledged(bool),
     /// Replace the entire `[mcp_servers]` table.
@@ -237,6 +239,11 @@ impl ConfigDocument {
             ConfigEdit::SetNoticeHideFullAccessWarning(acknowledged) => Ok(self.write_value(
                 Scope::Global,
                 &[Notice::TABLE_KEY, "hide_full_access_warning"],
+                value(*acknowledged),
+            )),
+            ConfigEdit::SetNoticeHideWorldWritableWarning(acknowledged) => Ok(self.write_value(
+                Scope::Global,
+                &[Notice::TABLE_KEY, "hide_world_writable_warning"],
                 value(*acknowledged),
             )),
             ConfigEdit::SetWindowsWslSetupAcknowledged(acknowledged) => Ok(self.write_value(
@@ -470,6 +477,12 @@ impl ConfigEditsBuilder {
     pub fn set_hide_full_access_warning(mut self, acknowledged: bool) -> Self {
         self.edits
             .push(ConfigEdit::SetNoticeHideFullAccessWarning(acknowledged));
+        self
+    }
+
+    pub fn set_hide_world_writable_warning(mut self, acknowledged: bool) -> Self {
+        self.edits
+            .push(ConfigEdit::SetNoticeHideWorldWritableWarning(acknowledged));
         self
     }
 

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -358,6 +358,8 @@ pub struct Tui {
 pub struct Notice {
     /// Tracks whether the user has acknowledged the full access warning prompt.
     pub hide_full_access_warning: Option<bool>,
+    /// Tracks whether the user has acknowledged the Windows world-writable directories warning.
+    pub hide_world_writable_warning: Option<bool>,
 }
 
 impl Notice {

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -27,6 +27,7 @@ base64 = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 clap = { workspace = true, features = ["derive"] }
 codex-ansi-escape = { workspace = true }
+codex-app-server-protocol = { workspace = true }
 codex-arg0 = { workspace = true }
 codex-common = { workspace = true, features = [
     "cli",
@@ -34,17 +35,13 @@ codex-common = { workspace = true, features = [
     "sandbox_summary",
 ] }
 codex-core = { workspace = true }
+codex-feedback = { workspace = true }
 codex-file-search = { workspace = true }
 codex-login = { workspace = true }
 codex-ollama = { workspace = true }
 codex-protocol = { workspace = true }
-codex-app-server-protocol = { workspace = true }
-codex-feedback = { workspace = true }
 color-eyre = { workspace = true }
-crossterm = { workspace = true, features = [
-    "bracketed-paste",
-    "event-stream",
-] }
+crossterm = { workspace = true, features = ["bracketed-paste", "event-stream"] }
 diffy = { workspace = true }
 dirs = { workspace = true }
 dunce = { workspace = true }
@@ -52,6 +49,7 @@ image = { workspace = true, features = ["jpeg", "png"] }
 itertools = { workspace = true }
 lazy_static = { workspace = true }
 mcp-types = { workspace = true }
+opentelemetry-appender-tracing = { workspace = true }
 pathdiff = { workspace = true }
 pulldown-cmark = { workspace = true }
 rand = { workspace = true }
@@ -71,8 +69,6 @@ strum_macros = { workspace = true }
 supports-color = { workspace = true }
 tempfile = { workspace = true }
 textwrap = { workspace = true }
-tree-sitter-highlight = { workspace = true }
-tree-sitter-bash = { workspace = true }
 tokio = { workspace = true, features = [
     "io-std",
     "macros",
@@ -85,10 +81,13 @@ toml = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 tracing-appender = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
-opentelemetry-appender-tracing = { workspace = true }
+tree-sitter-bash = { workspace = true }
+tree-sitter-highlight = { workspace = true }
 unicode-segmentation = { workspace = true }
 unicode-width = { workspace = true }
 url = { workspace = true }
+
+codex-windows-sandbox = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = { workspace = true }
@@ -105,5 +104,5 @@ chrono = { workspace = true, features = ["serde"] }
 insta = { workspace = true }
 pretty_assertions = { workspace = true }
 rand = { workspace = true }
-vt100 = { workspace = true }
 serial_test = { workspace = true }
+vt100 = { workspace = true }

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -461,7 +461,13 @@ impl App {
                 self.chat_widget.set_approval_policy(policy);
             }
             AppEvent::UpdateSandboxPolicy(policy) => {
-                self.chat_widget.set_sandbox_policy(policy.clone());
+                #[cfg(target_os = "windows")]
+                let policy_is_workspace_write = matches!(
+                    policy,
+                    codex_core::protocol::SandboxPolicy::WorkspaceWrite { .. }
+                );
+
+                self.chat_widget.set_sandbox_policy(policy);
 
                 // If sandbox policy becomes workspace-write, run the Windows world-writable scan.
                 #[cfg(target_os = "windows")]
@@ -473,10 +479,7 @@ impl App {
                     }
 
                     let should_check = codex_core::get_platform_sandbox().is_some()
-                        && matches!(
-                            policy,
-                            codex_core::protocol::SandboxPolicy::WorkspaceWrite { .. }
-                        )
+                        && policy_is_workspace_write
                         && !self.chat_widget.world_writable_warning_hidden();
                     if should_check {
                         use std::collections::HashMap;

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -79,6 +79,9 @@ pub(crate) struct App {
     pub(crate) feedback: codex_feedback::CodexFeedback,
     /// Set when the user confirms an update; propagated on exit.
     pub(crate) pending_update_action: Option<UpdateAction>,
+
+    // One-shot suppression of the next world-writable scan after user confirmation.
+    skip_world_writable_scan_once: bool,
 }
 
 impl App {
@@ -168,7 +171,41 @@ impl App {
             backtrack: BacktrackState::default(),
             feedback: feedback.clone(),
             pending_update_action: None,
+            skip_world_writable_scan_once: false,
         };
+
+        // On startup, if Auto mode (workspace-write) is active, warn about world-writable dirs on Windows.
+        #[cfg(target_os = "windows")]
+        {
+            let should_check = codex_core::get_platform_sandbox().is_some()
+                && matches!(
+                    app.config.sandbox_policy,
+                    codex_core::protocol::SandboxPolicy::WorkspaceWrite { .. }
+                )
+                && !app
+                    .config
+                    .notices
+                    .hide_world_writable_warning
+                    .unwrap_or(false);
+            if should_check {
+                use std::collections::HashMap;
+                let cwd = app.config.cwd.clone();
+                let env_map: HashMap<String, String> = std::env::vars().collect();
+                let tx = app.app_event_tx.clone();
+                tokio::task::spawn_blocking(move || {
+                    if codex_windows_sandbox::preflight_audit_everyone_writable(&cwd, &env_map)
+                        .is_err()
+                    {
+                        // Use the built-in Auto preset for labels and to drive actions.
+                        let preset = codex_common::approval_presets::builtin_approval_presets()
+                            .into_iter()
+                            .find(|p| p.id == "auto")
+                            .unwrap();
+                        tx.send(AppEvent::OpenWorldWritableWarningConfirmation { preset });
+                    }
+                });
+            }
+        }
 
         #[cfg(not(debug_assertions))]
         if let Some(latest_version) = upgrade_version {
@@ -360,6 +397,10 @@ impl App {
             AppEvent::OpenFullAccessConfirmation { preset } => {
                 self.chat_widget.open_full_access_confirmation(preset);
             }
+            AppEvent::OpenWorldWritableWarningConfirmation { preset } => {
+                self.chat_widget
+                    .open_world_writable_warning_confirmation(preset);
+            }
             AppEvent::OpenFeedbackNote {
                 category,
                 include_logs,
@@ -418,10 +459,54 @@ impl App {
                 self.chat_widget.set_approval_policy(policy);
             }
             AppEvent::UpdateSandboxPolicy(policy) => {
-                self.chat_widget.set_sandbox_policy(policy);
+                self.chat_widget.set_sandbox_policy(policy.clone());
+
+                // If sandbox policy becomes workspace-write, run the Windows world-writable scan.
+                #[cfg(target_os = "windows")]
+                {
+                    // One-shot suppression if the user just confirmed continue.
+                    if self.skip_world_writable_scan_once {
+                        self.skip_world_writable_scan_once = false;
+                        return Ok(true);
+                    }
+
+                    let should_check = codex_core::get_platform_sandbox().is_some()
+                        && matches!(
+                            policy,
+                            codex_core::protocol::SandboxPolicy::WorkspaceWrite { .. }
+                        )
+                        && !self.chat_widget.world_writable_warning_hidden();
+                    if should_check {
+                        use std::collections::HashMap;
+                        let cwd = self.config.cwd.clone();
+                        let env_map: HashMap<String, String> = std::env::vars().collect();
+                        let tx = self.app_event_tx.clone();
+                        tokio::task::spawn_blocking(move || {
+                            if codex_windows_sandbox::preflight_audit_everyone_writable(
+                                &cwd, &env_map,
+                            )
+                            .is_err()
+                            {
+                                // Use the built-in Auto preset to drive the confirmation.
+                                let preset = codex_common::approval_presets::builtin_approval_presets()
+                                    .into_iter()
+                                    .find(|p| p.id == "auto")
+                                    .unwrap();
+                                tx.send(AppEvent::OpenWorldWritableWarningConfirmation { preset });
+                            }
+                        });
+                    }
+                }
+            }
+            AppEvent::SkipNextWorldWritableScan => {
+                self.skip_world_writable_scan_once = true;
             }
             AppEvent::UpdateFullAccessWarningAcknowledged(ack) => {
                 self.chat_widget.set_full_access_warning_acknowledged(ack);
+            }
+            AppEvent::UpdateWorldWritableWarningAcknowledged(ack) => {
+                self.chat_widget
+                    .set_world_writable_warning_acknowledged(ack);
             }
             AppEvent::PersistFullAccessWarningAcknowledged => {
                 if let Err(err) = ConfigEditsBuilder::new(&self.config.codex_home)
@@ -435,6 +520,21 @@ impl App {
                     );
                     self.chat_widget.add_error_message(format!(
                         "Failed to save full access confirmation preference: {err}"
+                    ));
+                }
+            }
+            AppEvent::PersistWorldWritableWarningAcknowledged => {
+                if let Err(err) = ConfigEditsBuilder::new(&self.config.codex_home)
+                    .set_hide_world_writable_warning(true)
+                    .apply()
+                    .await
+                {
+                    tracing::error!(
+                        error = %err,
+                        "failed to persist world-writable warning acknowledgement"
+                    );
+                    self.chat_widget.add_error_message(format!(
+                        "Failed to save Auto mode warning preference: {err}"
                     ));
                 }
             }

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -196,12 +196,13 @@ impl App {
                     if codex_windows_sandbox::preflight_audit_everyone_writable(&cwd, &env_map)
                         .is_err()
                     {
-                        // Use the built-in Auto preset for labels and to drive actions.
-                        let preset = codex_common::approval_presets::builtin_approval_presets()
+                        // Use the built-in Auto preset for labels and to drive actions, if present.
+                        if let Some(preset) = codex_common::approval_presets::builtin_approval_presets()
                             .into_iter()
                             .find(|p| p.id == "auto")
-                            .unwrap();
-                        tx.send(AppEvent::OpenWorldWritableWarningConfirmation { preset });
+                        {
+                            tx.send(AppEvent::OpenWorldWritableWarningConfirmation { preset });
+                        }
                     }
                 });
             }
@@ -487,12 +488,13 @@ impl App {
                             )
                             .is_err()
                             {
-                                // Use the built-in Auto preset to drive the confirmation.
-                                let preset = codex_common::approval_presets::builtin_approval_presets()
+                                // Use the built-in Auto preset to drive the confirmation, if present.
+                                if let Some(preset) = codex_common::approval_presets::builtin_approval_presets()
                                     .into_iter()
                                     .find(|p| p.id == "auto")
-                                    .unwrap();
-                                tx.send(AppEvent::OpenWorldWritableWarningConfirmation { preset });
+                                {
+                                    tx.send(AppEvent::OpenWorldWritableWarningConfirmation { preset });
+                                }
                             }
                         });
                     }

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -634,7 +634,9 @@ impl App {
                         .into_iter()
                         .find(|p| p.id == "auto")
                     {
-                        tx.send(AppEvent::OpenWorldWritableWarningConfirmation { preset: Some(preset) });
+                        tx.send(AppEvent::OpenWorldWritableWarningConfirmation {
+                            preset: Some(preset),
+                        });
                     }
                 } else {
                     tx.send(AppEvent::OpenWorldWritableWarningConfirmation { preset: None });

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -197,9 +197,10 @@ impl App {
                         .is_err()
                     {
                         // Use the built-in Auto preset for labels and to drive actions, if present.
-                        if let Some(preset) = codex_common::approval_presets::builtin_approval_presets()
-                            .into_iter()
-                            .find(|p| p.id == "auto")
+                        if let Some(preset) =
+                            codex_common::approval_presets::builtin_approval_presets()
+                                .into_iter()
+                                .find(|p| p.id == "auto")
                         {
                             tx.send(AppEvent::OpenWorldWritableWarningConfirmation { preset });
                         }
@@ -489,11 +490,14 @@ impl App {
                             .is_err()
                             {
                                 // Use the built-in Auto preset to drive the confirmation, if present.
-                                if let Some(preset) = codex_common::approval_presets::builtin_approval_presets()
-                                    .into_iter()
-                                    .find(|p| p.id == "auto")
+                                if let Some(preset) =
+                                    codex_common::approval_presets::builtin_approval_presets()
+                                        .into_iter()
+                                        .find(|p| p.id == "auto")
                                 {
-                                    tx.send(AppEvent::OpenWorldWritableWarningConfirmation { preset });
+                                    tx.send(AppEvent::OpenWorldWritableWarningConfirmation {
+                                        preset,
+                                    });
                                 }
                             }
                         });

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -627,13 +627,12 @@ impl App {
         tx: AppEventSender,
     ) {
         tokio::task::spawn_blocking(move || {
-            if codex_windows_sandbox::preflight_audit_everyone_writable(&cwd, &env_map).is_err() {
-                if let Some(preset) = codex_common::approval_presets::builtin_approval_presets()
+            if codex_windows_sandbox::preflight_audit_everyone_writable(&cwd, &env_map).is_err()
+                && let Some(preset) = codex_common::approval_presets::builtin_approval_presets()
                     .into_iter()
                     .find(|p| p.id == "auto")
-                {
-                    tx.send(AppEvent::OpenWorldWritableWarningConfirmation { preset });
-                }
+            {
+                tx.send(AppEvent::OpenWorldWritableWarningConfirmation { preset });
             }
         });
     }

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -698,6 +698,7 @@ mod tests {
             backtrack: BacktrackState::default(),
             feedback: codex_feedback::CodexFeedback::new(),
             pending_update_action: None,
+            skip_world_writable_scan_once: false,
         }
     }
 

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -72,6 +72,11 @@ pub(crate) enum AppEvent {
         preset: ApprovalPreset,
     },
 
+    /// Open the Windows world-writable directories warning when enabling Auto mode.
+    OpenWorldWritableWarningConfirmation {
+        preset: ApprovalPreset,
+    },
+
     /// Show Windows Subsystem for Linux setup instructions for auto mode.
     ShowWindowsAutoModeInstructions,
 
@@ -84,8 +89,17 @@ pub(crate) enum AppEvent {
     /// Update whether the full access warning prompt has been acknowledged.
     UpdateFullAccessWarningAcknowledged(bool),
 
+    /// Update whether the world-writable directories warning has been acknowledged.
+    UpdateWorldWritableWarningAcknowledged(bool),
+
     /// Persist the acknowledgement flag for the full access warning prompt.
     PersistFullAccessWarningAcknowledged,
+
+    /// Persist the acknowledgement flag for the world-writable directories warning.
+    PersistWorldWritableWarningAcknowledged,
+
+    /// Skip the next world-writable scan (one-shot) after a user-confirmed continue.
+    SkipNextWorldWritableScan,
 
     /// Re-open the approval presets popup.
     OpenApprovalsPopup,

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -72,10 +72,13 @@ pub(crate) enum AppEvent {
         preset: ApprovalPreset,
     },
 
-    /// Open the Windows world-writable directories warning when enabling Auto mode.
+    /// Open the Windows world-writable directories warning.
+    /// If `preset` is `Some`, the confirmation will apply the provided
+    /// approval/sandbox configuration on Continue; if `None`, it performs no
+    /// policy change and only acknowledges/dismisses the warning.
     #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     OpenWorldWritableWarningConfirmation {
-        preset: ApprovalPreset,
+        preset: Option<ApprovalPreset>,
     },
 
     /// Show Windows Subsystem for Linux setup instructions for auto mode.

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -73,11 +73,13 @@ pub(crate) enum AppEvent {
     },
 
     /// Open the Windows world-writable directories warning when enabling Auto mode.
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     OpenWorldWritableWarningConfirmation {
         preset: ApprovalPreset,
     },
 
     /// Show Windows Subsystem for Linux setup instructions for auto mode.
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     ShowWindowsAutoModeInstructions,
 
     /// Update the current approval policy in the running app and widget.
@@ -90,15 +92,18 @@ pub(crate) enum AppEvent {
     UpdateFullAccessWarningAcknowledged(bool),
 
     /// Update whether the world-writable directories warning has been acknowledged.
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     UpdateWorldWritableWarningAcknowledged(bool),
 
     /// Persist the acknowledgement flag for the full access warning prompt.
     PersistFullAccessWarningAcknowledged,
 
     /// Persist the acknowledgement flag for the world-writable directories warning.
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     PersistWorldWritableWarningAcknowledged,
 
     /// Skip the next world-writable scan (one-shot) after a user-confirmed continue.
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     SkipNextWorldWritableScan,
 
     /// Re-open the approval presets popup.

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1880,25 +1880,32 @@ impl ChatWidget {
                         preset: preset_clone.clone(),
                     });
                 })]
-            } else if cfg!(target_os = "windows") && preset.id == "auto" {
-                if codex_core::get_platform_sandbox().is_none() {
-                    vec![Box::new(|tx| {
-                        tx.send(AppEvent::ShowWindowsAutoModeInstructions);
-                    })]
-                } else if !self
-                    .config
-                    .notices
-                    .hide_world_writable_warning
-                    .unwrap_or(false)
-                    && self.windows_world_writable_flagged()
+            } else if preset.id == "auto" {
+                #[cfg(target_os = "windows")]
                 {
-                    let preset_clone = preset.clone();
-                    vec![Box::new(move |tx| {
-                        tx.send(AppEvent::OpenWorldWritableWarningConfirmation {
-                            preset: preset_clone.clone(),
-                        });
-                    })]
-                } else {
+                    if codex_core::get_platform_sandbox().is_none() {
+                        vec![Box::new(|tx| {
+                            tx.send(AppEvent::ShowWindowsAutoModeInstructions);
+                        })]
+                    } else if !self
+                        .config
+                        .notices
+                        .hide_world_writable_warning
+                        .unwrap_or(false)
+                        && self.windows_world_writable_flagged()
+                    {
+                        let preset_clone = preset.clone();
+                        vec![Box::new(move |tx| {
+                            tx.send(AppEvent::OpenWorldWritableWarningConfirmation {
+                                preset: preset_clone.clone(),
+                            });
+                        })]
+                    } else {
+                        Self::approval_preset_actions(preset.approval, preset.sandbox.clone())
+                    }
+                }
+                #[cfg(not(target_os = "windows"))]
+                {
                     Self::approval_preset_actions(preset.approval, preset.sandbox.clone())
                 }
             } else {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2098,6 +2098,9 @@ impl ChatWidget {
         });
     }
 
+    #[cfg(not(target_os = "windows"))]
+    pub(crate) fn open_world_writable_warning_confirmation(&mut self, _preset: ApprovalPreset) {}
+
     #[cfg(target_os = "windows")]
     pub(crate) fn open_windows_auto_mode_instructions(&mut self) {
         use ratatui_macros::line;

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2156,6 +2156,7 @@ impl ChatWidget {
         self.config.notices.hide_world_writable_warning = Some(acknowledged);
     }
 
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     pub(crate) fn world_writable_warning_hidden(&self) -> bool {
         self.config
             .notices

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1956,10 +1956,7 @@ impl ChatWidget {
         for (k, v) in std::env::vars() {
             env_map.insert(k, v);
         }
-        match codex_windows_sandbox::preflight_audit_everyone_writable(
-            &self.config.cwd,
-            &env_map,
-        ) {
+        match codex_windows_sandbox::preflight_audit_everyone_writable(&self.config.cwd, &env_map) {
             Ok(()) => false,
             Err(_) => true,
         }
@@ -2030,17 +2027,13 @@ impl ChatWidget {
     }
 
     #[cfg(target_os = "windows")]
-    pub(crate) fn open_world_writable_warning_confirmation(
-        &mut self,
-        preset: ApprovalPreset,
-    ) {
+    pub(crate) fn open_world_writable_warning_confirmation(&mut self, preset: ApprovalPreset) {
         let approval = preset.approval;
         let sandbox = preset.sandbox;
         let mut header_children: Vec<Box<dyn Renderable>> = Vec::new();
         let title_line = Line::from("Auto mode has unprotected directories").bold();
         let info_line = Line::from(vec![
-            "Some important directories on this system are world-writable. "
-                .into(),
+            "Some important directories on this system are world-writable. ".into(),
             "The Windows sandbox cannot protect writes to these locations in Auto mode."
                 .fg(Color::Red),
         ]);
@@ -2083,9 +2076,7 @@ impl ChatWidget {
             },
             SelectionItem {
                 name: "Continue and don't warn again".to_string(),
-                description: Some(
-                    "Enable Auto mode and remember this choice".to_string(),
-                ),
+                description: Some("Enable Auto mode and remember this choice".to_string()),
                 actions: accept_and_remember_actions,
                 dismiss_on_select: true,
                 ..Default::default()

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1880,13 +1880,27 @@ impl ChatWidget {
                         preset: preset_clone.clone(),
                     });
                 })]
-            } else if cfg!(target_os = "windows")
-                && preset.id == "auto"
-                && codex_core::get_platform_sandbox().is_none()
-            {
-                vec![Box::new(|tx| {
-                    tx.send(AppEvent::ShowWindowsAutoModeInstructions);
-                })]
+            } else if cfg!(target_os = "windows") && preset.id == "auto" {
+                if codex_core::get_platform_sandbox().is_none() {
+                    vec![Box::new(|tx| {
+                        tx.send(AppEvent::ShowWindowsAutoModeInstructions);
+                    })]
+                } else if !self
+                    .config
+                    .notices
+                    .hide_world_writable_warning
+                    .unwrap_or(false)
+                    && self.windows_world_writable_flagged()
+                {
+                    let preset_clone = preset.clone();
+                    vec![Box::new(move |tx| {
+                        tx.send(AppEvent::OpenWorldWritableWarningConfirmation {
+                            preset: preset_clone.clone(),
+                        });
+                    })]
+                } else {
+                    Self::approval_preset_actions(preset.approval, preset.sandbox.clone())
+                }
             } else {
                 Self::approval_preset_actions(preset.approval, preset.sandbox.clone())
             };
@@ -1926,6 +1940,22 @@ impl ChatWidget {
             tx.send(AppEvent::UpdateAskForApprovalPolicy(approval));
             tx.send(AppEvent::UpdateSandboxPolicy(sandbox_clone));
         })]
+    }
+
+    #[cfg(target_os = "windows")]
+    fn windows_world_writable_flagged(&self) -> bool {
+        use std::collections::HashMap;
+        let mut env_map: HashMap<String, String> = HashMap::new();
+        for (k, v) in std::env::vars() {
+            env_map.insert(k, v);
+        }
+        match codex_windows_sandbox::preflight_audit_everyone_writable(
+            &self.config.cwd,
+            &env_map,
+        ) {
+            Ok(()) => false,
+            Err(_) => true,
+        }
     }
 
     pub(crate) fn open_full_access_confirmation(&mut self, preset: ApprovalPreset) {
@@ -1993,6 +2023,84 @@ impl ChatWidget {
     }
 
     #[cfg(target_os = "windows")]
+    pub(crate) fn open_world_writable_warning_confirmation(
+        &mut self,
+        preset: ApprovalPreset,
+    ) {
+        let approval = preset.approval;
+        let sandbox = preset.sandbox;
+        let mut header_children: Vec<Box<dyn Renderable>> = Vec::new();
+        let title_line = Line::from("Auto mode has unprotected directories").bold();
+        let info_line = Line::from(vec![
+            "Some important directories on this system are world-writable. "
+                .into(),
+            "The Windows sandbox cannot protect writes to these locations in Auto mode."
+                .fg(Color::Red),
+        ]);
+        header_children.push(Box::new(title_line));
+        header_children.push(Box::new(
+            Paragraph::new(vec![info_line]).wrap(Wrap { trim: false }),
+        ));
+        let header = ColumnRenderable::with(header_children);
+
+        // Build actions ensuring acknowledgement happens before applying the new sandbox policy,
+        // so downstream policy-change hooks don't re-trigger the warning.
+        let mut accept_actions: Vec<SelectionAction> = Vec::new();
+        {
+            let s = sandbox.clone();
+            // Suppress the immediate re-scan once after user confirms continue.
+            accept_actions.push(Box::new(|tx| {
+                tx.send(AppEvent::SkipNextWorldWritableScan);
+            }));
+            accept_actions.extend(Self::approval_preset_actions(approval, s));
+        }
+
+        let mut accept_and_remember_actions: Vec<SelectionAction> = Vec::new();
+        accept_and_remember_actions.push(Box::new(|tx| {
+            tx.send(AppEvent::UpdateWorldWritableWarningAcknowledged(true));
+            tx.send(AppEvent::PersistWorldWritableWarningAcknowledged);
+        }));
+        accept_and_remember_actions.extend(Self::approval_preset_actions(approval, sandbox));
+
+        let deny_actions: Vec<SelectionAction> = vec![Box::new(|tx| {
+            tx.send(AppEvent::OpenApprovalsPopup);
+        })];
+
+        let items = vec![
+            SelectionItem {
+                name: "Continue".to_string(),
+                description: Some("Apply Auto mode for this session".to_string()),
+                actions: accept_actions,
+                dismiss_on_select: true,
+                ..Default::default()
+            },
+            SelectionItem {
+                name: "Continue and don't warn again".to_string(),
+                description: Some(
+                    "Enable Auto mode and remember this choice".to_string(),
+                ),
+                actions: accept_and_remember_actions,
+                dismiss_on_select: true,
+                ..Default::default()
+            },
+            SelectionItem {
+                name: "Cancel".to_string(),
+                description: Some("Go back without enabling Auto mode".to_string()),
+                actions: deny_actions,
+                dismiss_on_select: true,
+                ..Default::default()
+            },
+        ];
+
+        self.bottom_pane.show_selection_view(SelectionViewParams {
+            footer_hint: Some(standard_popup_hint_line()),
+            items,
+            header: Box::new(header),
+            ..Default::default()
+        });
+    }
+
+    #[cfg(target_os = "windows")]
     pub(crate) fn open_windows_auto_mode_instructions(&mut self) {
         use ratatui_macros::line;
 
@@ -2041,6 +2149,17 @@ impl ChatWidget {
 
     pub(crate) fn set_full_access_warning_acknowledged(&mut self, acknowledged: bool) {
         self.config.notices.hide_full_access_warning = Some(acknowledged);
+    }
+
+    pub(crate) fn set_world_writable_warning_acknowledged(&mut self, acknowledged: bool) {
+        self.config.notices.hide_world_writable_warning = Some(acknowledged);
+    }
+
+    pub(crate) fn world_writable_warning_hidden(&self) -> bool {
+        self.config
+            .notices
+            .hide_world_writable_warning
+            .unwrap_or(false)
     }
 
     /// Set the reasoning effort in the widget's config copy.

--- a/codex-rs/windows-sandbox-rs/src/audit.rs
+++ b/codex-rs/windows-sandbox-rs/src/audit.rs
@@ -1,4 +1,4 @@
-use crate::acl::dacl_effective_allows_write;
+use crate::acl::dacl_has_write_allow_for_sid;
 use crate::token::world_sid;
 use crate::winutil::to_wide;
 use anyhow::anyhow;
@@ -13,6 +13,15 @@ use windows_sys::Win32::Foundation::LocalFree;
 use windows_sys::Win32::Foundation::ERROR_SUCCESS;
 use windows_sys::Win32::Foundation::HLOCAL;
 use windows_sys::Win32::Security::Authorization::GetNamedSecurityInfoW;
+use windows_sys::Win32::Security::Authorization::GetSecurityInfo;
+use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::Storage::FileSystem::CreateFileW;
+use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_BACKUP_SEMANTICS;
+use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_DELETE;
+use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_READ;
+use windows_sys::Win32::Storage::FileSystem::FILE_SHARE_WRITE;
+use windows_sys::Win32::Storage::FileSystem::OPEN_EXISTING;
 use windows_sys::Win32::Security::ACL;
 use windows_sys::Win32::Security::DACL_SECURITY_INFORMATION;
 
@@ -27,30 +36,22 @@ fn unique_push(set: &mut HashSet<PathBuf>, out: &mut Vec<PathBuf>, p: PathBuf) {
 fn gather_candidates(cwd: &Path, env: &std::collections::HashMap<String, String>) -> Vec<PathBuf> {
     let mut set: HashSet<PathBuf> = HashSet::new();
     let mut out: Vec<PathBuf> = Vec::new();
-    // Core roots
-    for p in [
-        PathBuf::from("C:/"),
-        PathBuf::from("C:/Windows"),
-        PathBuf::from("C:/ProgramData"),
-    ] {
-        unique_push(&mut set, &mut out, p);
+    // 1) CWD first (so immediate children get scanned early)
+    unique_push(&mut set, &mut out, cwd.to_path_buf());
+    // 2) TEMP/TMP next (often small, quick to scan)
+    for k in ["TEMP", "TMP"] {
+        if let Some(v) = env.get(k).cloned().or_else(|| std::env::var(k).ok()) {
+            unique_push(&mut set, &mut out, PathBuf::from(v));
+        }
     }
-    // User roots
+    // 3) User roots
     if let Some(up) = std::env::var_os("USERPROFILE") {
         unique_push(&mut set, &mut out, PathBuf::from(up));
     }
     if let Some(pubp) = std::env::var_os("PUBLIC") {
         unique_push(&mut set, &mut out, PathBuf::from(pubp));
     }
-    // CWD
-    unique_push(&mut set, &mut out, cwd.to_path_buf());
-    // TEMP/TMP
-    for k in ["TEMP", "TMP"] {
-        if let Some(v) = env.get(k).cloned().or_else(|| std::env::var(k).ok()) {
-            unique_push(&mut set, &mut out, PathBuf::from(v));
-        }
-    }
-    // PATH entries
+    // 4) PATH entries (best-effort)
     if let Some(path) = env
         .get("PATH")
         .cloned()
@@ -62,31 +63,79 @@ fn gather_candidates(cwd: &Path, env: &std::collections::HashMap<String, String>
             }
         }
     }
+    // 5) Core system roots last
+    for p in [
+        PathBuf::from("C:/"),
+        PathBuf::from("C:/Windows"),
+        PathBuf::from("C:/ProgramData"),
+    ] {
+        unique_push(&mut set, &mut out, p);
+    }
     out
 }
 
 unsafe fn path_has_world_write_allow(path: &Path) -> Result<bool> {
+    // Prefer handle-based query (often faster than name-based), fallback to name-based on error
     let mut p_sd: *mut c_void = std::ptr::null_mut();
     let mut p_dacl: *mut ACL = std::ptr::null_mut();
-    let code = GetNamedSecurityInfoW(
-        to_wide(path).as_ptr(),
-        1,
-        DACL_SECURITY_INFORMATION,
+
+    let mut try_named = false;
+    let wpath = to_wide(path);
+    let h = CreateFileW(
+        wpath.as_ptr(),
+        0x00020000, // READ_CONTROL
+        FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
         std::ptr::null_mut(),
-        std::ptr::null_mut(),
-        &mut p_dacl,
-        std::ptr::null_mut(),
-        &mut p_sd,
+        OPEN_EXISTING,
+        FILE_FLAG_BACKUP_SEMANTICS,
+        0,
     );
-    if code != ERROR_SUCCESS {
-        if !p_sd.is_null() {
-            LocalFree(p_sd as HLOCAL);
+    if h == INVALID_HANDLE_VALUE {
+        try_named = true;
+    } else {
+        let code = GetSecurityInfo(
+            h,
+            1, // SE_FILE_OBJECT
+            DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut p_dacl,
+            std::ptr::null_mut(),
+            &mut p_sd,
+        );
+        CloseHandle(h);
+        if code != ERROR_SUCCESS {
+            try_named = true;
+            if !p_sd.is_null() {
+                LocalFree(p_sd as HLOCAL);
+                p_sd = std::ptr::null_mut();
+                p_dacl = std::ptr::null_mut();
+            }
         }
-        return Ok(false);
     }
+
+    if try_named {
+        let code = GetNamedSecurityInfoW(
+            wpath.as_ptr(),
+            1,
+            DACL_SECURITY_INFORMATION,
+            std::ptr::null_mut(),
+            std::ptr::null_mut(),
+            &mut p_dacl,
+            std::ptr::null_mut(),
+            &mut p_sd,
+        );
+        if code != ERROR_SUCCESS {
+            if !p_sd.is_null() {
+                LocalFree(p_sd as HLOCAL);
+            }
+            return Ok(false);
+        }
+    }
+
     let mut world = world_sid()?;
     let psid_world = world.as_mut_ptr() as *mut c_void;
-    let has = dacl_effective_allows_write(p_dacl, psid_world);
+    let has = dacl_has_write_allow_for_sid(p_dacl, psid_world);
     if !p_sd.is_null() {
         LocalFree(p_sd as HLOCAL);
     }
@@ -100,18 +149,41 @@ pub fn audit_everyone_writable(
     let start = Instant::now();
     let mut flagged: Vec<PathBuf> = Vec::new();
     let mut checked = 0usize;
+    // Fast path: check CWD immediate children first so workspace issues are caught early.
+    if let Ok(read) = std::fs::read_dir(cwd) {
+        for ent in read.flatten().take(250) {
+            if start.elapsed() > Duration::from_secs(5) || checked > 5000 {
+                break;
+            }
+            let ft = match ent.file_type() {
+                Ok(ft) => ft,
+                Err(_) => continue,
+            };
+            if ft.is_symlink() || !ft.is_dir() {
+                continue;
+            }
+            let p = ent.path();
+            checked += 1;
+            let has = unsafe { path_has_world_write_allow(&p)? };
+            if has {
+                flagged.push(p);
+            }
+        }
+    }
+    // Continue with broader candidate sweep
     let candidates = gather_candidates(cwd, env);
     for root in candidates {
         if start.elapsed() > Duration::from_secs(5) || checked > 5000 {
             break;
         }
         checked += 1;
-        if unsafe { path_has_world_write_allow(&root)? } {
+        let has_root = unsafe { path_has_world_write_allow(&root)? };
+        if has_root {
             flagged.push(root.clone());
         }
         // one level down best-effort
         if let Ok(read) = std::fs::read_dir(&root) {
-            for ent in read.flatten().take(50) {
+            for ent in read.flatten().take(250) {
                 let p = ent.path();
                 if start.elapsed() > Duration::from_secs(5) || checked > 5000 {
                     break;
@@ -126,22 +198,42 @@ pub fn audit_everyone_writable(
                 }
                 if ft.is_dir() {
                     checked += 1;
-                    if unsafe { path_has_world_write_allow(&p)? } {
+                    let has_child = unsafe { path_has_world_write_allow(&p)? };
+                    if has_child {
                         flagged.push(p);
                     }
                 }
             }
         }
     }
+    let elapsed_ms = start.elapsed().as_millis();
     if !flagged.is_empty() {
         let mut list = String::new();
-        for p in flagged {
+        for p in &flagged {
             list.push_str(&format!("\n - {}", p.display()));
+        }
+        crate::logging::log_note(
+            &format!(
+                "AUDIT: world-writable scan FAILED; checked={checked}; duration_ms={elapsed_ms}; flagged:{}",
+                list
+            ),
+            Some(cwd),
+        );
+        let mut list_err = String::new();
+        for p in flagged {
+            list_err.push_str(&format!("\n - {}", p.display()));
         }
         return Err(anyhow!(
             "Refusing to run: found directories writable by Everyone: {}",
-            list
+            list_err
         ));
     }
+    // Log success once if nothing flagged
+    crate::logging::log_note(
+        &format!(
+            "AUDIT: world-writable scan OK; checked={checked}; duration_ms={elapsed_ms}"
+        ),
+        Some(cwd),
+    );
     Ok(())
 }

--- a/codex-rs/windows-sandbox-rs/src/logging.rs
+++ b/codex-rs/windows-sandbox-rs/src/logging.rs
@@ -55,3 +55,8 @@ pub fn debug_log(msg: &str, base_dir: Option<&Path>) {
         eprintln!("{msg}");
     }
 }
+
+// Unconditional note logging to sandbox_commands.rust.log
+pub fn log_note(msg: &str, base_dir: Option<&Path>) {
+    append_line(msg, base_dir);
+}


### PR DESCRIPTION
Show a warning when Auto Sandbox mode becomes enabled, if we detect Everyone-writable directories, since they cannot be protected by the current implementation of the Sandbox.

This PR also includes changes to how we detect Everyone-writable to be *much* faster