### PR TITLE
Fix FreeBSD/OpenBSD builds: target-specific keyring features and BSD hardening

### DIFF
--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -129,7 +129,7 @@ image = { version = "^0.25.8", default-features = false }
 indexmap = "2.12.0"
 insta = "1.43.2"
 itertools = "0.14.0"
-keyring = "3.6"
+keyring = { version = "3.6", default-features = false }
 landlock = "0.4.1"
 lazy_static = "1"
 libc = "0.2.175"

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -40,12 +40,7 @@ eventsource-stream = { workspace = true }
 futures = { workspace = true }
 http = { workspace = true }
 indexmap = { workspace = true }
-keyring = { workspace = true, features = [
-    "apple-native",
-    "crypto-rust",
-    "linux-native-async-persistent",
-    "windows-native",
-] }
+keyring = { workspace = true, features = ["crypto-rust"] }
 libc = { workspace = true }
 mcp-types = { workspace = true }
 os_info = { workspace = true }
@@ -90,9 +85,11 @@ wildmatch = { workspace = true }
 [target.'cfg(target_os = "linux")'.dependencies]
 landlock = { workspace = true }
 seccompiler = { workspace = true }
+keyring = { workspace = true, features = ["linux-native-async-persistent"] }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"
+keyring = { workspace = true, features = ["apple-native"] }
 
 # Build OpenSSL from source for musl builds.
 [target.x86_64-unknown-linux-musl.dependencies]
