### PR TITLE
Pr/pool idle timeout

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -1252,6 +1252,7 @@ mod tests {
             stream_max_retries: Some(0),
             stream_idle_timeout_ms: Some(1000),
             requires_openai_auth: false,
+            pool_idle_timeout_secs: None,
         };
 
         let otel_event_manager = otel_event_manager();
@@ -1316,6 +1317,7 @@ mod tests {
             stream_max_retries: Some(0),
             stream_idle_timeout_ms: Some(1000),
             requires_openai_auth: false,
+            pool_idle_timeout_secs: None,
         };
 
         let otel_event_manager = otel_event_manager();
@@ -1353,6 +1355,7 @@ mod tests {
             stream_max_retries: Some(0),
             stream_idle_timeout_ms: Some(1000),
             requires_openai_auth: false,
+            pool_idle_timeout_secs: None,
         };
 
         let otel_event_manager = otel_event_manager();
@@ -1392,6 +1395,7 @@ mod tests {
             stream_max_retries: Some(0),
             stream_idle_timeout_ms: Some(1000),
             requires_openai_auth: false,
+            pool_idle_timeout_secs: None,
         };
 
         let otel_event_manager = otel_event_manager();
@@ -1427,6 +1431,7 @@ mod tests {
             stream_max_retries: Some(0),
             stream_idle_timeout_ms: Some(1000),
             requires_openai_auth: false,
+            pool_idle_timeout_secs: None,
         };
 
         let otel_event_manager = otel_event_manager();
@@ -1462,6 +1467,7 @@ mod tests {
             stream_max_retries: Some(0),
             stream_idle_timeout_ms: Some(1000),
             requires_openai_auth: false,
+            pool_idle_timeout_secs: None,
         };
 
         let otel_event_manager = otel_event_manager();
@@ -1566,6 +1572,7 @@ mod tests {
                 stream_max_retries: Some(0),
                 stream_idle_timeout_ms: Some(1000),
                 requires_openai_auth: false,
+            pool_idle_timeout_secs: None,
             };
 
             let otel_event_manager = otel_event_manager();

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -44,6 +44,7 @@ use crate::client_common::create_text_param_for_request;
 use crate::config::Config;
 use crate::default_client::CodexHttpClient;
 use crate::default_client::create_client;
+use crate::default_client::create_client_with_pool_config;
 use crate::error::CodexErr;
 use crate::error::ConnectionFailedError;
 use crate::error::ResponseStreamFailed;
