### PR TITLE
Fix tests so they don't emit an extraneous `config.toml` in the source tree

### DIFF
--- a/codex-rs/tui/src/onboarding/trust_directory.rs
+++ b/codex-rs/tui/src/onboarding/trust_directory.rs
@@ -189,13 +189,14 @@ mod tests {
     use crossterm::event::KeyModifiers;
     use pretty_assertions::assert_eq;
     use ratatui::Terminal;
-
     use std::path::PathBuf;
+    use tempfile::TempDir;
 
     #[test]
     fn release_event_does_not_change_selection() {
+        let codex_home = TempDir::new().expect("temp home");
         let mut widget = TrustDirectoryWidget {
-            codex_home: PathBuf::from("."),
+            codex_home: codex_home.path().to_path_buf(),
             cwd: PathBuf::from("."),
             is_git_repo: false,
             selection: None,
@@ -217,8 +218,9 @@ mod tests {
 
     #[test]
     fn renders_snapshot_for_git_repo() {
+        let codex_home = TempDir::new().expect("temp home");
         let widget = TrustDirectoryWidget {
-            codex_home: PathBuf::from("."),
+            codex_home: codex_home.path().to_path_buf(),
             cwd: PathBuf::from("/workspace/project"),
             is_git_repo: true,
             selection: None,


### PR DESCRIPTION
This PR fixes the `release_event_does_not_change_selection` test so it doesn't cause an extra `config.toml` to be emitted in the sources when running the tests locally. Prior to this fix, I needed to delete this file every time I ran the tests to prevent it from showing up as an uncommitted source file.