### PR TITLE
docs: add bun installation instructions to README and PNPM.md

### DIFF
--- a/PNPM.md
+++ b/PNPM.md
@@ -14,8 +14,11 @@ This project has been migrated from npm to pnpm to improve dependency management
 ### Installation
 
 ```bash
-# Global installation of pnpm
+# Global installation of pnpm with npm
 npm install -g pnpm@10.8.1
+
+# Or with bun
+bun install -g pnpm@10.8.1
 
 # Or with corepack (available with Node.js 22+)
 corepack enable

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><code>npm i -g @openai/codex</code><br />or <code>brew install --cask codex</code></p>
+<p align="center"><code>npm i -g @openai/codex</code><br />or <code>bun install -g @openai/codex</code><br />or <code>brew install --cask codex</code></p>
 
 <p align="center"><strong>Codex CLI</strong> is a coding agent from OpenAI that runs locally on your computer.
 </br>
@@ -15,14 +15,19 @@
 
 ### Installing and running Codex CLI
 
-Install globally with your preferred package manager. If you use npm:
+Install globally with your preferred package manager:
 
+**With npm:**
 ```shell
 npm install -g @openai/codex
 ```
 
-Alternatively, if you use Homebrew:
+**With bun:**
+```shell
+bun install -g @openai/codex
+```
 
+**With Homebrew:**
 ```shell
 brew install --cask codex
 ```


### PR DESCRIPTION
The codebase already has full support for bun installations:
- Package manager detection in codex-cli/bin/codex.js
- Auto-update with BunGlobalLatest in codex-rs/tui/src/update_action.rs
- Complete test coverage for bun detection and updates

However, the documentation only mentioned npm and brew installations. This commit adds bun installation instructions to:
- README.md: Added bun install command in header and Quickstart section
- PNPM.md: Added bun as an option for installing pnpm globally