### PR TITLE
Fix /status rate-limit progress bars

### DIFF
--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -215,9 +215,10 @@ impl StatusHistoryCell {
         let mut lines = Vec::with_capacity(rows.len().saturating_mul(2));
 
         for row in rows {
-            let percent_remaining = (100.0 - row.percent_used).clamp(0.0, 100.0);
+            let percent_used = row.percent_used.clamp(0.0, 100.0);
+            let percent_remaining = (100.0 - percent_used).clamp(0.0, 100.0);
             let value_spans = vec![
-                Span::from(render_status_limit_progress_bar(percent_remaining)),
+                Span::from(render_status_limit_progress_bar(percent_used)),
                 Span::from(" "),
                 Span::from(format_status_limit_summary(percent_remaining)),
             ];

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
@@ -18,5 +18,5 @@ expression: sanitized
 │                                                                            │
 │  Token usage:      1.2K total  (800 input + 400 output)                    │
 │  Context window:   100% left (1.2K used / 272K)                            │
-│  Monthly limit:    [██████████████████░░] 88% left (resets 07:08 on 7 May) │
+│  Monthly limit:    [██░░░░░░░░░░░░░░░░░░] 88% left (resets 07:08 on 7 May) │
 ╰────────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
@@ -18,6 +18,6 @@ expression: sanitized
 │                                                                     │
 │  Token usage:      1.9K total  (1K input + 900 output)              │
 │  Context window:   100% left (2.25K used / 272K)                    │
-│  5h limit:         [██████░░░░░░░░░░░░░░] 28% left (resets 03:14)   │
-│  Weekly limit:     [███████████░░░░░░░░░] 55% left (resets 03:24)   │
+│  5h limit:         [███████████████░░░░░] 28% left (resets 03:14)   │
+│  Weekly limit:     [█████████░░░░░░░░░░░] 55% left (resets 03:24)   │
 ╰─────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
@@ -18,7 +18,7 @@ expression: sanitized
 │                                                                     │
 │  Token usage:      1.9K total  (1K input + 900 output)              │
 │  Context window:   100% left (2.25K used / 272K)                    │
-│  5h limit:         [██████░░░░░░░░░░░░░░] 28% left (resets 03:14)   │
-│  Weekly limit:     [████████████░░░░░░░░] 60% left (resets 03:34)   │
+│  5h limit:         [███████████████░░░░░] 28% left (resets 03:14)   │
+│  Weekly limit:     [████████░░░░░░░░░░░░] 60% left (resets 03:34)   │
 │  Warning:          limits may be stale - start new turn to refresh. │
 ╰─────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
@@ -19,6 +19,6 @@ expression: sanitized
 │                                            │
 │  Token usage:      1.9K total  (1K input + │
 │  Context window:   100% left (2.25K used / │
-│  5h limit:         [██████░░░░░░░░░░░░░░]  │
+│  5h limit:         [███████████████░░░░░]  │
 │                    (resets 03:14)          │
 ╰────────────────────────────────────────────╯


### PR DESCRIPTION
## Summary
- Fix the `/status` rate-limit bars so the filled portion reflects percent used instead of percent remaining (Fixes #6617)
- Refresh the `/status` snapshots so the textual percentages and glyph bars stay consistent

## Commands ran
- `cargo test -p codex-tui`
- `just fix -p codex-tui`
- `cargo clippy --all-features --tests -p codex-tui`
- `cargo insta accept --manifest-path tui/Cargo.toml`