### PR TITLE
Show truncation indicator in /status when AGENTS.md exceeds limit

### DIFF
--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -408,9 +408,9 @@ impl HistoryCell for StatusHistoryCell {
         let mut agents_spans = vec![Span::from(self.agents_summary.clone())];
         if self.agents_truncated {
             let limit_label = format_byte_limit(self.agents_limit_bytes);
-            agents_spans.push(Span::from(" (truncated; limit ").magenta());
-            agents_spans.push(Span::from(limit_label).magenta());
-            agents_spans.push(Span::from(")").magenta());
+            agents_spans.push(Span::from(" (truncated; limit ").dim());
+            agents_spans.push(Span::from(limit_label).dim());
+            agents_spans.push(Span::from(")").dim());
         }
         lines.push(formatter.line("Agents.md", agents_spans));
 

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -408,9 +408,9 @@ impl HistoryCell for StatusHistoryCell {
         let mut agents_spans = vec![Span::from(self.agents_summary.clone())];
         if self.agents_truncated {
             let limit_label = format_byte_limit(self.agents_limit_bytes);
-            agents_spans.push(Span::from(" (truncated; limit ").yellow());
-            agents_spans.push(Span::from(limit_label).yellow());
-            agents_spans.push(Span::from(")").yellow());
+            agents_spans.push(Span::from(" (truncated; limit ").magenta());
+            agents_spans.push(Span::from(limit_label).magenta());
+            agents_spans.push(Span::from(")").magenta());
         }
         lines.push(formatter.line("Agents.md", agents_spans));
 

--- a/codex-rs/tui/src/status/helpers.rs
+++ b/codex-rs/tui/src/status/helpers.rs
@@ -6,7 +6,9 @@ use codex_app_server_protocol::AuthMode;
 use codex_core::AuthManager;
 use codex_core::config::Config;
 use codex_core::project_doc::discover_project_doc_paths;
+use std::fs;
 use std::path::Path;
+use std::path::PathBuf;
 use unicode_width::UnicodeWidthStr;
 
 use super::account::StatusAccountDisplay;
@@ -35,9 +37,13 @@ pub(crate) fn compose_model_display(
     (config.model.clone(), details)
 }
 
-pub(crate) fn compose_agents_summary(config: &Config) -> String {
+/// Returns a comma-delimited summary of discovered project docs along with a
+/// flag indicating whether the underlying files exceeded the configured byte
+/// budget and were truncated when embedded.
+pub(crate) fn compose_agents_summary(config: &Config) -> (String, bool) {
     match discover_project_doc_paths(config) {
         Ok(paths) => {
+            let truncated = docs_truncated(&paths, config.project_doc_max_bytes);
             let mut rels: Vec<String> = Vec::new();
             for p in paths {
                 let file_name = p
@@ -74,13 +80,47 @@ pub(crate) fn compose_agents_summary(config: &Config) -> String {
                 rels.push(display);
             }
             if rels.is_empty() {
-                "<none>".to_string()
+                ("<none>".to_string(), truncated)
             } else {
-                rels.join(", ")
+                (rels.join(", "), truncated)
             }
         }
-        Err(_) => "<none>".to_string(),
+        Err(_) => ("<none>".to_string(), false),
     }
+}
+
+/// Replicates the truncation logic in `project_doc::read_project_docs` by
+/// walking the resolved doc paths and tracking how much of the configured
+/// budget remains. Returns `true` when any file would exceed the budget (or
+/// when the budget is zero but docs exist), signaling that the TUI should warn
+/// the user in `/status`.
+fn docs_truncated(paths: &[PathBuf], max_bytes: usize) -> bool {
+    if paths.is_empty() {
+        return false;
+    }
+    if max_bytes == 0 {
+        // Docs exist but embedding disabled entirely.
+        return true;
+    }
+
+    let mut remaining = max_bytes as u64;
+    for path in paths {
+        if remaining == 0 {
+            return true;
+        }
+        let size = match fs::metadata(path) {
+            Ok(meta) => meta.len(),
+            Err(_) => continue,
+        };
+        if size == 0 {
+            continue;
+        }
+        if size > remaining {
+            return true;
+        }
+        remaining = remaining.saturating_sub(size);
+    }
+    false
 }
 
 pub(crate) fn compose_account_display(auth_manager: &AuthManager) -> Option<StatusAccountDisplay> {


### PR DESCRIPTION
Fixes #7138

Shows a `(truncated; limit X KB)` indicator in the `/status` display when project docs exceed the configured byte limit.

**Changes:**
- Display truncation warning when AGENTS.md is truncated
- Add byte formatting helper (B, KB, MB, GB, TB)
- Add test coverage for truncation indicator

**Before:**
<img width="1126" height="620" alt="before_fix@2x" src="https://github.com/user-attachments/assets/bcad30af-ecce-410e-9317-a5ade03ce1e0" />

**After:**
<img width="1134" height="616" alt="CleanShot 2025-11-22 at 10 16 15@2x" src="https://github.com/user-attachments/assets/a1b2b761-7a4e-49ad-a4fe-79a875159eee" />

Tested locally.