### PR TITLE
docs: add installation instructions for Arch Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<p align="center"><code>npm i -g @openai/codex</code><br />or <code>brew install --cask codex</code></p>
+<p align="center"><code>npm i -g @openai/codex</code><br />or <code>brew install --cask codex</code><br />or <code>pacman -S openai-codex</code></p>
 
 <p align="center"><strong>Codex CLI</strong> is a coding agent from OpenAI that runs locally on your computer.
 </br>
@@ -25,6 +25,12 @@ Alternatively, if you use Homebrew:
 
 ```shell
 brew install --cask codex
+```
+
+On Arch Linux, install from the official [`extra`](https://archlinux.org/packages/extra/x86_64/openai-codex/) repo:
+
+```shell
+pacman -S openai-codex
 ```
 
 Then simply run `codex` to get started:

--- a/docs/install.md
+++ b/docs/install.md
@@ -12,6 +12,16 @@
 
 The GitHub Release also contains a [DotSlash](https://dotslash-cli.com/) file for the Codex CLI named `codex`. Using a DotSlash file makes it possible to make a lightweight commit to source control to ensure all contributors use the same version of an executable, regardless of what platform they use for development.
 
+### Arch Linux
+
+Codex is packaged in Arch Linux's `extra` repository. Install it with:
+
+```bash
+sudo pacman -S openai-codex
+```
+
+See the [package page](https://archlinux.org/packages/extra/x86_64/openai-codex/) for details.
+
 ### Build from source
 
 ```bash


### PR DESCRIPTION
Hey :wave:, Arch Linux maintainer of Codex here.

I thought it would be nice to include Arch instructions in the documentation as well (btw)
