### PR TITLE
fix(seatbelt): Allow reading hw.physicalcpu

### DIFF
--- a/codex-rs/core/src/seatbelt_base_policy.sbpl
+++ b/codex-rs/core/src/seatbelt_base_policy.sbpl
@@ -49,6 +49,7 @@
   (sysctl-name "hw.packages")
   (sysctl-name "hw.pagesize_compat")
   (sysctl-name "hw.pagesize")
+  (sysctl-name "hw.physicalcpu")
   (sysctl-name "hw.physicalcpu_max")
   (sysctl-name "hw.tbfrequency_compat")
   (sysctl-name "hw.vectorunit")


### PR DESCRIPTION
Allow reading `hw.physicalcpu` so numpy can be imported when running in the sandbox.
 
resolves #6420 