### PR TITLE
fixing localshell tool calls

### DIFF
--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -281,7 +281,6 @@ impl ShellHandler {
             }
         }
 
-        // Regular shell execution path.
         let source = ExecCommandSource::Agent;
         let emitter =
             ToolEmitter::shell(exec_params.command.clone(), exec_params.cwd.clone(), source);

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -117,7 +117,6 @@ impl ToolHandler for ShellHandler {
                     turn,
                     tracker,
                     call_id,
-                    false,
                 )
                 .await
             }
@@ -130,7 +129,6 @@ impl ToolHandler for ShellHandler {
                     turn,
                     tracker,
                     call_id,
-                    false,
                 )
                 .await
             }
@@ -178,7 +176,6 @@ impl ToolHandler for ShellCommandHandler {
             turn,
             tracker,
             call_id,
-            false,
         )
         .await
     }
@@ -192,7 +189,6 @@ impl ShellHandler {
         turn: Arc<TurnContext>,
         tracker: crate::tools::context::SharedTurnDiffTracker,
         call_id: String,
-        is_user_shell_command: bool,
     ) -> Result<ToolOutput, FunctionCallError> {
         // Approval policy guard for explicit escalation in non-OnRequest modes.
         if exec_params.with_escalated_permissions.unwrap_or(false)
@@ -286,11 +282,7 @@ impl ShellHandler {
         }
 
         // Regular shell execution path.
-        let source = if is_user_shell_command {
-            ExecCommandSource::UserShell
-        } else {
-            ExecCommandSource::Agent
-        };
+        let source = ExecCommandSource::Agent;
         let emitter =
             ToolEmitter::shell(exec_params.command.clone(), exec_params.cwd.clone(), source);
         let event_ctx = ToolEventCtx::new(session.as_ref(), turn.as_ref(), &call_id, None);

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -130,7 +130,7 @@ impl ToolHandler for ShellHandler {
                     turn,
                     tracker,
                     call_id,
-                    true,
+                    false,
                 )
                 .await
             }


### PR DESCRIPTION
- Local-shell tool responses were always tagged as `ExecCommandSource::UserShell` because handler would call `run_exec_like` with `is_user_shell_cmd` set to true.
- Treat `ToolPayload::LocalShell` the same as other model generated shell tool calls by deleting `is_user_shell_cmd` from `run_exec_like` (since actual user shell commands follow a separate code path)
