### PR TITLE
Cause collect_output_until_deadline to return when session exits.

### DIFF
--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -1,7 +1,6 @@
 #![cfg(not(target_os = "windows"))]
 use std::collections::HashMap;
 use std::sync::OnceLock;
-use std::time::Duration;
 use std::time::Instant;
 
 use anyhow::Context;


### PR DESCRIPTION
The `yield_time_ms` parameter of the model issued exec_command
and `write_stdin ToolCalls` is meant as a safe-guard: a deadline
for the maximum time to wait for shell output.

> Note: in the case of `write_stdin` that only really makes sense if
> the `write_stdin` issued a command itself and isn't a poll-- but the
> test `suite::unified_exec::unified_exec_timeout_and_followup_poll`,
> that was recently added, tests that even in the case of a poll it
> waits (for the output of a previous exec_command), so I didn't
> change this. The model typically sends a yield_time_ms of 1000
> with every poll, which is OK.

If there is no output expected anymore at all, because the process
exited, then that is "output" too: namely, the process telling the
CLI that no more output will follow (`completed`).

`collect_output_until_deadline` should not continue waiting for a
notification that there is more output to be read if the PTY closed
that connection: it is done collecting output and should return.

This patch fixes the fact that `collect_output_until_deadline` would
wait till the end of `deadline`, even after the reader task saw EOF.

# Description of changes

When the reader task (`reader_handle`) exits because it reached EOF or
because of a fatal read error, it sends an empty message to `output_tx`.
This guarantees that this is synchronized with (happens after) any
output written by the PTY.

When `output_task` receives the empty chunk, it marks the output (buffer) as
`completed`-- notifies any waiters, waking up `collect_output_until_deadline`
from a possible `tokio::select!`-- and exits.

If `collect_output_until_deadline` sees that the output buffer has the `completed`
flag set, then it exits immediately (as opposed to waiting till the deadline
is reached, as was the case before this patch).

By using `completed` instead of `has_exited`, there is no race and it is
guaranteed that `collect_output_until_deadline` does not return until *all*
output has been collected (unless canceled).

Both `exec_command` and `write_stdin` - that call `collect_output_until_deadline`,
if they see that `output_completed` is set, follow up with a call to
`wait_for_exited_until_deadline` (where the `deadline` is possibly extended to
be at least 1 second into the future at this point), to wait for the process
to actually exit. If the process exits they continue immediately, otherwise,
if the process does not exit within the set deadline despite that the PTY closed
its output fd(s) they assume the process is still "Alive".

Related issue link: [6715](https://github.com/openai/codex/issues/6715)