### PR TITLE
Fix: Claude models return incomplete responses due to empty finish_reason handling

### DIFF
--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -673,7 +673,9 @@ async fn process_chat_sse<S>(
             }
 
             // Emit end-of-turn when finish_reason signals completion.
-            if let Some(finish_reason) = choice.get("finish_reason").and_then(|v| v.as_str()) {
+             if let Some(finish_reason) = choice.get("finish_reason").and_then(|v| v.as_str())
+                && !finish_reason.is_empty()
+            {
                 match finish_reason {
                     "tool_calls" if fn_call_state.active => {
                         // First, flush the terminal raw reasoning so UIs can finalize

--- a/codex-rs/core/src/chat_completions.rs
+++ b/codex-rs/core/src/chat_completions.rs
@@ -673,7 +673,7 @@ async fn process_chat_sse<S>(
             }
 
             // Emit end-of-turn when finish_reason signals completion.
-             if let Some(finish_reason) = choice.get("finish_reason").and_then(|v| v.as_str())
+            if let Some(finish_reason) = choice.get("finish_reason").and_then(|v| v.as_str())
                 && !finish_reason.is_empty()
             {
                 match finish_reason {

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -156,7 +156,7 @@ pub async fn run_main(
         developer_instructions: None,
         compact_prompt: None,
         include_apply_patch_tool: None,
-        show_raw_agent_reasoning: cli.oss.then_some(true),
+        show_raw_agent_reasoning: Some(true),
         tools_web_search_request: None,
         experimental_sandbox_command_assessment: None,
         additional_writable_roots: additional_dirs,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -156,7 +156,7 @@ pub async fn run_main(
         developer_instructions: None,
         compact_prompt: None,
         include_apply_patch_tool: None,
-        show_raw_agent_reasoning: Some(true),
+        show_raw_agent_reasoning: cli.oss.then_some(true),
         tools_web_search_request: None,
         experimental_sandbox_command_assessment: None,
         additional_writable_roots: additional_dirs,


### PR DESCRIPTION
## Summary
Fixes streaming issue where Claude models return only 1-4 characters instead of full responses when used through certain API providers/proxies.

## Environment
- **OS**: Windows
- **Models affected**: Claude models (e.g., claude-haiku-4-5-20251001)
- **API Provider**: AAAI API proxy (https://api.aaai.vip/v1)
- **Working models**: GLM, Google models work correctly

## Problem
When using Claude models in both TUI and exec modes, only 1-4 characters are displayed despite the backend receiving the full response. Debug logs revealed that some API providers send SSE chunks with an empty string finish_reason during active streaming, rather than null or omitting the field entirely.

The current code treats any non-null finish_reason as a termination signal, causing the stream to exit prematurely after the first chunk. The problematic chunks contain finish_reason with an empty string instead of null.

## Solution
Fix empty finish_reason handling in chat_completions.rs by adding a check to only process non-empty finish_reason values. This ensures empty strings are ignored and streaming continues normally.

## Testing
- Tested on Windows with Claude Haiku model via AAAI API proxy
- Full responses now received and displayed correctly in both TUI and exec modes
- Other models (GLM, Google) continue to work as expected
- No regression in existing functionality

## Impact
- Improves compatibility with API providers that send empty finish_reason during streaming
- Enables Claude models to work correctly in Windows environment
- No breaking changes to existing functionality

## Related Issues
This fix resolves the issue where Claude models appeared to return incomplete responses. The root cause was identified as a compatibility issue in parsing SSE responses from certain API providers/proxies, rather than a model-specific problem. This change improves overall robustness when working with various API endpoints.
