### PR TITLE
Propagate top-level flags to exec subcommand

### DIFF
--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -44,6 +44,7 @@ const CHANNEL_CAPACITY: usize = 128;
 pub async fn run_main(
     codex_linux_sandbox_exe: Option<PathBuf>,
     cli_config_overrides: CliConfigOverrides,
+    config_overrides: ConfigOverrides,
 ) -> IoResult<()> {
     // Set up channels.
     let (incoming_tx, mut incoming_rx) = mpsc::channel::<JSONRPCMessage>(CHANNEL_CAPACITY);
@@ -80,7 +81,7 @@ pub async fn run_main(
             format!("error parsing -c overrides: {e}"),
         )
     })?;
-    let config = Config::load_with_cli_overrides(cli_kv_overrides, ConfigOverrides::default())
+    let config = Config::load_with_cli_overrides(cli_kv_overrides, config_overrides)
         .await
         .map_err(|e| {
             std::io::Error::new(ErrorKind::InvalidData, format!("error loading config: {e}"))

--- a/codex-rs/app-server/src/main.rs
+++ b/codex-rs/app-server/src/main.rs
@@ -4,7 +4,12 @@ use codex_common::CliConfigOverrides;
 
 fn main() -> anyhow::Result<()> {
     arg0_dispatch_or_else(|codex_linux_sandbox_exe| async move {
-        run_main(codex_linux_sandbox_exe, CliConfigOverrides::default()).await?;
+        run_main(
+            codex_linux_sandbox_exe,
+            CliConfigOverrides::default(),
+            codex_core::config::ConfigOverrides::default(),
+        )
+        .await?;
         Ok(())
     })
 }

--- a/codex-rs/common/src/common_cli.rs
+++ b/codex-rs/common/src/common_cli.rs
@@ -1,0 +1,108 @@
+use clap::Parser;
+use clap::ValueHint;
+use std::path::PathBuf;
+
+use crate::SandboxModeCliArg;
+
+/// Flags shared across multiple Codex CLIs.
+#[derive(Parser, Debug, Default, Clone)]
+pub struct CommonCli {
+    /// Optional image(s) to attach to the initial prompt.
+    #[arg(
+        long = "image",
+        short = 'i',
+        value_name = "FILE",
+        value_delimiter = ',',
+        num_args = 1..,
+        global = true
+    )]
+    pub images: Vec<PathBuf>,
+
+    /// Model the agent should use.
+    #[arg(long, short = 'm', global = true)]
+    pub model: Option<String>,
+
+    /// Convenience flag to select the local open source model provider. Equivalent to -c
+    /// model_provider=oss; verifies a local LM Studio or Ollama server is running.
+    #[arg(long = "oss", default_value_t = false, global = true)]
+    pub oss: bool,
+
+    /// Specify which local provider to use (lmstudio or ollama).
+    /// If not specified with --oss, will use config default or show selection.
+    #[arg(long = "local-provider", global = true)]
+    pub oss_provider: Option<String>,
+
+    /// Configuration profile from config.toml to specify default options.
+    #[arg(long = "profile", short = 'p', global = true)]
+    pub config_profile: Option<String>,
+
+    /// Select the sandbox policy to use when executing model-generated shell
+    /// commands.
+    #[arg(long = "sandbox", short = 's', value_enum, global = true)]
+    pub sandbox_mode: Option<SandboxModeCliArg>,
+
+    /// Convenience alias for low-friction sandboxed automatic execution (-a on-request, --sandbox workspace-write).
+    #[arg(long = "full-auto", default_value_t = false, global = true)]
+    pub full_auto: bool,
+
+    /// Skip all confirmation prompts and execute commands without sandboxing.
+    /// EXTREMELY DANGEROUS. Intended solely for running in environments that are externally sandboxed.
+    #[arg(
+        long = "dangerously-bypass-approvals-and-sandbox",
+        alias = "yolo",
+        default_value_t = false,
+        conflicts_with = "full_auto",
+        global = true
+    )]
+    pub dangerously_bypass_approvals_and_sandbox: bool,
+
+    /// Tell the agent to use the specified directory as its working root.
+    #[clap(long = "cd", short = 'C', value_name = "DIR", global = true)]
+    pub cwd: Option<PathBuf>,
+
+    /// Additional directories that should be writable alongside the primary workspace.
+    #[arg(
+        long = "add-dir",
+        value_name = "DIR",
+        value_hint = ValueHint::DirPath,
+        global = true
+    )]
+    pub add_dir: Vec<PathBuf>,
+}
+
+impl CommonCli {
+    /// Apply overrides from another `CommonCli`, giving precedence to fields that
+    /// are explicitly set on `other`.
+    pub fn apply_overrides(&mut self, other: &CommonCli) {
+        if let Some(model) = &other.model {
+            self.model = Some(model.clone());
+        }
+        if other.oss {
+            self.oss = true;
+        }
+        if let Some(provider) = &other.oss_provider {
+            self.oss_provider = Some(provider.clone());
+        }
+        if let Some(profile) = &other.config_profile {
+            self.config_profile = Some(profile.clone());
+        }
+        if let Some(sandbox) = other.sandbox_mode {
+            self.sandbox_mode = Some(sandbox);
+        }
+        if other.full_auto {
+            self.full_auto = true;
+        }
+        if other.dangerously_bypass_approvals_and_sandbox {
+            self.dangerously_bypass_approvals_and_sandbox = true;
+        }
+        if let Some(cwd) = &other.cwd {
+            self.cwd = Some(cwd.clone());
+        }
+        if !other.images.is_empty() {
+            self.images = other.images.clone();
+        }
+        if !other.add_dir.is_empty() {
+            self.add_dir.extend(other.add_dir.clone());
+        }
+    }
+}

