### PR TITLE
fix: clear out duplicate entries for `bash` in the GitHub release

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -407,6 +407,14 @@ jobs:
       - name: List
         run: ls -R dist/
 
+      # This is a temporary fix: we should modify shell-tool-mcp.yml so these
+      # files do not end up in dist/ in the first place.
+      - name: Delete entries from dist/ that should not go in the release
+        run: |
+          rm -rf dist/shell-tool-mcp*
+
+          ls -R dist/
+
       - name: Define release name
         id: release_name
         run: |


### PR DESCRIPTION
https://github.com/openai/codex/pull/7005 introduced a new part of the release process that added multiple files named `bash` in the `dist/` folder used as the basis of the GitHub Release. I believe that all file names in a GitHub Release have to be unique, which is why the recent release build failed:

https://github.com/openai/codex/actions/runs/19577669780/job/56070183504

Based on the output of the **List** step, I believe these are the appropriate artifacts to delete as a quick fix.