### PR TITLE
bugfix: correct token usage calculation for context window

### DIFF
--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -832,7 +832,7 @@ impl TokenUsage {
         }
 
         let effective_window = context_window - BASELINE_TOKENS;
-        let used = (self.tokens_in_context_window() - BASELINE_TOKENS).max(0);
+        let used = self.tokens_in_context_window();
         let remaining = (effective_window - used).max(0);
         ((remaining as f64 / effective_window as f64) * 100.0)
             .clamp(0.0, 100.0)

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
@@ -17,7 +17,7 @@ expression: sanitized
 │  Agents.md:        <none>                                           │
 │                                                                     │
 │  Token usage:      1.9K total  (1K input + 900 output)              │
-│  Context window:   100% left (2.25K used / 272K)                    │
+│  Context window:   99% left (2.25K used / 272K)                     │
 │  5h limit:         [███████████████░░░░░] 72% used (resets 03:14)   │
 │  Weekly limit:     [█████████░░░░░░░░░░░] 45% used (resets 03:24)   │
 ╰─────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
@@ -17,7 +17,7 @@ expression: sanitized
 │  Agents.md:        <none>                                           │
 │                                                                     │
 │  Token usage:      1.9K total  (1K input + 900 output)              │
-│  Context window:   100% left (2.25K used / 272K)                    │
+│  Context window:   99% left (2.25K used / 272K)                     │
 │  5h limit:         [███████████████░░░░░] 72% used (resets 03:14)   │
 │  Weekly limit:     [████████░░░░░░░░░░░░] 40% used (resets 03:34)   │
 │  Warning:          limits may be stale - start new turn to refresh. │

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
@@ -19,7 +19,7 @@ expression: sanitized
 │  Agents.md:        <none>                  │
 │                                            │
 │  Token usage:      1.9K total  (1K input + │
-│  Context window:   100% left (2.25K used / │
+│  Context window:   99% left (2.25K used /  │
 │  5h limit:         [███████████████░░░░░]  │
 │                    (resets 03:14)          │
 ╰────────────────────────────────────────────╯


### PR DESCRIPTION
- Fixed TokenUsage::context_window_percent_left to avoid double‑subtracting BASELINE_TOKENS.
- Updated related snapshot files to reflect the changes.

