### PR TITLE
[app-server] fix: emit item/fileChange/outputDelta for file change items

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -511,6 +511,7 @@ server_notification_definitions! {
     ItemCompleted => "item/completed" (v2::ItemCompletedNotification),
     AgentMessageDelta => "item/agentMessage/delta" (v2::AgentMessageDeltaNotification),
     CommandExecutionOutputDelta => "item/commandExecution/outputDelta" (v2::CommandExecutionOutputDeltaNotification),
+    FileChangeOutputDelta => "item/fileChange/outputDelta" (v2::FileChangeOutputDeltaNotification),
     McpToolCallProgress => "item/mcpToolCall/progress" (v2::McpToolCallProgressNotification),
     AccountUpdated => "account/updated" (v2::AccountUpdatedNotification),
     AccountRateLimitsUpdated => "account/rateLimits/updated" (v2::AccountRateLimitsUpdatedNotification),

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1356,6 +1356,16 @@ pub struct CommandExecutionOutputDeltaNotification {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
+pub struct FileChangeOutputDeltaNotification {
+    pub thread_id: String,
+    pub turn_id: String,
+    pub item_id: String,
+    pub delta: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct McpToolCallProgressNotification {
     pub thread_id: String,
     pub turn_id: String,


### PR DESCRIPTION
Emit `item/fileChange/outputDelta` instead of `item/execCommand/outputDelta` for FileChange items.

The underlying `EventMsg::ExecCommandOutputDelta` is emitted for apply_patch, shell, and unified exec, and since we represent apply_patch calls as `FileChange` items, we were seeing these events:
```
item/started <- FileChange
item/execCommand/outputDelta <- our code assumed that EventMsg::ExecCommandOutputDelta is always for the CommandExecution item
item/completed <- FileChange
```

With this fix we'll have these events:
```
item/started <- FileChange
item/fileChange/outputDelta <- our code assumed that EventMsg::ExecCommandOutputDelta is always for the CommandExecution item
item/completed <- FileChange
```