### PR TITLE
Fix AltGr/backslash input on Windows Codex terminal

### DIFF
--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -248,6 +248,16 @@ impl TextArea {
                 self.delete_backward_word()
             },
             KeyEvent {
+                code: KeyCode::Char(c),
+                modifiers,
+                ..
+            } if modifiers.contains(KeyModifiers::ALT)
+                && modifiers.contains(KeyModifiers::CONTROL) =>
+            {
+                // AltGr on many keyboards reports as Ctrl+Alt; treat it as a literal char.
+                self.insert_str(&c.to_string());
+            },
+            KeyEvent {
                 code: KeyCode::Backspace,
                 modifiers: KeyModifiers::ALT,
                 ..
@@ -1452,6 +1462,17 @@ mod tests {
         t.input(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::CONTROL));
         assert_eq!(t.text(), "124");
         assert_eq!(t.cursor(), 3);
+    }
+
+    #[test]
+    fn altgr_ctrl_alt_char_inserts_literal() {
+        let mut t = ta_with("");
+        t.input(KeyEvent::new(
+            KeyCode::Char('c'),
+            KeyModifiers::CONTROL | KeyModifiers::ALT,
+        ));
+        assert_eq!(t.text(), "c");
+        assert_eq!(t.cursor(), 1);
     }
 
     #[test]


### PR DESCRIPTION
### Summary

  - Treat AltGr chords (Ctrl+Alt) as literal character input in the Codex TUI textarea so Windows terminals that report
    backslash and other characters via AltGr insert correctly.
  - Add regression test altgr_ctrl_alt_char_inserts_literal to ensure Ctrl+Alt char events append the character and
    advance the cursor.

 ### Motivation

  On US/UK keyboard layouts, backslash is produced by a plain key, so Ctrl+Alt handling is never exercised and the
  bug isn’t visible. On many non‑US layouts (e.g., German), backslash and other symbols require AltGr, which terminals
  report as Ctrl+Alt+<char>. Our textarea previously filtered these chords like navigation bindings, so AltGr input was
  dropped on affected layouts. This change treats AltGr chords as literal input so backslash and similar symbols work on
  Windows terminals.

This fixes multiple reported Issues where the \ symbol got cut off. Like:
C:\Users\Admin
became
C:UsersAdmin