### PR TITLE
Re-add prettier log-level=warn to generate-ts

### DIFF
--- a/codex-rs/app-server-protocol/src/export.rs
+++ b/codex-rs/app-server-protocol/src/export.rs
@@ -92,6 +92,8 @@ pub fn generate_ts(out_dir: &Path, prettier: Option<&Path>) -> Result<()> {
     {
         let status = Command::new(prettier_bin)
             .arg("--write")
+            .arg("--log-level")
+            .arg("warn")
             .args(ts_files.iter().map(|p| p.as_os_str()))
             .status()
             .with_context(|| format!("Failed to invoke Prettier at {}", prettier_bin.display()))?;


### PR DESCRIPTION
I added it in https://github.com/openai/codex/pull/6342 but it was removed in https://github.com/openai/codex/pull/5063/files#diff-e2aa6dad1e886b7765158a27aefd1be5de99baa71b44f6bc5ce3fe462b9ae5d3R135 as a result of a bad diamond merge