### PR TITLE
[app-server-test-client] add send-followup-v2

### DIFF
--- a/codex-rs/app-server-test-client/src/main.rs
+++ b/codex-rs/app-server-test-client/src/main.rs
@@ -101,6 +101,15 @@ enum CliCommand {
     /// Start a V2 turn that should not elicit an ExecCommand approval.
     #[command(name = "no-trigger-cmd-approval")]
     NoTriggerCmdApproval,
+    /// Send two sequential V2 turns in the same thread to test follow-up behavior.
+    SendFollowUpV2 {
+        /// Initial user message for the first turn.
+        #[arg()]
+        first_message: String,
+        /// Follow-up user message for the second turn.
+        #[arg()]
+        follow_up_message: String,
+    },
     /// Trigger the ChatGPT login flow and wait for completion.
     TestLogin,
     /// Fetch the current account rate limits from the Codex app-server.
@@ -120,6 +129,10 @@ fn main() -> Result<()> {
             trigger_patch_approval(codex_bin, user_message)
         }
         CliCommand::NoTriggerCmdApproval => no_trigger_cmd_approval(codex_bin),
+        CliCommand::SendFollowUpV2 {
+            first_message,
+            follow_up_message,
+        } => send_follow_up_v2(codex_bin, first_message, follow_up_message),
         CliCommand::TestLogin => test_login(codex_bin),
         CliCommand::GetAccountRateLimits => get_account_rate_limits(codex_bin),
     }
@@ -205,6 +218,44 @@ fn send_message_v2_with_policies(
     println!("< turn/start response: {turn_response:?}");
 
     client.stream_turn(&thread_response.thread.id, &turn_response.turn.id)?;
+
+    Ok(())
+}
+
+fn send_follow_up_v2(
+    codex_bin: String,
+    first_message: String,
+    follow_up_message: String,
+) -> Result<()> {
+    let mut client = CodexClient::spawn(codex_bin)?;
+
+    let initialize = client.initialize()?;
+    println!("< initialize response: {initialize:?}");
+
+    let thread_response = client.thread_start(ThreadStartParams::default())?;
+    println!("< thread/start response: {thread_response:?}");
+
+    let first_turn_params = TurnStartParams {
+        thread_id: thread_response.thread.id.clone(),
+        input: vec![V2UserInput::Text {
+            text: first_message,
+        }],
+        ..Default::default()
+    };
+    let first_turn_response = client.turn_start(first_turn_params)?;
+    println!("< turn/start response (initial): {first_turn_response:?}");
+    client.stream_turn(&thread_response.thread.id, &first_turn_response.turn.id)?;
+
+    let follow_up_params = TurnStartParams {
+        thread_id: thread_response.thread.id.clone(),
+        input: vec![V2UserInput::Text {
+            text: follow_up_message,
+        }],
+        ..Default::default()
+    };
+    let follow_up_response = client.turn_start(follow_up_params)?;
+    println!("< turn/start response (follow-up): {follow_up_response:?}");
+    client.stream_turn(&thread_response.thread.id, &follow_up_response.turn.id)?;
 
     Ok(())
 }


### PR DESCRIPTION
Add a new endpoint that allows us to test multi-turn behavior.

Tested with running:
```
RUST_LOG=codex_app_server=debug CODEX_BIN=target/debug/codex \
      cargo run -p codex-app-server-test-client -- \
      send-follow-up-v2 "hello" "and now a follow-up question"
```