### PR TITLE
use config.cwd instead of current_dir(). Re-introduce logging

### DIFF
--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -190,15 +190,10 @@ impl MessageProcessor {
             return;
         }
 
-        // This function is stubbed out to return None on non-Windows platforms
-        let cwd = match std::env::current_dir() {
-            Ok(cwd) => cwd,
-            Err(_) => return,
-        };
         if let Some((sample_paths, extra_count, failed_scan)) =
             codex_windows_sandbox::world_writable_warning_details(
                 self.config.codex_home.as_path(),
-                cwd,
+                self.config.cwd.as_path(),
             )
         {
             self.outgoing

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2300,11 +2300,10 @@ impl ChatWidget {
         {
             return None;
         }
-        let cwd = match std::env::current_dir() {
-            Ok(cwd) => cwd,
-            Err(_) => return Some((Vec::new(), 0, true)),
-        };
-        codex_windows_sandbox::world_writable_warning_details(self.config.codex_home.as_path(), cwd)
+        codex_windows_sandbox::world_writable_warning_details(
+            self.config.codex_home.as_path(),
+            self.config.cwd.as_path(),
+        )
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/codex-rs/windows-sandbox-rs/src/audit.rs
+++ b/codex-rs/windows-sandbox-rs/src/audit.rs
@@ -268,6 +268,13 @@ pub fn audit_everyone_writable(
         for p in &flagged {
             list.push_str(&format!("\n - {}", p.display()));
         }
+        crate::logging::log_note(
+            &format!(
+                "AUDIT: world-writable scan FAILED; checked={checked}; duration_ms={elapsed_ms}; flagged:{}",
+                list
+            ),
+            logs_base_dir,
+        );
 
         return Ok(flagged);
     }


### PR DESCRIPTION
config.cwd is more correct than current_dir()
also some logging was removed by a previous PR that should not have been.