### PR TITLE
increasing user shell timeout to 1 hour

### DIFF
--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -31,6 +31,8 @@ use crate::user_shell_command::user_shell_command_record_item;
 use super::SessionTask;
 use super::SessionTaskContext;
 
+const USER_SHELL_TIMEOUT_MS: u64 = 60 * 60 * 1000; // 1 hour
+
 #[derive(Clone)]
 pub(crate) struct UserShellCommandTask {
     command: String,
@@ -93,7 +95,7 @@ impl SessionTask for UserShellCommandTask {
             command: command.clone(),
             cwd: cwd.clone(),
             env: create_env(&turn_context.shell_environment_policy),
-            timeout_ms: None,
+            timeout_ms: Some(USER_SHELL_TIMEOUT_MS),
             sandbox: SandboxType::None,
             with_escalated_permissions: None,
             justification: None,


### PR DESCRIPTION
setting user shell timeout to an unreasonably high value since there isn't an easy way to have a command run without timeouts

currently, user shell commands timeout is 10 seconds