### PR TITLE
reintroduce winget step to release job

### DIFF
--- a/.github/actions/winget-submit/action.yml
+++ b/.github/actions/winget-submit/action.yml
@@ -1,0 +1,47 @@
+name: Winget Submit
+description: Template + validate + submission of WinGet manifests for Codex
+inputs:
+  version:
+    description: Release version (e.g., 0.58.0)
+    required: true
+  windows_x64_sha256:
+    description: Windows x64 SHA256 for codex-x86_64-pc-windows-msvc.exe
+    required: true
+  windows_arm64_sha256:
+    description: Windows arm64 SHA256 for codex-aarch64-pc-windows-msvc.exe
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Build manifest directory
+      shell: bash
+      continue-on-error: true
+      run: |
+        set -euo pipefail
+        # Mirror the winget-pkgs repo layout so validation matches what
+        # we will submit:
+        # manifests/<first-letter-lowercase>/<Publisher>/<PackageName>/<Version>/
+        # For OpenAI.Codex vX.Y.Z → manifests/o/OpenAI/Codex/X.Y.Z
+        VERSION="${{ inputs.version }}"
+        X64_SHA="${{ inputs.windows_x64_sha256 }}"
+        ARM_SHA="${{ inputs.windows_arm64_sha256 }}"
+        root="manifests/o/OpenAI/Codex/$VERSION"
+        tpl=".github/winget_templates"
+        mkdir -p "$root"
+        for f in OpenAI.Codex.yaml OpenAI.Codex.locale.en-US.yaml OpenAI.Codex.installer.yaml; do
+          sed -e "s/{{VERSION}}/$VERSION/g" \
+              -e "s/{{X64_SHA256}}/$X64_SHA/g" \
+              -e "s/{{ARM64_SHA256}}/$ARM_SHA/g" \
+              "$tpl/$f" > "$root/$f"
+        done
+        echo "Manifest staged at $root"
+
+    - name: Install WinGet Create
+      shell: bash
+      continue-on-error: true
+      run: winget install --id Microsoft.WingetCreate -e --accept-package-agreements --accept-source-agreements
+
+    - name: Validate manifests
+      shell: bash
+      continue-on-error: true
+      run: winget validate "manifests/o/OpenAI/Codex/${{ inputs.version }}"

--- a/.github/winget_templates/OpenAI.Codex.installer.yaml
+++ b/.github/winget_templates/OpenAI.Codex.installer.yaml
@@ -1,0 +1,17 @@
+﻿PackageIdentifier: OpenAI.Codex
+PackageVersion: {{VERSION}}
+Installers:
+  - Architecture: x64
+    InstallerType: portable
+    InstallerUrl: https://github.com/openai/codex/releases/download/rust-v{{VERSION}}/codex-x86_64-pc-windows-msvc.exe
+    InstallerSha256: {{X64_SHA256}}
+    Commands:
+      - codex
+  - Architecture: arm64
+    InstallerType: portable
+    InstallerUrl: https://github.com/openai/codex/releases/download/rust-v{{VERSION}}/codex-aarch64-pc-windows-msvc.exe
+    InstallerSha256: {{ARM64_SHA256}}
+    Commands:
+      - codex
+ManifestType: installer
+ManifestVersion: 1.5.0

--- a/.github/winget_templates/OpenAI.Codex.locale.en-US.yaml
+++ b/.github/winget_templates/OpenAI.Codex.locale.en-US.yaml
@@ -1,0 +1,19 @@
+﻿PackageIdentifier: OpenAI.Codex
+PackageVersion: {{VERSION}}
+PackageLocale: en-US
+Publisher: OpenAI
+PublisherUrl: https://github.com/openai
+PublisherSupportUrl: https://github.com/openai/codex/issues
+PrivacyUrl: https://openai.com/policies/privacy-policy
+PackageName: Codex
+PackageUrl: https://github.com/openai/codex
+License: Proprietary
+ShortDescription: Native Codex CLI (Rust) for terminal and TUI workflows.
+Moniker: codex
+Tags:
+  - codex
+  - cli
+  - ai
+  - agent
+ManifestType: defaultLocale
+ManifestVersion: 1.5.0

--- a/.github/winget_templates/OpenAI.Codex.yaml
+++ b/.github/winget_templates/OpenAI.Codex.yaml
@@ -1,0 +1,5 @@
+﻿PackageIdentifier: OpenAI.Codex
+PackageVersion: {{VERSION}}
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.5.0

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -383,6 +383,8 @@ jobs:
       tag: ${{ github.ref_name }}
       should_publish_npm: ${{ steps.npm_publish_settings.outputs.should_publish }}
       npm_tag: ${{ steps.npm_publish_settings.outputs.npm_tag }}
+      windows_x64_sha256: ${{ steps.win_hash.outputs.windows_x64_sha256 }}
+      windows_arm64_sha256: ${{ steps.win_hash.outputs.windows_arm64_sha256 }}
 
     steps:
       - name: Checkout repository
@@ -394,6 +396,16 @@ jobs:
 
       - name: List
         run: ls -R dist/
