### PR TITLE
fix: put read-only permission in review thread

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1844,6 +1844,7 @@ async fn spawn_review_thread(
             per_turn_config.model_family.slug.as_str(),
         );
 
+    let review_sandbox_policy = SandboxPolicy::ReadOnly;
     let per_turn_config = Arc::new(per_turn_config);
     let client = ModelClient::new(
         per_turn_config.clone(),
@@ -1865,7 +1866,7 @@ async fn spawn_review_thread(
         base_instructions: Some(base_instructions.clone()),
         compact_prompt: parent_turn_context.compact_prompt.clone(),
         approval_policy: parent_turn_context.approval_policy,
-        sandbox_policy: parent_turn_context.sandbox_policy.clone(),
+        sandbox_policy: review_sandbox_policy,
         shell_environment_policy: parent_turn_context.shell_environment_policy.clone(),
         cwd: parent_turn_context.cwd.clone(),
         final_output_json_schema: None,

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -16,6 +16,7 @@ use tokio_util::sync::CancellationToken;
 use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::codex_delegate::run_codex_conversation_one_shot;
+use crate::protocol::SandboxPolicy;
 use crate::review_format::format_review_findings_block;
 use crate::state::TaskKind;
 use codex_protocol::user_input::UserInput;
@@ -97,7 +98,7 @@ async fn start_review_conversation(
     // Avoid loading project docs; reviewer only needs findings
     sub_agent_config.project_doc_max_bytes = 0;
     // Enforce read-only sandbox for the review child session.
-    sub_agent_config.sandbox_mode = SandboxPolicy::ReadOnly;
+    sub_agent_config.sandbox_policy = SandboxPolicy::ReadOnly;
     // Carry over review-only feature restrictions so the delegate cannot
     // re-enable blocked tools (web search, view image).
     sub_agent_config

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -96,6 +96,8 @@ async fn start_review_conversation(
     sub_agent_config.user_instructions = None;
     // Avoid loading project docs; reviewer only needs findings
     sub_agent_config.project_doc_max_bytes = 0;
+    // Enforce read-only sandbox for the review child session.
+    sub_agent_config.sandbox_mode = SandboxPolicy::ReadOnly;
     // Carry over review-only feature restrictions so the delegate cannot
     // re-enable blocked tools (web search, view image).
     sub_agent_config


### PR DESCRIPTION
This PR should close #7267 (and also #7311 which is a closed duplicate) where `codex` accidentally changed some files as part of the review process.

The review turn context in `core/src/codex.rs::spawn_review_thread` now forces `SandboxPolicy::ReadOnly`, so `/review` always runs under a read-only sandbox regardless of the parent session’s sandbox mode.