### PR TITLE
Add vim keybinds to transcript overlay

### DIFF
--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -109,5 +109,6 @@ insta = { workspace = true }
 pretty_assertions = { workspace = true }
 rand = { workspace = true }
 serial_test = { workspace = true }
+tokio = { workspace = true, features = ["test-util"] }
 vt100 = { workspace = true }
 uuid = { workspace = true }

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__static_overlay_snapshot_basic.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__static_overlay_snapshot_basic.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/src/pager_overlay.rs
+assertion_line: 835
 expression: term.backend()
 ---
 "/ S T A T I C / / / / / / / / / / / / / "
@@ -9,6 +10,6 @@ expression: term.backend()
 "~                                       "
 "~                                       "
 "───────────────────────────────── 100% ─"
-" ↑/↓ to scroll   pgup/pgdn to page   hom"
+" ↑/↓/k/j to scroll   pgup/ctrl + b/ctrl "
 " q to quit                              "
 "                                        "

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__static_overlay_wraps_long_lines.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__static_overlay_wraps_long_lines.snap
@@ -1,6 +1,6 @@
 ---
 source: tui/src/pager_overlay.rs
-assertion_line: 798
+assertion_line: 847
 expression: term.backend()
 ---
 "/ S T A T I C / / / / / "
@@ -8,6 +8,6 @@ expression: term.backend()
 "should wrap when        "
 "rendered within a narrow"
 "─────────────────── 0% ─"
-" ↑/↓ to scroll   pgup/pg"
+" ↑/↓/k/j to scroll   pgu"
 " q to quit              "
 "                        "

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_apply_patch_scroll_vt100.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_apply_patch_scroll_vt100.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/src/pager_overlay.rs
+assertion_line: 771
 expression: snapshot
 ---
 / T R A N S C R I P T / / / / / / / / / / / / / / / / / / / / / / / / / / / / /
@@ -11,5 +12,5 @@ expression: snapshot
     1 +hello
     2 +world
 ─────────────────────────────────────────────────────────────────────────── 0% ─
- ↑/↓ to scroll   pgup/pgdn to page   home/end to jump
+ ↑/↓/k/j to scroll   pgup/ctrl + b/ctrl + u to scroll up faster   pgdn/space/ctr
  q to quit   esc to edit prev

--- a/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_snapshot_basic.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__pager_overlay__tests__transcript_overlay_snapshot_basic.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/src/pager_overlay.rs
+assertion_line: 689
 expression: term.backend()
 ---
 "/ T R A N S C R I P T / / / / / / / / / "
@@ -9,6 +10,6 @@ expression: term.backend()
 "                                        "
 "gamma                                   "
 "───────────────────────────────── 100% ─"
-" ↑/↓ to scroll   pgup/pgdn to page   hom"
+" ↑/↓/k/j to scroll   pgup/ctrl + b/ctrl "
 " q to quit   esc to edit prev           "
 "                                        "


### PR DESCRIPTION
## Summary
- add vim-style navigation keys (j/k and ctrl+f/b/d/u) to the transcript and static pager overlays
- refresh pager key hints and snapshot baselines to reflect the new shortcuts
- enable tokio test utilities for tui dev tests so snapshot suites can run

## Testing
- RUSTFLAGS="--cfg tokio_unstable" just fix -p codex-tui
- RUSTFLAGS="--cfg tokio_unstable" cargo test -p codex-tui


------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69309d26da508329908b2dc8ca40afb7)