### PR TITLE
Add Linux and Windows code signing to release workflow

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -136,15 +136,30 @@ jobs:
           done
 
       - if: ${{ contains(matrix.target, 'windows') }}
+        name: Azure login for Trusted Signing (OIDC)
+        uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_TRUSTED_SIGNING_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TRUSTED_SIGNING_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_TRUSTED_SIGNING_SUBSCRIPTION_ID }}
+
+      - if: ${{ contains(matrix.target, 'windows') }}
         name: Sign Windows binaries with Azure Trusted Signing
         uses: azure/trusted-signing-action@v0
         with:
           endpoint: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
-          code-signing-account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          trusted-signing-account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
           certificate-profile-name: ${{ secrets.AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE }}
-          app-registration-client-id: ${{ secrets.AZURE_TRUSTED_SIGNING_CLIENT_ID }}
-          app-registration-tenant-id: ${{ secrets.AZURE_TRUSTED_SIGNING_TENANT_ID }}
-          app-registration-client-secret: ${{ secrets.AZURE_TRUSTED_SIGNING_CLIENT_SECRET }}
+          exclude-environment-credential: true
+          exclude-workload-identity-credential: true
+          exclude-managed-identity-credential: true
+          exclude-shared-token-cache-credential: true
+          exclude-visual-studio-credential: true
+          exclude-visual-studio-code-credential: true
+          exclude-azure-cli-credential: false
+          exclude-azure-powershell-credential: true
+          exclude-azure-developer-cli-credential: true
+          exclude-interactive-browser-credential: true
           files: |
             ${{ github.workspace }}/codex-rs/target/${{ matrix.target }}/release/codex.exe
             ${{ github.workspace }}/codex-rs/target/${{ matrix.target }}/release/codex-responses-api-proxy.exe

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -8,8 +8,11 @@
 name: rust-release
 on:
   push:
+    branches:
+      - "**"
     tags:
       - "rust-v*.*.*"
+  pull_request:
 
 concurrency:
   group: ${{ github.workflow }}
@@ -17,6 +20,7 @@ concurrency:
 
 jobs:
   tag-check:
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -47,6 +51,7 @@ jobs:
 
   build:
     needs: tag-check
+    if: ${{ github.event_name == 'pull_request' || needs.tag-check.result == 'success' || needs.tag-check.result == 'skipped' }}
     name: Build - ${{ matrix.runner }} - ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
