### PR TITLE
Overhaul shell detection and centralize command generation for unified exec

### DIFF
--- a/codex-rs/core/src/bash.rs
+++ b/codex-rs/core/src/bash.rs
@@ -3,6 +3,9 @@ use tree_sitter::Parser;
 use tree_sitter::Tree;
 use tree_sitter_bash::LANGUAGE as BASH;
 
+use crate::shell::ShellType;
+use crate::shell::detect_shell_type;
+
 /// Parse the provided bash source using tree-sitter-bash, returning a Tree on
 /// success or None if parsing failed.
 pub fn try_parse_shell(shell_lc_arg: &str) -> Option<Tree> {
@@ -88,23 +91,13 @@ pub fn try_parse_word_only_commands_sequence(tree: &Tree, src: &str) -> Option<V
     Some(commands)
 }
 
-pub fn is_well_known_sh_shell(shell: &str) -> bool {
-    if shell == "bash" || shell == "zsh" {
-        return true;
-    }
-
-    let shell_name = std::path::Path::new(shell)
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or(shell);
-    matches!(shell_name, "bash" | "zsh")
-}
-
 pub fn extract_bash_command(command: &[String]) -> Option<(&str, &str)> {
     let [shell, flag, script] = command else {
         return None;
     };
-    if !matches!(flag.as_str(), "-lc" | "-c") || !is_well_known_sh_shell(shell) {
+    if !matches!(flag.as_str(), "-lc" | "-c")
+        || !matches!(detect_shell_type(shell), ShellType::Zsh | ShellType::Bash)
+    {
         return None;
     }
     Some((shell, script))

--- a/codex-rs/core/src/bash.rs
+++ b/codex-rs/core/src/bash.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use tree_sitter::Node;
 use tree_sitter::Parser;
 use tree_sitter::Tree;
@@ -96,7 +98,10 @@ pub fn extract_bash_command(command: &[String]) -> Option<(&str, &str)> {
         return None;
     };
     if !matches!(flag.as_str(), "-lc" | "-c")
-        || !matches!(detect_shell_type(shell), ShellType::Zsh | ShellType::Bash)
+        || !matches!(
+            detect_shell_type(&PathBuf::from(shell)),
+            Some(ShellType::Zsh) | Some(ShellType::Bash)
+        )
     {
         return None;
     }

--- a/codex-rs/core/src/command_safety/is_safe_command.rs
+++ b/codex-rs/core/src/command_safety/is_safe_command.rs
@@ -1,4 +1,5 @@
 use crate::bash::parse_shell_lc_plain_commands;
+use crate::command_safety::windows_safe_commands::is_safe_command_windows;
 
 pub fn is_known_safe_command(command: &[String]) -> bool {
     let command: Vec<String> = command
@@ -11,12 +12,9 @@ pub fn is_known_safe_command(command: &[String]) -> bool {
             }
         })
         .collect();
-    #[cfg(target_os = "windows")]
-    {
-        use super::windows_safe_commands::is_safe_command_windows;
-        if is_safe_command_windows(&command) {
-            return true;
-        }
+
+    if is_safe_command_windows(&command) {
+        return true;
     }
 
     if is_safe_to_call_with_exec(&command) {

--- a/codex-rs/core/src/command_safety/mod.rs
+++ b/codex-rs/core/src/command_safety/mod.rs
@@ -1,4 +1,3 @@
 pub mod is_dangerous_command;
 pub mod is_safe_command;
-#[cfg(target_os = "windows")]
 pub mod windows_safe_commands;

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -329,7 +329,6 @@ mod tests {
             Some(workspace_write_policy(vec!["/repo"], false)),
             Some(Shell::Bash(BashShell {
                 shell_path: "/bin/bash".into(),
-                bashrc_path: "/home/user/.bashrc".into(),
             })),
         );
         let context2 = EnvironmentContext::new(
@@ -338,7 +337,6 @@ mod tests {
             Some(workspace_write_policy(vec!["/repo"], false)),
             Some(Shell::Zsh(ZshShell {
                 shell_path: "/bin/zsh".into(),
-                zshrc_path: "/home/user/.zshrc".into(),
             })),
         );
 

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -217,7 +217,7 @@ pub fn detect_shell_type(shell_path: &PathBuf) -> Option<ShellType> {
 fn detect_default_user_shell() -> Shell {
     get_user_shell_path()
         .and_then(|shell| detect_shell_type(&shell))
-        .and_then(|t| get_shell(t))
+        .and_then(get_shell)
         .unwrap_or(Shell::Unknown)
 }
 
@@ -232,17 +232,44 @@ mod detect_shell_type_tests {
 
     #[test]
     fn test_detect_shell_type() {
-        assert_eq!(detect_shell_type("zsh"), ShellType::Zsh);
-        assert_eq!(detect_shell_type("bash"), ShellType::Bash);
-        assert_eq!(detect_shell_type("pwsh"), ShellType::PowerShell);
-        assert_eq!(detect_shell_type("powershell"), ShellType::PowerShell);
-        assert_eq!(detect_shell_type("fish"), ShellType::Unknown);
-        assert_eq!(detect_shell_type("other"), ShellType::Unknown);
-        assert_eq!(detect_shell_type("/bin/zsh"), ShellType::Zsh);
-        assert_eq!(detect_shell_type("/bin/bash"), ShellType::Bash);
-        assert_eq!(detect_shell_type("powershell.exe"), ShellType::PowerShell);
-        assert_eq!(detect_shell_type("pwsh.exe"), ShellType::PowerShell);
-        assert_eq!(detect_shell_type("/usr/local/bin/pwsh"), ShellType::Unknown);
+        assert_eq!(
+            detect_shell_type(&PathBuf::from("zsh")),
+            Some(ShellType::Zsh)
+        );
+        assert_eq!(
+            detect_shell_type(&PathBuf::from("bash")),
+            Some(ShellType::Bash)
+        );
+        assert_eq!(
+            detect_shell_type(&PathBuf::from("pwsh")),
+            Some(ShellType::PowerShell)
+        );
+        assert_eq!(
+            detect_shell_type(&PathBuf::from("powershell")),
+            Some(ShellType::PowerShell)
+        );
+        assert_eq!(detect_shell_type(&PathBuf::from("fish")), None);
+        assert_eq!(detect_shell_type(&PathBuf::from("other")), None);
+        assert_eq!(
+            detect_shell_type(&PathBuf::from("/bin/zsh")),
+            Some(ShellType::Zsh)
+        );
+        assert_eq!(
+            detect_shell_type(&PathBuf::from("/bin/bash")),
+            Some(ShellType::Bash)
+        );
+        assert_eq!(
+            detect_shell_type(&PathBuf::from("powershell.exe")),
+            Some(ShellType::PowerShell)
+        );
+        assert_eq!(
+            detect_shell_type(&PathBuf::from("pwsh.exe")),
+            Some(ShellType::PowerShell)
+        );
+        assert_eq!(
+            detect_shell_type(&PathBuf::from("/usr/local/bin/pwsh")),
+            None
+        );
     }
 }
 
@@ -252,6 +279,12 @@ mod tests {
     use super::*;
     use std::path::PathBuf;
     use std::process::Command;
+
+    #[test]
+    fn detects_zsh() {
+        let zsh_shell = get_zsh_shell().unwrap();
+        assert_eq!(zsh_shell.shell_path, PathBuf::from("/bin/zsh"));
+    }
 
     #[tokio::test]
     async fn test_current_shell_detects_zsh() {

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -160,6 +160,12 @@ fn get_powershell_shell() -> Option<PowerShellConfig> {
     shell_path.map(|shell_path| PowerShellConfig { shell_path })
 }
 
+pub fn get_shell_by_model_provided_path(shell_path: &PathBuf) -> Shell {
+    detect_shell_type(shell_path)
+        .and_then(get_shell)
+        .unwrap_or(Shell::Unknown)
+}
+
 pub fn get_shell(shell_type: ShellType) -> Option<Shell> {
     match shell_type {
         ShellType::Zsh => get_zsh_shell().map(Shell::Zsh),

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -260,6 +260,7 @@ mod tests {
     use std::process::Command;
 
     #[test]
+    #[cfg(target_os = "macos")]
     fn detects_zsh() {
         let zsh_shell = get_shell(ShellType::Zsh).unwrap();
 

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -167,7 +167,8 @@ fn get_zsh_shell() -> Option<ZshShell> {
 
     shell_path.map(|shell_path| ZshShell {
         shell_path,
-        zshrc_path: get_user_home().and_then(|home| file_exists(format!("{home}/.zshrc").as_str())),
+        zshrc_path: get_user_home()
+            .and_then(|home| file_exists(&PathBuf::from(format!("{home}/.zshrc")))),
     })
 }
 
@@ -177,7 +178,7 @@ fn get_bash_shell() -> Option<BashShell> {
     shell_path.map(|shell_path| BashShell {
         shell_path,
         bashrc_path: get_user_home()
-            .and_then(|home| file_exists(format!("{home}/.bashrc").as_str())),
+            .and_then(|home| file_exists(&PathBuf::from(format!("{home}/.bashrc")))),
     })
 }
 

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -307,7 +307,6 @@ mod tests {
 #[cfg(windows)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
     #[tokio::test]
     async fn detects_powershell_as_default() {

--- a/codex-rs/core/src/tools/events.rs
+++ b/codex-rs/core/src/tools/events.rs
@@ -87,7 +87,7 @@ pub(crate) enum ToolEmitter {
         auto_approved: bool,
     },
     UnifiedExec {
-        command: String,
+        command: Vec<String>,
         cwd: PathBuf,
         // True for `exec_command` and false for `write_stdin`.
         #[allow(dead_code)]
@@ -111,9 +111,9 @@ impl ToolEmitter {
         }
     }
 
-    pub fn unified_exec(command: String, cwd: PathBuf, is_startup_command: bool) -> Self {
+    pub fn unified_exec(command: &[String], cwd: PathBuf, is_startup_command: bool) -> Self {
         Self::UnifiedExec {
-            command,
+            command: command.to_vec(),
             cwd,
             is_startup_command,
         }
@@ -218,7 +218,7 @@ impl ToolEmitter {
                 emit_patch_end(ctx, String::new(), (*message).to_string(), false).await;
             }
             (Self::UnifiedExec { command, cwd, .. }, ToolEventStage::Begin) => {
-                emit_exec_command_begin(ctx, &[command.to_string()], cwd.as_path(), false).await;
+                emit_exec_command_begin(ctx, command, cwd.as_path(), false).await;
             }
             (Self::UnifiedExec { .. }, ToolEventStage::Success(output)) => {
                 emit_exec_end(

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -324,6 +324,8 @@ impl ShellHandler {
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use crate::is_safe_command::is_known_safe_command;
     use crate::shell::BashShell;
     use crate::shell::Shell;
@@ -336,13 +338,11 @@ mod tests {
     fn commands_generated_by_shell_command_handler_can_be_matched_by_is_known_safe_command() {
         let bash_shell = Shell::Bash(BashShell {
             shell_path: PathBuf::from("/bin/bash"),
-            bashrc_path: Some(PathBuf::from("/home/user/.bashrc")),
         });
         assert_safe(&bash_shell, "ls -la");
 
         let zsh_shell = Shell::Zsh(ZshShell {
             shell_path: PathBuf::from("/bin/zsh"),
-            zshrc_path: Some(PathBuf::from("/home/user/.zshrc")),
         });
         assert_safe(&zsh_shell, "ls -la");
 

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -335,14 +335,14 @@ mod tests {
     #[test]
     fn commands_generated_by_shell_command_handler_can_be_matched_by_is_known_safe_command() {
         let bash_shell = Shell::Bash(BashShell {
-            shell_path: "/bin/bash".to_string(),
-            bashrc_path: "/home/user/.bashrc".to_string(),
+            shell_path: PathBuf::from("/bin/bash"),
+            bashrc_path: Some(PathBuf::from("/home/user/.bashrc")),
         });
         assert_safe(&bash_shell, "ls -la");
 
         let zsh_shell = Shell::Zsh(ZshShell {
-            shell_path: "/bin/zsh".to_string(),
-            zshrc_path: "/home/user/.zshrc".to_string(),
+            shell_path: PathBuf::from("/bin/zsh"),
+            zshrc_path: Some(PathBuf::from("/home/user/.zshrc")),
         });
         assert_safe(&zsh_shell, "ls -la");
 

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -328,6 +328,7 @@ mod tests {
 
     use crate::is_safe_command::is_known_safe_command;
     use crate::shell::BashShell;
+    use crate::shell::PowerShellConfig;
     use crate::shell::Shell;
     use crate::shell::ZshShell;
 
@@ -346,16 +347,10 @@ mod tests {
         });
         assert_safe(&zsh_shell, "ls -la");
 
-        #[cfg(target_os = "windows")]
-        {
-            use crate::shell::PowerShellConfig;
-
-            let powershell = Shell::PowerShell(PowerShellConfig {
-                exe: "pwsh.exe".to_string(),
-                bash_exe_fallback: None,
-            });
-            assert_safe(&powershell, "ls -Name");
-        }
+        let powershell = Shell::PowerShell(PowerShellConfig {
+            shell_path: PathBuf::from("pwsh.exe"),
+        });
+        assert_safe(&powershell, "ls -Name");
     }
 
     fn assert_safe(shell: &Shell, command: &str) {

--- a/codex-rs/core/src/unified_exec/mod.rs
+++ b/codex-rs/core/src/unified_exec/mod.rs
@@ -64,10 +64,8 @@ impl UnifiedExecContext {
 }
 
 #[derive(Debug)]
-pub(crate) struct ExecCommandRequest<'a> {
-    pub command: &'a str,
-    pub shell: &'a str,
-    pub login: bool,
+pub(crate) struct ExecCommandRequest {
+    pub command: Vec<String>,
     pub yield_time_ms: Option<u64>,
     pub max_output_tokens: Option<usize>,
     pub workdir: Option<PathBuf>,
@@ -105,7 +103,7 @@ struct SessionEntry {
     session_ref: Arc<Session>,
     turn_ref: Arc<TurnContext>,
     call_id: String,
-    command: String,
+    command: Vec<String>,
     cwd: PathBuf,
     started_at: tokio::time::Instant,
 }
@@ -197,9 +195,7 @@ mod tests {
             .unified_exec_manager
             .exec_command(
                 ExecCommandRequest {
-                    command: cmd,
-                    shell: "/bin/bash",
-                    login: true,
+                    command: vec!["bash".to_string(), "-lc".to_string(), cmd.to_string()],
                     yield_time_ms,
                     max_output_tokens: None,
                     workdir: None,

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -137,7 +137,7 @@ fn collect_tool_outputs(bodies: &[Value]) -> Result<HashMap<String, ParsedUnifie
                     let content = extract_output_text(item)
                         .ok_or_else(|| anyhow::anyhow!("missing tool output content"))?;
                     let trimmed = content.trim();
-                if trimmed.is_empty() {
+                    if trimmed.is_empty() {
                         continue;
                     }
                     let parsed = parse_unified_exec_output(content).with_context(|| {

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -215,7 +215,7 @@ async fn unified_exec_emits_exec_command_begin_event() -> Result<()> {
     assert_eq!(
         begin_event.command,
         vec![
-            "bash".to_string(),
+            "/bin/bash".to_string(),
             "-lc".to_string(),
             "/bin/echo hello unified exec".to_string()
         ]

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -214,7 +214,11 @@ async fn unified_exec_emits_exec_command_begin_event() -> Result<()> {
 
     assert_eq!(
         begin_event.command,
-        vec!["/bin/echo hello unified exec".to_string()]
+        vec![
+            "bash".to_string(),
+            "-lc".to_string(),
+            "/bin/echo hello unified exec".to_string()
+        ]
     );
     assert_eq!(begin_event.cwd, cwd.path());
 
@@ -654,7 +658,14 @@ async fn unified_exec_skips_begin_event_for_empty_input() -> Result<()> {
         "expected only the initial command to emit begin event"
     );
     assert_eq!(begin_events[0].call_id, open_call_id);
-    assert_eq!(begin_events[0].command[0], "/bin/sh -c echo ready");
+    assert_eq!(
+        begin_events[0].command,
+        vec![
+            "/bin/bash".to_string(),
+            "-lc".to_string(),
+            "/bin/sh -c echo ready".to_string()
+        ]
+    );
 
     Ok(())
 }

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -137,7 +137,7 @@ fn collect_tool_outputs(bodies: &[Value]) -> Result<HashMap<String, ParsedUnifie
                     let content = extract_output_text(item)
                         .ok_or_else(|| anyhow::anyhow!("missing tool output content"))?;
                     let trimmed = content.trim();
-                    if trimmed.is_empty() {
+                if trimmed.is_empty() {
                         continue;
                     }
                     let parsed = parse_unified_exec_output(content).with_context(|| {


### PR DESCRIPTION
This fixes command display for unified exec. All `cd`s and `ls`es are now parsed.

<img width="452" height="237" alt="image" src="https://github.com/user-attachments/assets/ce92d81f-f74c-485a-9b34-1eaa29290ec6" />

Deletes a ton of tests that were doing nothing from shell.rs.