### PR TITLE
Added alternate form of `dependabot` to CLA allow list

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -48,4 +48,5 @@ jobs:
           branch: cla-signatures
           allowlist: |
             codex
+            dependabot
             dependabot[bot]


### PR DESCRIPTION
This fixes the CI check for CLA, which recently started to flag the GitHub dependabot as "not having signed the CLA".