### PR TITLE
Promote shared helpers for suite tests

### DIFF
--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -134,13 +134,27 @@ impl TestCodex {
     }
 
     pub async fn submit_turn(&self, prompt: &str) -> Result<()> {
-        self.submit_turn_with_policy(prompt, SandboxPolicy::DangerFullAccess)
-            .await
+        self.submit_turn_with_policies(
+            prompt,
+            AskForApproval::Never,
+            SandboxPolicy::DangerFullAccess,
+        )
+        .await
     }
 
     pub async fn submit_turn_with_policy(
         &self,
         prompt: &str,
+        sandbox_policy: SandboxPolicy,
+    ) -> Result<()> {
+        self.submit_turn_with_policies(prompt, AskForApproval::Never, sandbox_policy)
+            .await
+    }
+
+    pub async fn submit_turn_with_policies(
+        &self,
+        prompt: &str,
+        approval_policy: AskForApproval,
         sandbox_policy: SandboxPolicy,
     ) -> Result<()> {
         let session_model = self.session_configured.model.clone();
@@ -151,7 +165,7 @@ impl TestCodex {
                 }],
                 final_output_json_schema: None,
                 cwd: self.cwd.path().to_path_buf(),
-                approval_policy: AskForApproval::Never,
+                approval_policy,
                 sandbox_policy,
                 model: session_model,
                 effort: None,

--- a/codex-rs/core/tests/suite/grep_files.rs
+++ b/codex-rs/core/tests/suite/grep_files.rs
@@ -2,28 +2,17 @@
 
 use anyhow::Result;
 use codex_core::model_family::find_family_for_model;
-use codex_core::protocol::AskForApproval;
-use codex_core::protocol::EventMsg;
-use codex_core::protocol::Op;
-use codex_core::protocol::SandboxPolicy;
-use codex_protocol::config_types::ReasoningSummary;
-use codex_protocol::user_input::UserInput;
-use core_test_support::responses;
-use core_test_support::responses::ev_assistant_message;
-use core_test_support::responses::ev_completed;
-use core_test_support::responses::ev_function_call;
-use core_test_support::responses::ev_response_created;
-use core_test_support::responses::sse;
+use core_test_support::responses::extract_content_and_success;
+use core_test_support::responses::find_function_call_output;
+use core_test_support::responses::mount_tool_sequence;
+use core_test_support::responses::recorded_bodies;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
-use core_test_support::wait_for_event;
-use serde_json::Value;
 use std::collections::HashSet;
 use std::path::Path;
 use std::process::Command as StdCommand;
-use wiremock::matchers::any;
 
 const MODEL_WITH_TOOL: &str = "test-gpt-5-codex";
 
@@ -70,10 +59,10 @@ async fn grep_files_tool_collects_matches() -> Result<()> {
     .to_string();
 
     mount_tool_sequence(&server, call_id, &arguments, "grep_files").await;
-    submit_turn(&test, "please find uses of needle").await?;
+    test.submit_turn("please find uses of needle").await?;
 
     let bodies = recorded_bodies(&server).await?;
-    let tool_output = find_tool_output(&bodies, call_id).expect("tool output present");
+    let tool_output = find_function_call_output(&bodies, call_id).expect("tool output present");
     let payload = tool_output.get("output").expect("output field present");
     let (content_opt, success_opt) = extract_content_and_success(payload);
     let content = content_opt.expect("content present");
@@ -119,10 +108,10 @@ async fn grep_files_tool_reports_empty_results() -> Result<()> {
     .to_string();
 
     mount_tool_sequence(&server, call_id, &arguments, "grep_files").await;
-    submit_turn(&test, "search again").await?;
+    test.submit_turn("search again").await?;
 
     let bodies = recorded_bodies(&server).await?;
-    let tool_output = find_tool_output(&bodies, call_id).expect("tool output present");
+    let tool_output = find_function_call_output(&bodies, call_id).expect("tool output present");
     let payload = tool_output.get("output").expect("output field present");
     let (content_opt, success_opt) = extract_content_and_success(payload);
     let content = content_opt.expect("content present");
@@ -144,73 +133,6 @@ async fn build_test_codex(server: &wiremock::MockServer) -> Result<TestCodex> {
     builder.build(server).await
 }
 
-async fn submit_turn(test: &TestCodex, prompt: &str) -> Result<()> {
-    let session_model = test.session_configured.model.clone();
-
-    test.codex
-        .submit(Op::UserTurn {
-            items: vec![UserInput::Text {
-                text: prompt.into(),
-            }],
-            final_output_json_schema: None,
-            cwd: test.cwd.path().to_path_buf(),
-            approval_policy: AskForApproval::Never,
-            sandbox_policy: SandboxPolicy::DangerFullAccess,
-            model: session_model,
-            effort: None,
-            summary: ReasoningSummary::Auto,
-        })
-        .await?;
-
-    wait_for_event(&test.codex, |event| {
-        matches!(event, EventMsg::TaskComplete(_))
-    })
-    .await;
-    Ok(())
-}
-
-async fn mount_tool_sequence(
-    server: &wiremock::MockServer,
-    call_id: &str,
-    arguments: &str,
-    tool_name: &str,
-) {
-    let first_response = sse(vec![
-        ev_response_created("resp-1"),
-        ev_function_call(call_id, tool_name, arguments),
-        ev_completed("resp-1"),
-    ]);
-    responses::mount_sse_once_match(server, any(), first_response).await;
-
-    let second_response = sse(vec![
-        ev_assistant_message("msg-1", "done"),
-        ev_completed("resp-2"),
-    ]);
-    responses::mount_sse_once_match(server, any(), second_response).await;
-}
-
-#[allow(clippy::expect_used)]
-async fn recorded_bodies(server: &wiremock::MockServer) -> Result<Vec<Value>> {
-    let requests = server.received_requests().await.expect("requests recorded");
-    Ok(requests
-        .iter()
-        .map(|req| req.body_json::<Value>().expect("request json"))
-        .collect())
-}
-
-fn find_tool_output<'a>(requests: &'a [Value], call_id: &str) -> Option<&'a Value> {
-    requests.iter().find_map(|body| {
-        body.get("input")
-            .and_then(Value::as_array)
-            .and_then(|items| {
-                items.iter().find(|item| {
-                    item.get("type").and_then(Value::as_str) == Some("function_call_output")
-                        && item.get("call_id").and_then(Value::as_str) == Some(call_id)
-                })
-            })
-    })
-}
-
 fn collect_file_names(content: &str) -> HashSet<String> {
     content
         .lines()
@@ -223,15 +145,4 @@ fn collect_file_names(content: &str) -> HashSet<String> {
                 .map(|name| name.to_string_lossy().into_owned())
         })
         .collect()
