### PR TITLE
 fix: add custom CA certificate support for login flows

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2121,6 +2121,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serial_test",
  "sha2",
  "tempfile",
  "tiny_http",

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2111,6 +2111,7 @@ name = "codex-login"
 version = "0.0.0"
 dependencies = [
  "anyhow",
+ "assert_cmd",
  "base64 0.22.1",
  "chrono",
  "codex-app-server-protocol",
@@ -2121,7 +2122,6 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
- "serial_test",
  "sha2",
  "tempfile",
  "tiny_http",

--- a/codex-rs/login/Cargo.toml
+++ b/codex-rs/login/Cargo.toml
@@ -37,3 +37,4 @@ core_test_support = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
 wiremock = { workspace = true }
+serial_test = { workspace = true }

--- a/codex-rs/login/Cargo.toml
+++ b/codex-rs/login/Cargo.toml
@@ -14,7 +14,6 @@ codex-core = { workspace = true }
 codex-app-server-protocol = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true, features = ["json", "blocking"] }
-rustls-pki-types = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }

--- a/codex-rs/login/Cargo.toml
+++ b/codex-rs/login/Cargo.toml
@@ -14,6 +14,7 @@ codex-core = { workspace = true }
 codex-app-server-protocol = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true, features = ["json", "blocking"] }
+rustls-pki-types = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
@@ -33,8 +34,8 @@ webbrowser = { workspace = true }
 
 [dev-dependencies]
 anyhow = { workspace = true }
+assert_cmd = { workspace = true }
 core_test_support = { workspace = true }
 pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
 wiremock = { workspace = true }
-serial_test = { workspace = true }

--- a/codex-rs/login/src/bin/login_ca_probe.rs
+++ b/codex-rs/login/src/bin/login_ca_probe.rs
@@ -1,0 +1,23 @@
+//! Helper binary for exercising custom CA environment handling in tests.
+//!
+//! The login flows honor `CODEX_CA_CERTIFICATE` and `SSL_CERT_FILE`, but those
+//! environment variables are process-global and unsafe to mutate in parallel
+//! test execution. This probe keeps the behavior under test while letting
+//! integration tests (`tests/ca_env.rs`) set env vars per-process, proving:
+//! - env precedence is respected,
+//! - multi-cert PEM bundles load,
+//! - error messages guide users when CA files are invalid.
+
+use std::process;
+
+fn main() {
+    match codex_login::build_login_http_client() {
+        Ok(_) => {
+            println!("ok");
+        }
+        Err(error) => {
+            eprintln!("{error}");
+            process::exit(1);
+        }
+    }
+}

--- a/codex-rs/login/src/device_code_auth.rs
+++ b/codex-rs/login/src/device_code_auth.rs
@@ -8,6 +8,7 @@ use std::time::Instant;
 
 use crate::pkce::PkceCodes;
 use crate::server::ServerOptions;
+use crate::server::build_login_http_client;
 use std::io;
 
 const ANSI_BLUE: &str = "\x1b[94m";
