### PR TITLE
[app-server] make `file_path` for config optional

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -209,6 +209,7 @@ pub struct OverriddenMetadata {
 pub struct ConfigWriteResponse {
     pub status: WriteStatus,
     pub version: String,
+    pub file_path: String,
     pub overridden_metadata: Option<OverriddenMetadata>,
 }
 
@@ -245,10 +246,11 @@ pub struct ConfigReadResponse {
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct ConfigValueWriteParams {
-    pub file_path: String,
     pub key_path: String,
     pub value: JsonValue,
     pub merge_strategy: MergeStrategy,
+    /// Path to the config file to write; defaults to the user's `config.toml` when omitted.
+    pub file_path: Option<String>,
     pub expected_version: Option<String>,
 }
 
@@ -256,8 +258,9 @@ pub struct ConfigValueWriteParams {
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct ConfigBatchWriteParams {
-    pub file_path: String,
     pub edits: Vec<ConfigEdit>,
+    /// Path to the config file to write; defaults to the user's `config.toml` when omitted.
+    pub file_path: Option<String>,
     pub expected_version: Option<String>,
 }
 

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -209,6 +209,7 @@ pub struct OverriddenMetadata {
 pub struct ConfigWriteResponse {
     pub status: WriteStatus,
     pub version: String,
+    /// Canonical path to the config file that was written.
     pub file_path: String,
     pub overridden_metadata: Option<OverriddenMetadata>,
 }

--- a/codex-rs/app-server/tests/suite/v2/config_rpc.rs
+++ b/codex-rs/app-server/tests/suite/v2/config_rpc.rs
@@ -219,9 +219,16 @@ model = "gpt-old"
     )
     .await??;
     let write: ConfigWriteResponse = to_response(write_resp)?;
+    let expected_file_path = codex_home
+        .path()
+        .join("config.toml")
+        .canonicalize()
+        .unwrap()
+        .display()
+        .to_string();
 
     assert_eq!(write.status, WriteStatus::Ok);
-    assert!(write.file_path.is_empty());
+    assert_eq!(write.file_path, expected_file_path);
     assert!(write.overridden_metadata.is_none());
 
     let verify_id = mcp
@@ -315,10 +322,14 @@ async fn config_batch_write_applies_multiple_edits() -> Result<()> {
     .await??;
     let batch_write: ConfigWriteResponse = to_response(batch_resp)?;
     assert_eq!(batch_write.status, WriteStatus::Ok);
-    assert_eq!(
-        batch_write.file_path,
-        codex_home.path().join("config.toml").display().to_string()
-    );
+    let expected_file_path = codex_home
+        .path()
+        .join("config.toml")
+        .canonicalize()
+        .unwrap()
+        .display()
+        .to_string();
+    assert_eq!(batch_write.file_path, expected_file_path);
 
     let read_id = mcp
         .send_config_read_request(ConfigReadParams {

--- a/codex-rs/app-server/tests/suite/v2/config_rpc.rs
+++ b/codex-rs/app-server/tests/suite/v2/config_rpc.rs
@@ -206,7 +206,7 @@ model = "gpt-old"
 
     let write_id = mcp
         .send_config_value_write_request(ConfigValueWriteParams {
-            file_path: codex_home.path().join("config.toml").display().to_string(),
+            file_path: None,
             key_path: "model".to_string(),
             value: json!("gpt-new"),
             merge_strategy: MergeStrategy::Replace,
@@ -221,6 +221,7 @@ model = "gpt-old"
     let write: ConfigWriteResponse = to_response(write_resp)?;
 
     assert_eq!(write.status, WriteStatus::Ok);
+    assert!(write.file_path.is_empty());
     assert!(write.overridden_metadata.is_none());
 
     let verify_id = mcp
@@ -254,7 +255,7 @@ model = "gpt-old"
 
     let write_id = mcp
         .send_config_value_write_request(ConfigValueWriteParams {
-            file_path: codex_home.path().join("config.toml").display().to_string(),
+            file_path: Some(codex_home.path().join("config.toml").display().to_string()),
             key_path: "model".to_string(),
             value: json!("gpt-new"),
             merge_strategy: MergeStrategy::Replace,
@@ -288,7 +289,7 @@ async fn config_batch_write_applies_multiple_edits() -> Result<()> {
 
     let batch_id = mcp
         .send_config_batch_write_request(ConfigBatchWriteParams {
-            file_path: codex_home.path().join("config.toml").display().to_string(),
+            file_path: Some(codex_home.path().join("config.toml").display().to_string()),
             edits: vec![
                 ConfigEdit {
                     key_path: "sandbox_mode".to_string(),
@@ -314,6 +315,10 @@ async fn config_batch_write_applies_multiple_edits() -> Result<()> {
     .await??;
     let batch_write: ConfigWriteResponse = to_response(batch_resp)?;
     assert_eq!(batch_write.status, WriteStatus::Ok);
+    assert_eq!(
+        batch_write.file_path,
+        codex_home.path().join("config.toml").display().to_string()
+    );
 
     let read_id = mcp
         .send_config_read_request(ConfigReadParams {


### PR DESCRIPTION
When we are writing to config using `config/value/write` or `config/batchWrite`, it always require a `config/read` before it right now in order to get the correct file path to write to. make this optional so we read from the default user config file if this is not passed in.