-}
-
-fn extract_content_and_success(value: &Value) -> (Option<&str>, Option<bool>) {
-    match value {
-        Value::String(text) => (Some(text.as_str()), None),
-        Value::Object(obj) => (
-            obj.get("content").and_then(Value::as_str),
-            obj.get("success").and_then(Value::as_bool),
-        ),
-        _ => (None, None),
-    }
 }

--- a/codex-rs/core/tests/suite/list_dir.rs
+++ b/codex-rs/core/tests/suite/list_dir.rs
@@ -1,25 +1,17 @@
 #![cfg(not(target_os = "windows"))]
 
-use codex_core::protocol::AskForApproval;
-use codex_core::protocol::EventMsg;
-use codex_core::protocol::Op;
-use codex_core::protocol::SandboxPolicy;
-use codex_protocol::config_types::ReasoningSummary;
-use codex_protocol::user_input::UserInput;
-use core_test_support::responses;
-use core_test_support::responses::ev_assistant_message;
-use core_test_support::responses::ev_completed;
-use core_test_support::responses::ev_function_call;
-use core_test_support::responses::ev_response_created;
-use core_test_support::responses::sse;
+use anyhow::Context;
+use core_test_support::responses::find_function_call_output;
+use core_test_support::responses::mount_tool_sequence;
+use core_test_support::responses::recorded_bodies;
 use core_test_support::responses::start_mock_server;
+use core_test_support::responses::tool_output_text;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
-use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
-use serde_json::Value;
-use wiremock::matchers::any;
+use serde_json::json;
+use wiremock::MockServer;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "disabled until we enable list_dir tool"]
@@ -27,99 +19,31 @@ async fn list_dir_tool_returns_entries() -> anyhow::Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
+    let test = test_codex().build(&server).await?;
 
-    let TestCodex {
-        codex,
-        cwd,
-        session_configured,
-        ..
-    } = test_codex().build(&server).await?;
-
-    let dir_path = cwd.path().join("sample_dir");
+    let dir_path = test.cwd.path().join("sample_dir");
     std::fs::create_dir(&dir_path)?;
     std::fs::write(dir_path.join("alpha.txt"), "first file")?;
     std::fs::create_dir(dir_path.join("nested"))?;
     let dir_path = dir_path.to_string_lossy().to_string();
 
     let call_id = "list-dir-call";
