### PR TITLE
storing credits

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1005,6 +1005,7 @@ impl From<CoreRateLimitWindow> for RateLimitWindow {
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct CreditsSnapshot {
+    pub has_credits: bool,
     pub unlimited: bool,
     pub balance: Option<String>,
 }
@@ -1012,6 +1013,7 @@ pub struct CreditsSnapshot {
 impl From<CoreCreditsSnapshot> for CreditsSnapshot {
     fn from(value: CoreCreditsSnapshot) -> Self {
         Self {
+            has_credits: value.has_credits,
             unlimited: value.unlimited,
             balance: value.balance,
         }

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -11,6 +11,7 @@ use codex_protocol::items::AgentMessageContent as CoreAgentMessageContent;
 use codex_protocol::items::TurnItem as CoreTurnItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::parse_command::ParsedCommand as CoreParsedCommand;
+use codex_protocol::protocol::CreditsSnapshot as CoreCreditsSnapshot;
 use codex_protocol::protocol::RateLimitSnapshot as CoreRateLimitSnapshot;
 use codex_protocol::protocol::RateLimitWindow as CoreRateLimitWindow;
 use codex_protocol::user_input::UserInput as CoreUserInput;
@@ -968,6 +969,7 @@ pub struct AccountRateLimitsUpdatedNotification {
 pub struct RateLimitSnapshot {
     pub primary: Option<RateLimitWindow>,
     pub secondary: Option<RateLimitWindow>,
+    pub credits: Option<CreditsSnapshot>,
 }
 
 impl From<CoreRateLimitSnapshot> for RateLimitSnapshot {
@@ -975,6 +977,7 @@ impl From<CoreRateLimitSnapshot> for RateLimitSnapshot {
         Self {
             primary: value.primary.map(RateLimitWindow::from),
             secondary: value.secondary.map(RateLimitWindow::from),
+            credits: value.credits.map(CreditsSnapshot::from),
         }
     }
 }
@@ -994,6 +997,23 @@ impl From<CoreRateLimitWindow> for RateLimitWindow {
             used_percent: value.used_percent.round() as i32,
             window_duration_mins: value.window_minutes,
             resets_at: value.resets_at,
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct CreditsSnapshot {
+    pub unlimited: bool,
+    pub balance: Option<String>,
+}
+
+impl From<CoreCreditsSnapshot> for CreditsSnapshot {
+    fn from(value: CoreCreditsSnapshot) -> Self {
+        Self {
+            unlimited: value.unlimited,
+            balance: value.balance,
         }
     }
 }

--- a/codex-rs/app-server/src/outgoing_message.rs
+++ b/codex-rs/app-server/src/outgoing_message.rs
@@ -229,6 +229,7 @@ mod tests {
                         resets_at: Some(123),
                     }),
                     secondary: None,
+                    credits: None,
                 },
             });
 
@@ -243,7 +244,8 @@ mod tests {
                             "windowDurationMins": 15,
                             "resetsAt": 123
                         },
-                        "secondary": null
+                        "secondary": null,
+                        "credits": null
                     }
                 },
             }),

--- a/codex-rs/app-server/tests/suite/v2/rate_limits.rs
+++ b/codex-rs/app-server/tests/suite/v2/rate_limits.rs
@@ -152,6 +152,7 @@ async fn get_account_rate_limits_returns_snapshot() -> Result<()> {
                 window_duration_mins: Some(1440),
                 resets_at: Some(secondary_reset_timestamp),
             }),
+            credits: None,
         },
     };
     assert_eq!(received, expected);

--- a/codex-rs/backend-client/src/client.rs
+++ b/codex-rs/backend-client/src/client.rs
@@ -319,6 +319,7 @@ impl Client {
         };
 
         Some(CreditsSnapshot {
+            has_credits: details.has_credits,
             unlimited: details.unlimited,
             balance: details.balance.and_then(|inner| inner),
         })

--- a/codex-rs/backend-client/src/client.rs
+++ b/codex-rs/backend-client/src/client.rs
@@ -1,4 +1,5 @@
 use crate::types::CodeTaskDetailsResponse;
+use crate::types::CreditStatusDetails;
 use crate::types::PaginatedListTaskListItem;
 use crate::types::RateLimitStatusPayload;
 use crate::types::RateLimitWindowSnapshot;
@@ -6,6 +7,7 @@ use crate::types::TurnAttemptsSiblingTurnsResponse;
 use anyhow::Result;
 use codex_core::auth::CodexAuth;
 use codex_core::default_client::get_codex_user_agent;
