### PR TITLE
Use shared network gating helper in chat completion tests

### DIFF
--- a/codex-rs/core/tests/chat_completions_payload.rs
+++ b/codex-rs/core/tests/chat_completions_payload.rs
@@ -10,11 +10,11 @@ use codex_core::ModelProviderInfo;
 use codex_core::Prompt;
 use codex_core::ResponseItem;
 use codex_core::WireApi;
-use codex_core::spawn::CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR;
 use codex_otel::otel_event_manager::OtelEventManager;
 use codex_protocol::ConversationId;
 use codex_protocol::models::ReasoningItemContent;
 use core_test_support::load_default_config_for_test;
+use core_test_support::skip_if_no_network;
 use futures::StreamExt;
 use serde_json::Value;
 use tempfile::TempDir;
@@ -23,10 +23,6 @@ use wiremock::MockServer;
 use wiremock::ResponseTemplate;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
-
-fn network_disabled() -> bool {
-    std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok()
-}
 
 async fn run_request(input: Vec<ResponseItem>) -> Value {
     let server = MockServer::start().await;
@@ -191,12 +187,7 @@ fn first_assistant(messages: &[Value]) -> &Value {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn omits_reasoning_when_none_present() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let body = run_request(vec![user_message("u1"), assistant_message("a1")]).await;
     let messages = messages_from(&body);
@@ -208,12 +199,7 @@ async fn omits_reasoning_when_none_present() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn attaches_reasoning_to_previous_assistant() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let body = run_request(vec![
         user_message("u1"),
@@ -230,12 +216,7 @@ async fn attaches_reasoning_to_previous_assistant() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn attaches_reasoning_to_function_call_anchor() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let body = run_request(vec![
         user_message("u1"),
@@ -257,12 +238,7 @@ async fn attaches_reasoning_to_function_call_anchor() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn attaches_reasoning_to_local_shell_call() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let body = run_request(vec![
         user_message("u1"),
@@ -282,12 +258,7 @@ async fn attaches_reasoning_to_local_shell_call() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn drops_reasoning_when_last_role_is_user() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let body = run_request(vec![
         assistant_message("aPrev"),
@@ -301,12 +272,7 @@ async fn drops_reasoning_when_last_role_is_user() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn ignores_reasoning_before_last_user() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let body = run_request(vec![
         user_message("u1"),
@@ -321,12 +287,7 @@ async fn ignores_reasoning_before_last_user() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn skips_empty_reasoning_segments() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let body = run_request(vec![
         user_message("u1"),
@@ -342,12 +303,7 @@ async fn skips_empty_reasoning_segments() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn suppresses_duplicate_assistant_messages() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let body = run_request(vec![assistant_message("dup"), assistant_message("dup")]).await;
     let messages = messages_from(&body);

--- a/codex-rs/core/tests/chat_completions_sse.rs
+++ b/codex-rs/core/tests/chat_completions_sse.rs
@@ -10,11 +10,11 @@ use codex_core::Prompt;
 use codex_core::ResponseEvent;
 use codex_core::ResponseItem;
 use codex_core::WireApi;
-use codex_core::spawn::CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR;
 use codex_otel::otel_event_manager::OtelEventManager;
 use codex_protocol::ConversationId;
 use codex_protocol::models::ReasoningItemContent;
 use core_test_support::load_default_config_for_test;
+use core_test_support::skip_if_no_network;
 use futures::StreamExt;
 use tempfile::TempDir;
 use wiremock::Mock;
@@ -22,10 +22,6 @@ use wiremock::MockServer;
 use wiremock::ResponseTemplate;
 use wiremock::matchers::method;
 use wiremock::matchers::path;
-
-fn network_disabled() -> bool {
-    std::env::var(CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR).is_ok()
-}
 
 async fn run_stream(sse_body: &str) -> Vec<ResponseEvent> {
     run_stream_with_bytes(sse_body.as_bytes()).await
@@ -157,12 +153,7 @@ fn assert_reasoning(item: &ResponseItem, expected: &str) {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn streams_text_without_reasoning() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let sse = concat!(
         "data: {\"choices\":[{\"delta\":{\"content\":\"hi\"}}]}\n\n",
@@ -193,12 +184,7 @@ async fn streams_text_without_reasoning() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn streams_reasoning_from_string_delta() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let sse = concat!(
         "data: {\"choices\":[{\"delta\":{\"reasoning\":\"think1\"}}]}\n\n",
@@ -244,12 +230,7 @@ async fn streams_reasoning_from_string_delta() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn streams_reasoning_from_object_delta() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let sse = concat!(
         "data: {\"choices\":[{\"delta\":{\"reasoning\":{\"text\":\"partA\"}}}]}\n\n",
@@ -301,12 +282,7 @@ async fn streams_reasoning_from_object_delta() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn streams_reasoning_from_final_message() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let sse = "data: {\"choices\":[{\"message\":{\"reasoning\":\"final-cot\"},\"finish_reason\":\"stop\"}]}\n\n";
 
@@ -333,12 +309,7 @@ async fn streams_reasoning_from_final_message() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn streams_reasoning_before_tool_call() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let sse = concat!(
         "data: {\"choices\":[{\"delta\":{\"reasoning\":\"pre-tool\"}}]}\n\n",
@@ -383,12 +354,7 @@ async fn streams_reasoning_before_tool_call() {
 #[tokio::test]
 #[traced_test]
 async fn chat_sse_emits_failed_on_parse_error() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let sse_body = concat!("data: not-json\n\n", "data: [DONE]\n\n");
 
@@ -420,12 +386,7 @@ async fn chat_sse_emits_failed_on_parse_error() {
 #[tokio::test]
 #[traced_test]
 async fn chat_sse_done_chunk_emits_event() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let sse_body = "data: [DONE]\n\n";
 
@@ -443,12 +404,7 @@ async fn chat_sse_done_chunk_emits_event() {
 #[tokio::test]
 #[traced_test]
 async fn chat_sse_emits_error_on_invalid_utf8() {
-    if network_disabled() {
-        println!(
-            "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
-        );
-        return;
-    }
+    skip_if_no_network!();
 
     let _ = run_stream_with_bytes(b"data: \x80\x80\n\n").await;
 


### PR DESCRIPTION
## Summary
- replace the bespoke network check in the chat completion payload and SSE tests with the existing `skip_if_no_network!` helper so they follow the same gating convention as the rest of the suite

## Testing
- `just fmt`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69112d4cb9f08321ba773e8ccf39778e)