### PR TITLE
Attempt to fix `unified_exec_formats_large_output_summary` flakiness 

### DIFF
--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -1622,8 +1622,8 @@ async fn unified_exec_formats_large_output_summary() -> Result<()> {
     } = builder.build(&server).await?;
 
     let script = r#"python3 - <<'PY'
-for i in range(10000):
-    print("token token ")
+import sys
+sys.stdout.write("token token \n" * 5000)
 PY
 "#;
 


### PR DESCRIPTION
second attempt to fix this test after https://github.com/openai/codex/pull/6884. I think this flakiness is happening because yield_time is too small for a 10,000 step loop in python. 