### PR TITLE
Fixed the deduplicator github action

### DIFF
--- a/.github/workflows/issue-deduplicator.yml
+++ b/.github/workflows/issue-deduplicator.yml
@@ -46,7 +46,6 @@ jobs:
         with:
           openai-api-key: ${{ secrets.CODEX_OPENAI_API_KEY }}
           allow-users: "*"
-          model: gpt-5.1
           prompt: |
             You are an assistant that triages new GitHub issues by identifying potential duplicates.
 


### PR DESCRIPTION
It stopped working (found zero duplicates) starting three days ago when the model was switched from `gpt-5` to `gpt-5.1`. I'm not sure why it stopped working. This is an attempt to get it working again by using the default model for the codex action (which is presumably `gpt-5.1-codex-max`).