### PR TITLE
:bug: fix(rmcp-client): refresh OAuth tokens using expires_at

### DIFF
--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -17,6 +17,7 @@ use urlencoding::decode;
 use crate::OAuthCredentialsStoreMode;
 use crate::StoredOAuthTokens;
 use crate::WrappedOAuthTokenResponse;
+use crate::oauth::compute_expires_at_millis;
 use crate::save_oauth_tokens;
 use crate::utils::apply_default_headers;
 use crate::utils::build_default_headers;
@@ -91,11 +92,13 @@ pub async fn perform_oauth_login(
     let credentials =
         credentials_opt.ok_or_else(|| anyhow!("OAuth provider did not return credentials"))?;
 
+    let expires_at = compute_expires_at_millis(&credentials);
     let stored = StoredOAuthTokens {
         server_name: server_name.to_string(),
         url: server_url.to_string(),
         client_id,
         token_response: WrappedOAuthTokenResponse(credentials),
+        expires_at,
     };
     save_oauth_tokens(server_name, &stored, store_mode)?;
 

--- a/codex-rs/rmcp-client/src/rmcp_client.rs
+++ b/codex-rs/rmcp-client/src/rmcp_client.rs
@@ -259,6 +259,7 @@ impl RmcpClient {
         params: Option<ListToolsRequestParams>,
         timeout: Option<Duration>,
     ) -> Result<ListToolsResult> {
+        self.refresh_oauth_if_needed().await;
         let service = self.service().await?;
         let rmcp_params = params
             .map(convert_to_rmcp::<_, PaginatedRequestParam>)
@@ -276,6 +277,7 @@ impl RmcpClient {
         params: Option<ListResourcesRequestParams>,
         timeout: Option<Duration>,
     ) -> Result<ListResourcesResult> {
+        self.refresh_oauth_if_needed().await;
         let service = self.service().await?;
         let rmcp_params = params
             .map(convert_to_rmcp::<_, PaginatedRequestParam>)
@@ -293,6 +295,7 @@ impl RmcpClient {
         params: Option<ListResourceTemplatesRequestParams>,
         timeout: Option<Duration>,
     ) -> Result<ListResourceTemplatesResult> {
+        self.refresh_oauth_if_needed().await;
         let service = self.service().await?;
         let rmcp_params = params
             .map(convert_to_rmcp::<_, PaginatedRequestParam>)
@@ -310,6 +313,7 @@ impl RmcpClient {
         params: ReadResourceRequestParams,
         timeout: Option<Duration>,
     ) -> Result<ReadResourceResult> {
+        self.refresh_oauth_if_needed().await;
         let service = self.service().await?;
         let rmcp_params: ReadResourceRequestParam = convert_to_rmcp(params)?;
         let fut = service.read_resource(rmcp_params);
@@ -325,6 +329,7 @@ impl RmcpClient {
         arguments: Option<serde_json::Value>,
         timeout: Option<Duration>,
     ) -> Result<CallToolResult> {
+        self.refresh_oauth_if_needed().await;
         let service = self.service().await?;
         let params = CallToolRequestParams { arguments, name };
         let rmcp_params: CallToolRequestParam = convert_to_rmcp(params)?;
@@ -361,6 +366,14 @@ impl RmcpClient {
             && let Err(error) = runtime.persist_if_needed().await
         {
             warn!("failed to persist OAuth tokens: {error}");
+        }
+    }
+
+    async fn refresh_oauth_if_needed(&self) {
+        if let Some(runtime) = self.oauth_persistor().await
+            && let Err(error) = runtime.refresh_if_needed().await
+        {
+            warn!("failed to refresh OAuth tokens: {error}");
         }
     }
 }


### PR DESCRIPTION
## Summary
- persist OAuth credential expiry timestamps and rehydrate `expires_in`
- proactively refresh rmcp OAuth tokens when `expires_at` is near, then persist

## Testing
- just fmt
- just fix -p codex-rmcp-client
- cargo test -p codex-rmcp-client

Fixes #6572