+use codex_protocol::protocol::CreditsSnapshot;
 use codex_protocol::protocol::RateLimitSnapshot;
 use codex_protocol::protocol::RateLimitWindow;
 use reqwest::header::AUTHORIZATION;
@@ -272,19 +274,23 @@ impl Client {
 
     // rate limit helpers
     fn rate_limit_snapshot_from_payload(payload: RateLimitStatusPayload) -> RateLimitSnapshot {
-        let Some(details) = payload
+        let rate_limit_details = payload
             .rate_limit
-            .and_then(|inner| inner.map(|boxed| *boxed))
-        else {
-            return RateLimitSnapshot {
-                primary: None,
-                secondary: None,
-            };
+            .and_then(|inner| inner.map(|boxed| *boxed));
+
+        let (primary, secondary) = if let Some(details) = rate_limit_details {
+            (
+                Self::map_rate_limit_window(details.primary_window),
+                Self::map_rate_limit_window(details.secondary_window),
+            )
+        } else {
+            (None, None)
         };
 
         RateLimitSnapshot {
-            primary: Self::map_rate_limit_window(details.primary_window),
-            secondary: Self::map_rate_limit_window(details.secondary_window),
+            primary,
+            secondary,
+            credits: Self::map_credits(payload.credits),
         }
     }
 
@@ -303,6 +309,18 @@ impl Client {
             used_percent,
             window_minutes,
             resets_at,
+        })
+    }
+
+    fn map_credits(credits: Option<Option<Box<CreditStatusDetails>>>) -> Option<CreditsSnapshot> {
+        let details = match credits {
+            Some(Some(details)) => *details,
+            _ => return None,
+        };
+
+        Some(CreditsSnapshot {
+            unlimited: details.unlimited,
+            balance: details.balance.and_then(|inner| inner),
         })
     }
 

--- a/codex-rs/backend-client/src/types.rs
+++ b/codex-rs/backend-client/src/types.rs
@@ -1,3 +1,4 @@
+pub use codex_backend_openapi_models::models::CreditStatusDetails;
 pub use codex_backend_openapi_models::models::PaginatedListTaskListItem;
 pub use codex_backend_openapi_models::models::PlanType;
 pub use codex_backend_openapi_models::models::RateLimitStatusDetails;

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -762,7 +762,7 @@ fn parse_rate_limit_window(
 
 fn parse_credits_snapshot(headers: &HeaderMap) -> Option<CreditsSnapshot> {
     let has_credits = parse_header_bool(headers, "x-codex-credits-has-credits")?;
-    let unlimited = parse_header_bool(headers, "x-codex-credits-unlimited").unwrap_or(false);
+    let unlimited = parse_header_bool(headers, "x-codex-credits-unlimited")?;
     let balance = parse_header_str(headers, "x-codex-credits-balance")
         .map(str::trim)
         .filter(|value| !value.is_empty())

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -56,6 +56,7 @@ use crate::model_family::ModelFamily;
 use crate::model_provider_info::ModelProviderInfo;
 use crate::model_provider_info::WireApi;
 use crate::openai_model_info::get_model_info;
+use crate::protocol::CreditsSnapshot;
 use crate::protocol::RateLimitSnapshot;
 use crate::protocol::RateLimitWindow;
 use crate::protocol::TokenUsage;
@@ -726,7 +727,13 @@ fn parse_rate_limit_snapshot(headers: &HeaderMap) -> Option<RateLimitSnapshot> {
         "x-codex-secondary-reset-at",
     );
 
-    Some(RateLimitSnapshot { primary, secondary })
+    let credits = parse_credits_snapshot(headers);
+
+    Some(RateLimitSnapshot {
+        primary,
+        secondary,
+        credits,
+    })
 }
 
 fn parse_rate_limit_window(
@@ -753,6 +760,15 @@ fn parse_rate_limit_window(
     })
 }
 
