### PR TITLE
fix: wrap long exec lines in transcript overlay

### DIFF
--- a/codex-rs/tui/src/exec_cell/render.rs
+++ b/codex-rs/tui/src/exec_cell/render.rs
@@ -219,7 +219,12 @@ impl HistoryCell for ExecCell {
 
             if let Some(output) = call.output.as_ref() {
                 if !call.is_unified_exec_interaction() {
-                    lines.extend(output.formatted_output.lines().map(ansi_escape_line));
+                    let wrap_width = width.max(1) as usize;
+                    let wrap_opts = RtOptions::new(wrap_width);
+                    for unwrapped in output.formatted_output.lines().map(ansi_escape_line) {
+                        let wrapped = word_wrap_line(&unwrapped, wrap_opts.clone());
+                        push_owned_lines(&wrapped, &mut lines);
+                    }
                 }
                 let duration = call
                     .duration


### PR DESCRIPTION
What
-----
- Fix the Ctrl+T transcript overlay so that very long exec output lines are soft‑wrapped to the viewport width instead of being rendered as a single truncated row.
- Add a regression test to `TranscriptOverlay` to ensure long exec outputs are rendered on multiple lines in the overlay.

Why
----
- Previously, the transcript overlay rendered extremely long single exec lines as one on‑screen row and simply cut them off at the right edge, with no horizontal scrolling.
- This made it impossible to inspect the full content of long tool/exec outputs in the transcript view, even though the main TUI view already wrapped those lines.
- Fixes #7454.

How
----
- Update `ExecCell::transcript_lines` to wrap exec output lines using the existing `RtOptions`/`word_wrap_line` helpers so that transcript rendering is width‑aware.
- Reuse the existing line utilities to expand the wrapped `Line` values into the transcript overlay, preserving styling while respecting the current viewport width.
- Add `transcript_overlay_wraps_long_exec_output_lines` test in `pager_overlay.rs` that constructs a long single‑line exec output, renders the transcript overlay into a small buffer, and asserts that the long marker string spans multiple rendered lines.