### PR TITLE
Make generate_ts prettier output warn-only

### DIFF
--- a/codex-rs/protocol-ts/src/lib.rs
+++ b/codex-rs/protocol-ts/src/lib.rs
@@ -46,6 +46,8 @@ pub fn generate_ts(out_dir: &Path, prettier: Option<&Path>) -> Result<()> {
     {
         let status = Command::new(prettier_bin)
             .arg("--write")
+            .arg("--log-level")
+            .arg("warn")
             .args(ts_files.iter().map(|p| p.as_os_str()))
             .status()
             .with_context(|| format!("Failed to invoke Prettier at {}", prettier_bin.display()))?;


### PR DESCRIPTION
Before, every file would be outputted with the time prettier spent formatting it. This made downstream scripts way too noisy.