### PR TITLE
execpolicy2 extension

### DIFF
--- a/codex-rs/execpolicy2/README.md
+++ b/codex-rs/execpolicy2/README.md
@@ -45,9 +45,13 @@ prefix_rule(
 - The effective `decision` is the strictest severity across all matches (`forbidden` > `prompt` > `allow`).
 
 ## CLI
-- Provide a policy file (for example `src/default.codexpolicy`) to check a command:
+- Provide one or more policy files (for example `src/default.codexpolicy`) to check a command:
 ```bash
 cargo run -p codex-execpolicy2 -- check --policy path/to/policy.codexpolicy git status
+```
+- Pass multiple `--policy` flags to merge rules, evaluated in the order provided:
+```bash
+cargo run -p codex-execpolicy2 -- check --policy base.codexpolicy --policy overrides.codexpolicy git status
 ```
 - Example outcomes:
   - Match: `{"match": { ... "decision": "allow" ... }}`

--- a/codex-rs/execpolicy2/README.md
+++ b/codex-rs/execpolicy2/README.md
@@ -53,6 +53,7 @@ cargo run -p codex-execpolicy2 -- check --policy path/to/policy.codexpolicy git 
 ```bash
 cargo run -p codex-execpolicy2 -- check --policy base.codexpolicy --policy overrides.codexpolicy git status
 ```
+- Output is newline-delimited JSON by default; pass `--pretty` for pretty-printed JSON if desired.
 - Example outcomes:
   - Match: `{"match": { ... "decision": "allow" ... }}`
   - No match: `"noMatch"`

--- a/codex-rs/execpolicy2/src/main.rs
+++ b/codex-rs/execpolicy2/src/main.rs
@@ -43,19 +43,12 @@ fn cmd_check(policies: Vec<PathBuf>, args: Vec<String>) -> Result<()> {
 }
 
 fn load_policies(policy_paths: &[PathBuf]) -> Result<codex_execpolicy2::Policy> {
-    let loaded_policies: Vec<(String, String)> = policy_paths
-        .iter()
-        .map(|policy_path| {
-            let policy_file_contents = fs::read_to_string(policy_path)
-                .with_context(|| format!("failed to read policy at {}", policy_path.display()))?;
-            let policy_identifier = policy_path.to_string_lossy().to_string();
-            Ok((policy_identifier, policy_file_contents))
-        })
-        .collect::<Result<_>>()
-        .context("failed to load policy files")?;
     let mut parser = PolicyParser::new();
-    for (policy_identifier, policy_file_contents) in &loaded_policies {
-        parser.parse(policy_identifier, policy_file_contents)?;
+    for policy_path in policy_paths {
+        let policy_file_contents = fs::read_to_string(policy_path)
+            .with_context(|| format!("failed to read policy at {}", policy_path.display()))?;
+        let policy_identifier = policy_path.to_string_lossy().to_string();
+        parser.parse(&policy_identifier, &policy_file_contents)?;
     }
     Ok(parser.build())
 }

--- a/codex-rs/execpolicy2/src/main.rs
+++ b/codex-rs/execpolicy2/src/main.rs
@@ -53,9 +53,9 @@ fn load_policies(policy_paths: &[PathBuf]) -> Result<codex_execpolicy2::Policy> 
         })
         .collect::<Result<_>>()
         .context("failed to load policy files")?;
-    Ok(PolicyParser::parse_many(loaded_policies.iter().map(
-        |(policy_identifier, policy_file_contents)| {
-            (policy_identifier.as_str(), policy_file_contents.as_str())
-        },
-    ))?)
+    let mut parser = PolicyParser::new();
+    for (policy_identifier, policy_file_contents) in &loaded_policies {
+        parser.parse(policy_identifier, policy_file_contents)?;
+    }
+    Ok(parser.build())
 }

--- a/codex-rs/execpolicy2/src/main.rs
+++ b/codex-rs/execpolicy2/src/main.rs
@@ -1,5 +1,4 @@
 use std::fs;
