### PR TITLE
fix: Allow reading Apple SystemConfiguration in sandbox

### DIFF
--- a/codex-rs/core/src/seatbelt_base_policy.sbpl
+++ b/codex-rs/core/src/seatbelt_base_policy.sbpl
@@ -91,4 +91,5 @@
 
 (allow mach-lookup
   (global-name "com.apple.PowerManagement.control")
+  (global-name "com.apple.SystemConfiguration.configd")
 )


### PR DESCRIPTION
for `taplo` and other tools that use the [system_configuration crate](https://docs.rs/system-configuration/latest/system_configuration/index.html) to access Apple [SystemConfiguration](https://developer.apple.com/documentation/systemconfiguration?language=objc)

resolves #5914