### PR TITLE
feat: Add support for --add-dir to exec and TypeScript SDK

### DIFF
--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -52,6 +52,10 @@ pub struct Cli {
     #[arg(long = "skip-git-repo-check", default_value_t = false)]
     pub skip_git_repo_check: bool,
 
+    /// Additional directories that should be writable alongside the primary workspace.
+    #[arg(long = "add-dir", value_name = "DIR", value_hint = clap::ValueHint::DirPath)]
+    pub add_dir: Vec<PathBuf>,
+
     /// Path to a JSON Schema file describing the model's final response shape.
     #[arg(long = "output-schema", value_name = "FILE")]
     pub output_schema: Option<PathBuf>,

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -62,6 +62,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         dangerously_bypass_approvals_and_sandbox,
         cwd,
         skip_git_repo_check,
+        add_dir,
         color,
         last_message_file,
         json: json_mode,
@@ -180,7 +181,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         show_raw_agent_reasoning: oss.then_some(true),
         tools_web_search_request: None,
         experimental_sandbox_command_assessment: None,
-        additional_writable_roots: Vec::new(),
+        additional_writable_roots: add_dir,
     };
     // Parse `-c` overrides.
     let cli_kv_overrides = match config_overrides.parse_overrides() {

--- a/codex-rs/exec/tests/suite/add_dir.rs
+++ b/codex-rs/exec/tests/suite/add_dir.rs
@@ -38,7 +38,7 @@ async fn accepts_add_dir_flag() -> anyhow::Result<()> {
 }
 
 /// Verify that multiple --add-dir flags can be specified.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn accepts_multiple_add_dir_flags() -> anyhow::Result<()> {
     let test = test_codex_exec();
 

--- a/codex-rs/exec/tests/suite/add_dir.rs
+++ b/codex-rs/exec/tests/suite/add_dir.rs
@@ -1,0 +1,72 @@
+#![cfg(not(target_os = "windows"))]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use core_test_support::responses;
+use core_test_support::test_codex_exec::test_codex_exec;
+
+/// Verify that the --add-dir flag is accepted and the command runs successfully.
+/// This test confirms the CLI argument is properly wired up.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn accepts_add_dir_flag() -> anyhow::Result<()> {
+    let test = test_codex_exec();
+
+    let server = responses::start_mock_server().await;
+    let body = responses::sse(vec![
+        responses::ev_response_created("response_1"),
+        responses::ev_assistant_message("response_1", "Task completed"),
+        responses::ev_completed("response_1"),
+    ]);
+    responses::mount_sse_once(&server, body).await;
+
+    // Create temporary directories to use with --add-dir
+    let temp_dir1 = tempfile::tempdir()?;
+    let temp_dir2 = tempfile::tempdir()?;
+
+    test.cmd_with_server(&server)
+        .arg("--skip-git-repo-check")
+        .arg("--sandbox")
+        .arg("workspace-write")
+        .arg("--add-dir")
+        .arg(temp_dir1.path())
+        .arg("--add-dir")
+        .arg(temp_dir2.path())
+        .arg("test with additional directories")
+        .assert()
+        .code(0);
+
+    Ok(())
+}
+
+/// Verify that multiple --add-dir flags can be specified.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn accepts_multiple_add_dir_flags() -> anyhow::Result<()> {
+    let test = test_codex_exec();
+
+    let server = responses::start_mock_server().await;
+    let body = responses::sse(vec![
+        responses::ev_response_created("response_1"),
+        responses::ev_assistant_message("response_1", "Multiple directories accepted"),
+        responses::ev_completed("response_1"),
+    ]);
+    responses::mount_sse_once(&server, body).await;
+
+    let temp_dir1 = tempfile::tempdir()?;
+    let temp_dir2 = tempfile::tempdir()?;
+    let temp_dir3 = tempfile::tempdir()?;
+
+    test.cmd_with_server(&server)
+        .arg("--skip-git-repo-check")
+        .arg("--sandbox")
+        .arg("workspace-write")
+        .arg("--add-dir")
+        .arg(temp_dir1.path())
+        .arg("--add-dir")
+        .arg(temp_dir2.path())
+        .arg("--add-dir")
+        .arg(temp_dir3.path())
+        .arg("test with three directories")
+        .assert()
+        .code(0);
+
+    Ok(())
+}

