### PR TITLE
Exempt the "codex" github user from signing the CLA

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -46,4 +46,6 @@ jobs:
           path-to-document: https://github.com/openai/codex/blob/main/docs/CLA.md
           path-to-signatures: signatures/cla.json
           branch: cla-signatures
-          allowlist: dependabot[bot]
+          allowlist: |
+            codex
+            dependabot[bot]


### PR DESCRIPTION
This fixes bug #6697
