### PR TITLE
fix(scripts) next_minor_version should reset patch number

### DIFF
--- a/codex-rs/scripts/create_github_release
+++ b/codex-rs/scripts/create_github_release
@@ -298,8 +298,8 @@ def create_tag_ref(version: str, tag_sha: str) -> None:
 
 def determine_version(args: argparse.Namespace) -> str:
     latest_version = get_latest_release_version()
-    major, minor, patch = parse_semver(latest_version)
-    next_minor_version = format_version(major, minor + 1, patch)
+    major, minor, _patch = parse_semver(latest_version)
+    next_minor_version = format_version(major, minor + 1, 0)
 
     if args.publish_release:
         return next_minor_version

--- a/codex-rs/scripts/create_github_release
+++ b/codex-rs/scripts/create_github_release
@@ -298,6 +298,10 @@ def create_tag_ref(version: str, tag_sha: str) -> None:
 
 def determine_version(args: argparse.Namespace) -> str:
     latest_version = get_latest_release_version()
+    # When determining the next version after the current release,
+    # we should always increment the minor version, but reset the
+    # patch to zero. In practice, `patch` should only be non-zero if
+    # --emergency-version-override was used.
     major, minor, _patch = parse_semver(latest_version)
     next_minor_version = format_version(major, minor + 1, 0)
 


### PR DESCRIPTION
## Summary
When incrementing the minor version, we should reset patch to 0, rather than keeping it.

## Testing
- [x] tested locally with dry_run and `get_latest_release_version` mocked out