### PR TITLE
Revert "fix: read `max_output_tokens` param from config"

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -273,7 +273,6 @@ impl ModelClient {
             include,
             prompt_cache_key: Some(self.conversation_id.to_string()),
             text,
-            max_output_tokens: self.config.model_max_output_tokens,
         };
 
         let mut payload_json = serde_json::to_value(&payload)?;

--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -280,8 +280,6 @@ pub(crate) struct ResponsesApiRequest<'a> {
     pub(crate) prompt_cache_key: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) text: Option<TextControls>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) max_output_tokens: Option<i64>,
 }
 
 pub(crate) mod tools {
@@ -465,7 +463,6 @@ mod tests {
                 verbosity: Some(OpenAiVerbosity::Low),
                 format: None,
             }),
-            max_output_tokens: Some(10_000),
         };
 
         let v = serde_json::to_value(&req).expect("json");
@@ -504,7 +501,6 @@ mod tests {
             include: vec![],
             prompt_cache_key: None,
             text: Some(text_controls),
-            max_output_tokens: Some(10_000),
         };
 
         let v = serde_json::to_value(&req).expect("json");
@@ -541,7 +537,6 @@ mod tests {
             include: vec![],
             prompt_cache_key: None,
             text: None,
-            max_output_tokens: Some(10_000),
         };
 
         let v = serde_json::to_value(&req).expect("json");

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -282,8 +282,7 @@ async fn compact_resume_and_fork_preserve_model_history_view() {
       "include": [
         "reasoning.encrypted_content"
       ],
-      "prompt_cache_key": prompt_cache_key,
-      "max_output_tokens": 128000,
+      "prompt_cache_key": prompt_cache_key
     });
     let compact_1 = json!(
     {
@@ -352,8 +351,7 @@ async fn compact_resume_and_fork_preserve_model_history_view() {
       "include": [
         "reasoning.encrypted_content"
       ],
-      "prompt_cache_key": prompt_cache_key,
-      "max_output_tokens": 128000,
+      "prompt_cache_key": prompt_cache_key
     });
     let user_turn_2_after_compact = json!(
     {
@@ -413,8 +411,7 @@ async fn compact_resume_and_fork_preserve_model_history_view() {
       "include": [
         "reasoning.encrypted_content"
       ],
-      "prompt_cache_key": prompt_cache_key,
-      "max_output_tokens": 128000,
+      "prompt_cache_key": prompt_cache_key
     });
     let usert_turn_3_after_resume = json!(
     {
@@ -494,8 +491,7 @@ async fn compact_resume_and_fork_preserve_model_history_view() {
       "include": [
         "reasoning.encrypted_content"
       ],
-      "prompt_cache_key": prompt_cache_key,
-      "max_output_tokens": 128000,
+      "prompt_cache_key": prompt_cache_key
     });
     let user_turn_3_after_fork = json!(
     {
@@ -575,8 +571,7 @@ async fn compact_resume_and_fork_preserve_model_history_view() {
       "include": [
         "reasoning.encrypted_content"
       ],
-      "prompt_cache_key": fork_prompt_cache_key,
-      "max_output_tokens": 128000,
+      "prompt_cache_key": fork_prompt_cache_key
     });
     let mut expected = json!([
         user_turn_1,


### PR DESCRIPTION
Reverts openai/codex#4139