### PR TITLE
Align /status limit bar color with web ui and improve contrast

### DIFF
--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -216,11 +216,9 @@ impl StatusHistoryCell {
 
         for row in rows {
             let percent_remaining = (100.0 - row.percent_used).clamp(0.0, 100.0);
-            let value_spans = vec![
-                Span::from(render_status_limit_progress_bar(percent_remaining)),
-                Span::from(" "),
-                Span::from(format_status_limit_summary(percent_remaining)),
-            ];
+            let mut value_spans = render_status_limit_progress_bar(percent_remaining);
+            value_spans.push(Span::from(" "));
+            value_spans.push(Span::from(format_status_limit_summary(percent_remaining)));
             let base_spans = formatter.full_spans(row.label.as_str(), value_spans);
             let base_line = Line::from(base_spans.clone());
 

--- a/codex-rs/tui/src/status/rate_limits.rs
+++ b/codex-rs/tui/src/status/rate_limits.rs
@@ -7,6 +7,9 @@ use chrono::Local;
 use chrono::Utc;
 use codex_core::protocol::RateLimitSnapshot;
 use codex_core::protocol::RateLimitWindow;
+use ratatui::style::Color;
+use ratatui::style::Stylize;
+use ratatui::text::Span;
 
 const STATUS_LIMIT_BAR_SEGMENTS: usize = 20;
 const STATUS_LIMIT_BAR_FILLED: &str = "█";
@@ -124,16 +127,21 @@ pub(crate) fn compose_rate_limit_data(
     }
 }
 
-pub(crate) fn render_status_limit_progress_bar(percent_remaining: f64) -> String {
+pub(crate) fn render_status_limit_progress_bar(percent_remaining: f64) -> Vec<Span<'static>> {
     let ratio = (percent_remaining / 100.0).clamp(0.0, 1.0);
     let filled = (ratio * STATUS_LIMIT_BAR_SEGMENTS as f64).round() as usize;
     let filled = filled.min(STATUS_LIMIT_BAR_SEGMENTS);
     let empty = STATUS_LIMIT_BAR_SEGMENTS.saturating_sub(filled);
-    format!(
-        "[{}{}]",
-        STATUS_LIMIT_BAR_FILLED.repeat(filled),
-        STATUS_LIMIT_BAR_EMPTY.repeat(empty)
-    )
+    let mut spans = Vec::with_capacity(2 + STATUS_LIMIT_BAR_SEGMENTS);
+    spans.push("[".into());
+    if filled > 0 {
+        spans.push(Span::from(STATUS_LIMIT_BAR_FILLED.repeat(filled)).fg(Color::Rgb(0, 128, 0)));
+    }
+    if empty > 0 {
+        spans.push(Span::from(STATUS_LIMIT_BAR_EMPTY.repeat(empty)));
+    }
+    spans.push("]".into());
+    spans
 }
 
 pub(crate) fn format_status_limit_summary(percent_remaining: f64) -> String {

--- a/codex-rs/tui/src/status/rate_limits.rs
+++ b/codex-rs/tui/src/status/rate_limits.rs
@@ -7,13 +7,12 @@ use chrono::Local;
 use chrono::Utc;
 use codex_core::protocol::RateLimitSnapshot;
 use codex_core::protocol::RateLimitWindow;
-use ratatui::style::Color;
 use ratatui::style::Stylize;
 use ratatui::text::Span;
 
 const STATUS_LIMIT_BAR_SEGMENTS: usize = 20;
 const STATUS_LIMIT_BAR_FILLED: &str = "█";
-const STATUS_LIMIT_BAR_EMPTY: &str = "░";
+const STATUS_LIMIT_BAR_EMPTY: &str = " ";
 
 #[derive(Debug, Clone)]
 pub(crate) struct StatusRateLimitRow {
@@ -135,7 +134,11 @@ pub(crate) fn render_status_limit_progress_bar(percent_remaining: f64) -> Vec<Sp
     let mut spans = Vec::with_capacity(2 + STATUS_LIMIT_BAR_SEGMENTS);
     spans.push("[".into());
     if filled > 0 {
-        spans.push(Span::from(STATUS_LIMIT_BAR_FILLED.repeat(filled)).fg(Color::Rgb(0, 128, 0)));
+        spans.push(
+            Span::from(STATUS_LIMIT_BAR_FILLED.repeat(filled))
+                .green()
+                .dim(),
+        );
     }
     if empty > 0 {
         spans.push(Span::from(STATUS_LIMIT_BAR_EMPTY.repeat(empty)));

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_monthly_limit.snap
@@ -18,5 +18,5 @@ expression: sanitized
 │                                                                            │
 │  Token usage:      1.2K total  (800 input + 400 output)                    │
 │  Context window:   100% left (1.2K used / 272K)                            │
-│  Monthly limit:    [██████████████████░░] 88% left (resets 07:08 on 7 May) │
+│  Monthly limit:    [██████████████████  ] 88% left (resets 07:08 on 7 May) │
 ╰────────────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_reasoning_details.snap
@@ -18,6 +18,6 @@ expression: sanitized
 │                                                                     │
 │  Token usage:      1.9K total  (1K input + 900 output)              │
 │  Context window:   100% left (2.25K used / 272K)                    │
-│  5h limit:         [██████░░░░░░░░░░░░░░] 28% left (resets 03:14)   │
-│  Weekly limit:     [███████████░░░░░░░░░] 55% left (resets 03:24)   │
+│  5h limit:         [██████              ] 28% left (resets 03:14)   │
+│  Weekly limit:     [███████████         ] 55% left (resets 03:24)   │
 ╰─────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_shows_stale_limits_message.snap
@@ -18,7 +18,7 @@ expression: sanitized
 │                                                                     │
 │  Token usage:      1.9K total  (1K input + 900 output)              │
 │  Context window:   100% left (2.25K used / 272K)                    │
-│  5h limit:         [██████░░░░░░░░░░░░░░] 28% left (resets 03:14)   │
-│  Weekly limit:     [████████████░░░░░░░░] 60% left (resets 03:34)   │
+│  5h limit:         [██████              ] 28% left (resets 03:14)   │
+│  Weekly limit:     [████████████        ] 60% left (resets 03:34)   │
 │  Warning:          limits may be stale - start new turn to refresh. │
 ╰─────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_truncates_in_narrow_terminal.snap
@@ -19,6 +19,6 @@ expression: sanitized
 │                                            │
 │  Token usage:      1.9K total  (1K input + │
 │  Context window:   100% left (2.25K used / │
-│  5h limit:         [██████░░░░░░░░░░░░░░]  │
+│  5h limit:         [██████              ]  │
 │                    (resets 03:14)          │
 ╰────────────────────────────────────────────╯


### PR DESCRIPTION
## Summary
- Keep current behavior, already aligned with web ui gauge bar (https://github.com/openai/codex/pull/6482), but make the filled portion with dimmed green glyphs (Fixes #6617)
- Mutually exclusive with PR https://github.com/openai/codex/pull/6621

## Commands ran
- `cargo test -p codex-tui`
- `just fix -p codex-tui`
- `cargo clippy --all-features --tests -p codex-tui`
- `cargo insta accept --manifest-path tui/Cargo.toml`

## Example
<img width="452" height="48" alt="image" src="https://github.com/user-attachments/assets/44d75d24-9c30-4cd4-9c85-0de0ef925c04" />
