### PR TITLE
feat: add warning message for the model

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1036,6 +1036,10 @@ impl Session {
     }
 
     pub(crate) async fn record_model_warning(&self, message: impl Into<String>) {
+        if !self.enabled(Feature::ModelWarnings) {
+            return;
+        }
+
         let item = ResponseItem::Message {
             id: None,
             role: "user".to_string(),

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1035,6 +1035,19 @@ impl Session {
         state.record_items(items.iter(), turn_context.truncation_policy);
     }
 
+    pub(crate) async fn record_model_warning(&self, message: impl Into<String>) {
+        let item = ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: format!("Warning: {}", message.into()),
+            }],
+        };
+
+        let mut state = self.state.lock().await;
+        state.record_items([item].iter(), TruncationPolicy::no_truncation());
+    }
+
     pub(crate) async fn replace_history(&self, items: Vec<ResponseItem>) {
         let mut state = self.state.lock().await;
         state.replace_history(items);
@@ -2785,6 +2798,32 @@ mod tests {
         });
 
         (session, turn_context, rx_event)
+    }
+
+    #[tokio::test]
+    async fn record_model_warning_appends_user_message() {
+        let (session, _turn_context) = make_session_and_context();
+
+        session
+            .record_model_warning("too many unified exec sessions")
+            .await;
+
+        let mut history = session.clone_history().await;
+        let history_items = history.get_history();
+        let last = history_items.last().expect("warning recorded");
+
+        match last {
+            ResponseItem::Message { role, content, .. } => {
+                assert_eq!(role, "user");
+                assert_eq!(
+                    content,
+                    &vec![ContentItem::InputText {
+                        text: "Warning: too many unified exec sessions".to_string(),
+                    }]
+                );
+            }
+            other => panic!("expected user message, got {other:?}"),
+        }
     }
 
     #[derive(Clone, Copy)]

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2809,6 +2809,14 @@ mod tests {
         let (session, _turn_context) = make_session_and_context();
 
         session
+            .state
+            .lock()
+            .await
+            .session_configuration
+            .features
+            .enable(Feature::ModelWarnings);
+
+        session
             .record_model_warning("too many unified exec sessions")
             .await;
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1036,7 +1036,7 @@ impl Session {
     }
 
     pub(crate) async fn record_model_warning(&self, message: impl Into<String>) {
-        if !self.enabled(Feature::ModelWarnings) {
+        if !self.enabled(Feature::ModelWarnings).await {
             return;
         }
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2816,7 +2816,7 @@ mod tests {
             .enable(Feature::ModelWarnings);
 
         session
-            .record_model_warning("too many unified exec sessions", turn_context)
+            .record_model_warning("too many unified exec sessions", &turn_context)
             .await;
 
         let mut history = session.clone_history().await;

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -51,6 +51,8 @@ pub enum Feature {
     ShellTool,
     /// Allow model to call multiple tools in parallel (only for models supporting it).
     ParallelToolCalls,
+    /// Send warnings to the model to correct it on the tool usage.
+    ModelWarnings,
 }
 
 impl Feature {
@@ -265,6 +267,12 @@ pub const FEATURES: &[FeatureSpec] = &[
         stage: Stage::Stable,
         default_enabled: true,
     },
+    FeatureSpec {
+        id: Feature::ShellTool,
+        key: "shell_tool",
+        stage: Stage::Stable,
+        default_enabled: true,
+    },
     // Unstable features.
     FeatureSpec {
         id: Feature::UnifiedExec,
@@ -321,9 +329,9 @@ pub const FEATURES: &[FeatureSpec] = &[
         default_enabled: false,
     },
     FeatureSpec {
-        id: Feature::ShellTool,
-        key: "shell_tool",
-        stage: Stage::Stable,
-        default_enabled: true,
+        id: Feature::ModelWarnings,
+        key: "warnings",
+        stage: Stage::Experimental,
+        default_enabled: false,
     },
 ];

--- a/codex-rs/core/src/truncate.rs
+++ b/codex-rs/core/src/truncate.rs
@@ -72,10 +72,6 @@ impl TruncationPolicy {
             TruncationPolicy::Tokens(tokens) => approx_bytes_for_tokens(*tokens),
         }
     }
-
-    pub fn no_truncation() -> Self {
-        TruncationPolicy::Tokens(999_999)
-    }
 }
 
 pub(crate) fn formatted_truncate_text(content: &str, policy: TruncationPolicy) -> String {

--- a/codex-rs/core/src/truncate.rs
+++ b/codex-rs/core/src/truncate.rs
@@ -72,6 +72,10 @@ impl TruncationPolicy {
             TruncationPolicy::Tokens(tokens) => approx_bytes_for_tokens(*tokens),
         }
     }
+
+    pub fn no_truncation() -> Self {
+        TruncationPolicy::Tokens(999_999)
+    }
 }
 
 pub(crate) fn formatted_truncate_text(content: &str, policy: TruncationPolicy) -> String {

--- a/codex-rs/core/src/unified_exec/mod.rs
+++ b/codex-rs/core/src/unified_exec/mod.rs
@@ -48,6 +48,9 @@ pub(crate) const UNIFIED_EXEC_OUTPUT_MAX_BYTES: usize = 1024 * 1024; // 1 MiB
 pub(crate) const UNIFIED_EXEC_OUTPUT_MAX_TOKENS: usize = UNIFIED_EXEC_OUTPUT_MAX_BYTES / 4;
 pub(crate) const MAX_UNIFIED_EXEC_SESSIONS: usize = 64;
 
+// Send a warning message to the models when it reaches this number of sessions.
+pub(crate) const WARNING_UNIFIED_EXEC_SESSIONS: usize = 60;
+
 pub(crate) struct UnifiedExecContext {
     pub session: Arc<Session>,
     pub turn: Arc<TurnContext>,

--- a/codex-rs/core/src/unified_exec/session_manager.rs
+++ b/codex-rs/core/src/unified_exec/session_manager.rs
@@ -41,6 +41,7 @@ use super::UnifiedExecContext;
 use super::UnifiedExecError;
 use super::UnifiedExecResponse;
 use super::UnifiedExecSessionManager;
+use super::WARNING_UNIFIED_EXEC_SESSIONS;
 use super::WriteStdinRequest;
 use super::clamp_yield_time;
 use super::generate_chunk_id;
@@ -421,9 +422,21 @@ impl UnifiedExecSessionManager {
             started_at,
             last_used: started_at,
         };
-        let mut store = self.session_store.lock().await;
-        Self::prune_sessions_if_needed(&mut store);
-        store.sessions.insert(process_id, entry);
+        let number_sessions = {
+            let mut store = self.session_store.lock().await;
+            Self::prune_sessions_if_needed(&mut store);
+            store.sessions.insert(process_id, entry);
+            store.sessions.len()
+        };
+
+        if number_sessions >= WARNING_UNIFIED_EXEC_SESSIONS {
+            context
+                .session
+                .record_model_warning(
+                    format!("The maximum number of unified exec sessions you can keep open is {WARNING_UNIFIED_EXEC_SESSIONS} and you currently have {number_sessions} sessions open. Re-use older sessions or close them to prevent automatic pruning of old session"),
+                )
+                .await;
+        };
     }
 
     async fn emit_exec_end_from_entry(
@@ -633,9 +646,9 @@ impl UnifiedExecSessionManager {
         collected
     }
 
-    fn prune_sessions_if_needed(store: &mut SessionStore) {
+    fn prune_sessions_if_needed(store: &mut SessionStore) -> bool {
         if store.sessions.len() < MAX_UNIFIED_EXEC_SESSIONS {
-            return;
+            return false;
         }
 
         let meta: Vec<(String, Instant, bool)> = store
@@ -646,7 +659,10 @@ impl UnifiedExecSessionManager {
 
         if let Some(session_id) = Self::session_id_to_prune_from_meta(&meta) {
             store.remove(&session_id);
+            return true;
         }
+
+        false
     }
 
     // Centralized pruning policy so we can easily swap strategies later.

--- a/codex-rs/core/src/unified_exec/session_manager.rs
+++ b/codex-rs/core/src/unified_exec/session_manager.rs
@@ -434,6 +434,7 @@ impl UnifiedExecSessionManager {
                 .session
                 .record_model_warning(
                     format!("The maximum number of unified exec sessions you can keep open is {WARNING_UNIFIED_EXEC_SESSIONS} and you currently have {number_sessions} sessions open. Reuse older sessions or close them to prevent automatic pruning of old session"),
+                    &context.turn
                 )
                 .await;
         };

--- a/codex-rs/core/src/unified_exec/session_manager.rs
+++ b/codex-rs/core/src/unified_exec/session_manager.rs
@@ -433,7 +433,7 @@ impl UnifiedExecSessionManager {
             context
                 .session
                 .record_model_warning(
-                    format!("The maximum number of unified exec sessions you can keep open is {WARNING_UNIFIED_EXEC_SESSIONS} and you currently have {number_sessions} sessions open. Re-use older sessions or close them to prevent automatic pruning of old session"),
+                    format!("The maximum number of unified exec sessions you can keep open is {WARNING_UNIFIED_EXEC_SESSIONS} and you currently have {number_sessions} sessions open. Reuse older sessions or close them to prevent automatic pruning of old session"),
                 )
                 .await;
         };


### PR DESCRIPTION
Add a warning message as a user turn to the model if the model does not behave as expected (here, for example, if the model opens too many `unified_exec` sessions)