-use std::path::Path;
 use std::path::PathBuf;
 
 use anyhow::Context;
@@ -13,8 +12,8 @@ use codex_execpolicy2::PolicyParser;
 enum Cli {
     /// Evaluate a command against a policy.
     Check {
-        #[arg(short, long, value_name = "PATH")]
-        policy: PathBuf,
+        #[arg(short, long, value_name = "PATH", required = true)]
+        policies: Vec<PathBuf>,
 
         /// Command tokens to check.
         #[arg(
@@ -30,12 +29,12 @@ enum Cli {
 fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli {
-        Cli::Check { policy, command } => cmd_check(policy, command),
+        Cli::Check { policies, command } => cmd_check(policies, command),
     }
 }
 
-fn cmd_check(policy_path: PathBuf, args: Vec<String>) -> Result<()> {
-    let policy = load_policy(&policy_path)?;
+fn cmd_check(policies: Vec<PathBuf>, args: Vec<String>) -> Result<()> {
+    let policy = load_policies(&policies)?;
 
     let eval = policy.check(&args);
     let json = serde_json::to_string_pretty(&eval)?;
@@ -43,12 +42,20 @@ fn cmd_check(policy_path: PathBuf, args: Vec<String>) -> Result<()> {
     Ok(())
 }
 
-fn load_policy(policy_path: &Path) -> Result<codex_execpolicy2::Policy> {
-    let policy_file_contents = fs::read_to_string(policy_path)
-        .with_context(|| format!("failed to read policy at {}", policy_path.display()))?;
-    let policy_identifier = policy_path.to_string_lossy();
-    Ok(PolicyParser::parse(
-        policy_identifier.as_ref(),
-        &policy_file_contents,
-    )?)
+fn load_policies(policy_paths: &[PathBuf]) -> Result<codex_execpolicy2::Policy> {
+    let loaded_policies: Vec<(String, String)> = policy_paths
+        .iter()
+        .map(|policy_path| {
+            let policy_file_contents = fs::read_to_string(policy_path)
+                .with_context(|| format!("failed to read policy at {}", policy_path.display()))?;
+            let policy_identifier = policy_path.to_string_lossy().to_string();
+            Ok((policy_identifier, policy_file_contents))
+        })
+        .collect::<Result<_>>()
+        .context("failed to load policy files")?;
+    Ok(PolicyParser::parse_many(loaded_policies.iter().map(
+        |(policy_identifier, policy_file_contents)| {
+            (policy_identifier.as_str(), policy_file_contents.as_str())
+        },
+    ))?)
 }

--- a/codex-rs/execpolicy2/src/main.rs
+++ b/codex-rs/execpolicy2/src/main.rs
@@ -12,7 +12,7 @@ use codex_execpolicy2::PolicyParser;
 enum Cli {
     /// Evaluate a command against a policy.
     Check {
-        #[arg(short, long, value_name = "PATH", required = true)]
+        #[arg(short, long = "policy", value_name = "PATH", required = true)]
         policies: Vec<PathBuf>,
 
         /// Command tokens to check.
@@ -33,8 +33,8 @@ fn main() -> Result<()> {
     }
 }
 
-fn cmd_check(policies: Vec<PathBuf>, args: Vec<String>) -> Result<()> {
-    let policy = load_policies(&policies)?;
+fn cmd_check(policy_paths: Vec<PathBuf>, args: Vec<String>) -> Result<()> {
+    let policy = load_policies(&policy_paths)?;
 
     let eval = policy.check(&args);
     let json = serde_json::to_string_pretty(&eval)?;

--- a/codex-rs/execpolicy2/src/main.rs
+++ b/codex-rs/execpolicy2/src/main.rs
@@ -15,6 +15,10 @@ enum Cli {
         #[arg(short, long = "policy", value_name = "PATH", required = true)]
         policies: Vec<PathBuf>,
 
+        /// Pretty-print the JSON output.
+        #[arg(long)]
+        pretty: bool,
+
         /// Command tokens to check.
         #[arg(
             value_name = "COMMAND",
@@ -29,15 +33,23 @@ enum Cli {
 fn main() -> Result<()> {
     let cli = Cli::parse();
     match cli {
-        Cli::Check { policies, command } => cmd_check(policies, command),
+        Cli::Check {
+            policies,
+            command,
+            pretty,
+        } => cmd_check(policies, command, pretty),
     }
 }
 
-fn cmd_check(policy_paths: Vec<PathBuf>, args: Vec<String>) -> Result<()> {
+fn cmd_check(policy_paths: Vec<PathBuf>, args: Vec<String>, pretty: bool) -> Result<()> {
     let policy = load_policies(&policy_paths)?;
 
     let eval = policy.check(&args);
-    let json = serde_json::to_string_pretty(&eval)?;
+    let json = if pretty {
+        serde_json::to_string_pretty(&eval)?
+    } else {
+        serde_json::to_string(&eval)?
+    };
     println!("{json}");
     Ok(())
 }

--- a/codex-rs/execpolicy2/src/parser.rs
+++ b/codex-rs/execpolicy2/src/parser.rs
@@ -47,17 +47,19 @@ impl PolicyParser {
     pub fn parse(&mut self, policy_identifier: &str, policy_file_contents: &str) -> Result<()> {
         let mut dialect = Dialect::Extended.clone();
         dialect.enable_f_strings = true;
-        let globals = GlobalsBuilder::standard().with(policy_builtins).build();
         let ast = AstModule::parse(
             policy_identifier,
             policy_file_contents.to_string(),
             &dialect,
         )
         .map_err(Error::Starlark)?;
+        let globals = GlobalsBuilder::standard().with(policy_builtins).build();
         let module = Module::new();
-        let mut eval = Evaluator::new(&module);
-        eval.extra = Some(&self.builder);
-        eval.eval_module(ast, &globals).map_err(Error::Starlark)?;
+        {
+            let mut eval = Evaluator::new(&module);
+            eval.extra = Some(&self.builder);
+            eval.eval_module(ast, &globals).map_err(Error::Starlark)?;
+        }
         Ok(())
     }
 

--- a/codex-rs/execpolicy2/tests/basic.rs
+++ b/codex-rs/execpolicy2/tests/basic.rs
@@ -41,7 +41,11 @@ prefix_rule(
     pattern = ["git", "status"],
 )
     "#;
-    let policy = PolicyParser::parse("test.codexpolicy", policy_src).expect("parse policy");
+    let mut parser = PolicyParser::new();
+    parser
+        .parse("test.codexpolicy", policy_src)
+        .expect("parse policy");
+    let policy = parser.build();
     let cmd = tokens(&["git", "status"]);
     let evaluation = policy.check(&cmd);
     assert_eq!(
@@ -70,12 +74,14 @@ prefix_rule(
     decision = "forbidden",
 )
     "#;
-
-    let policy = PolicyParser::parse_many([
-        ("first.codexpolicy", first_policy),
-        ("second.codexpolicy", second_policy),
-    ])
-    .expect("parse policy");
+    let mut parser = PolicyParser::new();
+    parser
+        .parse("first.codexpolicy", first_policy)
+        .expect("parse policy");
+    parser
+        .parse("second.codexpolicy", second_policy)
+        .expect("parse policy");
+    let policy = parser.build();
 
     let git_rules = rule_snapshots(policy.rules().get_vec("git").expect("git rules"));
     assert_eq!(
@@ -136,7 +142,11 @@ prefix_rule(
     pattern = [["bash", "sh"], ["-c", "-l"]],
 )
     "#;
-    let policy = PolicyParser::parse("test.codexpolicy", policy_src).expect("parse policy");
+    let mut parser = PolicyParser::new();
+    parser
+        .parse("test.codexpolicy", policy_src)
+        .expect("parse policy");
+    let policy = parser.build();
 
     let bash_rules = rule_snapshots(policy.rules().get_vec("bash").expect("bash rules"));
     let sh_rules = rule_snapshots(policy.rules().get_vec("sh").expect("sh rules"));
@@ -193,7 +203,11 @@ prefix_rule(
     pattern = ["npm", ["i", "install"], ["--legacy-peer-deps", "--no-save"]],
 )
     "#;
-    let policy = PolicyParser::parse("test.codexpolicy", policy_src).expect("parse policy");
+    let mut parser = PolicyParser::new();
+    parser
+        .parse("test.codexpolicy", policy_src)
+        .expect("parse policy");
+    let policy = parser.build();
 
     let rules = rule_snapshots(policy.rules().get_vec("npm").expect("npm rules"));
     assert_eq!(
@@ -251,7 +265,11 @@ prefix_rule(
     ],
 )
     "#;
-    let policy = PolicyParser::parse("test.codexpolicy", policy_src).expect("parse policy");
+    let mut parser = PolicyParser::new();
+    parser
+        .parse("test.codexpolicy", policy_src)
+        .expect("parse policy");
+    let policy = parser.build();
     let match_eval = policy.check(&tokens(&["git", "status"]));
     assert_eq!(
         Evaluation::Match {
@@ -289,7 +307,11 @@ prefix_rule(
     decision = "forbidden",
 )
     "#;
-    let policy = PolicyParser::parse("test.codexpolicy", policy_src).expect("parse policy");
+    let mut parser = PolicyParser::new();
+    parser
+        .parse("test.codexpolicy", policy_src)
+        .expect("parse policy");
+    let policy = parser.build();
 
     let status = policy.check(&tokens(&["git", "status"]));
     assert_eq!(
@@ -344,7 +366,11 @@ prefix_rule(
     decision = "forbidden",
 )
     "#;
-    let policy = PolicyParser::parse("test.codexpolicy", policy_src).expect("parse policy");
+    let mut parser = PolicyParser::new();
+    parser
+        .parse("test.codexpolicy", policy_src)
+        .expect("parse policy");
+    let policy = parser.build();
 
     let commands = vec![
         tokens(&["git", "status"]),

--- a/codex-rs/execpolicy2/tests/basic.rs
+++ b/codex-rs/execpolicy2/tests/basic.rs
@@ -296,11 +296,11 @@ fn strictest_decision_wins_across_matches() {
     let policy_src = r#"
 prefix_rule(
     pattern = ["git", "status"],
-    decision = "allow",
+    decision = "prompt",
 )
 prefix_rule(
     pattern = ["git"],
-    decision = "prompt",
+    decision = "allow",
 )
 prefix_rule(
     pattern = ["git", "commit"],
@@ -320,11 +320,11 @@ prefix_rule(
             matched_rules: vec![
                 RuleMatch::PrefixRuleMatch {
                     matched_prefix: tokens(&["git", "status"]),
-                    decision: Decision::Allow,
+                    decision: Decision::Prompt,
                 },
                 RuleMatch::PrefixRuleMatch {
                     matched_prefix: tokens(&["git"]),
-                    decision: Decision::Prompt,
+                    decision: Decision::Allow,
                 },
             ],
         },
@@ -338,7 +338,7 @@ prefix_rule(
             matched_rules: vec![
                 RuleMatch::PrefixRuleMatch {
                     matched_prefix: tokens(&["git"]),
-                    decision: Decision::Prompt,
+                    decision: Decision::Allow,
                 },
                 RuleMatch::PrefixRuleMatch {
                     matched_prefix: tokens(&["git", "commit"]),

--- a/codex-rs/execpolicy2/tests/basic.rs
+++ b/codex-rs/execpolicy2/tests/basic.rs
@@ -355,11 +355,11 @@ fn strictest_decision_across_multiple_commands() {
     let policy_src = r#"
 prefix_rule(
     pattern = ["git", "status"],
-    decision = "allow",
+    decision = "prompt",
 )
 prefix_rule(
     pattern = ["git"],
-    decision = "prompt",
+    decision = "allow",
 )
 prefix_rule(
     pattern = ["git", "commit"],
@@ -384,15 +384,15 @@ prefix_rule(
             matched_rules: vec![
                 RuleMatch::PrefixRuleMatch {
                     matched_prefix: tokens(&["git", "status"]),
+                    decision: Decision::Prompt,
+                },
+                RuleMatch::PrefixRuleMatch {
+                    matched_prefix: tokens(&["git"]),
                     decision: Decision::Allow,
                 },
                 RuleMatch::PrefixRuleMatch {
                     matched_prefix: tokens(&["git"]),
-                    decision: Decision::Prompt,
-                },
-                RuleMatch::PrefixRuleMatch {
-                    matched_prefix: tokens(&["git"]),
-                    decision: Decision::Prompt,
+                    decision: Decision::Allow,
                 },
                 RuleMatch::PrefixRuleMatch {
                     matched_prefix: tokens(&["git", "commit"]),

--- a/codex-rs/execpolicy2/tests/basic.rs
+++ b/codex-rs/execpolicy2/tests/basic.rs
@@ -295,12 +295,8 @@ prefix_rule(
 fn strictest_decision_wins_across_matches() {
     let policy_src = r#"
 prefix_rule(
-    pattern = ["git", "status"],
-    decision = "prompt",
-)
-prefix_rule(
     pattern = ["git"],
-    decision = "allow",
+    decision = "prompt",
 )
 prefix_rule(
     pattern = ["git", "commit"],
@@ -313,24 +309,6 @@ prefix_rule(
         .expect("parse policy");
     let policy = parser.build();
 
-    let status = policy.check(&tokens(&["git", "status"]));
-    assert_eq!(
-        Evaluation::Match {
-            decision: Decision::Prompt,
-            matched_rules: vec![
-                RuleMatch::PrefixRuleMatch {
-                    matched_prefix: tokens(&["git", "status"]),
-                    decision: Decision::Prompt,
-                },
-                RuleMatch::PrefixRuleMatch {
-                    matched_prefix: tokens(&["git"]),
-                    decision: Decision::Allow,
-                },
-            ],
-        },
-        status
-    );
-
     let commit = policy.check(&tokens(&["git", "commit", "-m", "hi"]));
     assert_eq!(
         Evaluation::Match {
@@ -338,7 +316,7 @@ prefix_rule(
             matched_rules: vec![
                 RuleMatch::PrefixRuleMatch {
                     matched_prefix: tokens(&["git"]),
-                    decision: Decision::Allow,
+                    decision: Decision::Prompt,
                 },
                 RuleMatch::PrefixRuleMatch {
                     matched_prefix: tokens(&["git", "commit"]),
@@ -354,12 +332,8 @@ prefix_rule(
 fn strictest_decision_across_multiple_commands() {
     let policy_src = r#"
 prefix_rule(
-    pattern = ["git", "status"],
-    decision = "prompt",
-)
-prefix_rule(
     pattern = ["git"],
-    decision = "allow",
+    decision = "prompt",
 )
 prefix_rule(
     pattern = ["git", "commit"],
@@ -383,16 +357,12 @@ prefix_rule(
             decision: Decision::Forbidden,
             matched_rules: vec![
                 RuleMatch::PrefixRuleMatch {
-                    matched_prefix: tokens(&["git", "status"]),
+                    matched_prefix: tokens(&["git"]),
                     decision: Decision::Prompt,
                 },
                 RuleMatch::PrefixRuleMatch {
                     matched_prefix: tokens(&["git"]),
-                    decision: Decision::Allow,
-                },
-                RuleMatch::PrefixRuleMatch {
-                    matched_prefix: tokens(&["git"]),
-                    decision: Decision::Allow,
+                    decision: Decision::Prompt,
                 },
                 RuleMatch::PrefixRuleMatch {
                     matched_prefix: tokens(&["git", "commit"]),


### PR DESCRIPTION
- enabling execpolicy2 parser to parse multiple policy files to build a combined `Policy` (useful if codex detects many `.codexpolicy` files)
- adding functionality to `Policy` to allow evaluation of multiple cmds at once (useful when we have chained commands)