### PR TITLE
chore(core) Add shell_serialization coverage

### DIFF
--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -323,8 +323,9 @@ impl TestCodexHarness {
     pub async fn shell_output(&self, call_id: &str, output_type: ShellModelOutput) -> String {
         match output_type {
             ShellModelOutput::LocalShell => self.local_shell_call_output(call_id).await,
-            ShellModelOutput::Shell
-            | ShellModelOutput::ShellCommand => self.function_call_stdout(call_id).await,
+            ShellModelOutput::Shell | ShellModelOutput::ShellCommand => {
+                self.function_call_stdout(call_id).await
+            }
         }
     }
 }

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -298,15 +298,6 @@ impl TestCodexHarness {
             .to_string()
     }
 
-    pub async fn local_shell_call_output(&self, call_id: &str) -> String {
-        let bodies = self.request_bodies().await;
-        local_shell_call_output(&bodies, call_id)
-            .get("output")
-            .and_then(Value::as_str)
-            .expect("output string")
-            .to_string()
-    }
-
     pub async fn apply_patch_output(
         &self,
         call_id: &str,
@@ -317,15 +308,6 @@ impl TestCodexHarness {
             ApplyPatchModelOutput::Function
             | ApplyPatchModelOutput::Shell
             | ApplyPatchModelOutput::ShellViaHeredoc => self.function_call_stdout(call_id).await,
-        }
-    }
-
-    pub async fn shell_output(&self, call_id: &str, output_type: ShellModelOutput) -> String {
-        match output_type {
-            ShellModelOutput::LocalShell => self.local_shell_call_output(call_id).await,
-            ShellModelOutput::Shell | ShellModelOutput::ShellCommand => {
-                self.function_call_stdout(call_id).await
-            }
         }
     }
 }
@@ -358,21 +340,6 @@ fn function_call_output<'a>(bodies: &'a [Value], call_id: &str) -> &'a Value {
         }
     }
     panic!("function_call_output {call_id} not found");
-}
-
-fn local_shell_call_output<'a>(bodies: &'a [Value], call_id: &str) -> &'a Value {
-    for body in bodies {
-        if let Some(items) = body.get("input").and_then(Value::as_array) {
-            for item in items {
-                if item.get("type").and_then(Value::as_str) == Some("local_shell_call_output")
-                    && item.get("call_id").and_then(Value::as_str) == Some(call_id)
-                {
-                    return item;
-                }
-            }
-        }
-    }
-    panic!("local_shell_call_output {call_id} not found");
 }
 
 pub fn test_codex() -> TestCodexBuilder {

--- a/codex-rs/core/tests/suite/apply_patch_cli.rs
+++ b/codex-rs/core/tests/suite/apply_patch_cli.rs
@@ -29,7 +29,7 @@ use core_test_support::wait_for_event;
 use serde_json::json;
 use test_case::test_case;
 
-async fn apply_patch_harness() -> Result<TestCodexHarness> {
+pub async fn apply_patch_harness() -> Result<TestCodexHarness> {
     apply_patch_harness_with(|_| {}).await
 }
 
@@ -43,7 +43,7 @@ async fn apply_patch_harness_with(
     .await
 }
 
-async fn mount_apply_patch(
+pub async fn mount_apply_patch(
     harness: &TestCodexHarness,
     call_id: &str,
     patch: &str,


### PR DESCRIPTION
## Summary
Similar to #6545, this PR updates the shell_serialization test suite to cover the various `shell` tool invocations we have. Note that this does not cover unified_exec, which has its own suite of tests. This should provide some test coverage for when we eventually consolidate serialization logic.

## Testing
- [x] These are tests