+fn parse_credits_snapshot(headers: &HeaderMap) -> Option<CreditsSnapshot> {
+    let unlimited = parse_header_bool(headers, "x-codex-credits-unlimited")?;
+    let balance = parse_header_str(headers, "x-codex-credits-balance")
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(std::string::ToString::to_string);
+    Some(CreditsSnapshot { unlimited, balance })
+}
+
 fn parse_header_f64(headers: &HeaderMap, name: &str) -> Option<f64> {
     parse_header_str(headers, name)?
         .parse::<f64>()
@@ -762,6 +778,17 @@ fn parse_header_f64(headers: &HeaderMap, name: &str) -> Option<f64> {
 
 fn parse_header_i64(headers: &HeaderMap, name: &str) -> Option<i64> {
     parse_header_str(headers, name)?.parse::<i64>().ok()
+}
+
+fn parse_header_bool(headers: &HeaderMap, name: &str) -> Option<bool> {
+    let raw = parse_header_str(headers, name)?;
+    if raw.eq_ignore_ascii_case("true") || raw == "1" {
+        Some(true)
+    } else if raw.eq_ignore_ascii_case("false") || raw == "0" {
+        Some(false)
+    } else {
+        None
+    }
 }
 
 fn parse_header_str<'a>(headers: &'a HeaderMap, name: &str) -> Option<&'a str> {

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -766,7 +766,11 @@ fn parse_credits_snapshot(headers: &HeaderMap) -> Option<CreditsSnapshot> {
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(std::string::ToString::to_string);
-    Some(CreditsSnapshot { unlimited, balance })
+    Some(CreditsSnapshot {
+        has_credits: true,
+        unlimited,
+        balance,
+    })
 }
 
 fn parse_header_f64(headers: &HeaderMap, name: &str) -> Option<f64> {

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -761,13 +761,14 @@ fn parse_rate_limit_window(
 }
 
 fn parse_credits_snapshot(headers: &HeaderMap) -> Option<CreditsSnapshot> {
-    let unlimited = parse_header_bool(headers, "x-codex-credits-unlimited")?;
+    let has_credits = parse_header_bool(headers, "x-codex-credits-has-credits")?;
+    let unlimited = parse_header_bool(headers, "x-codex-credits-unlimited").unwrap_or(false);
     let balance = parse_header_str(headers, "x-codex-credits-balance")
         .map(str::trim)
         .filter(|value| !value.is_empty())
         .map(std::string::ToString::to_string);
     Some(CreditsSnapshot {
-        has_credits: true,
+        has_credits,
         unlimited,
         balance,
     })

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -499,6 +499,7 @@ mod tests {
                 window_minutes: Some(120),
                 resets_at: Some(secondary_reset_at),
             }),
+            credits: None,
         }
     }
 

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -1240,7 +1240,8 @@ async fn usage_limit_error_emits_rate_limit_event() -> anyhow::Result<()> {
             "used_percent": 87.5,
             "window_minutes": 60,
             "resets_at": null
-        }
+        },
+        "credits": null
     });
 
     let submission_id = codex

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -1121,7 +1121,8 @@ async fn token_count_includes_rate_limits_snapshot() {
                     "used_percent": 40.0,
                     "window_minutes": 60,
                     "resets_at": 1704074400
-                }
+                },
+                "credits": null
             }
         })
     );
@@ -1168,7 +1169,8 @@ async fn token_count_includes_rate_limits_snapshot() {
                     "used_percent": 40.0,
                     "window_minutes": 60,
                     "resets_at": 1704074400
-                }
+                },
+                "credits": null
             }
         })
     );

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -807,6 +807,7 @@ pub struct RateLimitWindow {
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema, TS)]
 pub struct CreditsSnapshot {
+    pub has_credits: bool,
     pub unlimited: bool,
     pub balance: Option<String>,
 }

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -790,6 +790,8 @@ pub struct TokenCountEvent {
 pub struct RateLimitSnapshot {
     pub primary: Option<RateLimitWindow>,
     pub secondary: Option<RateLimitWindow>,
+    #[ts(type = "CreditsSnapshot | null")]
+    pub credits: Option<CreditsSnapshot>,
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema, TS)]
@@ -802,6 +804,13 @@ pub struct RateLimitWindow {
     /// Unix timestamp (seconds since epoch) when the window resets.
     #[ts(type = "number | null")]
     pub resets_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema, TS)]
+pub struct CreditsSnapshot {
+    pub unlimited: bool,
+    #[ts(type = "string | null")]
+    pub balance: Option<String>,
 }
 
 // Includes prompts, tools and space to call compact.

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -790,7 +790,6 @@ pub struct TokenCountEvent {
 pub struct RateLimitSnapshot {
     pub primary: Option<RateLimitWindow>,
     pub secondary: Option<RateLimitWindow>,
-    #[ts(type = "CreditsSnapshot | null")]
     pub credits: Option<CreditsSnapshot>,
 }
 
@@ -809,7 +808,6 @@ pub struct RateLimitWindow {
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema, TS)]
 pub struct CreditsSnapshot {
     pub unlimited: bool,
-    #[ts(type = "string | null")]
     pub balance: Option<String>,
 }
 

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -81,6 +81,7 @@ fn snapshot(percent: f64) -> RateLimitSnapshot {
             resets_at: None,
         }),
         secondary: None,
