### PR TITLE
Support full powershell paths in is_safe_command

### DIFF
--- a/codex-rs/core/src/command_safety/is_safe_command.rs
+++ b/codex-rs/core/src/command_safety/is_safe_command.rs
@@ -268,6 +268,15 @@ mod tests {
     }
 
     #[test]
+    fn windows_powershell_full_path_is_safe() {
+        assert!(is_known_safe_command(&vec_str(&[
+            r"C:\Program Files\PowerShell\7\pwsh.exe",
+            "-Command",
+            "Get-Location",
+        ])));
+    }
+
+    #[test]
     fn bash_lc_safe_examples() {
         assert!(is_known_safe_command(&vec_str(&["bash", "-lc", "ls"])));
         assert!(is_known_safe_command(&vec_str(&["bash", "-lc", "ls -1"])));

--- a/codex-rs/core/src/command_safety/is_safe_command.rs
+++ b/codex-rs/core/src/command_safety/is_safe_command.rs
@@ -269,7 +269,8 @@ mod tests {
 
     #[test]
     fn windows_powershell_full_path_is_safe() {
-        if cfg!(windows) {
+        if !cfg!(windows) {
+            // Windows only because on Linux path splitting doesn't handle `/` separators properly
             return;
         }
 

--- a/codex-rs/core/src/command_safety/is_safe_command.rs
+++ b/codex-rs/core/src/command_safety/is_safe_command.rs
@@ -269,6 +269,10 @@ mod tests {
 
     #[test]
     fn windows_powershell_full_path_is_safe() {
+        if cfg!(windows) {
+            return;
+        }
+
         assert!(is_known_safe_command(&vec_str(&[
             r"C:\Program Files\PowerShell\7\pwsh.exe",
             "-Command",

--- a/codex-rs/core/src/command_safety/windows_safe_commands.rs
+++ b/codex-rs/core/src/command_safety/windows_safe_commands.rs
@@ -1,4 +1,5 @@
 use shlex::split as shlex_split;
+use std::path::Path;
 
 /// On Windows, we conservatively allow only clearly read-only PowerShell invocations
 /// that match a small safelist. Anything else (including direct CMD commands) is unsafe.
@@ -131,8 +132,14 @@ fn split_into_commands(tokens: Vec<String>) -> Option<Vec<Vec<String>>> {
 
 /// Returns true when the executable name is one of the supported PowerShell binaries.
 fn is_powershell_executable(exe: &str) -> bool {
+    let executable_name = Path::new(exe)
+        .file_name()
+        .and_then(|osstr| osstr.to_str())
+        .unwrap_or(exe)
+        .to_ascii_lowercase();
+
     matches!(
-        exe.to_ascii_lowercase().as_str(),
+        executable_name.as_str(),
         "powershell" | "powershell.exe" | "pwsh" | "pwsh.exe"
     )
 }
@@ -310,6 +317,22 @@ mod tests {
             "-NoProfile",
             "-Command",
             "Get-ChildItem",
+        ])));
+    }
+
+    #[test]
+    fn accepts_full_path_powershell_invocations() {
+        assert!(is_safe_command_windows(&vec_str(&[
+            r"C:\Program Files\PowerShell\7\pwsh.exe",
+            "-NoProfile",
+            "-Command",
+            "Get-ChildItem -Path .",
+        ])));
+
+        assert!(is_safe_command_windows(&vec_str(&[
+            r"C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe",
+            "-Command",
+            "Get-Content Cargo.toml",
         ])));
     }
 

--- a/codex-rs/core/src/command_safety/windows_safe_commands.rs
+++ b/codex-rs/core/src/command_safety/windows_safe_commands.rs
@@ -322,7 +322,7 @@ mod tests {
 
     #[test]
     fn accepts_full_path_powershell_invocations() {
-        if cfg!(windows) {
+        if !cfg!(windows) {
             // Windows only because on Linux path splitting doesn't handle `/` separators properly
             return;
         }

--- a/codex-rs/core/src/command_safety/windows_safe_commands.rs
+++ b/codex-rs/core/src/command_safety/windows_safe_commands.rs
@@ -322,6 +322,11 @@ mod tests {
 
     #[test]
     fn accepts_full_path_powershell_invocations() {
+        if cfg!(windows) {
+            // Windows only because on Linux path splitting doesn't handle `/` separators properly
+            return;
+        }
+
         assert!(is_safe_command_windows(&vec_str(&[
             r"C:\Program Files\PowerShell\7\pwsh.exe",
             "-NoProfile",


### PR DESCRIPTION
New shell implementation always uses full paths. 