### PR TITLE
Updated contributing guidelines and PR template to request link to bug report in PR notes

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,3 +4,5 @@ Before opening this Pull Request, please read the dedicated "Contributing" markd
 https://github.com/openai/codex/blob/main/docs/contributing.md
 
 If your PR conforms to our contribution guidelines, replace this text with a detailed and high quality description of your changes.
+
+Include a link to a bug report or enhancement request.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -24,6 +24,7 @@ If you want to add a new feature or change the behavior of an existing one, plea
 ### Opening a pull request
 
 - Fill in the PR template (or include similar information) - **What? Why? How?**
+- Include a link to a bug report or enhancement request in the issue tracker
 - Run **all** checks locally (`cargo test && cargo clippy --tests && cargo fmt -- --config imports_granularity=Item`). CI failures that could have been caught locally slow down the process.
 - Make sure your branch is up-to-date with `main` and that you have resolved merge conflicts.
 - Mark the PR as **Ready for review** only when you believe it is in a merge-able state.


### PR DESCRIPTION
Some PRs are being submitted without reference to existing bug reports or feature requests. This updates the PR template and contributing guidelines to request that all PRs from the community contain such a link. This provides additional context and helps prioritize, track, and assess PRs.