### PR TITLE
add deny ACEs for world writable dirs

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -225,6 +225,7 @@ pub(crate) struct App {
 }
 
 impl App {
+    #[allow(clippy::too_many_arguments)]
     pub async fn run(
         tui: &mut tui::Tui,
         auth_manager: Arc<AuthManager>,

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -225,7 +225,6 @@ pub(crate) struct App {
 }
 
 impl App {
-    #[allow(clippy::too_many_arguments)]
     pub async fn run(
         tui: &mut tui::Tui,
         auth_manager: Arc<AuthManager>,
@@ -343,7 +342,8 @@ impl App {
                 let env_map: std::collections::HashMap<String, String> = std::env::vars().collect();
                 let tx = app.app_event_tx.clone();
                 let logs_base_dir = app.config.codex_home.clone();
-                Self::spawn_world_writable_scan(cwd, env_map, logs_base_dir, tx);
+                let sandbox_policy = app.config.sandbox_policy.clone();
+                Self::spawn_world_writable_scan(cwd, env_map, logs_base_dir, sandbox_policy, tx);
             }
         }
 
@@ -717,7 +717,14 @@ impl App {
                             std::env::vars().collect();
                         let tx = self.app_event_tx.clone();
                         let logs_base_dir = self.config.codex_home.clone();
-                        Self::spawn_world_writable_scan(cwd, env_map, logs_base_dir, tx);
+                        let sandbox_policy = self.config.sandbox_policy.clone();
+                        Self::spawn_world_writable_scan(
+                            cwd,
+                            env_map,
+                            logs_base_dir,
+                            sandbox_policy,
+                            tx,
+                        );
                     }
                 }
             }
@@ -911,6 +918,7 @@ impl App {
         cwd: PathBuf,
         env_map: std::collections::HashMap<String, String>,
         logs_base_dir: PathBuf,
+        sandbox_policy: codex_core::protocol::SandboxPolicy,
         tx: AppEventSender,
     ) {
         #[inline]
@@ -920,8 +928,10 @@ impl App {
         }
         tokio::task::spawn_blocking(move || {
             let result = codex_windows_sandbox::preflight_audit_everyone_writable(
+                &logs_base_dir,
                 &cwd,
                 &env_map,
+                &sandbox_policy,
                 Some(logs_base_dir.as_path()),
             );
             if let Ok(ref paths) = result

--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -38,6 +38,7 @@ mod windows_impl {
     use super::env::normalize_null_device_env;
     use super::logging::debug_log;
     use super::logging::log_failure;
+    use super::logging::log_note;
     use super::logging::log_start;
     use super::logging::log_success;
     use super::policy::parse_policy;
@@ -178,11 +179,29 @@ mod windows_impl {
     }
 
     pub fn preflight_audit_everyone_writable(
+        codex_home: &Path,
         cwd: &Path,
         env_map: &HashMap<String, String>,
+        sandbox_policy: &SandboxPolicy,
         logs_base_dir: Option<&Path>,
     ) -> Result<Vec<PathBuf>> {
-        audit::audit_everyone_writable(cwd, env_map, logs_base_dir)
+        let flagged = audit::audit_everyone_writable(cwd, env_map, logs_base_dir)?;
+        if flagged.is_empty() {
+            return Ok(flagged);
+        }
+        if let Err(err) = audit::apply_capability_denies_for_world_writable(
+            codex_home,
+            &flagged,
+            sandbox_policy,
+            cwd,
+            logs_base_dir,
+        ) {
+            log_note(
+                &format!("AUDIT: failed to apply capability deny ACEs: {}", err),
+                logs_base_dir,
+            );
+        }
+        Ok(Vec::new())
     }
 
     pub fn run_windows_sandbox_capture(
@@ -446,8 +465,10 @@ mod stub {
     }
 
     pub fn preflight_audit_everyone_writable(
+        _codex_home: &Path,
         _cwd: &Path,
         _env_map: &HashMap<String, String>,
+        _sandbox_policy: &crate::policy::SandboxPolicy,
         _logs_base_dir: Option<&Path>,
     ) -> Result<Vec<std::path::PathBuf>> {
         bail!("Windows sandbox is only available on Windows")

--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -453,6 +453,7 @@ mod windows_impl {
 mod stub {
     use anyhow::bail;
     use anyhow::Result;
+    use codex_protocol::protocol::SandboxPolicy;
     use std::collections::HashMap;
     use std::path::Path;
 
@@ -468,7 +469,7 @@ mod stub {
         _codex_home: &Path,
         _cwd: &Path,
         _env_map: &HashMap<String, String>,
-        _sandbox_policy: &crate::policy::SandboxPolicy,
+        _sandbox_policy: &SandboxPolicy,
         _logs_base_dir: Option<&Path>,
     ) -> Result<Vec<std::path::PathBuf>> {
         bail!("Windows sandbox is only available on Windows")


### PR DESCRIPTION
Our Restricted Token contains 3 SIDs (Logon, Everyone, {WorkspaceWrite Capability || ReadOnly Capability})

because it must include Everyone, that left us vulnerable to directories that allow writes to Everyone. Even though those directories do not have ACEs that enable our capability SIDs to write to them, they could still be written to even in ReadOnly mode, or even in WorkspaceWrite mode if they are outside of a writable root.

A solution to this is to explicitly add *Deny* ACEs to these directories, always for the ReadOnly Capability SID, and for the WorkspaceWrite SID if the directory is outside of a workspace root.

Under a restricted token, Windows always checks Deny ACEs before Allow ACEs so even though our restricted token would allow a write to these directories due to the Everyone SID, it fails first because of the Deny ACE on the capability SID