### PR TITLE
fix(tui): clear scrollback and redraw history on resize to avoid terminal glitches

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -4450,7 +4450,7 @@ checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
 dependencies = [
  "base64",
  "indexmap 2.12.0",
- "quick-xml",
+ "quick-xml 0.38.0",
  "serde",
  "time",
 ]
@@ -7093,7 +7093,7 @@ version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "rustix 1.0.8",
  "wayland-backend",
  "wayland-scanner",
@@ -7105,7 +7105,7 @@ version = "0.32.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -7117,7 +7117,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -7726,7 +7726,7 @@ dependencies = [
  "os_pipe",
  "rustix 0.38.44",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tree_magic_mini",
  "wayland-backend",
  "wayland-client",

--- a/codex-rs/tui/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui/src/onboarding/onboarding_screen.rs
@@ -411,7 +411,7 @@ pub(crate) async fn run_onboarding_app(
                 TuiEvent::Paste(text) => {
                     onboarding_screen.handle_paste(text);
                 }
-                TuiEvent::Draw => {
+                TuiEvent::Draw | TuiEvent::Resize(_) => {
                     if !did_full_clear_after_success
                         && onboarding_screen.steps.iter().any(|step| {
                             if let Step::Auth(w) = step {


### PR DESCRIPTION


- Clear scrollback and screen via ANSI/OSC 1337 before re-rendering history, reducing chopped or re-drawn text outside the scroll area on resize.
- Handle resize explicitly, rebuilding transcript cells at the new width and redrawing, and treat onboarding resize like draw to ensure a full clear.
- Add ClearScrollback command leveraging ESC[3J][H][2J plus iTerm’s 1337 code; works on Ghostty/WezTerm/Kitty, partial on Terminal.app, not on Alacritty.
- Note: may introduce resize flicker; debouncing/notification parity still TBD.
