### PR TITLE
Don't lock PRs that have been closed without merging

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -16,10 +16,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: contributor-assistant/github-action@v2.6.1
+        # Run on close only if the PR was merged. This will lock the PR to preserve
+        # the CLA agreement. We don't want to lock PRs that have been closed without
+        # merging because the contributor may want to respond with additional comments.
         if: |
-          github.event_name == 'pull_request_target' ||
-          github.event.comment.body == 'recheck' ||
-          github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+          (
+            github.event_name == 'pull_request_target' &&
+            (
+              github.event.action == 'opened' ||
+              github.event.action == 'synchronize' ||
+              (github.event.action == 'closed' && github.event.pull_request.merged == true)
+            )
+          ) ||
+          (
+            github.event_name == 'issue_comment' &&
+            (
+              github.event.comment.body == 'recheck' ||
+              github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA'
+            )
+          )
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -19,6 +19,8 @@ jobs:
         # Run on close only if the PR was merged. This will lock the PR to preserve
         # the CLA agreement. We don't want to lock PRs that have been closed without
         # merging because the contributor may want to respond with additional comments.
+        # This action has a "lock-pullrequest-aftermerge" option that can be set to false,
+        # but that would unconditionally skip locking even in cases where the PR was merged.
         if: |
           (
             github.event_name == 'pull_request_target' &&


### PR DESCRIPTION
The CLA action is designed to automatically lock a PR when it is closed. This preserves the CLA agreement statements, preventing the contributor from deleting them after the fact. However, this action is currently locking PRs that are closed without merging. I'd like to keep such PRs open so the contributor can respond with additional comments. I'm currently manually unlocking PRs that I close, but I'd like to eliminate this manual step.