### PR TITLE
[SDK] Add network_access and web_search options to TypeScript SDK

### DIFF
--- a/sdk/typescript/src/exec.ts
+++ b/sdk/typescript/src/exec.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import readline from "node:readline";
 import { fileURLToPath } from "node:url";
 
-import { SandboxMode, ModelReasoningEffort } from "./threadOptions";
+import { SandboxMode, ModelReasoningEffort, ApprovalMode } from "./threadOptions";
 
 export type CodexExecArgs = {
   input: string;
@@ -28,6 +28,8 @@ export type CodexExecArgs = {
   networkAccess?: boolean;
   // --config tools.web_search
   webSearch?: boolean;
+  // --ask-for-approval
+  approvalPolicy?: ApprovalMode;
 };
 
 const INTERNAL_ORIGINATOR_ENV = "CODEX_INTERNAL_ORIGINATOR_OVERRIDE";
@@ -72,6 +74,10 @@ export class CodexExec {
 
     if (args.webSearch !== undefined) {
       commandArgs.push("--config", `tools.web_search=${args.webSearch}`);
+    }
+
+    if (args.approvalPolicy) {
+      commandArgs.push("--ask-for-approval", args.approvalPolicy);
     }
 
     if (args.images?.length) {

--- a/sdk/typescript/src/exec.ts
+++ b/sdk/typescript/src/exec.ts
@@ -24,6 +24,10 @@ export type CodexExecArgs = {
   outputSchemaFile?: string;
   // --config model_reasoning_effort
   modelReasoningEffort?: ModelReasoningEffort;
+  // --config sandbox_workspace_write.network_access
+  networkAccess?: boolean;
+  // --config tools.web_search
+  webSearch?: boolean;
 };
 
 const INTERNAL_ORIGINATOR_ENV = "CODEX_INTERNAL_ORIGINATOR_OVERRIDE";
@@ -60,6 +64,14 @@ export class CodexExec {
 
     if (args.modelReasoningEffort) {
       commandArgs.push("--config", `model_reasoning_effort="${args.modelReasoningEffort}"`);
+    }
+
+    if (args.networkAccess !== undefined) {
+      commandArgs.push("--config", `sandbox_workspace_write.network_access=${args.networkAccess}`);
+    }
+
+    if (args.webSearch !== undefined) {
+      commandArgs.push("--config", `tools.web_search=${args.webSearch}`);
     }
 
     if (args.images?.length) {

--- a/sdk/typescript/src/exec.ts
+++ b/sdk/typescript/src/exec.ts
@@ -28,7 +28,7 @@ export type CodexExecArgs = {
   networkAccessEnabled?: boolean;
   // --config features.web_search_request
   webSearchEnabled?: boolean;
-  // --ask-for-approval
+  // --config approval_policy
   approvalPolicy?: ApprovalMode;
 };
 
@@ -77,7 +77,7 @@ export class CodexExec {
     }
 
     if (args.approvalPolicy) {
-      commandArgs.push("--ask-for-approval", args.approvalPolicy);
+      commandArgs.push("--config", `approval_policy="${args.approvalPolicy}"`);
     }
 
     if (args.images?.length) {

--- a/sdk/typescript/src/exec.ts
+++ b/sdk/typescript/src/exec.ts
@@ -26,7 +26,7 @@ export type CodexExecArgs = {
   modelReasoningEffort?: ModelReasoningEffort;
   // --config sandbox_workspace_write.network_access
   networkAccessEnabled?: boolean;
-  // --config tools.web_search
+  // --config features.web_search_request
   webSearchEnabled?: boolean;
   // --ask-for-approval
   approvalPolicy?: ApprovalMode;
@@ -73,7 +73,7 @@ export class CodexExec {
     }
 
     if (args.webSearchEnabled !== undefined) {
-      commandArgs.push("--config", `tools.web_search=${args.webSearchEnabled}`);
+      commandArgs.push("--config", `features.web_search_request=${args.webSearchEnabled}`);
     }
 
     if (args.approvalPolicy) {

--- a/sdk/typescript/src/exec.ts
+++ b/sdk/typescript/src/exec.ts
@@ -25,9 +25,9 @@ export type CodexExecArgs = {
   // --config model_reasoning_effort
   modelReasoningEffort?: ModelReasoningEffort;
   // --config sandbox_workspace_write.network_access
-  networkAccess?: boolean;
+  networkAccessEnabled?: boolean;
   // --config tools.web_search
-  webSearch?: boolean;
+  webSearchEnabled?: boolean;
   // --ask-for-approval
   approvalPolicy?: ApprovalMode;
 };
@@ -68,12 +68,12 @@ export class CodexExec {
       commandArgs.push("--config", `model_reasoning_effort="${args.modelReasoningEffort}"`);
     }
 
-    if (args.networkAccess !== undefined) {
-      commandArgs.push("--config", `sandbox_workspace_write.network_access=${args.networkAccess}`);
+    if (args.networkAccessEnabled !== undefined) {
+      commandArgs.push("--config", `sandbox_workspace_write.network_access=${args.networkAccessEnabled}`);
     }
 
-    if (args.webSearch !== undefined) {
-      commandArgs.push("--config", `tools.web_search=${args.webSearch}`);
+    if (args.webSearchEnabled !== undefined) {
+      commandArgs.push("--config", `tools.web_search=${args.webSearchEnabled}`);
     }
 
     if (args.approvalPolicy) {

--- a/sdk/typescript/src/thread.ts
+++ b/sdk/typescript/src/thread.ts
@@ -88,6 +88,7 @@ export class Thread {
       modelReasoningEffort: options?.modelReasoningEffort,
       networkAccess: options?.networkAccess,
       webSearch: options?.webSearch,
+      approvalPolicy: options?.approvalPolicy,
     });
     try {
       for await (const item of generator) {

--- a/sdk/typescript/src/thread.ts
+++ b/sdk/typescript/src/thread.ts
@@ -86,8 +86,8 @@ export class Thread {
       skipGitRepoCheck: options?.skipGitRepoCheck,
       outputSchemaFile: schemaPath,
       modelReasoningEffort: options?.modelReasoningEffort,
-      networkAccess: options?.networkAccess,
-      webSearch: options?.webSearch,
+      networkAccessEnabled: options?.networkAccessEnabled,
+      webSearchEnabled: options?.webSearchEnabled,
       approvalPolicy: options?.approvalPolicy,
     });
     try {

--- a/sdk/typescript/src/thread.ts
+++ b/sdk/typescript/src/thread.ts
@@ -86,6 +86,8 @@ export class Thread {
       skipGitRepoCheck: options?.skipGitRepoCheck,
       outputSchemaFile: schemaPath,
       modelReasoningEffort: options?.modelReasoningEffort,
+      networkAccess: options?.networkAccess,
+      webSearch: options?.webSearch,
     });
     try {
       for await (const item of generator) {

--- a/sdk/typescript/src/threadOptions.ts
+++ b/sdk/typescript/src/threadOptions.ts
@@ -12,4 +12,5 @@ export type ThreadOptions = {
   modelReasoningEffort?: ModelReasoningEffort;
   networkAccess?: boolean;
   webSearch?: boolean;
+  approvalPolicy?: ApprovalMode;
 };

--- a/sdk/typescript/src/threadOptions.ts
+++ b/sdk/typescript/src/threadOptions.ts
@@ -10,4 +10,6 @@ export type ThreadOptions = {
   workingDirectory?: string;
   skipGitRepoCheck?: boolean;
   modelReasoningEffort?: ModelReasoningEffort;
+  networkAccess?: boolean;
+  webSearch?: boolean;
 };

--- a/sdk/typescript/src/threadOptions.ts
+++ b/sdk/typescript/src/threadOptions.ts
@@ -10,7 +10,7 @@ export type ThreadOptions = {
   workingDirectory?: string;
   skipGitRepoCheck?: boolean;
   modelReasoningEffort?: ModelReasoningEffort;
-  networkAccess?: boolean;
-  webSearch?: boolean;
+  networkAccessEnabled?: boolean;
+  webSearchEnabled?: boolean;
   approvalPolicy?: ApprovalMode;
 };

--- a/sdk/typescript/tests/run.test.ts
+++ b/sdk/typescript/tests/run.test.ts
@@ -254,6 +254,99 @@ describe("Codex", () => {
     }
   });
 
+  it("passes networkAccessEnabled to exec", async () => {
+    const { url, close } = await startResponsesTestProxy({
+      statusCode: 200,
+      responseBodies: [
+        sse(
+          responseStarted("response_1"),
+          assistantMessage("Network access enabled", "item_1"),
+          responseCompleted("response_1"),
+        ),
+      ],
+    });
+
+    const { args: spawnArgs, restore } = codexExecSpy();
+
+    try {
+      const client = new Codex({ codexPathOverride: codexExecPath, baseUrl: url, apiKey: "test" });
+
+      const thread = client.startThread({
+        networkAccessEnabled: true,
+      });
+      await thread.run("test network access");
+
+      const commandArgs = spawnArgs[0];
+      expect(commandArgs).toBeDefined();
+      expectPair(commandArgs, ["--config", "sandbox_workspace_write.network_access=true"]);
+    } finally {
+      restore();
+      await close();
+    }
+  });
+
+  it("passes webSearchEnabled to exec", async () => {
+    const { url, close } = await startResponsesTestProxy({
+      statusCode: 200,
+      responseBodies: [
+        sse(
+          responseStarted("response_1"),
+          assistantMessage("Web search enabled", "item_1"),
+          responseCompleted("response_1"),
+        ),
+      ],
+    });
+
+    const { args: spawnArgs, restore } = codexExecSpy();
+
+    try {
+      const client = new Codex({ codexPathOverride: codexExecPath, baseUrl: url, apiKey: "test" });
+
+      const thread = client.startThread({
+        webSearchEnabled: true,
+      });
+      await thread.run("test web search");
+
+      const commandArgs = spawnArgs[0];
+      expect(commandArgs).toBeDefined();
+      expectPair(commandArgs, ["--config", "tools.web_search=true"]);
+    } finally {
+      restore();
+      await close();
+    }
+  });
+
+  it("passes approvalPolicy to exec", async () => {
+    const { url, close } = await startResponsesTestProxy({
+      statusCode: 200,
+      responseBodies: [
+        sse(
+          responseStarted("response_1"),
+          assistantMessage("Approval policy set", "item_1"),
+          responseCompleted("response_1"),
+        ),
+      ],
+    });
+
+    const { args: spawnArgs, restore } = codexExecSpy();
+
+    try {
+      const client = new Codex({ codexPathOverride: codexExecPath, baseUrl: url, apiKey: "test" });
+
+      const thread = client.startThread({
+        approvalPolicy: "on-request",
+      });
+      await thread.run("test approval policy");
+
+      const commandArgs = spawnArgs[0];
+      expect(commandArgs).toBeDefined();
+      expectPair(commandArgs, ["--ask-for-approval", "on-request"]);
+    } finally {
+      restore();
+      await close();
+    }
+  });
+
   it("writes output schema to a temporary file and forwards it", async () => {
     const { url, close, requests } = await startResponsesTestProxy({
       statusCode: 200,

--- a/sdk/typescript/tests/run.test.ts
+++ b/sdk/typescript/tests/run.test.ts
@@ -309,7 +309,7 @@ describe("Codex", () => {
 
       const commandArgs = spawnArgs[0];
       expect(commandArgs).toBeDefined();
-      expectPair(commandArgs, ["--config", "tools.web_search=true"]);
+      expectPair(commandArgs, ["--config", "features.web_search_request=true"]);
     } finally {
       restore();
       await close();

--- a/sdk/typescript/tests/run.test.ts
+++ b/sdk/typescript/tests/run.test.ts
@@ -340,7 +340,7 @@ describe("Codex", () => {
 
       const commandArgs = spawnArgs[0];
       expect(commandArgs).toBeDefined();
-      expectPair(commandArgs, ["--ask-for-approval", "on-request"]);
+      expectPair(commandArgs, ["--config", 'approval_policy="on-request"']);
     } finally {
       restore();
       await close();


### PR DESCRIPTION
## Summary

This PR adds two new optional boolean fields to `ThreadOptions` in the TypeScript SDK:

- **`networkAccess`**: Enables network access in the sandbox by setting `sandbox_workspace_write.network_access` config
- **`webSearch`**: Enables the web search tool by setting `tools.web_search` config

These options map to existing Codex configuration options and are properly threaded through the SDK layers:
1. `ThreadOptions` (threadOptions.ts) - User-facing API
2. `CodexExecArgs` (exec.ts) - Internal execution args  
3. CLI flags via `--config` in the `codex exec` command

## Changes

- `sdk/typescript/src/threadOptions.ts`: Added `networkAccess` and `webSearch` fields to `ThreadOptions` type
- `sdk/typescript/src/exec.ts`: Added fields to `CodexExecArgs` and CLI flag generation
- `sdk/typescript/src/thread.ts`: Pass options through to exec layer

## Test Plan

- [x] Build succeeds (`pnpm build`)
- [x] Linter passes (`pnpm lint`)
- [x] Type definitions are properly exported
- [ ] Manual testing with sample code (to be done by reviewer)
