### PR TITLE
feat: parse and return token usage in Chat Completions stream

### DIFF
--- a/codex-rs/codex-api/src/sse/chat.rs
+++ b/codex-rs/codex-api/src/sse/chat.rs
@@ -113,10 +113,9 @@ pub async fn process_chat_sse<S>(
             }
         };
 
-        if response_id.is_empty() {
-            if let Some(id) = value.get("id").and_then(|s| s.as_str()) {
-                response_id = id.to_string();
-            }
+        if response_id.is_empty()
+            && let Some(id) = value.get("id").and_then(serde_json::Value::as_str) {
+            response_id = id.to_string();
         }
 
         if let Some(usage) = value.get("usage") {

--- a/codex-rs/codex-api/src/sse/chat.rs
+++ b/codex-rs/codex-api/src/sse/chat.rs
@@ -114,7 +114,8 @@ pub async fn process_chat_sse<S>(
         };
 
         if response_id.is_empty()
-            && let Some(id) = value.get("id").and_then(serde_json::Value::as_str) {
+            && let Some(id) = value.get("id").and_then(serde_json::Value::as_str)
+        {
             response_id = id.to_string();
         }
 


### PR DESCRIPTION
This pull request enhances the SSE (Server-Sent Events) processing logic in `chat_completions.rs` to improve how response metadata is handled, specifically by capturing and propagating the `response_id` and detailed token usage statistics from the OpenAI API responses. The changes ensure that this information is correctly parsed, stored, and included in the `ResponseEvent::Completed` messages, making downstream processing more robust and informative.

**Improvements to response metadata handling:**

* Added a `parse_openai_usage` function to extract detailed token usage statistics—including input, output, cached, and reasoning tokens—from the OpenAI API response, and populate a `TokenUsage` struct.
* Updated the SSE processing loop in `process_chat_sse` to capture and store the `response_id` and parsed `token_usage` from each incoming chunk, ensuring these fields are preserved across the session.

**Enhancements to event emission:**

* Modified all `ResponseEvent::Completed` emissions to include the actual `response_id` and `token_usage` instead of defaulting to empty or `None`, improving traceability and observability for clients consuming these events. 

Link Issue: https://github.com/openai/codex/issues/6834

