### PR TITLE
execpolicy helpers

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1281,6 +1281,7 @@ dependencies = [
  "serde_json",
  "shlex",
  "starlark",
+ "tempfile",
  "thiserror 2.0.17",
 ]
 

--- a/codex-rs/execpolicy/Cargo.toml
+++ b/codex-rs/execpolicy/Cargo.toml
@@ -28,3 +28,4 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+tempfile = { workspace = true }

--- a/codex-rs/execpolicy/src/amend.rs
+++ b/codex-rs/execpolicy/src/amend.rs
@@ -37,11 +37,6 @@ pub enum AmendError {
         path: PathBuf,
         source: std::io::Error,
     },
-    #[error("failed to unlock policy file {path}: {source}")]
-    UnlockPolicyFile {
-        path: PathBuf,
-        source: std::io::Error,
-    },
     #[error("failed to seek policy file {path}: {source}")]
     SeekPolicyFile {
         path: PathBuf,
@@ -138,11 +133,7 @@ fn append_locked_line(policy_path: &Path, line: &str) -> Result<(), AmendError> 
             source,
         })?;
 
-    file.unlock()
-        .map_err(|source| AmendError::UnlockPolicyFile {
-            path: policy_path,
-            source,
-        })
+    Ok(())
 }
 
 #[cfg(test)]

--- a/codex-rs/execpolicy/src/amend.rs
+++ b/codex-rs/execpolicy/src/amend.rs
@@ -97,11 +97,10 @@ fn append_locked_line(policy_path: &Path, line: &str) -> Result<(), AmendError> 
             path: policy_path.clone(),
             source,
         })?;
-    file.lock()
-        .map_err(|source| AmendError::LockPolicyFile {
-            path: policy_path.clone(),
-            source,
-        })?;
+    file.lock().map_err(|source| AmendError::LockPolicyFile {
+        path: policy_path.clone(),
+        source,
+    })?;
 
     let len = file
         .metadata()

--- a/codex-rs/execpolicy/src/amend.rs
+++ b/codex-rs/execpolicy/src/amend.rs
@@ -104,6 +104,7 @@ fn append_locked_line(policy_path: &Path, line: &str) -> Result<(), AmendError> 
         })?
         .len();
 