@@ -158,7 +159,7 @@ fn print_device_code_prompt(verification_url: &str, code: &str) {
 }
 
 pub async fn request_device_code(opts: &ServerOptions) -> std::io::Result<DeviceCode> {
-    let client = reqwest::Client::new();
+    let client = build_login_http_client()?;
     let base_url = opts.issuer.trim_end_matches('/');
     let api_base_url = format!("{base_url}/api/accounts");
     let uc = request_user_code(&client, &api_base_url, &opts.client_id).await?;
@@ -175,7 +176,7 @@ pub async fn complete_device_code_login(
     opts: ServerOptions,
     device_code: DeviceCode,
 ) -> std::io::Result<()> {
-    let client = reqwest::Client::new();
+    let client = build_login_http_client()?;
     let base_url = opts.issuer.trim_end_matches('/');
     let api_base_url = format!("{base_url}/api/accounts");
 

--- a/codex-rs/login/src/lib.rs
+++ b/codex-rs/login/src/lib.rs
@@ -9,6 +9,7 @@ pub use device_code_auth::run_device_code_login;
 pub use server::LoginServer;
 pub use server::ServerOptions;
 pub use server::ShutdownHandle;
+pub use server::build_login_http_client;
 pub use server::run_login_server;
 
 // Re-export commonly used auth types and helpers from codex-core for compatibility

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -1452,4 +1452,71 @@ mod tests {
         let err = client.expect_err("client should fail for malformed cert");
         assert!(err.to_string().contains("failed to parse PEM file"));
     }
+
+    #[serial(login_cert_env)]
+    #[test]
+    fn build_client_handles_multi_certificate_bundle() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let cert_path = write_test_cert_bundle(&temp_dir, "bundle.pem");
+        let (codex_env_before, ssl_env_before) = capture_env();
+
+        set_env_var(CODEX_CA_CERT_ENV, &cert_path);
+        remove_env_var(SSL_CERT_FILE_ENV);
+
+        let client = build_login_http_client();
+
+        restore_env(CODEX_CA_CERT_ENV, codex_env_before);
+        restore_env(SSL_CERT_FILE_ENV, ssl_env_before);
+
+        assert!(
+            client.is_ok(),
+            "Failed to build client with bundle: {:?}",
+            client.err()
+        );
+    }
+
+    #[serial(login_cert_env)]
+    #[test]
+    fn build_client_rejects_empty_pem_file() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let cert_path = temp_dir.path().join("empty.pem");
+        fs::write(&cert_path, "").expect("write empty file");
+        let (codex_env_before, ssl_env_before) = capture_env();
+
+        set_env_var(CODEX_CA_CERT_ENV, &cert_path);
+        remove_env_var(SSL_CERT_FILE_ENV);
+
+        let client = build_login_http_client();
+
+        restore_env(CODEX_CA_CERT_ENV, codex_env_before);
+        restore_env(SSL_CERT_FILE_ENV, ssl_env_before);
+
+        assert!(client.is_err());
+        let err = client.unwrap_err();
+        assert!(err.to_string().contains("no certificates found"));
+    }
+
+    #[serial(login_cert_env)]
+    #[test]
+    fn build_client_rejects_malformed_pem() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let cert_path = temp_dir.path().join("malformed.pem");
+        fs::write(&cert_path, "-----BEGIN CERTIFICATE-----\nMIIBroken").expect("write malformed");
+        let (codex_env_before, ssl_env_before) = capture_env();
+
+        set_env_var(CODEX_CA_CERT_ENV, &cert_path);
+        remove_env_var(SSL_CERT_FILE_ENV);
+
+        let client = build_login_http_client();
+
+        restore_env(CODEX_CA_CERT_ENV, codex_env_before);
+        restore_env(SSL_CERT_FILE_ENV, ssl_env_before);
+
+        assert!(client.is_err());
+        let err = client.unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("BEGIN CERTIFICATE without matching END")
+        );
+    }
 }

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -778,7 +778,7 @@ fn read_ca_certificates(path: &Path) -> io::Result<Vec<reqwest::Certificate>> {
 /// Enterprise TLS inspection proxies often rely on custom CA roots, which means
 /// system roots alone cannot validate the OAuth exchange. We allow opt-in CA
 /// overrides via `CODEX_CA_CERTIFICATE` (preferred) or `SSL_CERT_FILE`.
-pub(crate) fn build_login_http_client() -> io::Result<reqwest::Client> {
+pub fn build_login_http_client() -> io::Result<reqwest::Client> {
     build_login_http_client_with_env(&ProcessEnv)
 }
 
@@ -1451,72 +1451,5 @@ mod tests {
 
         let err = client.expect_err("client should fail for malformed cert");
         assert!(err.to_string().contains("failed to parse PEM file"));
-    }
-
-    #[serial(login_cert_env)]
-    #[test]
-    fn build_client_handles_multi_certificate_bundle() {
-        let temp_dir = TempDir::new().expect("tempdir");
-        let cert_path = write_test_cert_bundle(&temp_dir, "bundle.pem");
-        let (codex_env_before, ssl_env_before) = capture_env();
-
-        set_env_var(CODEX_CA_CERT_ENV, &cert_path);
-        remove_env_var(SSL_CERT_FILE_ENV);
-
-        let client = build_login_http_client();
-
-        restore_env(CODEX_CA_CERT_ENV, codex_env_before);
-        restore_env(SSL_CERT_FILE_ENV, ssl_env_before);
-
-        assert!(
-            client.is_ok(),
-            "Failed to build client with bundle: {:?}",
-            client.err()
-        );
-    }
-
-    #[serial(login_cert_env)]
-    #[test]
-    fn build_client_rejects_empty_pem_file() {
-        let temp_dir = TempDir::new().expect("tempdir");
-        let cert_path = temp_dir.path().join("empty.pem");
-        fs::write(&cert_path, "").expect("write empty file");
-        let (codex_env_before, ssl_env_before) = capture_env();
-
-        set_env_var(CODEX_CA_CERT_ENV, &cert_path);
-        remove_env_var(SSL_CERT_FILE_ENV);
-
-        let client = build_login_http_client();
-
-        restore_env(CODEX_CA_CERT_ENV, codex_env_before);
-        restore_env(SSL_CERT_FILE_ENV, ssl_env_before);
-
-        assert!(client.is_err());
-        let err = client.unwrap_err();
-        assert!(err.to_string().contains("no certificates found"));
-    }
-
-    #[serial(login_cert_env)]
-    #[test]
-    fn build_client_rejects_malformed_pem() {
-        let temp_dir = TempDir::new().expect("tempdir");
-        let cert_path = temp_dir.path().join("malformed.pem");
-        fs::write(&cert_path, "-----BEGIN CERTIFICATE-----\nMIIBroken").expect("write malformed");
-        let (codex_env_before, ssl_env_before) = capture_env();
-
-        set_env_var(CODEX_CA_CERT_ENV, &cert_path);
-        remove_env_var(SSL_CERT_FILE_ENV);
-
-        let client = build_login_http_client();
-
-        restore_env(CODEX_CA_CERT_ENV, codex_env_before);
-        restore_env(SSL_CERT_FILE_ENV, ssl_env_before);
-
-        assert!(client.is_err());
-        let err = client.unwrap_err();
-        assert!(
-            err.to_string()
-                .contains("BEGIN CERTIFICATE without matching END")
-        );
     }
 }

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -708,38 +708,6 @@ fn login_ca_certificate_path(env_source: &dyn EnvSource) -> Option<PathBuf> {
 fn strip_pem_block(input: &str, label: &str) -> String {
     let begin = format!("-----BEGIN {label}-----");
     let end = format!("-----END {label}-----");
-<<<<<<< HEAD
-=======
-
-    let mut output = String::new();
-    let mut rest = input;
-
-    loop {
-        if let Some(begin_idx) = rest.find(&begin) {
-            output.push_str(&rest[..begin_idx]);
-            if let Some(end_idx) = rest[begin_idx..].find(&end) {
-                let after_end = begin_idx + end_idx + end.len();
-                rest = &rest[after_end..];
-                continue;
-            } else {
-                output.push_str(&rest[begin_idx..]);
-                break;
-            }
-        } else {
-            output.push_str(rest);
-            break;
-        }
-    }
-
-    output
-}
-
-fn pem_parse_error(path: &Path, error: &pem::Error) -> io::Error {
-    let detail = match error {
-        pem::Error::NoItemsFound => "no certificates found in PEM file".to_string(),
-        _ => format!("failed to parse PEM file: {error}"),
-    };
->>>>>>> 16c91a1e5 (login: tolerate CRL blocks in CA bundles and test)
 
     let mut output = String::new();
     let mut rest = input;
@@ -787,13 +755,7 @@ fn read_ca_certificates(path: &Path) -> io::Result<Vec<reqwest::Certificate>> {
         )
     })?;
 
-<<<<<<< HEAD
     let mut normalized_pem = String::from_utf8(pem_data)
-=======
-    // Support both standard CERTIFICATE and TRUSTED CERTIFICATE labels by
-    // normalizing the latter to the former before parsing.
-    let mut normalized_pem = String::from_utf8(pem_data.clone())
->>>>>>> 16c91a1e5 (login: tolerate CRL blocks in CA bundles and test)
         .map(|s| {
             s.replace("BEGIN TRUSTED CERTIFICATE", "BEGIN CERTIFICATE")
                 .replace("END TRUSTED CERTIFICATE", "END CERTIFICATE")
@@ -801,21 +763,8 @@ fn read_ca_certificates(path: &Path) -> io::Result<Vec<reqwest::Certificate>> {
         .unwrap_or_else(|error| String::from_utf8_lossy(&error.into_bytes()).into_owned());
     normalized_pem = strip_pem_block(&normalized_pem, "X509 CRL");
 
-<<<<<<< HEAD
     let certificates = reqwest::Certificate::from_pem_bundle(normalized_pem.as_bytes())
         .map_err(|error| pem_parse_error(path, format!("failed to parse PEM file: {error}")))?;
-=======
-    // Strip CRL blocks so mixed bundles (certs + CRLs) do not fail parsing.
-    normalized_pem = strip_pem_block(&normalized_pem, "X509 CRL");
-
-    let mut certificates = Vec::new();
-    for cert_result in
-        <CertificateDer<'static> as PemObject>::pem_slice_iter(normalized_pem.as_bytes())
-    {
-        let cert = cert_result.map_err(|error| pem_parse_error(path, &error))?;
-        certificates.push(cert);
-    }
->>>>>>> 16c91a1e5 (login: tolerate CRL blocks in CA bundles and test)
 
     if certificates.is_empty() {
         return Err(pem_parse_error(path, "no certificates found in PEM file"));

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -708,6 +708,38 @@ fn login_ca_certificate_path(env_source: &dyn EnvSource) -> Option<PathBuf> {
 fn strip_pem_block(input: &str, label: &str) -> String {
     let begin = format!("-----BEGIN {label}-----");
     let end = format!("-----END {label}-----");
+<<<<<<< HEAD
+=======
+
+    let mut output = String::new();
+    let mut rest = input;
+
+    loop {
+        if let Some(begin_idx) = rest.find(&begin) {
+            output.push_str(&rest[..begin_idx]);
+            if let Some(end_idx) = rest[begin_idx..].find(&end) {
+                let after_end = begin_idx + end_idx + end.len();
+                rest = &rest[after_end..];
+                continue;
+            } else {
+                output.push_str(&rest[begin_idx..]);
+                break;
+            }
+        } else {
+            output.push_str(rest);
+            break;
+        }
+    }
+
+    output
+}
+
+fn pem_parse_error(path: &Path, error: &pem::Error) -> io::Error {
+    let detail = match error {
+        pem::Error::NoItemsFound => "no certificates found in PEM file".to_string(),
+        _ => format!("failed to parse PEM file: {error}"),
+    };
+>>>>>>> 16c91a1e5 (login: tolerate CRL blocks in CA bundles and test)
 
     let mut output = String::new();
     let mut rest = input;
@@ -755,7 +787,13 @@ fn read_ca_certificates(path: &Path) -> io::Result<Vec<reqwest::Certificate>> {
         )
     })?;
 
+<<<<<<< HEAD
     let mut normalized_pem = String::from_utf8(pem_data)
+=======
+    // Support both standard CERTIFICATE and TRUSTED CERTIFICATE labels by
+    // normalizing the latter to the former before parsing.
+    let mut normalized_pem = String::from_utf8(pem_data.clone())
+>>>>>>> 16c91a1e5 (login: tolerate CRL blocks in CA bundles and test)
         .map(|s| {
             s.replace("BEGIN TRUSTED CERTIFICATE", "BEGIN CERTIFICATE")
                 .replace("END TRUSTED CERTIFICATE", "END CERTIFICATE")
@@ -763,8 +801,21 @@ fn read_ca_certificates(path: &Path) -> io::Result<Vec<reqwest::Certificate>> {
         .unwrap_or_else(|error| String::from_utf8_lossy(&error.into_bytes()).into_owned());
     normalized_pem = strip_pem_block(&normalized_pem, "X509 CRL");
 
+<<<<<<< HEAD
     let certificates = reqwest::Certificate::from_pem_bundle(normalized_pem.as_bytes())
         .map_err(|error| pem_parse_error(path, format!("failed to parse PEM file: {error}")))?;
+=======
+    // Strip CRL blocks so mixed bundles (certs + CRLs) do not fail parsing.
+    normalized_pem = strip_pem_block(&normalized_pem, "X509 CRL");
+
+    let mut certificates = Vec::new();
+    for cert_result in
+        <CertificateDer<'static> as PemObject>::pem_slice_iter(normalized_pem.as_bytes())
+    {
+        let cert = cert_result.map_err(|error| pem_parse_error(path, &error))?;
+        certificates.push(cert);
+    }
+>>>>>>> 16c91a1e5 (login: tolerate CRL blocks in CA bundles and test)
 
     if certificates.is_empty() {
         return Err(pem_parse_error(path, "no certificates found in PEM file"));

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -11,6 +11,8 @@
 //! This module therefore keeps the user-facing error path and the structured-log path separate.
 //! Returned `io::Error` values still carry the detail needed by CLI/browser callers, while
 //! structured logs only emit explicitly reviewed fields plus redacted URL/error values.
+use std::env;
+use std::fs;
 use std::io::Cursor;
 use std::io::Read;
 use std::io::Write;
@@ -47,6 +49,9 @@ use tracing::warn;
 
 const DEFAULT_ISSUER: &str = "https://auth.openai.com";
 const DEFAULT_PORT: u16 = 1455;
+const CODEX_CA_CERT_ENV: &str = "CODEX_CA_CERTIFICATE";
+const SSL_CERT_FILE_ENV: &str = "SSL_CERT_FILE";
+const CA_CERT_HINT: &str = "If you set CODEX_CA_CERTIFICATE or SSL_CERT_FILE, ensure it points to a PEM file containing one or more CERTIFICATE blocks, or unset it to use system roots.";
 
 /// Options for launching the local login callback server.
 #[derive(Debug, Clone)]
@@ -675,6 +680,121 @@ fn sanitize_url_for_logging(url: &str) -> String {
 /// non-JSON error text is preserved there. Structured logging stays narrower: it logs reviewed
 /// fields from parsed token responses and redacted transport errors, but does not log the final
 /// callback-layer `%err` string.
+trait EnvSource {
+    fn var(&self, key: &str) -> Option<String>;
+}
+
+struct ProcessEnv;
+
+impl EnvSource for ProcessEnv {
+    fn var(&self, key: &str) -> Option<String> {
+        env::var(key).ok()
+    }
+}
+
+fn login_ca_certificate_path(env_source: &dyn EnvSource) -> Option<PathBuf> {
+    env_source
+        .var(CODEX_CA_CERT_ENV)
+        .filter(|value| !value.is_empty())
+        .map(PathBuf::from)
+        .or_else(|| {
+            env_source
+                .var(SSL_CERT_FILE_ENV)
+                .filter(|value| !value.is_empty())
+                .map(PathBuf::from)
+        })
+}
+
+fn strip_pem_block(input: &str, label: &str) -> String {
+    let begin = format!("-----BEGIN {label}-----");
+    let end = format!("-----END {label}-----");
+
+    let mut output = String::new();
+    let mut rest = input;
+
+    loop {
+        if let Some(begin_idx) = rest.find(&begin) {
+            output.push_str(&rest[..begin_idx]);
+            if let Some(end_idx) = rest[begin_idx..].find(&end) {
+                let after_end = begin_idx + end_idx + end.len();
+                rest = &rest[after_end..];
+                continue;
+            }
+
+            output.push_str(&rest[begin_idx..]);
+            break;
+        }
+
+        output.push_str(rest);
+        break;
+    }
+
+    output
+}
+
+fn pem_parse_error(path: &Path, detail: impl std::fmt::Display) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::InvalidData,
+        format!(
+            "Failed to load CA certificates from {path}: {detail}. {hint}",
+            path = path.display(),
+            hint = CA_CERT_HINT
+        ),
+    )
+}
+
+fn read_ca_certificates(path: &Path) -> io::Result<Vec<reqwest::Certificate>> {
+    let pem_data = fs::read(path).map_err(|error| {
+        io::Error::new(
+            error.kind(),
+            format!(
+                "Failed to read CA certificate file {path}: {error}. {hint}",
+                path = path.display(),
+                hint = CA_CERT_HINT
+            ),
+        )
+    })?;
+
+    let mut normalized_pem = String::from_utf8(pem_data)
+        .map(|s| {
+            s.replace("BEGIN TRUSTED CERTIFICATE", "BEGIN CERTIFICATE")
+                .replace("END TRUSTED CERTIFICATE", "END CERTIFICATE")
+        })
+        .unwrap_or_else(|error| String::from_utf8_lossy(&error.into_bytes()).into_owned());
+    normalized_pem = strip_pem_block(&normalized_pem, "X509 CRL");
+
+    let certificates = reqwest::Certificate::from_pem_bundle(normalized_pem.as_bytes())
+        .map_err(|error| pem_parse_error(path, format!("failed to parse PEM file: {error}")))?;
+
+    if certificates.is_empty() {
+        return Err(pem_parse_error(path, "no certificates found in PEM file"));
+    }
+
+    Ok(certificates)
+}
+
+/// Custom CA handling for login flows.
+///
+/// Enterprise TLS inspection proxies often rely on custom CA roots, which means
+/// system roots alone cannot validate the OAuth exchange. We allow opt-in CA
+/// overrides via `CODEX_CA_CERTIFICATE` (preferred) or `SSL_CERT_FILE`.
+pub(crate) fn build_login_http_client() -> io::Result<reqwest::Client> {
+    build_login_http_client_with_env(&ProcessEnv)
+}
+
+fn build_login_http_client_with_env(env_source: &dyn EnvSource) -> io::Result<reqwest::Client> {
+    let mut builder = reqwest::Client::builder();
+
+    if let Some(path) = login_ca_certificate_path(env_source) {
+        let certificates = read_ca_certificates(&path)?;
+        for certificate in certificates {
+            builder = builder.add_root_certificate(certificate);
+        }
+    }
+
+    builder.build().map_err(io::Error::other)
+}
+
 pub(crate) async fn exchange_code_for_tokens(
     issuer: &str,
     client_id: &str,
@@ -689,7 +809,7 @@ pub(crate) async fn exchange_code_for_tokens(
         refresh_token: String,
     }
 
-    let client = reqwest::Client::new();
+    let client = build_login_http_client()?;
     info!(
         issuer = %sanitize_url_for_logging(issuer),
         redirect_uri = %redirect_uri,
@@ -1055,7 +1175,7 @@ pub(crate) async fn obtain_api_key(
     struct ExchangeResp {
         access_token: String,
     }
-    let client = reqwest::Client::new();
+    let client = build_login_http_client()?;
     let resp = client
         .post(format!("{issuer}/oauth/token"))
         .header("Content-Type", "application/x-www-form-urlencoded")
@@ -1082,13 +1202,34 @@ pub(crate) async fn obtain_api_key(
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use pretty_assertions::assert_eq;
+    use std::collections::HashMap;
+    use std::fs;
+    use std::path::PathBuf;
+    use tempfile::TempDir;
 
-    use super::TokenEndpointErrorDetail;
-    use super::parse_token_endpoint_error;
-    use super::redact_sensitive_query_value;
-    use super::redact_sensitive_url_parts;
-    use super::sanitize_url_for_logging;
+    const TEST_CERT_1: &str = "-----BEGIN CERTIFICATE-----\nMIIDBTCCAe2gAwIBAgIURA/8mcaBUM3VeC/959yHcE5qhg0wDQYJKoZIhvcNAQEL\nBQAwEjEQMA4GA1UEAwwHdGVzdC1jYTAeFw0yNTExMTkwMTI5NDJaFw0yNjExMTkw\nMTI5NDJaMBIxEDAOBgNVBAMMB3Rlc3QtY2EwggEiMA0GCSqGSIb3DQEBAQUAA4IB\nDwAwggEKAoIBAQCQlu3GsymtWBmmFeIYzObIWzV1/BcSYr34Q7etqNxz/FcPwVw0\nXKJ6K4+TH3kOcjnUyWazCdwKINDsniN3i9rzTnDhFxuU/kHfV2pYOAGd5zOqQZYG\nfathKAxZTGLcBFqG4EmfgwZURSugi5xPsT56UJAdOmoltkcyhy3xeRL1dK2xdi++\nCmZcI3fTD/e3ZwzubPXPUOSXRae2yt1C53p70uiA+6R9UlIIoFxpHh4cD2go8z6v\nqKwnkKWycGJD2LFXdYRYOHRP1px4OCsnLAteUjgUsGTu0K4uJEsJYyLdmhg0Dpjz\n148Cwh5UuRbkWUGvZ2BNCHZB8ttQO2g0RzP/AgMBAAGjUzBRMB0GA1UdDgQWBBTV\n08esey9TtVpv5K3saN8rUoc3KzAfBgNVHSMEGDAWgBTV08esey9TtVpv5K3saN8r\nUoc3KzAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBcxHdHiiyY\nsoWsCd/PuQLFOb4iAD5Gkftb55lxyL/WBtDqbWMGqtWSKFbjlSyVCqcrRduCTOne\nWgT5h4vyHzpBwRTuL0E3E72Y/vVc2kZ8djaB/gBO/IsEs3jDgVIOZk5SmVPTzBxI\nPBc3Rp6TmMCmLzRrrVg5BpCIH/0YVcgH71abUGpiJJp+cVvet5Yh+1+HlFZriWit\nh1OZe3bUuYvLxLnYrRpn4kDvsCXZOPJmIhEtQvoxWTllj6Xp5cVZ5JZdVyx6g9+7\npw5sOGsOCrQ4RV6U22e7T/ClsN9TYfM+JzQeIbAD0LL7mASVxXGE/LJ7EVdyGbrL\nCnUUO0SOj4m4\n-----END CERTIFICATE-----\n";
+    const TEST_CERT_2: &str = "-----BEGIN CERTIFICATE-----\nMIIDGTCCAgGgAwIBAgIUWxlcvHzwITWAHWHbKMFUTgeDmjwwDQYJKoZIhvcNAQEL\nBQAwHDEaMBgGA1UEAwwRdGVzdC1pbnRlcm1lZGlhdGUwHhcNMjUxMTE5MTU1MDIz\nWhcNMjYxMTE5MTU1MDIzWjAcMRowGAYDVQQDDBF0ZXN0LWludGVybWVkaWF0ZTCC\nASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANq7xbeYpC2GaXANqD1nLk0t\nj9j2sOk6e7DqTapxnIUijS7z4DF0Vo1xHM07wK1m+wsB/t9CubNYRvtn6hrIzx7K\njjlmvxo4/YluwO1EDMQWZAXkaY2O28ESKVx7QLfBPYAc4bf/5B4Nmt6KX5sQyyyH\n2qTfzVBUCAl3sI+Ydd3mx7NOye1yNNkCNqyK3Hj45F1JuH8NZxcb4OlKssZhMlD+\nEQx4G46AzKE9Ho8AqlQvg/tiWrMHRluw7zolMJ/AXzedAXedNIrX4fCOmZwcTkA1\na8eLPP8oM9VFrr67a7on6p4zPqugUEQ4fawp7A5KqSjUAVCt1FXmn2V8N8V6W/sC\nAwEAAaNTMFEwHQYDVR0OBBYEFBEwRwW0gm3IjhLw1U3eOAvR0r6SMB8GA1UdIwQY\nMBaAFBEwRwW0gm3IjhLw1U3eOAvR0r6SMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZI\nhvcNAQELBQADggEBAB2fjAlpevK42Odv8XUEgV6VWlEP9HAmkRvugW9hjhzx1Iz9\nVh/l9VcxL7PcqdpyGH+BIRvQIMokcYF5TXzf/KV1T2y56U8AWaSd2/xSjYNWwkgE\nTLE5V+H/YDKzvTe58UrOaxa5N3URscQL9f+ZKworODmfMlkJ1mlREK130ZMlBexB\np9w5wo1M1fjx76Rqzq9MkpwBSbIO2zx/8+qy4BAH23MPGW+9OOnnq2DiIX3qUu1v\nhnjYOxYpCB28MZEJmqsjFJQQ9RF+Te4U2/oknVcf8lZIMJ2ZBOwt2zg8RqCtM52/\nIbATwYj77wg3CFLFKcDYs3tdUqpiniabKcf6zAs=\n-----END CERTIFICATE-----\n";
+
+    struct MapEnv {
+        values: HashMap<String, String>,
+    }
+
+    impl EnvSource for MapEnv {
+        fn var(&self, key: &str) -> Option<String> {
+            self.values.get(key).cloned()
+        }
+    }
+
+    fn map_env(pairs: &[(&str, &str)]) -> MapEnv {
+        MapEnv {
+            values: pairs
+                .iter()
+                .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+                .collect(),
+        }
+    }
 
     #[test]
     fn parse_token_endpoint_error_prefers_error_description() {
@@ -1186,5 +1327,129 @@ mod tests {
             redacted,
             "https://example.com/base?token=%3Credacted%3E&env=prod".to_string()
         );
+    }
+
+    #[test]
+    fn ca_path_prefers_codex_env() {
+        let env = map_env(&[
+            (CODEX_CA_CERT_ENV, "/tmp/codex.pem"),
+            (SSL_CERT_FILE_ENV, "/tmp/fallback.pem"),
+        ]);
+
+        assert_eq!(
+            login_ca_certificate_path(&env),
+            Some(PathBuf::from("/tmp/codex.pem"))
+        );
+    }
+
+    #[test]
+    fn ca_path_falls_back_to_ssl_cert_file() {
+        let env = map_env(&[(SSL_CERT_FILE_ENV, "/tmp/fallback.pem")]);
+
+        assert_eq!(
+            login_ca_certificate_path(&env),
+            Some(PathBuf::from("/tmp/fallback.pem"))
+        );
+    }
+
+    #[test]
+    fn ca_path_ignores_empty_values() {
+        let env = map_env(&[
+            (CODEX_CA_CERT_ENV, ""),
+            (SSL_CERT_FILE_ENV, "/tmp/fallback.pem"),
+        ]);
+
+        assert_eq!(
+            login_ca_certificate_path(&env),
+            Some(PathBuf::from("/tmp/fallback.pem"))
+        );
+    }
+
+    fn build_client(env: MapEnv) -> io::Result<reqwest::Client> {
+        build_login_http_client_with_env(&env)
+    }
+
+    fn write_test_cert(temp_dir: &TempDir, file_name: &str, contents: &str) -> PathBuf {
+        let path = temp_dir.path().join(file_name);
+        fs::write(&path, contents).expect("write cert fixture");
+        path
+    }
+
+    #[test]
+    fn build_client_uses_codex_ca_cert_env() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let cert_path = write_test_cert(&temp_dir, "ca.pem", TEST_CERT_1);
+        let env = map_env(&[(CODEX_CA_CERT_ENV, cert_path.to_str().unwrap())]);
+
+        let client = build_client(env);
+
+        assert!(client.is_ok(), "Failed to build client: {:?}", client.err());
+    }
+
+    #[test]
+    fn build_client_uses_ssl_cert_file_fallback() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let cert_path = write_test_cert(&temp_dir, "ssl-cert.pem", TEST_CERT_1);
+        let env = map_env(&[(SSL_CERT_FILE_ENV, cert_path.to_str().unwrap())]);
+
+        let client = build_client(env);
+
+        assert!(client.is_ok(), "Failed to build client: {:?}", client.err());
+    }
+
+    #[test]
+    fn build_client_rejects_invalid_certificate_data() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let cert_path = write_test_cert(&temp_dir, "invalid.pem", "not-a-certificate");
+        let env = map_env(&[(CODEX_CA_CERT_ENV, cert_path.to_str().unwrap())]);
+
+        let client = build_client(env);
+
+        let err = client.expect_err("client should fail for invalid cert");
+        assert!(err.to_string().contains("no certificates found"));
+    }
+
+    #[test]
+    fn build_client_handles_multi_certificate_bundle() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let bundle = format!("{TEST_CERT_1}\n{TEST_CERT_2}");
+        let cert_path = write_test_cert(&temp_dir, "bundle.pem", &bundle);
+        let env = map_env(&[(CODEX_CA_CERT_ENV, cert_path.to_str().unwrap())]);
+
+        let client = build_client(env);
+
+        assert!(
+            client.is_ok(),
+            "Failed to build client with bundle: {:?}",
+            client.err()
+        );
+    }
+
+    #[test]
+    fn build_client_rejects_empty_pem_file() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let cert_path = write_test_cert(&temp_dir, "empty.pem", "");
+        let env = map_env(&[(CODEX_CA_CERT_ENV, cert_path.to_str().unwrap())]);
+
+        let client = build_client(env);
+
+        let err = client.expect_err("client should fail for empty cert file");
+        assert!(err.to_string().contains("no certificates found"));
+    }
+
+    #[test]
+    fn build_client_rejects_malformed_pem() {
+        let temp_dir = TempDir::new().expect("tempdir");
+        let cert_path = write_test_cert(
+            &temp_dir,
+            "malformed.pem",
+            "-----BEGIN CERTIFICATE-----\nMIIBroken",
+        );
+        let env = map_env(&[(CODEX_CA_CERT_ENV, cert_path.to_str().unwrap())]);
+
+        let client = build_client(env);
+
+        let err = client.expect_err("client should fail for malformed cert");
+        assert!(err.to_string().contains("failed to parse PEM file"));
     }
 }

--- a/codex-rs/login/tests/ca_env.rs
+++ b/codex-rs/login/tests/ca_env.rs
@@ -143,3 +143,16 @@ fn rejects_malformed_pem_with_hint() {
     assert!(stderr.contains("CODEX_CA_CERTIFICATE"));
     assert!(stderr.contains("SSL_CERT_FILE"));
 }
+
+#[test]
+fn accepts_trusted_certificate_label() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let trusted = TEST_CERT_1
+        .replace("BEGIN CERTIFICATE", "BEGIN TRUSTED CERTIFICATE")
+        .replace("END CERTIFICATE", "END TRUSTED CERTIFICATE");
+    let cert_path = write_cert_file(&temp_dir, "trusted.pem", &trusted);
+
+    let output = run_probe(&[(CODEX_CA_CERT_ENV, cert_path.as_path())]);
+
+    assert!(output.status.success());
+}

--- a/codex-rs/login/tests/ca_env.rs
+++ b/codex-rs/login/tests/ca_env.rs
@@ -156,3 +156,15 @@ fn accepts_trusted_certificate_label() {
 
     assert!(output.status.success());
 }
+
+#[test]
+fn accepts_bundle_with_crl() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let crl = "-----BEGIN X509 CRL-----\nMIIC\n-----END X509 CRL-----";
+    let bundle = format!("{TEST_CERT_1}\n{crl}");
+    let cert_path = write_cert_file(&temp_dir, "bundle_crl.pem", &bundle);
+
+    let output = run_probe(&[(CODEX_CA_CERT_ENV, cert_path.as_path())]);
+
+    assert!(output.status.success());
+}

--- a/codex-rs/login/tests/ca_env.rs
+++ b/codex-rs/login/tests/ca_env.rs
@@ -1,0 +1,145 @@
+use assert_cmd::cargo::CommandCargoExt;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+const CODEX_CA_CERT_ENV: &str = "CODEX_CA_CERTIFICATE";
+const SSL_CERT_FILE_ENV: &str = "SSL_CERT_FILE";
+
+const TEST_CERT_1: &str = "-----BEGIN CERTIFICATE-----
+MIIDBTCCAe2gAwIBAgIUZYhGvBUG7SucNzYh9VIeZ7b9zHowDQYJKoZIhvcNAQEL
+BQAwEjEQMA4GA1UEAwwHdGVzdC1jYTAeFw0yNTEyMTEyMzEyNTFaFw0zNTEyMDky
+MzEyNTFaMBIxEDAOBgNVBAMMB3Rlc3QtY2EwggEiMA0GCSqGSIb3DQEBAQUAA4IB
+DwAwggEKAoIBAQC+NJRZAdn15FFBN8eR1HTAe+LMVpO19kKtiCsQjyqHONfhfHcF
+7zQfwmH6MqeNpC/5k5m8V1uSIhyHBskQm83Jv8/vHlffNxE/hl0Na/Yd1bc+2kxH
+twIAsF32GKnSKnFva/iGczV81+/ETgG6RXfTfy/Xs6fXL8On8SRRmTcMw0bEfwko
+ziid87VOHg2JfdRKN5QpS9lvQ8q4q2M3jMftolpUTpwlR0u8j9OXnZfn+ja33X0l
+kjkoCbXE2fVbAzO/jhUHQX1H5RbTGGUnrrCWAj84Rq/E80KK1nrRF91K+vgZmilM
+gOZosLMMI1PeqTakwg1yIRngpTyk0eJP+haxAgMBAAGjUzBRMB0GA1UdDgQWBBT6
+sqvfjMIl0DFZkeu8LU577YqMVDAfBgNVHSMEGDAWgBT6sqvfjMIl0DFZkeu8LU57
+7YqMVDAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQBQ1sYs2RvB
+TZ+xSBglLwH/S7zXVJIDwQ23Rlj11dgnVvcilSJCX24Rr+pfIVLpYNDdZzc/DIJd
+S1dt2JuLnvXnle29rU7cxuzYUkUkRtaeY2Sj210vsE3lqUFyIy8XCc/lteb+FiJ7
+zo/gPk7P+y4ihK9Mm6SBqkDVEYSFSn9bgoemK+0e93jGe2182PyuTwfTmZgENSBO
+2f9dSuay4C7e5UO8bhVccQJg6f4d70zUNG0oPHrnVxJLjwCd++jx25Gh4U7+ek13
+CW57pxJrpPMDWb2YK64rT2juHMKF73YuplW92SInd+QLpI2ekTLc+bRw8JvqzXg+
+SprtRUBjlWzj
+-----END CERTIFICATE-----
+";
+
+const TEST_CERT_2: &str = "-----BEGIN CERTIFICATE-----
+MIIDGTCCAgGgAwIBAgIUWxlcvHzwITWAHWHbKMFUTgeDmjwwDQYJKoZIhvcNAQEL
+BQAwHDEaMBgGA1UEAwwRdGVzdC1pbnRlcm1lZGlhdGUwHhcNMjUxMTE5MTU1MDIz
+WhcNMjYxMTE5MTU1MDIzWjAcMRowGAYDVQQDDBF0ZXN0LWludGVybWVkaWF0ZTCC
+ASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoCggEBANq7xbeYpC2GaXANqD1nLk0t
+j9j2sOk6e7DqTapxnIUijS7z4DF0Vo1xHM07wK1m+wsB/t9CubNYRvtn6hrIzx7K
+jjlmvxo4/YluwO1EDMQWZAXkaY2O28ESKVx7QLfBPYAc4bf/5B4Nmt6KX5sQyyyH
+2qTfzVBUCAl3sI+Ydd3mx7NOye1yNNkCNqyK3Hj45F1JuH8NZxcb4OlKssZhMlD+
+EQx4G46AzKE9Ho8AqlQvg/tiWrMHRluw7zolMJ/AXzedAXedNIrX4fCOmZwcTkA1
+a8eLPP8oM9VFrr67a7on6p4zPqugUEQ4fawp7A5KqSjUAVCt1FXmn2V8N8V6W/sC
+AwEAAaNTMFEwHQYDVR0OBBYEFBEwRwW0gm3IjhLw1U3eOAvR0r6SMB8GA1UdIwQY
+MBaAFBEwRwW0gm3IjhLw1U3eOAvR0r6SMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZI
+hvcNAQELBQADggEBAB2fjAlpevK42Odv8XUEgV6VWlEP9HAmkRvugW9hjhzx1Iz9
+Vh/l9VcxL7PcqdpyGH+BIRvQIMokcYF5TXzf/KV1T2y56U8AWaSd2/xSjYNWwkgE
+TLE5V+H/YDKzvTe58UrOaxa5N3URscQL9f+ZKworODmfMlkJ1mlREK130ZMlBexB
+p9w5wo1M1fjx76Rqzq9MkpwBSbIO2zx/8+qy4BAH23MPGW+9OOnnq2DiIX3qUu1v
+hnjYOxYpCB28MZEJmqsjFJQQ9RF+Te4U2/oknVcf8lZIMJ2ZBOwt2zg8RqCtM52/
+IbATwYj77wg3CFLFKcDYs3tdUqpiniabKcf6zAs=
+-----END CERTIFICATE-----
+";
+
+fn write_cert_file(temp_dir: &TempDir, name: &str, contents: &str) -> std::path::PathBuf {
+    let path = temp_dir.path().join(name);
+    fs::write(&path, contents).unwrap_or_else(|error| {
+        panic!("write cert fixture failed for {}: {error}", path.display())
+    });
+    path
+}
+
+fn run_probe(envs: &[(&str, &Path)]) -> std::process::Output {
+    let mut cmd = Command::cargo_bin("login_ca_probe")
+        .unwrap_or_else(|error| panic!("failed to locate login_ca_probe: {error}"));
+    for (key, value) in envs {
+        cmd.env(key, value);
+    }
+    cmd.output()
+        .unwrap_or_else(|error| panic!("failed to run login_ca_probe: {error}"))
+}
+
+#[test]
+fn uses_codex_ca_cert_env() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let cert_path = write_cert_file(&temp_dir, "ca.pem", TEST_CERT_1);
+
+    let output = run_probe(&[(CODEX_CA_CERT_ENV, cert_path.as_path())]);
+
+    assert!(output.status.success());
+}
+
+#[test]
+fn falls_back_to_ssl_cert_file() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let cert_path = write_cert_file(&temp_dir, "ssl.pem", TEST_CERT_1);
+
+    let output = run_probe(&[(SSL_CERT_FILE_ENV, cert_path.as_path())]);
+
+    assert!(output.status.success());
+}
+
+#[test]
+fn prefers_codex_ca_cert_over_ssl_cert_file() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let cert_path = write_cert_file(&temp_dir, "ca.pem", TEST_CERT_1);
+    let bad_path = write_cert_file(&temp_dir, "bad.pem", "");
+
+    let output = run_probe(&[
+        (CODEX_CA_CERT_ENV, cert_path.as_path()),
+        (SSL_CERT_FILE_ENV, bad_path.as_path()),
+    ]);
+
+    assert!(output.status.success());
+}
+
+#[test]
+fn handles_multi_certificate_bundle() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let bundle = format!("{TEST_CERT_1}\n{TEST_CERT_2}");
+    let cert_path = write_cert_file(&temp_dir, "bundle.pem", &bundle);
+
+    let output = run_probe(&[(CODEX_CA_CERT_ENV, cert_path.as_path())]);
+
+    assert!(output.status.success());
+}
+
+#[test]
+fn rejects_empty_pem_file_with_hint() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let cert_path = write_cert_file(&temp_dir, "empty.pem", "");
+
+    let output = run_probe(&[(CODEX_CA_CERT_ENV, cert_path.as_path())]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("no certificates found in PEM file"));
+    assert!(stderr.contains("CODEX_CA_CERTIFICATE"));
+    assert!(stderr.contains("SSL_CERT_FILE"));
+}
+
+#[test]
+fn rejects_malformed_pem_with_hint() {
+    let temp_dir = TempDir::new().expect("tempdir");
+    let cert_path = write_cert_file(
+        &temp_dir,
+        "malformed.pem",
+        "-----BEGIN CERTIFICATE-----\nMIIBroken",
+    );
+
+    let output = run_probe(&[(CODEX_CA_CERT_ENV, cert_path.as_path())]);
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("failed to parse PEM file"));
+    assert!(stderr.contains("CODEX_CA_CERTIFICATE"));
+    assert!(stderr.contains("SSL_CERT_FILE"));
+}