+        credits: None,
     }
 }
 

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -28,6 +28,7 @@ use super::helpers::format_tokens_compact;
 use super::rate_limits::RateLimitSnapshotDisplay;
 use super::rate_limits::StatusRateLimitData;
 use super::rate_limits::StatusRateLimitRow;
+use super::rate_limits::StatusRateLimitValue;
 use super::rate_limits::compose_rate_limit_data;
 use super::rate_limits::format_status_limit_summary;
 use super::rate_limits::render_status_limit_progress_bar;
@@ -215,29 +216,41 @@ impl StatusHistoryCell {
         let mut lines = Vec::with_capacity(rows.len().saturating_mul(2));
 
         for row in rows {
-            let percent_remaining = (100.0 - row.percent_used).clamp(0.0, 100.0);
-            let value_spans = vec![
-                Span::from(render_status_limit_progress_bar(percent_remaining)),
-                Span::from(" "),
-                Span::from(format_status_limit_summary(percent_remaining)),
-            ];
-            let base_spans = formatter.full_spans(row.label.as_str(), value_spans);
-            let base_line = Line::from(base_spans.clone());
+            match &row.value {
+                StatusRateLimitValue::Window {
+                    percent_used,
+                    resets_at,
+                } => {
+                    let percent_remaining = (100.0 - percent_used).clamp(0.0, 100.0);
+                    let value_spans = vec![
+                        Span::from(render_status_limit_progress_bar(percent_remaining)),
+                        Span::from(" "),
+                        Span::from(format_status_limit_summary(percent_remaining)),
+                    ];
+                    let base_spans = formatter.full_spans(row.label.as_str(), value_spans);
+                    let base_line = Line::from(base_spans.clone());
 
-            if let Some(resets_at) = row.resets_at.as_ref() {
-                let resets_span = Span::from(format!("(resets {resets_at})")).dim();
-                let mut inline_spans = base_spans.clone();
-                inline_spans.push(Span::from(" ").dim());
-                inline_spans.push(resets_span.clone());
+                    if let Some(resets_at) = resets_at.as_ref() {
+                        let resets_span = Span::from(format!("(resets {resets_at})")).dim();
+                        let mut inline_spans = base_spans.clone();
+                        inline_spans.push(Span::from(" ").dim());
+                        inline_spans.push(resets_span.clone());
 
-                if line_display_width(&Line::from(inline_spans.clone())) <= available_inner_width {
-                    lines.push(Line::from(inline_spans));
-                } else {
-                    lines.push(base_line);
-                    lines.push(formatter.continuation(vec![resets_span]));
+                        if line_display_width(&Line::from(inline_spans.clone()))
+                            <= available_inner_width
+                        {
+                            lines.push(Line::from(inline_spans));
+                        } else {
+                            lines.push(base_line);
+                            lines.push(formatter.continuation(vec![resets_span]));
+                        }
+                    } else {
+                        lines.push(base_line);
+                    }
                 }
-            } else {
-                lines.push(base_line);
+                StatusRateLimitValue::Text(text) => {
+                    lines.push(formatter.line(row.label.as_str(), vec![Span::from(text.clone())]));
+                }
             }
         }
 

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -249,7 +249,9 @@ impl StatusHistoryCell {
                     }
                 }
                 StatusRateLimitValue::Text(text) => {
-                    lines.push(formatter.line(row.label.as_str(), vec![Span::from(text.clone())]));
+                    let spans =
+                        formatter.full_spans(row.label.as_str(), vec![Span::from(text.clone())]);
+                    lines.push(Line::from(spans));
                 }
             }
         }

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -249,8 +249,9 @@ impl StatusHistoryCell {
                     }
                 }
                 StatusRateLimitValue::Text(text) => {
+                    let label = row.label.clone();
                     let spans =
-                        formatter.full_spans(row.label.as_str(), vec![Span::from(text.clone())]);
+                        formatter.full_spans(label.as_str(), vec![Span::from(text.clone())]);
                     lines.push(Line::from(spans));
                 }
             }

--- a/codex-rs/tui/src/status/rate_limits.rs
+++ b/codex-rs/tui/src/status/rate_limits.rs
@@ -206,11 +206,15 @@ fn format_credit_balance(raw: &str) -> Option<String> {
         return None;
     }
 