--- a/codex-rs/exec/tests/suite/add_dir.rs
+++ b/codex-rs/exec/tests/suite/add_dir.rs
@@ -6,7 +6,7 @@ use core_test_support::test_codex_exec::test_codex_exec;
 
 /// Verify that the --add-dir flag is accepted and the command runs successfully.
 /// This test confirms the CLI argument is properly wired up.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
 async fn accepts_add_dir_flag() -> anyhow::Result<()> {
     let test = test_codex_exec();
 
@@ -38,7 +38,7 @@ async fn accepts_add_dir_flag() -> anyhow::Result<()> {
 }
 
 /// Verify that multiple --add-dir flags can be specified.
-#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn accepts_multiple_add_dir_flags() -> anyhow::Result<()> {
     let test = test_codex_exec();
 

--- a/codex-rs/exec/tests/suite/mod.rs
+++ b/codex-rs/exec/tests/suite/mod.rs
@@ -1,4 +1,5 @@
 // Aggregates all former standalone integration tests as modules.
+mod add_dir;
 mod apply_patch;
 mod auth_env;
 mod originator;

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -28,7 +28,8 @@
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "vendor"
   ],
   "sideEffects": false,
   "scripts": {

--- a/sdk/typescript/package.json
+++ b/sdk/typescript/package.json
@@ -28,8 +28,7 @@
     }
   },
   "files": [
-    "dist",
-    "vendor"
+    "dist"
   ],
   "sideEffects": false,
   "scripts": {

--- a/sdk/typescript/src/exec.ts
+++ b/sdk/typescript/src/exec.ts
@@ -18,6 +18,8 @@ export type CodexExecArgs = {
   sandboxMode?: SandboxMode;
   // --cd
   workingDirectory?: string;
+  // --add-dir 
+  additionalDirectories?: string[];
   // --skip-git-repo-check
   skipGitRepoCheck?: boolean;
   // --output-schema
@@ -54,6 +56,11 @@ export class CodexExec {
 
     if (args.workingDirectory) {
       commandArgs.push("--cd", args.workingDirectory);
+    }
+
+    if (args.additionalDirectories?.length) {
+      const writableRootsArray = args.additionalDirectories.map((dir) => `"${dir}"`).join(", ");
+      commandArgs.push("--config", `sandbox_workspace_write.writable_roots=[${writableRootsArray}]`);
     }
 
     if (args.skipGitRepoCheck) {

--- a/sdk/typescript/src/exec.ts
+++ b/sdk/typescript/src/exec.ts
@@ -18,8 +18,8 @@ export type CodexExecArgs = {
   sandboxMode?: SandboxMode;
   // --cd
   workingDirectory?: string;
-  // --config sandbox_workspace_write.writable_roots
-  writeableRoots?: string[];
+  // --add-dir
+  additionalDirectories?: string[];
   // --skip-git-repo-check
   skipGitRepoCheck?: boolean;
   // --output-schema
@@ -58,9 +58,10 @@ export class CodexExec {
       commandArgs.push("--cd", args.workingDirectory);
     }
 
-    if (args.writeableRoots?.length) {
-      const writableRootsArray = args.writeableRoots.map((dir) => `"${dir}"`).join(", ");
-      commandArgs.push("--config", `sandbox_workspace_write.writable_roots=[${writableRootsArray}]`);
+    if (args.additionalDirectories?.length) {
+      for (const dir of args.additionalDirectories) {
+        commandArgs.push("--add-dir", dir);
+      }
     }
 
     if (args.skipGitRepoCheck) {

--- a/sdk/typescript/src/exec.ts
+++ b/sdk/typescript/src/exec.ts
@@ -18,8 +18,8 @@ export type CodexExecArgs = {
   sandboxMode?: SandboxMode;
   // --cd
   workingDirectory?: string;
-  // --add-dir 
-  additionalDirectories?: string[];
+  // --config sandbox_workspace_write.writable_roots
+  writeableRoots?: string[];
   // --skip-git-repo-check
   skipGitRepoCheck?: boolean;
   // --output-schema
@@ -58,8 +58,8 @@ export class CodexExec {
       commandArgs.push("--cd", args.workingDirectory);
     }
 
-    if (args.additionalDirectories?.length) {
-      const writableRootsArray = args.additionalDirectories.map((dir) => `"${dir}"`).join(", ");
+    if (args.writeableRoots?.length) {
+      const writableRootsArray = args.writeableRoots.map((dir) => `"${dir}"`).join(", ");
       commandArgs.push("--config", `sandbox_workspace_write.writable_roots=[${writableRootsArray}]`);
     }
 

--- a/sdk/typescript/src/thread.ts
+++ b/sdk/typescript/src/thread.ts
@@ -89,7 +89,7 @@ export class Thread {
       networkAccessEnabled: options?.networkAccessEnabled,
       webSearchEnabled: options?.webSearchEnabled,
       approvalPolicy: options?.approvalPolicy,
-      additionalDirectories: options?.additionalDirectories,
+      writeableRoots: options?.writeableRoots,
     });
     try {
       for await (const item of generator) {

--- a/sdk/typescript/src/thread.ts
+++ b/sdk/typescript/src/thread.ts
@@ -89,7 +89,7 @@ export class Thread {
       networkAccessEnabled: options?.networkAccessEnabled,
       webSearchEnabled: options?.webSearchEnabled,
       approvalPolicy: options?.approvalPolicy,
-      writeableRoots: options?.writeableRoots,
+      additionalDirectories: options?.additionalDirectories,
     });
     try {
       for await (const item of generator) {

--- a/sdk/typescript/src/thread.ts
+++ b/sdk/typescript/src/thread.ts
@@ -89,6 +89,7 @@ export class Thread {
       networkAccessEnabled: options?.networkAccessEnabled,
       webSearchEnabled: options?.webSearchEnabled,
       approvalPolicy: options?.approvalPolicy,
+      additionalDirectories: options?.additionalDirectories,
     });
     try {
       for await (const item of generator) {

--- a/sdk/typescript/src/threadOptions.ts
+++ b/sdk/typescript/src/threadOptions.ts
@@ -13,4 +13,5 @@ export type ThreadOptions = {
   networkAccessEnabled?: boolean;
   webSearchEnabled?: boolean;
   approvalPolicy?: ApprovalMode;
+  additionalDirectories?: string[];
 };

--- a/sdk/typescript/src/threadOptions.ts
+++ b/sdk/typescript/src/threadOptions.ts
@@ -13,5 +13,5 @@ export type ThreadOptions = {
   networkAccessEnabled?: boolean;
   webSearchEnabled?: boolean;
   approvalPolicy?: ApprovalMode;
-  writeableRoots?: string[];
+  additionalDirectories?: string[];
 };

--- a/sdk/typescript/src/threadOptions.ts
+++ b/sdk/typescript/src/threadOptions.ts
@@ -13,5 +13,5 @@ export type ThreadOptions = {
   networkAccessEnabled?: boolean;
   webSearchEnabled?: boolean;
   approvalPolicy?: ApprovalMode;
-  additionalDirectories?: string[];
+  writeableRoots?: string[];
 };

--- a/sdk/typescript/tests/run.test.ts
+++ b/sdk/typescript/tests/run.test.ts
@@ -374,16 +374,20 @@ describe("Codex", () => {
       if (!commandArgs) {
         throw new Error("Command args missing");
       }
-      const addDirValues: string[] = [];
+
+      // Find the --config flag with sandbox_workspace_write.writable_roots
+      let foundConfig = false;
       for (let i = 0; i < commandArgs.length; i += 1) {
-        if (commandArgs[i] === "--add-dir") {
-          const directory = commandArgs[i + 1];
-          if (typeof directory === "string") {
-            addDirValues.push(directory);
+        if (commandArgs[i] === "--config") {
+          const configValue = commandArgs[i + 1];
+          if (typeof configValue === "string" && configValue.includes("sandbox_workspace_write.writable_roots")) {
+            expect(configValue).toBe('sandbox_workspace_write.writable_roots=["../backend", "/tmp/shared"]');
+            foundConfig = true;
+            break;
           }
         }
       }
-      expect(addDirValues).toEqual(["../backend", "/tmp/shared"]);
+      expect(foundConfig).toBe(true);
     } finally {
       restore();
       await close();

--- a/sdk/typescript/tests/run.test.ts
+++ b/sdk/typescript/tests/run.test.ts
@@ -347,7 +347,7 @@ describe("Codex", () => {
     }
   });
 
-  it("passes writeableRoots as repeated flags", async () => {
+  it("passes additionalDirectories as repeated flags", async () => {
     const { url, close } = await startResponsesTestProxy({
       statusCode: 200,
       responseBodies: [
@@ -365,7 +365,7 @@ describe("Codex", () => {
       const client = new Codex({ codexPathOverride: codexExecPath, baseUrl: url, apiKey: "test" });
 
       const thread = client.startThread({
-        writeableRoots: ["../backend", "/tmp/shared"],
+        additionalDirectories: ["../backend", "/tmp/shared"],
       });
       await thread.run("test additional dirs");
 
@@ -375,19 +375,14 @@ describe("Codex", () => {
         throw new Error("Command args missing");
       }
 
-      // Find the --config flag with sandbox_workspace_write.writable_roots
-      let foundConfig = false;
+      // Find the --add-dir flags
+      const addDirArgs: string[] = [];
       for (let i = 0; i < commandArgs.length; i += 1) {
-        if (commandArgs[i] === "--config") {
-          const configValue = commandArgs[i + 1];
-          if (typeof configValue === "string" && configValue.includes("sandbox_workspace_write.writable_roots")) {
-            expect(configValue).toBe('sandbox_workspace_write.writable_roots=["../backend", "/tmp/shared"]');
-            foundConfig = true;
-            break;
-          }
+        if (commandArgs[i] === "--add-dir") {
+          addDirArgs.push(commandArgs[i + 1] ?? "");
         }
       }
-      expect(foundConfig).toBe(true);
+      expect(addDirArgs).toEqual(["../backend", "/tmp/shared"]);
     } finally {
       restore();
       await close();

--- a/sdk/typescript/tests/run.test.ts
+++ b/sdk/typescript/tests/run.test.ts
@@ -347,7 +347,7 @@ describe("Codex", () => {
     }
   });
 
-  it("passes additionalDirectories as repeated flags", async () => {
+  it("passes writeableRoots as repeated flags", async () => {
     const { url, close } = await startResponsesTestProxy({
       statusCode: 200,
       responseBodies: [
@@ -365,7 +365,7 @@ describe("Codex", () => {
       const client = new Codex({ codexPathOverride: codexExecPath, baseUrl: url, apiKey: "test" });
 
       const thread = client.startThread({
-        additionalDirectories: ["../backend", "/tmp/shared"],
+        writeableRoots: ["../backend", "/tmp/shared"],
       });
       await thread.run("test additional dirs");
 


### PR DESCRIPTION
## Summary

Adds support for specifying additional directories in the TypeScript SDK through a new `additionalDirectories` option in `ThreadOptions`.

## Changes

- Added `additionalDirectories` parameter to `ThreadOptions` interface
- Updated `CodexExec` to accept and pass through additional directories via the `--config` flag for `sandbox_workspace_write.writable_roots`
- Added comprehensive test coverage for the new functionality

## Test plan

- Added test case that verifies `additionalDirectories` is correctly passed as repeated flags
- Existing tests continue to pass