### PR TITLE
fix: close non-stdio fds before exec

### DIFF
--- a/codex-rs/core/src/spawn.rs
+++ b/codex-rs/core/src/spawn.rs
@@ -73,6 +73,44 @@ pub(crate) async fn spawn_child_async(
                 return Err(std::io::Error::last_os_error());
             }
 
+            #[cfg(target_os = "macos")]
+            {
+                // macOS network stack (via reqwest/hyper) opens PF_SYSTEM control sockets
+                // such as com.apple.netsrc without setting FD_CLOEXEC. Those descriptors
+                // get inherited by shell tool children, which is surprising and lets the
+                // child talk to that kernel control socket. Close everything above stdio
+                // to keep those sockets (and any similar long-lived fds) out of subshells.
+                // We bound the sweep by min(RLIMIT_NOFILE, 128) because netsrc fds are
+                // low and this avoids a pathological case where another thread lowers
+                // the rlimit between opening the socket and spawning the child. If we ever
+                // move the reqwest traffic into a helper process, leaking these fds would
+                // be less concerning.
+                let mut max_fd = 128_i64;
+                let mut limit = libc::rlimit {
+                    rlim_cur: 0,
+                    rlim_max: 0,
+                };
+                if libc::getrlimit(libc::RLIMIT_NOFILE, &mut limit) == 0
+                    && limit.rlim_cur != libc::RLIM_INFINITY
+                {
+                    let soft_limit = limit.rlim_cur.min(i64::MAX as libc::rlim_t) as i64;
+                    max_fd = max_fd.min(soft_limit);
+                }
+
+                let bound = max_fd.max(3);
+                let mut fd = 3;
+                while (fd as i64) < bound {
+                    let flags = libc::fcntl(fd, libc::F_GETFD);
+                    // We leave CLOEXEC fds alone (for example, the stdlib
+                    // error-reporting pipe used when exec fails) and only close
+                    // descriptors that would have been inherited.
+                    if flags != -1 && (flags & libc::FD_CLOEXEC) == 0 {
+                        libc::close(fd);
+                    }
+                    fd += 1;
+                }
+            }
+
             // This relies on prctl(2), so it only works on Linux.
             #[cfg(target_os = "linux")]
             {


### PR DESCRIPTION
We discovered that, on macOS, child processes spawned by Codex had an unexpected fd open (usually some number less than 20). We asked Codex to look into it and it deduced that using `reqwest` (or more generally, `libnetwork`) opens a `PF_SYSTEM` control socket to `com.apple.netsrc`, which is a kernel control interface the OS uses for network statistics/QoS bookkeeping.

While this seems innocuous, out of an abundance of caution, this PR updates Codex to close all non-stdio file descriptors between `fork()` and `exec()` when spawning a child process on macOS. Note this is a fairly common thing to do in systems programming. For example, Chrome defines `CloseSuperfluousFds()` as follows:

https://source.chromium.org/chromium/chromium/src/+/main:base/process/launch_posix.cc;l=225-293;drc=f6ee10c0369d457f0ebec4d43a47063065384f50

Here is a standalone Python script to reproduce the behavior on macOS to show how making a network request results in creating a file descriptor without `FD_CLOEXEC` set:

```python
#!/usr/bin/env python3
"""Demonstrate that a simple HTTPS request opens a com.apple.netsrc PF_SYSTEM fd."""

import errno
import fcntl
import os
import subprocess
import sys
import urllib.error
import urllib.request


def list_fds(label: str) -> None:
    print(f"-- {label}")
    fds = []
    try:
        entries = os.listdir("/dev/fd")
    except OSError as exc:
        print(f"failed to list /dev/fd: {exc}")
        return

    for entry in entries:
        if not entry.isdigit():
            continue
        fd = int(entry)
        try:
            flags = fcntl.fcntl(fd, fcntl.F_GETFD)
        except OSError:
            continue
        cloexec = bool(flags & fcntl.FD_CLOEXEC)
        try:
            target = os.readlink(f"/dev/fd/{fd}")
        except OSError as exc:
            if exc.errno == errno.EINVAL:
                target = "unreadable (EINVAL from readlink)"
            else:
                target = f"unreadable ({exc.strerror})"
        fds.append((fd, cloexec, target))

    for fd, cloexec, target in sorted(fds):
        print(f"{fd}: cloexec={cloexec} target={target}")


def main() -> None:
    list_fds("startup")

    try:
        urllib.request.urlopen("https://example.com", timeout=10).read(1)
    except urllib.error.URLError as exc:
        print(f"request failed: {exc}")

    list_fds("after https request")

    try:
        output = subprocess.check_output(
            ["lsof", "-p", str(os.getpid())], text=True, stderr=subprocess.DEVNULL
        )
    except FileNotFoundError:
        print("lsof not found; skipping netsrc filter")
    else:
        lines = [line for line in output.splitlines() if "netsrc" in line]
        print("-- lsof netsrc lines")
        if lines:
            for line in lines:
                print(line)
        else:
            print("no com.apple.netsrc entries reported by lsof")

    # Keep fds open so the child shows that the non-CLOEXEC netsrc socket is inherited.
    child_fds = subprocess.check_output(
        [
            sys.executable,
            "-c",
            "import os; print(sorted([e for e in os.listdir('/dev/fd') if e.isdigit()]))",
        ],
        text=True,
        close_fds=False,
    ).strip()
    print(f"child /dev/fd entries: {child_fds}")


if __name__ == "__main__":
    main()
```

Sample output:

```
-- startup
0: cloexec=False target=unreadable (EINVAL from readlink)
1: cloexec=False target=unreadable (EINVAL from readlink)
2: cloexec=False target=unreadable (EINVAL from readlink)
-- after https request
0: cloexec=False target=unreadable (EINVAL from readlink)
1: cloexec=False target=unreadable (EINVAL from readlink)
2: cloexec=False target=unreadable (EINVAL from readlink)
3: cloexec=True target=unreadable (EINVAL from readlink)
4: cloexec=False target=unreadable (EINVAL from readlink)
5: cloexec=True target=unreadable (EINVAL from readlink)
-- lsof netsrc lines
python3.1 6099 mbolin    4u    systm 0x4289e80c6b3d390c      0t0                     [ctl com.apple.netsrc id 7 unit 90]
child /dev/fd entries: ['0', '1', '2', '3', '4']
```

Note these two lines in particular:

```
4: cloexec=False target=unreadable (EINVAL from readlink)
python3.1 6099 mbolin    4u    systm 0x4289e80c6b3d390c      0t0                     [ctl com.apple.netsrc id 7 unit 90]
```

In this example, fd4 is the fd created for the `PF_SYSTEM` control socket. Note how `cloexec=False` is set, so by default, child processes will inherit it unless it is explicitly closed.