### PR TITLE
codex-exec: allow resume --last to read prompt #6717

### DIFF
--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -95,7 +95,7 @@ pub struct ResumeArgs {
     pub session_id: Option<String>,
 
     /// Resume the most recent recorded session (newest) without specifying an id.
-    #[arg(long = "last", default_value_t = false, conflicts_with = "session_id")]
+    #[arg(long = "last", default_value_t = false)]
     pub last: bool,
 
     /// Prompt to send after resuming the session. If `-` is used, read from stdin.

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -76,7 +76,21 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
     let prompt_arg = match &command {
         // Allow prompt before the subcommand by falling back to the parent-level prompt
         // when the Resume subcommand did not provide its own prompt.
-        Some(ExecCommand::Resume(args)) => args.prompt.clone().or(prompt),
+        Some(ExecCommand::Resume(args)) => {
+            let resume_prompt = args
+                .prompt
+                .clone()
+                // When using `resume --last <PROMPT>`, clap still parses the first positional
+                // as `session_id`. Reinterpret it as the prompt so the flag works with JSON mode.
+                .or_else(|| {
+                    if args.last {
+                        args.session_id.clone()
+                    } else {
+                        None
+                    }
+                });
+            resume_prompt.or(prompt)
+        }
         None => prompt,
     };
 


### PR DESCRIPTION
### Description

  - codex exec --json resume --last "<prompt>" bailed out because clap treated the prompt as SESSION_ID. I removed the conflicts_with flag and reinterpret that positional as a prompt when
    --last is set, so the flow now keeps working in JSON mode. (codex-rs/exec/src/cli.rs:84-104, codex-rs/exec/src/lib.rs:75-130)
  - Added a regression test that exercises resume --last in JSON mode to ensure the prompt is accepted and the rollout file is updated. (codex-rs/exec/tests/suite/resume.rs:126-178)

### Testing

  - just fmt
  - cargo test -p codex-exec
  - just fix -p codex-exec
  - cargo test -p codex-exec

#6717
