### PR TITLE
chore: add cargo-deny configuration

### DIFF
--- a/.github/workflows/cargo-deny.yml
+++ b/.github/workflows/cargo-deny.yml
@@ -1,0 +1,26 @@
+name: cargo-deny
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  cargo-deny:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./codex-rs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Run cargo-deny
+        uses: EmbarkStudios/cargo-deny-action@v1
+        with:
+          rust-version: stable
+          manifest-path: ./codex-rs/Cargo.toml

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1634,7 +1634,7 @@ version = "0.0.0"
 
 [[package]]
 name = "codex-windows-sandbox"
-version = "0.1.0"
+version = "0.0.0"
 dependencies = [
  "anyhow",
  "codex-protocol",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -51,6 +51,7 @@ version = "0.0.0"
 # crates created with `cargo new -w ...` automatically inherit the 2024
 # edition.
 edition = "2024"
+license = "Apache-2.0"
 
 [workspace.dependencies]
 # Internal

--- a/codex-rs/ansi-escape/Cargo.toml
+++ b/codex-rs/ansi-escape/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-ansi-escape"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 name = "codex_ansi_escape"

--- a/codex-rs/app-server-protocol/Cargo.toml
+++ b/codex-rs/app-server-protocol/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-app-server-protocol"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 name = "codex_app_server_protocol"

--- a/codex-rs/app-server-test-client/Cargo.toml
+++ b/codex-rs/app-server-test-client/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "codex-app-server-test-client"
-version = { workspace = true }
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/codex-rs/app-server/Cargo.toml
+++ b/codex-rs/app-server/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-app-server"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "codex-app-server"

--- a/codex-rs/app-server/tests/common/Cargo.toml
+++ b/codex-rs/app-server/tests/common/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "app_test_support"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/codex-rs/apply-patch/Cargo.toml
+++ b/codex-rs/apply-patch/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-apply-patch"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 name = "codex_apply_patch"

--- a/codex-rs/arg0/Cargo.toml
+++ b/codex-rs/arg0/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-arg0"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 name = "codex_arg0"

--- a/codex-rs/async-utils/Cargo.toml
+++ b/codex-rs/async-utils/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition.workspace = true
 name = "codex-async-utils"
 version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/codex-rs/backend-client/Cargo.toml
+++ b/codex-rs/backend-client/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "codex-backend-client"
-version = "0.0.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 publish = false
 
 [lib]

--- a/codex-rs/chatgpt/Cargo.toml
+++ b/codex-rs/chatgpt/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-chatgpt"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-cli"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "codex"

--- a/codex-rs/cloud-tasks-client/Cargo.toml
+++ b/codex-rs/cloud-tasks-client/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "codex-cloud-tasks-client"
-version = { workspace = true }
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 name = "codex_cloud_tasks_client"

--- a/codex-rs/cloud-tasks/Cargo.toml
+++ b/codex-rs/cloud-tasks/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-cloud-tasks"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 name = "codex_cloud_tasks"

--- a/codex-rs/codex-backend-openapi-models/Cargo.toml
+++ b/codex-rs/codex-backend-openapi-models/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "codex-backend-openapi-models"
-version = { workspace = true }
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 name = "codex_backend_openapi_models"

--- a/codex-rs/common/Cargo.toml
+++ b/codex-rs/common/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-common"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-core"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 doctest = false

--- a/codex-rs/core/tests/common/Cargo.toml
+++ b/codex-rs/core/tests/common/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "core_test_support"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/codex-rs/deny.toml
+++ b/codex-rs/deny.toml
@@ -1,0 +1,235 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# Root options
+
+# The graph table configures how the dependency graph is constructed and thus
+# which crates the checks are performed against
+[graph]
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    #"x86_64-unknown-linux-musl",
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+# When creating the dependency graph used as the source of truth when checks are
+# executed, this field can be used to prune crates from the graph, removing them
+# from the view of cargo-deny. This is an extremely heavy hammer, as if a crate
+# is pruned from the graph, all of its dependencies will also be pruned unless
+# they are connected to another crate in the graph that hasn't been pruned,
+# so it should be used with care. The identifiers are [Package ID Specifications]
+# (https://doc.rust-lang.org/cargo/reference/pkgid-spec.html)
+#exclude = []
+# If true, metadata will be collected with `--all-features`. Note that this can't
+# be toggled off if true, if you want to conditionally enable `--all-features` it
+# is recommended to pass `--all-features` on the cmd line instead
+all-features = false
+# If true, metadata will be collected with `--no-default-features`. The same
+# caveat with `all-features` applies
+no-default-features = false
+# If set, these feature will be enabled when collecting metadata. If `--features`
+# is specified on the cmd line they will take precedence over this option.
+#features = []
+
+# The output table provides options for how/if diagnostics are outputted
+[output]
+# When outputting inclusion graphs in diagnostics that include features, this
+# option can be used to specify the depth at which feature edges will be added.
+# This option is included since the graphs can be quite large and the addition
+# of features from the crate(s) to all of the graph roots can be far too verbose.
+# This option can be overridden via `--feature-depth` on the cmd line
+feature-depth = 1
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory databases are cloned/fetched into
+#db-path = "$CARGO_HOME/advisory-dbs"
+# The url(s) of the advisory databases to use
+#db-urls = ["https://github.com/rustsec/advisory-db"]
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+    #"RUSTSEC-0000-0000",
+    #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
+    #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
+    #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
+]
+# If this is true, then cargo deny will use the git executable to fetch advisory database.
+# If this is false, then it uses a built-in git library.
+# Setting this to true can be helpful if you have special authentication requirements that cargo-deny does not support.
+# See Git Authentication for more information about setting up git authentication.
+#git-fetch-with-cli = true
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# List of explicitly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    #"MIT",
+    #"Apache-2.0",
+    #"Apache-2.0 WITH LLVM-exception",
+]
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.8
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], crate = "adler32" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+#[[licenses.clarify]]
+# The package spec the clarification applies to
+#crate = "ring"
+# The SPDX expression for the license requirements of the crate
+#expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+#license-files = [
+# Each entry is a crate relative path, and the (opaque) hash of its contents
+#{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries.
+# To see how to mark a crate as unpublished (to the official registry),
+# visit https://doc.rust-lang.org/cargo/reference/manifest.html#the-publish-field.
+ignore = false
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "warn"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# The default lint level for `default` features for crates that are members of
+# the workspace that is being checked. This can be overridden by allowing/denying
+# `default` on a crate-by-crate basis if desired.
+workspace-default-features = "allow"
+# The default lint level for `default` features for external crates that are not
+# members of the workspace. This can be overridden by allowing/denying `default`
+# on a crate-by-crate basis if desired.
+external-default-features = "allow"
+# List of crates that are allowed. Use with care!
+allow = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is allowed" },
+]
+# List of crates to deny
+deny = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason it is banned" },
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ crate = "ansi_term@0.11.0", wrappers = ["this-crate-directly-depends-on-ansi_term"] },
+]
+
+# List of features to allow/deny
+# Each entry the name of a crate and a version range. If version is
+# not specified, all versions will be matched.
+#[[bans.features]]
+#crate = "reqwest"
+# Features to not allow
+#deny = ["json"]
+# Features to allow
+#allow = [
+#    "rustls",
+#    "__rustls",
+#    "__tls",
+#    "hyper-rustls",
+#    "rustls",
+#    "rustls-pemfile",
+#    "rustls-tls-webpki-roots",
+#    "tokio-rustls",
+#    "webpki-roots",
+#]
+# If true, the allowed features must exactly match the enabled feature set. If
+# this is set there is no point setting `deny`
+#exact = true
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+    #"ansi_term@0.11.0",
+    #{ crate = "ansi_term@0.11.0", reason = "you can specify a reason why it can't be updated/removed" },
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate
+# detection. Unlike skip, it also includes the entire tree of transitive
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite.
+skip-tree = [
+    #"ansi_term@0.11.0", # will be skipped along with _all_ of its direct and transitive dependencies
+    #{ crate = "ansi_term@0.11.0", depth = 20 },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = []
+
+[sources.allow-org]
+# github.com organizations to allow git sources for
+github = []
+# gitlab.com organizations to allow git sources for
+gitlab = []
+# bitbucket.org organizations to allow git sources for
+bitbucket = []

--- a/codex-rs/deny.toml
+++ b/codex-rs/deny.toml
@@ -70,10 +70,9 @@ feature-depth = 1
 # A list of advisory IDs to ignore. Note that ignored advisories will still
 # output a note when they are encountered.
 ignore = [
-    #"RUSTSEC-0000-0000",
-    #{ id = "RUSTSEC-0000-0000", reason = "you can specify a reason the advisory is ignored" },
-    #"a-crate-that-is-yanked@0.1.1", # you can also ignore yanked crate versions if you wish
-    #{ crate = "a-crate-that-is-yanked@0.1.1", reason = "you can specify why you are ignoring the yanked crate" },
+    { id = "RUSTSEC-2024-0388", reason = "derivative is unmaintained; pulled in via starlark v0.13.0 used by execpolicy/cli/core; no fixed release yet" },
+    { id = "RUSTSEC-2025-0057", reason = "fxhash is unmaintained; pulled in via starlark_map/starlark v0.13.0 used by execpolicy/cli/core; no fixed release yet" },
+    { id = "RUSTSEC-2024-0436", reason = "paste is unmaintained; pulled in via ratatui/rmcp/starlark used by tui/execpolicy; no fixed release yet" },
 ]
 # If this is true, then cargo deny will use the git executable to fetch advisory database.
 # If this is false, then it uses a built-in git library.
@@ -89,9 +88,45 @@ ignore = [
 # See https://spdx.org/licenses/ for list of possible licenses
 # [possible values: any SPDX 3.11 short identifier (+ optional exception)].
 allow = [
-    #"MIT",
-    #"Apache-2.0",
-    #"Apache-2.0 WITH LLVM-exception",
+    # Apache-2.0 - https://www.apache.org/licenses/LICENSE-2.0
+    # Used by: allocative, anyhow, arboard, askama, assert_cmd, assert_matches, async-channel, async-trait, base64, chardetng, chrono, clap, clap_complete, color-eyre, ctor, diffy, dirs, dunce, encoding_rs, env_logger, escargot, eventsource-stream, futures, http, image, indexmap, insta, itertools, keyring, landlock, lazy_static, libc, log, maplit, multimap, once_cell, opentelemetry, opentelemetry-appender-tracing, opentelemetry-otlp, opentelemetry-semantic-conventions, opentelemetry_sdk, pathdiff, predicates, pretty_assertions, rand, regex-lite, reqwest, seccompiler, serde, serde_json, serde_with, sha1, sha2, shlex, similar, socket2, starlark, supports-color, sys-locale, tempfile, test-log, thiserror, time, tiny_http, toml, toml_edit, unicode-segmentation, unicode-width, url, uuid, webbrowser, wiremock, zeroize
+    "Apache-2.0",
+    # BSD-2-Clause - https://opensource.org/license/bsd-2-clause
+    # Used by: transitive only
+    "BSD-2-Clause",
+    # BSD-3-Clause - https://opensource.org/license/bsd-3-clause
+    # Used by: encoding_rs, seccompiler
+    "BSD-3-Clause",
+    # BSL-1.0 - https://www.boost.org/users/license.html
+    # Used by: transitive only
+    "BSL-1.0",
+    # CC0-1.0 - https://creativecommons.org/publicdomain/zero/1.0/
+    # Used by: dunce, notify
+    "CC0-1.0",
+    # CDLA-Permissive-2.0 - https://cdla.dev/permissive-2-0/
+    # Used by: transitive only
+    "CDLA-Permissive-2.0",
+    # ISC - https://opensource.org/license/isc-license-txt
+    # Used by: transitive only
+    "ISC",
+    # MIT - https://opensource.org/license/mit
+    # Used by: allocative, ansi-to-tui, anyhow, arboard, askama, assert_cmd, assert_matches, async-channel, async-stream, async-trait, axum, base64, bytes, chardetng, chrono, clap, clap_complete, color-eyre, crossterm, ctor, derive_more, diffy, dirs, dotenvy, encoding_rs, env-flags, env_logger, escargot, eventsource-stream, futures, http, ignore, image, indexmap, itertools, keyring, landlock, lazy_static, libc, log, lru, maplit, mime_guess, multimap, once_cell, openssl-sys, os_info, owo-colors, path-absolutize, pathdiff, portable-pty, predicates, pretty_assertions, pulldown-cmark, rand, ratatui, ratatui-macros, regex-lite, reqwest, rmcp, schemars, serde, serde_json, serde_with, serial_test, sha1, sha2, shlex, socket2, strum, strum_macros, sys-locale, tempfile, test-log, textwrap, thiserror, time, tiny_http, tokio, tokio-stream, tokio-test, tokio-util, toml, toml_edit, tonic, tracing, tracing-appender, tracing-subscriber, tracing-test, tree-sitter, tree-sitter-bash, tree-sitter-highlight, ts-rs, uds_windows, unicode-segmentation, unicode-width, url, urlencoding, uuid, vt100, walkdir, webbrowser, which, wildmatch, wiremock, zeroize
+    "MIT",
+    # MIT-0 - https://opensource.org/license/mit-0
+    # Used by: dunce
+    "MIT-0",
+    # MPL-2.0 - https://www.mozilla.org/MPL/2.0/
+    # Used by: nucleo-matcher
+    "MPL-2.0",
+    # Unicode-3.0 - https://opensource.org/license/unicode
+    # Used by: icu_decimal, icu_locale_core, icu_provider
+    "Unicode-3.0",
+    # Unlicense - https://opensource.org/license/unlicense/
+    # Used by: ignore, walkdir
+    "Unlicense",
+    # Zlib - https://opensource.org/license/zlib
+    # Used by: transitive only
+    "Zlib",
 ]
 # The confidence threshold for detecting a license from license text.
 # The higher the value, the more closely the license text must be to the
@@ -228,7 +263,9 @@ allow-git = []
 
 [sources.allow-org]
 # github.com organizations to allow git sources for
-github = []
+github = [
+    "nornagon", # ratatui and crossterm forks
+]
 # gitlab.com organizations to allow git sources for
 gitlab = []
 # bitbucket.org organizations to allow git sources for

--- a/codex-rs/exec-server/Cargo.toml
+++ b/codex-rs/exec-server/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-exec-server"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "codex-execve-wrapper"

--- a/codex-rs/exec/Cargo.toml
+++ b/codex-rs/exec/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-exec"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "codex-exec"

--- a/codex-rs/execpolicy-legacy/Cargo.toml
+++ b/codex-rs/execpolicy-legacy/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
-edition = "2024"
 name = "codex-execpolicy-legacy"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Legacy exec policy engine for validating proposed exec calls."
-version = { workspace = true }
 
 [[bin]]
 name = "codex-execpolicy-legacy"

--- a/codex-rs/execpolicy/Cargo.toml
+++ b/codex-rs/execpolicy/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "codex-execpolicy"
-version = { workspace = true }
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 description = "Codex exec policy: prefix-based Starlark rules for command decisions."
 
 [lib]

--- a/codex-rs/feedback/Cargo.toml
+++ b/codex-rs/feedback/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition.workspace = true
 name = "codex-feedback"
 version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 anyhow = { workspace = true }

--- a/codex-rs/file-search/Cargo.toml
+++ b/codex-rs/file-search/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-file-search"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "codex-file-search"

--- a/codex-rs/keyring-store/Cargo.toml
+++ b/codex-rs/keyring-store/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-keyring-store"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/codex-rs/linux-sandbox/Cargo.toml
+++ b/codex-rs/linux-sandbox/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-linux-sandbox"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "codex-linux-sandbox"

--- a/codex-rs/lmstudio/Cargo.toml
+++ b/codex-rs/lmstudio/Cargo.toml
@@ -2,6 +2,7 @@
 name = "codex-lmstudio"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [lib]
 name = "codex_lmstudio"

--- a/codex-rs/login/Cargo.toml
+++ b/codex-rs/login/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-login"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/codex-rs/mcp-server/Cargo.toml
+++ b/codex-rs/mcp-server/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-mcp-server"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "codex-mcp-server"

--- a/codex-rs/mcp-server/tests/common/Cargo.toml
+++ b/codex-rs/mcp-server/tests/common/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "mcp_test_support"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 path = "lib.rs"

--- a/codex-rs/mcp-types/Cargo.toml
+++ b/codex-rs/mcp-types/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "mcp-types"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/codex-rs/ollama/Cargo.toml
+++ b/codex-rs/ollama/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-ollama"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 name = "codex_ollama"

--- a/codex-rs/otel/Cargo.toml
+++ b/codex-rs/otel/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-otel"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 doctest = false

--- a/codex-rs/process-hardening/Cargo.toml
+++ b/codex-rs/process-hardening/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-process-hardening"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 name = "codex_process_hardening"

--- a/codex-rs/protocol/Cargo.toml
+++ b/codex-rs/protocol/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-protocol"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 name = "codex_protocol"

--- a/codex-rs/responses-api-proxy/Cargo.toml
+++ b/codex-rs/responses-api-proxy/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-responses-api-proxy"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lib]
 name = "codex_responses_api_proxy"

--- a/codex-rs/rmcp-client/Cargo.toml
+++ b/codex-rs/rmcp-client/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-rmcp-client"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/codex-rs/stdio-to-uds/Cargo.toml
+++ b/codex-rs/stdio-to-uds/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-stdio-to-uds"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "codex-stdio-to-uds"

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition = "2024"
 name = "codex-tui"
-version = { workspace = true }
+version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [[bin]]
 name = "codex-tui"

--- a/codex-rs/utils/cache/Cargo.toml
+++ b/codex-rs/utils/cache/Cargo.toml
@@ -2,6 +2,7 @@
 name = "codex-utils-cache"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/codex-rs/utils/git/Cargo.toml
+++ b/codex-rs/utils/git/Cargo.toml
@@ -1,8 +1,9 @@
 [package]
-edition.workspace = true
 name = "codex-git"
-readme = "README.md"
 version.workspace = true
+edition.workspace = true
+license.workspace = true
+readme = "README.md"
 
 [lints]
 workspace = true

--- a/codex-rs/utils/image/Cargo.toml
+++ b/codex-rs/utils/image/Cargo.toml
@@ -2,6 +2,7 @@
 name = "codex-utils-image"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/codex-rs/utils/json-to-toml/Cargo.toml
+++ b/codex-rs/utils/json-to-toml/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition.workspace = true
 name = "codex-utils-json-to-toml"
 version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [dependencies]
 serde_json = { workspace = true }

--- a/codex-rs/utils/pty/Cargo.toml
+++ b/codex-rs/utils/pty/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 edition = "2021"
+license.workspace = true
 name = "codex-utils-pty"
-version = { workspace = true }
+version.workspace = true
 
 [lints]
 workspace = true
@@ -9,8 +10,4 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 portable-pty = { workspace = true }
-tokio = { workspace = true, features = [
-    "macros",
-    "rt-multi-thread",
-    "sync",
-] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }

--- a/codex-rs/utils/readiness/Cargo.toml
+++ b/codex-rs/utils/readiness/Cargo.toml
@@ -2,6 +2,7 @@
 name = "codex-utils-readiness"
 version.workspace = true
 edition.workspace = true
+license.workspace = true
 
 [dependencies]
 async-trait = { workspace = true }

--- a/codex-rs/utils/string/Cargo.toml
+++ b/codex-rs/utils/string/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-edition.workspace = true
 name = "codex-utils-string"
 version.workspace = true
+edition.workspace = true
+license.workspace = true
 
 [lints]
 workspace = true

--- a/codex-rs/windows-sandbox-rs/Cargo.toml
+++ b/codex-rs/windows-sandbox-rs/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
-name = "codex-windows-sandbox"
-version = "0.1.0"
 edition = "2021"
+license.workspace = true
+name = "codex-windows-sandbox"
+version.workspace = true
 
 [lib]
 name = "codex_windows_sandbox"
@@ -9,20 +10,19 @@ path = "src/lib.rs"
 
 [dependencies]
 anyhow = "1.0"
+dunce = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-dunce = "1.0"
 [dependencies.codex-protocol]
 package = "codex-protocol"
 path = "../protocol"
 [dependencies.rand]
-version = "0.8"
 default-features = false
 features = ["std", "small_rng"]
+version = "0.8"
 [dependencies.dirs-next]
 version = "2.0"
 [dependencies.windows-sys]
-version = "0.52"
 features = [
     "Win32_Foundation",
     "Win32_System_Diagnostics_Debug",
@@ -45,3 +45,4 @@ features = [
     "Win32_System_Com",
     "Win32_Security_Authentication_Identity",
 ]
+version = "0.52"


### PR DESCRIPTION
- add GitHub workflow running cargo-deny on push/PR
- document cargo-deny allowlist with workspace-dep notes and advisory ignores
- align workspace crates to inherit version/edition/license for consistent checks