### PR TITLE
Enable TUI notifications by default

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1323,7 +1323,7 @@ persistence = "none"
     }
 
     #[test]
-    fn tui_config_missing_notifications_field_defaults_to_disabled() {
+    fn tui_config_missing_notifications_field_defaults_to_enabled() {
         let cfg = r#"
 [tui]
 "#;
@@ -1332,7 +1332,7 @@ persistence = "none"
             .expect("TUI config without notifications should succeed");
         let tui = parsed.tui.expect("config should include tui section");
 
-        assert_eq!(tui.notifications, Notifications::Enabled(false));
+        assert_eq!(tui.notifications, Notifications::Enabled(true));
     }
 
     #[test]

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -338,7 +338,7 @@ pub enum Notifications {
 
 impl Default for Notifications {
     fn default() -> Self {
-        Self::Enabled(false)
+        Self::Enabled(true)
     }
 }
 
@@ -346,7 +346,7 @@ impl Default for Notifications {
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct Tui {
     /// Enable desktop notifications from the TUI when the terminal is unfocused.
-    /// Defaults to `false`.
+    /// Defaults to `true`.
     #[serde(default)]
     pub notifications: Notifications,
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -856,7 +856,7 @@ Options that are specific to the TUI.
 ```toml
 [tui]
 # Send desktop notifications when approvals are required or a turn completes.
-# Defaults to false.
+# Defaults to true.
 notifications = true
 
 # You can optionally filter to specific notification types.
@@ -947,7 +947,7 @@ Valid values:
 | `history.max_bytes`                              | number                                                            | Currently ignored (not enforced).                                                                                          |
 | `file_opener`                                    | `vscode` \| `vscode-insiders` \| `windsurf` \| `cursor` \| `none` | URI scheme for clickable citations (default: `vscode`).                                                                    |
 | `tui`                                            | table                                                             | TUI‑specific options.                                                                                                      |
-| `tui.notifications`                              | boolean \| array<string>                                          | Enable desktop notifications in the tui (default: false).                                                                  |
+| `tui.notifications`                              | boolean \| array<string>                                          | Enable desktop notifications in the tui (default: true).                                                                   |
 | `hide_agent_reasoning`                           | boolean                                                           | Hide model reasoning events.                                                                                               |
 | `show_raw_agent_reasoning`                       | boolean                                                           | Show raw reasoning (when available).                                                                                       |
 | `model_reasoning_effort`                         | `minimal` \| `low` \| `medium` \| `high`                          | Responses API reasoning effort.                                                                                            |

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -136,8 +136,8 @@ file_opener = "vscode"
 ################################################################################
 
 [tui]
-# Desktop notifications from the TUI: boolean or filtered list. Default: false
-# Examples: true | ["agent-turn-complete", "approval-requested"]
+# Desktop notifications from the TUI: boolean or filtered list. Default: true
+# Examples: false | ["agent-turn-complete", "approval-requested"]
 notifications = false
 
 # Suppress internal reasoning events from output (default: false)


### PR DESCRIPTION
## Summary
- default the `tui.notifications` setting to enabled so desktop notifications work out of the box
- update configuration tests and documentation to reflect the new default

## Testing
- `cargo test -p codex-core` *(fails: `exec::tests::kill_child_process_group_kills_grandchildren_on_timeout` is flaky in this sandbox because the spawned grandchild process stays alive)*
- `cargo test -p codex-core exec::tests::kill_child_process_group_kills_grandchildren_on_timeout` *(fails: same sandbox limitation as above)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69166f811144832c9e8aaf8ee2642373)