### PR TITLE
fix(unified_exec): use platform default shell when unified_exec shell…

### DIFF
--- a/codex-rs/core/src/tools/handlers/unified_exec.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec.rs
@@ -6,6 +6,7 @@ use crate::protocol::EventMsg;
 use crate::protocol::ExecCommandOutputDeltaEvent;
 use crate::protocol::ExecCommandSource;
 use crate::protocol::ExecOutputStream;
+use crate::shell::default_user_shell;
 use crate::shell::get_shell_by_model_provided_path;
 use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolOutput;
@@ -30,8 +31,8 @@ struct ExecCommandArgs {
     cmd: String,
     #[serde(default)]
     workdir: Option<String>,
-    #[serde(default = "default_shell")]
-    shell: String,
+    #[serde(default)]
+    shell: Option<String>,
     #[serde(default = "default_login")]
     login: bool,
     #[serde(default = "default_exec_yield_time_ms")]
@@ -62,10 +63,6 @@ fn default_exec_yield_time_ms() -> u64 {
 
 fn default_write_stdin_yield_time_ms() -> u64 {
     250
-}
-
-fn default_shell() -> String {
-    "/bin/bash".to_string()
 }
 
 fn default_login() -> bool {
@@ -241,7 +238,12 @@ impl ToolHandler for UnifiedExecHandler {
 }
 
 fn get_command(args: &ExecCommandArgs) -> Vec<String> {
-    let shell = get_shell_by_model_provided_path(&PathBuf::from(args.shell.clone()));
+    let shell = if let Some(shell_str) = &args.shell {
+        get_shell_by_model_provided_path(&PathBuf::from(shell_str))
+    } else {
+        default_user_shell()
+    };
+
     shell.derive_exec_args(&args.cmd, args.login)
 }
 
@@ -272,4 +274,66 @@ fn format_response(response: &UnifiedExecResponse) -> String {
     sections.push(response.output.clone());
 
     sections.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_command_uses_default_shell_when_unspecified() {
+        let json = r#"{"cmd": "echo hello"}"#;
+
+        let args: ExecCommandArgs =
+            serde_json::from_str(json).expect("deserialize ExecCommandArgs");
+
+        assert!(args.shell.is_none());
+
+        let command = get_command(&args);
+
+        assert_eq!(command.len(), 3);
+        assert_eq!(command[2], "echo hello");
+    }
+
+    #[test]
+    fn test_get_command_respects_explicit_bash_shell() {
+        let json = r#"{"cmd": "echo hello", "shell": "/bin/bash"}"#;
+
+        let args: ExecCommandArgs =
+            serde_json::from_str(json).expect("deserialize ExecCommandArgs");
+
+        assert_eq!(args.shell.as_deref(), Some("/bin/bash"));
+
+        let command = get_command(&args);
+
+        assert_eq!(command[2], "echo hello");
+    }
+
+    #[test]
+    fn test_get_command_respects_explicit_powershell_shell() {
+        let json = r#"{"cmd": "echo hello", "shell": "powershell"}"#;
+
+        let args: ExecCommandArgs =
+            serde_json::from_str(json).expect("deserialize ExecCommandArgs");
+
+        assert_eq!(args.shell.as_deref(), Some("powershell"));
+
+        let command = get_command(&args);
+
+        assert_eq!(command[2], "echo hello");
+    }
+
+    #[test]
+    fn test_get_command_respects_explicit_cmd_shell() {
+        let json = r#"{"cmd": "echo hello", "shell": "cmd"}"#;
+
+        let args: ExecCommandArgs =
+            serde_json::from_str(json).expect("deserialize ExecCommandArgs");
+
+        assert_eq!(args.shell.as_deref(), Some("cmd"));
+
+        let command = get_command(&args);
+
+        assert_eq!(command[2], "echo hello");
+    }
 }

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -1,4 +1,4 @@
-// #![cfg(not(target_os = "windows"))]
+#![cfg(not(target_os = "windows"))]
 use std::collections::HashMap;
 use std::sync::OnceLock;
 


### PR DESCRIPTION
# Unified Exec Shell Selection on Windows

## Problem

reference issue #7466

The `unified_exec` handler currently deserializes model-provided tool calls into the `ExecCommandArgs` struct:

```rust
#[derive(Debug, Deserialize)]
struct ExecCommandArgs {
    cmd: String,
    #[serde(default)]
    workdir: Option<String>,
    #[serde(default = "default_shell")]
    shell: String,
    #[serde(default = "default_login")]
    login: bool,
    #[serde(default = "default_exec_yield_time_ms")]
    yield_time_ms: u64,
    #[serde(default)]
    max_output_tokens: Option<usize>,
    #[serde(default)]
    with_escalated_permissions: Option<bool>,
    #[serde(default)]
    justification: Option<String>,
}
```

The `shell` field uses a hard-coded default:

```rust
fn default_shell() -> String {
    "/bin/bash".to_string()
}
```

When the model returns a tool call JSON that only contains `cmd` (which is the common case), Serde fills in `shell` with this default value. Later, `get_command` uses that value as if it were a model-provided shell path:

```rust
fn get_command(args: &ExecCommandArgs) -> Vec<String> {
    let shell = get_shell_by_model_provided_path(&PathBuf::from(args.shell.clone()));
    shell.derive_exec_args(&args.cmd, args.login)
}
```

On Unix, this usually resolves to `/bin/bash` and works as expected. However, on Windows this behavior is problematic:

- The hard-coded `"/bin/bash"` is not a valid Windows path.
- `get_shell_by_model_provided_path` treats this as a model-specified shell, and tries to resolve it (e.g. via `which::which("bash")`), which may or may not exist and may not behave as intended.
- In practice, this leads to commands being executed under a non-default or non-existent shell on Windows (for example, WSL bash), instead of the expected Windows PowerShell or `cmd.exe`.

The core of the issue is that **"model did not specify `shell`" is currently interpreted as "the model explicitly requested `/bin/bash`"**, which is both Unix-specific and wrong on Windows.

## Proposed Solution

Instead of hard-coding `"/bin/bash"` into `ExecCommandArgs`, we should distinguish between:

1. **The model explicitly specifying a shell**, e.g.:

   ```json
   {
     "cmd": "echo hello",
     "shell": "pwsh"
   }
   ```

   In this case, we *do* want to respect the model’s choice and use `get_shell_by_model_provided_path`.

2. **The model omitting the `shell` field entirely**, e.g.:

   ```json
   {
     "cmd": "echo hello"
   }
   ```

   In this case, we should *not* assume `/bin/bash`. Instead, we should use `default_user_shell()` and let the platform decide.

To express this distinction, we can:

1. Change `shell` to be optional in `ExecCommandArgs`:

   ```rust
   #[derive(Debug, Deserialize)]
   struct ExecCommandArgs {
       cmd: String,
       #[serde(default)]
       workdir: Option<String>,
       #[serde(default)]
       shell: Option<String>,
       #[serde(default = "default_login")]
       login: bool,
       #[serde(default = "default_exec_yield_time_ms")]
       yield_time_ms: u64,
       #[serde(default)]
       max_output_tokens: Option<usize>,
       #[serde(default)]
       with_escalated_permissions: Option<bool>,
       #[serde(default)]
       justification: Option<String>,
   }
   ```

   Here, the absence of `shell` in the JSON is represented as `shell: None`, rather than a hard-coded string value.