### PR TITLE
Allow seatbelt binding/listening on local addresses

### DIFF
--- a/codex-rs/core/src/seatbelt_base_policy.sbpl
+++ b/codex-rs/core/src/seatbelt_base_policy.sbpl
@@ -81,6 +81,9 @@
   (iokit-registry-entry-class "RootDomainUserClient")
 )
 
+; allow binding/listening on local addresses
+(allow network-inbound (local ip "localhost:*"))
+
 ; needed to look up user info, see https://crbug.com/792228
 (allow mach-lookup
   (global-name "com.apple.system.opendirectoryd.libinfo")


### PR DESCRIPTION
Some build tools, such as Elixir’s Mix, open a local listening socket to coordinate work across multiple worker processes. Allowing network-inbound on localhost enables this behavior while preserving the intended threat model, since it only permits connections from the same machine. Any process able to connect over loopback already has full local execution privileges.

This commit does not allow network-outbound on purpose, as it would effectively allow the command to communicate with other services which may not be sandboxed.

See https://github.com/openai/codex/issues/6737.