### PR TITLE
For npm upgrade on Windows, go through cmd.exe to get path traversal working

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -272,7 +272,9 @@ fn run_update_action(action: UpdateAction) -> anyhow::Result<()> {
     let (cmd, args) = action.command_args();
     let cmd_str = action.command_str();
     println!("Updating Codex via `{cmd_str}`...");
+    #[cfg(not(windows))]
     let command_path = normalize_for_wsl(cmd);
+    #[cfg(not(windows))]
     let normalized_args: Vec<String> = args.iter().map(normalize_for_wsl).collect();
     // On Windows, run via cmd.exe so .CMD/.BAT are correctly resolved (PATHEXT semantics).
     #[cfg(windows)]

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -26,9 +26,11 @@ use std::path::PathBuf;
 use supports_color::Stream;
 
 mod mcp_cmd;
+#[cfg(not(windows))]
 mod wsl_paths;
 
 use crate::mcp_cmd::McpCli;
+#[cfg(not(windows))]
 use crate::wsl_paths::normalize_for_wsl;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
@@ -269,8 +271,9 @@ fn handle_app_exit(exit_info: AppExitInfo) -> anyhow::Result<()> {
 /// Run the update action and print the result.
 fn run_update_action(action: UpdateAction) -> anyhow::Result<()> {
     println!();
-    let (cmd, args) = action.command_args();
     let cmd_str = action.command_str();
+    #[cfg(not(windows))]
+    let (cmd, args) = action.command_args();
     println!("Updating Codex via `{cmd_str}`...");
     #[cfg(not(windows))]
     let command_path = normalize_for_wsl(cmd);

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -274,6 +274,13 @@ fn run_update_action(action: UpdateAction) -> anyhow::Result<()> {
     println!("Updating Codex via `{cmd_str}`...");
     let command_path = normalize_for_wsl(cmd);
     let normalized_args: Vec<String> = args.iter().map(normalize_for_wsl).collect();
+    // On Windows, run via cmd.exe so .CMD/.BAT are correctly resolved (PATHEXT semantics).
+    #[cfg(windows)]
+    let status = std::process::Command::new("cmd")
+        .args(["/C", &cmd_str])
+        .status()?;
+
+    #[cfg(not(windows))]
     let status = std::process::Command::new(&command_path)
         .args(&normalized_args)
         .status()?;


### PR DESCRIPTION
On Windows, `npm` by itself does not resolve under std::process::Command which does not consider PATHEXT to resolve it to `npm.cmd` in the PATH.
By running the npm upgrade command via cmd.exe we get proper path semantics so it actually works.