### PR TITLE
fix flaky `tool_call_output_exceeds_limit_truncated_chars_limit`

### DIFF
--- a/codex-rs/core/tests/suite/truncation.rs
+++ b/codex-rs/core/tests/suite/truncation.rs
@@ -248,14 +248,11 @@ async fn tool_call_output_exceeds_limit_truncated_chars_limit() -> Result<()> {
 
     assert_regex_match(truncated_pattern, &output);
 
-    // Normalize wall time to eliminate runtime variance and keep a strict length check.
-    let wall_time_line = output
-        .lines()
-        .find(|line| line.starts_with("Wall time: "))
-        .expect("wall time line present");
-    let normalized_output = output.replacen(wall_time_line, "Wall time: 0 seconds", 1);
-
-    assert_eq!(normalized_output.len(), 9_976); // ~10k characters after truncation
+    let len = output.len();
+    assert!(
+        (9_900..=10_000).contains(&len),
+        "expected ~10k chars after truncation, got {len}"
+    );
 
     Ok(())
 }


### PR DESCRIPTION
I am suspecting this is flaky because of the wall time can become 0, 0.1, or 1.