### PR TITLE
fix(sandbox) allow /bin/ps in macos seatbelt policy

### DIFF
--- a/codex-rs/core/src/seatbelt_base_policy.sbpl
+++ b/codex-rs/core/src/seatbelt_base_policy.sbpl
@@ -12,6 +12,10 @@
 (allow process-fork)
 (allow signal (target same-sandbox))
 
+; Permit /bin/ps to run without sandboxing so Homebrew's `brew shellenv`
+; can detect the shell even though /bin/ps is setuid.
+(allow process-exec (path "/bin/ps") (with no-sandbox))
+
 ; Allow cf prefs to work.
 (allow user-preference-read)
 


### PR DESCRIPTION
## Summary
Allows `/bin/ps` inside the base seatbelt policy on macos, which is commonly used by homebrew.

## Testing
- [x] Added test for this case.