### PR TITLE
fix(tui): fix ctrl+v on some linux terminals

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -2,6 +2,7 @@ use crate::app_backtrack::BacktrackState;
 use crate::app_event::AppEvent;
 use crate::app_event_sender::AppEventSender;
 use crate::bottom_pane::ApprovalRequest;
+use crate::bottom_pane::normalize_paste_text;
 use crate::chatwidget::ChatWidget;
 use crate::diff_render::DiffSummary;
 use crate::exec_command::strip_bash_lc_and_escape;
@@ -243,11 +244,7 @@ impl App {
                     self.handle_key_event(tui, key_event).await;
                 }
                 TuiEvent::Paste(pasted) => {
-                    // Many terminals convert newlines to \r when pasting (e.g., iTerm2),
-                    // but tui-textarea expects \n. Normalize CR to LF.
-                    // [tui-textarea]: https://github.com/rhysd/tui-textarea/blob/4d18622eeac13b309e0ff6a55a46ac6706da68cf/src/textarea.rs#L782-L783
-                    // [iTerm2]: https://github.com/gnachman/iTerm2/blob/5d0c0d9f68523cbd0494dad5422998964a2ecd8d/sources/iTermPasteHelper.m#L206-L216
-                    let pasted = pasted.replace("\r", "\n");
+                    let pasted = normalize_paste_text(pasted);
                     self.chat_widget.handle_paste(pasted);
                 }
                 TuiEvent::Draw => {

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -47,6 +47,7 @@ pub(crate) enum CancellationEvent {
 
 pub(crate) use chat_composer::ChatComposer;
 pub(crate) use chat_composer::InputResult;
+pub(crate) use chat_composer::normalize_paste_text;
 use codex_protocol::custom_prompts::CustomPrompt;
 
 use crate::status_indicator_widget::StatusIndicatorWidget;

--- a/codex-rs/tui/src/clipboard_paste.rs
+++ b/codex-rs/tui/src/clipboard_paste.rs
@@ -207,6 +207,23 @@ pub fn pasted_image_format(path: &Path) -> EncodedImageFormat {
     }
 }
 
+/// Paste text from the system clipboard.
+///
+/// Used to support Ctrl+V paste when keyboard enhancement is enabled.
+#[cfg(not(target_os = "android"))]
+pub fn paste_text_from_clipboard() -> Result<String, Box<dyn std::error::Error>> {
+    let mut cb = arboard::Clipboard::new()?;
+    let text = cb.get_text()?;
+    Ok(text)
+}
+
+/// Android/Termux does not support arboard; do nothing.
+#[cfg(target_os = "android")]
+pub fn paste_text_from_clipboard() -> Result<String, Box<dyn std::error::Error>> {
+    tracing::debug!("clipboard paste not supported on Android/Termux");
+    Ok(String::new())
+}
+
 #[cfg(test)]
 mod pasted_paths_tests {
     use super::*;


### PR DESCRIPTION
Closes #5054

### Summary

Users on Ubuntu and Arch Linux have reported that Ctrl+V paste doesn't work in the chat composer. The workaround is to use Ctrl+Shift+V instead, which is confusing.

### Root Cause

The root cause is that Codex enables the Kitty Keyboard Protocol for enhanced key handling (to support features like Shift+Enter for newlines). When this protocol is enabled, terminals send Ctrl+V as a `KeyEvent` rather than triggering `Event::Paste`. Codex only handled the latter, so Ctrl+V did nothing.

This only affects terminals that support the Kitty Keyboard Protocol (Kitty, WezTerm, GNOME Terminal 3.38+, Windows Terminal 1.12+). Older terminals like Alacritty and iTerm2 don't support keyboard enhancement, so they continue sending Ctrl+V as bracketed paste, which Codex handles correctly. That's why macOS users (primarily using iTerm2/Terminal.app) didn't experience this issue.

### Solution

This change adds an explicit Ctrl+V handler that reads from the system clipboard using the existing `arboard` library (already used for image pasting).