@@ -445,201 +450,201 @@ jobs:
           path: |
             codex-rs/dist/${{ matrix.target }}/*
 
-  shell-tool-mcp:
-    name: shell-tool-mcp
-    needs: tag-check
-    uses: ./.github/workflows/shell-tool-mcp.yml
-    with:
-      release-tag: ${{ github.ref_name }}
-      publish: true
-    secrets: inherit
+  # shell-tool-mcp:
+  #   name: shell-tool-mcp
+  #   needs: tag-check
+  #   uses: ./.github/workflows/shell-tool-mcp.yml
+  #   with:
+  #     release-tag: ${{ github.ref_name }}
+  #     publish: true
+  #   secrets: inherit
 
-  release:
-    needs:
-      - build
-      - shell-tool-mcp
-    name: release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      actions: read
-    outputs:
-      version: ${{ steps.release_name.outputs.name }}
-      tag: ${{ github.ref_name }}
-      should_publish_npm: ${{ steps.npm_publish_settings.outputs.should_publish }}
-      npm_tag: ${{ steps.npm_publish_settings.outputs.npm_tag }}
+  # release:
+  #   needs:
+  #     - build
+  #     - shell-tool-mcp
+  #   name: release
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     contents: write
+  #     actions: read
+  #   outputs:
+  #     version: ${{ steps.release_name.outputs.name }}
+  #     tag: ${{ github.ref_name }}
+  #     should_publish_npm: ${{ steps.npm_publish_settings.outputs.should_publish }}
+  #     npm_tag: ${{ steps.npm_publish_settings.outputs.npm_tag }}
 
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
+  #   steps:
+  #     - name: Checkout repository
+  #       uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
-        with:
-          path: dist
+  #     - uses: actions/download-artifact@v4
+  #       with:
+  #         path: dist
 
-      - name: List
-        run: ls -R dist/
+  #     - name: List
+  #       run: ls -R dist/
 
-      # This is a temporary fix: we should modify shell-tool-mcp.yml so these
-      # files do not end up in dist/ in the first place.
-      - name: Delete entries from dist/ that should not go in the release
-        run: |
-          rm -rf dist/shell-tool-mcp*
+  #     # This is a temporary fix: we should modify shell-tool-mcp.yml so these
+  #     # files do not end up in dist/ in the first place.
+  #     - name: Delete entries from dist/ that should not go in the release
+  #       run: |
+  #         rm -rf dist/shell-tool-mcp*
 
-          ls -R dist/
+  #         ls -R dist/
 
-      - name: Define release name
-        id: release_name
-        run: |
-          # Extract the version from the tag name, which is in the format
-          # "rust-v0.1.0".
-          version="${GITHUB_REF_NAME#rust-v}"
-          echo "name=${version}" >> $GITHUB_OUTPUT
+  #     - name: Define release name
+  #       id: release_name
+  #       run: |
+  #         # Extract the version from the tag name, which is in the format
+  #         # "rust-v0.1.0".
+  #         version="${GITHUB_REF_NAME#rust-v}"
+  #         echo "name=${version}" >> $GITHUB_OUTPUT
 
-      - name: Determine npm publish settings
-        id: npm_publish_settings
-        env:
-          VERSION: ${{ steps.release_name.outputs.name }}
-        run: |
-          set -euo pipefail
-          version="${VERSION}"
+  #     - name: Determine npm publish settings
+  #       id: npm_publish_settings
+  #       env:
+  #         VERSION: ${{ steps.release_name.outputs.name }}
+  #       run: |
+  #         set -euo pipefail
+  #         version="${VERSION}"
 
-          if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "should_publish=true" >> "$GITHUB_OUTPUT"
-            echo "npm_tag=" >> "$GITHUB_OUTPUT"
-          elif [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]; then
-            echo "should_publish=true" >> "$GITHUB_OUTPUT"
-            echo "npm_tag=alpha" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            echo "npm_tag=" >> "$GITHUB_OUTPUT"
-          fi
+  #         if [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  #           echo "should_publish=true" >> "$GITHUB_OUTPUT"
+  #           echo "npm_tag=" >> "$GITHUB_OUTPUT"
+  #         elif [[ "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+-alpha\.[0-9]+$ ]]; then
+  #           echo "should_publish=true" >> "$GITHUB_OUTPUT"
+  #           echo "npm_tag=alpha" >> "$GITHUB_OUTPUT"
+  #         else
+  #           echo "should_publish=false" >> "$GITHUB_OUTPUT"
+  #           echo "npm_tag=" >> "$GITHUB_OUTPUT"
+  #         fi
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
+  #     - name: Setup pnpm
+  #       uses: pnpm/action-setup@v4
+  #       with:
+  #         run_install: false
 
-      - name: Setup Node.js for npm packaging
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
+  #     - name: Setup Node.js for npm packaging
+  #       uses: actions/setup-node@v5
+  #       with:
+  #         node-version: 22
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+  #     - name: Install dependencies
+  #       run: pnpm install --frozen-lockfile
 
-      # stage_npm_packages.py requires DotSlash when staging releases.
-      - uses: facebook/install-dotslash@v2
-      - name: Stage npm packages
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          ./scripts/stage_npm_packages.py \
-            --release-version "${{ steps.release_name.outputs.name }}" \
-            --package codex \
-            --package codex-responses-api-proxy \
-            --package codex-sdk
+  #     # stage_npm_packages.py requires DotSlash when staging releases.
+  #     - uses: facebook/install-dotslash@v2
+  #     - name: Stage npm packages
+  #       env:
+  #         GH_TOKEN: ${{ github.token }}
+  #       run: |
+  #         ./scripts/stage_npm_packages.py \
+  #           --release-version "${{ steps.release_name.outputs.name }}" \
+  #           --package codex \
+  #           --package codex-responses-api-proxy \
+  #           --package codex-sdk
 
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          name: ${{ steps.release_name.outputs.name }}
-          tag_name: ${{ github.ref_name }}
-          files: dist/**
-          # Mark as prerelease only when the version has a suffix after x.y.z
-          # (e.g. -alpha, -beta). Otherwise publish a normal release.
-          prerelease: ${{ contains(steps.release_name.outputs.name, '-') }}
+  #     - name: Create GitHub Release
+  #       uses: softprops/action-gh-release@v2
+  #       with:
+  #         name: ${{ steps.release_name.outputs.name }}
+  #         tag_name: ${{ github.ref_name }}
+  #         files: dist/**
+  #         # Mark as prerelease only when the version has a suffix after x.y.z
+  #         # (e.g. -alpha, -beta). Otherwise publish a normal release.
+  #         prerelease: ${{ contains(steps.release_name.outputs.name, '-') }}
 
-      - uses: facebook/dotslash-publish-release@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag: ${{ github.ref_name }}
-          config: .github/dotslash-config.json
+  #     - uses: facebook/dotslash-publish-release@v2
+  #       env:
+  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       with:
+  #         tag: ${{ github.ref_name }}
+  #         config: .github/dotslash-config.json
 
-  # Publish to npm using OIDC authentication.
-  # July 31, 2025: https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
-  # npm docs: https://docs.npmjs.com/trusted-publishers
-  publish-npm:
-    # Publish to npm for stable releases and alpha pre-releases with numeric suffixes.
-    if: ${{ needs.release.outputs.should_publish_npm == 'true' }}
-    name: publish-npm
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write # Required for OIDC
-      contents: read
+  # # Publish to npm using OIDC authentication.
+  # # July 31, 2025: https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/
+  # # npm docs: https://docs.npmjs.com/trusted-publishers
+  # publish-npm:
+  #   # Publish to npm for stable releases and alpha pre-releases with numeric suffixes.
+  #   if: ${{ needs.release.outputs.should_publish_npm == 'true' }}
+  #   name: publish-npm
+  #   needs: release
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     id-token: write # Required for OIDC
+  #     contents: read
 
-    steps:
-      - name: Setup Node.js
-        uses: actions/setup-node@v5
-        with:
-          node-version: 22
-          registry-url: "https://registry.npmjs.org"
-          scope: "@openai"
+  #   steps:
+  #     - name: Setup Node.js
+  #       uses: actions/setup-node@v5
+  #       with:
+  #         node-version: 22
+  #         registry-url: "https://registry.npmjs.org"
+  #         scope: "@openai"
 
-      # Trusted publishing requires npm CLI version 11.5.1 or later.
-      - name: Update npm
-        run: npm install -g npm@latest
+  #     # Trusted publishing requires npm CLI version 11.5.1 or later.
+  #     - name: Update npm
+  #       run: npm install -g npm@latest
 
-      - name: Download npm tarballs from release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          version="${{ needs.release.outputs.version }}"
-          tag="${{ needs.release.outputs.tag }}"
-          mkdir -p dist/npm
-          gh release download "$tag" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --pattern "codex-npm-${version}.tgz" \
-            --dir dist/npm
-          gh release download "$tag" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --pattern "codex-responses-api-proxy-npm-${version}.tgz" \
-            --dir dist/npm
-          gh release download "$tag" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --pattern "codex-sdk-npm-${version}.tgz" \
-            --dir dist/npm
+  #     - name: Download npm tarballs from release
+  #       env:
+  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       run: |
+  #         set -euo pipefail
+  #         version="${{ needs.release.outputs.version }}"
+  #         tag="${{ needs.release.outputs.tag }}"
+  #         mkdir -p dist/npm
+  #         gh release download "$tag" \
+  #           --repo "${GITHUB_REPOSITORY}" \
+  #           --pattern "codex-npm-${version}.tgz" \
+  #           --dir dist/npm
+  #         gh release download "$tag" \
+  #           --repo "${GITHUB_REPOSITORY}" \
+  #           --pattern "codex-responses-api-proxy-npm-${version}.tgz" \
+  #           --dir dist/npm
+  #         gh release download "$tag" \
+  #           --repo "${GITHUB_REPOSITORY}" \
+  #           --pattern "codex-sdk-npm-${version}.tgz" \
+  #           --dir dist/npm
 
-      # No NODE_AUTH_TOKEN needed because we use OIDC.
-      - name: Publish to npm
-        env:
-          VERSION: ${{ needs.release.outputs.version }}
-          NPM_TAG: ${{ needs.release.outputs.npm_tag }}
-        run: |
-          set -euo pipefail
-          tag_args=()
-          if [[ -n "${NPM_TAG}" ]]; then
-            tag_args+=(--tag "${NPM_TAG}")
-          fi
+  #     # No NODE_AUTH_TOKEN needed because we use OIDC.
+  #     - name: Publish to npm
+  #       env:
+  #         VERSION: ${{ needs.release.outputs.version }}
+  #         NPM_TAG: ${{ needs.release.outputs.npm_tag }}
+  #       run: |
+  #         set -euo pipefail
+  #         tag_args=()
+  #         if [[ -n "${NPM_TAG}" ]]; then
+  #           tag_args+=(--tag "${NPM_TAG}")
+  #         fi
 
-          tarballs=(
-            "codex-npm-${VERSION}.tgz"
-            "codex-responses-api-proxy-npm-${VERSION}.tgz"
-            "codex-sdk-npm-${VERSION}.tgz"
-          )
+  #         tarballs=(
+  #           "codex-npm-${VERSION}.tgz"
+  #           "codex-responses-api-proxy-npm-${VERSION}.tgz"
+  #           "codex-sdk-npm-${VERSION}.tgz"
+  #         )
 
-          for tarball in "${tarballs[@]}"; do
-            npm publish "${GITHUB_WORKSPACE}/dist/npm/${tarball}" "${tag_args[@]}"
-          done
+  #         for tarball in "${tarballs[@]}"; do
+  #           npm publish "${GITHUB_WORKSPACE}/dist/npm/${tarball}" "${tag_args[@]}"
+  #         done
 
-  update-branch:
-    name: Update latest-alpha-cli branch
-    permissions:
-      contents: write
-    needs: release
-    runs-on: ubuntu-latest
+  # update-branch:
+  #   name: Update latest-alpha-cli branch
+  #   permissions:
+  #     contents: write
+  #   needs: release
+  #   runs-on: ubuntu-latest
 
-    steps:
-      - name: Update latest-alpha-cli branch
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          set -euo pipefail
-          gh api \
-            repos/${GITHUB_REPOSITORY}/git/refs/heads/latest-alpha-cli \
-            -X PATCH \
-            -f sha="${GITHUB_SHA}" \
-            -F force=true
+  #   steps:
+  #     - name: Update latest-alpha-cli branch
+  #       env:
+  #         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #       run: |
+  #         set -euo pipefail
+  #         gh api \
+  #           repos/${GITHUB_REPOSITORY}/git/refs/heads/latest-alpha-cli \
+  #           -X PATCH \
+  #           -f sha="${GITHUB_SHA}" \
+  #           -F force=true

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -50,6 +50,9 @@ jobs:
     name: Build - ${{ matrix.runner }} - ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: codex-rs
@@ -99,6 +102,52 @@ jobs:
 
       - name: Cargo build
         run: cargo build --target ${{ matrix.target }} --release --bin codex --bin codex-responses-api-proxy
+
+      - if: ${{ contains(matrix.target, 'linux') }}
+        name: Install cosign
+        uses: sigstore/cosign-installer@v3.7.0
+
+      - if: ${{ contains(matrix.target, 'linux') }}
+        name: Cosign Linux artifacts
+        shell: bash
+        env:
+          COSIGN_EXPERIMENTAL: "1"
+          COSIGN_YES: "true"
+          COSIGN_OIDC_CLIENT_ID: "sigstore"
+          COSIGN_OIDC_ISSUER: "https://oauth2.sigstore.dev/auth"
+        run: |
+          set -euo pipefail
+
+          dest="dist/${{ matrix.target }}"
+          if [[ ! -d "$dest" ]]; then
+            echo "Destination $dest does not exist"
+            exit 1
+          fi
+
+          shopt -s nullglob
+          for artifact in "$dest"/*; do
+            if [[ -f "$artifact" ]]; then
+              cosign sign-blob \
+                --yes \
+                --output-signature "${artifact}.sig" \
+                --output-certificate "${artifact}.pem" \
+                "$artifact"
+            fi
+          done
+
+      - if: ${{ contains(matrix.target, 'windows') }}
+        name: Sign Windows binaries with Azure Trusted Signing
+        uses: azure/trusted-signing-action@v0
+        with:
+          endpoint: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          code-signing-account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE }}
+          app-registration-client-id: ${{ secrets.AZURE_TRUSTED_SIGNING_CLIENT_ID }}
+          app-registration-tenant-id: ${{ secrets.AZURE_TRUSTED_SIGNING_TENANT_ID }}
+          app-registration-client-secret: ${{ secrets.AZURE_TRUSTED_SIGNING_CLIENT_SECRET }}
+          files: |
+            ${{ github.workspace }}/codex-rs/target/${{ matrix.target }}/release/codex.exe
+            ${{ github.workspace }}/codex-rs/target/${{ matrix.target }}/release/codex-responses-api-proxy.exe
 
       - if: ${{ matrix.runner == 'macos-15-xlarge' }}
         name: Configure Apple code signing
@@ -283,6 +332,11 @@ jobs:
             cp target/${{ matrix.target }}/release/codex-responses-api-proxy "$dest/codex-responses-api-proxy-${{ matrix.target }}"
           fi
 
+          if [[ "${{ matrix.target }}" == *linux* ]]; then
+            cp target/${{ matrix.target }}/release/codex.sigstore "$dest/codex-${{ matrix.target }}.sigstore"
+            cp target/${{ matrix.target }}/release/codex-responses-api-proxy.sigstore "$dest/codex-responses-api-proxy-${{ matrix.target }}.sigstore"
+          fi
+
       - if: ${{ matrix.runner == 'windows-11-arm' }}
         name: Install zstd
         shell: powershell
@@ -318,6 +372,11 @@ jobs:
             # Skip files that are already archives (shouldn't happen, but be
             # safe).
             if [[ "$base" == *.tar.gz || "$base" == *.zip ]]; then
+              continue
+            fi
+
+            # Don't try to compress signature bundles.
+            if [[ "$base" == *.sigstore ]]; then
               continue
             fi
 


### PR DESCRIPTION
## Summary
- install Sigstore cosign during Linux release builds and produce `.sigstore` bundles for each binary
- run Azure Trusted Signing for Windows targets and publish the resulting signatures alongside the artifacts
- document the new signing requirements in the release management guide

- [ ] Swap out `AZURE_TRUSTED_SIGNING_CLIENT_ID` for release flow. 

