### PR TITLE
Fix SDK documentation: replace 'file diffs' with 'file change notifications'

### DIFF
--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -33,7 +33,7 @@ const nextTurn = await thread.run("Implement the fix");
 
 ### Streaming responses
 
-`run()` buffers events until the turn finishes. To react to intermediate progress—tool calls, streaming responses, and file diffs—use `runStreamed()` instead, which returns an async generator of structured events.
+`run()` buffers events until the turn finishes. To react to intermediate progress—tool calls, streaming responses, and file change notifications—use `runStreamed()` instead, which returns an async generator of structured events.
 
 ```typescript
 const { events } = await thread.runStreamed("Diagnose the test failure and propose a fix");


### PR DESCRIPTION
The TypeScript SDK's README incorrectly claimed that runStreamed() emits "file diffs". However, the FileChangeItem type only contains metadata (path, kind, status) without actual diff content.

Updated line 36 to accurately describe the SDK as providing "file change notifications" instead of "file diffs" to match the actual implementation in items.ts.

Fixes #5850