-    let arguments = serde_json::json!({
+    let arguments = json!({
         "dir_path": dir_path,
         "offset": 1,
         "limit": 2,
     })
     .to_string();
 
-    let first_response = sse(vec![
-        ev_response_created("resp-1"),
-        ev_function_call(call_id, "list_dir", &arguments),
-        ev_completed("resp-1"),
-    ]);
-    responses::mount_sse_once_match(&server, any(), first_response).await;
-
-    let second_response = sse(vec![
-        ev_assistant_message("msg-1", "done"),
-        ev_completed("resp-2"),
-    ]);
-    responses::mount_sse_once_match(&server, any(), second_response).await;
-
-    let session_model = session_configured.model.clone();
-
-    codex
-        .submit(Op::UserTurn {
-            items: vec![UserInput::Text {
-                text: "list directory contents".into(),
-            }],
-            final_output_json_schema: None,
-            cwd: cwd.path().to_path_buf(),
-            approval_policy: AskForApproval::Never,
-            sandbox_policy: SandboxPolicy::DangerFullAccess,
-            model: session_model,
-            effort: None,
-            summary: ReasoningSummary::Auto,
-        })
-        .await?;
-
-    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
-
-    let requests = server.received_requests().await.expect("recorded requests");
-    let request_bodies = requests
-        .iter()
-        .map(|req| req.body_json::<Value>().unwrap())
-        .collect::<Vec<_>>();
-    assert!(
-        !request_bodies.is_empty(),
-        "expected at least one request body"
-    );
-
-    let tool_output_item = request_bodies
-        .iter()
-        .find_map(|body| {
-            body.get("input")
-                .and_then(Value::as_array)
-                .and_then(|items| {
-                    items.iter().find(|item| {
-                        item.get("type").and_then(Value::as_str) == Some("function_call_output")
-                    })
-                })
-        })
-        .unwrap_or_else(|| {
-            panic!("function_call_output item not found in requests: {request_bodies:#?}")
-        });
-
-    assert_eq!(
-        tool_output_item.get("call_id").and_then(Value::as_str),
-        Some(call_id)
-    );
-
-    let output_text = tool_output_item
-        .get("output")
-        .and_then(|value| match value {
-            Value::String(text) => Some(text.as_str()),
-            Value::Object(obj) => obj.get("content").and_then(Value::as_str),
-            _ => None,
-        })
-        .expect("output text present");
-    assert_eq!(output_text, "E1: [file] alpha.txt\nE2: [dir] nested");
+    let output = collect_tool_output(
+        &test,
+        &server,
+        call_id,
+        &arguments,
+        "list directory contents",
+    )
+    .await?;
+    assert_eq!(output, "E1: [file] alpha.txt\nE2: [dir] nested");
 
     Ok(())
 }
@@ -130,15 +54,9 @@ async fn list_dir_tool_depth_one_omits_children() -> anyhow::Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
+    let test = test_codex().build(&server).await?;
 
-    let TestCodex {
-        codex,
-        cwd,
-        session_configured,
-        ..
-    } = test_codex().build(&server).await?;
-
-    let dir_path = cwd.path().join("depth_one");
+    let dir_path = test.cwd.path().join("depth_one");
     std::fs::create_dir(&dir_path)?;
     std::fs::write(dir_path.join("alpha.txt"), "alpha")?;
     std::fs::create_dir(dir_path.join("nested"))?;
@@ -146,7 +64,7 @@ async fn list_dir_tool_depth_one_omits_children() -> anyhow::Result<()> {
     let dir_path = dir_path.to_string_lossy().to_string();
 
     let call_id = "list-dir-depth1";
-    let arguments = serde_json::json!({
+    let arguments = json!({
         "dir_path": dir_path,
         "offset": 1,
         "limit": 10,
@@ -154,77 +72,15 @@ async fn list_dir_tool_depth_one_omits_children() -> anyhow::Result<()> {
     })
     .to_string();
 
-    let first_response = sse(vec![
-        ev_response_created("resp-1"),
-        ev_function_call(call_id, "list_dir", &arguments),
-        ev_completed("resp-1"),
-    ]);
-    responses::mount_sse_once_match(&server, any(), first_response).await;
-
-    let second_response = sse(vec![
-        ev_assistant_message("msg-1", "done"),
-        ev_completed("resp-2"),
-    ]);
-    responses::mount_sse_once_match(&server, any(), second_response).await;
-
-    let session_model = session_configured.model.clone();
-
-    codex
-        .submit(Op::UserTurn {
-            items: vec![UserInput::Text {
-                text: "list directory contents depth one".into(),
-            }],
-            final_output_json_schema: None,
-            cwd: cwd.path().to_path_buf(),
-            approval_policy: AskForApproval::Never,
-            sandbox_policy: SandboxPolicy::DangerFullAccess,
-            model: session_model,
-            effort: None,
-            summary: ReasoningSummary::Auto,
-        })
-        .await?;
-
-    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
-
-    let requests = server.received_requests().await.expect("recorded requests");
-    let request_bodies = requests
-        .iter()
-        .map(|req| req.body_json::<Value>().unwrap())
-        .collect::<Vec<_>>();
-    assert!(
-        !request_bodies.is_empty(),
-        "expected at least one request body"
-    );
-
-    let tool_output_item = request_bodies
-        .iter()
-        .find_map(|body| {
-            body.get("input")
-                .and_then(Value::as_array)
-                .and_then(|items| {
-                    items.iter().find(|item| {
-                        item.get("type").and_then(Value::as_str) == Some("function_call_output")
-                    })
-                })
-        })
-        .unwrap_or_else(|| {
-            panic!("function_call_output item not found in requests: {request_bodies:#?}")
-        });
-
-    assert_eq!(
-        tool_output_item.get("call_id").and_then(Value::as_str),
-        Some(call_id)
-    );
-
-    let output_text = tool_output_item
-        .get("output")
-        .and_then(|value| match value {
-            Value::String(text) => Some(text.as_str()),
-            Value::Object(obj) => obj.get("content").and_then(Value::as_str),
-            _ => None,
-        })
-        .expect("output text present");
-    assert_eq!(output_text, "E1: [file] alpha.txt\nE2: [dir] nested");
+    let output = collect_tool_output(
+        &test,
+        &server,
+        call_id,
+        &arguments,
+        "list directory contents depth one",
+    )
+    .await?;
+    assert_eq!(output, "E1: [file] alpha.txt\nE2: [dir] nested");
 
     Ok(())
 }
@@ -235,15 +91,9 @@ async fn list_dir_tool_depth_two_includes_children_only() -> anyhow::Result<()> 
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
+    let test = test_codex().build(&server).await?;
 
-    let TestCodex {
-        codex,
-        cwd,
-        session_configured,
-        ..
-    } = test_codex().build(&server).await?;
-
-    let dir_path = cwd.path().join("depth_two");
+    let dir_path = test.cwd.path().join("depth_two");
     std::fs::create_dir(&dir_path)?;
     std::fs::write(dir_path.join("alpha.txt"), "alpha")?;
     let nested = dir_path.join("nested");
@@ -255,7 +105,7 @@ async fn list_dir_tool_depth_two_includes_children_only() -> anyhow::Result<()> 
     let dir_path_string = dir_path.to_string_lossy().to_string();
 
     let call_id = "list-dir-depth2";
-    let arguments = serde_json::json!({
+    let arguments = json!({
         "dir_path": dir_path_string,
         "offset": 1,
         "limit": 10,
@@ -263,81 +113,16 @@ async fn list_dir_tool_depth_two_includes_children_only() -> anyhow::Result<()> 
     })
     .to_string();
 
-    let first_response = sse(vec![
-        serde_json::json!({
-            "type": "response.created",
-            "response": {"id": "resp-1"}
-        }),
-        ev_function_call(call_id, "list_dir", &arguments),
-        ev_completed("resp-1"),
-    ]);
-    responses::mount_sse_once_match(&server, any(), first_response).await;
-
-    let second_response = sse(vec![
-        ev_assistant_message("msg-1", "done"),
-        ev_completed("resp-2"),
-    ]);
-    responses::mount_sse_once_match(&server, any(), second_response).await;
-
-    let session_model = session_configured.model.clone();
-
-    codex
-        .submit(Op::UserTurn {
-            items: vec![UserInput::Text {
-                text: "list directory contents depth two".into(),
-            }],
-            final_output_json_schema: None,
-            cwd: cwd.path().to_path_buf(),
-            approval_policy: AskForApproval::Never,
-            sandbox_policy: SandboxPolicy::DangerFullAccess,
-            model: session_model,
-            effort: None,
-            summary: ReasoningSummary::Auto,
-        })
-        .await?;
-
-    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
-
-    let requests = server.received_requests().await.expect("recorded requests");
-    let request_bodies = requests
-        .iter()
-        .map(|req| req.body_json::<Value>().unwrap())
-        .collect::<Vec<_>>();
-    assert!(
-        !request_bodies.is_empty(),
-        "expected at least one request body"
-    );
-
-    let tool_output_item = request_bodies
-        .iter()
-        .find_map(|body| {
-            body.get("input")
-                .and_then(Value::as_array)
-                .and_then(|items| {
-                    items.iter().find(|item| {
-                        item.get("type").and_then(Value::as_str) == Some("function_call_output")
-                    })
-                })
-        })
-        .unwrap_or_else(|| {
-            panic!("function_call_output item not found in requests: {request_bodies:#?}")
-        });
-
+    let output = collect_tool_output(
+        &test,
+        &server,
+        call_id,
+        &arguments,
+        "list directory contents depth two",
+    )
+    .await?;
     assert_eq!(
-        tool_output_item.get("call_id").and_then(Value::as_str),
-        Some(call_id)
-    );
-
-    let output_text = tool_output_item
-        .get("output")
-        .and_then(|value| match value {
-            Value::String(text) => Some(text.as_str()),
-            Value::Object(obj) => obj.get("content").and_then(Value::as_str),
-            _ => None,
-        })
-        .expect("output text present");
-    assert_eq!(
-        output_text,
+        output,
         "E1: [file] alpha.txt\nE2: [dir] nested\nE3: [file] nested/beta.txt\nE4: [dir] nested/grand"
     );
 
@@ -350,15 +135,9 @@ async fn list_dir_tool_depth_three_includes_grandchildren() -> anyhow::Result<()
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
+    let test = test_codex().build(&server).await?;
 
-    let TestCodex {
-        codex,
-        cwd,
-        session_configured,
-        ..
-    } = test_codex().build(&server).await?;
-
-    let dir_path = cwd.path().join("depth_three");
+    let dir_path = test.cwd.path().join("depth_three");
     std::fs::create_dir(&dir_path)?;
     std::fs::write(dir_path.join("alpha.txt"), "alpha")?;
     let nested = dir_path.join("nested");
@@ -370,7 +149,7 @@ async fn list_dir_tool_depth_three_includes_grandchildren() -> anyhow::Result<()
     let dir_path_string = dir_path.to_string_lossy().to_string();
 
     let call_id = "list-dir-depth3";
-    let arguments = serde_json::json!({
+    let arguments = json!({
         "dir_path": dir_path_string,
         "offset": 1,
         "limit": 10,
@@ -378,83 +157,36 @@ async fn list_dir_tool_depth_three_includes_grandchildren() -> anyhow::Result<()
     })
     .to_string();
 
-    let first_response = sse(vec![
-        serde_json::json!({
-            "type": "response.created",
-            "response": {"id": "resp-1"}
-        }),
-        ev_function_call(call_id, "list_dir", &arguments),
-        ev_completed("resp-1"),
-    ]);
-    responses::mount_sse_once_match(&server, any(), first_response).await;
-
-    let second_response = sse(vec![
-        ev_assistant_message("msg-1", "done"),
-        ev_completed("resp-2"),
-    ]);
-    responses::mount_sse_once_match(&server, any(), second_response).await;
-
-    let session_model = session_configured.model.clone();
-
-    codex
-        .submit(Op::UserTurn {
-            items: vec![UserInput::Text {
-                text: "list directory contents depth three".into(),
-            }],
-            final_output_json_schema: None,
-            cwd: cwd.path().to_path_buf(),
-            approval_policy: AskForApproval::Never,
-            sandbox_policy: SandboxPolicy::DangerFullAccess,
-            model: session_model,
-            effort: None,
-            summary: ReasoningSummary::Auto,
-        })
-        .await?;
-
-    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
-
-    let requests = server.received_requests().await.expect("recorded requests");
-    let request_bodies = requests
-        .iter()
-        .map(|req| req.body_json::<Value>().unwrap())
-        .collect::<Vec<_>>();
-    assert!(
-        !request_bodies.is_empty(),
-        "expected at least one request body"
-    );
-
-    let tool_output_item = request_bodies
-        .iter()
-        .find_map(|body| {
-            body.get("input")
-                .and_then(Value::as_array)
-                .and_then(|items| {
-                    items.iter().find(|item| {
-                        item.get("type").and_then(Value::as_str) == Some("function_call_output")
-                    })
-                })
-        })
-        .unwrap_or_else(|| {
-            panic!("function_call_output item not found in requests: {request_bodies:#?}")
-        });
-
+    let output = collect_tool_output(
+        &test,
+        &server,
+        call_id,
+        &arguments,
+        "list directory contents depth three",
+    )
+    .await?;
     assert_eq!(
-        tool_output_item.get("call_id").and_then(Value::as_str),
-        Some(call_id)
-    );
-
-    let output_text = tool_output_item
-        .get("output")
-        .and_then(|value| match value {
-            Value::String(text) => Some(text.as_str()),
-            Value::Object(obj) => obj.get("content").and_then(Value::as_str),
-            _ => None,
-        })
-        .expect("output text present");
-    assert_eq!(
-        output_text,
+        output,
         "E1: [file] alpha.txt\nE2: [dir] nested\nE3: [file] nested/beta.txt\nE4: [dir] nested/grand\nE5: [file] nested/grand/gamma.txt"
     );
 
     Ok(())
+}
+
+async fn collect_tool_output(
+    test: &TestCodex,
+    server: &MockServer,
+    call_id: &str,
+    arguments: &str,
+    prompt: &str,
+) -> anyhow::Result<String> {
+    mount_tool_sequence(server, call_id, arguments, "list_dir").await;
+    test.submit_turn(prompt).await?;
+
+    let bodies = recorded_bodies(server).await?;
+    let tool_output_item = find_function_call_output(&bodies, call_id)
+        .unwrap_or_else(|| panic!("function_call_output item not found in requests: {bodies:#?}"));
+    let output_text =
+        tool_output_text(tool_output_item).context("output text present in tool output")?;
+    Ok(output_text.to_string())
 }

--- a/codex-rs/core/tests/suite/list_dir.rs
+++ b/codex-rs/core/tests/suite/list_dir.rs
@@ -1,6 +1,5 @@
 #![cfg(not(target_os = "windows"))]
 
-use anyhow::Context;
 use core_test_support::responses::mount_function_call_agent_response;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
@@ -32,8 +31,7 @@ async fn list_dir_tool_returns_entries() -> anyhow::Result<()> {
     })
     .to_string();
 
-    let mocks =
-        mount_function_call_agent_response(&server, call_id, &arguments, "list_dir").await;
+    let mocks = mount_function_call_agent_response(&server, call_id, &arguments, "list_dir").await;
     test.submit_turn("list directory contents").await?;
     let req = mocks.completion.single_request();
     let (content_opt, _) = req
@@ -69,9 +67,9 @@ async fn list_dir_tool_depth_one_omits_children() -> anyhow::Result<()> {
     })
     .to_string();
 
-    let mocks =
-        mount_function_call_agent_response(&server, call_id, &arguments, "list_dir").await;
-    test.submit_turn("list directory contents depth one").await?;
+    let mocks = mount_function_call_agent_response(&server, call_id, &arguments, "list_dir").await;
+    test.submit_turn("list directory contents depth one")
+        .await?;
     let req = mocks.completion.single_request();
     let (content_opt, _) = req
         .function_call_output_content_and_success(call_id)
@@ -110,9 +108,9 @@ async fn list_dir_tool_depth_two_includes_children_only() -> anyhow::Result<()> 
     })
     .to_string();
 
-    let mocks =
-        mount_function_call_agent_response(&server, call_id, &arguments, "list_dir").await;
-    test.submit_turn("list directory contents depth two").await?;
+    let mocks = mount_function_call_agent_response(&server, call_id, &arguments, "list_dir").await;
+    test.submit_turn("list directory contents depth two")
+        .await?;
     let req = mocks.completion.single_request();
     let (content_opt, _) = req
         .function_call_output_content_and_success(call_id)
@@ -154,9 +152,9 @@ async fn list_dir_tool_depth_three_includes_grandchildren() -> anyhow::Result<()
     })
     .to_string();
 
-    let mocks =
-        mount_function_call_agent_response(&server, call_id, &arguments, "list_dir").await;
-    test.submit_turn("list directory contents depth three").await?;
+    let mocks = mount_function_call_agent_response(&server, call_id, &arguments, "list_dir").await;
+    test.submit_turn("list directory contents depth three")
+        .await?;
     let req = mocks.completion.single_request();
     let (content_opt, _) = req
         .function_call_output_content_and_success(call_id)

--- a/codex-rs/core/tests/suite/list_dir.rs
+++ b/codex-rs/core/tests/suite/list_dir.rs
@@ -3,11 +3,9 @@
 use core_test_support::responses::mount_function_call_agent_response;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
-use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
 use pretty_assertions::assert_eq;
 use serde_json::json;
-use wiremock::MockServer;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "disabled until we enable list_dir tool"]