-    if let Ok(int_value) = trimmed.parse::<i64>() && int_value > 0 {
+    if let Ok(int_value) = trimmed.parse::<i64>()
+        && int_value > 0
+    {
         return Some(int_value.to_string());
     }
 
-    if let Ok(value) = trimmed.parse::<f64>()  && value > 0.0 {
+    if let Ok(value) = trimmed.parse::<f64>()
+        && value > 0.0
+    {
         let rounded = value.round() as i64;
         return Some(rounded.to_string());
     }

--- a/codex-rs/tui/src/status/rate_limits.rs
+++ b/codex-rs/tui/src/status/rate_limits.rs
@@ -201,10 +201,19 @@ fn format_credit_balance(raw: &str) -> Option<String> {
         return None;
     }
 
-    if let Ok(value) = trimmed.parse::<f64>()
-        && value <= 0.0
-    {
+    if let Ok(int_value) = trimmed.parse::<i64>() {
+        if int_value > 0 {
+            return Some(int_value.to_string());
+        }
         return None;
+    }
+
+    if let Ok(value) = trimmed.parse::<f64>() {
+        if value <= 0.0 {
+            return None;
+        }
+        let rounded = value.round() as i64;
+        return Some(rounded.to_string());
     }
 
     Some(trimmed.to_string())

--- a/codex-rs/tui/src/status/rate_limits.rs
+++ b/codex-rs/tui/src/status/rate_limits.rs
@@ -201,10 +201,10 @@ fn format_credit_balance(raw: &str) -> Option<String> {
         return None;
     }
 
-    if let Ok(value) = trimmed.parse::<f64>() {
-        if value <= 0.0 {
-            return None;
-        }
+    if let Ok(value) = trimmed.parse::<f64>()
+        && value <= 0.0
+    {
+        return None;
     }
 
     Some(trimmed.to_string())

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_cached_limits_hide_credits_without_flag.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_cached_limits_hide_credits_without_flag.snap
@@ -1,0 +1,24 @@
+---
+source: tui/src/status/tests.rs
+expression: sanitized
+---
+/status
+
+╭─────────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                           │
+│                                                                     │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date       │
+│ information on rate limits and credits                              │
+│                                                                     │
+│  Model:            gpt-5.1-codex (reasoning none, summaries auto)   │
+│  Directory: [[workspace]]                                           │
+│  Approval:         on-request                                       │
+│  Sandbox:          read-only                                        │
+│  Agents.md:        <none>                                           │
+│                                                                     │
+│  Token usage:      1.05K total  (700 input + 350 output)            │
+│  Context window:   100% left (1.45K used / 272K)                    │
+│  5h limit:         [████████░░░░░░░░░░░░] 40% left (resets 11:32)   │
+│  Weekly limit:     [█████████████░░░░░░░] 65% left (resets 11:52)   │
+│  Warning:          limits may be stale - start new turn to refresh. │
+╰─────────────────────────────────────────────────────────────────────╯

--- a/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_credits_and_limits.snap
+++ b/codex-rs/tui/src/status/snapshots/codex_tui__status__tests__status_snapshot_includes_credits_and_limits.snap
@@ -1,0 +1,24 @@
+---
+source: tui/src/status/tests.rs
+expression: sanitized
+---
+/status
+
+╭───────────────────────────────────────────────────────────────────╮
+│  >_ OpenAI Codex (v0.0.0)                                         │
+│                                                                   │
+│ Visit https://chatgpt.com/codex/settings/usage for up-to-date     │
+│ information on rate limits and credits                            │
+│                                                                   │
+│  Model:            gpt-5.1-codex (reasoning none, summaries auto) │
+│  Directory: [[workspace]]                                         │
+│  Approval:         on-request                                     │
+│  Sandbox:          read-only                                      │
+│  Agents.md:        <none>                                         │
+│                                                                   │
+│  Token usage:      2K total  (1.4K input + 600 output)            │
+│  Context window:   100% left (2.2K used / 272K)                   │
+│  5h limit:         [███████████░░░░░░░░░] 55% left (resets 09:25) │
+│  Weekly limit:     [██████████████░░░░░░] 70% left (resets 09:55) │
+│  Credits:          38 credits                                     │
+╰───────────────────────────────────────────────────────────────────╯


### PR DESCRIPTION
 Expand the rate-limit cache/TUI: store credit snapshots alongside primary and secondary windows, render “Credits” when the backend reports they exist (unlimited vs rounded integer balances)