### PR TITLE
fix: inline function marked as dead code

### DIFF
--- a/codex-rs/core/src/rollout/list.rs
+++ b/codex-rs/core/src/rollout/list.rs
@@ -141,13 +141,6 @@ pub(crate) async fn get_conversations(
     Ok(result)
 }
 
-/// Load the full contents of a single conversation session file at `path`.
-/// Returns the entire file contents as a String.
-#[allow(dead_code)]
-pub(crate) async fn get_conversation(path: &Path) -> io::Result<String> {
-    tokio::fs::read_to_string(path).await
-}
-
 /// Load conversation file paths from disk using directory traversal.
 ///
 /// Directory layout: `~/.codex/sessions/YYYY/MM/DD/rollout-YYYY-MM-DDThh-mm-ss-<uuid>.jsonl`

--- a/codex-rs/core/src/rollout/tests.rs
+++ b/codex-rs/core/src/rollout/tests.rs
@@ -16,7 +16,6 @@ use crate::rollout::INTERACTIVE_SESSION_SOURCES;
 use crate::rollout::list::ConversationItem;
 use crate::rollout::list::ConversationsPage;
 use crate::rollout::list::Cursor;
-use crate::rollout::list::get_conversation;
 use crate::rollout::list::get_conversations;
 use anyhow::Result;
 use codex_protocol::ConversationId;
@@ -510,7 +509,7 @@ async fn test_get_conversation_contents() {
     .unwrap();
     let path = &page.items[0].path;
 
-    let content = get_conversation(path).await.unwrap();
+    let content = tokio::fs::read_to_string(path).await.unwrap();
 
     // Page equality (single item)
     let expected_path = home


### PR DESCRIPTION
I was debugging something else and noticed we could eliminate an instance of `#[allow(dead_code)]` pretty easily.