### PR TITLE
chore: conversation_id -> thread_id in app-server feedback/upload

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -2,7 +2,6 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 
 use crate::protocol::common::AuthMode;
-use codex_protocol::ConversationId;
 use codex_protocol::account::PlanType;
 use codex_protocol::approvals::SandboxCommandAssessment as CoreSandboxCommandAssessment;
 use codex_protocol::config_types::ReasoningEffort;
@@ -664,7 +663,7 @@ pub struct ListMcpServersResponse {
 pub struct FeedbackUploadParams {
     pub classification: String,
     pub reason: Option<String>,
-    pub conversation_id: Option<ConversationId>,
+    pub thread_id: Option<String>,
     pub include_logs: bool,
 }
 


### PR DESCRIPTION
Use `thread_id: Option<String>` instead of `conversation_id: Option<ConversationId>` to be consistent with the rest of app-server v2 APIs.