### PR TITLE
fix: prevent MCP startup failure on missing 'type' field

### DIFF
--- a/codex-rs/mcp-types/src/lib.rs
+++ b/codex-rs/mcp-types/src/lib.rs
@@ -1474,6 +1474,10 @@ pub struct Tool {
     pub title: Option<String>,
 }
 
+fn tool_output_schema_type_default_str() -> String {
+    "object".to_string()
+}
+
 /// An optional JSON Schema object defining the structure of the tool's output returned in
 /// the structuredContent field of a CallToolResult.
 #[derive(Debug, Clone, PartialEq, Deserialize, Serialize, JsonSchema, TS)]
@@ -1484,7 +1488,12 @@ pub struct ToolOutputSchema {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub required: Option<Vec<String>>,
+    #[serde(default = "tool_output_schema_type_default_str")]
     pub r#type: String, // &'static str = "object"
+}
+
+fn tool_input_schema_type_default_str() -> String {
+    "object".to_string()
 }
 
 /// A JSON Schema object defining the expected parameters for the tool.
@@ -1496,6 +1505,7 @@ pub struct ToolInputSchema {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub required: Option<Vec<String>>,
+    #[serde(default = "tool_input_schema_type_default_str")]
     pub r#type: String, // &'static str = "object"
 }
 


### PR DESCRIPTION
Fix the issue #7416 that the codex-cli produce an error "MCP startup failure on missing 'type' field" in the startup.

- Cause: serde in `convert_to_rmcp` (`codex-rs/rmcp-client/src/utils.rs`) failed because no `r#type` value was provided
- Fix: set a default `r#type` value in the corresponding structs
