### PR TITLE
Fix otel tests

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -4450,7 +4450,7 @@ checksum = "3af6b589e163c5a788fab00ce0c0366f6efbb9959c2f9874b224936af7fce7e1"
 dependencies = [
  "base64",
  "indexmap 2.12.0",
- "quick-xml",
+ "quick-xml 0.38.0",
  "serde",
  "time",
 ]
@@ -7093,7 +7093,7 @@ version = "0.31.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "rustix 1.0.8",
  "wayland-backend",
  "wayland-scanner",
@@ -7105,7 +7105,7 @@ version = "0.32.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efa790ed75fbfd71283bd2521a1cfdc022aabcc28bdcff00851f9e4ae88d9901"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "wayland-backend",
  "wayland-client",
  "wayland-scanner",
@@ -7117,7 +7117,7 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "efd94963ed43cf9938a090ca4f7da58eb55325ec8200c3848963e98dc25b78ec"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.10.0",
  "wayland-backend",
  "wayland-client",
  "wayland-protocols",
@@ -7726,7 +7726,7 @@ dependencies = [
  "os_pipe",
  "rustix 0.38.44",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.17",
  "tree_magic_mini",
  "wayland-backend",
  "wayland-client",

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -446,12 +446,6 @@ pub async fn mount_sse_once(server: &MockServer, body: String) -> ResponseMock {
     response_mock
 }
 
-pub async fn mount_sse(server: &MockServer, body: String) -> ResponseMock {
-    let (mock, response_mock) = base_mock();
-    mock.respond_with(sse_response(body)).mount(server).await;
-    response_mock
-}
-
 pub async fn start_mock_server() -> MockServer {
     MockServer::builder()
         .body_print_limit(BodyPrintLimit::Limited(80_000))

--- a/codex-rs/core/tests/suite/otel.rs
+++ b/codex-rs/core/tests/suite/otel.rs
@@ -9,7 +9,6 @@ use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_custom_tool_call;
 use core_test_support::responses::ev_function_call;
-use core_test_support::responses::mount_sse;
 use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
@@ -443,7 +442,7 @@ async fn process_sse_emits_completed_telemetry() {
 async fn handle_response_item_records_tool_result_for_custom_tool_call() {
     let server = start_mock_server().await;
 
-    mount_sse(
+    mount_sse_once(
         &server,
         sse(vec![
             ev_custom_tool_call(
@@ -513,7 +512,7 @@ async fn handle_response_item_records_tool_result_for_custom_tool_call() {
 async fn handle_response_item_records_tool_result_for_function_call() {
     let server = start_mock_server().await;
 
-    mount_sse(
+    mount_sse_once(
         &server,
         sse(vec![
             ev_function_call("function-call", "nonexistent", "{\"value\":1}"),
@@ -580,7 +579,7 @@ async fn handle_response_item_records_tool_result_for_function_call() {
 async fn handle_response_item_records_tool_result_for_local_shell_missing_ids() {
     let server = start_mock_server().await;
 
-    mount_sse(
+    mount_sse_once(
         &server,
         sse(vec![
             serde_json::json!({
@@ -651,7 +650,7 @@ async fn handle_response_item_records_tool_result_for_local_shell_missing_ids() 
 async fn handle_response_item_records_tool_result_for_local_shell_call() {
     let server = start_mock_server().await;
 
-    mount_sse(
+    mount_sse_once(
         &server,
         sse(vec![
             ev_local_shell_call("shell-call", "completed", vec!["/bin/echo", "shell"]),
@@ -803,7 +802,7 @@ async fn handle_container_exec_autoapprove_from_config_records_tool_decision() {
 #[traced_test]
 async fn handle_container_exec_user_approved_records_tool_decision() {
     let server = start_mock_server().await;
-    mount_sse(
+    mount_sse_once(
         &server,
         sse(vec![
             ev_local_shell_call("user_approved_call", "completed", vec!["/bin/date"]),
@@ -862,7 +861,7 @@ async fn handle_container_exec_user_approved_records_tool_decision() {
 async fn handle_container_exec_user_approved_for_session_records_tool_decision() {
     let server = start_mock_server().await;
 
-    mount_sse(
+    mount_sse_once(
         &server,
         sse(vec![
             ev_local_shell_call("user_approved_session_call", "completed", vec!["/bin/date"]),
@@ -920,7 +919,7 @@ async fn handle_container_exec_user_approved_for_session_records_tool_decision()
 async fn handle_sandbox_error_user_approves_retry_records_tool_decision() {
     let server = start_mock_server().await;
 
-    mount_sse(
+    mount_sse_once(
         &server,
         sse(vec![
             ev_local_shell_call("sandbox_retry_call", "completed", vec!["/bin/date"]),
@@ -978,7 +977,7 @@ async fn handle_sandbox_error_user_approves_retry_records_tool_decision() {
 async fn handle_container_exec_user_denies_records_tool_decision() {
     let server = start_mock_server().await;
 
-    mount_sse(
+    mount_sse_once(
         &server,
         sse(vec![
             ev_local_shell_call("user_denied_call", "completed", vec!["/bin/date"]),
@@ -1036,7 +1035,7 @@ async fn handle_container_exec_user_denies_records_tool_decision() {
 async fn handle_sandbox_error_user_approves_for_session_records_tool_decision() {
     let server = start_mock_server().await;
 
-    mount_sse(
+    mount_sse_once(
         &server,
         sse(vec![
             ev_local_shell_call("sandbox_session_call", "completed", vec!["/bin/date"]),
@@ -1094,7 +1093,7 @@ async fn handle_sandbox_error_user_approves_for_session_records_tool_decision() 
 async fn handle_sandbox_error_user_denies_records_tool_decision() {
     let server = start_mock_server().await;
 
-    mount_sse(
+    mount_sse_once(
         &server,
         sse(vec![
             ev_local_shell_call("sandbox_deny_call", "completed", vec!["/bin/date"]),

--- a/codex-rs/core/tests/suite/otel.rs
+++ b/codex-rs/core/tests/suite/otel.rs
@@ -100,6 +100,7 @@ async fn process_sse_emits_failed_event_on_parse_error() {
 
     mount_sse_once(&server, "data: not-json\n\n".to_string()).await;
 
+<<<<<<< Updated upstream
     let TestCodex { codex, .. } = test_codex()
         .with_config(move |config| {
             config.features.disable(Feature::GhostCommit);
@@ -109,6 +110,9 @@ async fn process_sse_emits_failed_event_on_parse_error() {
         .build(&server)
         .await
         .unwrap();
+=======
+    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
+>>>>>>> Stashed changes
 
     codex
         .submit(Op::UserInput {
@@ -141,6 +145,7 @@ async fn process_sse_records_failed_event_when_stream_closes_without_completed()
 
     mount_sse_once(&server, sse(vec![ev_assistant_message("id", "hi")])).await;
 
+<<<<<<< Updated upstream
     let TestCodex { codex, .. } = test_codex()
         .with_config(move |config| {
             config.features.disable(Feature::GhostCommit);
@@ -150,6 +155,9 @@ async fn process_sse_records_failed_event_when_stream_closes_without_completed()
         .build(&server)
         .await
         .unwrap();
+=======
+    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
+>>>>>>> Stashed changes
 
     codex
         .submit(Op::UserInput {
@@ -193,7 +201,16 @@ async fn process_sse_failed_event_records_response_error_message() {
         })]),
     )
     .await;
+    mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-1", "local shell done"),
+            ev_completed("done"),
+        ]),
+    )
+    .await;
 
+<<<<<<< Updated upstream
     let TestCodex { codex, .. } = test_codex()
         .with_config(move |config| {
             config.features.disable(Feature::GhostCommit);
@@ -203,6 +220,9 @@ async fn process_sse_failed_event_records_response_error_message() {
         .build(&server)
         .await
         .unwrap();
+=======
+    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
+>>>>>>> Stashed changes
 
     codex
         .submit(Op::UserInput {
@@ -245,6 +265,7 @@ async fn process_sse_failed_event_logs_parse_error() {
     )
     .await;
 
+<<<<<<< Updated upstream
     let TestCodex { codex, .. } = test_codex()
         .with_config(move |config| {
             config.features.disable(Feature::GhostCommit);
@@ -254,6 +275,18 @@ async fn process_sse_failed_event_logs_parse_error() {
         .build(&server)
         .await
         .unwrap();
+=======
+    mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-1", "local shell done"),
+            ev_completed("done"),
+        ]),
+    )
+    .await;
+
+    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
+>>>>>>> Stashed changes
 
     codex
         .submit(Op::UserInput {
@@ -291,6 +324,7 @@ async fn process_sse_failed_event_logs_missing_error() {
     )
     .await;
 
+<<<<<<< Updated upstream
     let TestCodex { codex, .. } = test_codex()
         .with_config(move |config| {
             config.features.disable(Feature::GhostCommit);
@@ -300,6 +334,9 @@ async fn process_sse_failed_event_logs_missing_error() {
         .build(&server)
         .await
         .unwrap();
+=======
+    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
+>>>>>>> Stashed changes
 
     codex
         .submit(Op::UserInput {
@@ -337,6 +374,7 @@ async fn process_sse_failed_event_logs_response_completed_parse_error() {
     )
     .await;
 
+<<<<<<< Updated upstream
     let TestCodex { codex, .. } = test_codex()
         .with_config(move |config| {
             config.features.disable(Feature::GhostCommit);
@@ -346,6 +384,18 @@ async fn process_sse_failed_event_logs_response_completed_parse_error() {
         .build(&server)
         .await
         .unwrap();
+=======
+    mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-1", "local shell done"),
+            ev_completed("done"),
+        ]),
+    )
+    .await;
+
+    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
+>>>>>>> Stashed changes
 
     codex
         .submit(Op::UserInput {
@@ -442,7 +492,16 @@ async fn handle_response_item_records_tool_result_for_custom_tool_call() {
         ]),
     )
     .await;
+    mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-1", "local shell done"),
+            ev_completed("done"),
+        ]),
+    )
+    .await;
 
+<<<<<<< Updated upstream
     let TestCodex { codex, .. } = test_codex()
         .with_config(move |config| {
             config.features.disable(Feature::GhostCommit);
@@ -452,6 +511,9 @@ async fn handle_response_item_records_tool_result_for_custom_tool_call() {
         .build(&server)
         .await
         .unwrap();
+=======
+    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
+>>>>>>> Stashed changes
 
     codex
         .submit(Op::UserInput {
@@ -503,6 +565,7 @@ async fn handle_response_item_records_tool_result_for_function_call() {
     )
     .await;
 
+<<<<<<< Updated upstream
     let TestCodex { codex, .. } = test_codex()
         .with_config(move |config| {
             config.features.disable(Feature::GhostCommit);
@@ -512,6 +575,18 @@ async fn handle_response_item_records_tool_result_for_function_call() {
         .build(&server)
         .await
         .unwrap();
+=======
+    mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-1", "local shell done"),
+            ev_completed("done"),
+        ]),
+    )
+    .await;
+
+    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
+>>>>>>> Stashed changes
 
     codex
         .submit(Op::UserInput {
@@ -573,6 +648,7 @@ async fn handle_response_item_records_tool_result_for_local_shell_missing_ids() 
     )
     .await;
 
+<<<<<<< Updated upstream
     let TestCodex { codex, .. } = test_codex()
         .with_config(move |config| {
             config.features.disable(Feature::GhostCommit);
@@ -582,6 +658,18 @@ async fn handle_response_item_records_tool_result_for_local_shell_missing_ids() 
         .build(&server)
         .await
         .unwrap();
+=======
+    mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-1", "local shell done"),
+            ev_completed("done"),
+        ]),
+    )
+    .await;
+
+    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
+>>>>>>> Stashed changes
 
     codex
         .submit(Op::UserInput {
@@ -627,6 +715,7 @@ async fn handle_response_item_records_tool_result_for_local_shell_call() {
     )
     .await;
 
+<<<<<<< Updated upstream
     let TestCodex { codex, .. } = test_codex()
         .with_config(move |config| {
             config.features.disable(Feature::GhostCommit);
@@ -636,6 +725,18 @@ async fn handle_response_item_records_tool_result_for_local_shell_call() {
         .build(&server)
         .await
         .unwrap();
+=======
+    mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-1", "local shell done"),
+            ev_completed("done"),
+        ]),
+    )
+    .await;
+
+    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
+>>>>>>> Stashed changes
 
     codex
         .submit(Op::UserInput {
@@ -710,10 +811,23 @@ fn tool_decision_assertion<'a>(
 #[traced_test]
 async fn handle_container_exec_autoapprove_from_config_records_tool_decision() {
     let server = start_mock_server().await;
-    mount_sse(
+    mount_sse_once(
         &server,
         sse(vec![
-            ev_local_shell_call("auto_config_call", "completed", vec!["/bin/echo", "hello"]),
+            ev_local_shell_call(
+                "auto_config_call",
+                "completed",
+                vec!["/bin/echo", "local shell"],
+            ),
+            ev_completed("done"),
+        ]),
+    )
+    .await;
+
+    mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-1", "local shell done"),
             ev_completed("done"),
         ]),
     )
@@ -723,8 +837,6 @@ async fn handle_container_exec_autoapprove_from_config_records_tool_decision() {
         .with_config(|config| {
             config.approval_policy = AskForApproval::OnRequest;
             config.sandbox_policy = SandboxPolicy::DangerFullAccess;
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
         })
         .build(&server)
         .await
@@ -739,7 +851,7 @@ async fn handle_container_exec_autoapprove_from_config_records_tool_decision() {
         .await
         .unwrap();
 
-    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TokenCount(_))).await;
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
 
     logs_assert(tool_decision_assertion(
         "auto_config_call",
@@ -761,11 +873,18 @@ async fn handle_container_exec_user_approved_records_tool_decision() {
     )
     .await;
 
+    mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-1", "local shell done"),
+            ev_completed("done"),
+        ]),
+    )
+    .await;
+
     let TestCodex { codex, .. } = test_codex()
         .with_config(|config| {
             config.approval_policy = AskForApproval::UnlessTrusted;
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
         })
         .build(&server)
         .await
@@ -812,12 +931,18 @@ async fn handle_container_exec_user_approved_for_session_records_tool_decision()
         ]),
     )
     .await;
+    mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-1", "local shell done"),
+            ev_completed("done"),
+        ]),
+    )
+    .await;
 
     let TestCodex { codex, .. } = test_codex()
         .with_config(|config| {
             config.approval_policy = AskForApproval::UnlessTrusted;
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
         })
         .build(&server)
         .await
@@ -864,12 +989,18 @@ async fn handle_sandbox_error_user_approves_retry_records_tool_decision() {
         ]),
     )
     .await;
+    mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-1", "local shell done"),
+            ev_completed("done"),
+        ]),
+    )
+    .await;
 
     let TestCodex { codex, .. } = test_codex()
         .with_config(|config| {
             config.approval_policy = AskForApproval::UnlessTrusted;
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
         })
         .build(&server)
         .await
@@ -917,11 +1048,17 @@ async fn handle_container_exec_user_denies_records_tool_decision() {
     )
     .await;
 
+    mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-1", "local shell done"),
+            ev_completed("done"),
+        ]),
+    )
+    .await;
     let TestCodex { codex, .. } = test_codex()
         .with_config(|config| {
             config.approval_policy = AskForApproval::UnlessTrusted;
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
         })
         .build(&server)
         .await
@@ -968,12 +1105,18 @@ async fn handle_sandbox_error_user_approves_for_session_records_tool_decision() 
         ]),
     )
     .await;
+    mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-1", "local shell done"),
+            ev_completed("done"),
+        ]),
+    )
+    .await;
 
     let TestCodex { codex, .. } = test_codex()
         .with_config(|config| {
             config.approval_policy = AskForApproval::UnlessTrusted;
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
         })
         .build(&server)
         .await
@@ -1021,11 +1164,18 @@ async fn handle_sandbox_error_user_denies_records_tool_decision() {
     )
     .await;
 
+    mount_sse_once(
+        &server,
+        sse(vec![
+            ev_assistant_message("msg-1", "local shell done"),
+            ev_completed("done"),
+        ]),
+    )
+    .await;
+
     let TestCodex { codex, .. } = test_codex()
         .with_config(|config| {
             config.approval_policy = AskForApproval::UnlessTrusted;
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
         })
         .build(&server)
         .await

--- a/codex-rs/core/tests/suite/otel.rs
+++ b/codex-rs/core/tests/suite/otel.rs
@@ -100,19 +100,13 @@ async fn process_sse_emits_failed_event_on_parse_error() {
 
     mount_sse_once(&server, "data: not-json\n\n".to_string()).await;
 
-<<<<<<< Updated upstream
     let TestCodex { codex, .. } = test_codex()
         .with_config(move |config| {
             config.features.disable(Feature::GhostCommit);
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
         })
         .build(&server)
         .await
         .unwrap();
-=======
-    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
->>>>>>> Stashed changes
 
     codex
         .submit(Op::UserInput {
@@ -145,19 +139,13 @@ async fn process_sse_records_failed_event_when_stream_closes_without_completed()
 
     mount_sse_once(&server, sse(vec![ev_assistant_message("id", "hi")])).await;
 
-<<<<<<< Updated upstream
     let TestCodex { codex, .. } = test_codex()
         .with_config(move |config| {
             config.features.disable(Feature::GhostCommit);
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
         })
         .build(&server)
         .await
         .unwrap();
-=======
-    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
->>>>>>> Stashed changes
 
     codex
         .submit(Op::UserInput {
@@ -210,19 +198,13 @@ async fn process_sse_failed_event_records_response_error_message() {
     )
     .await;
 
-<<<<<<< Updated upstream
     let TestCodex { codex, .. } = test_codex()
         .with_config(move |config| {
             config.features.disable(Feature::GhostCommit);
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
         })
         .build(&server)
         .await
         .unwrap();
-=======
-    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
->>>>>>> Stashed changes
 
     codex
         .submit(Op::UserInput {
@@ -264,18 +246,6 @@ async fn process_sse_failed_event_logs_parse_error() {
         })]),
     )
     .await;
-
-<<<<<<< Updated upstream
-    let TestCodex { codex, .. } = test_codex()
-        .with_config(move |config| {
-            config.features.disable(Feature::GhostCommit);
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
-        })
-        .build(&server)
-        .await
-        .unwrap();
-=======
     mount_sse_once(
         &server,
         sse(vec![
@@ -285,8 +255,13 @@ async fn process_sse_failed_event_logs_parse_error() {
     )
     .await;
 
-    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
->>>>>>> Stashed changes
+    let TestCodex { codex, .. } = test_codex()
+        .with_config(move |config| {
+            config.features.disable(Feature::GhostCommit);
+        })
+        .build(&server)
+        .await
+        .unwrap();
 
     codex
         .submit(Op::UserInput {
@@ -324,19 +299,13 @@ async fn process_sse_failed_event_logs_missing_error() {
     )
     .await;
 
-<<<<<<< Updated upstream
     let TestCodex { codex, .. } = test_codex()
         .with_config(move |config| {
             config.features.disable(Feature::GhostCommit);
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
         })
         .build(&server)
         .await
         .unwrap();
-=======
-    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
->>>>>>> Stashed changes
 
     codex
         .submit(Op::UserInput {
@@ -374,17 +343,6 @@ async fn process_sse_failed_event_logs_response_completed_parse_error() {
     )
     .await;
 
-<<<<<<< Updated upstream
-    let TestCodex { codex, .. } = test_codex()
-        .with_config(move |config| {
-            config.features.disable(Feature::GhostCommit);
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
-        })
-        .build(&server)
-        .await
-        .unwrap();
-=======
     mount_sse_once(
         &server,
         sse(vec![
@@ -394,8 +352,13 @@ async fn process_sse_failed_event_logs_response_completed_parse_error() {
     )
     .await;
 
-    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
->>>>>>> Stashed changes
+    let TestCodex { codex, .. } = test_codex()
+        .with_config(move |config| {
+            config.features.disable(Feature::GhostCommit);
+        })
+        .build(&server)
+        .await
+        .unwrap();
 
     codex
         .submit(Op::UserInput {
@@ -501,19 +464,13 @@ async fn handle_response_item_records_tool_result_for_custom_tool_call() {
     )
     .await;
 
-<<<<<<< Updated upstream
     let TestCodex { codex, .. } = test_codex()
         .with_config(move |config| {
             config.features.disable(Feature::GhostCommit);
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
         })
         .build(&server)
         .await
         .unwrap();
-=======
-    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
->>>>>>> Stashed changes
 
     codex
         .submit(Op::UserInput {
@@ -565,17 +522,6 @@ async fn handle_response_item_records_tool_result_for_function_call() {
     )
     .await;
 
-<<<<<<< Updated upstream
-    let TestCodex { codex, .. } = test_codex()
-        .with_config(move |config| {
-            config.features.disable(Feature::GhostCommit);
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
-        })
-        .build(&server)
-        .await
-        .unwrap();
-=======
     mount_sse_once(
         &server,
         sse(vec![
@@ -585,8 +531,13 @@ async fn handle_response_item_records_tool_result_for_function_call() {
     )
     .await;
 
-    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
->>>>>>> Stashed changes
+    let TestCodex { codex, .. } = test_codex()
+        .with_config(move |config| {
+            config.features.disable(Feature::GhostCommit);
+        })
+        .build(&server)
+        .await
+        .unwrap();
 
     codex
         .submit(Op::UserInput {
@@ -648,17 +599,6 @@ async fn handle_response_item_records_tool_result_for_local_shell_missing_ids() 
     )
     .await;
 
-<<<<<<< Updated upstream
-    let TestCodex { codex, .. } = test_codex()
-        .with_config(move |config| {
-            config.features.disable(Feature::GhostCommit);
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
-        })
-        .build(&server)
-        .await
-        .unwrap();
-=======
     mount_sse_once(
         &server,
         sse(vec![
@@ -668,8 +608,13 @@ async fn handle_response_item_records_tool_result_for_local_shell_missing_ids() 
     )
     .await;
 
-    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
->>>>>>> Stashed changes
+    let TestCodex { codex, .. } = test_codex()
+        .with_config(move |config| {
+            config.features.disable(Feature::GhostCommit);
+        })
+        .build(&server)
+        .await
+        .unwrap();
 
     codex
         .submit(Op::UserInput {
@@ -715,17 +660,6 @@ async fn handle_response_item_records_tool_result_for_local_shell_call() {
     )
     .await;
 
-<<<<<<< Updated upstream
-    let TestCodex { codex, .. } = test_codex()
-        .with_config(move |config| {
-            config.features.disable(Feature::GhostCommit);
-            config.model_provider.request_max_retries = Some(0);
-            config.model_provider.stream_max_retries = Some(0);
-        })
-        .build(&server)
-        .await
-        .unwrap();
-=======
     mount_sse_once(
         &server,
         sse(vec![
@@ -735,8 +669,13 @@ async fn handle_response_item_records_tool_result_for_local_shell_call() {
     )
     .await;
 
-    let TestCodex { codex, .. } = test_codex().build(&server).await.unwrap();
->>>>>>> Stashed changes
+    let TestCodex { codex, .. } = test_codex()
+        .with_config(move |config| {
+            config.features.disable(Feature::GhostCommit);
+        })
+        .build(&server)
+        .await
+        .unwrap();
 
     codex
         .submit(Op::UserInput {


### PR DESCRIPTION
Mount responses only once, remove unneeded retries and add a final assistant messages to complete the turn.