### PR TITLE
chore: verify boolean values can be parsed as config overrides

### DIFF
--- a/codex-rs/common/src/config_override.rs
+++ b/codex-rs/common/src/config_override.rs
@@ -152,6 +152,15 @@ mod tests {
     }
 
     #[test]
+    fn parses_bool() {
+        let true_literal = parse_toml_value("true").expect("parse");
+        assert_eq!(true_literal.as_bool(), Some(true));
+
+        let false_literal = parse_toml_value("false").expect("parse");
+        assert_eq!(false_literal.as_bool(), Some(false));
+    }
+
+    #[test]
     fn fails_on_unquoted_string() {
         assert!(parse_toml_value("hello").is_err());
     }


### PR DESCRIPTION
This is important to ensure that this:

```
codex --enable unified_exec
```

and this:

```
codex --config features.unified_exec=true
```

are equivalent. Also that when it is passed programmatically:

https://github.com/openai/codex/blob/807e2c27f0a9f2e85c50e7e6df5533f0d9b853c7/codex-rs/app-server-protocol/src/protocol/v1.rs#L55

then this should work for `config`:

```json
{"features": {"shell_command_tool": true}}
```

though I believe also this:

```json
{"features.shell_command_tool": true}
```
