### PR TITLE
fix(exec): fix exit code when sending ctrl+c

### DIFF
--- a/codex-rs/common/src/exit.rs
+++ b/codex-rs/common/src/exit.rs
@@ -1,0 +1,27 @@
+//! Exit code handling for Codex.
+//!
+//! Provides systematic exit reason tracking with POSIX-compliant exit codes.
+
+/// The reason Codex is exiting with a non-zero status.
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ExitReason {
+    /// Server or runtime error
+    Error = 1,
+
+    /// User interrupted with SIGINT (Ctrl+C)
+    ///
+    /// Following POSIX convention: 128 + SIGINT (signal 2) = 130
+    Interrupted = 130,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn exit_codes_match_discriminants() {
+        assert_eq!(ExitReason::Error as i32, 1);
+        assert_eq!(ExitReason::Interrupted as i32, 130); // 128 + 2
+    }
+}

--- a/codex-rs/common/src/lib.rs
+++ b/codex-rs/common/src/lib.rs
@@ -37,3 +37,5 @@ pub mod model_presets;
 // Shared approval presets (AskForApproval + Sandbox) used by TUI and MCP server
 // Not to be confused with AskForApproval, which we should probably rename to EscalationPolicy.
 pub mod approval_presets;
+// Shared exit code handling
+pub mod exit;

--- a/codex-rs/exec/src/event_processor_with_jsonl_output.rs
+++ b/codex-rs/exec/src/event_processor_with_jsonl_output.rs
@@ -494,6 +494,8 @@ impl EventProcessor for EventProcessorWithJsonOutput {
                 handle_last_message(last_agent_message.as_deref(), output_file);
             }
             CodexStatus::InitiateShutdown
+        } else if matches!(msg, EventMsg::ShutdownComplete) {
+            CodexStatus::Shutdown
         } else {
             CodexStatus::Running
         }

--- a/codex-rs/exec/tests/suite/mod.rs
+++ b/codex-rs/exec/tests/suite/mod.rs
@@ -6,3 +6,4 @@ mod output_schema;
 mod resume;
 mod sandbox;
 mod server_error_exit;
+mod sigint_exit_code;

--- a/codex-rs/exec/tests/suite/server_error_exit.rs
+++ b/codex-rs/exec/tests/suite/server_error_exit.rs
@@ -5,8 +5,8 @@ use core_test_support::responses;
 use core_test_support::test_codex_exec::test_codex_exec;
 use wiremock::matchers::any;
 
