### PR TITLE
Fixes two bugs in example-config.md documentation

### DIFF
--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -180,6 +180,9 @@ chatgpt_base_url = "https://chatgpt.com/backend-api/"
 # Allowed values: chatgpt | api
 # forced_login_method = "chatgpt"
 
+# Preferred store for MCP OAuth credentials: auto (default) | file | keyring
+mcp_oauth_credentials_store = "auto"
+
 ################################################################################
 # Project Documentation Controls
 ################################################################################
@@ -231,16 +234,6 @@ experimental_use_rmcp_client = false
 
 # Include apply_patch via freeform editing path (affects default tool set). Default: false
 experimental_use_freeform_apply_patch = false
-
-# Enable model-based sandbox command assessment. Default: false
-experimental_sandbox_command_assessment = false
-
-################################################################################
-# MCP (Model Context Protocol) servers
-################################################################################
-
-# Preferred store for MCP OAuth credentials: auto (default) | file | keyring
-mcp_oauth_credentials_store = "auto"
 
 # Define MCP servers under this table. Leave empty to disable.
 [mcp_servers]


### PR DESCRIPTION
This PR is a modified version of [a PR](https://github.com/openai/codex/pull/7316) submitted by @yydrowz3.
* Removes a redundant `experimental_sandbox_command_assessment` flag
* Moves `mcp_oauth_credentials_store` from the `[features]` table, where it doesn't belong
