### PR TITLE
fix: start publishing @openai/codex-shell-tool-mcp to npm

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -377,8 +377,7 @@ jobs:
     uses: ./.github/workflows/shell-tool-mcp.yml
     with:
       release-tag: ${{ github.ref_name }}
-      # We are not ready to publish yet.
-      publish: false
+      publish: true
     secrets: inherit
 
   release:


### PR DESCRIPTION
Start publishing as part of the normal release process.