### PR TITLE
fix: when displaying execv, show file instead of arg0

### DIFF
--- a/codex-rs/exec-server/src/posix/mcp_escalation_policy.rs
+++ b/codex-rs/exec-server/src/posix/mcp_escalation_policy.rs
@@ -43,12 +43,17 @@ impl McpEscalationPolicy {
 
     async fn prompt(
         &self,
-        _file: &Path,
+        file: &Path,
         argv: &[String],
         workdir: &Path,
         context: RequestContext<RoleServer>,
     ) -> Result<CreateElicitationResult, McpError> {
-        let command = shlex::try_join(argv.iter().map(String::as_str)).unwrap_or_default();
+        let args = shlex::try_join(argv.iter().skip(1).map(String::as_str)).unwrap_or_default();
+        let command = if args.is_empty() {
+            file.display().to_string()
+        } else {
+            format!("{} {}", file.display(), args)
+        };
         context
             .peer
             .create_elicitation(CreateElicitationRequestParam {


### PR DESCRIPTION
After merging https://github.com/openai/codex/pull/6958, I realized that the `command` I was displaying was not quite right. Since we know it, we should show the _exact_ program being executed (the first arg to `execve(3)`) rather than `arg0` to be more precise.

Below is the same command I used to test https://github.com/openai/codex/pull/6958, but now you can see it shows `/Users/mbolin/.openai/bin/git` instead of just `git`.

<img width="1526" height="1444" alt="image" src="https://github.com/user-attachments/assets/428128d1-c658-456e-a64e-fc6a0009cb34" />
