### PR TITLE
[App-server] Implement `account/read` endpoint

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -760,8 +760,7 @@ mod tests {
         let request = ClientRequest::GetAccount {
             request_id: RequestId::Integer(5),
             params: v2::GetAccountParams {
-                include_token: None,
-                refresh_token: None,
+                refresh_token: false,
             },
         };
         assert_eq!(
@@ -769,8 +768,7 @@ mod tests {
                 "method": "account/read",
                 "id": 5,
                 "params": {
-                    "includeToken": null,
-                    "refreshToken": null
+                    "refreshToken": false
                 }
             }),
             serde_json::to_value(&request)?,
@@ -780,13 +778,10 @@ mod tests {
 
     #[test]
     fn account_serializes_fields_in_camel_case() -> Result<()> {
-        let api_key = v2::Account::ApiKey {
-            api_key: Some("secret".to_string()),
-        };
+        let api_key = v2::Account::ApiKey {};
         assert_eq!(
             json!({
                 "type": "apiKey",
-                "apiKey": "secret",
             }),
             serde_json::to_value(&api_key)?,
         );
@@ -794,14 +789,12 @@ mod tests {
         let chatgpt = v2::Account::Chatgpt {
             email: "user@example.com".to_string(),
             plan_type: PlanType::Plus,
-            auth_token: None,
         };
         assert_eq!(
             json!({
                 "type": "chatgpt",
                 "email": "user@example.com",
                 "planType": "plus",
-                "authToken": null,
             }),
             serde_json::to_value(&chatgpt)?,
         );

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -191,7 +191,7 @@ client_request_definitions! {
     #[serde(rename = "account/read")]
     #[ts(rename = "account/read")]
     GetAccount {
-        params: #[ts(type = "undefined")] #[serde(skip_serializing_if = "Option::is_none")] Option<()>,
+        params: v2::GetAccountParams,
         response: v2::GetAccountResponse,
     },
 
@@ -758,12 +758,19 @@ mod tests {
     fn serialize_get_account() -> Result<()> {
         let request = ClientRequest::GetAccount {
             request_id: RequestId::Integer(5),
-            params: None,
+            params: v2::GetAccountParams {
+                include_token: None,
+                refresh_token: None,
+            },
         };
         assert_eq!(
             json!({
                 "method": "account/read",
                 "id": 5,
+                "params": {
+                    "includeToken": null,
+                    "refreshToken": null
+                }
             }),
             serde_json::to_value(&request)?,
         );

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -263,6 +263,7 @@ client_request_definitions! {
         params: #[ts(type = "undefined")] #[serde(skip_serializing_if = "Option::is_none")] Option<()>,
         response: v1::LogoutChatGptResponse,
     },
+    /// DEPRECATED in favor of GetAccount
     GetAuthStatus {
         params: v1::GetAuthStatusParams,
         response: v1::GetAuthStatusResponse,
@@ -780,7 +781,7 @@ mod tests {
     #[test]
     fn account_serializes_fields_in_camel_case() -> Result<()> {
         let api_key = v2::Account::ApiKey {
-            api_key: "secret".to_string(),
+            api_key: Some("secret".to_string()),
         };
         assert_eq!(
             json!({
@@ -791,14 +792,16 @@ mod tests {
         );
 
         let chatgpt = v2::Account::Chatgpt {
-            email: Some("user@example.com".to_string()),
+            email: "user@example.com".to_string(),
             plan_type: PlanType::Plus,
+            auth_token: None,
         };
         assert_eq!(
             json!({
                 "type": "chatgpt",
                 "email": "user@example.com",
                 "planType": "plus",
+                "authToken": null,
             }),
             serde_json::to_value(&chatgpt)?,
         );

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -123,12 +123,12 @@ impl From<codex_protocol::protocol::SandboxPolicy> for SandboxPolicy {
 pub enum Account {
     #[serde(rename = "apiKey", rename_all = "camelCase")]
     #[ts(rename = "apiKey", rename_all = "camelCase")]
-    ApiKey { api_key: String },
+    ApiKey { api_key: Option<String> },
 
     #[serde(rename = "chatgpt", rename_all = "camelCase")]
     #[ts(rename = "chatgpt", rename_all = "camelCase")]
     Chatgpt {
-        email: Option<String>,
+        email: String,
         plan_type: PlanType,
         auth_token: Option<String>,
     },
@@ -206,7 +206,7 @@ pub struct GetAccountParams {
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct GetAccountResponse {
-    pub account: Account,
+    pub account: Option<Account>,
     pub requires_openai_auth: bool,
 }
 

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -123,15 +123,11 @@ impl From<codex_protocol::protocol::SandboxPolicy> for SandboxPolicy {
 pub enum Account {
     #[serde(rename = "apiKey", rename_all = "camelCase")]
     #[ts(rename = "apiKey", rename_all = "camelCase")]
-    ApiKey { api_key: Option<String> },
+    ApiKey {},
 
     #[serde(rename = "chatgpt", rename_all = "camelCase")]
     #[ts(rename = "chatgpt", rename_all = "camelCase")]
-    Chatgpt {
-        email: String,
-        plan_type: PlanType,
-        auth_token: Option<String>,
-    },
+    Chatgpt { email: String, plan_type: PlanType },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
@@ -198,8 +194,8 @@ pub struct GetAccountRateLimitsResponse {
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct GetAccountParams {
-    pub include_token: Option<bool>,
-    pub refresh_token: Option<bool>,
+    #[serde(default)]
+    pub refresh_token: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -130,6 +130,7 @@ pub enum Account {
     Chatgpt {
         email: Option<String>,
         plan_type: PlanType,
+        auth_token: Option<String>,
     },
 }
 
@@ -196,8 +197,17 @@ pub struct GetAccountRateLimitsResponse {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
+pub struct GetAccountParams {
+    pub include_token: Option<bool>,
+    pub refresh_token: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct GetAccountResponse {
     pub account: Account,
+    pub requires_openai_auth: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema, TS)]

--- a/codex-rs/app-server/tests/common/mcp_process.rs
+++ b/codex-rs/app-server/tests/common/mcp_process.rs
@@ -19,6 +19,7 @@ use codex_app_server_protocol::CancelLoginChatGptParams;
 use codex_app_server_protocol::ClientInfo;
 use codex_app_server_protocol::ClientNotification;
 use codex_app_server_protocol::FeedbackUploadParams;
+use codex_app_server_protocol::GetAccountParams;
 use codex_app_server_protocol::GetAuthStatusParams;
 use codex_app_server_protocol::InitializeParams;
 use codex_app_server_protocol::InterruptConversationParams;
@@ -247,6 +248,15 @@ impl McpProcess {
     /// Send an `account/rateLimits/read` JSON-RPC request.
     pub async fn send_get_account_rate_limits_request(&mut self) -> anyhow::Result<i64> {
         self.send_request("account/rateLimits/read", None).await
+    }
+
+    /// Send an `account/read` JSON-RPC request.
+    pub async fn send_get_account_request(
+        &mut self,
+        params: GetAccountParams,
+    ) -> anyhow::Result<i64> {
+        let params = Some(serde_json::to_value(params)?);
+        self.send_request("account/read", params).await
     }
 
     /// Send a `feedback/upload` JSON-RPC request.


### PR DESCRIPTION
This PR does two things:
1. add a new function in core that maps the core-internal plan type to the external plan type;
2. implement account/read that get account status (v2 of `getAuthStatus`).