### PR TITLE
rollout(recorder): warn on flush failure and exit writer task on shutdown

### DIFF
--- a/codex-rs/core/src/rollout/recorder.rs
+++ b/codex-rs/core/src/rollout/recorder.rs
@@ -381,6 +381,7 @@ async fn rollout_writer(
             RolloutCmd::Flush { ack } => {
                 // Ensure underlying file is flushed and then ack.
                 if let Err(e) = writer.file.flush().await {
+                    warn!("failed to flush rollout file: {e}");
                     let _ = ack.send(());
                     return Err(e);
                 }
@@ -388,6 +389,8 @@ async fn rollout_writer(
             }
             RolloutCmd::Shutdown { ack } => {
                 let _ = ack.send(());
+                // need to break the loop to end the task
+                break;
             }
         }
     }

--- a/codex-rs/core/src/rollout/recorder.rs
+++ b/codex-rs/core/src/rollout/recorder.rs
@@ -389,8 +389,10 @@ async fn rollout_writer(
             }
             RolloutCmd::Shutdown { ack } => {
                 let _ = ack.send(());
-                // need to break the loop to end the task
-                break;
+                // Do not break or return here. After a Shutdown command there may still be
+                // queued AddItems messages that must be written. We only acknowledge and
+                // keep looping; the writer task exits naturally when all senders are dropped
+                // and rx.recv() yields None.
             }
         }
     }


### PR DESCRIPTION
## Summary
Improve robustness and observability of the rollout recorder by:

- Logging a warning when file flush fails.
- ~~Breaking out of the writer loop after sending the Shutdown ack so the task can exit cleanly~~.

## Changes
- Add `warn!("failed to flush rollout file: {e}");` when `writer.file.flush()` returns an error.


## Rationale
- Emitting a warning on flush failures makes it easier to diagnose disk/permission or I/O issues that prevent rollouts from being persisted.
- ~~Previously the writer task continued running after acknowledging Shutdown, which could leave background tasks hanging and delay process shutdown or resource cleanup.~~ Add comments to explain why not exit the loop
