### PR TITLE
consolidate world-writable-directories scanning.

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2380,11 +2380,18 @@ impl ChatWidget {
         {
             return None;
         }
-        let cwd = match std::env::current_dir() {
-            Ok(cwd) => cwd,
-            Err(_) => return Some((Vec::new(), 0, true)),
-        };
-        codex_windows_sandbox::world_writable_warning_details(self.config.codex_home.as_path(), cwd)
+        let cwd = self.config.cwd.clone();
+        let env_map: std::collections::HashMap<String, String> = std::env::vars().collect();
+        match codex_windows_sandbox::apply_world_writable_scan_and_denies(
+            self.config.codex_home.as_path(),
+            cwd.as_path(),
+            &env_map,
+            &self.config.sandbox_policy,
+            Some(self.config.codex_home.as_path()),
+        ) {
+            Ok(_) => None,
+            Err(_) => Some((Vec::new(), 0, true)),
+        }
     }
 
     #[cfg(not(target_os = "windows"))]

--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -7,20 +7,16 @@ macro_rules! windows_modules {
 windows_modules!(acl, allow, audit, cap, env, logging, policy, token, winutil);
 
 #[cfg(target_os = "windows")]
-pub use audit::world_writable_warning_details;
-#[cfg(target_os = "windows")]
-pub use windows_impl::preflight_audit_everyone_writable;
+pub use audit::apply_world_writable_scan_and_denies;
 #[cfg(target_os = "windows")]
 pub use windows_impl::run_windows_sandbox_capture;
 #[cfg(target_os = "windows")]
 pub use windows_impl::CaptureResult;
 
 #[cfg(not(target_os = "windows"))]
-pub use stub::preflight_audit_everyone_writable;
-#[cfg(not(target_os = "windows"))]
 pub use stub::run_windows_sandbox_capture;
 #[cfg(not(target_os = "windows"))]
-pub use stub::world_writable_warning_details;
+pub use stub::apply_world_writable_scan_and_denies;
 #[cfg(not(target_os = "windows"))]
 pub use stub::CaptureResult;
 
@@ -30,7 +26,6 @@ mod windows_impl {
     use super::acl::allow_null_device;
     use super::acl::revoke_ace;
     use super::allow::compute_allow_paths;
-    use super::audit;
     use super::cap::cap_sid_file;
     use super::cap::load_or_create_cap_sids;
     use super::env::apply_no_network_to_env;
@@ -38,7 +33,6 @@ mod windows_impl {
     use super::env::normalize_null_device_env;
     use super::logging::debug_log;
     use super::logging::log_failure;
-    use super::logging::log_note;
     use super::logging::log_start;
     use super::logging::log_success;
     use super::policy::parse_policy;
@@ -180,32 +174,6 @@ mod windows_impl {
         pub stdout: Vec<u8>,
         pub stderr: Vec<u8>,
         pub timed_out: bool,
-    }
-
-    pub fn preflight_audit_everyone_writable(
-        codex_home: &Path,
-        cwd: &Path,
-        env_map: &HashMap<String, String>,
-        sandbox_policy: &SandboxPolicy,
-        logs_base_dir: Option<&Path>,
-    ) -> Result<Vec<PathBuf>> {
-        let flagged = audit::audit_everyone_writable(cwd, env_map, logs_base_dir)?;
-        if flagged.is_empty() {
-            return Ok(flagged);
-        }
-        if let Err(err) = audit::apply_capability_denies_for_world_writable(
-            codex_home,
-            &flagged,
-            sandbox_policy,
-            cwd,
-            logs_base_dir,
-        ) {
-            log_note(
-                &format!("AUDIT: failed to apply capability deny ACEs: {}", err),
-                logs_base_dir,
-            );
-        }
-        Ok(Vec::new())
     }
 
     pub fn run_windows_sandbox_capture(
@@ -502,16 +470,6 @@ mod stub {
         pub timed_out: bool,
     }
 
-    pub fn preflight_audit_everyone_writable(
-        _codex_home: &Path,
-        _cwd: &Path,
-        _env_map: &HashMap<String, String>,
-        _sandbox_policy: &SandboxPolicy,
-        _logs_base_dir: Option<&Path>,
-    ) -> Result<Vec<std::path::PathBuf>> {
-        bail!("Windows sandbox is only available on Windows")
-    }
-
     pub fn run_windows_sandbox_capture(
         _policy_json_or_preset: &str,
         _sandbox_policy_cwd: &Path,
@@ -524,10 +482,13 @@ mod stub {
         bail!("Windows sandbox is only available on Windows")
     }
 
-    pub fn world_writable_warning_details(
-        _codex_home: impl AsRef<Path>,
-        _cwd: impl AsRef<Path>,
-    ) -> Option<(Vec<String>, usize, bool)> {
-        None
+    pub fn apply_world_writable_scan_and_denies(
+        _codex_home: &Path,
+        _cwd: &Path,
+        _env_map: &HashMap<String, String>,
+        _sandbox_policy: &SandboxPolicy,
+        _logs_base_dir: Option<&Path>,
+    ) -> Result<()> {
+        bail!("Windows sandbox is only available on Windows")
     }
 }

--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -14,9 +14,9 @@ pub use windows_impl::run_windows_sandbox_capture;
 pub use windows_impl::CaptureResult;
 
 #[cfg(not(target_os = "windows"))]
-pub use stub::run_windows_sandbox_capture;
-#[cfg(not(target_os = "windows"))]
 pub use stub::apply_world_writable_scan_and_denies;
+#[cfg(not(target_os = "windows"))]
+pub use stub::run_windows_sandbox_capture;
 #[cfg(not(target_os = "windows"))]
 pub use stub::CaptureResult;
 


### PR DESCRIPTION
clean up the code for scanning for world writable directories

One path (selecting a sandbox mode from /approvals) was using an incorrect method that did not use the new method of creating deny aces to prevent writing to those directories. Now all paths are the same.
