### PR TITLE
feat: support --version flag for @openai/codex-shell-tool-mcp

### DIFF
--- a/codex-rs/exec-server/src/posix.rs
+++ b/codex-rs/exec-server/src/posix.rs
@@ -78,6 +78,7 @@ mod stopwatch;
 const CODEX_EXECVE_WRAPPER_EXE_NAME: &str = "codex-execve-wrapper";
 
 #[derive(Parser)]
+#[clap(version)]
 struct McpServerCli {
     /// Executable to delegate execve(2) calls to in Bash.
     #[arg(long = "execve")]


### PR DESCRIPTION
I find it helpful to easily verify which version is running.

Tested:

```shell
~/code/codex3/codex-rs/exec-server$ cargo run --bin codex-exec-mcp-server -- --help
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.19s
     Running `/Users/mbolin/code/codex3/codex-rs/target/debug/codex-exec-mcp-server --help`
Usage: codex-exec-mcp-server [OPTIONS]

Options:
      --execve <EXECVE_WRAPPER>  Executable to delegate execve(2) calls to in Bash
      --bash <BASH_PATH>         Path to Bash that has been patched to support execve() wrapping
  -h, --help                     Print help
  -V, --version                  Print version
~/code/codex3/codex-rs/exec-server$ cargo run --bin codex-exec-mcp-server -- --version
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.17s
     Running `/Users/mbolin/code/codex3/codex-rs/target/debug/codex-exec-mcp-server --version`
codex-exec-server 0.0.0
```