### PR TITLE
windows sandbox: support multiple workspace roots

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1004,7 +1004,6 @@ dependencies = [
  "predicates",
  "pretty_assertions",
  "regex-lite",
- "serde",
  "serde_json",
  "supports-color",
  "tempfile",

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1004,6 +1004,7 @@ dependencies = [
  "predicates",
  "pretty_assertions",
  "regex-lite",
+ "serde",
  "serde_json",
  "supports-color",
  "tempfile",
@@ -1606,6 +1607,7 @@ name = "codex-windows-sandbox"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "codex-protocol",
  "dirs-next",
  "dunce",
  "rand 0.8.5",

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -38,6 +38,7 @@ ctor = { workspace = true }
 libc = { workspace = true }
 owo-colors = { workspace = true }
 regex-lite = { workspace = true}
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 supports-color = { workspace = true }
 toml = { workspace = true }

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -38,7 +38,6 @@ ctor = { workspace = true }
 libc = { workspace = true }
 owo-colors = { workspace = true }
 regex-lite = { workspace = true}
-serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 supports-color = { workspace = true }
 toml = { workspace = true }

--- a/codex-rs/cli/src/debug_sandbox.rs
+++ b/codex-rs/cli/src/debug_sandbox.rs
@@ -138,11 +138,7 @@ async fn run_command_under_sandbox(
         {
             use codex_windows_sandbox::run_windows_sandbox_capture;
 
-            let policy_str = match &config.sandbox_policy {
-                codex_core::protocol::SandboxPolicy::DangerFullAccess => "workspace-write",
-                codex_core::protocol::SandboxPolicy::ReadOnly => "read-only",
-                codex_core::protocol::SandboxPolicy::WorkspaceWrite { .. } => "workspace-write",
-            };
+            let policy_str = serde_json::to_string(&config.sandbox_policy)?;
 
             let sandbox_cwd = sandbox_policy_cwd.clone();
             let cwd_clone = cwd.clone();
@@ -153,7 +149,7 @@ async fn run_command_under_sandbox(
             // Preflight audit is invoked elsewhere at the appropriate times.
             let res = tokio::task::spawn_blocking(move || {
                 run_windows_sandbox_capture(
-                    policy_str,
+                    policy_str.as_str(),
                     &sandbox_cwd,
                     base_dir.as_path(),
                     command_vec,

--- a/codex-rs/windows-sandbox-rs/Cargo.toml
+++ b/codex-rs/windows-sandbox-rs/Cargo.toml
@@ -12,6 +12,9 @@ anyhow = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 dunce = "1.0"
+[dependencies.codex-protocol]
+package = "codex-protocol"
+path = "../protocol"
 [dependencies.rand]
 version = "0.8"
 default-features = false

--- a/codex-rs/windows-sandbox-rs/src/allow.rs
+++ b/codex-rs/windows-sandbox-rs/src/allow.rs
@@ -1,37 +1,83 @@
-use crate::policy::SandboxMode;
 use crate::policy::SandboxPolicy;
+use dunce::canonicalize;
 use std::collections::HashMap;
 use std::path::Path;
 use std::path::PathBuf;
 
 pub fn compute_allow_paths(
     policy: &SandboxPolicy,
-    _policy_cwd: &Path,
+    policy_cwd: &Path,
     command_cwd: &Path,
     env_map: &HashMap<String, String>,
 ) -> Vec<PathBuf> {
     let mut allow: Vec<PathBuf> = Vec::new();
     let mut seen = std::collections::HashSet::new();
-    if matches!(policy.0, SandboxMode::WorkspaceWrite) {
-        let abs = command_cwd.to_path_buf();
-        if seen.insert(abs.to_string_lossy().to_string()) && abs.exists() {
-            allow.push(abs);
+
+    let mut add_path = |p: PathBuf| {
+        if seen.insert(p.to_string_lossy().to_string()) && p.exists() {
+            allow.push(p);
+        }
+    };
+
+    if matches!(policy, SandboxPolicy::WorkspaceWrite { .. }) {
+        add_path(command_cwd.to_path_buf());
+        if let SandboxPolicy::WorkspaceWrite { writable_roots, .. } = policy {
+            for root in writable_roots {
+                let candidate = if root.is_absolute() {
+                    root.clone()
+                } else {
+                    policy_cwd.join(root)
+                };
+                let canonical = canonicalize(&candidate).unwrap_or(candidate);
+                add_path(canonical);
+            }
         }
     }
-    if !matches!(policy.0, SandboxMode::ReadOnly) {
+    if !matches!(policy, SandboxPolicy::ReadOnly) {
         for key in ["TEMP", "TMP"] {
             if let Some(v) = env_map.get(key) {
                 let abs = PathBuf::from(v);
-                if seen.insert(abs.to_string_lossy().to_string()) && abs.exists() {
-                    allow.push(abs);
-                }
+                add_path(abs);
             } else if let Ok(v) = std::env::var(key) {
                 let abs = PathBuf::from(v);
-                if seen.insert(abs.to_string_lossy().to_string()) && abs.exists() {
-                    allow.push(abs);
-                }
+                add_path(abs);
             }
         }
     }
     allow
+}
+
+#[cfg(test)]
+mod tests {
+    use super::compute_allow_paths;
+    use codex_protocol::protocol::SandboxPolicy;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::PathBuf;
+
+    #[test]
+    fn includes_additional_writable_roots() {
+        let command_cwd = PathBuf::from(r"C:\Workspace");
+        let extra_root = PathBuf::from(r"C:\AdditionalWritableRoot");
+        let _ = fs::create_dir_all(&command_cwd);
+        let _ = fs::create_dir_all(&extra_root);
+
+        let policy = SandboxPolicy::WorkspaceWrite {
+            writable_roots: vec![extra_root.clone()],
+            network_access: false,
+            exclude_tmpdir_env_var: false,
+            exclude_slash_tmp: false,
+        };
+
+        let allow = compute_allow_paths(&policy, &command_cwd, &command_cwd, &HashMap::new());
+
+        assert!(
+            allow.iter().any(|p| p == &command_cwd),
+            "command cwd should be allowed"
+        );
+        assert!(
+            allow.iter().any(|p| p == &extra_root),
+            "additional writable root should be allowed"
+        );
+    }
 }

--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -36,7 +36,7 @@ mod windows_impl {
     use super::logging::log_failure;
     use super::logging::log_start;
     use super::logging::log_success;
-    use super::policy::SandboxMode;
+    use super::policy::parse_policy;
     use super::policy::SandboxPolicy;
     use super::token::convert_string_sid_to_sid;
     use super::winutil::format_last_error;
@@ -190,7 +190,7 @@ mod windows_impl {
         mut env_map: HashMap<String, String>,
         timeout_ms: Option<u64>,
     ) -> Result<CaptureResult> {
-        let policy = SandboxPolicy::parse(policy_json_or_preset)?;
+        let policy = parse_policy(policy_json_or_preset)?;
         normalize_null_device_env(&mut env_map);
         ensure_non_interactive_pager(&mut env_map);
         apply_no_network_to_env(&mut env_map)?;
@@ -203,26 +203,29 @@ mod windows_impl {
         log_start(&command, logs_base_dir);
         let cap_sid_path = cap_sid_file(codex_home);
         let (h_token, psid_to_use): (HANDLE, *mut c_void) = unsafe {
-            match &policy.0 {
-                SandboxMode::ReadOnly => {
+            match &policy {
+                SandboxPolicy::ReadOnly => {
                     let caps = load_or_create_cap_sids(codex_home);
                     ensure_dir(&cap_sid_path)?;
                     fs::write(&cap_sid_path, serde_json::to_string(&caps)?)?;
                     let psid = convert_string_sid_to_sid(&caps.readonly).unwrap();
                     super::token::create_readonly_token_with_cap(psid)?
                 }
-                SandboxMode::WorkspaceWrite => {
+                SandboxPolicy::WorkspaceWrite { .. } => {
                     let caps = load_or_create_cap_sids(codex_home);
                     ensure_dir(&cap_sid_path)?;
                     fs::write(&cap_sid_path, serde_json::to_string(&caps)?)?;
                     let psid = convert_string_sid_to_sid(&caps.workspace).unwrap();
                     super::token::create_workspace_write_token_with_cap(psid)?
                 }
+                SandboxPolicy::DangerFullAccess => {
+                    anyhow::bail!("DangerFullAccess is not supported for sandboxing")
+                }
             }
         };
 
         unsafe {
-            if matches!(policy.0, SandboxMode::WorkspaceWrite) {
+            if matches!(policy, SandboxPolicy::WorkspaceWrite { .. }) {
                 if let Ok(base) = super::token::get_current_token_for_restriction() {
                     if let Ok(bytes) = super::token::get_logon_sid_bytes(base) {
                         let mut tmp = bytes.clone();
@@ -234,7 +237,7 @@ mod windows_impl {
             }
         }
 
-        let persist_aces = matches!(policy.0, SandboxMode::WorkspaceWrite);
+        let persist_aces = matches!(policy, SandboxPolicy::WorkspaceWrite { .. });
         let allow = compute_allow_paths(&policy, sandbox_policy_cwd, &current_dir, &env_map);
         let mut guards: Vec<(PathBuf, *mut c_void)> = Vec::new();
         unsafe {

--- a/codex-rs/windows-sandbox-rs/src/policy.rs
+++ b/codex-rs/windows-sandbox-rs/src/policy.rs
@@ -1,36 +1,17 @@
 use anyhow::Result;
-use serde::Deserialize;
-use serde::Serialize;
+pub use codex_protocol::protocol::SandboxPolicy;
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
-pub struct PolicyJson {
-    pub mode: String,
-    #[serde(default)]
-    pub workspace_roots: Vec<String>,
-}
-
-#[derive(Clone, Debug)]
-pub enum SandboxMode {
-    ReadOnly,
-    WorkspaceWrite,
-}
-
-#[derive(Clone, Debug)]
-pub struct SandboxPolicy(pub SandboxMode);
-
-impl SandboxPolicy {
-    pub fn parse(value: &str) -> Result<Self> {
-        match value {
-            "read-only" => Ok(SandboxPolicy(SandboxMode::ReadOnly)),
-            "workspace-write" => Ok(SandboxPolicy(SandboxMode::WorkspaceWrite)),
-            other => {
-                let pj: PolicyJson = serde_json::from_str(other)?;
-                Ok(match pj.mode.as_str() {
-                    "read-only" => SandboxPolicy(SandboxMode::ReadOnly),
-                    "workspace-write" => SandboxPolicy(SandboxMode::WorkspaceWrite),
-                    _ => SandboxPolicy(SandboxMode::ReadOnly),
-                })
+pub fn parse_policy(value: &str) -> Result<SandboxPolicy> {
+    match value {
+        "read-only" => Ok(SandboxPolicy::ReadOnly),
+        "workspace-write" => Ok(SandboxPolicy::new_workspace_write_policy()),
+        "danger-full-access" => anyhow::bail!("DangerFullAccess is not supported for sandboxing"),
+        other => {
+            let parsed: SandboxPolicy = serde_json::from_str(other)?;
+            if matches!(parsed, SandboxPolicy::DangerFullAccess) {
+                anyhow::bail!("DangerFullAccess is not supported for sandboxing");
             }
+            Ok(parsed)
         }
     }
 }


### PR DESCRIPTION
The Windows sandbox did not previously support multiple workspace roots via config. Now it does