+
+      - name: Compute SHA256 for Windows EXEs
+        id: win_hash
+        shell: bash
+        run: |
+          set -euo pipefail
+          x64_sha=$(sha256sum "dist/x86_64-pc-windows-msvc/codex-rs/dist/x86_64-pc-windows-msvc/codex-x86_64-pc-windows-msvc.exe" | awk '{print $1}')
+          arm_sha=$(sha256sum "dist/aarch64-pc-windows-msvc/codex-rs/dist/aarch64-pc-windows-msvc/codex-aarch64-pc-windows-msvc.exe" | awk '{print $1}')
+          echo "windows_x64_sha256=${x64_sha}" >> "$GITHUB_OUTPUT"
+          echo "windows_arm64_sha256=${arm_sha}" >> "$GITHUB_OUTPUT"
 
       - name: Define release name
         id: release_name
@@ -549,4 +561,16 @@ jobs:
             repos/${GITHUB_REPOSITORY}/git/refs/heads/latest-alpha-cli \
             -X PATCH \
             -f sha="${GITHUB_SHA}" \
-            -F force=true
+          -F force=true
+
+  winget:
+    needs: release
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+      - name: Validate WinGet manifests
+        uses: ./.github/actions/winget-submit
+        with:
+          version: ${{ needs.release.outputs.version }}
+          windows_x64_sha256: ${{ needs.release.outputs.windows_x64_sha256 }}
+          windows_arm64_sha256: ${{ needs.release.outputs.windows_arm64_sha256 }}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -399,11 +399,27 @@ jobs:
 
       - name: Compute SHA256 for Windows EXEs
         id: win_hash
+        continue-on-error: true
         shell: bash
         run: |
-          set -euo pipefail
-          x64_sha=$(sha256sum "dist/x86_64-pc-windows-msvc/codex-rs/dist/x86_64-pc-windows-msvc/codex-x86_64-pc-windows-msvc.exe" | awk '{print $1}')
-          arm_sha=$(sha256sum "dist/aarch64-pc-windows-msvc/codex-rs/dist/aarch64-pc-windows-msvc/codex-aarch64-pc-windows-msvc.exe" | awk '{print $1}')
+          set -uo pipefail
+          x64_sha=""
+          arm_sha=""
+          x64_path="dist/x86_64-pc-windows-msvc/codex-x86_64-pc-windows-msvc.exe"
+          arm_path="dist/aarch64-pc-windows-msvc/codex-aarch64-pc-windows-msvc.exe"
+
+          if [[ -f "$x64_path" ]]; then
+            x64_sha=$(sha256sum "$x64_path" | awk '{print $1}')
+          else
+            echo "::warning::Windows x64 binary not found at $x64_path; winget validation will be skipped."
+          fi
+
+          if [[ -f "$arm_path" ]]; then
+            arm_sha=$(sha256sum "$arm_path" | awk '{print $1}')
+          else
+            echo "::warning::Windows arm64 binary not found at $arm_path; winget validation will be skipped."
+          fi
+
           echo "windows_x64_sha256=${x64_sha}" >> "$GITHUB_OUTPUT"
           echo "windows_arm64_sha256=${arm_sha}" >> "$GITHUB_OUTPUT"
 

--- a/codex-rs/cli/packaging/winget/README.md
+++ b/codex-rs/cli/packaging/winget/README.md
@@ -1,0 +1,36 @@
+WinGet manifests for the Codex CLI
+
+Local testing
+
+- Validate: `winget validate .\manifests\o\OpenAI\Codex\0.57.0`
+- Install from local manifests: `winget install --manifest .\manifests\o\OpenAI\Codex\0.57.0`
+- Verify: `codex --version` and `where codex`
+- Uninstall: `winget uninstall OpenAI.Codex`
+
+Submitting to winget-pkgs
+
+- Ensure URLs and SHA256 match the public GitHub Release for this version.
+- Submit with `wingetcreate submit <path>` or copy this tree into a fork of `microsoft/winget-pkgs` under the same path.
+Winget manifests
+
+- Templates live under `.github/winget_templates/` and use placeholders:
+  - `{{VERSION}}`, `{{X64_SHA256}}`, `{{ARM64_SHA256}}`
+- The CI calls a composite action (`.github/actions/winget-submit`) from the release job:
+  - Fills the templates using the release version and precomputed SHA256s,
+  - Validates the manifests with `winget validate` (submission is separate).
+
+Setup
+
+- Ensure releases include raw Windows assets:
+  - `codex-x86_64-pc-windows-msvc.exe`
+  - `codex-aarch64-pc-windows-msvc.exe`
+- Add a repo secret `WINGET_PUBLISH_PAT` with `repo` (or `public_repo`) scope for PR submission.
+
+Local test
+
+- Build a versioned manifest set:
+  - Replace placeholders in the files under `template/` and stage under `manifests/o/OpenAI/Codex/<VERSION>/`.
+- Validate:
+  - `wingetcreate validate manifests/o/OpenAI/Codex/<VERSION>`
+- Install locally:
+  - `winget install --manifest manifests/o/OpenAI/Codex/<VERSION>`


### PR DESCRIPTION
This fixes the previous bug (the exe path was wrong when we were generating SHAs)
and also makes it so the main job won't fail if this part fails.