### PR TITLE
Version 2

### DIFF
--- a/codex-rs/tui/migration_journal_template.md
+++ b/codex-rs/tui/migration_journal_template.md
@@ -1,0 +1,16 @@
+# Migration journal – {{MIGRATION_SUMMARY}}
+
+> Workspace: `{{WORKSPACE_NAME}}`
+> Created: {{CREATED_AT}}
+
+Use this log for async updates, agent hand-offs, and to publish what was learned during each workstream. Keep entries concise and focused on signals other collaborators need.
+
+## Logging guidance
+- Start each entry with a timestamp and author/agent/workstream name.
+- Capture what changed, how it was validated, links to diffs/tests, and any open questions.
+- Highlight blockers, decisions needed, or knowledge that other agents should adopt.
+- Update the plan (`plan.md`) when scope changes; use this journal for progress + lessons.
+
+| Timestamp | Agent / Workstream | Update / Learnings | Blockers & Risks | Next action / owner |
+| --------- | ------------------ | ------------------ | ---------------- | ------------------- |
+|  |  |  |  |  |

--- a/codex-rs/tui/migration_plan_template.md
+++ b/codex-rs/tui/migration_plan_template.md
@@ -1,0 +1,35 @@
+# Migration plan – {{MIGRATION_SUMMARY}}
+
+> Workspace: `{{WORKSPACE_NAME}}`
+> Generated: {{CREATED_AT}}
+
+Use this document as the single source of truth for the migration effort. Keep it updated so any engineer (or agent) can jump in mid-flight.
+
+## 1. Context & stakes
+- Current state snapshot
+- Target end state and deadline/launch windows
+- Guardrails, SLAs, compliance/regulatory constraints
+
+## 2. Incremental plan (numbered)
+1. `[Step name]` — Purpose, scope, primary owner/skillset, upstream/downstream dependencies, validation & rollback signals.
+2. `…`
+
+Each step must explain:
+- Preconditions & artifacts required before starting
+- Specific code/data/infrastructure changes
+- Telemetry, tests, or dry-runs that prove success
+
+## 3. Parallel workstreams
+| Workstream | Objective | Inputs & dependencies | Ownership / skills | Progress & telemetry hooks |
+| ---------- | --------- | --------------------- | ------------------ | ------------------------- |
+| _Fill in during planning_ |  |  |  |  |
+
+## 4. Data + rollout considerations
+- Data migration / backfill plan
+- Environment readiness, feature flags, or config toggles
+- Rollout plan (phases, smoke tests, canaries) and explicit rollback/kill-switch criteria
+
+## 5. Risks, decisions, and follow-ups
+- Top risks with mitigation owners
+- Open questions / decisions with DRI and due date
+- Handoff expectations (reference `journal.md` for ongoing updates)