--- a/codex-rs/common/src/lib.rs
+++ b/codex-rs/common/src/lib.rs
@@ -11,6 +11,9 @@ pub use approval_mode_cli_arg::ApprovalModeCliArg;
 mod sandbox_mode_cli_arg;
 
 #[cfg(feature = "cli")]
+mod common_cli;
+
+#[cfg(feature = "cli")]
 pub use sandbox_mode_cli_arg::SandboxModeCliArg;
 
 #[cfg(feature = "cli")]
@@ -21,6 +24,9 @@ mod config_override;
 
 #[cfg(feature = "cli")]
 pub use config_override::CliConfigOverrides;
+
+#[cfg(feature = "cli")]
+pub use common_cli::CommonCli;
 
 mod sandbox_summary;
 

--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -1,6 +1,7 @@
 use clap::Parser;
 use clap::ValueEnum;
 use codex_common::CliConfigOverrides;
+use codex_common::CommonCli;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug)]
@@ -10,57 +11,13 @@ pub struct Cli {
     #[command(subcommand)]
     pub command: Option<Command>,
 
-    /// Optional image(s) to attach to the initial prompt.
-    #[arg(long = "image", short = 'i', value_name = "FILE", value_delimiter = ',', num_args = 1..)]
-    pub images: Vec<PathBuf>,
-
-    /// Model the agent should use.
-    #[arg(long, short = 'm')]
-    pub model: Option<String>,
-
-    /// Use open-source provider.
-    #[arg(long = "oss", default_value_t = false)]
-    pub oss: bool,
-
-    /// Specify which local provider to use (lmstudio or ollama).
-    /// If not specified with --oss, will use config default or show selection.
-    #[arg(long = "local-provider")]
-    pub oss_provider: Option<String>,
-
-    /// Select the sandbox policy to use when executing model-generated shell
-    /// commands.
-    #[arg(long = "sandbox", short = 's', value_enum)]
-    pub sandbox_mode: Option<codex_common::SandboxModeCliArg>,
-
-    /// Configuration profile from config.toml to specify default options.
-    #[arg(long = "profile", short = 'p')]
-    pub config_profile: Option<String>,
-
-    /// Convenience alias for low-friction sandboxed automatic execution (-a on-request, --sandbox workspace-write).
-    #[arg(long = "full-auto", default_value_t = false)]
-    pub full_auto: bool,
-
-    /// Skip all confirmation prompts and execute commands without sandboxing.
-    /// EXTREMELY DANGEROUS. Intended solely for running in environments that are externally sandboxed.
-    #[arg(
-        long = "dangerously-bypass-approvals-and-sandbox",
-        alias = "yolo",
-        default_value_t = false,
-        conflicts_with = "full_auto"
-    )]
-    pub dangerously_bypass_approvals_and_sandbox: bool,
-
-    /// Tell the agent to use the specified directory as its working root.
-    #[clap(long = "cd", short = 'C', value_name = "DIR")]
-    pub cwd: Option<PathBuf>,
+    /// Model and execution controls shared with the interactive CLI.
+    #[clap(flatten)]
+    pub common: CommonCli,
 
     /// Allow running Codex outside a Git repository.
     #[arg(long = "skip-git-repo-check", default_value_t = false)]
     pub skip_git_repo_check: bool,
-
-    /// Additional directories that should be writable alongside the primary workspace.
-    #[arg(long = "add-dir", value_name = "DIR", value_hint = clap::ValueHint::DirPath)]
-    pub add_dir: Vec<PathBuf>,
 
     /// Path to a JSON Schema file describing the model's final response shape.
     #[arg(long = "output-schema", value_name = "FILE")]

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -11,6 +11,7 @@ pub mod event_processor_with_jsonl_output;
 pub mod exec_events;
 
 pub use cli::Cli;
+use codex_common::CommonCli;
 use codex_common::oss::ensure_oss_provider_ready;
 use codex_common::oss::get_default_model_for_oss_provider;
 use codex_core::AuthManager;
