### PR TITLE
[DRAFT] Allow project level configuration.

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -286,12 +286,7 @@ impl Config {
             ..Default::default()
         };
 
-        let root_value = load_resolved_config(
-            &codex_home,
-            cli_overrides,
-            loader_overrides,
-        )
-        .await?;
+        let root_value = load_resolved_config(&codex_home, cli_overrides, loader_overrides).await?;
 
         let cfg: ConfigToml = root_value.try_into().map_err(|e| {
             tracing::error!("Failed to deserialize overridden config: {e}");
@@ -3001,7 +2996,10 @@ model_verbosity = "high"
             use_experimental_use_rmcp_client: false,
             features: Features::with_defaults(),
             active_profile: Some("gpt3".to_string()),
-            active_project: ProjectConfig { trust_level: None, allow_project_config: None },
+            active_project: ProjectConfig {
+                trust_level: None,
+                allow_project_config: None,
+            },
             windows_wsl_setup_acknowledged: false,
             notices: Default::default(),
             disable_paste_burst: false,
@@ -3087,7 +3085,10 @@ model_verbosity = "high"
             use_experimental_use_rmcp_client: false,
             features: Features::with_defaults(),
             active_profile: Some("zdr".to_string()),
-            active_project: ProjectConfig { trust_level: None, allow_project_config: None },
+            active_project: ProjectConfig {
+                trust_level: None,
+                allow_project_config: None,
+            },
             windows_wsl_setup_acknowledged: false,
             notices: Default::default(),
             disable_paste_burst: false,
@@ -3159,7 +3160,10 @@ model_verbosity = "high"
             use_experimental_use_rmcp_client: false,
             features: Features::with_defaults(),
             active_profile: Some("gpt5".to_string()),
-            active_project: ProjectConfig { trust_level: None, allow_project_config: None },
+            active_project: ProjectConfig {
+                trust_level: None,
+                allow_project_config: None,
+            },
             windows_wsl_setup_acknowledged: false,
             notices: Default::default(),
             disable_paste_burst: false,

--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -223,7 +223,7 @@ fn check_project_config_allows(project_toml: &TomlValue) -> bool {
     // Check explicit allow_project_config setting
     if let Some(allow) = project_toml
         .get("allow_project_config")
-        .and_then(|v| v.as_bool())
+        .and_then(TomlValue::as_bool)
     {
         return allow;
     }
@@ -231,7 +231,7 @@ fn check_project_config_allows(project_toml: &TomlValue) -> bool {
     // Fall back to checking trust_level (trusted projects allow by default)
     let is_trusted = project_toml
         .get("trust_level")
-        .and_then(|v| v.as_str())
+        .and_then(TomlValue::as_str)
         .map(|s| s == "trusted")
         .unwrap_or(false);
 

--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -207,11 +207,10 @@ fn is_project_config_allowed(user_config: &TomlValue, cwd: &Path) -> bool {
     }
 
     // If in a git repo, try matching the git root
-    if let Some(git_root) = get_git_repo_root(cwd) {
-        if let Some(project_config) = projects_table.get(git_root.to_string_lossy().as_ref()) {
+    if let Some(git_root) = get_git_repo_root(cwd)
+        && let Some(project_config) = projects_table.get(git_root.to_string_lossy().as_ref()) {
             return check_project_config_allows(project_config);
         }
-    }
 
     // No matching project found, default to not allowed
     tracing::debug!("No matching trusted project found for {}", cwd.display());
@@ -229,13 +228,13 @@ fn check_project_config_allows(project_toml: &TomlValue) -> bool {
     }
 
     // Fall back to checking trust_level (trusted projects allow by default)
-    let is_trusted = project_toml
+    
+
+    project_toml
         .get("trust_level")
         .and_then(TomlValue::as_str)
         .map(|s| s == "trusted")
-        .unwrap_or(false);
-
-    is_trusted
+        .unwrap_or(false)
 }
 
 /// Merge config `overlay` into `base`, giving `overlay` precedence.

--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -105,7 +105,8 @@ async fn load_config_layers_internal(
     let user_config = read_config_from_path(&user_config_path, true).await?;
 
     // Load project config only if it exists AND is allowed by trust settings
-    let project_config = if let Some(project_config_path) = find_project_config_path(&resolved_cwd) {
+    let project_config = if let Some(project_config_path) = find_project_config_path(&resolved_cwd)
+    {
         // Check if this project is allowed to use project configs
         let empty_table = default_empty_table();
         let user_config_value = user_config.as_ref().unwrap_or(&empty_table);

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -579,7 +579,10 @@ mod tests {
             temp_dir.path().to_path_buf(),
         )?;
         config.did_user_set_custom_approval_policy_or_sandbox_mode = false;
-        config.active_project = ProjectConfig { trust_level: None };
+        config.active_project = ProjectConfig {
+            trust_level: None,
+            allow_project_config: None,
+        };
         set_windows_sandbox_enabled(false);
 
         let should_show = should_show_trust_screen(&config);


### PR DESCRIPTION
**What**: This PR adds support for project-level .codex/config.toml configuration files.

**Why**: Currently, MCP servers and other configurations can only be defined globally in ~/.codex/config.toml. This creates friction for:

- Projects needing different MCP servers
- Teams wanting to share project-specific Codex configurations
- Monorepos requiring custom settings per package
- Projects with specific model or sandbox requirements

**How**:

- Added project config discovery that walks up from cwd looking for .codex/config.toml
- Implemented trust-based security: project configs only load for explicitly trusted projects
- Updated configuration precedence: user → project → managed → preferences → CLI
- Added allow_project_config field to ProjectConfig for fine-grained control
- Comprehensive tests and documentation included

**Testing**:
✅ Unit test: loads project config for trusted projects
✅ Unit test: ignores project config for untrusted projects
✅ Unit test: respects allow_project_config setting
✅ All existing tests pass
✅ Clippy and fmt checks pass