### PR TITLE
[app-server] feat: add old_content and new_content to FileChange updates

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1146,7 +1146,11 @@ pub struct FileUpdateChange {
 pub enum PatchChangeKind {
     Add,
     Delete,
-    Update { move_path: Option<PathBuf> },
+    Update {
+        move_path: Option<PathBuf>,
+        old_content: String,
+        new_content: String,
+    },
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -968,8 +968,15 @@ fn map_patch_change_kind(change: &CoreFileChange) -> V2PatchChangeKind {
     match change {
         CoreFileChange::Add { .. } => V2PatchChangeKind::Add,
         CoreFileChange::Delete { .. } => V2PatchChangeKind::Delete,
-        CoreFileChange::Update { move_path, .. } => V2PatchChangeKind::Update {
+        CoreFileChange::Update {
+            move_path,
+            old_content,
+            new_content,
+            ..
+        } => V2PatchChangeKind::Update {
             move_path: move_path.clone(),
+            old_content: old_content.clone(),
+            new_content: new_content.clone(),
         },
     }
 }
@@ -981,6 +988,7 @@ fn format_file_change_diff(change: &CoreFileChange) -> String {
         CoreFileChange::Update {
             unified_diff,
             move_path,
+            ..
         } => {
             if let Some(path) = move_path {
                 format!("{unified_diff}\n\nMoved to: {}", path.display())

--- a/codex-rs/apply-patch/src/lib.rs
+++ b/codex-rs/apply-patch/src/lib.rs
@@ -194,6 +194,8 @@ pub enum ApplyPatchFileChange {
         move_path: Option<PathBuf>,
         /// new_content that will result after the unified_diff is applied.
         new_content: String,
+        /// original content before the diff was applied.
+        old_content: String,
     },
 }
 
@@ -329,6 +331,7 @@ pub fn maybe_parse_apply_patch_verified(argv: &[String], cwd: &Path) -> MaybeApp
                         let ApplyPatchFileUpdate {
                             unified_diff,
                             content: contents,
+                            old_content,
                         } = match unified_diff_from_chunks(&path, &chunks) {
                             Ok(diff) => diff,
                             Err(e) => {
@@ -341,6 +344,7 @@ pub fn maybe_parse_apply_patch_verified(argv: &[String], cwd: &Path) -> MaybeApp
                                 unified_diff,
                                 move_path: move_path.map(|p| effective_cwd.join(p)),
                                 new_content: contents,
+                                old_content,
                             },
                         );
                     }
@@ -846,6 +850,7 @@ fn apply_replacements(
 pub struct ApplyPatchFileUpdate {
     unified_diff: String,
     content: String,
+    old_content: String,
 }
 
 pub fn unified_diff_from_chunks(
@@ -869,6 +874,7 @@ pub fn unified_diff_from_chunks_with_context(
     Ok(ApplyPatchFileUpdate {
         unified_diff,
         content: new_contents,
+        old_content: original_contents,
     })
 }
 
@@ -1467,6 +1473,7 @@ PATCH"#,
         let expected = ApplyPatchFileUpdate {
             unified_diff: expected_diff.to_string(),
             content: "foo\nBAR\nbaz\nQUX\n".to_string(),
+            old_content: "foo\nbar\nbaz\nqux\n".to_string(),
         };
         assert_eq!(expected, diff);
     }
@@ -1503,6 +1510,7 @@ PATCH"#,
         let expected = ApplyPatchFileUpdate {
             unified_diff: expected_diff.to_string(),
             content: "FOO\nbar\nbaz\n".to_string(),
+            old_content: "foo\nbar\nbaz\n".to_string(),
         };
         assert_eq!(expected, diff);
     }
@@ -1540,6 +1548,7 @@ PATCH"#,
         let expected = ApplyPatchFileUpdate {
             unified_diff: expected_diff.to_string(),
             content: "foo\nbar\nBAZ\n".to_string(),
+            old_content: "foo\nbar\nbaz\n".to_string(),
         };
         assert_eq!(expected, diff);
     }
@@ -1574,6 +1583,7 @@ PATCH"#,
         let expected = ApplyPatchFileUpdate {
             unified_diff: expected_diff.to_string(),
             content: "foo\nbar\nbaz\nquux\n".to_string(),
+            old_content: "foo\nbar\nbaz\n".to_string(),
         };
         assert_eq!(expected, diff);
     }
@@ -1629,6 +1639,7 @@ PATCH"#,
         let expected = ApplyPatchFileUpdate {
             unified_diff: expected_diff.to_string(),
             content: "a\nB\nc\nd\nE\nf\ng\n".to_string(),
+            old_content: "a\nb\nc\nd\ne\nf\n".to_string(),
         };
 
         assert_eq!(expected, diff);
@@ -1688,6 +1699,7 @@ g
                         .to_string(),
                         move_path: None,
                         new_content: "updated session directory content\n".to_string(),
+                        old_content: "session directory content\n".to_string(),
                     },
                 )]),
                 patch: argv[1].clone(),

