### PR TITLE
chore: make create_approval_requirement_for_command an async fn

### DIFF
--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -115,7 +115,7 @@ fn evaluate_with_policy(
     }
 }
 
-pub(crate) fn create_approval_requirement_for_command(
+pub(crate) async fn create_approval_requirement_for_command(
     policy: &Policy,
     command: &[String],
     approval_policy: AskForApproval,
@@ -296,8 +296,8 @@ prefix_rule(pattern=["rm"], decision="forbidden")
         );
     }
 
-    #[test]
-    fn approval_requirement_prefers_execpolicy_match() {
+    #[tokio::test]
+    async fn approval_requirement_prefers_execpolicy_match() {
         let policy_src = r#"prefix_rule(pattern=["rm"], decision="prompt")"#;
         let mut parser = PolicyParser::new();
         parser
@@ -312,7 +312,8 @@ prefix_rule(pattern=["rm"], decision="forbidden")
             AskForApproval::OnRequest,
             &SandboxPolicy::DangerFullAccess,
             SandboxPermissions::UseDefault,
-        );
+        )
+        .await;
 
         assert_eq!(
             requirement,
@@ -322,8 +323,8 @@ prefix_rule(pattern=["rm"], decision="forbidden")
         );
     }
 
-    #[test]
-    fn approval_requirement_respects_approval_policy() {
+    #[tokio::test]
+    async fn approval_requirement_respects_approval_policy() {
         let policy_src = r#"prefix_rule(pattern=["rm"], decision="prompt")"#;
         let mut parser = PolicyParser::new();
         parser
@@ -338,7 +339,8 @@ prefix_rule(pattern=["rm"], decision="forbidden")
             AskForApproval::Never,
             &SandboxPolicy::DangerFullAccess,
             SandboxPermissions::UseDefault,
-        );
+        )
+        .await;
 
         assert_eq!(
             requirement,
@@ -348,8 +350,8 @@ prefix_rule(pattern=["rm"], decision="forbidden")
         );
     }
 
-    #[test]
-    fn approval_requirement_falls_back_to_heuristics() {
+    #[tokio::test]
+    async fn approval_requirement_falls_back_to_heuristics() {
         let command = vec!["python".to_string()];
 
         let empty_policy = Policy::empty();
@@ -359,7 +361,8 @@ prefix_rule(pattern=["rm"], decision="forbidden")
             AskForApproval::UnlessTrusted,
             &SandboxPolicy::ReadOnly,
             SandboxPermissions::UseDefault,
-        );
+        )
+        .await;
 
         assert_eq!(
             requirement,

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -231,6 +231,15 @@ impl ShellHandler {
         let event_ctx = ToolEventCtx::new(session.as_ref(), turn.as_ref(), &call_id, None);
         emitter.begin(event_ctx).await;
 
+        let approval_requirement = create_approval_requirement_for_command(
+            &turn.exec_policy,
+            &exec_params.command,
+            turn.approval_policy,
+            &turn.sandbox_policy,
+            SandboxPermissions::from(exec_params.with_escalated_permissions.unwrap_or(false)),
+        )
+        .await;
+
         let req = ShellRequest {
             command: exec_params.command.clone(),
             cwd: exec_params.cwd.clone(),
@@ -238,13 +247,7 @@ impl ShellHandler {
             env: exec_params.env.clone(),
             with_escalated_permissions: exec_params.with_escalated_permissions,
             justification: exec_params.justification.clone(),
-            approval_requirement: create_approval_requirement_for_command(
-                &turn.exec_policy,
-                &exec_params.command,
-                turn.approval_policy,
-                &turn.sandbox_policy,
-                SandboxPermissions::from(exec_params.with_escalated_permissions.unwrap_or(false)),
-            ),
+            approval_requirement,
         };
         let mut orchestrator = ToolOrchestrator::new();
         let mut runtime = ShellRuntime::new();

--- a/codex-rs/core/src/unified_exec/session_manager.rs
+++ b/codex-rs/core/src/unified_exec/session_manager.rs
@@ -554,19 +554,21 @@ impl UnifiedExecSessionManager {
         let env = apply_unified_exec_env(create_env(&context.turn.shell_environment_policy));
         let mut orchestrator = ToolOrchestrator::new();
         let mut runtime = UnifiedExecRuntime::new(self);
+        let approval_requirement = create_approval_requirement_for_command(
+            &context.turn.exec_policy,
+            command,
+            context.turn.approval_policy,
+            &context.turn.sandbox_policy,
+            SandboxPermissions::from(with_escalated_permissions.unwrap_or(false)),
+        )
+        .await;
         let req = UnifiedExecToolRequest::new(
             command.to_vec(),
             cwd,
             env,
             with_escalated_permissions,
             justification,
-            create_approval_requirement_for_command(
-                &context.turn.exec_policy,
-                command,
-                context.turn.approval_policy,
-                &context.turn.sandbox_policy,
-                SandboxPermissions::from(with_escalated_permissions.unwrap_or(false)),
-            ),
+            approval_requirement,
         );
         let tool_ctx = ToolCtx {
             session: context.session.as_ref(),


### PR DESCRIPTION
I think this might help with https://github.com/openai/codex/pull/7033 because `create_approval_requirement_for_command()` will soon need access to `Session.state`, which is a `tokio::sync::Mutex` that needs to be accessed via `async`.