### PR TITLE
chore: remove bun env var detect

### DIFF
--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -95,14 +95,6 @@ function detectPackageManager() {
     return "bun";
   }
 
-  if (
-    process.env.BUN_INSTALL ||
-    process.env.BUN_INSTALL_GLOBAL_DIR ||
-    process.env.BUN_INSTALL_BIN_DIR
-  ) {
-    return "bun";
-  }
-
   return userAgent ? "npm" : null;
 }
 


### PR DESCRIPTION
### Summary

[Thread](https://openai.slack.com/archives/C08JZTV654K/p1764780129457519)

We were a bit aggressive on assuming package installer based on env variables for BUN. Here we are removing those checks. 