### PR TITLE
core: relax git info url assertions

### DIFF
--- a/codex-rs/core/src/git_info.rs
+++ b/codex-rs/core/src/git_info.rs
@@ -826,9 +826,12 @@ mod tests {
             .expect("Should collect git info from repo");
 
         // Should have repository URL
-        assert_eq!(
-            git_info.repository_url,
-            Some("https://github.com/example/repo.git".to_string())
+        let url = git_info
+            .repository_url
+            .expect("repository_url should be populated");
+        assert!(
+            url.ends_with("example/repo.git"),
+            "unexpected repository_url: {url}"
         );
     }
 

--- a/codex-rs/core/tests/suite/cli_stream.rs
+++ b/codex-rs/core/tests/suite/cli_stream.rs
@@ -499,9 +499,9 @@ async fn integration_git_info_unit_test() {
         "Git info should contain repository_url"
     );
     let repo_url = git_info.repository_url.as_ref().unwrap();
-    assert_eq!(
-        repo_url, "https://github.com/example/integration-test.git",
-        "Repository URL should match what we configured"
+    assert!(
+        repo_url.ends_with("example/integration-test.git"),
+        "Repository URL should end with expected path, got {repo_url}"
     );
 
     println!("✅ Git info collection test passed!");


### PR DESCRIPTION
Allow substring matching so git info tests tolerate different repository
URL prefixes.

Fixes #7044
