### PR TITLE
bypass sandbox for policy approved commands

### DIFF
--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -107,7 +107,9 @@ fn evaluate_with_policy(
                     })
                 }
             }
-            Decision::Allow => Some(ApprovalRequirement::Skip),
+            Decision::Allow => Some(ApprovalRequirement::Skip {
+                bypass_sandbox: true,
+            }),
         },
         Evaluation::NoMatch { .. } => None,
     }
@@ -132,7 +134,9 @@ pub(crate) fn create_approval_requirement_for_command(
     ) {
         ApprovalRequirement::NeedsApproval { reason: None }
     } else {
-        ApprovalRequirement::Skip
+        ApprovalRequirement::Skip {
+            bypass_sandbox: false,
+        }
     }
 }
 

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -57,7 +57,7 @@ impl ToolOrchestrator {
             default_approval_requirement(approval_policy, &turn_ctx.sandbox_policy)
         });
         match requirement {
-            ApprovalRequirement::Skip => {
+            ApprovalRequirement::Skip { .. } => {
                 otel.tool_decision(otel_tn, otel_ci, ReviewDecision::Approved, otel_cfg);
             }
             ApprovalRequirement::Forbidden { reason } => {
@@ -103,7 +103,7 @@ impl ToolOrchestrator {
         let mut initial_sandbox = self
             .sandbox
             .select_initial(&turn_ctx.sandbox_policy, tool.sandbox_preference());
-        if tool.wants_escalated_first_attempt(req) {
+        if tool.should_bypass_sandbox_first_attempt(req) {
             initial_sandbox = crate::exec::SandboxType::None;
         }
         // Platform-specific flag gating is handled by SandboxManager::select_initial

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -100,12 +100,15 @@ impl ToolOrchestrator {
         }
 
         // 2) First attempt under the selected sandbox.
-        let mut initial_sandbox = self
-            .sandbox
-            .select_initial(&turn_ctx.sandbox_policy, tool.sandbox_preference());
-        if tool.should_bypass_sandbox_first_attempt(req) {
-            initial_sandbox = crate::exec::SandboxType::None;
-        }
+        let initial_sandbox = match tool.sandbox_override(req) {
+            crate::tools::sandboxing::SandboxOverride::BypassSandboxFirstAttempt => {
+                crate::exec::SandboxType::None
+            }
+            crate::tools::sandboxing::SandboxOverride::NoOverride => self
+                .sandbox
+                .select_initial(&turn_ctx.sandbox_policy, tool.sandbox_preference()),
+        };
+
         // Platform-specific flag gating is handled by SandboxManager::select_initial
         // via crate::safety::get_platform_sandbox().
         let initial_attempt = SandboxAttempt {

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -14,6 +14,7 @@ use crate::tools::sandboxing::ApprovalCtx;
 use crate::tools::sandboxing::ApprovalRequirement;
 use crate::tools::sandboxing::ProvidesSandboxRetryData;
 use crate::tools::sandboxing::SandboxAttempt;
+use crate::tools::sandboxing::SandboxOverride;
 use crate::tools::sandboxing::ToolCtx;
 use crate::tools::sandboxing::ToolError;
 use crate::tools::sandboxing::ToolRuntime;
@@ -100,11 +101,9 @@ impl ToolOrchestrator {
         }
 
         // 2) First attempt under the selected sandbox.
-        let initial_sandbox = match tool.sandbox_override(req) {
-            crate::tools::sandboxing::SandboxOverride::BypassSandboxFirstAttempt => {
-                crate::exec::SandboxType::None
-            }
-            crate::tools::sandboxing::SandboxOverride::NoOverride => self
+        let initial_sandbox = match tool.sandbox_mode_for_first_attempt(req) {
+            SandboxOverride::BypassSandboxFirstAttempt => crate::exec::SandboxType::None,
+            SandboxOverride::NoOverride => self
                 .sandbox
                 .select_initial(&turn_ctx.sandbox_policy, tool.sandbox_preference()),
         };

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -118,7 +118,7 @@ impl Approvable<ShellRequest> for ShellRuntime {
         Some(req.approval_requirement.clone())
     }
 
-    fn sandbox_override(&self, req: &ShellRequest) -> SandboxOverride {
+    fn sandbox_mode_for_first_attempt(&self, req: &ShellRequest) -> SandboxOverride {
         if req.with_escalated_permissions.unwrap_or(false)
             || matches!(
                 req.approval_requirement,

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -117,8 +117,14 @@ impl Approvable<ShellRequest> for ShellRuntime {
         Some(req.approval_requirement.clone())
     }
 
-    fn wants_escalated_first_attempt(&self, req: &ShellRequest) -> bool {
+    fn should_bypass_sandbox_first_attempt(&self, req: &ShellRequest) -> bool {
         req.with_escalated_permissions.unwrap_or(false)
+            || matches!(
+                req.approval_requirement,
+                ApprovalRequirement::Skip {
+                    bypass_sandbox: true
+                }
+            )
     }
 }
 

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -12,6 +12,7 @@ use crate::tools::sandboxing::ApprovalCtx;
 use crate::tools::sandboxing::ApprovalRequirement;
 use crate::tools::sandboxing::ProvidesSandboxRetryData;
 use crate::tools::sandboxing::SandboxAttempt;
+use crate::tools::sandboxing::SandboxOverride;
 use crate::tools::sandboxing::SandboxRetryData;
 use crate::tools::sandboxing::Sandboxable;
 use crate::tools::sandboxing::SandboxablePreference;
@@ -117,14 +118,19 @@ impl Approvable<ShellRequest> for ShellRuntime {
         Some(req.approval_requirement.clone())
     }
 
-    fn should_bypass_sandbox_first_attempt(&self, req: &ShellRequest) -> bool {
-        req.with_escalated_permissions.unwrap_or(false)
+    fn sandbox_override(&self, req: &ShellRequest) -> SandboxOverride {
+        if req.with_escalated_permissions.unwrap_or(false)
             || matches!(
                 req.approval_requirement,
                 ApprovalRequirement::Skip {
                     bypass_sandbox: true
                 }
             )
+        {
+            SandboxOverride::BypassSandboxFirstAttempt
+        } else {
+            SandboxOverride::NoOverride
+        }
     }
 }
 

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -136,7 +136,7 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
         Some(req.approval_requirement.clone())
     }
 
-    fn sandbox_override(&self, req: &UnifiedExecRequest) -> SandboxOverride {
+    fn sandbox_mode_for_first_attempt(&self, req: &UnifiedExecRequest) -> SandboxOverride {
         if req.with_escalated_permissions.unwrap_or(false)
             || matches!(
                 req.approval_requirement,

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -135,8 +135,14 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
         Some(req.approval_requirement.clone())
     }
 
-    fn wants_escalated_first_attempt(&self, req: &UnifiedExecRequest) -> bool {
+    fn should_bypass_sandbox_first_attempt(&self, req: &UnifiedExecRequest) -> bool {
         req.with_escalated_permissions.unwrap_or(false)
+            || matches!(
+                req.approval_requirement,
+                ApprovalRequirement::Skip {
+                    bypass_sandbox: true
+                }
+            )
     }
 }
 

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -13,6 +13,7 @@ use crate::tools::sandboxing::ApprovalCtx;
 use crate::tools::sandboxing::ApprovalRequirement;
 use crate::tools::sandboxing::ProvidesSandboxRetryData;
 use crate::tools::sandboxing::SandboxAttempt;
+use crate::tools::sandboxing::SandboxOverride;
 use crate::tools::sandboxing::SandboxRetryData;
 use crate::tools::sandboxing::Sandboxable;
 use crate::tools::sandboxing::SandboxablePreference;
@@ -135,14 +136,19 @@ impl Approvable<UnifiedExecRequest> for UnifiedExecRuntime<'_> {
         Some(req.approval_requirement.clone())
     }
 
-    fn should_bypass_sandbox_first_attempt(&self, req: &UnifiedExecRequest) -> bool {
-        req.with_escalated_permissions.unwrap_or(false)
+    fn sandbox_override(&self, req: &UnifiedExecRequest) -> SandboxOverride {
+        if req.with_escalated_permissions.unwrap_or(false)
             || matches!(
                 req.approval_requirement,
                 ApprovalRequirement::Skip {
                     bypass_sandbox: true
                 }
             )
+        {
+            SandboxOverride::BypassSandboxFirstAttempt
+        } else {
+            SandboxOverride::NoOverride
+        }
     }
 }
 

--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -89,10 +89,12 @@ pub(crate) struct ApprovalCtx<'a> {
 // Specifies what tool orchestrator should do with a given tool call.
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ApprovalRequirement {
-    /// No approval required for this tool call. `bypass_sandbox` signals that
-    /// the first attempt should skip sandboxing (e.g., when explicitly
-    /// greenlit by policy).
-    Skip { bypass_sandbox: bool },
+    /// No approval required for this tool call.
+    Skip {
+        /// The first attempt should skip sandboxing (e.g., when explicitly
+        /// greenlit by policy).
+        bypass_sandbox: bool,
+    },
     /// Approval required for this tool call
     NeedsApproval { reason: Option<String> },
     /// Execution forbidden for this tool call

--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -129,8 +129,8 @@ pub(crate) trait Approvable<Req> {
     fn approval_key(&self, req: &Req) -> Self::ApprovalKey;
 
     /// Some tools may request to skip the sandbox on the first attempt
-    /// (e.g., when a policy greenlights a command or the request explicitly
-    /// asks for escalated permissions). Defaults to `false`.
+    /// (e.g., when the request explicitly asks for escalated permissions).
+    /// Defaults to `false`.
     fn should_bypass_sandbox_first_attempt(&self, _req: &Req) -> bool {
         false
     }

--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -137,7 +137,7 @@ pub(crate) trait Approvable<Req> {
     /// Some tools may request to skip the sandbox on the first attempt
     /// (e.g., when the request explicitly asks for escalated permissions).
     /// Defaults to `NoOverride`.
-    fn sandbox_override(&self, _req: &Req) -> SandboxOverride {
+    fn sandbox_mode_for_first_attempt(&self, _req: &Req) -> SandboxOverride {
         SandboxOverride::NoOverride
     }
 

--- a/codex-rs/core/src/tools/sandboxing.rs
+++ b/codex-rs/core/src/tools/sandboxing.rs
@@ -123,6 +123,12 @@ pub(crate) fn default_approval_requirement(
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum SandboxOverride {
+    NoOverride,
+    BypassSandboxFirstAttempt,
+}
+
 pub(crate) trait Approvable<Req> {
     type ApprovalKey: Hash + Eq + Clone + Debug + Serialize;
 
@@ -130,9 +136,9 @@ pub(crate) trait Approvable<Req> {
 
     /// Some tools may request to skip the sandbox on the first attempt
     /// (e.g., when the request explicitly asks for escalated permissions).
-    /// Defaults to `false`.
-    fn should_bypass_sandbox_first_attempt(&self, _req: &Req) -> bool {
-        false
+    /// Defaults to `NoOverride`.
+    fn sandbox_override(&self, _req: &Req) -> SandboxOverride {
+        SandboxOverride::NoOverride
     }
 
     fn should_bypass_approval(&self, policy: AskForApproval, already_approved: bool) -> bool {


### PR DESCRIPTION
allowing cmds greenlit by execpolicy to bypass sandbox + minor refactor for a world where we have execpolicy rules with specific sandbox requirements