--- a/codex-rs/core/src/apply_patch.rs
+++ b/codex-rs/core/src/apply_patch.rs
@@ -105,10 +105,13 @@ pub(crate) fn convert_apply_patch_to_protocol(
             ApplyPatchFileChange::Update {
                 unified_diff,
                 move_path,
-                new_content: _new_content,
+                new_content,
+                old_content,
             } => FileChange::Update {
                 unified_diff: unified_diff.clone(),
                 move_path: move_path.clone(),
+                old_content: old_content.clone(),
+                new_content: new_content.clone(),
             },
         };
         result.insert(path.clone(), protocol_change);

--- a/codex-rs/core/src/turn_diff_tracker.rs
+++ b/codex-rs/core/src/turn_diff_tracker.rs
@@ -545,6 +545,8 @@ index {ZERO_OID}..{right_oid}
             FileChange::Update {
                 unified_diff: "".to_owned(),
                 move_path: None,
+                old_content: "foo\n".to_owned(),
+                new_content: "foo\nbar\n".to_owned(),
             },
         )]);
         acc.on_patch_begin(&update_changes);
@@ -620,6 +622,8 @@ index {left_oid}..{ZERO_OID}
             FileChange::Update {
                 unified_diff: "".to_owned(),
                 move_path: Some(dest.clone()),
+                old_content: "line\n".to_owned(),
+                new_content: "line2\n".to_owned(),
             },
         )]);
         acc.on_patch_begin(&mv_changes);
@@ -660,6 +664,8 @@ index {left_oid}..{right_oid}
             FileChange::Update {
                 unified_diff: "".to_owned(),
                 move_path: Some(dest.clone()),
+                old_content: "same\n".to_owned(),
+                new_content: "same\n".to_owned(),
             },
         )]);
         acc.on_patch_begin(&mv_changes);
@@ -682,6 +688,8 @@ index {left_oid}..{right_oid}
             FileChange::Update {
                 unified_diff: "".into(),
                 move_path: Some(dest.clone()),
+                old_content: String::new(),
+                new_content: "hello\n".to_owned(),
             },
         )]);
         acc.on_patch_begin(&mv);
@@ -722,6 +730,8 @@ index {ZERO_OID}..{right_oid}
             FileChange::Update {
                 unified_diff: "".to_owned(),
                 move_path: None,
+                old_content: "foo\n".to_owned(),
+                new_content: "foo\nbar\n".to_owned(),
             },
         )]);
         acc.on_patch_begin(&update_a);
@@ -802,6 +812,8 @@ index {left_oid_b}..{ZERO_OID}
             FileChange::Update {
                 unified_diff: "".to_owned(),
                 move_path: None,
+                old_content: String::new(),
+                new_content: String::new(),
             },
         )]);
         acc.on_patch_begin(&update_changes);
@@ -868,6 +880,8 @@ index {ZERO_OID}..{right_oid}
             FileChange::Update {
                 unified_diff: "".to_owned(),
                 move_path: None,
+                old_content: "foo\n".to_owned(),
+                new_content: "foo\nbar\n".to_owned(),
             },
         )]);
         acc.on_patch_begin(&update_changes);

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -406,6 +406,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
                         FileChange::Update {
                             unified_diff,
                             move_path,
+                            ..
                         } => {
                             let header = if let Some(dest) = move_path {
                                 format!(

--- a/codex-rs/exec/tests/event_processor_with_json_output.rs
+++ b/codex-rs/exec/tests/event_processor_with_json_output.rs
@@ -823,6 +823,8 @@ fn patch_apply_success_produces_item_completed_patchapply() {
         FileChange::Update {
             unified_diff: "--- c/modified.txt\n+++ c/modified.txt\n@@\n-old\n+new\n".to_string(),
             move_path: Some(PathBuf::from("c/renamed.txt")),
+            old_content: "-old\n".to_string(),
+            new_content: "+new\n".to_string(),
         },
     );
 
@@ -895,6 +897,8 @@ fn patch_apply_failure_produces_item_completed_patchapply_failed() {
         FileChange::Update {
             unified_diff: "--- file.txt\n+++ file.txt\n@@\n-old\n+new\n".to_string(),
             move_path: None,
+            old_content: "-old\n".to_string(),
+            new_content: "+new\n".to_string(),
         },
     );
 

--- a/codex-rs/mcp-server/tests/suite/codex_tool.rs
+++ b/codex-rs/mcp-server/tests/suite/codex_tool.rs
@@ -269,6 +269,8 @@ async fn patch_approval_triggers_elicitation() -> anyhow::Result<()> {
         FileChange::Update {
             unified_diff: "@@ -1 +1 @@\n-original content\n+modified content\n".to_string(),
             move_path: None,
+            old_content: "original content\n".to_string(),
+            new_content: "modified content\n".to_string(),
         },
     );
 

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -1653,6 +1653,8 @@ pub enum FileChange {
     Update {
         unified_diff: String,
         move_path: Option<PathBuf>,
+        old_content: String,
+        new_content: String,
     },
 }
 
@@ -1715,6 +1717,21 @@ mod tests {
         };
 
         assert!(event.as_legacy_events(false).is_empty());
+    }
+
+    #[test]
+    fn file_change_update_serializes_old_and_new_content() {
+        let change = FileChange::Update {
+            unified_diff: "--- a\n+++ b\n@@ -1 +1 @@\n-old\n+new\n".to_string(),
+            move_path: None,
+            old_content: "old\n".to_string(),
+            new_content: "new\n".to_string(),
+        };
+
+        let serialized = serde_json::to_value(change).expect("should serialize");
+
+        assert_eq!(serialized["old_content"], "old\n");
+        assert_eq!(serialized["new_content"], "new\n");
     }
 
     /// Serialize Event to verify that its JSON representation has the expected

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1560,6 +1560,8 @@ impl ChatWidget {
                                 FileChange::Update {
                                     unified_diff: "+test\n-test2".to_string(),
                                     move_path: None,
+                                    old_content: "test2".to_string(),
+                                    new_content: "test".to_string(),
                                 },
                             ),
                         ]),

