### PR TITLE
feat: tweak windows sandbox strings

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -293,7 +293,7 @@ impl App {
             skip_world_writable_scan_once: false,
         };
 
-        // On startup, if Auto mode (workspace-write) or ReadOnly is active, warn about world-writable dirs on Windows.
+        // On startup, if Agent mode (workspace-write) or ReadOnly is active, warn about world-writable dirs on Windows.
         #[cfg(target_os = "windows")]
         {
             let should_check = codex_core::get_platform_sandbox().is_some()
@@ -546,7 +546,7 @@ impl App {
             AppEvent::OpenWindowsSandboxEnablePrompt { preset } => {
                 self.chat_widget.open_windows_sandbox_enable_prompt(preset);
             }
-            AppEvent::EnableWindowsSandboxForAuto { preset } => {
+            AppEvent::EnableWindowsSandboxForAgentMode { preset } => {
                 #[cfg(target_os = "windows")]
                 {
                     let profile = self.active_profile.as_deref();
@@ -587,8 +587,7 @@ impl App {
                                 self.app_event_tx
                                     .send(AppEvent::UpdateSandboxPolicy(preset.sandbox.clone()));
                                 self.chat_widget.add_info_message(
-                                    "Enabled the Windows sandbox feature and switched to Auto mode."
-                                        .to_string(),
+                                    "Enabled experimental Windows sandbox.".to_string(),
                                     None,
                                 );
                             }
@@ -732,7 +731,7 @@ impl App {
                         "failed to persist world-writable warning acknowledgement"
                     );
                     self.chat_widget.add_error_message(format!(
-                        "Failed to save Auto mode warning preference: {err}"
+                        "Failed to save Agent mode warning preference: {err}"
                     ));
                 }
             }

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -91,15 +91,15 @@ pub(crate) enum AppEvent {
         failed_scan: bool,
     },
 
-    /// Prompt to enable the Windows sandbox feature before using Auto mode.
+    /// Prompt to enable the Windows sandbox feature before using Agent mode.
     #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     OpenWindowsSandboxEnablePrompt {
         preset: ApprovalPreset,
     },
 
-    /// Enable the Windows sandbox feature and switch to Auto mode.
+    /// Enable the Windows sandbox feature and switch to Agent mode.
     #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
-    EnableWindowsSandboxForAuto {
+    EnableWindowsSandboxForAgentMode {
         preset: ApprovalPreset,
     },
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2369,11 +2369,8 @@ impl ChatWidget {
             ])
         } else {
             Line::from(vec![
-                "Some important directories on this system are world-writable. ".into(),
-                format!(
-                    "The Windows sandbox cannot protect writes to these locations in {mode_label}."
-                )
-                .fg(Color::Red),
+                "The Windows sandbox cannot protect writes to folders that are writable by Everyone.".into(),
+                "Consider removing write access for Everyone from the following folders:"
             ])
         };
         header_children.push(Box::new(
@@ -2383,7 +2380,6 @@ impl ChatWidget {
         if !sample_paths.is_empty() {
             // Show up to three examples and optionally an "and X more" line.
             let mut lines: Vec<Line> = Vec::new();
-            lines.push(Line::from("Examples:").bold());
             lines.push(Line::from(""));
             for p in &sample_paths {
                 lines.push(Line::from(format!("  - {p}")));

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2370,7 +2370,7 @@ impl ChatWidget {
         } else {
             Line::from(vec![
                 "The Windows sandbox cannot protect writes to folders that are writable by Everyone.".into(),
-                "Consider removing write access for Everyone from the following folders:"
+                " Consider removing write access for Everyone from the following folders:"
             ])
         };
         header_children.push(Box::new(

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1490,14 +1490,14 @@ fn windows_auto_mode_prompt_requests_enabling_sandbox_feature() {
 
     let popup = render_bottom_popup(&chat, 120);
     assert!(
-        popup.contains("experimental Windows sandbox"),
+        popup.contains("Agent mode on Windows uses an experimental sandbox"),
         "expected auto mode prompt to mention enabling the sandbox feature, popup: {popup}"
     );
 }
 
 #[cfg(target_os = "windows")]
 #[test]
-fn startup_prompts_for_windows_sandbox_when_auto_requested() {
+fn startup_prompts_for_windows_sandbox_when_agent_requested() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual();
 
     set_windows_sandbox_enabled(false);
@@ -1507,7 +1507,11 @@ fn startup_prompts_for_windows_sandbox_when_auto_requested() {
 
     let popup = render_bottom_popup(&chat, 120);
     assert!(
-        popup.contains("Turn on Windows sandbox and use Auto mode"),
+        popup.contains("Agent mode on Windows uses an experimental sandbox"),
+        "expected startup prompt to explain sandbox: {popup}"
+    );
+    assert!(
+        popup.contains("Enable experimental sandbox"),
         "expected startup prompt to offer enabling the sandbox: {popup}"
     );
 


### PR DESCRIPTION
New strings:
1. Approval mode picker just says "Select Approval Mode"
1. Updated "Auto" to "Agent"
1. When you select "Agent", you get "Agent mode on Windows uses an experimental sandbox to limit network and filesystem access. [Learn more]"
1. Updated world-writable warning to "The Windows sandbox cannot protect writes to folders that are writable by Everyone. Consider removing write access for Everyone from the following folders: {folders}"