### PR TITLE
feat(tui): default reasoning selection to medium

### DIFF
--- a/codex-rs/tui/src/bottom_pane/list_selection_view.rs
+++ b/codex-rs/tui/src/bottom_pane/list_selection_view.rs
@@ -52,6 +52,7 @@ pub(crate) struct SelectionViewParams {
     pub is_searchable: bool,
     pub search_placeholder: Option<String>,
     pub header: Box<dyn Renderable>,
+    pub initial_selected_idx: Option<usize>,
 }
 
 impl Default for SelectionViewParams {
@@ -64,6 +65,7 @@ impl Default for SelectionViewParams {
             is_searchable: false,
             search_placeholder: None,
             header: Box::new(()),
+            initial_selected_idx: None,
         }
     }
 }
@@ -80,6 +82,7 @@ pub(crate) struct ListSelectionView {
     filtered_indices: Vec<usize>,
     last_selected_actual_idx: Option<usize>,
     header: Box<dyn Renderable>,
+    initial_selected_idx: Option<usize>,
 }
 
 impl ListSelectionView {
@@ -110,6 +113,7 @@ impl ListSelectionView {
             filtered_indices: Vec::new(),
             last_selected_actual_idx: None,
             header,
+            initial_selected_idx: params.initial_selected_idx,
         };
         s.apply_filter();
         s
@@ -132,7 +136,8 @@ impl ListSelectionView {
                 (!self.is_searchable)
                     .then(|| self.items.iter().position(|item| item.is_current))
                     .flatten()
-            });
+            })
+            .or_else(|| self.initial_selected_idx.take());
 
         if self.is_searchable && !self.search_query.is_empty() {
             let query_lower = self.search_query.to_lowercase();

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2118,6 +2118,13 @@ impl ChatWidget {
         } else {
             default_choice
         };
+        let initial_selected_idx = choices
+            .iter()
+            .position(|choice| choice.stored == highlight_choice)
+            .or_else(|| {
+                highlight_choice
+                    .and_then(|effort| choices.iter().position(|choice| choice.display == effort))
+            });
         let mut items: Vec<SelectionItem> = Vec::new();
         for choice in choices.iter() {
             let effort = choice.display;
@@ -2194,6 +2201,7 @@ impl ChatWidget {
             header: Box::new(header),
             footer_hint: Some(standard_popup_hint_line()),
             items,
+            initial_selected_idx,
             ..Default::default()
         });
     }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2118,11 +2118,12 @@ impl ChatWidget {
         } else {
             default_choice
         };
+        let selection_choice = highlight_choice.or(default_choice);
         let initial_selected_idx = choices
             .iter()
-            .position(|choice| choice.stored == highlight_choice)
+            .position(|choice| choice.stored == selection_choice)
             .or_else(|| {
-                highlight_choice
+                selection_choice
                     .and_then(|effort| choices.iter().position(|choice| choice.display == effort))
             });
         let mut items: Vec<SelectionItem> = Vec::new();


### PR DESCRIPTION
## Summary
- allow selection popups to request an initial highlighted row
- begin the /models reasoning selector focused on the default effort

## Testing
- just fmt
- just fix -p codex-tui
- cargo test -p codex-tui


https://github.com/user-attachments/assets/b322aeb1-e8f3-4578-92f7-5c2fa5ee4c98



------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_691f75e8fc188322a910fbe2138666ef)