### PR TITLE
fix(tui) : Make status command displays session-specific account information

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -268,6 +268,7 @@ pub(crate) struct ChatWidget {
     // Previous status header to restore after a transient stream retry.
     retry_status_header: Option<String>,
     conversation_id: Option<ConversationId>,
+    account_info: Option<crate::status::StatusAccountDisplay>,
     frame_requester: FrameRequester,
     // Whether to include the initial welcome banner on session configured
     show_welcome_banner: bool,
@@ -1013,6 +1014,7 @@ impl ChatWidget {
         let mut rng = rand::rng();
         let placeholder = EXAMPLE_PROMPTS[rng.random_range(0..EXAMPLE_PROMPTS.len())].to_string();
         let codex_op_tx = spawn_agent(config.clone(), app_event_tx.clone(), conversation_manager);
+        let account_info = crate::status::compose_account_display(&config);
 
         Self {
             app_event_tx: app_event_tx.clone(),
@@ -1047,6 +1049,7 @@ impl ChatWidget {
             current_status_header: String::from("Working"),
             retry_status_header: None,
             conversation_id: None,
+            account_info,
             queued_user_messages: VecDeque::new(),
             show_welcome_banner: true,
             suppress_session_configured_redraw: false,
@@ -1080,6 +1083,7 @@ impl ChatWidget {
 
         let codex_op_tx =
             spawn_agent_from_existing(conversation, session_configured, app_event_tx.clone());
+        let account_info = crate::status::compose_account_display(&config);
 
         Self {
             app_event_tx: app_event_tx.clone(),
@@ -1114,6 +1118,7 @@ impl ChatWidget {
             current_status_header: String::from("Working"),
             retry_status_header: None,
             conversation_id: None,
+            account_info,
             queued_user_messages: VecDeque::new(),
             show_welcome_banner: true,
             suppress_session_configured_redraw: true,
@@ -1713,6 +1718,7 @@ impl ChatWidget {
             context_usage,
             &self.conversation_id,
             self.rate_limit_snapshot.as_ref(),
+            self.account_info.as_ref(),
             Local::now(),
         ));
     }

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -309,6 +309,7 @@ fn make_chatwidget_manual() -> (
         current_status_header: String::from("Working"),
         retry_status_header: None,
         conversation_id: None,
+        account_info: None,
         frame_requester: FrameRequester::test_dummy(),
         show_welcome_banner: true,
         queued_user_messages: VecDeque::new(),

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -20,7 +20,6 @@ use super::format::FieldFormatter;
 use super::format::line_display_width;
 use super::format::push_label;
 use super::format::truncate_line_to_width;
-use super::helpers::compose_account_display;
 use super::helpers::compose_agents_summary;
 use super::helpers::compose_model_display;
 use super::helpers::format_directory_display;
@@ -69,6 +68,7 @@ pub(crate) fn new_status_output(
     context_usage: Option<&TokenUsage>,
     session_id: &Option<ConversationId>,
     rate_limits: Option<&RateLimitSnapshotDisplay>,
+    account_info: Option<&StatusAccountDisplay>,
     now: DateTime<Local>,
 ) -> CompositeHistoryCell {
     let command = PlainHistoryCell::new(vec!["/status".magenta().into()]);
@@ -78,6 +78,7 @@ pub(crate) fn new_status_output(
         context_usage,
         session_id,
         rate_limits,
+        account_info,
         now,
     );
 
@@ -91,6 +92,7 @@ impl StatusHistoryCell {
         context_usage: Option<&TokenUsage>,
         session_id: &Option<ConversationId>,
         rate_limits: Option<&RateLimitSnapshotDisplay>,
+        account_info: Option<&StatusAccountDisplay>,
         now: DateTime<Local>,
     ) -> Self {
         let config_entries = create_config_summary_entries(config);
@@ -106,7 +108,7 @@ impl StatusHistoryCell {
             SandboxPolicy::WorkspaceWrite { .. } => "workspace-write".to_string(),
         };
         let agents_summary = compose_agents_summary(config);
-        let account = compose_account_display(config);
+        let account = account_info.cloned();
         let session_id = session_id.as_ref().map(std::string::ToString::to_string);
         let context_window = config.model_context_window.and_then(|window| {
             context_usage.map(|usage| StatusContextWindowData {

--- a/codex-rs/tui/src/status/mod.rs
+++ b/codex-rs/tui/src/status/mod.rs
@@ -4,7 +4,9 @@ mod format;
 mod helpers;
 mod rate_limits;
 
+pub(crate) use account::StatusAccountDisplay;
 pub(crate) use card::new_status_output;
+pub(crate) use helpers::compose_account_display;
 pub(crate) use rate_limits::RateLimitSnapshotDisplay;
 pub(crate) use rate_limits::rate_limit_snapshot_display;
 

--- a/codex-rs/tui/src/status/tests.rs
+++ b/codex-rs/tui/src/status/tests.rs
@@ -117,6 +117,7 @@ fn status_snapshot_includes_reasoning_details() {
         Some(&usage),
         &None,
         Some(&rate_display),
+        None,
         captured_at,
     );
     let mut rendered_lines = render_lines(&composite.display_lines(80));
@@ -165,6 +166,7 @@ fn status_snapshot_includes_monthly_limit() {
         Some(&usage),
         &None,
         Some(&rate_display),
+        None,
         captured_at,
     );
     let mut rendered_lines = render_lines(&composite.display_lines(80));
@@ -197,7 +199,7 @@ fn status_card_token_usage_excludes_cached_tokens() {
         .single()
         .expect("timestamp");
 
-    let composite = new_status_output(&config, &usage, Some(&usage), &None, None, now);
+    let composite = new_status_output(&config, &usage, Some(&usage), &None, None, None, now);
     let rendered = render_lines(&composite.display_lines(120));
 
     assert!(
@@ -244,6 +246,7 @@ fn status_snapshot_truncates_in_narrow_terminal() {
         Some(&usage),
         &None,
         Some(&rate_display),
+        None,
         captured_at,
     );
     let mut rendered_lines = render_lines(&composite.display_lines(46));
@@ -277,7 +280,7 @@ fn status_snapshot_shows_missing_limits_message() {
         .single()
         .expect("timestamp");
 
-    let composite = new_status_output(&config, &usage, Some(&usage), &None, None, now);
+    let composite = new_status_output(&config, &usage, Some(&usage), &None, None, None, now);
     let mut rendered_lines = render_lines(&composite.display_lines(80));
     if cfg!(windows) {
         for line in &mut rendered_lines {
@@ -319,6 +322,7 @@ fn status_snapshot_shows_empty_limits_message() {
         Some(&usage),
         &None,
         Some(&rate_display),
+        None,
         captured_at,
     );
     let mut rendered_lines = render_lines(&composite.display_lines(80));
@@ -371,6 +375,7 @@ fn status_snapshot_shows_stale_limits_message() {
         Some(&usage),
         &None,
         Some(&rate_display),
+        None,
         now,
     );
     let mut rendered_lines = render_lines(&composite.display_lines(80));
@@ -409,7 +414,15 @@ fn status_context_window_uses_last_usage() {
         .single()
         .expect("timestamp");
 
-    let composite = new_status_output(&config, &total_usage, Some(&last_usage), &None, None, now);
+    let composite = new_status_output(
+        &config,
+        &total_usage,
+        Some(&last_usage),
+        &None,
+        None,
+        None,
+        now,
+    );
     let rendered_lines = render_lines(&composite.display_lines(80));
     let context_line = rendered_lines
         .into_iter()


### PR DESCRIPTION
Currently the /status command reads account information from the global auth.json file. When using two accounts(or keys) with different session, the status command shows the recent account information.
This PR fixes /status command to displays session-specific account information instead of reading from the globally shared auth.json file.

- Before: Each /status call read account info from CODEX_HOME/auth.json, which could be overwritten by other sessions
- After: Account info is cached when the ChatWidget is initialized, ensuring each session shows its own account metadata

Fixes #6360 