### PR TITLE
Fallback to model_family if no model_reasoning_effort in config

### DIFF
--- a/codex-rs/common/src/config_summary.rs
+++ b/codex-rs/common/src/config_summary.rs
@@ -15,13 +15,12 @@ pub fn create_config_summary_entries(config: &Config) -> Vec<(&'static str, Stri
     if config.model_provider.wire_api == WireApi::Responses
         && config.model_family.supports_reasoning_summaries
     {
-        entries.push((
-            "reasoning effort",
-            config
-                .model_reasoning_effort
-                .map(|effort| effort.to_string())
-                .unwrap_or_else(|| "none".to_string()),
-        ));
+        let reasoning_effort = config
+            .model_reasoning_effort
+            .or(config.model_family.default_reasoning_effort)
+            .map(|effort| effort.to_string())
+            .unwrap_or_else(|| "none".to_string());
+        entries.push(("reasoning effort", reasoning_effort));
         entries.push((
             "reasoning summaries",
             config.model_reasoning_summary.to_string(),


### PR DESCRIPTION
This closes #6748 by implementing fallback to `model_family.default_reasoning_effort` in `reasoning_effort` display of `/status` when no `model_reasoning_effort` is set in the configuration. 

Duplicate of #6749 because of tests not passing for what may seem to be a cache issue

## common/src/config_summary.rs

- `create_config_summary_entries` now fills the "reasoning effort" entry with the explicit `config.model_reasoning_effort` when present and falls back to `config.model_family.default_reasoning_effort` when it is `None`, instead of emitting the literal string `none`.
- This ensures downstream consumers such as `tui/src/status/helpers.rs` continue to work unchanged while automatically picking up model-family defaults when the user has not selected a reasoning effort.