@@ -59,6 +60,17 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
 
     let Cli {
         command,
+        common,
+        skip_git_repo_check,
+        color,
+        last_message_file,
+        json: json_mode,
+        prompt,
+        output_schema: output_schema_path,
+        config_overrides,
+    } = cli;
+
+    let CommonCli {
         images,
         model: model_cli_arg,
         oss,
@@ -67,16 +79,10 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         full_auto,
         dangerously_bypass_approvals_and_sandbox,
         cwd,
-        skip_git_repo_check,
         add_dir,
-        color,
-        last_message_file,
-        json: json_mode,
         sandbox_mode: sandbox_mode_cli_arg,
-        prompt,
-        output_schema: output_schema_path,
-        config_overrides,
-    } = cli;
+        ..
+    } = common;
 
     // Determine the prompt source (parent or subcommand) and read from stdin if needed.
     let prompt_arg = match &command {

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -1,19 +1,17 @@
 use clap::Parser;
-use clap::ValueHint;
 use codex_common::ApprovalModeCliArg;
 use codex_common::CliConfigOverrides;
-use std::path::PathBuf;
+use codex_common::CommonCli;
 
 #[derive(Parser, Debug)]
 #[command(version)]
 pub struct Cli {
+    #[clap(flatten)]
+    pub common: CommonCli,
+
     /// Optional user prompt to start the session.
     #[arg(value_name = "PROMPT", value_hint = clap::ValueHint::Other)]
     pub prompt: Option<String>,
-
-    /// Optional image(s) to attach to the initial prompt.
-    #[arg(long = "image", short = 'i', value_name = "FILE", value_delimiter = ',', num_args = 1..)]
-    pub images: Vec<PathBuf>,
 
     // Internal controls set by the top-level `codex resume` subcommand.
     // These are not exposed as user flags on the base `codex` command.
@@ -28,58 +26,13 @@ pub struct Cli {
     #[clap(skip)]
     pub resume_session_id: Option<String>,
 
-    /// Model the agent should use.
-    #[arg(long, short = 'm')]
-    pub model: Option<String>,
-
-    /// Convenience flag to select the local open source model provider. Equivalent to -c
-    /// model_provider=oss; verifies a local LM Studio or Ollama server is running.
-    #[arg(long = "oss", default_value_t = false)]
-    pub oss: bool,
-
-    /// Specify which local provider to use (lmstudio or ollama).
-    /// If not specified with --oss, will use config default or show selection.
-    #[arg(long = "local-provider")]
-    pub oss_provider: Option<String>,
-
-    /// Configuration profile from config.toml to specify default options.
-    #[arg(long = "profile", short = 'p')]
-    pub config_profile: Option<String>,
-
-    /// Select the sandbox policy to use when executing model-generated shell
-    /// commands.
-    #[arg(long = "sandbox", short = 's')]
-    pub sandbox_mode: Option<codex_common::SandboxModeCliArg>,
-
     /// Configure when the model requires human approval before executing a command.
     #[arg(long = "ask-for-approval", short = 'a')]
     pub approval_policy: Option<ApprovalModeCliArg>,
 
-    /// Convenience alias for low-friction sandboxed automatic execution (-a on-request, --sandbox workspace-write).
-    #[arg(long = "full-auto", default_value_t = false)]
-    pub full_auto: bool,
-
-    /// Skip all confirmation prompts and execute commands without sandboxing.
-    /// EXTREMELY DANGEROUS. Intended solely for running in environments that are externally sandboxed.
-    #[arg(
-        long = "dangerously-bypass-approvals-and-sandbox",
-        alias = "yolo",
-        default_value_t = false,
-        conflicts_with_all = ["approval_policy", "full_auto"]
-    )]
-    pub dangerously_bypass_approvals_and_sandbox: bool,
-
-    /// Tell the agent to use the specified directory as its working root.
-    #[clap(long = "cd", short = 'C', value_name = "DIR")]
-    pub cwd: Option<PathBuf>,
-
     /// Enable web search (off by default). When enabled, the native Responses `web_search` tool is available to the model (no per‑call approval).
     #[arg(long = "search", default_value_t = false)]
     pub web_search: bool,
-
-    /// Additional directories that should be writable alongside the primary workspace.
-    #[arg(long = "add-dir", value_name = "DIR", value_hint = ValueHint::DirPath)]
-    pub add_dir: Vec<PathBuf>,
 
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,


### PR DESCRIPTION
This fixes flags before the exec subcommend being ignored:
```
codex -m test-model exec "Hello world"
```

The above previously would ignore the -m override and use the configured default.

EDIT:

Updated to create a new type for common flags that clap then merges automatically.  Have tests that the behavior we want works for app-server and exec.  Updated resume to also merge common flags on the common type itself and then only handling its additional flags.