### PR TITLE
use markdown for rendering tips

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -573,18 +573,19 @@ impl TooltipHistoryCell {
 
 impl HistoryCell for TooltipHistoryCell {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
-        let indent: Line<'static> = "  ".into();
-        let mut lines = Vec::new();
-        let tooltip_line: Line<'static> = vec!["Tip: ".cyan(), self.tip.into()].into();
-        let wrap_opts = RtOptions::new(usize::from(width.max(1)))
-            .initial_indent(indent.clone())
-            .subsequent_indent(indent.clone());
-        lines.extend(
-            word_wrap_line(&tooltip_line, wrap_opts.clone())
-                .into_iter()
-                .map(|line| line_to_static(&line)),
+        let indent = "  ";
+        let indent_width = UnicodeWidthStr::width(indent);
+        let wrap_width = usize::from(width.max(1))
+            .saturating_sub(indent_width)
+            .max(1);
+        let mut lines: Vec<Line<'static>> = Vec::new();
+        append_markdown(
+            &format!("**Tip:** {}", self.tip),
+            Some(wrap_width),
+            &mut lines,
         );
-        lines
+
+        prefix_lines(lines, indent.into(), indent.into())
     }
 }
 

--- a/codex-rs/tui/tooltips.txt
+++ b/codex-rs/tui/tooltips.txt
@@ -8,4 +8,4 @@ Type / to open the command popup; Tab autocompletes slash commands and saved pro
 Use /prompts:<name> key=value to expand a saved prompt with placeholders before sending.
 With the composer empty, press Esc to step back and edit your last message; Enter confirms.
 Paste an image with Ctrl+V to attach it to your next message.
-You can resume a previous conversation by doing `codex resume`
+You can resume a previous conversation by running `codex resume`


### PR DESCRIPTION
## Summary
- render tooltip content through the markdown renderer and prepend a bold Tip label
- wrap tooltips at the available width using the indent’s measured width before adding the indent

## Testing
- `/root/.cargo/bin/just fmt`
- `RUSTFLAGS="--cfg tokio_unstable" TOKIO_UNSTABLE=1 /root/.cargo/bin/just fix -p codex-tui` *(fails: codex-tui tests reference tokio::time::advance/start_paused gated behind the tokio test-util feature)*
- `RUSTFLAGS="--cfg tokio_unstable" TOKIO_UNSTABLE=1 cargo test -p codex-tui` *(fails: codex-tui tests reference tokio::time::advance/start_paused gated behind the tokio test-util feature)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_693081406050832c9772ae9fa5dd77ca)