### PR TITLE
chore(ci): ci failures should trigger github annotations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
 
       - name: Stage npm package
         id: stage_npm_package
+        if: github.repository_owner == 'openai'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -47,6 +48,7 @@ jobs:
 
       - name: Upload staged npm package artifact
         uses: actions/upload-artifact@v5
+        if: github.repository_owner == 'openai'
         with:
           name: codex-npm-staging
           path: ${{ steps.stage_npm_package.outputs.pack_output }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,6 +22,7 @@ jobs:
         # This action has a "lock-pullrequest-aftermerge" option that can be set to false,
         # but that would unconditionally skip locking even in cases where the PR was merged.
         if: |
+          github.repository_owner == 'openai' &&
           (
             github.event_name == 'pull_request_target' &&
             (

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -411,14 +411,13 @@ jobs:
         env:
           RUST_BACKTRACE: 1
 
-      - name: Publish Test Report
-        uses: mikepenz/action-junit-report@v4
+      - name: Upload JUnit artifact
         if: always()
+        uses: actions/upload-artifact@v5
         with:
-          report_paths: '**/target/nextest/*/junit.xml'
-          check_name: 'Test Results (${{ matrix.target }})'
-          detailed_summary: true
-          include_passed: false
+          name: junit-${{ matrix.target }}.xml
+          path: codex-rs/target/nextest/ci-test/junit.xml
+          if-no-files-found: ignore
 
       - name: Save cargo home cache
         if: always() && !cancelled() && steps.cache_cargo_home_restore.outputs.cache-hit != 'true'
@@ -469,7 +468,65 @@ jobs:
     needs: [changed, general, cargo_shear, lint_build, tests]
     if: always()
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
+      - uses: actions/checkout@v5
+
+      - name: Download JUnit artifacts
+        if: always()
+        uses: actions/download-artifact@v5
+        with:
+          pattern: junit-*.xml
+          path: junit-results
+
+      - name: Deduplicate JUnit artifacts with Codex
+        if: |
+          always() &&
+          ( github.repository_owner == 'openai' || github.repository_owner == 'Electroid' )
+        id: dedupe-junit
+        uses: openai/codex-action@main
+        with:
+          openai-api-key: ${{ secrets.CODEX_OPENAI_API_KEY }}
+          allow-users: "*"
+          model: gpt-5
+          prompt: |
+            You are an assistant that deduplicates JUnit artifacts across platforms.
+
+            You MUST read ALL of the following JUnit artifacts from the `junit-results` directory:
+            - `junit-{platform}.xml`: JUnit artifacts for each platform.
+
+            Output:
+              - JUnit XML file (strict! must be valid XML with no other text or formatting)
+
+            Instructions:
+            - Select AT MOST 10 test failures to keep.
+            - Order the test failures by severity, starting with the most severe.
+            - Group test failures by file and line number.
+            - If a test failed on multiple operating systems or architectures, add a note at the end of the error message indicating which platforms it failed on, examples:
+              + "Failed on macOS, Linux, and Windows"
+              + "Failed on Windows"
+              + "Failed on macOS aarch64 and Linux x64"
+            - If a test does not have a filename and line number in its XML entry, or that file or line is incorrect based on the error context, correct it.
+            - You MUST output a full JUnit XML structure, including the <testsuites> and <testsuite> tags.
+            - Aside from specifying the platform, do NOT edit or change the content of the errors or test cases.
+
+      - name: Save JUnit artifact
+        if: always() && steps.dedupe-junit.outputs.final-message != ''
+        shell: bash
+        run: |
+          echo "${{ steps.dedupe-junit.outputs.final-message }}" > junit-results/junit.xml
+
+      - name: Generate GitHub annotations
+        if: always() && steps.dedupe-junit.outputs.final-message != ''
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: 'junit-results/junit.xml'
+          check_name: 'Tests'
+          detailed_summary: true
+          include_passed: false
+          fail_on_failure: false
+
       - name: Summarize
         shell: bash
         run: |

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -407,9 +407,18 @@ jobs:
       - name: tests
         id: test
         continue-on-error: true
-        run: cargo nextest run --all-features --no-fail-fast --target ${{ matrix.target }} --cargo-profile ci-test
+        run: cargo nextest run --all-features --no-fail-fast --target ${{ matrix.target }} --profile ci-test --cargo-profile ci-test
         env:
           RUST_BACKTRACE: 1
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always()
+        with:
+          report_paths: '**/target/nextest/*/junit.xml'
+          check_name: 'Test Results (${{ matrix.target }})'
+          detailed_summary: true
+          include_passed: false
 
       - name: Save cargo home cache
         if: always() && !cancelled() && steps.cache_cargo_home_restore.outputs.cache-hit != 'true'

--- a/codex-rs/.config/nextest.toml
+++ b/codex-rs/.config/nextest.toml
@@ -1,0 +1,7 @@
+# https://nexte.st/docs/configuration/reference/
+[profile.ci-test]
+
+# JUnit output for GitHub Actions annotations
+[profile.ci-test.junit]
+path = "junit.xml"
+store-failure-output = true

--- a/codex-rs/.config/nextest.toml
+++ b/codex-rs/.config/nextest.toml
@@ -5,3 +5,4 @@
 [profile.ci-test.junit]
 path = "junit.xml"
 store-failure-output = true
+store-success-output = false

--- a/codex-rs/app-server-protocol/src/lib.rs
+++ b/codex-rs/app-server-protocol/src/lib.rs
@@ -9,3 +9,17 @@ pub use jsonrpc_lite::*;
 pub use protocol::common::*;
 pub use protocol::v1::*;
 pub use protocol::v2::*;
+
+#[cfg(test)]
+mod test_junit_reporting {
+    #[test]
+    fn test_that_fails_for_junit_demo() {
+        // TODO: This file is going to be removed prior to merge.
+        // This is just to test that JUnit + GitHub annotations are working.
+        assert_eq!(
+            2 + 2,
+            5,
+            "This test intentionally fails to test JUnit reporting"
+        );
+    }
+}


### PR DESCRIPTION
### Summary

This is a quality-of-life improvement for contributors finding errors in CI.

Right now, you have to dig around with Ctrl-F to find failures in the GitHub Actions workflow. This change will use nextest's `junit.xml` support, alongside the `mikepenz/action-junit-report` GitHub action to render GitHub annotations for each error.

I added a dummy failure to test what it will look like. Once it's confirmed that it all works, I can remove the test and it should be ready to merge.

### Example

Here's an example of what it would look like:

![](https://github.com/mikepenz/action-junit-report/raw/main/.github/images/annotated.png)