--- a/codex-rs/core/tests/suite/read_file.rs
+++ b/codex-rs/core/tests/suite/read_file.rs
@@ -1,25 +1,12 @@
 #![cfg(not(target_os = "windows"))]
 
-use codex_core::protocol::AskForApproval;
-use codex_core::protocol::EventMsg;
-use codex_core::protocol::Op;
-use codex_core::protocol::SandboxPolicy;
-use codex_protocol::config_types::ReasoningSummary;
-use codex_protocol::user_input::UserInput;
-use core_test_support::responses;
-use core_test_support::responses::ev_assistant_message;
-use core_test_support::responses::ev_completed;
-use core_test_support::responses::ev_function_call;
-use core_test_support::responses::ev_response_created;
-use core_test_support::responses::sse;
+use core_test_support::responses::mount_tool_sequence;
 use core_test_support::responses::start_mock_server;
+use core_test_support::responses::tool_output_text;
 use core_test_support::skip_if_no_network;
-use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
-use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
-use serde_json::Value;
-use wiremock::matchers::any;
+use serde_json::json;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[ignore = "disabled until we enable read_file tool"]
@@ -27,72 +14,27 @@ async fn read_file_tool_returns_requested_lines() -> anyhow::Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
+    let test = test_codex().build(&server).await?;
 
