### PR TITLE
fix(app-server) remove www warning

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -860,7 +860,6 @@ dependencies = [
  "codex-login",
  "codex-protocol",
  "codex-utils-json-to-toml",
- "codex-windows-sandbox",
  "core_test_support",
  "mcp-types",
  "opentelemetry-appender-tracing",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -169,7 +169,6 @@ reqwest = "0.12"
 rmcp = { version = "0.8.5", default-features = false }
 schemars = "0.8.22"
 seccompiler = "0.5.0"
-sentry = "0.34.0"
 serde = "1"
 serde_json = "1"
 serde_with = "3.14"

--- a/codex-rs/app-server/Cargo.toml
+++ b/codex-rs/app-server/Cargo.toml
@@ -40,7 +40,6 @@ tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 opentelemetry-appender-tracing = { workspace = true }
 uuid = { workspace = true, features = ["serde", "v7"] }
-codex-windows-sandbox.workspace = true
 
 [dev-dependencies]
 app_test_support = { workspace = true }

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -91,7 +91,6 @@ use codex_app_server_protocol::TurnStatus;
 use codex_app_server_protocol::UserInfoResponse;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_app_server_protocol::UserSavedConfig;
-use codex_app_server_protocol::WindowsWorldWritableWarningNotification;
 use codex_app_server_protocol::build_turns_from_event_msgs;
 use codex_backend_client::Client as BackendClient;
 use codex_core::AuthManager;
@@ -1276,10 +1275,6 @@ impl CodexMessageProcessor {
                 return;
             }
         };
-        if cfg!(windows) && config.features.enabled(Feature::WindowsSandbox) {
-            self.handle_windows_world_writable_warning(config.cwd.clone())
-                .await;
-        }
 
         match self.conversation_manager.new_conversation(config).await {
             Ok(conversation_id) => {
@@ -1999,10 +1994,6 @@ impl CodexMessageProcessor {
                 return;
             }
         };
-        if cfg!(windows) && config.features.enabled(Feature::WindowsSandbox) {
-            self.handle_windows_world_writable_warning(config.cwd.clone())
-                .await;
-        }
 
         let conversation_history = if let Some(path) = path {
             match RolloutRecorder::get_rollout_history(&path).await {
@@ -2859,53 +2850,6 @@ impl CodexMessageProcessor {
         {
             Ok(conv) => Some(conv.rollout_path()),
             Err(_) => None,
-        }
-    }
-
-    /// On Windows, when using the experimental sandbox, we need to warn the user about world-writable directories.
-    async fn handle_windows_world_writable_warning(&self, cwd: PathBuf) {
-        if !cfg!(windows) {
-            return;
-        }
-
-        if !self.config.features.enabled(Feature::WindowsSandbox) {
-            return;
-        }
-
-        if !matches!(
-            self.config.sandbox_policy,
-            codex_protocol::protocol::SandboxPolicy::WorkspaceWrite { .. }
-                | codex_protocol::protocol::SandboxPolicy::ReadOnly
-        ) {
-            return;
-        }
-
-        if self
-            .config
-            .notices
-            .hide_world_writable_warning
-            .unwrap_or(false)
-        {
-            return;
-        }
-
-        // This function is stubbed out to return None on non-Windows platforms
-        if let Some((sample_paths, extra_count, failed_scan)) =
-            codex_windows_sandbox::world_writable_warning_details(
-                self.config.codex_home.as_path(),
-                cwd,
-            )
-        {
-            tracing::warn!("world writable warning: {sample_paths:?} {extra_count} {failed_scan}");
-            self.outgoing
-                .send_server_notification(ServerNotification::WindowsWorldWritableWarning(
-                    WindowsWorldWritableWarningNotification {
-                        sample_paths,
-                        extra_count,
-                        failed_scan,
-                    },
-                ))
-                .await;
         }
     }
 }


### PR DESCRIPTION
### Summary
After #7022, we no longer need this warning. We should also clean up the schema for the notification, but this is a quick fix to just stop the behavior in the VSCE

## Testing
- [x] Ran locally