### PR TITLE
chore(ci): add cargo audit workflow and policy

### DIFF
--- a/codex-rs/.cargo/audit.toml
+++ b/codex-rs/.cargo/audit.toml
@@ -1,0 +1,6 @@
+[advisories]
+ignore = [
+    "RUSTSEC-2024-0388", # derivative 2.2.0 via starlark; upstream crate is unmaintained
+    "RUSTSEC-2025-0057", # fxhash 0.2.1 via starlark_map; upstream crate is unmaintained
+    "RUSTSEC-2024-0436", # paste 1.0.15 via starlark/ratatui; upstream crate is unmaintained
+]

--- a/codex-rs/.github/workflows/cargo-audit.yml
+++ b/codex-rs/.github/workflows/cargo-audit.yml
@@ -1,0 +1,26 @@
+name: Cargo audit
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: codex-rs
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-audit
+      - name: Run cargo audit
+        run: cargo audit --deny warnings


### PR DESCRIPTION
- add  to ignore current unmaintained advisories (derivative, fxhash, paste) so audits gate new issues only
- introduce GitHub Actions workflow to run  on push/PR using  to install cargo-audit

Existing advisories (all "unmaintained"):
- https://rustsec.org/advisories/RUSTSEC-2024-0388
- https://rustsec.org/advisories/RUSTSEC-2025-0057
- https://rustsec.org/advisories/RUSTSEC-2024-0436
