### PR TITLE
Fix config documentation: correct TOML parsing description

### DIFF
--- a/codex-rs/common/src/config_override.rs
+++ b/codex-rs/common/src/config_override.rs
@@ -19,8 +19,8 @@ use toml::Value;
 pub struct CliConfigOverrides {
     /// Override a configuration value that would otherwise be loaded from
     /// `~/.codex/config.toml`. Use a dotted path (`foo.bar.baz`) to override
-    /// nested values. The `value` portion is parsed as JSON. If it fails to
-    /// parse as JSON, the raw string is used as a literal.
+    /// nested values. The `value` portion is parsed as TOML. If it fails to
+    /// parse as TOML, the raw string is used as a literal.
     ///
     /// Examples:
     ///   - `-c model="o3"`
@@ -59,7 +59,7 @@ impl CliConfigOverrides {
                     return Err(format!("Empty key in override: {s}"));
                 }
 
-                // Attempt to parse as JSON. If that fails, treat it as a raw
+                // Attempt to parse as TOML. If that fails, treat it as a raw
                 // string. This allows convenient usage such as
                 // `-c model=o3` without the quotes.
                 let value: Value = match parse_toml_value(value_str) {


### PR DESCRIPTION
The CLI help text and inline comments incorrectly stated that -c key=value flag parses values as JSON, when the implementation actually uses TOML parsing via parse_toml_value(). This caused confusion when users attempted to configure MCP servers using JSON syntax based on the documentation.

Changes:
- Updated help text to correctly state TOML parsing instead of JSON

Fixes #4531