### PR TITLE
chore: remove experimental_use_rmcp_client

### DIFF
--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -53,11 +53,11 @@ pub enum McpSubcommand {
     Remove(RemoveArgs),
 
     /// [experimental] Authenticate with a configured MCP server via OAuth.
-    /// Requires experimental_use_rmcp_client = true in config.toml.
+    /// Requires [features].rmcp_client = true in config.toml.
     Login(LoginArgs),
 
     /// [experimental] Remove stored OAuth credentials for a server.
-    /// Requires experimental_use_rmcp_client = true in config.toml.
+    /// Requires [features].rmcp_client = true in config.toml.
     Logout(LogoutArgs),
 }
 
@@ -285,7 +285,7 @@ async fn run_add(config_overrides: &CliConfigOverrides, add_args: AddArgs) -> Re
             Ok(true) => {
                 if !config.features.enabled(Feature::RmcpClient) {
                     println!(
-                        "MCP server supports login. Add `experimental_use_rmcp_client = true` \
+                        "MCP server supports login. Add `[features].rmcp_client = true` \
                          to your config.toml and run `codex mcp login {name}` to login."
                     );
                 } else {

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -718,7 +718,6 @@ pub struct ConfigToml {
     pub experimental_instructions_file: Option<PathBuf>,
     pub experimental_compact_prompt_file: Option<PathBuf>,
     pub experimental_use_unified_exec_tool: Option<bool>,
-    pub experimental_use_rmcp_client: Option<bool>,
     pub experimental_use_freeform_apply_patch: Option<bool>,
     pub experimental_sandbox_command_assessment: Option<bool>,
     /// Preferred OSS provider for local models, e.g. "lmstudio" or "ollama".
@@ -1807,10 +1806,12 @@ trust_level = "trusted"
     #[test]
     fn legacy_toggles_map_to_features() -> std::io::Result<()> {
         let codex_home = TempDir::new()?;
+        let mut entries = BTreeMap::new();
+        entries.insert("unified_exec".to_string(), true);
+        entries.insert("rmcp_client".to_string(), true);
+        entries.insert("apply_patch_freeform".to_string(), true);
         let cfg = ConfigToml {
-            experimental_use_unified_exec_tool: Some(true),
-            experimental_use_rmcp_client: Some(true),
-            experimental_use_freeform_apply_patch: Some(true),
+            features: Some(crate::features::FeaturesToml { entries }),
             ..Default::default()
         };
 

--- a/codex-rs/core/src/config/profile.rs
+++ b/codex-rs/core/src/config/profile.rs
@@ -25,7 +25,6 @@ pub struct ConfigProfile {
     pub experimental_compact_prompt_file: Option<PathBuf>,
     pub include_apply_patch_tool: Option<bool>,
     pub experimental_use_unified_exec_tool: Option<bool>,
-    pub experimental_use_rmcp_client: Option<bool>,
     pub experimental_use_freeform_apply_patch: Option<bool>,
     pub experimental_sandbox_command_assessment: Option<bool>,
     pub tools_web_search: Option<bool>,

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -190,7 +190,6 @@ impl Features {
             experimental_sandbox_command_assessment: cfg.experimental_sandbox_command_assessment,
             experimental_use_freeform_apply_patch: cfg.experimental_use_freeform_apply_patch,
             experimental_use_unified_exec_tool: cfg.experimental_use_unified_exec_tool,
-            experimental_use_rmcp_client: cfg.experimental_use_rmcp_client,
             tools_web_search: cfg.tools.as_ref().and_then(|t| t.web_search),
             tools_view_image: cfg.tools.as_ref().and_then(|t| t.view_image),
             ..Default::default()
@@ -209,7 +208,6 @@ impl Features {
                 .experimental_use_freeform_apply_patch,
 
             experimental_use_unified_exec_tool: config_profile.experimental_use_unified_exec_tool,
-            experimental_use_rmcp_client: config_profile.experimental_use_rmcp_client,
             tools_web_search: config_profile.tools_web_search,
             tools_view_image: config_profile.tools_view_image,
         };

--- a/codex-rs/core/src/features/legacy.rs
+++ b/codex-rs/core/src/features/legacy.rs
@@ -18,10 +18,6 @@ const ALIASES: &[Alias] = &[
         feature: Feature::UnifiedExec,
     },
     Alias {
-        legacy_key: "experimental_use_rmcp_client",
-        feature: Feature::RmcpClient,
-    },
-    Alias {
         legacy_key: "experimental_use_freeform_apply_patch",
         feature: Feature::ApplyPatchFreeform,
     },
@@ -51,7 +47,6 @@ pub struct LegacyFeatureToggles {
     pub experimental_sandbox_command_assessment: Option<bool>,
     pub experimental_use_freeform_apply_patch: Option<bool>,
     pub experimental_use_unified_exec_tool: Option<bool>,
-    pub experimental_use_rmcp_client: Option<bool>,
     pub tools_web_search: Option<bool>,
     pub tools_view_image: Option<bool>,
 }
@@ -81,12 +76,6 @@ impl LegacyFeatureToggles {
             Feature::UnifiedExec,
             self.experimental_use_unified_exec_tool,
             "experimental_use_unified_exec_tool",
-        );
-        set_if_some(
-            features,
-            Feature::RmcpClient,
-            self.experimental_use_rmcp_client,
-            "experimental_use_rmcp_client",
         );
         set_if_some(
             features,

--- a/docs/config.md
+++ b/docs/config.md
@@ -464,10 +464,11 @@ http_headers = { "HEADER_NAME" = "HEADER_VALUE" }
 env_http_headers = { "HEADER_NAME" = "ENV_VAR" }
 ```
 
-Streamable HTTP connections always use the experimental Rust MCP client under the hood, so expect occasional rough edges. OAuth login flows are gated on the `experimental_use_rmcp_client = true` flag:
+Streamable HTTP connections always use the experimental Rust MCP client under the hood, so expect occasional rough edges. OAuth login flows are gated on the `rmcp_client` feature flag:
 
 ```toml
-experimental_use_rmcp_client = true
+[features]
+rmcp_client = true
 ```
 
 After enabling it, run `codex mcp login <server-name>` when the server supports OAuth.
@@ -491,10 +492,11 @@ When both `enabled_tools` and `disabled_tools` are specified, Codex first restri
 
 #### Experimental RMCP client
 
-This flag enables OAuth support for streamable HTTP servers.
+This feature enables OAuth support for streamable HTTP servers.
 
 ```toml
-experimental_use_rmcp_client = true
+[features]
+rmcp_client = true
 
 [mcp_servers.server_name]
 …

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -229,9 +229,6 @@ enable_experimental_windows_sandbox = false
 # Use experimental unified exec tool. Default: false
 experimental_use_unified_exec_tool = false
 
-# Use experimental Rust MCP client (enables OAuth for HTTP MCP). Default: false
-experimental_use_rmcp_client = false
-
 # Include apply_patch via freeform editing path (affects default tool set). Default: false
 experimental_use_freeform_apply_patch = false
 
@@ -320,7 +317,6 @@ experimental_use_freeform_apply_patch = false
 # experimental_compact_prompt_file = "compact_prompt.txt"
 # include_apply_patch_tool = false
 # experimental_use_unified_exec_tool = false
-# experimental_use_rmcp_client = false
 # experimental_use_freeform_apply_patch = false
 # experimental_sandbox_command_assessment = false
 # tools_web_search = false


### PR DESCRIPTION
### Summary
* Removing `experimental_use_rmcp_client` flag in preparation for MCP getting out of exp state. 