### PR TITLE
doc: fix conflict values in `example-config.md`

### DIFF
--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -215,7 +215,6 @@ rmcp_client = false
 apply_patch_freeform = false
 view_image_tool = true
 web_search_request = false
-experimental_sandbox_command_assessment = false
 ghost_commit = false
 enable_experimental_windows_sandbox = false
 
@@ -239,8 +238,8 @@ experimental_sandbox_command_assessment = false
 # MCP (Model Context Protocol) servers
 ################################################################################
 
-# Preferred store for MCP OAuth credentials: auto (default) | file | keyring
-mcp_oauth_credentials_store = "auto"
+# Preferred store for MCP OAuth credentials. Default: false
+mcp_oauth_credentials_store = false
 
 # Define MCP servers under this table. Leave empty to disable.
 [mcp_servers]


### PR DESCRIPTION
I have read the document of [example-config.md]() and I created the example configuration file `~/.codex/config.toml` following the document instruction. When I tried to run `codex cli` with `codex`, some errors happened in my shell environment when loading `config.toml`.

```
Error loading config.toml: TOML parse error at line 231, column 1
    |
231 | experimental_sandbox_command_assessment = false
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
duplicate key
```
<img width="609" height="107" alt="duplicate key error" src="https://github.com/user-attachments/assets/551a8b9e-e551-4da3-a391-4e802a6ee41b" />

I noticed that a same key value pair `experimental_sandbox_command_assessment = false` is already written with a detailed explanation below, so same one above should be deleted in order to avoid `duplicate key` error.

<img width="792" height="526" alt="duplicated key" src="https://github.com/user-attachments/assets/1e42966b-35b3-4088-8cc3-4d1206fa7b1d" />

---

```
Error loading config.toml: invalid type: string "auto", expected a boolean
in `features`
```

<img width="687" height="48" alt="expected boolean" src="https://github.com/user-attachments/assets/461a46db-6b04-4a28-8721-25c2c08f1f1f" />

Also, the value of `mcp_oauth_credentials_store = "auto"` seems to be wrong configed and documented, since the this key needs a `Boolean` value according to the error message.

<img width="721" height="135" alt="expected boolean doc" src="https://github.com/user-attachments/assets/5d47b60c-a48b-40a6-ba61-6d7cc47ff5a2" />

When I replace the value with `false` and also delete the above duplicated key, the command `codex` can be successfully executed without any config loading errors.

I have read the CLA Document and I hereby sign the CLA.