### PR TITLE
Prevent dismissal of login menu in TUI

### DIFF
--- a/codex-rs/tui/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui/src/onboarding/onboarding_screen.rs
@@ -170,6 +170,12 @@ impl OnboardingScreen {
         out
     }
 
+    fn is_auth_in_progress(&self) -> bool {
+        self.steps.iter().any(|step| {
+            matches!(step, Step::Auth(_)) && matches!(step.get_step_state(), StepState::InProgress)
+        })
+    }
+
     pub(crate) fn is_done(&self) -> bool {
         self.is_done
             || !self
@@ -216,7 +222,9 @@ impl KeyboardHandler for OnboardingScreen {
                 kind: KeyEventKind::Press,
                 ..
             } => {
-                self.is_done = true;
+                if !self.is_auth_in_progress() {
+                    self.is_done = true;
+                }
             }
             _ => {
                 if let Some(Step::Welcome(widget)) = self


### PR DESCRIPTION
We currently allow the user to dismiss the login menu via Ctrl+C. This leaves them in a bad state where they're not auth'ed but have an input prompt. In the extension, this isn't a problem because we don't allow the user to dismiss the login screen.

Testing: I confirmed that Ctrl+C no longer dismisses the login menu.

This is an alternative (simpler) fix for a [community PR](https://github.com/openai/codex/pull/3234).