--- a/codex-rs/tui/prompt_for_migrate_command.md
+++ b/codex-rs/tui/prompt_for_migrate_command.md
@@ -1,0 +1,25 @@
+You are the migration showrunner orchestrating "{{MIGRATION_SUMMARY}}".
+
+Workspace root: {{WORKSPACE_PATH}}
+Plan document to maintain: {{PLAN_PATH}}
+Shared journal for progress + learnings: {{JOURNAL_PATH}}
+
+Before writing any code, study the repository layout, dependencies, release process, deployment gates, data stores, and cross-team stakeholders.
+
+Deliverables:
+1. Start with a concise **Executive Overview** summarizing the target state, key risks, and the biggest unknowns.
+2. Provide an **Incremental plan** as a numbered list (1., 2., 3., …). Each item must include:
+   - Objective and concrete changes required.
+   - Dependencies or prerequisites, including approvals and data/state migrations.
+   - Ownership expectations (skillsets/teams) and automation hooks.
+   - Validation signals, telemetry, and rollback/kill-switch instructions.
+3. Add a **Parallel workstreams** table. Group tasks that can run concurrently, show how learnings are exchanged, and specify when progress should be published to {{JOURNAL_PATH}}.
+4. Capture **Coordination & learning loops**: how agents collaborate, what artifacts live in {{PLAN_PATH}} vs. {{JOURNAL_PATH}}, and how to keep successors unblocked.
+5. Outline a **Risk / data / rollout** section covering backfills, environment sequencing, feature flags, monitoring, and fallback criteria.
+
+General guidance:
+- Call out missing information explicitly and request the files, owners, or metrics needed to proceed.
+- Highlight dependencies on other teams, scheduled freezes, or compliance gates.
+- Emphasize opportunities for automation, reuse of tooling, and knowledge sharing so multiple agents can contribute safely.
+
+After sharing the plan in chat, mirror the same structure into {{PLAN_PATH}} (using apply_patch or editing tools) so it remains the canonical artifact. Encourage collaborators to keep {{JOURNAL_PATH}} updated with progress, blockers, and learnings.

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -450,6 +450,9 @@ impl App {
             AppEvent::OpenReviewCustomPrompt => {
                 self.chat_widget.show_review_custom_prompt();
             }
+            AppEvent::StartMigration { summary } => {
+                self.chat_widget.start_migration(summary);
+            }
             AppEvent::FullScreenApprovalRequest(request) => match request {
                 ApprovalRequest::ApplyPatch { cwd, changes, .. } => {
                     let _ = tui.enter_alt_screen();

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -102,6 +102,11 @@ pub(crate) enum AppEvent {
     /// Open the custom prompt option from the review popup.
     OpenReviewCustomPrompt,
 
+    /// Kick off the `/migrate` workflow after the user names the migration.
+    StartMigration {
+        summary: String,
+    },
+
     /// Open the approval popup.
     FullScreenApprovalRequest(ApprovalRequest),
 

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -17,6 +17,7 @@ pub enum SlashCommand {
     Review,
     New,
     Init,
+    Migrate,
     Compact,
     Undo,
     Diff,
@@ -39,6 +40,7 @@ impl SlashCommand {
             SlashCommand::New => "start a new chat during a conversation",
             SlashCommand::Init => "create an AGENTS.md file with instructions for Codex",
             SlashCommand::Compact => "summarize conversation to prevent hitting the context limit",
+            SlashCommand::Migrate => "spin up a migration workspace and planning prompt",
             SlashCommand::Review => "review my current changes and find issues",
             SlashCommand::Undo => "ask Codex to undo a turn",
             SlashCommand::Quit | SlashCommand::Exit => "exit Codex",
@@ -65,6 +67,7 @@ impl SlashCommand {
         match self {
             SlashCommand::New
             | SlashCommand::Init
+            | SlashCommand::Migrate
             | SlashCommand::Compact
             | SlashCommand::Undo
             | SlashCommand::Model

--- a/docs/slash_commands.md
+++ b/docs/slash_commands.md
@@ -17,6 +17,7 @@ Control Codex’s behavior during an interactive session with slash commands.
 | `/review`    | review my current changes and find issues                   |
 | `/new`       | start a new chat during a conversation                      |
 | `/init`      | create an AGENTS.md file with instructions for Codex        |
+| `/migrate`   | spin up a migration workspace and prompt Codex to plan it   |
 | `/compact`   | summarize conversation to prevent hitting the context limit |
 | `/undo`      | ask Codex to undo a turn                                    |
 | `/diff`      | show git diff (including untracked files)                   |


### PR DESCRIPTION
## Summary
- upgrade `/migrate` to prompt for a migration description, spin up a dedicated workspace with plan/journal templates, and dispatch a context-rich planning prompt
- add reusable markdown templates for `plan.md` and `journal.md` plus stronger instructions inside the migration system prompt so multi-agent plans include parallelizable workstreams and coordination guidance
- refresh the slash-command descriptions/docs so the CLI advertises the enhanced migration workflow

## Testing
- cargo test -p codex-tui

------
https://chatgpt.com/codex/tasks/task_i_690c29d940f88333bc171c36d26436c8