### PR TITLE
Support all types of search actions

### DIFF
--- a/codex-rs/core/src/event_mapping.rs
+++ b/codex-rs/core/src/event_mapping.rs
@@ -117,7 +117,7 @@ pub fn parse_turn_item(item: &ResponseItem) -> Option<TurnItem> {
             ..
         } => Some(TurnItem::WebSearch(WebSearchItem {
             id: id.clone().unwrap_or_default(),
-            query: query.clone(),
+            query: query.clone().unwrap_or_default(),
         })),
         _ => None,
     }
@@ -306,7 +306,7 @@ mod tests {
             id: Some("ws_1".to_string()),
             status: Some("completed".to_string()),
             action: WebSearchAction::Search {
-                query: "weather".to_string(),
+                query: Some("weather".to_string()),
             },
         };
 

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -992,7 +992,7 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
         id: Some("web-search-id".into()),
         status: Some("completed".into()),
         action: WebSearchAction::Search {
-            query: "weather".into(),
+            query: Some("weather".into()),
         },
     });
     prompt.input.push(ResponseItem::FunctionCall {


### PR DESCRIPTION
Fixes the 

```
{
  "error": {
    "message": "Invalid value: 'other'. Supported values are: 'search', 'open_page', and 'find_in_page'.",
    "type": "invalid_request_error",
    "param": "input[150].action.type",
    "code": "invalid_value"
  }
```
error.


The actual-actual fix here is supporting absent `query` parameter. 