### PR TITLE
fix(cli): correct mcp add usage order

### DIFF
--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -79,7 +79,7 @@ pub struct GetArgs {
 }
 
 #[derive(Debug, clap::Parser)]
-#[command(override_usage = "codex mcp add [OPTIONS] <NAME> [--url <URL> | -- <COMMAND>...]")]
+#[command(override_usage = "codex mcp add [OPTIONS] <NAME> (--url <URL> | -- <COMMAND>...)")]
 pub struct AddArgs {
     /// Name for the MCP server configuration.
     pub name: String,

--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -79,6 +79,7 @@ pub struct GetArgs {
 }
 
 #[derive(Debug, clap::Parser)]
+#[command(override_usage = "codex mcp add [OPTIONS] <NAME> [--url <URL> | -- <COMMAND>...]")]
 pub struct AddArgs {
     /// Name for the MCP server configuration.
     pub name: String,


### PR DESCRIPTION
## Summary
- add an explicit `override_usage` string to `AddArgs` so clap prints `<NAME>` before the command/url choice, matching the actual parser and docs

### Before

Usage: codex mcp add [OPTIONS] <COMMAND|--url <URL>> <NAME>


### After

Usage: codex mcp add [OPTIONS] <NAME> [--url <URL> | -- <COMMAND>...]