--- a/codex-rs/tui/src/diff_render.rs
+++ b/codex-rs/tui/src/diff_render.rs
@@ -484,6 +484,8 @@ mod tests {
             FileChange::Update {
                 unified_diff: patch,
                 move_path: None,
+                old_content: original.to_string(),
+                new_content: modified.to_string(),
             },
         );
 
@@ -504,6 +506,8 @@ mod tests {
             FileChange::Update {
                 unified_diff: patch,
                 move_path: Some(PathBuf::from("new_name.rs")),
+                old_content: original.to_string(),
+                new_content: modified.to_string(),
             },
         );
 
@@ -524,6 +528,8 @@ mod tests {
             FileChange::Update {
                 unified_diff: patch_a,
                 move_path: None,
+                old_content: "one\n".to_string(),
+                new_content: "one changed\n".to_string(),
             },
         );
 
@@ -590,6 +596,8 @@ mod tests {
             FileChange::Update {
                 unified_diff: patch,
                 move_path: None,
+                old_content: original.to_string(),
+                new_content: modified.to_string(),
             },
         );
 
@@ -613,6 +621,8 @@ mod tests {
             FileChange::Update {
                 unified_diff: patch,
                 move_path: None,
+                old_content: original.to_string(),
+                new_content: modified.to_string(),
             },
         );
 
@@ -640,6 +650,8 @@ mod tests {
             FileChange::Update {
                 unified_diff: patch,
                 move_path: None,
+                old_content: original.clone(),
+                new_content: modified.clone(),
             },
         );
 
@@ -663,6 +675,8 @@ mod tests {
             FileChange::Update {
                 unified_diff: patch,
                 move_path: Some(abs_new),
+                old_content: original.to_string(),
+                new_content: modified.to_string(),
             },
         );
 

--- a/codex-rs/tui/src/diff_render.rs
+++ b/codex-rs/tui/src/diff_render.rs
@@ -650,8 +650,8 @@ mod tests {
             FileChange::Update {
                 unified_diff: patch,
                 move_path: None,
-                old_content: original.clone(),
-                new_content: modified.clone(),
+                old_content: original,
+                new_content: modified,
             },
         );
 


### PR DESCRIPTION
A partner building on top of app-server is interested in these fields (`old_content` and `new_content`) in addition to `unified_diff` which we already return. These fields are trivial to add since it's already available in the internals of `apply_patch` tool call handling. 

This is what it looks like in app-server API v2.

```
{
  "method": "item/started",
  "params": {
    "item": {
      "changes": [
        {
          "diff": "@@ -1 +1 @@\n-new line\n+updated line\n",
          "kind": {
            "move_path": null,
            "new_content": "updated line\n",
            "old_content": "new line\n",
            "type": "update"
          },
          "path": "/Users/owen/repos/codex/codex-rs/apply_patch_demo.txt"
        }
      ],
      "id": "call_YhJYOZMD5WYQAdQhDLX7S4pH",
      "status": "inProgress",
      "type": "fileChange"
    },
    "threadId": "019ae136-42a6-7430-a929-db97539e2cc9",
    "turnId": "3"
  }
}
```