### PR TITLE
feat: emulate bash alt+d key to delete forward word

### DIFF
--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -275,6 +275,13 @@ impl TextArea {
                 ..
             }  => self.delete_forward_word(),
             KeyEvent {
+                code: KeyCode::Char('d'),
+                modifiers: KeyModifiers::ALT,
+                ..
+            } => {
+                self.delete_forward_word();
+            }
+            KeyEvent {
                 code: KeyCode::Delete,
                 ..
             }


### PR DESCRIPTION
#  Handle Alt+D delete-word in TUI input

**What**

- Map Alt+D/Meta+D to delete_forward_word in the chat textarea.

**Why**

- Matches bash/readline behavior; previously Alt+D did nothing in the Codex TUI input.

**How**

- Extend key handling in tui/src/bottom_pane/textarea.rs to treat Alt+D like Delete+Alt.

---

I have read the CLA Document and I hereby sign the CLA.