-    let TestCodex {
-        codex,
-        cwd,
-        session_configured,
-        ..
-    } = test_codex().build(&server).await?;
-
-    let file_path = cwd.path().join("sample.txt");
+    let file_path = test.cwd.path().join("sample.txt");
     std::fs::write(&file_path, "first\nsecond\nthird\nfourth\n")?;
     let file_path = file_path.to_string_lossy().to_string();
 
     let call_id = "read-file-call";
-    let arguments = serde_json::json!({
+    let arguments = json!({
         "file_path": file_path,
         "offset": 2,
         "limit": 2,
     })
     .to_string();
 
-    let first_response = sse(vec![
-        ev_response_created("resp-1"),
-        ev_function_call(call_id, "read_file", &arguments),
-        ev_completed("resp-1"),
-    ]);
-    responses::mount_sse_once_match(&server, any(), first_response).await;
+    let mocks = mount_tool_sequence(&server, call_id, &arguments, "read_file").await;
 
-    let second_response = sse(vec![
-        ev_assistant_message("msg-1", "done"),
-        ev_completed("resp-2"),
-    ]);
-    let second_mock = responses::mount_sse_once_match(&server, any(), second_response).await;
+    test.submit_turn("please inspect sample.txt").await?;
 
-    let session_model = session_configured.model.clone();
-
-    codex
-        .submit(Op::UserTurn {
-            items: vec![UserInput::Text {
-                text: "please inspect sample.txt".into(),
-            }],
-            final_output_json_schema: None,
-            cwd: cwd.path().to_path_buf(),
-            approval_policy: AskForApproval::Never,
-            sandbox_policy: SandboxPolicy::DangerFullAccess,
-            model: session_model,
-            effort: None,
-            summary: ReasoningSummary::Auto,
-        })
-        .await?;
-
-    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
-
-    let req = second_mock.single_request();
+    let req = mocks.completion.single_request();
     let tool_output_item = req.function_call_output(call_id);
-    assert_eq!(
-        tool_output_item.get("call_id").and_then(Value::as_str),
-        Some(call_id)
-    );
-    let output_text = tool_output_item
-        .get("output")
-        .and_then(|value| match value {
-            Value::String(text) => Some(text.as_str()),
-            Value::Object(obj) => obj.get("content").and_then(Value::as_str),
-            _ => None,
-        })
-        .expect("output text present");
+    let output_text = tool_output_text(&tool_output_item).expect("output text present");
     assert_eq!(output_text, "L2: second\nL3: third");
 
     Ok(())

--- a/codex-rs/core/tests/suite/shell_serialization.rs
+++ b/codex-rs/core/tests/suite/shell_serialization.rs
@@ -3,12 +3,7 @@
 use anyhow::Result;
 use codex_core::features::Feature;
 use codex_core::model_family::find_family_for_model;
-use codex_core::protocol::AskForApproval;
-use codex_core::protocol::EventMsg;
-use codex_core::protocol::Op;
 use codex_core::protocol::SandboxPolicy;
-use codex_protocol::config_types::ReasoningSummary;
-use codex_protocol::user_input::UserInput;
 use core_test_support::assert_regex_match;
 use core_test_support::responses::ev_apply_patch_function_call;
 use core_test_support::responses::ev_assistant_message;
@@ -17,13 +12,14 @@ use core_test_support::responses::ev_custom_tool_call;
 use core_test_support::responses::ev_function_call;
 use core_test_support::responses::ev_local_shell_call;
 use core_test_support::responses::ev_response_created;
+use core_test_support::responses::find_custom_tool_call_output;
+use core_test_support::responses::find_function_call_output;
 use core_test_support::responses::mount_sse_sequence;
+use core_test_support::responses::recorded_bodies;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
-use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
-use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
 use regex_lite::Regex;
 use serde_json::Value;
@@ -41,69 +37,6 @@ const FIXTURE_JSON: &str = r#"{
     }
 }
 "#;
