### PR TITLE
[app-server] feat: add Declined status for command exec

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -859,6 +859,7 @@ pub enum CommandExecutionStatus {
     InProgress,
     Completed,
     Failed,
+    Declined,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]

--- a/codex-rs/exec/src/exec_events.rs
+++ b/codex-rs/exec/src/exec_events.rs
@@ -144,6 +144,7 @@ pub enum CommandExecutionStatus {
     InProgress,
     Completed,
     Failed,
+    Declined,
 }
 
 /// A command executed by the agent.


### PR DESCRIPTION
Add a `Declined` status for when we request an approval from the user and the user declines. This allows us to distinguish from commands that actually ran, but failed.

This behaves similarly to apply_patch / FileChange, which does the same thing.
