### PR TITLE
fix flaky test: `approval_matrix_covers_all_modes`

### DIFF
--- a/codex-rs/.config/nextest.toml
+++ b/codex-rs/.config/nextest.toml
@@ -10,4 +10,4 @@ slow-timeout = { period = "1m", terminate-after = 4 }
 
 [[profile.default.overrides]]
 filter = 'test(approval_matrix_covers_all_modes)'
-slow-timeout = { period = "60s", terminate-after = 2 }
+slow-timeout = { period = "30s", terminate-after = 2 }

--- a/codex-rs/.config/nextest.toml
+++ b/codex-rs/.config/nextest.toml
@@ -7,3 +7,7 @@ slow-timeout = { period = "15s", terminate-after = 2 }
 # Do not add new tests here
 filter = 'test(rmcp_client) | test(humanlike_typing_1000_chars_appears_live_no_placeholder)'
 slow-timeout = { period = "1m", terminate-after = 4 }
+
+[[profile.default.overrides]]
+filter = 'test(approval_matrix_covers_all_modes)'
+slow-timeout = { period = "60s", terminate-after = 2 }


### PR DESCRIPTION
looks like it sometimes flake around 30. let's give it more time. 