### PR TITLE
Add IDE font size config for Codex VS Code window

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v1.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v1.rs
@@ -323,6 +323,12 @@ pub struct SetDefaultModelResponse {}
 
 #[derive(Deserialize, Debug, Clone, PartialEq, Serialize, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
+pub struct IdeConfig {
+    pub font_size: Option<i64>,
+}
+
+#[derive(Deserialize, Debug, Clone, PartialEq, Serialize, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
 pub struct UserSavedConfig {
     pub approval_policy: Option<AskForApproval>,
     pub sandbox_mode: Option<SandboxMode>,
@@ -334,6 +340,7 @@ pub struct UserSavedConfig {
     pub model_reasoning_summary: Option<ReasoningSummary>,
     pub model_verbosity: Option<Verbosity>,
     pub tools: Option<Tools>,
+    pub ide: Option<IdeConfig>,
     pub profile: Option<String>,
     pub profiles: HashMap<String, Profile>,
 }

--- a/codex-rs/app-server/tests/suite/config.rs
+++ b/codex-rs/app-server/tests/suite/config.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use app_test_support::McpProcess;
 use app_test_support::to_response;
 use codex_app_server_protocol::GetUserSavedConfigResponse;
+use codex_app_server_protocol::IdeConfig;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::Profile;
 use codex_app_server_protocol::RequestId;
@@ -46,6 +47,9 @@ exclude_slash_tmp = true
 [tools]
 web_search = false
 view_image = true
+
+[ide]
+font_size = 15
 
 [profiles.test]
 model = "gpt-4o"
@@ -95,6 +99,9 @@ async fn get_config_toml_parses_all_fields() -> Result<()> {
                 web_search: Some(false),
                 view_image: Some(true),
             }),
+            ide: Some(IdeConfig {
+                font_size: Some(15),
+            }),
             profile: Some("test".to_string()),
             profiles: HashMap::from([(
                 "test".into(),
@@ -142,6 +149,7 @@ async fn get_config_toml_empty() -> Result<()> {
             model_reasoning_summary: None,
             model_verbosity: None,
             tools: None,
+            ide: None,
             profile: None,
             profiles: HashMap::new(),
         },

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1,6 +1,7 @@
 use crate::auth::AuthCredentialsStoreMode;
 use crate::config::types::DEFAULT_OTEL_ENVIRONMENT;
 use crate::config::types::History;
+use crate::config::types::Ide;
 use crate::config::types::McpServerConfig;
 use crate::config::types::Notice;
 use crate::config::types::Notifications;
@@ -34,6 +35,7 @@ use crate::project_doc::DEFAULT_PROJECT_DOC_FILENAME;
 use crate::project_doc::LOCAL_PROJECT_DOC_FILENAME;
 use crate::protocol::AskForApproval;
 use crate::protocol::SandboxPolicy;
+use codex_app_server_protocol::IdeConfig;
 use codex_app_server_protocol::Tools;
 use codex_app_server_protocol::UserSavedConfig;
 use codex_protocol::config_types::ForcedLoginMethod;
@@ -656,6 +658,9 @@ pub struct ConfigToml {
     /// output will be hyperlinked using the specified URI scheme.
     pub file_opener: Option<UriBasedFileOpener>,
 
+    /// Preferences for IDE clients such as the Codex VS Code window.
+    pub ide: Option<Ide>,
+
     /// Collection of settings that are specific to the TUI.
     pub tui: Option<Tui>,
 
@@ -740,6 +745,7 @@ impl From<ConfigToml> for UserSavedConfig {
             model_reasoning_summary: config_toml.model_reasoning_summary,
             model_verbosity: config_toml.model_verbosity,
             tools: config_toml.tools.map(From::from),
+            ide: config_toml.ide.map(From::from),
             profile: config_toml.profile,
             profiles,
         }
@@ -776,6 +782,14 @@ impl From<ToolsToml> for Tools {
         Self {
             web_search: tools_toml.web_search,
             view_image: tools_toml.view_image,
+        }
+    }
+}
+
+impl From<Ide> for IdeConfig {
+    fn from(ide: Ide) -> Self {
+        Self {
+            font_size: ide.font_size,
         }
     }
 }

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -397,6 +397,13 @@ impl Notice {
     pub(crate) const TABLE_KEY: &'static str = "notice";
 }
 
+/// Preferences for IDE clients such as the Codex VS Code window.
+#[derive(Deserialize, Debug, Clone, PartialEq, Default)]
+pub struct Ide {
+    /// Override the font size used by IDE clients (e.g., VS Code Codex window).
+    pub font_size: Option<i64>,
+}
+
 #[derive(Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct SandboxWorkspaceWrite {
     #[serde(default)]

--- a/docs/config.md
+++ b/docs/config.md
@@ -896,6 +896,16 @@ animations = false
 
 > [!NOTE] > `tui.notifications` is built‑in and limited to the TUI session. For programmatic or cross‑environment notifications—or to integrate with OS‑specific notifiers—use the top‑level `notify` option to run an external program that receives event JSON. The two settings are independent and can be used together.
 
+### ide
+
+Preferences for IDE clients such as the Codex window in VS Code, Windsurf, or Cursor.
+
+```toml
+[ide]
+# Override the Codex window font size in your IDE (points). Defaults to the IDE's Codex UI setting.
+font_size = 14
+```
+
 ## Authentication and authorization
 
 ### Forcing a login method
@@ -976,6 +986,7 @@ Valid values:
 | `file_opener`                                    | `vscode` \| `vscode-insiders` \| `windsurf` \| `cursor` \| `none` | URI scheme for clickable citations (default: `vscode`).                                                                    |
 | `tui`                                            | table                                                             | TUI‑specific options.                                                                                                      |
 | `tui.notifications`                              | boolean \| array<string>                                          | Enable desktop notifications in the tui (default: true).                                                                   |
+| `ide.font_size`                                  | number                                                            | Override the Codex window font size in IDE clients (points).                                                               |
 | `hide_agent_reasoning`                           | boolean                                                           | Hide model reasoning events.                                                                                               |
 | `check_for_update_on_startup`                    | boolean                                                           | Check for Codex updates on startup (default: true). Set to `false` only if updates are centrally managed.                  |
 | `show_raw_agent_reasoning`                       | boolean                                                           | Show raw reasoning (when available).                                                                                       |

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -142,6 +142,10 @@ notifications = false
 # Enables welcome/status/spinner animations. Default: true
 animations = true
 
+[ide]
+# Override Codex window font size in IDE clients (points). Default: unset.
+# font_size = 14
+
 # Suppress internal reasoning events from output. Default: false
 hide_agent_reasoning = false
 


### PR DESCRIPTION
Addresses #3412.

## Summary
- Add an `[ide]` config section with `font_size` so IDE clients (Codex VS Code window, etc.) can control UI font size.
- Plumb `ide.font_size` through `UserSavedConfig/IdeConfig` in the app-server protocol and core config conversion.
- Document the new setting in `docs/config.md` and `docs/example-config.md`.
- Extend app-server config tests to cover the IDE font-size field.

## Testing
- `just fmt`
- `cargo test -p codex-app-server-protocol` ✅
- `cargo test -p codex-core` ⚠️ fails here on user-agent/zsh path expectations (`codex_cli_rs` vs `codex_vscode`; `/bin/zsh` vs Homebrew `/usr/local/bin/zsh`).
- `cargo test -p codex-app-server` ⚠️ user-agent expectation mismatch (`codex_cli_rs` vs `codex_vscode`).

Note: Changes authored with assistance from OpenAI Codex CLI in VS Code