--- a/codex-rs/login/tests/ca_env.rs
+++ b/codex-rs/login/tests/ca_env.rs
@@ -1,4 +1,3 @@
-use assert_cmd::cargo::CommandCargoExt;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
@@ -58,8 +57,7 @@ fn write_cert_file(temp_dir: &TempDir, name: &str, contents: &str) -> std::path:
 }
 
 fn run_probe(envs: &[(&str, &Path)]) -> std::process::Output {
-    let mut cmd = Command::cargo_bin("login_ca_probe")
-        .unwrap_or_else(|error| panic!("failed to locate login_ca_probe: {error}"));
+    let mut cmd = Command::new(assert_cmd::cargo::cargo_bin!("login_ca_probe"));
     for (key, value) in envs {
         cmd.env(key, value);
     }

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,17 +1,33 @@
-# Configuration
+# Config
 
-For basic configuration instructions, see [this documentation](https://developers.openai.com/codex/config-basic).
+Codex configuration gives you fine-grained control over the model, execution environment, and integrations available to the CLI. Use this guide alongside the workflows in [`codex exec`](./exec.md), the guardrails in [Sandbox & approvals](./sandbox.md), and project guidance from [AGENTS.md discovery](./agents_md.md).
 
-For advanced configuration instructions, see [this documentation](https://developers.openai.com/codex/config-advanced).
+## Quick navigation
 
-For a full configuration reference, see [this documentation](https://developers.openai.com/codex/config-reference).
+- [Feature flags](#feature-flags)
+- [Model selection](#model-selection)
+- [Execution environment](#execution-environment)
+- [MCP integration](#mcp-integration)
+- [Observability and telemetry](#observability-and-telemetry)
+- [Profiles and overrides](#profiles-and-overrides)
+- [Reference table](#config-reference)
 
-## Connecting to MCP servers
+Codex supports several mechanisms for setting config values:
 
-Codex can connect to MCP servers configured in `~/.codex/config.toml`. See the configuration reference for the latest MCP server options:
+- Config-specific command-line flags, such as `--model o3` (highest precedence).
+- A generic `-c`/`--config` flag that takes a `key=value` pair, such as `--config model="o3"`.
+  - The key can contain dots to set a value deeper than the root, e.g. `--config model_providers.openai.wire_api="chat"`.
+  - For consistency with `config.toml`, values are a string in TOML format rather than JSON format, so use `key='{a = 1, b = 2}'` rather than `key='{"a": 1, "b": 2}'`.
+    - The quotes around the value are necessary, as without them your shell would split the config argument on spaces, resulting in `codex` receiving `-c key={a` with (invalid) additional arguments `=`, `1,`, `b`, `=`, `2}`.
+  - Values can contain any TOML object, such as `--config shell_environment_policy.include_only='["PATH", "HOME", "USER"]'`.
+  - If `value` cannot be parsed as a valid TOML value, it is treated as a string value. This means that `-c model='"o3"'` and `-c model=o3` are equivalent.
+    - In the first case, the value is the TOML string `"o3"`, while in the second the value is `o3`, which is not valid TOML and therefore treated as the TOML string `"o3"`.
+    - Because quotes are interpreted by one's shell, `-c key="true"` will be correctly interpreted in TOML as `key = true` (a boolean) and not `key = "true"` (a string). If for some reason you needed the string `"true"`, you would need to use `-c key='"true"'` (note the two sets of quotes).
+- The `$CODEX_HOME/config.toml` configuration file where the `CODEX_HOME` environment value defaults to `~/.codex`. (Note `CODEX_HOME` will also be where logs and other Codex-related information are stored.)
 
-- https://developers.openai.com/codex/config-reference
+Both the `--config` flag and the `config.toml` file support the following options:
 
+<<<<<<< HEAD
 ## Apps (Connectors)
 
 Use `$` in the composer to insert a ChatGPT connector; the popover lists accessible
@@ -19,9 +35,13 @@ apps. The `/apps` command lists available and installed apps. Connected apps app
 and are labeled as connected; others are marked as can be installed.
 
 ## Notify
+=======
+## Feature flags
+>>>>>>> 75d082940 (docs: add CA certificate environment variable documentation)
 
-Codex can run a notification hook when the agent finishes a turn. See the configuration reference for the latest notification settings:
+Optional and experimental capabilities are toggled via the `[features]` table in `$CODEX_HOME/config.toml`. If you see a deprecation notice mentioning a legacy key (for example `experimental_use_exec_command_tool`), move the setting into `[features]` or pass `--enable <feature>`.
 
+<<<<<<< HEAD
 - https://developers.openai.com/codex/config-reference
 
 When Codex knows which client started the turn, the legacy notify JSON payload also includes a top-level `client` field. The TUI reports `codex-tui`, and the app server reports the `clientInfo.name` value from `initialize`.
@@ -50,3 +70,1004 @@ override), not "inherit the global default". There is currently no separate
 config value for "follow the global default in Plan mode".
 
 Ctrl+C/Ctrl+D quitting uses a ~1 second double-press hint (`ctrl + c again to quit`).
+=======
+```toml
+[features]
+web_search_request = true        # allow the model to request web searches
+# view_image_tool defaults to true; omit to keep defaults
+```
+
+Supported features:
+
+| Key                                   | Default | Stage        | Description                                           |
+| ------------------------------------- | :-----: | ------------ | ----------------------------------------------------- |
+| `unified_exec`                        |  false  | Experimental | Use the unified PTY-backed exec tool                  |
+| `rmcp_client`                         |  false  | Experimental | Enable oauth support for streamable HTTP MCP servers  |
+| `apply_patch_freeform`                |  false  | Beta         | Include the freeform `apply_patch` tool               |
+| `view_image_tool`                     |  true   | Stable       | Include the `view_image` tool                         |
+| `web_search_request`                  |  false  | Stable       | Allow the model to issue web searches                 |
+| `ghost_commit`                        |  false  | Experimental | Create a ghost commit each turn                       |
+| `enable_experimental_windows_sandbox` |  false  | Experimental | Use the Windows restricted-token sandbox              |
+| `tui2`                                |  false  | Experimental | Use the experimental TUI v2 (viewport) implementation |
+
+Notes:
+
+- Omit a key to accept its default.
+- Legacy booleans such as `experimental_use_exec_command_tool`, `experimental_use_unified_exec_tool`, `include_apply_patch_tool`, and similar `experimental_use_*` keys are deprecated; setting the corresponding `[features].<key>` avoids repeated warnings.
+
+## Model selection
+
+### model
+
+The model that Codex should use.
+
+```toml
+model = "gpt-5.1"  # overrides the default ("gpt-5.1-codex-max" across platforms)
+```
+
+### model_providers
+
+This option lets you add to the default set of model providers bundled with Codex. The map key becomes the value you use with `model_provider` to select the provider.
+
+> [!NOTE]
+> Built-in providers are not overwritten when you reuse their key. Entries you add only take effect when the key is **new**; for example `[model_providers.openai]` leaves the original OpenAI definition untouched. To customize the bundled OpenAI provider, prefer the dedicated knobs (for example the `OPENAI_BASE_URL` environment variable) or register a new provider key and point `model_provider` at it.
+
+For example, if you wanted to add a provider that uses the OpenAI 4o model via the chat completions API, then you could add the following configuration:
+
+```toml
+# Recall that in TOML, root keys must be listed before tables.
+model = "gpt-4o"
+model_provider = "openai-chat-completions"
+
+[model_providers.openai-chat-completions]
+# Name of the provider that will be displayed in the Codex UI.
+name = "OpenAI using Chat Completions"
+# The path `/chat/completions` will be amended to this URL to make the POST
+# request for the chat completions.
+base_url = "https://api.openai.com/v1"
+# If `env_key` is set, identifies an environment variable that must be set when
+# using Codex with this provider. The value of the environment variable must be
+# non-empty and will be used in the `Bearer TOKEN` HTTP header for the POST request.
+env_key = "OPENAI_API_KEY"
+# Valid values for wire_api are "chat" and "responses". Defaults to "chat" if omitted.
+wire_api = "chat"
+# If necessary, extra query params that need to be added to the URL.
+# See the Azure example below.
+query_params = {}
+```
+
+Note this makes it possible to use Codex CLI with non-OpenAI models, so long as they use a wire API that is compatible with the OpenAI chat completions API. For example, you could define the following provider to use Codex CLI with Ollama running locally:
+
+```toml
+[model_providers.ollama]
+name = "Ollama"
+base_url = "http://localhost:11434/v1"
+```
+
+Or a third-party provider (using a distinct environment variable for the API key):
+
+```toml
+[model_providers.mistral]
+name = "Mistral"
+base_url = "https://api.mistral.ai/v1"
+env_key = "MISTRAL_API_KEY"
+```
+
+It is also possible to configure a provider to include extra HTTP headers with a request. These can be hardcoded values (`http_headers`) or values read from environment variables (`env_http_headers`):
+
+```toml
+[model_providers.example]
+# name, base_url, ...
+
+# This will add the HTTP header `X-Example-Header` with value `example-value`
+# to each request to the model provider.
+http_headers = { "X-Example-Header" = "example-value" }
+
+# This will add the HTTP header `X-Example-Features` with the value of the
+# `EXAMPLE_FEATURES` environment variable to each request to the model provider
+# _if_ the environment variable is set and its value is non-empty.
+env_http_headers = { "X-Example-Features" = "EXAMPLE_FEATURES" }
+```
+
+#### Azure model provider example
+
+Note that Azure requires `api-version` to be passed as a query parameter, so be sure to specify it as part of `query_params` when defining the Azure provider:
+
+```toml
+[model_providers.azure]
+name = "Azure"
+# Make sure you set the appropriate subdomain for this URL.
+base_url = "https://YOUR_PROJECT_NAME.openai.azure.com/openai"
+env_key = "AZURE_OPENAI_API_KEY"  # Or "OPENAI_API_KEY", whichever you use.
+query_params = { api-version = "2025-04-01-preview" }
+wire_api = "responses"
+```
+
+Export your key before launching Codex: `export AZURE_OPENAI_API_KEY=…`
+
+#### Per-provider network tuning
+
+The following optional settings control retry behaviour and streaming idle timeouts **per model provider**. They must be specified inside the corresponding `[model_providers.<id>]` block in `config.toml`. (Older releases accepted top‑level keys; those are now ignored.)
+
+Example:
+
+```toml
+[model_providers.openai]
+name = "OpenAI"
+base_url = "https://api.openai.com/v1"
+env_key = "OPENAI_API_KEY"
+# network tuning overrides (all optional; falls back to built‑in defaults)
+request_max_retries = 4            # retry failed HTTP requests
+stream_max_retries = 10            # retry dropped SSE streams
+stream_idle_timeout_ms = 300000    # 5m idle timeout
+```
+
+##### request_max_retries
+
+How many times Codex will retry a failed HTTP request to the model provider. Defaults to `4`.
+
+##### stream_max_retries
+
+Number of times Codex will attempt to reconnect when a streaming response is interrupted. Defaults to `5`.
+
+##### stream_idle_timeout_ms
+
+How long Codex will wait for activity on a streaming response before treating the connection as lost. Defaults to `300_000` (5 minutes).
+
+### model_provider
+
+Identifies which provider to use from the `model_providers` map. Defaults to `"openai"`. You can override the `base_url` for the built-in `openai` provider via the `OPENAI_BASE_URL` environment variable.
+
+Note that if you override `model_provider`, then you likely want to override
+`model`, as well. For example, if you are running ollama with Mistral locally,
+then you would need to add the following to your config in addition to the new entry in the `model_providers` map:
+
+```toml
+model_provider = "ollama"
+model = "mistral"
+```
+
+### model_reasoning_effort
+
+If the selected model is known to support reasoning (for example: `o3`, `o4-mini`, `codex-*`, `gpt-5.1-codex-max`, `gpt-5.1`, `gpt-5.1-codex`), reasoning is enabled by default when using the Responses API. As explained in the [OpenAI Platform documentation](https://platform.openai.com/docs/guides/reasoning?api-mode=responses#get-started-with-reasoning), this can be set to:
+
+- `"minimal"`
+- `"low"`
+- `"medium"` (default)
+- `"high"`
+- `"xhigh"` (available only on `gpt-5.1-codex-max`)
+
+Note: to minimize reasoning, choose `"minimal"`.
+
+### model_reasoning_summary
+
+If the model name starts with `"o"` (as in `"o3"` or `"o4-mini"`) or `"codex"`, reasoning is enabled by default when using the Responses API. As explained in the [OpenAI Platform documentation](https://platform.openai.com/docs/guides/reasoning?api-mode=responses#reasoning-summaries), this can be set to:
+
+- `"auto"` (default)
+- `"concise"`
+- `"detailed"`
+
+To disable reasoning summaries, set `model_reasoning_summary` to `"none"` in your config:
+
+```toml
+model_reasoning_summary = "none"  # disable reasoning summaries
+```
+
+### model_verbosity
+
+Controls output length/detail on GPT‑5 family models when using the Responses API. Supported values:
+
+- `"low"`
+- `"medium"` (default when omitted)
+- `"high"`
+
+When set, Codex includes a `text` object in the request payload with the configured verbosity, for example: `"text": { "verbosity": "low" }`.
+
+Example:
+
+```toml
+model = "gpt-5.1"
+model_verbosity = "low"
+```
+
+Note: This applies only to providers using the Responses API. Chat Completions providers are unaffected.
+
+### model_supports_reasoning_summaries
+
+By default, `reasoning` is only set on requests to OpenAI models that are known to support them. To force `reasoning` to set on requests to the current model, you can force this behavior by setting the following in `config.toml`:
+
+```toml
+model_supports_reasoning_summaries = true
+```
+
+### model_context_window
+
+The size of the context window for the model, in tokens.
+
+In general, Codex knows the context window for the most common OpenAI models, but if you are using a new model with an old version of the Codex CLI, then you can use `model_context_window` to tell Codex what value to use to determine how much context is left during a conversation.
+
+### oss_provider
+
+Specifies the default OSS provider to use when running Codex. This is used when the `--oss` flag is provided without a specific provider.
+
+Valid values are:
+
+- `"lmstudio"` - Use LM Studio as the local model provider
+- `"ollama"` - Use Ollama as the local model provider
+
+```toml
+# Example: Set default OSS provider to LM Studio
+oss_provider = "lmstudio"
+```
+
+## Execution environment
+
+### approval_policy
+
+Determines when the user should be prompted to approve whether Codex can execute a command:
+
+```toml
+# Codex has hardcoded logic that defines a set of "trusted" commands.
+# Setting the approval_policy to `untrusted` means that Codex will prompt the
+# user before running a command not in the "trusted" set.
+#
+# See https://github.com/openai/codex/issues/1260 for the plan to enable
+# end-users to define their own trusted commands.
+approval_policy = "untrusted"
+```
+
+If you want to be notified whenever a command fails, use "on-failure":
+
+```toml
+# If the command fails when run in the sandbox, Codex asks for permission to
+# retry the command outside the sandbox.
+approval_policy = "on-failure"
+```
+
+If you want the model to run until it decides that it needs to ask you for escalated permissions, use "on-request":
+
+```toml
+# The model decides when to escalate
+approval_policy = "on-request"
+```
+
+Alternatively, you can have the model run until it is done, and never ask to run a command with escalated permissions:
+
+```toml
+# User is never prompted: if the command fails, Codex will automatically try
+# something out. Note the `exec` subcommand always uses this mode.
+approval_policy = "never"
+```
+
+### sandbox_mode
+
+Codex executes model-generated shell commands inside an OS-level sandbox.
+
+In most cases you can pick the desired behaviour with a single option:
+
+```toml
+# same as `--sandbox read-only`
+sandbox_mode = "read-only"
+```
+
+The default policy is `read-only`, which means commands can read any file on
+disk, but attempts to write a file or access the network will be blocked.
+
+A more relaxed policy is `workspace-write`. When specified, the current working directory for the Codex task will be writable (as well as `$TMPDIR` on macOS). Note that the CLI defaults to using the directory where it was spawned as `cwd`, though this can be overridden using `--cwd/-C`.
+
+On macOS (and soon Linux), all writable roots (including `cwd`) that contain a `.git/` folder _as an immediate child_ will configure the `.git/` folder to be read-only while the rest of the Git repository will be writable. This means that commands like `git commit` will fail, by default (as it entails writing to `.git/`), and will require Codex to ask for permission.
+
+```toml
+# same as `--sandbox workspace-write`
+sandbox_mode = "workspace-write"
+
+# Extra settings that only apply when `sandbox = "workspace-write"`.
+[sandbox_workspace_write]
+# By default, the cwd for the Codex session will be writable as well as $TMPDIR
+# (if set) and /tmp (if it exists). Setting the respective options to `true`
+# will override those defaults.
+exclude_tmpdir_env_var = false
+exclude_slash_tmp = false
+
+# Optional list of _additional_ writable roots beyond $TMPDIR and /tmp.
+writable_roots = ["/Users/YOU/.pyenv/shims"]
+
+# Allow the command being run inside the sandbox to make outbound network
+# requests. Disabled by default.
+network_access = false
+```
+
+To disable sandboxing altogether, specify `danger-full-access` like so:
+
+```toml
+# same as `--sandbox danger-full-access`
+sandbox_mode = "danger-full-access"
+```
+
+This is reasonable to use if Codex is running in an environment that provides its own sandboxing (such as a Docker container) such that further sandboxing is unnecessary.
+
+Though using this option may also be necessary if you try to use Codex in environments where its native sandboxing mechanisms are unsupported, such as older Linux kernels or on Windows.
+
+### tools.\*
+
+These `[tools]` configuration options are deprecated. Use `[features]` instead (see [Feature flags](#feature-flags)).
+
+Use the optional `[tools]` table to toggle built-in tools that the agent may call. `web_search` stays off unless you opt in, while `view_image` is now enabled by default:
+
+```toml
+[tools]
+web_search = true   # allow Codex to issue first-party web searches without prompting you (deprecated)
+view_image = false  # disable image uploads (they're enabled by default)
+```
+
+The `view_image` toggle is useful when you want to include screenshots or diagrams from your repo without pasting them manually. Codex still respects sandboxing: it can only attach files inside the workspace roots you allow.
+
+### approval_presets
+
+Codex provides three main Approval Presets:
+
+- Read Only: Codex can read files and answer questions; edits, running commands, and network access require approval.
+- Auto: Codex can read files, make edits, and run commands in the workspace without approval; asks for approval outside the workspace or for network access.
+- Full Access: Full disk and network access without prompts; extremely risky.
+
+You can further customize how Codex runs at the command line using the `--ask-for-approval` and `--sandbox` options.
+
+> See also [Sandbox & approvals](./sandbox.md) for in-depth examples and platform-specific behaviour.
+
+### shell_environment_policy
+
+Codex spawns subprocesses (e.g. when executing a `local_shell` tool-call suggested by the assistant). By default it now passes **your full environment** to those subprocesses. You can tune this behavior via the **`shell_environment_policy`** block in `config.toml`:
+
+```toml
+[shell_environment_policy]
+# inherit can be "all" (default), "core", or "none"
+inherit = "core"
+# set to true to *skip* the filter for `"*KEY*"` and `"*TOKEN*"`
+ignore_default_excludes = false
+# exclude patterns (case-insensitive globs)
+exclude = ["AWS_*", "AZURE_*"]
+# force-set / override values
+set = { CI = "1" }
+# if provided, *only* vars matching these patterns are kept
+include_only = ["PATH", "HOME"]
+```
+
+| Field                     | Type                 | Default | Description                                                                                                                                     |
+| ------------------------- | -------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `inherit`                 | string               | `all`   | Starting template for the environment:<br>`all` (clone full parent env), `core` (`HOME`, `PATH`, `USER`, …), or `none` (start empty).           |
+| `ignore_default_excludes` | boolean              | `false` | When `false`, Codex removes any var whose **name** contains `KEY`, `SECRET`, or `TOKEN` (case-insensitive) before other rules run.              |
+| `exclude`                 | array<string>        | `[]`    | Case-insensitive glob patterns to drop after the default filter.<br>Examples: `"AWS_*"`, `"AZURE_*"`.                                           |
+| `set`                     | table<string,string> | `{}`    | Explicit key/value overrides or additions – always win over inherited values.                                                                   |
+| `include_only`            | array<string>        | `[]`    | If non-empty, a whitelist of patterns; only variables that match _one_ pattern survive the final step. (Generally used with `inherit = "all"`.) |
+
+The patterns are **glob style**, not full regular expressions: `*` matches any
+number of characters, `?` matches exactly one, and character classes like
+`[A-Z]`/`[^0-9]` are supported. Matching is always **case-insensitive**. This
+syntax is documented in code as `EnvironmentVariablePattern` (see
+`core/src/config_types.rs`).
+
+If you just need a clean slate with a few custom entries you can write:
+
+```toml
+[shell_environment_policy]
+inherit = "none"
+set = { PATH = "/usr/bin", MY_FLAG = "1" }
+```
+
+Currently, `CODEX_SANDBOX_NETWORK_DISABLED=1` is also added to the environment, assuming network is disabled. This is not configurable.
+
+## MCP integration
+
+### mcp_servers
+
+You can configure Codex to use [MCP servers](https://modelcontextprotocol.io/about) to give Codex access to external applications, resources, or services.
+
+#### Server configuration
+
+##### STDIO
+
+[STDIO servers](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#stdio) are MCP servers that you can launch directly via commands on your computer.
+
+```toml
+# The top-level table name must be `mcp_servers`
+# The sub-table name (`server-name` in this example) can be anything you would like.
+[mcp_servers.server_name]
+command = "npx"
+# Optional
+args = ["-y", "mcp-server"]
+# Optional: propagate additional env vars to the MCP server.
+# A default whitelist of env vars will be propagated to the MCP server.
+# https://github.com/openai/codex/blob/main/codex-rs/rmcp-client/src/utils.rs#L82
+env = { "API_KEY" = "value" }
+# or
+[mcp_servers.server_name.env]
+API_KEY = "value"
+# Optional: Additional list of environment variables that will be whitelisted in the MCP server's environment.
+env_vars = ["API_KEY2"]
+
+# Optional: cwd that the command will be run from
+cwd = "/Users/<user>/code/my-server"
+```
+
+##### Streamable HTTP
+
+[Streamable HTTP servers](https://modelcontextprotocol.io/specification/2025-06-18/basic/transports#streamable-http) enable Codex to talk to resources that are accessed via a http url (either on localhost or another domain).
+
+```toml
+[mcp_servers.figma]
+url = "https://mcp.figma.com/mcp"
+# Optional environment variable containing a bearer token to use for auth
+bearer_token_env_var = "ENV_VAR"
+# Optional map of headers with hard-coded values.
+http_headers = { "HEADER_NAME" = "HEADER_VALUE" }
+# Optional map of headers whose values will be replaced with the environment variable.
+env_http_headers = { "HEADER_NAME" = "ENV_VAR" }
+```
+
+Streamable HTTP connections always use the experimental Rust MCP client under the hood, so expect occasional rough edges. OAuth login flows are gated on the `rmcp_client = true` flag:
+
+```toml
+[features]
+rmcp_client = true
+```
+
+After enabling it, run `codex mcp login <server-name>` when the server supports OAuth.
+
+#### Other configuration options
+
+```toml
+# Optional: override the default 10s startup timeout
+startup_timeout_sec = 20
+# Optional: override the default 60s per-tool timeout
+tool_timeout_sec = 30
+# Optional: disable a server without removing it
+enabled = false
+# Optional: only expose a subset of tools from this server
+enabled_tools = ["search", "summarize"]
+# Optional: hide specific tools (applied after `enabled_tools`, if set)
+disabled_tools = ["search"]
+```
+
+When both `enabled_tools` and `disabled_tools` are specified, Codex first restricts the server to the allow-list and then removes any tools that appear in the deny-list.
+
+#### MCP CLI commands
+
+```shell
+# List all available commands
+codex mcp --help
+
+# Add a server (env can be repeated; `--` separates the launcher command)
+codex mcp add docs -- docs-server --port 4000
+
+# List configured servers (pretty table or JSON)
+codex mcp list
+codex mcp list --json
+
+# Show one server (table or JSON)
+codex mcp get docs
+codex mcp get docs --json
+
+# Remove a server
+codex mcp remove docs
+
+# Log in to a streamable HTTP server that supports oauth
+codex mcp login SERVER_NAME
+
+# Log out from a streamable HTTP server that supports oauth
+codex mcp logout SERVER_NAME
+```
+
+### Examples of useful MCPs
+
+There is an ever growing list of useful MCP servers that can be helpful while you are working with Codex.
+
+Some of the most common MCPs we've seen are:
+
+- [Context7](https://github.com/upstash/context7) — connect to a wide range of up-to-date developer documentation
+- Figma [Local](https://developers.figma.com/docs/figma-mcp-server/local-server-installation/) and [Remote](https://developers.figma.com/docs/figma-mcp-server/remote-server-installation/) - access to your Figma designs
+- [Playwright](https://www.npmjs.com/package/@playwright/mcp) - control and inspect a browser using Playwright
+- [Chrome Developer Tools](https://github.com/ChromeDevTools/chrome-devtools-mcp/) — control and inspect a Chrome browser
+- [Sentry](https://docs.sentry.io/product/sentry-mcp/#codex) — access to your Sentry logs
+- [GitHub](https://github.com/github/github-mcp-server) — Control over your GitHub account beyond what git allows (like controlling PRs, issues, etc.)
+
+## Observability and telemetry
+
+### otel
+
+Codex can emit [OpenTelemetry](https://opentelemetry.io/) **log events** that
+describe each run: outbound API requests, streamed responses, user input,
+tool-approval decisions, and the result of every tool invocation. Export is
+**disabled by default** so local runs remain self-contained. Opt in by adding an
+`[otel]` table and choosing an exporter.
+
+```toml
+[otel]
+environment = "staging"   # defaults to "dev"
+exporter = "none"          # defaults to "none"; set to otlp-http or otlp-grpc to send events
+log_user_prompt = false    # defaults to false; redact prompt text unless explicitly enabled
+```
+
+Codex tags every exported event with `service.name = $ORIGINATOR` (the same
+value sent in the `originator` header, `codex_cli_rs` by default), the CLI
+version, and an `env` attribute so downstream collectors can distinguish
+dev/staging/prod traffic. Only telemetry produced inside the `codex_otel`
+crate—the events listed below—is forwarded to the exporter.
+
+### Event catalog
+
+Every event shares a common set of metadata fields: `event.timestamp`,
+`conversation.id`, `app.version`, `auth_mode` (when available),
+`user.account_id` (when available), `user.email` (when available), `terminal.type`, `model`, and `slug`.
+
+With OTEL enabled Codex emits the following event types (in addition to the
+metadata above):
+
+- `codex.conversation_starts`
+  - `provider_name`
+  - `reasoning_effort` (optional)
+  - `reasoning_summary`
+  - `context_window` (optional)
+  - `max_output_tokens` (optional)
+  - `auto_compact_token_limit` (optional)
+  - `approval_policy`
+  - `sandbox_policy`
+  - `mcp_servers` (comma-separated list)
+  - `active_profile` (optional)
+- `codex.api_request`
+  - `attempt`
+  - `duration_ms`
+  - `http.response.status_code` (optional)
+  - `error.message` (failures)
+- `codex.sse_event`
+  - `event.kind`
+  - `duration_ms`
+  - `error.message` (failures)
+  - `input_token_count` (responses only)
+  - `output_token_count` (responses only)
+  - `cached_token_count` (responses only, optional)
+  - `reasoning_token_count` (responses only, optional)
+  - `tool_token_count` (responses only)
+- `codex.user_prompt`
+  - `prompt_length`
+  - `prompt` (redacted unless `log_user_prompt = true`)
+- `codex.tool_decision`
+  - `tool_name`
+  - `call_id`
+  - `decision` (`approved`, `approved_execpolicy_amendment`, `approved_for_session`, `denied`, or `abort`)
+  - `source` (`config` or `user`)
+- `codex.tool_result`
+  - `tool_name`
+  - `call_id` (optional)
+  - `arguments` (optional)
+  - `duration_ms` (execution time for the tool)
+  - `success` (`"true"` or `"false"`)
+  - `output`
+
+These event shapes may change as we iterate.
+
+### Choosing an exporter
+
+Set `otel.exporter` to control where events go:
+
+- `none` – leaves instrumentation active but skips exporting. This is the
+  default.
+- `otlp-http` – posts OTLP log records to an OTLP/HTTP collector. Specify the
+  endpoint, protocol, and headers your collector expects:
+
+  ```toml
+  [otel.exporter."otlp-http"]
+  endpoint = "https://otel.example.com/v1/logs"
+  protocol = "binary"
+
+  [otel.exporter."otlp-http".headers]
+  "x-otlp-api-key" = "${OTLP_TOKEN}"
+  ```
+
+- `otlp-grpc` – streams OTLP log records over gRPC. Provide the endpoint and any
+  metadata headers:
+
+  ```toml
+  [otel]
+  exporter = { otlp-grpc = {endpoint = "https://otel.example.com:4317",headers = { "x-otlp-meta" = "abc123" }}}
+  ```
+
+Both OTLP exporters accept an optional `tls` block so you can trust a custom CA
+or enable mutual TLS. Relative paths are resolved against `~/.codex/`:
+
+```toml
+[otel.exporter."otlp-http"]
+endpoint = "https://otel.example.com/v1/logs"
+protocol = "binary"
+
+[otel.exporter."otlp-http".headers]
+"x-otlp-api-key" = "${OTLP_TOKEN}"
+
+[otel.exporter."otlp-http".tls]
+ca-certificate = "certs/otel-ca.pem"
+client-certificate = "/etc/codex/certs/client.pem"
+client-private-key = "/etc/codex/certs/client-key.pem"
+```
+
+If the exporter is `none` nothing is written anywhere; otherwise you must run or point to your
+own collector. All exporters run on a background batch worker that is flushed on
+shutdown.
+
+If you build Codex from source the OTEL crate is still behind an `otel` feature
+flag; the official prebuilt binaries ship with the feature enabled. When the
+feature is disabled the telemetry hooks become no-ops so the CLI continues to
+function without the extra dependencies.
+
+### notify
+
+Specify a program that will be executed to get notified about events generated by Codex. Note that the program will receive the notification argument as a string of JSON, e.g.:
+
+```json
+{
+  "type": "agent-turn-complete",
+  "thread-id": "b5f6c1c2-1111-2222-3333-444455556666",
+  "turn-id": "12345",
+  "cwd": "/Users/alice/projects/example",
+  "input-messages": ["Rename `foo` to `bar` and update the callsites."],
+  "last-assistant-message": "Rename complete and verified `cargo build` succeeds."
+}
+```
+
+The `"type"` property will always be set. Currently, `"agent-turn-complete"` is the only notification type that is supported.
+
+`"thread-id"` contains a string that identifies the Codex session that produced the notification; you can use it to correlate multiple turns that belong to the same task.
+
+`"cwd"` reports the absolute working directory for the session so scripts can disambiguate which project triggered the notification.
+
+As an example, here is a Python script that parses the JSON and decides whether to show a desktop push notification using [terminal-notifier](https://github.com/julienXX/terminal-notifier) on macOS:
+
+```python
+#!/usr/bin/env python3
+
+import json
+import subprocess
+import sys
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("Usage: notify.py <NOTIFICATION_JSON>")
+        return 1
+
+    try:
+        notification = json.loads(sys.argv[1])
+    except json.JSONDecodeError:
+        return 1
+
+    match notification_type := notification.get("type"):
+        case "agent-turn-complete":
+            assistant_message = notification.get("last-assistant-message")
+            if assistant_message:
+                title = f"Codex: {assistant_message}"
+            else:
+                title = "Codex: Turn Complete!"
+            input_messages = notification.get("input-messages", [])
+            message = " ".join(input_messages)
+            title += message
+        case _:
+            print(f"not sending a push notification for: {notification_type}")
+            return 0
+
+    thread_id = notification.get("thread-id", "")
+
+    subprocess.check_output(
+        [
+            "terminal-notifier",
+            "-title",
+            title,
+            "-message",
+            message,
+            "-group",
+            "codex-" + thread_id,
+            "-ignoreDnD",
+            "-activate",
+            "com.googlecode.iterm2",
+        ]
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+```
+
+To have Codex use this script for notifications, you would configure it via `notify` in `~/.codex/config.toml` using the appropriate path to `notify.py` on your computer:
+
+```toml
+notify = ["python3", "/Users/mbolin/.codex/notify.py"]
+```
+
+> [!NOTE]
+> Use `notify` for automation and integrations: Codex invokes your external program with a single JSON argument for each event, independent of the TUI. If you only want lightweight desktop notifications while using the TUI, prefer `tui.notifications`, which uses terminal escape codes and requires no external program. You can enable both; `tui.notifications` covers in‑TUI alerts (e.g., approval prompts), while `notify` is best for system‑level hooks or custom notifiers. Currently, `notify` emits only `agent-turn-complete`, whereas `tui.notifications` supports `agent-turn-complete` and `approval-requested` with optional filtering.
+
+### hide_agent_reasoning
+
+Codex intermittently emits "reasoning" events that show the model's internal "thinking" before it produces a final answer. Some users may find these events distracting, especially in CI logs or minimal terminal output.
+
+Setting `hide_agent_reasoning` to `true` suppresses these events in **both** the TUI as well as the headless `exec` sub-command:
+
+```toml
+hide_agent_reasoning = true   # defaults to false
+```
+
+### show_raw_agent_reasoning
+
+Surfaces the model’s raw chain-of-thought ("raw reasoning content") when available.
+
+Notes:
+
+- Only takes effect if the selected model/provider actually emits raw reasoning content. Many models do not. When unsupported, this option has no visible effect.
+- Raw reasoning may include intermediate thoughts or sensitive context. Enable only if acceptable for your workflow.
+
+Example:
+
+```toml
+show_raw_agent_reasoning = true  # defaults to false
+```
+
+## Profiles and overrides
+
+### profiles
+
+A _profile_ is a collection of configuration values that can be set together. Multiple profiles can be defined in `config.toml` and you can specify the one you
+want to use at runtime via the `--profile` flag.
+
+Here is an example of a `config.toml` that defines multiple profiles:
+
+```toml
+model = "o3"
+approval_policy = "untrusted"
+
+# Setting `profile` is equivalent to specifying `--profile o3` on the command
+# line, though the `--profile` flag can still be used to override this value.
+profile = "o3"
+
+[model_providers.openai-chat-completions]
+name = "OpenAI using Chat Completions"
+base_url = "https://api.openai.com/v1"
+env_key = "OPENAI_API_KEY"
+wire_api = "chat"
+
+[profiles.o3]
+model = "o3"
+model_provider = "openai"
+approval_policy = "never"
+model_reasoning_effort = "high"
+model_reasoning_summary = "detailed"
+
+[profiles.gpt3]
+model = "gpt-3.5-turbo"
+model_provider = "openai-chat-completions"
+
+[profiles.zdr]
+model = "o3"
+model_provider = "openai"
+approval_policy = "on-failure"
+```
+
+Users can specify config values at multiple levels. Order of precedence is as follows:
+
+1. custom command-line argument, e.g., `--model o3`
+2. as part of a profile, where the `--profile` is specified via a CLI (or in the config file itself)
+3. as an entry in `config.toml`, e.g., `model = "o3"`
+4. the default value that comes with Codex CLI (i.e., Codex CLI defaults to `gpt-5.1-codex-max`)
+
+### history
+
+By default, Codex CLI records messages sent to the model in `$CODEX_HOME/history.jsonl`. Note that on UNIX, the file permissions are set to `o600`, so it should only be readable and writable by the owner.
+
+To disable this behavior, configure `[history]` as follows:
+
+```toml
+[history]
+persistence = "none"  # "save-all" is the default value
+```
+
+To cap the size of `history.jsonl`, set `history.max_bytes` to a positive byte
+count. When the file grows beyond the limit, Codex removes the oldest entries,
+compacting the file down to roughly 80% of the hard cap while keeping the newest
+record intact. Omitting the option—or setting it to `0`—disables pruning.
+
+### file_opener
+
+Identifies the editor/URI scheme to use for hyperlinking citations in model output. If set, citations to files in the model output will be hyperlinked using the specified URI scheme so they can be ctrl/cmd-clicked from the terminal to open them.
+
+For example, if the model output includes a reference such as `【F:/home/user/project/main.py†L42-L50】`, then this would be rewritten to link to the URI `vscode://file/home/user/project/main.py:42`.
+
+Note this is **not** a general editor setting (like `$EDITOR`), as it only accepts a fixed set of values:
+
+- `"vscode"` (default)
+- `"vscode-insiders"`
+- `"windsurf"`
+- `"cursor"`
+- `"none"` to explicitly disable this feature
+
+Currently, `"vscode"` is the default, though Codex does not verify VS Code is installed. As such, `file_opener` may default to `"none"` or something else in the future.
+
+### project_doc_max_bytes
+
+Maximum number of bytes to read from an `AGENTS.md` file to include in the instructions sent with the first turn of a session. Defaults to 32 KiB.
+
+### project_doc_fallback_filenames
+
+Ordered list of additional filenames to look for when `AGENTS.md` is missing at a given directory level. The CLI always checks `AGENTS.md` first; the configured fallbacks are tried in the order provided. This lets monorepos that already use alternate instruction files (for example, `CLAUDE.md`) work out of the box while you migrate to `AGENTS.md` over time.
+
+```toml
+project_doc_fallback_filenames = ["CLAUDE.md", ".exampleagentrules.md"]
+```
+
+We recommend migrating instructions to AGENTS.md; other filenames may reduce model performance.
+
+> See also [AGENTS.md discovery](./agents_md.md) for how Codex locates these files during a session.
+
+### tui
+
+Options that are specific to the TUI.
+
+```toml
+[tui]
+# Send desktop notifications when approvals are required or a turn completes.
+# Defaults to true.
+notifications = true
+
+# You can optionally filter to specific notification types.
+# Available types are "agent-turn-complete" and "approval-requested".
+notifications = [ "agent-turn-complete", "approval-requested" ]
+
+# Disable terminal animations (welcome screen, status shimmer, spinner).
+# Defaults to true.
+animations = false
+```
+
+> [!NOTE]
+> Codex emits desktop notifications using terminal escape codes. Not all terminals support these (notably, macOS Terminal.app and VS Code's terminal do not support custom notifications. iTerm2, Ghostty and WezTerm do support these notifications).
+
+> [!NOTE] > `tui.notifications` is built‑in and limited to the TUI session. For programmatic or cross‑environment notifications—or to integrate with OS‑specific notifiers—use the top‑level `notify` option to run an external program that receives event JSON. The two settings are independent and can be used together.
+
+## Authentication and authorization
+
+### Forcing a login method
+
+To force users on a given machine to use a specific login method or workspace, use a combination of [managed configurations](https://developers.openai.com/codex/security#managed-configuration) as well as either or both of the following fields:
+
+```toml
+# Force the user to log in with ChatGPT or via an api key.
+forced_login_method = "chatgpt" or "api"
+# When logging in with ChatGPT, only the specified workspace ID will be presented during the login
+# flow and the id will be validated during the oauth callback as well as every time Codex starts.
+forced_chatgpt_workspace_id = "00000000-0000-0000-0000-000000000000"
+```
+
+If the active credentials don't match the config, the user will be logged out and Codex will exit.
+
+If `forced_chatgpt_workspace_id` is set but `forced_login_method` is not set, API key login will still work.
+
+### Control where login credentials are stored
+
+```toml
+cli_auth_credentials_store = "keyring"
+```
+
+Valid values:
+
+- `file` (default) – Store credentials in `auth.json` under `$CODEX_HOME`.
+- `keyring` – Store credentials in the operating system keyring via the [`keyring` crate](https://crates.io/crates/keyring); the CLI reports an error if secure storage is unavailable. Backends by OS:
+  - macOS: macOS Keychain
+  - Windows: Windows Credential Manager
+  - Linux: DBus‑based Secret Service, the kernel keyutils, or a combination
+  - FreeBSD/OpenBSD: DBus‑based Secret Service
+- `auto` – Save credentials to the operating system keyring when available; otherwise, fall back to `auth.json` under `$CODEX_HOME`.
+
+### Custom CA certificates for login
+
+When running behind a corporate proxy that performs SSL/TLS inspection with custom CA certificates, the `codex login` flow may fail during token exchange. To resolve this, you can configure Codex to trust additional certificate authorities using environment variables.
+
+Codex supports two environment variables for specifying custom CA certificates (checked in priority order):
+
+1. **`CODEX_CA_CERTIFICATE`** (primary) – Path to a PEM file containing one or more CA certificates
+2. **`SSL_CERT_FILE`** (fallback) – Standard environment variable used by many tools for CA certificate bundles
+
+**Usage:**
+
+```bash
+# Using CODEX_CA_CERTIFICATE (recommended for Codex-specific configuration)
+export CODEX_CA_CERTIFICATE=/path/to/corporate-ca.pem
+codex login
+
+# Or using SSL_CERT_FILE (useful if already set system-wide)
+export SSL_CERT_FILE=/path/to/ca-bundle.pem
+codex login
+```
+
+**Certificate format:**
+
+The PEM file can contain either a single certificate or a bundle of multiple certificates (root + intermediates). Both formats are supported:
+
+```pem
+# Single certificate
+-----BEGIN CERTIFICATE-----
+MIIDBTCCAe2gAwIBAgI...
+-----END CERTIFICATE-----
+
+# Or a bundle (multiple certificates)
+-----BEGIN CERTIFICATE-----
+MIIDBTCCAe2gAwIBAgI... (root CA)
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIDGTCCA... (intermediate CA)
+-----END CERTIFICATE-----
+```
+
+**Corporate proxy setup:**
+
+Corporate proxies typically distribute CA bundles containing root and intermediate certificates. Export your corporate CA certificate bundle to a PEM file and set one of the environment variables above. The certificates will be trusted for all OAuth authentication flows (browser login, device code login, and API key exchange).
+
+## Config reference
+
+| Key                                              | Type / Values                                                     | Notes                                                                                                                           |
+| ------------------------------------------------ | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `model`                                          | string                                                            | Model to use (e.g., `gpt-5.1-codex-max`).                                                                                       |
+| `model_provider`                                 | string                                                            | Provider id from `model_providers` (default: `openai`).                                                                         |
+| `model_context_window`                           | number                                                            | Context window tokens.                                                                                                          |
+| `tool_output_token_limit`                        | number                                                            | Token budget for stored function/tool outputs in history (default: 2,560 tokens).                                               |
+| `approval_policy`                                | `untrusted` \| `on-failure` \| `on-request` \| `never`            | When to prompt for approval.                                                                                                    |
+| `sandbox_mode`                                   | `read-only` \| `workspace-write` \| `danger-full-access`          | OS sandbox policy.                                                                                                              |
+| `sandbox_workspace_write.writable_roots`         | array<string>                                                     | Extra writable roots in workspace‑write.                                                                                        |
+| `sandbox_workspace_write.network_access`         | boolean                                                           | Allow network in workspace‑write (default: false).                                                                              |
+| `sandbox_workspace_write.exclude_tmpdir_env_var` | boolean                                                           | Exclude `$TMPDIR` from writable roots (default: false).                                                                         |
+| `sandbox_workspace_write.exclude_slash_tmp`      | boolean                                                           | Exclude `/tmp` from writable roots (default: false).                                                                            |
+| `notify`                                         | array<string>                                                     | External program for notifications.                                                                                             |
+| `tui.animations`                                 | boolean                                                           | Enable terminal animations (welcome screen, shimmer, spinner). Defaults to true; set to `false` to disable visual motion.       |
+| `instructions`                                   | string                                                            | Currently ignored; use `experimental_instructions_file` or `AGENTS.md`.                                                         |
+| `features.<feature-flag>`                        | boolean                                                           | See [feature flags](#feature-flags) for details                                                                                 |
+| `mcp_servers.<id>.command`                       | string                                                            | MCP server launcher command (stdio servers only).                                                                               |
+| `mcp_servers.<id>.args`                          | array<string>                                                     | MCP server args (stdio servers only).                                                                                           |
+| `mcp_servers.<id>.env`                           | map<string,string>                                                | MCP server env vars (stdio servers only).                                                                                       |
+| `mcp_servers.<id>.url`                           | string                                                            | MCP server url (streamable http servers only).                                                                                  |
+| `mcp_servers.<id>.bearer_token_env_var`          | string                                                            | environment variable containing a bearer token to use for auth (streamable http servers only).                                  |
+| `mcp_servers.<id>.enabled`                       | boolean                                                           | When false, Codex skips starting the server (default: true).                                                                    |
+| `mcp_servers.<id>.startup_timeout_sec`           | number                                                            | Startup timeout in seconds (default: 10). Timeout is applied both for initializing MCP server and initially listing tools.      |
+| `mcp_servers.<id>.tool_timeout_sec`              | number                                                            | Per-tool timeout in seconds (default: 60). Accepts fractional values; omit to use the default.                                  |
+| `mcp_servers.<id>.enabled_tools`                 | array<string>                                                     | Restrict the server to the listed tool names.                                                                                   |
+| `mcp_servers.<id>.disabled_tools`                | array<string>                                                     | Remove the listed tool names after applying `enabled_tools`, if any.                                                            |
+| `model_providers.<id>.name`                      | string                                                            | Display name.                                                                                                                   |
+| `model_providers.<id>.base_url`                  | string                                                            | API base URL.                                                                                                                   |
+| `model_providers.<id>.env_key`                   | string                                                            | Env var for API key.                                                                                                            |
+| `model_providers.<id>.wire_api`                  | `chat` \| `responses`                                             | Protocol used (default: `chat`).                                                                                                |
+| `model_providers.<id>.query_params`              | map<string,string>                                                | Extra query params (e.g., Azure `api-version`).                                                                                 |
+| `model_providers.<id>.http_headers`              | map<string,string>                                                | Additional static headers.                                                                                                      |
+| `model_providers.<id>.env_http_headers`          | map<string,string>                                                | Headers sourced from env vars.                                                                                                  |
+| `model_providers.<id>.request_max_retries`       | number                                                            | Per‑provider HTTP retry count (default: 4).                                                                                     |
+| `model_providers.<id>.stream_max_retries`        | number                                                            | SSE stream retry count (default: 5).                                                                                            |
+| `model_providers.<id>.stream_idle_timeout_ms`    | number                                                            | SSE idle timeout (ms) (default: 300000).                                                                                        |
+| `project_doc_max_bytes`                          | number                                                            | Max bytes to read from `AGENTS.md`.                                                                                             |
+| `profile`                                        | string                                                            | Active profile name.                                                                                                            |
+| `profiles.<name>.*`                              | various                                                           | Profile‑scoped overrides of the same keys.                                                                                      |
+| `history.persistence`                            | `save-all` \| `none`                                              | History file persistence (default: `save-all`).                                                                                 |
+| `history.max_bytes`                              | number                                                            | Maximum size of `history.jsonl` in bytes; when exceeded, history is compacted to ~80% of this limit by dropping oldest entries. |
+| `file_opener`                                    | `vscode` \| `vscode-insiders` \| `windsurf` \| `cursor` \| `none` | URI scheme for clickable citations (default: `vscode`).                                                                         |
+| `tui`                                            | table                                                             | TUI‑specific options.                                                                                                           |
+| `tui.notifications`                              | boolean \| array<string>                                          | Enable desktop notifications in the tui (default: true).                                                                        |
+| `hide_agent_reasoning`                           | boolean                                                           | Hide model reasoning events.                                                                                                    |
+| `check_for_update_on_startup`                    | boolean                                                           | Check for Codex updates on startup (default: true). Set to `false` only if updates are centrally managed.                       |
+| `show_raw_agent_reasoning`                       | boolean                                                           | Show raw reasoning (when available).                                                                                            |
+| `model_reasoning_effort`                         | `minimal` \| `low` \| `medium` \| `high`                          | Responses API reasoning effort.                                                                                                 |
+| `model_reasoning_summary`                        | `auto` \| `concise` \| `detailed` \| `none`                       | Reasoning summaries.                                                                                                            |
+| `model_verbosity`                                | `low` \| `medium` \| `high`                                       | GPT‑5 text verbosity (Responses API).                                                                                           |
+| `model_supports_reasoning_summaries`             | boolean                                                           | Force‑enable reasoning summaries.                                                                                               |
+| `model_reasoning_summary_format`                 | `none` \| `experimental`                                          | Force reasoning summary format.                                                                                                 |
+| `chatgpt_base_url`                               | string                                                            | Base URL for ChatGPT auth flow.                                                                                                 |
+| `experimental_instructions_file`                 | string (path)                                                     | Replace built‑in instructions (experimental).                                                                                   |
+| `experimental_use_exec_command_tool`             | boolean                                                           | Use experimental exec command tool.                                                                                             |
+| `projects.<path>.trust_level`                    | string                                                            | Mark project/worktree as trusted (only `"trusted"` is recognized).                                                              |
+| `tools.web_search`                               | boolean                                                           | Enable web search tool (deprecated) (default: false).                                                                           |
+| `tools.view_image`                               | boolean                                                           | Enable or disable the `view_image` tool so Codex can attach local image files from the workspace (default: true).               |
+| `forced_login_method`                            | `chatgpt` \| `api`                                                | Only allow Codex to be used with ChatGPT or API keys.                                                                           |
+| `forced_chatgpt_workspace_id`                    | string (uuid)                                                     | Only allow Codex to be used with the specified ChatGPT workspace.                                                               |
+| `cli_auth_credentials_store`                     | `file` \| `keyring` \| `auto`                                     | Where to store CLI login credentials (default: `file`).                                                                         |
+>>>>>>> 75d082940 (docs: add CA certificate environment variable documentation)

--- a/docs/config.md
+++ b/docs/config.md
@@ -27,68 +27,30 @@ Codex supports several mechanisms for setting config values:
 
 Both the `--config` flag and the `config.toml` file support the following options:
 
-<<<<<<< HEAD
-## Apps (Connectors)
-
-Use `$` in the composer to insert a ChatGPT connector; the popover lists accessible
-apps. The `/apps` command lists available and installed apps. Connected apps appear first
-and are labeled as connected; others are marked as can be installed.
-
-## Notify
-=======
 ## Feature flags
->>>>>>> 75d082940 (docs: add CA certificate environment variable documentation)
 
 Optional and experimental capabilities are toggled via the `[features]` table in `$CODEX_HOME/config.toml`. If you see a deprecation notice mentioning a legacy key (for example `experimental_use_exec_command_tool`), move the setting into `[features]` or pass `--enable <feature>`.
 
-<<<<<<< HEAD
-- https://developers.openai.com/codex/config-reference
-
-When Codex knows which client started the turn, the legacy notify JSON payload also includes a top-level `client` field. The TUI reports `codex-tui`, and the app server reports the `clientInfo.name` value from `initialize`.
-
-## JSON Schema
-
-The generated JSON Schema for `config.toml` lives at `codex-rs/core/config.schema.json`.
-
-## SQLite State DB
-
-Codex stores the SQLite-backed state DB under `sqlite_home` (config key) or the
-`CODEX_SQLITE_HOME` environment variable. When unset, WorkspaceWrite sandbox
-sessions default to a temp directory; other modes default to `CODEX_HOME`.
-
-## Notices
-
-Codex stores "do not show again" flags for some UI prompts under the `[notice]` table.
-
-## Plan mode defaults
-
-`plan_mode_reasoning_effort` lets you set a Plan-mode-specific default reasoning
-effort override. When unset, Plan mode uses the built-in Plan preset default
-(currently `medium`). When explicitly set (including `none`), it overrides the
-Plan preset. The string value `none` means "no reasoning" (an explicit Plan
-override), not "inherit the global default". There is currently no separate
-config value for "follow the global default in Plan mode".
-
-Ctrl+C/Ctrl+D quitting uses a ~1 second double-press hint (`ctrl + c again to quit`).
-=======
 ```toml
 [features]
+streamable_shell = true          # enable the streamable exec tool
 web_search_request = true        # allow the model to request web searches
 # view_image_tool defaults to true; omit to keep defaults
 ```
 
 Supported features:
 
-| Key                                   | Default | Stage        | Description                                           |
-| ------------------------------------- | :-----: | ------------ | ----------------------------------------------------- |
-| `unified_exec`                        |  false  | Experimental | Use the unified PTY-backed exec tool                  |
-| `rmcp_client`                         |  false  | Experimental | Enable oauth support for streamable HTTP MCP servers  |
-| `apply_patch_freeform`                |  false  | Beta         | Include the freeform `apply_patch` tool               |
-| `view_image_tool`                     |  true   | Stable       | Include the `view_image` tool                         |
-| `web_search_request`                  |  false  | Stable       | Allow the model to issue web searches                 |
-| `ghost_commit`                        |  false  | Experimental | Create a ghost commit each turn                       |
-| `enable_experimental_windows_sandbox` |  false  | Experimental | Use the Windows restricted-token sandbox              |
-| `tui2`                                |  false  | Experimental | Use the experimental TUI v2 (viewport) implementation |
+| Key                                       | Default | Stage        | Description                                          |
+| ----------------------------------------- | :-----: | ------------ | ---------------------------------------------------- |
+| `unified_exec`                            |  false  | Experimental | Use the unified PTY-backed exec tool                 |
+| `streamable_shell`                        |  false  | Experimental | Use the streamable exec-command/write-stdin pair     |
+| `rmcp_client`                             |  false  | Experimental | Enable oauth support for streamable HTTP MCP servers |
+| `apply_patch_freeform`                    |  false  | Beta         | Include the freeform `apply_patch` tool              |
+| `view_image_tool`                         |  true   | Stable       | Include the `view_image` tool                        |
+| `web_search_request`                      |  false  | Stable       | Allow the model to issue web searches                |
+| `experimental_sandbox_command_assessment` |  false  | Experimental | Enable model-based sandbox risk assessment           |
+| `ghost_commit`                            |  false  | Experimental | Create a ghost commit each turn                      |
+| `enable_experimental_windows_sandbox`     |  false  | Experimental | Use the Windows restricted-token sandbox             |
 
 Notes:
 
@@ -102,7 +64,7 @@ Notes:
 The model that Codex should use.
 
 ```toml
-model = "gpt-5.1"  # overrides the default ("gpt-5.1-codex-max" across platforms)
+model = "gpt-5.1"  # overrides the default ("gpt-5.1-codex" on macOS/Linux, "gpt-5.1" on Windows)
 ```
 
 ### model_providers
@@ -229,13 +191,12 @@ model = "mistral"
 
 ### model_reasoning_effort
 
-If the selected model is known to support reasoning (for example: `o3`, `o4-mini`, `codex-*`, `gpt-5.1-codex-max`, `gpt-5.1`, `gpt-5.1-codex`), reasoning is enabled by default when using the Responses API. As explained in the [OpenAI Platform documentation](https://platform.openai.com/docs/guides/reasoning?api-mode=responses#get-started-with-reasoning), this can be set to:
+If the selected model is known to support reasoning (for example: `o3`, `o4-mini`, `codex-*`, `gpt-5.1`, `gpt-5.1-codex`), reasoning is enabled by default when using the Responses API. As explained in the [OpenAI Platform documentation](https://platform.openai.com/docs/guides/reasoning?api-mode=responses#get-started-with-reasoning), this can be set to:
 
 - `"minimal"`
 - `"low"`
 - `"medium"` (default)
 - `"high"`
-- `"xhigh"` (available only on `gpt-5.1-codex-max`)
 
 Note: to minimize reasoning, choose `"minimal"`.
 
@@ -285,6 +246,12 @@ model_supports_reasoning_summaries = true
 The size of the context window for the model, in tokens.
 
 In general, Codex knows the context window for the most common OpenAI models, but if you are using a new model with an old version of the Codex CLI, then you can use `model_context_window` to tell Codex what value to use to determine how much context is left during a conversation.
+
+### model_max_output_tokens
+
+This is analogous to `model_context_window`, but for the maximum number of output tokens for the model.
+
+> See also [`codex exec`](./exec.md) to see how these model settings influence non-interactive runs.
 
 ### oss_provider
 
@@ -390,8 +357,6 @@ Though using this option may also be necessary if you try to use Codex in enviro
 
 ### tools.\*
 
-These `[tools]` configuration options are deprecated. Use `[features]` instead (see [Feature flags](#feature-flags)).
-
 Use the optional `[tools]` table to toggle built-in tools that the agent may call. `web_search` stays off unless you opt in, while `view_image` is now enabled by default:
 
 ```toml
@@ -399,6 +364,8 @@ Use the optional `[tools]` table to toggle built-in tools that the agent may cal
 web_search = true   # allow Codex to issue first-party web searches without prompting you (deprecated)
 view_image = false  # disable image uploads (they're enabled by default)
 ```
+
+`web_search` is deprecated; use the `web_search_request` feature flag instead.
 
 The `view_image` toggle is useful when you want to include screenshots or diagrams from your repo without pasting them manually. Codex still respects sandboxing: it can only attach files inside the workspace roots you allow.
 
@@ -504,11 +471,10 @@ http_headers = { "HEADER_NAME" = "HEADER_VALUE" }
 env_http_headers = { "HEADER_NAME" = "ENV_VAR" }
 ```
 
-Streamable HTTP connections always use the experimental Rust MCP client under the hood, so expect occasional rough edges. OAuth login flows are gated on the `rmcp_client = true` flag:
+Streamable HTTP connections always use the experimental Rust MCP client under the hood, so expect occasional rough edges. OAuth login flows are gated on the `experimental_use_rmcp_client = true` flag:
 
 ```toml
-[features]
-rmcp_client = true
+experimental_use_rmcp_client = true
 ```
 
 After enabling it, run `codex mcp login <server-name>` when the server supports OAuth.
@@ -529,6 +495,17 @@ disabled_tools = ["search"]
 ```
 
 When both `enabled_tools` and `disabled_tools` are specified, Codex first restricts the server to the allow-list and then removes any tools that appear in the deny-list.
+
+#### Experimental RMCP client
+
+This flag enables OAuth support for streamable HTTP servers.
+
+```toml
+experimental_use_rmcp_client = true
+
+[mcp_servers.server_name]
+…
+```
 
 #### MCP CLI commands
 
@@ -633,7 +610,7 @@ metadata above):
 - `codex.tool_decision`
   - `tool_name`
   - `call_id`
-  - `decision` (`approved`, `approved_execpolicy_amendment`, `approved_for_session`, `denied`, or `abort`)
+  - `decision` (`approved`, `approved_for_session`, `denied`, or `abort`)
   - `source` (`config` or `user`)
 - `codex.tool_result`
   - `tool_name`
@@ -655,12 +632,12 @@ Set `otel.exporter` to control where events go:
   endpoint, protocol, and headers your collector expects:
 
   ```toml
-  [otel.exporter."otlp-http"]
-  endpoint = "https://otel.example.com/v1/logs"
-  protocol = "binary"
-
-  [otel.exporter."otlp-http".headers]
-  "x-otlp-api-key" = "${OTLP_TOKEN}"
+  [otel]
+  exporter = { otlp-http = {
+    endpoint = "https://otel.example.com/v1/logs",
+    protocol = "binary",
+    headers = { "x-otlp-api-key" = "${OTLP_TOKEN}" }
+  }}
   ```
 
 - `otlp-grpc` – streams OTLP log records over gRPC. Provide the endpoint and any
@@ -668,24 +645,27 @@ Set `otel.exporter` to control where events go:
 
   ```toml
   [otel]
-  exporter = { otlp-grpc = {endpoint = "https://otel.example.com:4317",headers = { "x-otlp-meta" = "abc123" }}}
+  exporter = { otlp-grpc = {
+    endpoint = "https://otel.example.com:4317",
+    headers = { "x-otlp-meta" = "abc123" }
+  }}
   ```
 
 Both OTLP exporters accept an optional `tls` block so you can trust a custom CA
 or enable mutual TLS. Relative paths are resolved against `~/.codex/`:
 
 ```toml
-[otel.exporter."otlp-http"]
-endpoint = "https://otel.example.com/v1/logs"
-protocol = "binary"
-
-[otel.exporter."otlp-http".headers]
-"x-otlp-api-key" = "${OTLP_TOKEN}"
-
-[otel.exporter."otlp-http".tls]
-ca-certificate = "certs/otel-ca.pem"
-client-certificate = "/etc/codex/certs/client.pem"
-client-private-key = "/etc/codex/certs/client-key.pem"
+[otel]
+exporter = { otlp-http = {
+  endpoint = "https://otel.example.com/v1/logs",
+  protocol = "binary",
+  headers = { "x-otlp-api-key" = "${OTLP_TOKEN}" },
+  tls = {
+    ca-certificate = "certs/otel-ca.pem",
+    client-certificate = "/etc/codex/certs/client.pem",
+    client-private-key = "/etc/codex/certs/client-key.pem",
+  }
+}}
 ```
 
 If the exporter is `none` nothing is written anywhere; otherwise you must run or point to your
@@ -855,7 +835,7 @@ Users can specify config values at multiple levels. Order of precedence is as fo
 1. custom command-line argument, e.g., `--model o3`
 2. as part of a profile, where the `--profile` is specified via a CLI (or in the config file itself)
 3. as an entry in `config.toml`, e.g., `model = "o3"`
-4. the default value that comes with Codex CLI (i.e., Codex CLI defaults to `gpt-5.1-codex-max`)
+4. the default value that comes with Codex CLI (i.e., Codex CLI defaults to `gpt-5.1-codex`)
 
 ### history
 
@@ -867,11 +847,6 @@ To disable this behavior, configure `[history]` as follows:
 [history]
 persistence = "none"  # "save-all" is the default value
 ```
-
-To cap the size of `history.jsonl`, set `history.max_bytes` to a positive byte
-count. When the file grows beyond the limit, Codex removes the oldest entries,
-compacting the file down to roughly 80% of the hard cap while keeping the newest
-record intact. Omitting the option—or setting it to `0`—disables pruning.
 
 ### file_opener
 
@@ -918,10 +893,6 @@ notifications = true
 # You can optionally filter to specific notification types.
 # Available types are "agent-turn-complete" and "approval-requested".
 notifications = [ "agent-turn-complete", "approval-requested" ]
-
-# Disable terminal animations (welcome screen, status shimmer, spinner).
-# Defaults to true.
-animations = false
 ```
 
 > [!NOTE]
@@ -1009,65 +980,63 @@ Corporate proxies typically distribute CA bundles containing root and intermedia
 
 ## Config reference
 
-| Key                                              | Type / Values                                                     | Notes                                                                                                                           |
-| ------------------------------------------------ | ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
-| `model`                                          | string                                                            | Model to use (e.g., `gpt-5.1-codex-max`).                                                                                       |
-| `model_provider`                                 | string                                                            | Provider id from `model_providers` (default: `openai`).                                                                         |
-| `model_context_window`                           | number                                                            | Context window tokens.                                                                                                          |
-| `tool_output_token_limit`                        | number                                                            | Token budget for stored function/tool outputs in history (default: 2,560 tokens).                                               |
-| `approval_policy`                                | `untrusted` \| `on-failure` \| `on-request` \| `never`            | When to prompt for approval.                                                                                                    |
-| `sandbox_mode`                                   | `read-only` \| `workspace-write` \| `danger-full-access`          | OS sandbox policy.                                                                                                              |
-| `sandbox_workspace_write.writable_roots`         | array<string>                                                     | Extra writable roots in workspace‑write.                                                                                        |
-| `sandbox_workspace_write.network_access`         | boolean                                                           | Allow network in workspace‑write (default: false).                                                                              |
-| `sandbox_workspace_write.exclude_tmpdir_env_var` | boolean                                                           | Exclude `$TMPDIR` from writable roots (default: false).                                                                         |
-| `sandbox_workspace_write.exclude_slash_tmp`      | boolean                                                           | Exclude `/tmp` from writable roots (default: false).                                                                            |
-| `notify`                                         | array<string>                                                     | External program for notifications.                                                                                             |
-| `tui.animations`                                 | boolean                                                           | Enable terminal animations (welcome screen, shimmer, spinner). Defaults to true; set to `false` to disable visual motion.       |
-| `instructions`                                   | string                                                            | Currently ignored; use `experimental_instructions_file` or `AGENTS.md`.                                                         |
-| `features.<feature-flag>`                        | boolean                                                           | See [feature flags](#feature-flags) for details                                                                                 |
-| `mcp_servers.<id>.command`                       | string                                                            | MCP server launcher command (stdio servers only).                                                                               |
-| `mcp_servers.<id>.args`                          | array<string>                                                     | MCP server args (stdio servers only).                                                                                           |
-| `mcp_servers.<id>.env`                           | map<string,string>                                                | MCP server env vars (stdio servers only).                                                                                       |
-| `mcp_servers.<id>.url`                           | string                                                            | MCP server url (streamable http servers only).                                                                                  |
-| `mcp_servers.<id>.bearer_token_env_var`          | string                                                            | environment variable containing a bearer token to use for auth (streamable http servers only).                                  |
-| `mcp_servers.<id>.enabled`                       | boolean                                                           | When false, Codex skips starting the server (default: true).                                                                    |
-| `mcp_servers.<id>.startup_timeout_sec`           | number                                                            | Startup timeout in seconds (default: 10). Timeout is applied both for initializing MCP server and initially listing tools.      |
-| `mcp_servers.<id>.tool_timeout_sec`              | number                                                            | Per-tool timeout in seconds (default: 60). Accepts fractional values; omit to use the default.                                  |
-| `mcp_servers.<id>.enabled_tools`                 | array<string>                                                     | Restrict the server to the listed tool names.                                                                                   |
-| `mcp_servers.<id>.disabled_tools`                | array<string>                                                     | Remove the listed tool names after applying `enabled_tools`, if any.                                                            |
-| `model_providers.<id>.name`                      | string                                                            | Display name.                                                                                                                   |
-| `model_providers.<id>.base_url`                  | string                                                            | API base URL.                                                                                                                   |
-| `model_providers.<id>.env_key`                   | string                                                            | Env var for API key.                                                                                                            |
-| `model_providers.<id>.wire_api`                  | `chat` \| `responses`                                             | Protocol used (default: `chat`).                                                                                                |
-| `model_providers.<id>.query_params`              | map<string,string>                                                | Extra query params (e.g., Azure `api-version`).                                                                                 |
-| `model_providers.<id>.http_headers`              | map<string,string>                                                | Additional static headers.                                                                                                      |
-| `model_providers.<id>.env_http_headers`          | map<string,string>                                                | Headers sourced from env vars.                                                                                                  |
-| `model_providers.<id>.request_max_retries`       | number                                                            | Per‑provider HTTP retry count (default: 4).                                                                                     |
-| `model_providers.<id>.stream_max_retries`        | number                                                            | SSE stream retry count (default: 5).                                                                                            |
-| `model_providers.<id>.stream_idle_timeout_ms`    | number                                                            | SSE idle timeout (ms) (default: 300000).                                                                                        |
-| `project_doc_max_bytes`                          | number                                                            | Max bytes to read from `AGENTS.md`.                                                                                             |
-| `profile`                                        | string                                                            | Active profile name.                                                                                                            |
-| `profiles.<name>.*`                              | various                                                           | Profile‑scoped overrides of the same keys.                                                                                      |
-| `history.persistence`                            | `save-all` \| `none`                                              | History file persistence (default: `save-all`).                                                                                 |
-| `history.max_bytes`                              | number                                                            | Maximum size of `history.jsonl` in bytes; when exceeded, history is compacted to ~80% of this limit by dropping oldest entries. |
-| `file_opener`                                    | `vscode` \| `vscode-insiders` \| `windsurf` \| `cursor` \| `none` | URI scheme for clickable citations (default: `vscode`).                                                                         |
-| `tui`                                            | table                                                             | TUI‑specific options.                                                                                                           |
-| `tui.notifications`                              | boolean \| array<string>                                          | Enable desktop notifications in the tui (default: true).                                                                        |
-| `hide_agent_reasoning`                           | boolean                                                           | Hide model reasoning events.                                                                                                    |
-| `check_for_update_on_startup`                    | boolean                                                           | Check for Codex updates on startup (default: true). Set to `false` only if updates are centrally managed.                       |
-| `show_raw_agent_reasoning`                       | boolean                                                           | Show raw reasoning (when available).                                                                                            |
-| `model_reasoning_effort`                         | `minimal` \| `low` \| `medium` \| `high`                          | Responses API reasoning effort.                                                                                                 |
-| `model_reasoning_summary`                        | `auto` \| `concise` \| `detailed` \| `none`                       | Reasoning summaries.                                                                                                            |
-| `model_verbosity`                                | `low` \| `medium` \| `high`                                       | GPT‑5 text verbosity (Responses API).                                                                                           |
-| `model_supports_reasoning_summaries`             | boolean                                                           | Force‑enable reasoning summaries.                                                                                               |
-| `model_reasoning_summary_format`                 | `none` \| `experimental`                                          | Force reasoning summary format.                                                                                                 |
-| `chatgpt_base_url`                               | string                                                            | Base URL for ChatGPT auth flow.                                                                                                 |
-| `experimental_instructions_file`                 | string (path)                                                     | Replace built‑in instructions (experimental).                                                                                   |
-| `experimental_use_exec_command_tool`             | boolean                                                           | Use experimental exec command tool.                                                                                             |
-| `projects.<path>.trust_level`                    | string                                                            | Mark project/worktree as trusted (only `"trusted"` is recognized).                                                              |
-| `tools.web_search`                               | boolean                                                           | Enable web search tool (deprecated) (default: false).                                                                           |
-| `tools.view_image`                               | boolean                                                           | Enable or disable the `view_image` tool so Codex can attach local image files from the workspace (default: true).               |
-| `forced_login_method`                            | `chatgpt` \| `api`                                                | Only allow Codex to be used with ChatGPT or API keys.                                                                           |
-| `forced_chatgpt_workspace_id`                    | string (uuid)                                                     | Only allow Codex to be used with the specified ChatGPT workspace.                                                               |
-| `cli_auth_credentials_store`                     | `file` \| `keyring` \| `auto`                                     | Where to store CLI login credentials (default: `file`).                                                                         |
->>>>>>> 75d082940 (docs: add CA certificate environment variable documentation)
+| Key                                              | Type / Values                                                     | Notes                                                                                                                      |
+| ------------------------------------------------ | ----------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `model`                                          | string                                                            | Model to use (e.g., `gpt-5.1-codex`).                                                                                      |
+| `model_provider`                                 | string                                                            | Provider id from `model_providers` (default: `openai`).                                                                    |
+| `model_context_window`                           | number                                                            | Context window tokens.                                                                                                     |
+| `model_max_output_tokens`                        | number                                                            | Max output tokens.                                                                                                         |
+| `tool_output_token_limit`                        | number                                                            | Token budget for stored function/tool outputs in history (default: 2,560 tokens).                                          |
+| `approval_policy`                                | `untrusted` \| `on-failure` \| `on-request` \| `never`            | When to prompt for approval.                                                                                               |
+| `sandbox_mode`                                   | `read-only` \| `workspace-write` \| `danger-full-access`          | OS sandbox policy.                                                                                                         |
+| `sandbox_workspace_write.writable_roots`         | array<string>                                                     | Extra writable roots in workspace‑write.                                                                                   |
+| `sandbox_workspace_write.network_access`         | boolean                                                           | Allow network in workspace‑write (default: false).                                                                         |
+| `sandbox_workspace_write.exclude_tmpdir_env_var` | boolean                                                           | Exclude `$TMPDIR` from writable roots (default: false).                                                                    |
+| `sandbox_workspace_write.exclude_slash_tmp`      | boolean                                                           | Exclude `/tmp` from writable roots (default: false).                                                                       |
+| `notify`                                         | array<string>                                                     | External program for notifications.                                                                                        |
+| `instructions`                                   | string                                                            | Currently ignored; use `experimental_instructions_file` or `AGENTS.md`.                                                    |
+| `features.<feature-flag>`                        | boolean                                                           | See [feature flags](#feature-flags) for details                                                                            |
+| `mcp_servers.<id>.command`                       | string                                                            | MCP server launcher command (stdio servers only).                                                                          |
+| `mcp_servers.<id>.args`                          | array<string>                                                     | MCP server args (stdio servers only).                                                                                      |
+| `mcp_servers.<id>.env`                           | map<string,string>                                                | MCP server env vars (stdio servers only).                                                                                  |
+| `mcp_servers.<id>.url`                           | string                                                            | MCP server url (streamable http servers only).                                                                             |
+| `mcp_servers.<id>.bearer_token_env_var`          | string                                                            | environment variable containing a bearer token to use for auth (streamable http servers only).                             |
+| `mcp_servers.<id>.enabled`                       | boolean                                                           | When false, Codex skips starting the server (default: true).                                                               |
+| `mcp_servers.<id>.startup_timeout_sec`           | number                                                            | Startup timeout in seconds (default: 10). Timeout is applied both for initializing MCP server and initially listing tools. |
+| `mcp_servers.<id>.tool_timeout_sec`              | number                                                            | Per-tool timeout in seconds (default: 60). Accepts fractional values; omit to use the default.                             |
+| `mcp_servers.<id>.enabled_tools`                 | array<string>                                                     | Restrict the server to the listed tool names.                                                                              |
+| `mcp_servers.<id>.disabled_tools`                | array<string>                                                     | Remove the listed tool names after applying `enabled_tools`, if any.                                                       |
+| `model_providers.<id>.name`                      | string                                                            | Display name.                                                                                                              |
+| `model_providers.<id>.base_url`                  | string                                                            | API base URL.                                                                                                              |
+| `model_providers.<id>.env_key`                   | string                                                            | Env var for API key.                                                                                                       |
+| `model_providers.<id>.wire_api`                  | `chat` \| `responses`                                             | Protocol used (default: `chat`).                                                                                           |
+| `model_providers.<id>.query_params`              | map<string,string>                                                | Extra query params (e.g., Azure `api-version`).                                                                            |
+| `model_providers.<id>.http_headers`              | map<string,string>                                                | Additional static headers.                                                                                                 |
+| `model_providers.<id>.env_http_headers`          | map<string,string>                                                | Headers sourced from env vars.                                                                                             |
+| `model_providers.<id>.request_max_retries`       | number                                                            | Per‑provider HTTP retry count (default: 4).                                                                                |
+| `model_providers.<id>.stream_max_retries`        | number                                                            | SSE stream retry count (default: 5).                                                                                       |
+| `model_providers.<id>.stream_idle_timeout_ms`    | number                                                            | SSE idle timeout (ms) (default: 300000).                                                                                   |
+| `project_doc_max_bytes`                          | number                                                            | Max bytes to read from `AGENTS.md`.                                                                                        |
+| `profile`                                        | string                                                            | Active profile name.                                                                                                       |
+| `profiles.<name>.*`                              | various                                                           | Profile‑scoped overrides of the same keys.                                                                                 |
+| `history.persistence`                            | `save-all` \| `none`                                              | History file persistence (default: `save-all`).                                                                            |
+| `history.max_bytes`                              | number                                                            | Currently ignored (not enforced).                                                                                          |
+| `file_opener`                                    | `vscode` \| `vscode-insiders` \| `windsurf` \| `cursor` \| `none` | URI scheme for clickable citations (default: `vscode`).                                                                    |
+| `tui`                                            | table                                                             | TUI‑specific options.                                                                                                      |
+| `tui.notifications`                              | boolean \| array<string>                                          | Enable desktop notifications in the tui (default: true).                                                                   |
+| `hide_agent_reasoning`                           | boolean                                                           | Hide model reasoning events.                                                                                               |
+| `show_raw_agent_reasoning`                       | boolean                                                           | Show raw reasoning (when available).                                                                                       |
+| `model_reasoning_effort`                         | `minimal` \| `low` \| `medium` \| `high`                          | Responses API reasoning effort.                                                                                            |
+| `model_reasoning_summary`                        | `auto` \| `concise` \| `detailed` \| `none`                       | Reasoning summaries.                                                                                                       |
+| `model_verbosity`                                | `low` \| `medium` \| `high`                                       | GPT‑5 text verbosity (Responses API).                                                                                      |
+| `model_supports_reasoning_summaries`             | boolean                                                           | Force‑enable reasoning summaries.                                                                                          |
+| `model_reasoning_summary_format`                 | `none` \| `experimental`                                          | Force reasoning summary format.                                                                                            |
+| `chatgpt_base_url`                               | string                                                            | Base URL for ChatGPT auth flow.                                                                                            |
+| `experimental_instructions_file`                 | string (path)                                                     | Replace built‑in instructions (experimental).                                                                              |
+| `experimental_use_exec_command_tool`             | boolean                                                           | Use experimental exec command tool.                                                                                        |
+| `projects.<path>.trust_level`                    | string                                                            | Mark project/worktree as trusted (only `"trusted"` is recognized).                                                         |
+| `tools.web_search`                               | boolean                                                           | Enable web search tool (deprecated) (default: false).                                                                      |
+| `tools.view_image`                               | boolean                                                           | Enable or disable the `view_image` tool so Codex can attach local image files from the workspace (default: true).          |
+| `forced_login_method`                            | `chatgpt` \| `api`                                                | Only allow Codex to be used with ChatGPT or API keys.                                                                      |
+| `forced_chatgpt_workspace_id`                    | string (uuid)                                                     | Only allow Codex to be used with the specified ChatGPT workspace.                                                          |
+| `cli_auth_credentials_store`                     | `file` \| `keyring` \| `auto`                                     | Where to store CLI login credentials (default: `file`).                                                                    |


### PR DESCRIPTION
  ## What

  Adds support for custom CA certificates in OAuth login flows to fix authentication failures behind corporate
  proxies with SSL/TLS inspection.

  ## Why

  The Codex CLI fails to authenticate when running behind corporate proxies that perform SSL/TLS inspection with
  custom CA certificates. The OAuth token exchange fails because `reqwest::Client::new()` only trusts system
  default certificate roots, causing it to reject connections intercepted by corporate proxies presenting
  certificates signed by custom CAs.

  This affects all Codex CLI users in enterprise environments with:
  - SSL/TLS inspection proxies (Zscaler, Palo Alto Networks, etc.)
  - Custom internal CA certificates
  - Air-gapped environments with internal certificate authorities

  Fixes #6849

  ## How

  **Implementation:**
  - Added `build_login_http_client()` function that creates an HTTP client with custom CA certificate support
  - Reads CA certificate path from environment variables (priority order):
    1. `CODEX_CA_CERTIFICATE` (primary)
    2. `SSL_CERT_FILE` (fallback, standard across many tools)
  - Updated all three authentication flows to use the custom client:
    - `exchange_code_for_tokens()` (OAuth code exchange)
    - `obtain_api_key()` (API key exchange)
    - `run_device_code_login()` (device code flow)
  - Follows the same pattern as existing `otel_provider.rs` implementation

  **Testing:**
  - Added comprehensive test coverage with 3 new tests:
    - Certificate loading via `CODEX_CA_CERTIFICATE` env var
    - Certificate loading via `SSL_CERT_FILE` fallback
    - Invalid certificate rejection with proper error handling
  - All existing tests continue to pass
  - Added `serial_test` dependency to safely test env var manipulation

  **Usage:**
  ```bash
  export CODEX_CA_CERTIFICATE=/path/to/corporate-ca.pem
  codex login
  ```
  or using the standard env var:
  ```bash
  export SSL_CERT_FILE=/path/to/corporate-ca.pem
  codex login
  ````
  
  **Testing:**

  - ✅ All tests pass (cargo test)
  - ✅ No clippy warnings (cargo clippy --tests -- -D warnings)
  - ✅ Code formatted (cargo fmt --check)
  - ✅ Tested with both environment variables
  - ✅ Invalid certificate properly rejected with clear error message

