### PR TITLE
nit: useless log to debug

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -254,7 +254,7 @@ impl ChatComposer {
                 true
             }
             Err(err) => {
-                tracing::info!("ERR: {err}");
+                tracing::trace!("ERR: {err}");
                 false
             }
         }


### PR DESCRIPTION
When you type too fast in most terminals, it gets interpreted as paste, making this log spam