### PR TITLE
fix: add ts number annotations for app-server v2 types

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/mappers.rs
+++ b/codex-rs/app-server-protocol/src/protocol/mappers.rs
@@ -5,7 +5,9 @@ impl From<v1::ExecOneOffCommandParams> for v2::CommandExecParams {
     fn from(value: v1::ExecOneOffCommandParams) -> Self {
         Self {
             command: value.command,
-            timeout_ms: value.timeout_ms,
+            timeout_ms: value
+                .timeout_ms
+                .map(|timeout| i64::try_from(timeout).unwrap_or(60_000)),
             cwd: value.cwd,
             sandbox_policy: value.sandbox_policy.map(std::convert::Into::into),
         }

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -638,7 +638,7 @@ pub struct FeedbackUploadResponse {
 pub struct CommandExecParams {
     pub command: Vec<String>,
     #[ts(type = "number | null")]
-    pub timeout_ms: Option<u64>,
+    pub timeout_ms: Option<i64>,
     pub cwd: Option<PathBuf>,
     pub sandbox_policy: Option<SandboxPolicy>,
 }

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -637,6 +637,7 @@ pub struct FeedbackUploadResponse {
 #[ts(export_to = "v2/")]
 pub struct CommandExecParams {
     pub command: Vec<String>,
+    #[ts(type = "number | null")]
     pub timeout_ms: Option<u64>,
     pub cwd: Option<PathBuf>,
     pub sandbox_policy: Option<SandboxPolicy>,
@@ -785,6 +786,7 @@ pub struct Thread {
     /// Model provider used for this thread (for example, 'openai').
     pub model_provider: String,
     /// Unix timestamp (in seconds) when the thread was created.
+    #[ts(type = "number")]
     pub created_at: i64,
     /// [UNSTABLE] Path to the thread on disk.
     pub path: PathBuf,
@@ -1072,6 +1074,7 @@ pub enum ThreadItem {
         /// The command's exit code.
         exit_code: Option<i32>,
         /// The duration of the command execution in milliseconds.
+        #[ts(type = "number | null")]
         duration_ms: Option<i64>,
     },
     #[serde(rename_all = "camelCase")]
@@ -1338,6 +1341,7 @@ pub struct ReasoningSummaryTextDeltaNotification {
     pub turn_id: String,
     pub item_id: String,
     pub delta: String,
+    #[ts(type = "number")]
     pub summary_index: i64,
 }
 
@@ -1348,6 +1352,7 @@ pub struct ReasoningSummaryPartAddedNotification {
     pub thread_id: String,
     pub turn_id: String,
     pub item_id: String,
+    #[ts(type = "number")]
     pub summary_index: i64,
 }
 
@@ -1359,6 +1364,7 @@ pub struct ReasoningTextDeltaNotification {
     pub turn_id: String,
     pub item_id: String,
     pub delta: String,
+    #[ts(type = "number")]
     pub content_index: i64,
 }
 
@@ -1493,7 +1499,9 @@ impl From<CoreRateLimitSnapshot> for RateLimitSnapshot {
 #[ts(export_to = "v2/")]
 pub struct RateLimitWindow {
     pub used_percent: i32,
+    #[ts(type = "number | null")]
     pub window_duration_mins: Option<i64>,
+    #[ts(type = "number | null")]
     pub resets_at: Option<i64>,
 }
 

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1152,7 +1152,9 @@ impl CodexMessageProcessor {
 
         let cwd = params.cwd.unwrap_or_else(|| self.config.cwd.clone());
         let env = create_env(&self.config.shell_environment_policy);
-        let timeout_ms = params.timeout_ms;
+        let timeout_ms = params
+            .timeout_ms
+            .and_then(|timeout_ms| u64::try_from(timeout_ms).ok());
         let exec_params = ExecParams {
             command: params.command,
             cwd,


### PR DESCRIPTION
These will be more ergonomic to work with in Typescript.