### PR TITLE
Add pinned resume picker sessions

### DIFF
--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -320,8 +320,7 @@ impl PinnedConversations {
         paths.sort();
 
         let payload = PinnedConversationsFile { paths };
-        let data = serde_json::to_vec_pretty(&payload)
-            .map_err(|err| std::io::Error::new(ErrorKind::Other, err))?;
+        let data = serde_json::to_vec_pretty(&payload).map_err(std::io::Error::other)?;
         fs::write(path, data).await
     }
 }
@@ -894,7 +893,7 @@ fn render_list(
         let marker = if is_sel { "> ".bold() } else { "  ".into() };
         let marker_width = 2usize;
         let pin_span = if state.is_row_pinned(row) {
-            "★ ".yellow()
+            "★ ".cyan()
         } else {
             "  ".dim()
         };
@@ -936,7 +935,7 @@ fn render_list(
             spans.push("  ".into());
         }
         let preview_span = if state.is_row_pinned(row) {
-            Span::from(preview).yellow()
+            Span::from(preview).cyan()
         } else {
             Span::from(preview)
         };

--- a/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_table.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_table.snap
@@ -1,8 +1,9 @@
 ---
 source: tui/src/resume_picker.rs
+assertion_line: 1320
 expression: snapshot
 ---
-  Created         Updated         Conversation
-  16 minutes ago  42 seconds ago  Fix resume picker timestamps
-> 1 hour ago      35 minutes ago  Investigate lazy pagination cap
-  2 hours ago     2 hours ago     Explain the codebase
+  ★ Created         Updated         Conversation
+    16 minutes ago  42 seconds ago  Fix resume picker timestamps
+>   1 hour ago      35 minutes ago  Investigate lazy pagination cap
+    2 hours ago     2 hours ago     Explain the codebase


### PR DESCRIPTION
## Summary
- allow the resume picker to persist pinned sessions and highlight them with a star column
- expose a Shift+S shortcut to toggle the pin state, update hints, and keep pinned rows sorted before others
- refresh the resume picker snapshot and add tests to cover the new behaviors

## Testing
- `cargo test -p codex-tui`
- Worked locally when I did `cargo run -p codex-cli --bin codex resume` and used shift+s. 

<img width="962" height="388" alt="Screenshot 2025-11-10 at 5 31 40 PM" src="https://github.com/user-attachments/assets/0cfa227a-6da3-4ad3-9503-8569f7914660" />

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69127a6950908333b9230e3f74bfd6cc)