-/// Verify that when the server reports an error, `codex-exec` exits with a
-/// non-zero status code so automation can detect failures.
+/// Verify that server errors exit with code 1.
+/// Priority: interrupted > error > success
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn exits_non_zero_when_server_reports_error() -> anyhow::Result<()> {
     let test = test_codex_exec();
@@ -14,6 +14,7 @@ async fn exits_non_zero_when_server_reports_error() -> anyhow::Result<()> {
     // Mock a simple Responses API SSE stream that immediately reports a
     // `response.failed` event with an error message.
     let server = responses::start_mock_server().await;
+
     let body = responses::sse(vec![serde_json::json!({
         "type": "response.failed",
         "response": {

--- a/codex-rs/exec/tests/suite/sigint_exit_code.rs
+++ b/codex-rs/exec/tests/suite/sigint_exit_code.rs
@@ -1,0 +1,129 @@
+#![cfg(not(target_os = "windows"))]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use codex_core::auth::CODEX_API_KEY_ENV_VAR;
+use core_test_support::responses;
+use core_test_support::test_codex_exec::test_codex_exec;
+use std::process::Stdio;
+use std::time::Duration;
+use tokio::time::sleep;
+
+/// Verify that SIGINT (Ctrl+C) during exec mode exits with code 130.
+/// Priority: interrupted > error > success
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn exits_130_on_sigint() -> anyhow::Result<()> {
+    let test = test_codex_exec();
+    let server = responses::start_mock_server().await;
+
+    // Mock long-running response (no response.done)
+    let body = responses::sse(vec![
+        serde_json::json!({
+            "type": "response.created",
+            "response": {"id": "resp_test", "status": "in_progress"}
+        }),
+        serde_json::json!({
+            "type": "response.output_item.delta",
+            "response_id": "resp_test",
+            "delta": {"type": "thinking", "content": "Processing..."}
+        }),
+    ]);
+    responses::mount_sse(&server, body).await;
+
+    let bin_path = assert_cmd::cargo::cargo_bin("codex-exec");
+    let base_url = format!("{}/v1", server.uri());
+    let mut cmd = tokio::process::Command::new(&bin_path);
+    cmd.current_dir(test.cwd_path())
+        .env("CODEX_HOME", test.home_path())
+        .env(CODEX_API_KEY_ENV_VAR, "dummy")
+        .env("OPENAI_BASE_URL", &base_url)
+        .arg("--skip-git-repo-check")
+        .arg("test prompt")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn()?;
+
+    sleep(Duration::from_millis(1500)).await;
+
+    if let Some(pid) = child.id() {
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGINT);
+        }
+    }
+
+    let status = child.wait().await?;
+
+    assert_eq!(
+        status.code(),
+        Some(130),
+        "Expected exit code 130 on SIGINT, got {:?}",
+        status.code()
+    );
+
+    Ok(())
+}
+
+/// Verify that SIGINT takes precedence over errors.
+/// If both error events and SIGINT occur, exit code should be 130.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn sigint_takes_precedence_over_error() -> anyhow::Result<()> {
+    let test = test_codex_exec();
+    let server = responses::start_mock_server().await;
+
+    // Mock response with error event, but we'll interrupt with SIGINT
+    let body = responses::sse(vec![
+        serde_json::json!({
+            "type": "response.created",
+            "response": {"id": "resp_test", "status": "in_progress"}
+        }),
+        serde_json::json!({
+            "type": "response.output_item.delta",
+            "response_id": "resp_test",
+            "delta": {"type": "thinking", "content": "Processing..."}
+        }),
+        serde_json::json!({
+            "type": "response.failed",
+            "response": {
+                "id": "resp_test",
+                "error": {"code": "internal_error", "message": "synthetic error"}
+            }
+        }),
+    ]);
+    responses::mount_sse(&server, body).await;
+
+    let bin_path = assert_cmd::cargo::cargo_bin("codex-exec");
+    let base_url = format!("{}/v1", server.uri());
+    let mut cmd = tokio::process::Command::new(&bin_path);
+    cmd.current_dir(test.cwd_path())
+        .env("CODEX_HOME", test.home_path())
+        .env(CODEX_API_KEY_ENV_VAR, "dummy")
+        .env("OPENAI_BASE_URL", &base_url)
+        .arg("--skip-git-repo-check")
+        .arg("test prompt")
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn()?;
+
+    sleep(Duration::from_millis(1500)).await;
+
+    if let Some(pid) = child.id() {
+        unsafe {
+            libc::kill(pid as libc::pid_t, libc::SIGINT);
+        }
+    }
+
+    let status = child.wait().await?;
+
+    // Even if errors occurred, SIGINT takes precedence
+    assert_eq!(
+        status.code(),
+        Some(130),
+        "Expected SIGINT precedence: exit 130, got {:?}",
+        status.code()
+    );
+
+    Ok(())
+}

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -316,6 +316,7 @@ async fn run_ratatui_app(
                         token_usage: codex_core::protocol::TokenUsage::default(),
                         conversation_id: None,
                         update_action: Some(action),
+                        exit_reason: None,
                     });
                 }
             }
@@ -362,6 +363,7 @@ async fn run_ratatui_app(
                 token_usage: codex_core::protocol::TokenUsage::default(),
                 conversation_id: None,
                 update_action: None,
+                exit_reason: None,
             });
         }
         if onboarding_result.windows_install_selected {
@@ -375,6 +377,7 @@ async fn run_ratatui_app(
                 token_usage: codex_core::protocol::TokenUsage::default(),
                 conversation_id: None,
                 update_action: None,
+                exit_reason: None,
             });
         }
         // if the user acknowledged windows or made an explicit decision ato trust the directory, reload the config accordingly
@@ -411,6 +414,7 @@ async fn run_ratatui_app(
                     token_usage: codex_core::protocol::TokenUsage::default(),
                     conversation_id: None,
                     update_action: None,
+                    exit_reason: Some(codex_common::exit::ExitReason::Error),
                 });
             }
         }
@@ -448,6 +452,7 @@ async fn run_ratatui_app(
                     token_usage: codex_core::protocol::TokenUsage::default(),
                     conversation_id: None,
                     update_action: None,
+                    exit_reason: None,
                 });
             }
             other => other,

--- a/codex-rs/tui/src/main.rs
+++ b/codex-rs/tui/src/main.rs
@@ -22,10 +22,16 @@ fn main() -> anyhow::Result<()> {
             .raw_overrides
             .splice(0..0, top_cli.config_overrides.raw_overrides);
         let exit_info = run_main(inner, codex_linux_sandbox_exe).await?;
+
         let token_usage = exit_info.token_usage;
         if !token_usage.is_zero() {
             println!("{}", codex_core::protocol::FinalOutput::from(token_usage),);
         }
+
+        if let Some(reason) = exit_info.exit_reason {
+            std::process::exit(reason as i32);
+        }
+
         Ok(())
     })
 }


### PR DESCRIPTION
Closes #4721

### Summary

If you run `codex exec` and terminate the process early with Ctrl+C, it would exit with an exit code of 0. This change makes it so that when you terminate `codex` early, it will exit with a exit code of 130, which is standard for interrupted. This allows automated tooling to detect when codex was interrupted.

### Reproduction

1. Run `codex exec "Hello, how are you doing?"`
2. Type Ctrl+C before Codex is done.
3. Run `echo $?`

### Solution

This change adds a `ExitReason` enum, which has Error and Interrupted variant for now. For consistency, the exit code is the same between `codex` using the TUI and `codex exec`.