### PR TITLE
Support exiting from the login menu

### DIFF
--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -353,6 +353,16 @@ async fn run_ratatui_app(
             &mut tui,
         )
         .await?;
+        if onboarding_result.should_exit {
+            restore();
+            session_log::log_session_end();
+            let _ = tui.terminal.clear();
+            return Ok(AppExitInfo {
+                token_usage: codex_core::protocol::TokenUsage::default(),
+                conversation_id: None,
+                update_action: None,
+            });
+        }
         if onboarding_result.windows_install_selected {
             restore();
             session_log::log_session_end();

--- a/codex-rs/tui/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui/src/onboarding/onboarding_screen.rs
@@ -25,7 +25,6 @@ use crate::tui::FrameRequester;
 use crate::tui::Tui;
 use crate::tui::TuiEvent;
 use color_eyre::eyre::Result;
-use std::process;
 use std::sync::Arc;
 use std::sync::RwLock;
 
@@ -58,6 +57,7 @@ pub(crate) struct OnboardingScreen {
     steps: Vec<Step>,
     is_done: bool,
     windows_install_selected: bool,
+    should_exit: bool,
 }
 
 pub(crate) struct OnboardingScreenArgs {
@@ -72,6 +72,7 @@ pub(crate) struct OnboardingScreenArgs {
 pub(crate) struct OnboardingResult {
     pub directory_trust_decision: Option<TrustDirectorySelection>,
     pub windows_install_selected: bool,
+    pub should_exit: bool,
 }
 
 impl OnboardingScreen {
@@ -138,6 +139,7 @@ impl OnboardingScreen {
             steps,
             is_done: false,
             windows_install_selected: false,
+            should_exit: false,
         }
     }
 
@@ -201,6 +203,10 @@ impl OnboardingScreen {
     pub fn windows_install_selected(&self) -> bool {
         self.windows_install_selected
     }
+
+    pub fn should_exit(&self) -> bool {
+        self.should_exit
+    }
 }
 
 impl KeyboardHandler for OnboardingScreen {
@@ -226,8 +232,7 @@ impl KeyboardHandler for OnboardingScreen {
                 if self.is_auth_in_progress() {
                     // If the user cancels the auth menu, exit the app rather than
                     // leave the user at a prompt in an unauthed state.
-                    let _ = crate::tui::restore();
-                    process::exit(0);
+                    self.should_exit = true;
                 }
                 self.is_done = true;
             }
@@ -447,5 +452,6 @@ pub(crate) async fn run_onboarding_app(
     Ok(OnboardingResult {
         directory_trust_decision: onboarding_screen.directory_trust_decision(),
         windows_install_selected: onboarding_screen.windows_install_selected(),
+        should_exit: onboarding_screen.should_exit(),
     })
 }

--- a/codex-rs/tui/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui/src/onboarding/onboarding_screen.rs
@@ -25,6 +25,7 @@ use crate::tui::FrameRequester;
 use crate::tui::Tui;
 use crate::tui::TuiEvent;
 use color_eyre::eyre::Result;
+use std::process;
 use std::sync::Arc;
 use std::sync::RwLock;
 
@@ -222,9 +223,13 @@ impl KeyboardHandler for OnboardingScreen {
                 kind: KeyEventKind::Press,
                 ..
             } => {
-                if !self.is_auth_in_progress() {
-                    self.is_done = true;
+                if self.is_auth_in_progress() {
+                    // If the user cancels the auth menu, exit the app rather than
+                    // leave the user at a prompt in an unauthed state.
+                    let _ = crate::tui::restore();
+                    process::exit(0);
                 }
+                self.is_done = true;
             }
             _ => {
                 if let Some(Step::Welcome(widget)) = self


### PR DESCRIPTION
I recently fixed a bug in [this PR](https://github.com/openai/codex/pull/6285) that prevented Ctrl+C from dismissing the login menu in the TUI and leaving the user unauthed. 

A [user pointed out](https://github.com/openai/codex/issues/6418) that this makes Ctrl+C can no longer be used to exit the app. This PR changes the behavior so we exit the app rather than ignoring the Ctrl+C.