@@ -101,6 +98,12 @@ openssl-sys = { workspace = true, features = ["vendored"] }
 # Build OpenSSL from source for musl builds.
 [target.aarch64-unknown-linux-musl.dependencies]
 openssl-sys = { workspace = true, features = ["vendored"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+keyring = { workspace = true, features = ["windows-native"] }
+
+[target.'cfg(any(target_os = "freebsd", target_os = "openbsd"))'.dependencies]
+keyring = { workspace = true, features = ["sync-secret-service"] }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/codex-rs/keyring-store/Cargo.toml
+++ b/codex-rs/keyring-store/Cargo.toml
@@ -7,10 +7,17 @@ version = { workspace = true }
 workspace = true
 
 [dependencies]
-keyring = { workspace = true, features = [
-    "apple-native",
-    "crypto-rust",
-    "linux-native-async-persistent",
-    "windows-native",
-] }
+keyring = { workspace = true, features = ["crypto-rust"] }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+keyring = { workspace = true, features = ["linux-native-async-persistent"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+keyring = { workspace = true, features = ["apple-native"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+keyring = { workspace = true, features = ["windows-native"] }
+
+[target.'cfg(any(target_os = "freebsd", target_os = "openbsd"))'.dependencies]
+keyring = { workspace = true, features = ["sync-secret-service"] }
 tracing = { workspace = true }

--- a/codex-rs/keyring-store/Cargo.toml
+++ b/codex-rs/keyring-store/Cargo.toml
@@ -8,6 +8,7 @@ workspace = true
 
 [dependencies]
 keyring = { workspace = true, features = ["crypto-rust"] }
+tracing = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 keyring = { workspace = true, features = ["linux-native-async-persistent"] }
@@ -20,4 +21,3 @@ keyring = { workspace = true, features = ["windows-native"] }
 
 [target.'cfg(any(target_os = "freebsd", target_os = "openbsd"))'.dependencies]
 keyring = { workspace = true, features = ["sync-secret-service"] }
-tracing = { workspace = true }

--- a/codex-rs/process-hardening/Cargo.toml
+++ b/codex-rs/process-hardening/Cargo.toml
@@ -11,11 +11,4 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
-[target.'cfg(target_os = "linux")'.dependencies]
-libc = { workspace = true }
-
-[target.'cfg(target_os = "android")'.dependencies]
-libc = { workspace = true }
-
-[target.'cfg(target_os = "macos")'.dependencies]
 libc = { workspace = true }

--- a/codex-rs/process-hardening/src/lib.rs
+++ b/codex-rs/process-hardening/src/lib.rs
@@ -10,6 +10,10 @@ pub fn pre_main_hardening() {
     #[cfg(target_os = "macos")]
     pre_main_hardening_macos();
 
+    // On FreeBSD and OpenBSD, apply similar hardening to Linux/macOS:
+    #[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
+    pre_main_hardening_bsd();
+
     #[cfg(windows)]
     pre_main_hardening_windows();
 }
@@ -20,7 +24,6 @@ const PRCTL_FAILED_EXIT_CODE: i32 = 5;
 #[cfg(target_os = "macos")]
 const PTRACE_DENY_ATTACH_FAILED_EXIT_CODE: i32 = 6;
 
-#[cfg(any(target_os = "linux", target_os = "android", target_os = "macos"))]
 const SET_RLIMIT_CORE_FAILED_EXIT_CODE: i32 = 7;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]
@@ -50,6 +53,27 @@ pub(crate) fn pre_main_hardening_linux() {
         })
         .collect();
 
+    for key in ld_keys {
+        unsafe {
+            std::env::remove_var(key);
+        }
+    }
+}
+
+#[cfg(any(target_os = "freebsd", target_os = "openbsd"))]
+pub(crate) fn pre_main_hardening_bsd() {
+    // FreeBSD/OpenBSD: set RLIMIT_CORE to 0 and clear LD_* env vars
+    set_core_file_size_limit_to_zero();
+
+    let ld_keys: Vec<String> = std::env::vars()
+        .filter_map(|(key, _)| {
+            if key.starts_with("LD_") {
+                Some(key)
+            } else {
+                None
+            }
+        })
+        .collect();
     for key in ld_keys {
         unsafe {
             std::env::remove_var(key);

--- a/codex-rs/process-hardening/src/lib.rs
+++ b/codex-rs/process-hardening/src/lib.rs
@@ -24,6 +24,13 @@ const PRCTL_FAILED_EXIT_CODE: i32 = 5;
 #[cfg(target_os = "macos")]
 const PTRACE_DENY_ATTACH_FAILED_EXIT_CODE: i32 = 6;
 
+#[cfg(any(
+    target_os = "linux",
+    target_os = "android",
+    target_os = "macos",
+    target_os = "freebsd",
+    target_os = "openbsd"
+))]
 const SET_RLIMIT_CORE_FAILED_EXIT_CODE: i32 = 7;
 
 #[cfg(any(target_os = "linux", target_os = "android"))]

--- a/codex-rs/rmcp-client/Cargo.toml
+++ b/codex-rs/rmcp-client/Cargo.toml
@@ -16,12 +16,7 @@ codex-keyring-store = { workspace = true }
 codex-protocol = { workspace = true }
 dirs = { workspace = true }
 futures = { workspace = true, default-features = false, features = ["std"] }
-keyring = { workspace = true, features = [
-    "apple-native",
-    "crypto-rust",
-    "linux-native-async-persistent",
-    "windows-native",
-] }
+keyring = { workspace = true, features = ["crypto-rust"] }
 mcp-types = { path = "../mcp-types" }
 oauth2 = "5"
 reqwest = { version = "0.12", default-features = false, features = [
@@ -62,3 +57,14 @@ escargot = { workspace = true }
 pretty_assertions = { workspace = true }
 serial_test = { workspace = true }
 tempfile = { workspace = true }
+[target.'cfg(target_os = "linux")'.dependencies]
+keyring = { workspace = true, features = ["linux-native-async-persistent"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+keyring = { workspace = true, features = ["apple-native"] }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+keyring = { workspace = true, features = ["windows-native"] }
+
+[target.'cfg(any(target_os = "freebsd", target_os = "openbsd"))'.dependencies]
+keyring = { workspace = true, features = ["sync-secret-service"] }


### PR DESCRIPTION
## Summary
  Builds on FreeBSD and OpenBSD were failing due to globally enabled Linux-specific keyring features and hardening code paths not gated by OS. This PR scopes keyring native backends to the
  appropriate targets, disables default features at the workspace root, and adds a BSD-specific hardening function. Linux/macOS/Windows behavior remains unchanged, while FreeBSD/OpenBSD
  now build and run with a supported backend.

## Key Changes

  - Keyring features:
      - Disable keyring default features at the workspace root to avoid pulling Linux backends on non-Linux.
      - Move native backend features into target-specific sections in the affected crates:
          - Linux: linux-native-async-persistent
          - macOS: apple-native
          - Windows: windows-native
          - FreeBSD/OpenBSD: sync-secret-service
  - Process hardening:
      - Add pre_main_hardening_bsd() for FreeBSD/OpenBSD, applying:
          - Set RLIMIT_CORE to 0
          - Clear LD_* environment variables
      - Simplify process-hardening Cargo deps to unconditional libc (avoid conflicting OS fragments).
  - No changes to CODEX_SANDBOX_* behavior.

## Rationale

  - Previously, enabling keyring native backends globally pulled Linux-only features on BSD, causing build errors.
  - Hardening logic was tailored for Linux/macOS; BSD builds lacked a gated path with equivalent safeguards.
  - Target-scoped features and BSD hardening make the crates portable across these OSes without affecting existing behavior elsewhere.

## Impact by Platform

  - Linux: No functional change; backends now selected via target cfg.
  - macOS: No functional change; explicit apple-native mapping.
  - Windows: No functional change; explicit windows-native mapping.
  - FreeBSD/OpenBSD: Builds succeed using sync-secret-service; BSD hardening applied during startup.

## Testing

  - Verified compilation across affected crates with target-specific features.
  - Smoke-checked that Linux/macOS/Windows feature sets remain identical functionally after scoping.
  - On BSD, confirmed keyring resolves to sync-secret-service and hardening compiles.

## Risks / Compatibility

  - Minimal risk: only feature scoping and OS-gated additions.
  - No public API changes in the crates; runtime behavior on non-BSD platforms is preserved.
  - On BSD, the new hardening clears LD_*; this is consistent with security posture on other Unix platforms.

## Reviewer Notes

  - Pay attention to target-specific sections for keyring in the affected Cargo.toml files.
  - Confirm pre_main_hardening_bsd() mirrors the safe subset of Linux/macOS hardening without introducing Linux-only calls.
  - Confirm no references to CODEX_SANDBOX_ENV_VAR or CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR were added/modified.

## Checklist

  - Disable keyring default features at workspace root.
  - Target-specific keyring features mapped per OS (Linux/macOS/Windows/BSD).
  - Add BSD hardening (RLIMIT_CORE=0, clear LD_*).
  - Simplify process-hardening dependencies to unconditional libc.
  - No changes to sandbox env var code.
  - Formatting and linting: just fmt + just fix -p for changed crates.
  - Project tests pass for changed crates; broader suite unchanged.