+    // Ensure file ends in a newline before appending.
     if len > 0 {
         file.seek(SeekFrom::End(-1))
             .map_err(|source| AmendError::SeekPolicyFile {

--- a/codex-rs/execpolicy/src/amend.rs
+++ b/codex-rs/execpolicy/src/amend.rs
@@ -110,8 +110,11 @@ mod tests {
         let tmp = tempdir().expect("create temp dir");
         let policy_path = tmp.path().join("policy").join("default.codexpolicy");
 
-        append_allow_prefix_rule(&policy_path, &[String::from("echo"), String::from("Hello, world!")])
-            .expect("append rule");
+        append_allow_prefix_rule(
+            &policy_path,
+            &[String::from("echo"), String::from("Hello, world!")],
+        )
+        .expect("append rule");
 
         let contents =
             std::fs::read_to_string(&policy_path).expect("default.codexpolicy should exist");
@@ -132,7 +135,11 @@ mod tests {
         )
         .expect("write seed rule");
 
-        append_allow_prefix_rule(&policy_path, &[String::from("echo"), String::from("Hello, world!")]).expect("append rule");
+        append_allow_prefix_rule(
+            &policy_path,
+            &[String::from("echo"), String::from("Hello, world!")],
+        )
+        .expect("append rule");
 
         let contents = std::fs::read_to_string(&policy_path).expect("read policy");
         assert_eq!(

--- a/codex-rs/execpolicy/src/amend.rs
+++ b/codex-rs/execpolicy/src/amend.rs
@@ -54,7 +54,12 @@ pub enum AmendError {
     },
 }
 
-pub fn append_allow_prefix_rule(policy_path: &Path, prefix: &[String]) -> Result<(), AmendError> {
+/// Note this thread uses advisory file locking and performs blocking I/O, so it should be used with
+/// [`tokio::task::spawn_blocking`] when called from an async context.
+pub fn blocking_append_allow_prefix_rule(
+    policy_path: &Path,
+    prefix: &[String],
+) -> Result<(), AmendError> {
     if prefix.is_empty() {
         return Err(AmendError::EmptyPrefix);
     }
@@ -147,7 +152,7 @@ mod tests {
         let tmp = tempdir().expect("create temp dir");
         let policy_path = tmp.path().join("policy").join("default.codexpolicy");
 
-        append_allow_prefix_rule(
+        blocking_append_allow_prefix_rule(
             &policy_path,
             &[String::from("echo"), String::from("Hello, world!")],
         )
@@ -174,7 +179,7 @@ mod tests {
         )
         .expect("write seed rule");
 
-        append_allow_prefix_rule(
+        blocking_append_allow_prefix_rule(
             &policy_path,
             &[String::from("echo"), String::from("Hello, world!")],
         )
@@ -200,7 +205,7 @@ prefix_rule(pattern=["echo","Hello, world!"], decision="allow")
         )
         .expect("write seed rule without newline");
 
-        append_allow_prefix_rule(
+        blocking_append_allow_prefix_rule(
             &policy_path,
             &[String::from("echo"), String::from("Hello, world!")],
         )

--- a/codex-rs/execpolicy/src/amend.rs
+++ b/codex-rs/execpolicy/src/amend.rs
@@ -1,0 +1,143 @@
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+
+use serde_json;
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AmendError {
+    #[error("prefix rule requires at least one token")]
+    EmptyPrefix,
+    #[error("policy path has no parent: {path}")]
+    MissingParent { path: PathBuf },
+    #[error("failed to create policy directory {dir}: {source}")]
+    CreatePolicyDir {
+        dir: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to format prefix token {token}: {source}")]
+    SerializeToken {
+        token: String,
+        source: serde_json::Error,
+    },
+    #[error("failed to open policy file {path}: {source}")]
+    OpenPolicyFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to write to policy file {path}: {source}")]
+    WritePolicyFile {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+    #[error("failed to read metadata for policy file {path}: {source}")]
+    PolicyMetadata {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+}
+
+pub fn append_allow_prefix_rule(policy_path: &Path, prefix: &[String]) -> Result<(), AmendError> {
+    if prefix.is_empty() {
+        return Err(AmendError::EmptyPrefix);
+    }
+
+    let tokens: Vec<String> = prefix
+        .iter()
+        .map(|token| {
+            serde_json::to_string(token).map_err(|source| AmendError::SerializeToken {
+                token: token.clone(),
+                source,
+            })
+        })
+        .collect::<Result<_, _>>()?;
+    let pattern = tokens.join(", ");
+    let rule = format!("prefix_rule(pattern=[{pattern}], decision=\"allow\")\n");
+
+    let dir = policy_path
+        .parent()
+        .ok_or_else(|| AmendError::MissingParent {
+            path: policy_path.to_path_buf(),
+        })?;
+    match std::fs::create_dir(dir) {
+        Ok(()) => {}
+        Err(ref source) if source.kind() == std::io::ErrorKind::AlreadyExists => {}
+        Err(source) => {
+            return Err(AmendError::CreatePolicyDir {
+                dir: dir.to_path_buf(),
+                source,
+            });
+        }
+    }
+    let mut file = OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(policy_path)
+        .map_err(|source| AmendError::OpenPolicyFile {
+            path: policy_path.to_path_buf(),
+            source,
+        })?;
+    let needs_newline = file
+        .metadata()
+        .map(|metadata| metadata.len() > 0)
+        .map_err(|source| AmendError::PolicyMetadata {
+            path: policy_path.to_path_buf(),
+            source,
+        })?;
+    let final_rule = if needs_newline {
+        format!("\n{rule}")
+    } else {
+        rule
+    };
+
+    file.write_all(final_rule.as_bytes())
+        .map_err(|source| AmendError::WritePolicyFile {
+            path: policy_path.to_path_buf(),
+            source,
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use tempfile::tempdir;
+
+    #[test]
+    fn appends_rule_and_creates_directories() {
+        let tmp = tempdir().expect("create temp dir");
+        let policy_path = tmp.path().join("policy").join("default.codexpolicy");
+
+        append_allow_prefix_rule(&policy_path, &[String::from("echo"), String::from("Hello, world!")])
+            .expect("append rule");
+
+        let contents =
+            std::fs::read_to_string(&policy_path).expect("default.codexpolicy should exist");
+        assert_eq!(
+            contents,
+            "prefix_rule(pattern=[\"echo\", \"Hello, world!\"], decision=\"allow\")\n"
+        );
+    }
+
+    #[test]
+    fn separates_rules_with_newlines_when_appending() {
+        let tmp = tempdir().expect("create temp dir");
+        let policy_path = tmp.path().join("policy").join("default.codexpolicy");
+        std::fs::create_dir_all(policy_path.parent().unwrap()).expect("create policy dir");
+        std::fs::write(
+            &policy_path,
+            "prefix_rule(pattern=[\"ls\"], decision=\"allow\")\n",
+        )
+        .expect("write seed rule");
+
+        append_allow_prefix_rule(&policy_path, &[String::from("echo"), String::from("Hello, world!")]).expect("append rule");
+
+        let contents = std::fs::read_to_string(&policy_path).expect("read policy");
+        assert_eq!(
+            contents,
+            "prefix_rule(pattern=[\"ls\"], decision=\"allow\")\n\nprefix_rule(pattern=[\"echo\", \"Hello, world!\"], decision=\"allow\")\n"
+        );
+    }
+}

--- a/codex-rs/execpolicy/src/amend.rs
+++ b/codex-rs/execpolicy/src/amend.rs
@@ -82,25 +82,24 @@ pub fn append_allow_prefix_rule(policy_path: &Path, prefix: &[String]) -> Result
 }
 
 fn append_locked_line(policy_path: &Path, line: &str) -> Result<(), AmendError> {
-    let policy_path = policy_path.to_path_buf();
     let mut file = OpenOptions::new()
         .create(true)
         .read(true)
         .append(true)
-        .open(&policy_path)
+        .open(policy_path)
         .map_err(|source| AmendError::OpenPolicyFile {
-            path: policy_path.clone(),
+            path: policy_path.to_path_buf(),
             source,
         })?;
     file.lock().map_err(|source| AmendError::LockPolicyFile {
-        path: policy_path.clone(),
+        path: policy_path.to_path_buf(),
         source,
     })?;
 
     let len = file
         .metadata()
         .map_err(|source| AmendError::PolicyMetadata {
-            path: policy_path.clone(),
+            path: policy_path.to_path_buf(),
             source,
         })?
         .len();
@@ -108,20 +107,20 @@ fn append_locked_line(policy_path: &Path, line: &str) -> Result<(), AmendError> 
     if len > 0 {
         file.seek(SeekFrom::End(-1))
             .map_err(|source| AmendError::SeekPolicyFile {
-                path: policy_path.clone(),
+                path: policy_path.to_path_buf(),
                 source,
             })?;
         let mut last = [0; 1];
         file.read_exact(&mut last)
             .map_err(|source| AmendError::ReadPolicyFile {
-                path: policy_path.clone(),
+                path: policy_path.to_path_buf(),
                 source,
             })?;
 
         if last[0] != b'\n' {
             file.write_all(b"\n")
                 .map_err(|source| AmendError::WritePolicyFile {
-                    path: policy_path.clone(),
+                    path: policy_path.to_path_buf(),
                     source,
                 })?;
         }
@@ -129,7 +128,7 @@ fn append_locked_line(policy_path: &Path, line: &str) -> Result<(), AmendError> 
 
     file.write_all(format!("{line}\n").as_bytes())
         .map_err(|source| AmendError::WritePolicyFile {
-            path: policy_path.clone(),
+            path: policy_path.to_path_buf(),
             source,
         })?;
 

--- a/codex-rs/execpolicy/src/amend.rs
+++ b/codex-rs/execpolicy/src/amend.rs
@@ -132,8 +132,7 @@ fn append_locked_line(policy_path: &Path, line: &str) -> Result<(), AmendError> 
         }
     }
 
-    file.write_all(line.as_bytes())
-        .and_then(|()| file.write_all(b"\n"))
+    file.write_all(format!("{line}\n").as_bytes())
         .map_err(|source| AmendError::WritePolicyFile {
             path: policy_path.clone(),
             source,

--- a/codex-rs/execpolicy/src/amend.rs
+++ b/codex-rs/execpolicy/src/amend.rs
@@ -66,7 +66,7 @@ pub fn append_allow_prefix_rule(policy_path: &Path, prefix: &[String]) -> Result
 
     let pattern =
         serde_json::to_string(prefix).map_err(|source| AmendError::SerializePrefix { source })?;
-    let rule = format!("prefix_rule(pattern={pattern}, decision=\"allow\")");
+    let rule = format!(r#"prefix_rule(pattern={pattern}, decision="allow")"#);
 
     let dir = policy_path
         .parent()
@@ -166,7 +166,8 @@ mod tests {
             std::fs::read_to_string(&policy_path).expect("default.codexpolicy should exist");
         assert_eq!(
             contents,
-            "prefix_rule(pattern=[\"echo\",\"Hello, world!\"], decision=\"allow\")\n"
+            r#"prefix_rule(pattern=["echo","Hello, world!"], decision="allow")
+"#
         );
     }
 
@@ -177,7 +178,8 @@ mod tests {
         std::fs::create_dir_all(policy_path.parent().unwrap()).expect("create policy dir");
         std::fs::write(
             &policy_path,
-            "prefix_rule(pattern=[\"ls\"], decision=\"allow\")\n",
+            r#"prefix_rule(pattern=["ls"], decision="allow")
+"#,
         )
         .expect("write seed rule");
 
@@ -190,7 +192,9 @@ mod tests {
         let contents = std::fs::read_to_string(&policy_path).expect("read policy");
         assert_eq!(
             contents,
-            "prefix_rule(pattern=[\"ls\"], decision=\"allow\")\nprefix_rule(pattern=[\"echo\",\"Hello, world!\"], decision=\"allow\")\n"
+            r#"prefix_rule(pattern=["ls"], decision="allow")
+prefix_rule(pattern=["echo","Hello, world!"], decision="allow")
+"#
         );
     }
 
@@ -201,7 +205,7 @@ mod tests {
         std::fs::create_dir_all(policy_path.parent().unwrap()).expect("create policy dir");
         std::fs::write(
             &policy_path,
-            "prefix_rule(pattern=[\"ls\"], decision=\"allow\")",
+            r#"prefix_rule(pattern=["ls"], decision="allow")"#,
         )
         .expect("write seed rule without newline");
 
@@ -214,7 +218,9 @@ mod tests {
         let contents = std::fs::read_to_string(&policy_path).expect("read policy");
         assert_eq!(
             contents,
-            "prefix_rule(pattern=[\"ls\"], decision=\"allow\")\nprefix_rule(pattern=[\"echo\",\"Hello, world!\"], decision=\"allow\")\n"
+            r#"prefix_rule(pattern=["ls"], decision="allow")
+prefix_rule(pattern=["echo","Hello, world!"], decision="allow")
+"#
         );
     }
 }

--- a/codex-rs/execpolicy/src/lib.rs
+++ b/codex-rs/execpolicy/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod amend;
 pub mod decision;
 pub mod error;
 pub mod execpolicycheck;
@@ -5,6 +6,8 @@ pub mod parser;
 pub mod policy;
 pub mod rule;
 
+pub use amend::AmendError;
+pub use amend::append_allow_prefix_rule;
 pub use decision::Decision;
 pub use error::Error;
 pub use error::Result;

--- a/codex-rs/execpolicy/src/lib.rs
+++ b/codex-rs/execpolicy/src/lib.rs
@@ -7,7 +7,7 @@ pub mod policy;
 pub mod rule;
 
 pub use amend::AmendError;
-pub use amend::append_allow_prefix_rule;
+pub use amend::blocking_append_allow_prefix_rule;
 pub use decision::Decision;
 pub use error::Error;
 pub use error::Result;

--- a/codex-rs/execpolicy/tests/basic.rs
+++ b/codex-rs/execpolicy/tests/basic.rs
@@ -99,10 +99,10 @@ fn add_prefix_rule_rejects_empty_prefix() -> Result<()> {
     let mut policy = Policy::empty();
     let result = policy.add_prefix_rule(&[], Decision::Allow);
 
-    assert!(matches!(
-        result,
-        Err(Error::InvalidPattern(message)) if message == "prefix cannot be empty"
-    ));
+    match result.unwrap_err() {
+        Error::InvalidPattern(message) => assert_eq!(message, "prefix cannot be empty"),
+        other => panic!("expected InvalidPattern(..), got {other:?}"),
+    }
     Ok(())
 }
 


### PR DESCRIPTION
this PR 
- adds a helper function to amend `.codexpolicy` files with new prefix rules
- adds a utility to `Policy` allowing prefix rules to be added to existing `Policy` structs

both additions will be helpful as we thread codexpolicy into the TUI workflow
