### PR TITLE
fix: nix build missing rmcp output hash

### DIFF
--- a/codex-rs/default.nix
+++ b/codex-rs/default.nix
@@ -22,6 +22,7 @@ rustPlatform.buildRustPackage (_: {
   cargoLock.outputHashes = {
     "ratatui-0.29.0" = "sha256-HBvT5c8GsiCxMffNjJGLmHnvG77A6cqEL+1ARurBXho=";
     "crossterm-0.28.1" = "sha256-6qCtfSMuXACKFb9ATID39XyFDIEMFDmbx6SSmNe+728=";
+    "rmcp-0.9.0" = "sha256-0iPrpf0Ha/facO3p5e0hUKHBqGp/iS+C+OdS+pRKMOU=";
   };
 
   meta = with lib; {


### PR DESCRIPTION
Output hash for `rmcp-0.9.0` was missing from the nix package, (i.e. `error: No hash was found while vendoring the git dependency rmcp-0.9.0.`) blocking the build.