### PR TITLE
doc: fix relative links and add tips

### DIFF
--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -58,7 +58,7 @@ Send a `tools/list` request and you will see that there are two tools available:
 | **`prompt`** (required)         | string | The next user prompt to continue the Codex conversation. |
 | **`conversationId`** (required) | string | The id of the conversation to continue.                  |
 
-### Trying it Out {#mcp-server-trying-it-out}
+### Trying it Out
 
 > [!TIP]
 > Codex often takes a few minutes to run. To accommodate this, adjust the MCP inspector's Request and Total timeouts to 600000ms (10 minutes) under ⛭ Configuration.

--- a/docs/advanced.md
+++ b/docs/advanced.md
@@ -2,11 +2,11 @@
 
 If you already lean on Codex every day and just need a little more control, this page collects the knobs you are most likely to reach for: tweak defaults in [Config](./config.md), add extra tools through [Model Context Protocol support](#model-context-protocol), and script full runs with [`codex exec`](./exec.md). Jump to the section you need and keep building.
 
-## Config quickstart {#config-quickstart}
+## Config quickstart
 
 Most day-to-day tuning lives in `config.toml`: set approval + sandbox presets, pin model defaults, and add MCP server launchers. The [Config guide](./config.md) walks through every option and provides copy-paste examples for common setups.
 
-## Tracing / verbose logging {#tracing-verbose-logging}
+## Tracing / verbose logging
 
 Because Codex is written in Rust, it honors the `RUST_LOG` environment variable to configure its logging behavior.
 
@@ -20,15 +20,15 @@ By comparison, the non-interactive mode (`codex exec`) defaults to `RUST_LOG=err
 
 See the Rust documentation on [`RUST_LOG`](https://docs.rs/env_logger/latest/env_logger/#enabling-logging) for more information on the configuration options.
 
-## Model Context Protocol (MCP) {#model-context-protocol}
+## Model Context Protocol (MCP)
 
 The Codex CLI and IDE extension is a MCP client which means that it can be configured to connect to MCP servers. For more information, refer to the [`config docs`](./config.md#mcp-integration).
 
-## Using Codex as an MCP Server {#mcp-server}
+## Using Codex as an MCP Server
 
 The Codex CLI can also be run as an MCP _server_ via `codex mcp-server`. For example, you can use `codex mcp-server` to make Codex available as a tool inside of a multi-agent framework like the OpenAI [Agents SDK](https://platform.openai.com/docs/guides/agents). Use `codex mcp` separately to add/list/get/remove MCP server launchers in your configuration.
 
-### Codex MCP Server Quickstart {#mcp-server-quickstart}
+### Codex MCP Server Quickstart
 
 You can launch a Codex MCP server with the [Model Context Protocol Inspector](https://modelcontextprotocol.io/legacy/tools/inspector):
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -113,3 +113,7 @@ Paste images directly into the composer (Ctrl+V / Cmd+V) to attach them to your 
 codex -i screenshot.png "Explain this error"
 codex --image img1.png,img2.jpg "Summarize these diagrams"
 ```
+
+#### Environment variables and executables
+
+Make sure your environment is already set up before launching Codex so it does not spend tokens probing what to activate. For example, source your Python virtualenv (or other language runtimes), start any required daemons, and export the env vars you expect to use ahead of time.

--- a/docs/platform-sandboxing.md
+++ b/docs/platform-sandboxing.md
@@ -1,3 +1,3 @@
 ## Platform sandboxing
 
-This content now lives alongside the rest of the sandbox guidance. See [Sandbox mechanics by platform](./sandbox.md#platform-sandboxing-details) for up-to-date details.
+This content now lives alongside the rest of the sandbox guidance. See [Sandbox mechanics by platform](./sandbox.md#sandbox-mechanics-by-platform) for up-to-date details.


### PR DESCRIPTION
This PR is a documentation only one which:
- addresses the #7231 by adding a paragraph in `docs/getting-started.md` in the tips category to encourage users to load everything needed in their environment
- corrects link referencing in `docs/platform-sandboxing.md` so that the page link opens at the right section
- removes the explicit heading IDs like {#my-id} in `docs/advanced.md` which are not supported by GitHub and are **not** rendered in the UI:

<img width="1198" height="849" alt="Screenshot 2025-11-26 at 16 25 31" src="https://github.com/user-attachments/assets/308d33c3-81d3-4785-a6c1-e9377e6d3ea6" />

This caused the following links in `README.md` to not work in `main` but to work in this branch (you can test by going to https://github.com/openai/codex/blob/docs/getting-started-enhancement/README.md) - the MCP link goes straight to the correct section now:

```markdown
  - [**Advanced**](./docs/advanced.md)
  - [Tracing / verbose logging](./docs/advanced.md#tracing--verbose-logging)
  - [Model Context Protocol (MCP)](./docs/advanced.md#model-context-protocol-mcp)
```