@@ -117,7 +118,8 @@ impl ModelClient {
         conversation_id: ConversationId,
         session_source: SessionSource,
     ) -> Self {
-        let client = create_client();
+        // Create HTTP client with provider-specific pool idle timeout configuration
+        let client = create_client_with_pool_config(provider.pool_idle_timeout());
 
         Self {
             config,

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -2905,6 +2905,7 @@ model_verbosity = "high"
             stream_max_retries: Some(10),
             stream_idle_timeout_ms: Some(300_000),
             requires_openai_auth: false,
+            pool_idle_timeout_secs: None,
         };
         let model_provider_map = {
             let mut model_provider_map = built_in_model_providers();

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -88,6 +88,12 @@ pub struct ModelProviderInfo {
     /// the connection as lost.
     pub stream_idle_timeout_ms: Option<u64>,
 
+    /// Connection pool idle timeout (in seconds). How long to keep idle connections alive
+    /// in the connection pool before closing them. Set to 0 to disable connection pooling entirely.
+    /// If not specified, uses reqwest's default behavior (90 seconds).
+    /// Useful for providers that aggressively close connections server-side.
+    pub pool_idle_timeout_secs: Option<u64>,
+
     /// Does this provider require an OpenAI API Key or ChatGPT login token? If true,
     /// user is presented with login screen on first run, and login preference and token/key
     /// are stored in auth.json. If false (which is the default), login screen is skipped,
@@ -299,6 +305,13 @@ impl ModelProviderInfo {
         self.stream_idle_timeout_ms
             .map(Duration::from_millis)
             .unwrap_or(Duration::from_millis(DEFAULT_STREAM_IDLE_TIMEOUT_MS))
+    }
+
+    /// Effective connection pool idle timeout. Returns None if not configured (use reqwest default),
+    /// Some(Duration::ZERO) if pooling should be disabled, or Some(duration) for a specific timeout.
+    pub fn pool_idle_timeout(&self) -> Option<Duration> {
+        self.pool_idle_timeout_secs
+            .map(|secs| Duration::from_secs(secs))
     }
 }
 

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -92,6 +92,7 @@ pub struct ModelProviderInfo {
     /// in the connection pool before closing them. Set to 0 to disable connection pooling entirely.
     /// If not specified, uses reqwest's default behavior (90 seconds).
     /// Useful for providers that aggressively close connections server-side.
+    #[serde(default)]
     pub pool_idle_timeout_secs: Option<u64>,
 
     /// Does this provider require an OpenAI API Key or ChatGPT login token? If true,

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -367,6 +367,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
                 request_max_retries: None,
                 stream_max_retries: None,
                 stream_idle_timeout_ms: None,
+                pool_idle_timeout_secs: None,
                 requires_openai_auth: true,
             },
         ),
@@ -418,6 +419,7 @@ pub fn create_oss_provider_with_base_url(base_url: &str, wire_api: WireApi) -> M
         request_max_retries: None,
         stream_max_retries: None,
         stream_idle_timeout_ms: None,
+        pool_idle_timeout_secs: None,
         requires_openai_auth: false,
     }
 }


### PR DESCRIPTION
## Description

Adds a `pool_idle_timeout_secs` configuration option to allow users to control HTTP connection pool behavior on a per-provider basis. This fixes connection reuse failures with third-party providers that close idle connections more aggressively than reqwest's default 90-second timeout.

Fixes #7272

## Changes

- **`codex-rs/core/src/model_provider_info.rs`**: 
  - Add `pool_idle_timeout_secs: Option<u64>` field with `#[serde(default)]` for TOML deserialization
  - Add `pool_idle_timeout()` accessor method returning `Option<Duration>`

- **`codex-rs/core/src/default_client.rs`**:
  - Add `create_client_with_pool_config(pool_idle_timeout: Option<Duration>)` function
  - Configure reqwest client based on timeout value:
    - `None`: Use reqwest default (90 seconds)
    - `Some(0)`: Disable pooling with `pool_max_idle_per_host(0)`
    - `Some(N)`: Set custom timeout with `pool_idle_timeout(Duration::from_secs(N))`

- **`codex-rs/core/src/client.rs`**:
  - Update `ModelClient::new()` to use provider's pool timeout configuration

## Configuration Example

```toml
[model_providers.custom_provider]
name = "Custom Provider"
base_url = "https://api.example.com/v1"
pool_idle_timeout_secs = 10  # Close idle connections after 10 seconds
```

**Options:**
- Not set: Use reqwest default (90 seconds)
- Set to N: Close idle connections after N seconds
- Set to 0: Disable connection pooling entirely

## Testing

Tested with third-party providers that close connections after ~30 seconds:

**Before:**
- Frequent 400/404 errors with "reuse idle connection" in logs
- Reconnection loops and 429 rate limit errors

**After (with `pool_idle_timeout_secs = 10`):**
- Stable connections, no stale connection errors
- Reliable streaming without interruptions

## Benefits

- **Provider compatibility**: Flexible per-provider tuning without code changes
- **Reduced errors**: Prevents stale connection reuse failures
- **Better reliability**: Eliminates reconnection loops
- **Backward compatible**: Existing configurations unchanged (defaults preserved)

## Related

- Issue: #7272
- Branch: `pr/pool-idle-timeout`
- Base: `main`
