### PR TITLE
ci: only run CLA assistant for openai org repos

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -13,6 +13,9 @@ permissions:
 
 jobs:
   cla:
+    # Only run the CLA assistant for the canonical openai repo so forks are not blocked
+    # and contributors who signed previously do not receive duplicate CLA notifications.
+    if: ${{ github.repository_owner == 'openai' }}
     runs-on: ubuntu-latest
     steps:
       - uses: contributor-assistant/github-action@v2.6.1


### PR DESCRIPTION
This prevents notifications coming from PRs on forked repos