### PR TITLE
fix: path resolution bug in npx

### DIFF
--- a/shell-tool-mcp/src/index.ts
+++ b/shell-tool-mcp/src/index.ts
@@ -8,14 +8,9 @@ import { resolveBashPath } from "./bashSelection";
 import { readOsRelease } from "./osRelease";
 import { resolveTargetTriple } from "./platform";
 
-const scriptPath = process.argv[1]
-  ? path.resolve(process.argv[1])
-  : process.cwd();
-const __dirname = path.dirname(scriptPath);
-
 async function main(): Promise<void> {
   const targetTriple = resolveTargetTriple(process.platform, process.arch);
-  const vendorRoot = path.join(__dirname, "..", "vendor");
+  const vendorRoot = path.resolve(__dirname, "..", "vendor");
   const targetRoot = path.join(vendorRoot, targetTriple);
   const execveWrapperPath = path.join(targetRoot, "codex-execve-wrapper");
   const serverPath = path.join(targetRoot, "codex-exec-mcp-server");


### PR DESCRIPTION
When running `npx @openai/codex-shell-tool-mcp`, the old code derived `__dirname` from `process.argv[1]`, which points to npx’s transient wrapper script in `~/.npm/_npx/134d0fb7e1a27652/node_modules/.bin/codex-shell-tool-mcp`. That made `vendorRoot` resolve to `<npx cache>/vendor`, so the startup checks failed with "Required binary missing" because it looked for `codex-execve-wrapper` in the wrong place.

By relying on the real module `__dirname` and `path.resolve(__dirname, "..", "vendor")`, the package now anchors to its installed location under `node_modules/@openai/codex-shell-tool-mcp/`, so the bundled binaries are found and npx launches correctly.