-
-async fn submit_turn(test: &TestCodex, prompt: &str, sandbox_policy: SandboxPolicy) -> Result<()> {
-    let session_model = test.session_configured.model.clone();
-
-    test.codex
-        .submit(Op::UserTurn {
-            items: vec![UserInput::Text {
-                text: prompt.into(),
-            }],
-            final_output_json_schema: None,
-            cwd: test.cwd.path().to_path_buf(),
-            approval_policy: AskForApproval::Never,
-            sandbox_policy,
-            model: session_model,
-            effort: None,
-            summary: ReasoningSummary::Auto,
-        })
-        .await?;
-
-    wait_for_event(&test.codex, |event| {
-        matches!(event, EventMsg::TaskComplete(_))
-    })
-    .await;
-
-    Ok(())
-}
-
-fn request_bodies(requests: &[wiremock::Request]) -> Result<Vec<Value>> {
-    requests
-        .iter()
-        .map(|req| Ok(serde_json::from_slice::<Value>(&req.body)?))
-        .collect()
-}
-
-fn find_function_call_output<'a>(bodies: &'a [Value], call_id: &str) -> Option<&'a Value> {
-    for body in bodies {
-        if let Some(items) = body.get("input").and_then(Value::as_array) {
-            for item in items {
-                if item.get("type").and_then(Value::as_str) == Some("function_call_output")
-                    && item.get("call_id").and_then(Value::as_str) == Some(call_id)
-                {
-                    return Some(item);
-                }
-            }
-        }
-    }
-    None
-}
-
-fn find_custom_tool_call_output<'a>(bodies: &'a [Value], call_id: &str) -> Option<&'a Value> {
-    for body in bodies {
-        if let Some(items) = body.get("input").and_then(Value::as_array) {
-            for item in items {
-                if item.get("type").and_then(Value::as_str) == Some("custom_tool_call_output")
-                    && item.get("call_id").and_then(Value::as_str) == Some(call_id)
-                {
-                    return Some(item);
-                }
-            }
-        }
-    }
-    None
-}
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn shell_output_stays_json_without_freeform_apply_patch() -> Result<()> {
@@ -135,18 +68,13 @@ async fn shell_output_stays_json_without_freeform_apply_patch() -> Result<()> {
     ];
     mount_sse_sequence(&server, responses).await;
 
-    submit_turn(
-        &test,
+    test.submit_turn_with_policy(
         "run the json shell command",
         SandboxPolicy::DangerFullAccess,
     )
     .await?;
 
-    let requests = server
-        .received_requests()
-        .await
-        .expect("recorded requests present");
-    let bodies = request_bodies(&requests)?;
+    let bodies = recorded_bodies(&server).await?;
     let output_item = find_function_call_output(&bodies, call_id).expect("shell output present");
     let output = output_item
         .get("output")
@@ -204,18 +132,13 @@ async fn shell_output_is_structured_with_freeform_apply_patch() -> Result<()> {
     ];
     mount_sse_sequence(&server, responses).await;
 
-    submit_turn(
-        &test,
+    test.submit_turn_with_policy(
         "run the structured shell command",
         SandboxPolicy::DangerFullAccess,
     )
     .await?;
 
-    let requests = server
-        .received_requests()
-        .await
-        .expect("recorded requests present");
-    let bodies = request_bodies(&requests)?;
+    let bodies = recorded_bodies(&server).await?;
     let output_item =
         find_function_call_output(&bodies, call_id).expect("structured output present");
     let output = output_item
@@ -271,18 +194,13 @@ async fn shell_output_preserves_fixture_json_without_serialization() -> Result<(
     ];
     mount_sse_sequence(&server, responses).await;
 
-    submit_turn(
-        &test,
+    test.submit_turn_with_policy(
         "read the fixture JSON with sed",
         SandboxPolicy::DangerFullAccess,
     )
     .await?;
 
-    let requests = server
-        .received_requests()
-        .await
-        .expect("recorded requests present");
-    let bodies = request_bodies(&requests)?;
+    let bodies = recorded_bodies(&server).await?;
     let output_item = find_function_call_output(&bodies, call_id).expect("shell output present");
     let output = output_item
         .get("output")
@@ -347,18 +265,13 @@ async fn shell_output_structures_fixture_with_serialization() -> Result<()> {
     ];
     mount_sse_sequence(&server, responses).await;
 
-    submit_turn(
-        &test,
+    test.submit_turn_with_policy(
         "read the fixture JSON with structured output",
         SandboxPolicy::DangerFullAccess,
     )
     .await?;
 
-    let requests = server
-        .received_requests()
-        .await
-        .expect("recorded requests present");
-    let bodies = request_bodies(&requests)?;
+    let bodies = recorded_bodies(&server).await?;
     let output_item =
         find_function_call_output(&bodies, call_id).expect("structured output present");
     let output = output_item
@@ -422,18 +335,13 @@ async fn shell_output_for_freeform_tool_records_duration() -> Result<()> {
     ];
     mount_sse_sequence(&server, responses).await;
 
-    submit_turn(
-        &test,
+    test.submit_turn_with_policy(
         "run the structured shell command",
         SandboxPolicy::DangerFullAccess,
     )
     .await?;
 
-    let requests = server
-        .received_requests()
-        .await
-        .expect("recorded requests present");
-    let bodies = request_bodies(&requests)?;
+    let bodies = recorded_bodies(&server).await?;
     let output_item =
         find_function_call_output(&bodies, call_id).expect("structured output present");
     let output = output_item
@@ -492,18 +400,13 @@ async fn shell_output_reserializes_truncated_content() -> Result<()> {
     ];
     mount_sse_sequence(&server, responses).await;
 
-    submit_turn(
-        &test,
+    test.submit_turn_with_policy(
         "run the truncation shell command",
         SandboxPolicy::DangerFullAccess,
     )
     .await?;
 
-    let requests = server
-        .received_requests()
-        .await
-        .expect("recorded requests present");
-    let bodies = request_bodies(&requests)?;
+    let bodies = recorded_bodies(&server).await?;
     let output_item =
         find_function_call_output(&bodies, call_id).expect("truncated output present");
     let output = output_item
@@ -572,18 +475,13 @@ async fn apply_patch_custom_tool_output_is_structured() -> Result<()> {
     ];
     mount_sse_sequence(&server, responses).await;
 
-    submit_turn(
-        &test,
+    test.submit_turn_with_policy(
         "apply the patch via custom tool",
         SandboxPolicy::DangerFullAccess,
     )
     .await?;
 
-    let requests = server
-        .received_requests()
-        .await
-        .expect("recorded requests present");
-    let bodies = request_bodies(&requests)?;
+    let bodies = recorded_bodies(&server).await?;
     let output_item =
         find_custom_tool_call_output(&bodies, call_id).expect("apply_patch output present");
     let output = output_item
@@ -632,18 +530,13 @@ async fn apply_patch_custom_tool_call_creates_file() -> Result<()> {
     ];
     mount_sse_sequence(&server, responses).await;
 
-    submit_turn(
-        &test,
+    test.submit_turn_with_policy(
         "apply the patch via custom tool to create a file",
         SandboxPolicy::DangerFullAccess,
     )
     .await?;
 
-    let requests = server
-        .received_requests()
-        .await
-        .expect("recorded requests present");
-    let bodies = request_bodies(&requests)?;
+    let bodies = recorded_bodies(&server).await?;
     let output_item =
         find_custom_tool_call_output(&bodies, call_id).expect("apply_patch output present");
     let output = output_item
@@ -701,18 +594,13 @@ async fn apply_patch_custom_tool_call_updates_existing_file() -> Result<()> {
     ];
     mount_sse_sequence(&server, responses).await;
 
-    submit_turn(
-        &test,
+    test.submit_turn_with_policy(
         "apply the patch via custom tool to update a file",
         SandboxPolicy::DangerFullAccess,
     )
     .await?;
 
-    let requests = server
-        .received_requests()
-        .await
-        .expect("recorded requests present");
-    let bodies = request_bodies(&requests)?;
+    let bodies = recorded_bodies(&server).await?;
     let output_item =
         find_custom_tool_call_output(&bodies, call_id).expect("apply_patch output present");
     let output = output_item
@@ -764,18 +652,13 @@ async fn apply_patch_custom_tool_call_reports_failure_output() -> Result<()> {
     ];
     mount_sse_sequence(&server, responses).await;
 
-    submit_turn(
-        &test,
+    test.submit_turn_with_policy(
         "attempt a failing apply_patch via custom tool",
         SandboxPolicy::DangerFullAccess,
     )
     .await?;
 
-    let requests = server
-        .received_requests()
-        .await
-        .expect("recorded requests present");
-    let bodies = request_bodies(&requests)?;
+    let bodies = recorded_bodies(&server).await?;
     let output_item =
         find_custom_tool_call_output(&bodies, call_id).expect("apply_patch output present");
     let output = output_item
@@ -819,18 +702,13 @@ async fn apply_patch_function_call_output_is_structured() -> Result<()> {
     ];
     mount_sse_sequence(&server, responses).await;
 
-    submit_turn(
-        &test,
+    test.submit_turn_with_policy(
         "apply the patch via function-call apply_patch",
         SandboxPolicy::DangerFullAccess,
     )
     .await?;
 
-    let requests = server
-        .received_requests()
-        .await
-        .expect("recorded requests present");
-    let bodies = request_bodies(&requests)?;
+    let bodies = recorded_bodies(&server).await?;
     let output_item =
         find_function_call_output(&bodies, call_id).expect("apply_patch function output present");
     let output = output_item
@@ -882,18 +760,13 @@ async fn shell_output_is_structured_for_nonzero_exit() -> Result<()> {
     ];
     mount_sse_sequence(&server, responses).await;
 
-    submit_turn(
-        &test,
+    test.submit_turn_with_policy(
         "run the failing shell command",
         SandboxPolicy::DangerFullAccess,
     )
     .await?;
 
-    let requests = server
-        .received_requests()
-        .await
-        .expect("recorded requests present");
-    let bodies = request_bodies(&requests)?;
+    let bodies = recorded_bodies(&server).await?;
     let output_item = find_function_call_output(&bodies, call_id).expect("shell output present");
     let output = output_item
         .get("output")
@@ -936,18 +809,13 @@ async fn local_shell_call_output_is_structured() -> Result<()> {
     ];
     mount_sse_sequence(&server, responses).await;
 
-    submit_turn(
-        &test,
+    test.submit_turn_with_policy(
         "run the local shell command",
         SandboxPolicy::DangerFullAccess,
     )
     .await?;
 
-    let requests = server
-        .received_requests()
-        .await
-        .expect("recorded requests present");
-    let bodies = request_bodies(&requests)?;
+    let bodies = recorded_bodies(&server).await?;
     let output_item =
         find_function_call_output(&bodies, call_id).expect("local shell output present");
     let output = output_item

--- a/codex-rs/core/tests/suite/tool_harness.rs
+++ b/codex-rs/core/tests/suite/tool_harness.rs
@@ -14,6 +14,7 @@ use codex_protocol::plan_tool::StepStatus;
 use codex_protocol::user_input::UserInput;
 use core_test_support::assert_regex_match;
 use core_test_support::responses;
+use core_test_support::responses::ResponsesRequest;
 use core_test_support::responses::ev_apply_patch_function_call;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
@@ -30,12 +31,14 @@ use serde_json::Value;
 use serde_json::json;
 use wiremock::matchers::any;
 
-fn extract_output_text(item: &Value) -> Option<&str> {
-    item.get("output").and_then(|value| match value {
-        Value::String(text) => Some(text.as_str()),
-        Value::Object(obj) => obj.get("content").and_then(Value::as_str),
-        _ => None,
-    })
+fn call_output(req: &ResponsesRequest, call_id: &str) -> (String, Option<bool>) {
+    let (content, success) = req
+        .function_call_output_content_and_success(call_id)
+        .expect("function_call_output present");
+    (
+        content.expect("function_call_output content present"),
+        success,
+    )
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -90,9 +93,8 @@ async fn shell_tool_executes_command_and_streams_output() -> anyhow::Result<()> 
     wait_for_event(&codex, |event| matches!(event, EventMsg::TaskComplete(_))).await;
 
     let req = second_mock.single_request();
-    let output_item = req.function_call_output(call_id);
-    let output_text = extract_output_text(&output_item).expect("output text present");
-    let exec_output: Value = serde_json::from_str(output_text)?;
+    let (output_text, _) = call_output(&req, call_id);
+    let exec_output: Value = serde_json::from_str(&output_text)?;
     assert_eq!(exec_output["metadata"]["exit_code"], 0);
     let stdout = exec_output["output"].as_str().expect("stdout field");
     assert_regex_match(r"(?s)^tool harness\n?$", stdout);
@@ -174,12 +176,7 @@ async fn update_plan_tool_emits_plan_update_event() -> anyhow::Result<()> {
     assert!(saw_plan_update, "expected PlanUpdate event");
 
     let req = second_mock.single_request();
-    let output_item = req.function_call_output(call_id);
-    assert_eq!(
-        output_item.get("call_id").and_then(Value::as_str),
-        Some(call_id)
-    );
-    let output_text = extract_output_text(&output_item).expect("output text present");
+    let (output_text, _success_flag) = call_output(&req, call_id);
     assert_eq!(output_text, "Plan updated");
 
     Ok(())
@@ -252,22 +249,12 @@ async fn update_plan_tool_rejects_malformed_payload() -> anyhow::Result<()> {
     );
 
     let req = second_mock.single_request();
-    let output_item = req.function_call_output(call_id);
-    assert_eq!(
-        output_item.get("call_id").and_then(Value::as_str),
-        Some(call_id)
-    );
-    let output_text = extract_output_text(&output_item).expect("output text present");
+    let (output_text, success_flag) = call_output(&req, call_id);
     assert!(
         output_text.contains("failed to parse function arguments"),
         "expected parse error message in output text, got {output_text:?}"
     );
-    if let Some(success_flag) = output_item
-        .get("output")
-        .and_then(|value| value.as_object())
-        .and_then(|obj| obj.get("success"))
-        .and_then(serde_json::Value::as_bool)
-    {
+    if let Some(success_flag) = success_flag {
         assert!(
             !success_flag,
             "expected tool output to mark success=false for malformed payload"
@@ -357,12 +344,7 @@ async fn apply_patch_tool_executes_and_emits_patch_events() -> anyhow::Result<()
     assert!(patch_end_success);
 
     let req = second_mock.single_request();
-    let output_item = req.function_call_output(call_id);
-    assert_eq!(
-        output_item.get("call_id").and_then(Value::as_str),
-        Some(call_id)
-    );
-    let output_text = extract_output_text(&output_item).expect("output text present");
+    let (output_text, _success_flag) = call_output(&req, call_id);
 
     let expected_pattern = format!(
         r"(?s)^Exit code: 0
@@ -372,7 +354,7 @@ Success. Updated the following files:
 A {file_name}
 ?$"
     );
-    assert_regex_match(&expected_pattern, output_text);
+    assert_regex_match(&expected_pattern, &output_text);
 
     let updated_contents = fs::read_to_string(file_path)?;
     assert_eq!(
@@ -437,12 +419,7 @@ async fn apply_patch_reports_parse_diagnostics() -> anyhow::Result<()> {
     wait_for_event(&codex, |event| matches!(event, EventMsg::TaskComplete(_))).await;
 
     let req = second_mock.single_request();
-    let output_item = req.function_call_output(call_id);
-    assert_eq!(
-        output_item.get("call_id").and_then(Value::as_str),
-        Some(call_id)
-    );
-    let output_text = extract_output_text(&output_item).expect("output text present");
+    let (output_text, success_flag) = call_output(&req, call_id);
 
     assert!(
         output_text.contains("apply_patch verification failed"),
@@ -453,12 +430,7 @@ async fn apply_patch_reports_parse_diagnostics() -> anyhow::Result<()> {
         "expected parse diagnostics in output text, got {output_text:?}"
     );
 
-    if let Some(success_flag) = output_item
-        .get("output")
-        .and_then(|value| value.as_object())
-        .and_then(|obj| obj.get("success"))
-        .and_then(serde_json::Value::as_bool)
-    {
+    if let Some(success_flag) = success_flag {
         assert!(
             !success_flag,
             "expected tool output to mark success=false for parse failures"


### PR DESCRIPTION
## Summary
- add `TestCodex::submit_turn_with_policies` and extend the response helpers with reusable tool-call utilities
- update the grep_files, read_file, list_dir, shell_serialization, and tools suites to rely on the shared helpers instead of local copies
- make the list_dir helper return `anyhow::Result` so clippy no longer warns about `expect`

## Testing
- `just fix -p codex-core`
- `cargo test -p codex-core --test all suite::grep_files::grep_files_tool_collects_matches`
- `cargo test -p codex-core suite::grep_files::grep_files_tool_collects_matches -- --ignored` (filter requests ignored tests so nothing runs, but the build stays clean)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69112d53abac83219813cab4d7cb6446)