### PR TITLE
fix(tui) Support image paste via alt+v from clipboard on native Windows

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1370,7 +1370,9 @@ impl ChatWidget {
                 modifiers,
                 kind: KeyEventKind::Press,
                 ..
-            } if modifiers.contains(KeyModifiers::CONTROL) && c.eq_ignore_ascii_case(&'v') => {
+            } if modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+                && c.eq_ignore_ascii_case(&'v') =>
+            {
                 match paste_image_to_temp_png() {
                     Ok((path, info)) => {
                         self.attach_image(


### PR DESCRIPTION
Closes #3404 

## Summary
On windows, ctrl+v does not work for the same reason that cmd+v does not work on macos. This PR adds alt/option+v detection, which allows windows users to paste images from the clipboard using.

We could swap between just ctrl on mac and just alt on windows, but this felt simpler - I don't feel strongly about it.

Note that this will NOT address image pasting in WSL environments, due to issues with WSL <> Windows clipboards. I'm planning to address that in a separate PR since it will likely warrant some discussion.

## Testing
- [x] Tested locally on a Mac and Windows laptop