### PR TITLE
migrate `collect_tool_identifiers_for_model` to `test_codex`

### DIFF
--- a/codex-rs/core/tests/suite/model_tools.rs
+++ b/codex-rs/core/tests/suite/model_tools.rs
@@ -1,21 +1,11 @@
 #![allow(clippy::unwrap_used)]
 
-use codex_core::CodexAuth;
-use codex_core::ConversationManager;
-use codex_core::ModelProviderInfo;
-use codex_core::built_in_model_providers;
 use codex_core::features::Feature;
-use codex_core::model_family::find_family_for_model;
-use codex_core::protocol::EventMsg;
-use codex_core::protocol::Op;
-use codex_protocol::user_input::UserInput;
-use core_test_support::load_default_config_for_test;
 use core_test_support::load_sse_fixture_with_id;
 use core_test_support::responses;
+use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
-use core_test_support::wait_for_event;
-use tempfile::TempDir;
-use wiremock::MockServer;
+use core_test_support::test_codex::test_codex;
 
 fn sse_completed(id: &str) -> String {
     load_sse_fixture_with_id("tests/fixtures/completed_template.json", id)
@@ -39,46 +29,22 @@ fn tool_identifiers(body: &serde_json::Value) -> Vec<String> {
 
 #[allow(clippy::expect_used)]
 async fn collect_tool_identifiers_for_model(model: &str) -> Vec<String> {
-    let server = MockServer::start().await;
-
+    let server = start_mock_server().await;
     let sse = sse_completed(model);
     let resp_mock = responses::mount_sse_once(&server, sse).await;
 
-    let model_provider = ModelProviderInfo {
-        base_url: Some(format!("{}/v1", server.uri())),
-        ..built_in_model_providers()["openai"].clone()
-    };
-
-    let cwd = TempDir::new().unwrap();
-    let codex_home = TempDir::new().unwrap();
-    let mut config = load_default_config_for_test(&codex_home);
-    config.cwd = cwd.path().to_path_buf();
-    config.model_provider = model_provider;
-    config.model = model.to_string();
-    config.model_family =
-        find_family_for_model(model).unwrap_or_else(|| panic!("unknown model family for {model}"));
-    config.features.disable(Feature::ApplyPatchFreeform);
-    config.features.disable(Feature::ViewImageTool);
-    config.features.disable(Feature::WebSearchRequest);
-    config.features.disable(Feature::UnifiedExec);
-
-    let conversation_manager =
-        ConversationManager::with_auth(CodexAuth::from_api_key("Test API Key"));
-    let codex = conversation_manager
-        .new_conversation(config)
+    let mut builder = test_codex().with_model(model).with_config(|config| {
+        config.features.disable(Feature::ApplyPatchFreeform);
+        config.features.disable(Feature::ViewImageTool);
+        config.features.disable(Feature::WebSearchRequest);
+        config.features.disable(Feature::UnifiedExec);
+    });
+    let test = builder
+        .build(&server)
         .await
-        .expect("create new conversation")
-        .conversation;
+        .expect("create test Codex conversation");
 
-    codex
-        .submit(Op::UserInput {
-            items: vec![UserInput::Text {
-                text: "hello tools".into(),
-            }],
-        })
-        .await
-        .unwrap();
-    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
+    test.submit_turn("hello tools").await.expect("submit turn");
 
     let body = resp_mock.single_request().body_json();
     tool_identifiers(&body)

--- a/codex-rs/core/tests/suite/model_tools.rs
+++ b/codex-rs/core/tests/suite/model_tools.rs
@@ -1,6 +1,5 @@
 #![allow(clippy::unwrap_used)]
 
-use codex_core::features::Feature;
 use core_test_support::load_sse_fixture_with_id;
 use core_test_support::responses;
 use core_test_support::responses::start_mock_server;
@@ -33,12 +32,7 @@ async fn collect_tool_identifiers_for_model(model: &str) -> Vec<String> {
     let sse = sse_completed(model);
     let resp_mock = responses::mount_sse_once(&server, sse).await;
 
-    let mut builder = test_codex().with_model(model).with_config(|config| {
-        config.features.disable(Feature::ApplyPatchFreeform);
-        config.features.disable(Feature::ViewImageTool);
-        config.features.disable(Feature::WebSearchRequest);
-        config.features.disable(Feature::UnifiedExec);
-    });
+    let mut builder = test_codex().with_model(model);
     let test = builder
         .build(&server)
         .await
@@ -63,7 +57,8 @@ async fn model_selects_expected_tools() {
             "list_mcp_resources".to_string(),
             "list_mcp_resource_templates".to_string(),
             "read_mcp_resource".to_string(),
-            "update_plan".to_string()
+            "update_plan".to_string(),
+            "view_image".to_string()
         ],
         "codex-mini-latest should expose the local shell tool",
     );
@@ -77,7 +72,8 @@ async fn model_selects_expected_tools() {
             "list_mcp_resource_templates".to_string(),
             "read_mcp_resource".to_string(),
             "update_plan".to_string(),
-            "apply_patch".to_string()
+            "apply_patch".to_string(),
+            "view_image".to_string()
         ],
         "gpt-5-codex should expose the apply_patch tool",
     );
@@ -91,7 +87,8 @@ async fn model_selects_expected_tools() {
             "list_mcp_resource_templates".to_string(),
             "read_mcp_resource".to_string(),
             "update_plan".to_string(),
-            "apply_patch".to_string()
+            "apply_patch".to_string(),
+            "view_image".to_string()
         ],
         "gpt-5.1-codex should expose the apply_patch tool",
     );
@@ -105,6 +102,7 @@ async fn model_selects_expected_tools() {
             "list_mcp_resource_templates".to_string(),
             "read_mcp_resource".to_string(),
             "update_plan".to_string(),
+            "view_image".to_string()
         ],
         "gpt-5 should expose the apply_patch tool",
     );
@@ -118,7 +116,8 @@ async fn model_selects_expected_tools() {
             "list_mcp_resource_templates".to_string(),
             "read_mcp_resource".to_string(),
             "update_plan".to_string(),
-            "apply_patch".to_string()
+            "apply_patch".to_string(),
+            "view_image".to_string()
         ],
         "gpt-5.1 should expose the apply_patch tool",
     );


### PR DESCRIPTION
Maybe it solved flakiness