### PR TITLE
fix: keep tui log plain text

### DIFF
--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -267,7 +267,7 @@ pub async fn run_main(
 
     let file_layer = tracing_subscriber::fmt::layer()
         .with_writer(non_blocking)
-        .with_target(false)
+        .with_ansi(false)
         .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
         .with_filter(env_filter());
 


### PR DESCRIPTION
Disable ANSI output on the file tracing layer and re-enable targets so codex-tui.log stays readable while showing the source of each message.

Before:
<img width="1339" height="131" alt="image" src="https://github.com/user-attachments/assets/9c1b210a-a2e9-4eaf-b0d9-6ff1473e2c26" />

After:
<img width="1333" height="131" alt="image" src="https://github.com/user-attachments/assets/29cf19e6-41c6-42da-9b78-a326c360ad41" />
