### PR TITLE
Bumped number of fuzzy search results from 8 to 20

### DIFF
--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -31,7 +31,7 @@ use std::time::Duration;
 use crate::app_event::AppEvent;
 use crate::app_event_sender::AppEventSender;
 
-const MAX_FILE_SEARCH_RESULTS: NonZeroUsize = NonZeroUsize::new(8).unwrap();
+const MAX_FILE_SEARCH_RESULTS: NonZeroUsize = NonZeroUsize::new(20).unwrap();
 const NUM_FILE_SEARCH_THREADS: NonZeroUsize = NonZeroUsize::new(2).unwrap();
 
 /// How long to wait after a keystroke before firing the first search when none


### PR DESCRIPTION
I just noticed that in the VSCode / Codex extension when you type @ the number of results is around 70:

- small video of searching for `mod.rs` inside `codex` repository: https://github.com/user-attachments/assets/46e53d31-adff-465e-b32b-051c4c1c298c

- while in the CLI the number of results is currently of 8 which is quite small:
<img width="615" height="439" alt="Screenshot 2025-11-20 at 09 42 04" src="https://github.com/user-attachments/assets/1c6d12cb-3b1f-4d5b-9ad3-6b12975eaaec" />

I bumped it to 20. I had several cases where I wanted a file and did not find it because the number of results was too small