### PR TITLE
fix: retire Feature.RmcpClient

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -251,10 +251,6 @@ pub struct Config {
     /// If set to `true`, used only the experimental unified exec tool.
     pub use_experimental_unified_exec_tool: bool,
 
-    /// If set to `true`, use the experimental official Rust MCP client.
-    /// https://github.com/modelcontextprotocol/rust-sdk
-    pub use_experimental_use_rmcp_client: bool,
-
     /// Centralized feature flags; source of truth for feature gating.
     pub features: Features,
 
@@ -718,7 +714,6 @@ pub struct ConfigToml {
     pub experimental_instructions_file: Option<PathBuf>,
     pub experimental_compact_prompt_file: Option<PathBuf>,
     pub experimental_use_unified_exec_tool: Option<bool>,
-    pub experimental_use_rmcp_client: Option<bool>,
     pub experimental_use_freeform_apply_patch: Option<bool>,
     pub experimental_sandbox_command_assessment: Option<bool>,
     /// Preferred OSS provider for local models, e.g. "lmstudio" or "ollama".
@@ -1088,7 +1083,6 @@ impl Config {
         let include_apply_patch_tool_flag = features.enabled(Feature::ApplyPatchFreeform);
         let tools_web_search_request = features.enabled(Feature::WebSearchRequest);
         let use_experimental_unified_exec_tool = features.enabled(Feature::UnifiedExec);
-        let use_experimental_use_rmcp_client = features.enabled(Feature::RmcpClient);
         let experimental_sandbox_command_assessment =
             features.enabled(Feature::SandboxCommandAssessment);
 
@@ -1241,7 +1235,6 @@ impl Config {
             tools_web_search_request,
             experimental_sandbox_command_assessment,
             use_experimental_unified_exec_tool,
-            use_experimental_use_rmcp_client,
             features,
             active_profile: active_profile_name,
             active_project,
@@ -1809,7 +1802,6 @@ trust_level = "trusted"
         let codex_home = TempDir::new()?;
         let cfg = ConfigToml {
             experimental_use_unified_exec_tool: Some(true),
-            experimental_use_rmcp_client: Some(true),
             experimental_use_freeform_apply_patch: Some(true),
             ..Default::default()
         };
@@ -1822,12 +1814,10 @@ trust_level = "trusted"
 
         assert!(config.features.enabled(Feature::ApplyPatchFreeform));
         assert!(config.features.enabled(Feature::UnifiedExec));
-        assert!(config.features.enabled(Feature::RmcpClient));
 
         assert!(config.include_apply_patch_tool);
 
         assert!(config.use_experimental_unified_exec_tool);
-        assert!(config.use_experimental_use_rmcp_client);
 
         Ok(())
     }
@@ -2994,7 +2984,6 @@ model_verbosity = "high"
                 tools_web_search_request: false,
                 experimental_sandbox_command_assessment: false,
                 use_experimental_unified_exec_tool: false,
-                use_experimental_use_rmcp_client: false,
                 features: Features::with_defaults(),
                 active_profile: Some("o3".to_string()),
                 active_project: ProjectConfig { trust_level: None },
@@ -3068,7 +3057,6 @@ model_verbosity = "high"
             tools_web_search_request: false,
             experimental_sandbox_command_assessment: false,
             use_experimental_unified_exec_tool: false,
-            use_experimental_use_rmcp_client: false,
             features: Features::with_defaults(),
             active_profile: Some("gpt3".to_string()),
             active_project: ProjectConfig { trust_level: None },
@@ -3157,7 +3145,6 @@ model_verbosity = "high"
             tools_web_search_request: false,
             experimental_sandbox_command_assessment: false,
             use_experimental_unified_exec_tool: false,
-            use_experimental_use_rmcp_client: false,
             features: Features::with_defaults(),
             active_profile: Some("zdr".to_string()),
             active_project: ProjectConfig { trust_level: None },
@@ -3232,7 +3219,6 @@ model_verbosity = "high"
             tools_web_search_request: false,
             experimental_sandbox_command_assessment: false,
             use_experimental_unified_exec_tool: false,
-            use_experimental_use_rmcp_client: false,
             features: Features::with_defaults(),
             active_profile: Some("gpt5".to_string()),
             active_project: ProjectConfig { trust_level: None },

--- a/codex-rs/core/src/config/profile.rs
+++ b/codex-rs/core/src/config/profile.rs
@@ -25,7 +25,6 @@ pub struct ConfigProfile {
     pub experimental_compact_prompt_file: Option<PathBuf>,
     pub include_apply_patch_tool: Option<bool>,
     pub experimental_use_unified_exec_tool: Option<bool>,
-    pub experimental_use_rmcp_client: Option<bool>,
     pub experimental_use_freeform_apply_patch: Option<bool>,
     pub experimental_sandbox_command_assessment: Option<bool>,
     pub tools_web_search: Option<bool>,

--- a/codex-rs/core/src/features/legacy.rs
+++ b/codex-rs/core/src/features/legacy.rs
@@ -51,7 +51,6 @@ pub struct LegacyFeatureToggles {
     pub experimental_sandbox_command_assessment: Option<bool>,
     pub experimental_use_freeform_apply_patch: Option<bool>,
     pub experimental_use_unified_exec_tool: Option<bool>,
-    pub experimental_use_rmcp_client: Option<bool>,
     pub tools_web_search: Option<bool>,
     pub tools_view_image: Option<bool>,
 }
@@ -81,12 +80,6 @@ impl LegacyFeatureToggles {
             Feature::UnifiedExec,
             self.experimental_use_unified_exec_tool,
             "experimental_use_unified_exec_tool",
-        );
-        set_if_some(
-            features,
-            Feature::RmcpClient,
-            self.experimental_use_rmcp_client,
-            "experimental_use_rmcp_client",
         );
         set_if_some(
             features,

--- a/docs/config.md
+++ b/docs/config.md
@@ -42,7 +42,6 @@ Supported features:
 | Key                                       | Default | Stage        | Description                                          |
 | ----------------------------------------- | :-----: | ------------ | ---------------------------------------------------- |
 | `unified_exec`                            |  false  | Experimental | Use the unified PTY-backed exec tool                 |
-| `rmcp_client`                             |  false  | Experimental | Enable oauth support for streamable HTTP MCP servers |
 | `apply_patch_freeform`                    |  false  | Beta         | Include the freeform `apply_patch` tool              |
 | `view_image_tool`                         |  true   | Stable       | Include the `view_image` tool                        |
 | `web_search_request`                      |  false  | Stable       | Allow the model to issue web searches                |
@@ -53,6 +52,8 @@ Supported features:
 Notes:
 
 - Omit a key to accept its default.
+- The RMCP client is always enabled; legacy `rmcp_client` and `experimental_use_rmcp_client`
+  toggles are ignored.
 - Legacy booleans such as `experimental_use_exec_command_tool`, `experimental_use_unified_exec_tool`, `include_apply_patch_tool`, and similar `experimental_use_*` keys are deprecated; setting the corresponding `[features].<key>` avoids repeated warnings.
 
 ## Model selection
@@ -464,13 +465,9 @@ http_headers = { "HEADER_NAME" = "HEADER_VALUE" }
 env_http_headers = { "HEADER_NAME" = "ENV_VAR" }
 ```
 
-Streamable HTTP connections always use the experimental Rust MCP client under the hood, so expect occasional rough edges. OAuth login flows are gated on the `experimental_use_rmcp_client = true` flag:
-
-```toml
-experimental_use_rmcp_client = true
-```
-
-After enabling it, run `codex mcp login <server-name>` when the server supports OAuth.
+Streamable HTTP connections always use the Rust MCP client under the hood. OAuth login
+flows are supported by default; run `codex mcp login <server-name>` when the server
+supports OAuth to store credentials.
 
 #### Other configuration options
 
@@ -488,17 +485,6 @@ disabled_tools = ["search"]
 ```
 
 When both `enabled_tools` and `disabled_tools` are specified, Codex first restricts the server to the allow-list and then removes any tools that appear in the deny-list.
-
-#### Experimental RMCP client
-
-This flag enables OAuth support for streamable HTTP servers.
-
-```toml
-experimental_use_rmcp_client = true
-
-[mcp_servers.server_name]
-…
-```
 
 #### MCP CLI commands
 

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -214,13 +214,13 @@ view_image = true
 [features]
 # Leave this table empty to accept defaults. Set explicit booleans to opt in/out.
 unified_exec = false
-rmcp_client = false
 apply_patch_freeform = false
 view_image_tool = true
 web_search_request = false
 experimental_sandbox_command_assessment = false
 ghost_commit = false
 enable_experimental_windows_sandbox = false
+# The RMCP client is always enabled; legacy toggles are ignored.
 
 ################################################################################
 # Experimental toggles (legacy; prefer [features])
@@ -228,9 +228,6 @@ enable_experimental_windows_sandbox = false
 
 # Use experimental unified exec tool. Default: false
 experimental_use_unified_exec_tool = false
-
-# Use experimental Rust MCP client (enables OAuth for HTTP MCP). Default: false
-experimental_use_rmcp_client = false
 
 # Include apply_patch via freeform editing path (affects default tool set). Default: false
 experimental_use_freeform_apply_patch = false
@@ -320,7 +317,6 @@ experimental_use_freeform_apply_patch = false
 # experimental_compact_prompt_file = "compact_prompt.txt"
 # include_apply_patch_tool = false
 # experimental_use_unified_exec_tool = false
-# experimental_use_rmcp_client = false
 # experimental_use_freeform_apply_patch = false
 # experimental_sandbox_command_assessment = false
 # tools_web_search = false


### PR DESCRIPTION
Apparently we need to have code signing in place on all platforms before we can cut over?