### PR TITLE
Prefer `wait_for_event` over `wait_for_event_with_timeout`.

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,6 +84,7 @@ If you don’t have the tool:
 - Use `ResponseMock::single_request()` when a test should only issue one POST, or `ResponseMock::requests()` to inspect every captured `ResponsesRequest`.
 - `ResponsesRequest` exposes helpers (`body_json`, `input`, `function_call_output`, `custom_tool_call_output`, `call_output`, `header`, `path`, `query_param`) so assertions can target structured payloads instead of manual JSON digging.
 - Build SSE payloads with the provided `ev_*` constructors and the `sse(...)`.
+- Prefer `wait_for_event` over `wait_for_event_with_timeout`.
 
 - Typical pattern:
 

--- a/codex-rs/core/tests/suite/quota_exceeded.rs
+++ b/codex-rs/core/tests/suite/quota_exceeded.rs
@@ -1,5 +1,3 @@
-use std::time::Duration;
-
 use anyhow::Result;
 use codex_core::protocol::EventMsg;
 use codex_core::protocol::Op;
@@ -10,7 +8,7 @@ use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
-use core_test_support::wait_for_event_with_timeout;
+use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
 use serde_json::json;
 
@@ -53,8 +51,7 @@ async fn quota_exceeded_emits_single_error_event() -> Result<()> {
     let mut error_events = 0;
 
     loop {
-        let event =
-            wait_for_event_with_timeout(&test.codex, |_| true, Duration::from_secs(5)).await;
+        let event = wait_for_event(&test.codex, |_| true).await;
 
         match event {
             EventMsg::Error(err) => {


### PR DESCRIPTION
No need to specify the timeout in most cases.