### PR TITLE
fix: thread/list returning fewer than the requested amount due to filtering CXA-293

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1894,6 +1894,9 @@ impl CodexMessageProcessor {
                 .as_ref()
                 .and_then(|cursor| serde_json::to_value(cursor).ok())
                 .and_then(|value| value.as_str().map(str::to_owned));
+            if remaining == 0 {
+                break;
+            }
 
             match page.next_cursor {
                 Some(cursor_val) if remaining > 0 => {

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1848,7 +1848,7 @@ impl CodexMessageProcessor {
 
         while remaining > 0 {
             let page_size = remaining.min(THREAD_LIST_MAX_LIMIT);
-            let page = match RolloutRecorder::list_conversations(
+            let page = RolloutRecorder::list_conversations(
                 &self.config.codex_home,
                 page_size,
                 cursor_obj.as_ref(),
@@ -1857,16 +1857,11 @@ impl CodexMessageProcessor {
                 fallback_provider.as_str(),
             )
             .await
-            {
-                Ok(p) => p,
-                Err(err) => {
-                    return Err(JSONRPCErrorError {
-                        code: INTERNAL_ERROR_CODE,
-                        message: format!("failed to list conversations: {err}"),
-                        data: None,
-                    });
-                }
-            };
+            .map_err(|err| JSONRPCErrorError {
+                code: INTERNAL_ERROR_CODE,
+                message: format!("failed to list conversations: {err}"),
+                data: None,
+            })?;
 
             let mut filtered = page
                 .items


### PR DESCRIPTION
This caused some conversations to not appear when they otherwise should.

Prior to this change, `thread/list`/`list_conversations_common` would:
- Fetch N conversations from `RolloutRecorder::list_conversations`
- Then it would filter those (like by the provided `model_providers`)
- This would make it potentially return less than N items.

With this change:
- `list_conversations_common` now continues fetching more conversations from `RolloutRecorder::list_conversations` until it "fills up" the `requested_page_size`.
- Ultimately this means that clients can rely on getting eg 20 conversations if they request 20 conversations.