### PR TITLE
Fix: Update default review model to gpt-5.1-codex

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -63,8 +63,7 @@ pub mod types;
 pub const OPENAI_DEFAULT_MODEL: &str = "gpt-5";
 #[cfg(not(target_os = "windows"))]
 pub const OPENAI_DEFAULT_MODEL: &str = "gpt-5-codex";
-const OPENAI_DEFAULT_REVIEW_MODEL: &str = "gpt-5-codex";
-pub const GPT_5_CODEX_MEDIUM_MODEL: &str = "gpt-5-codex";
+const OPENAI_DEFAULT_REVIEW_MODEL: &str = "gpt-5.1-codex";
 
 /// Maximum number of bytes of the documentation that will be embedded. Larger
 /// files are *silently truncated* to this size so we do not take up too much of
@@ -79,7 +78,7 @@ pub struct Config {
     /// Optional override of model selection.
     pub model: String,
 
-    /// Model used specifically for review sessions. Defaults to "gpt-5-codex".
+    /// Model used specifically for review sessions. Defaults to "gpt-5.1-codex".
     pub review_model: String,
 
     pub model_family: ModelFamily,


### PR DESCRIPTION
## Summary
Fixes #6705

The `/review` command was failing with a `model_not_found` error because it was trying to use `gpt-5-codex` which no longer exists.

## Changes
- Updated `OPENAI_DEFAULT_REVIEW_MODEL` from `gpt-5-codex` to `gpt-5.1-codex`
- Updated documentation comment to reflect the new default model
- Removed unused `GPT_5_CODEX_MEDIUM_MODEL` constant

## Test Plan
- [x] Verified the model name change matches the available model
- [x] Updated relevant documentation comments
- [x] Test `/review` command with the new default model

## Related Issue
Resolves the error reported in #6705 where users on Pro subscription were seeing:
```
The requested model 'gpt-5-codex' does not exist.
```