### PR TITLE
remove `model_family` from `config

### DIFF
--- a/codex-rs/common/src/config_summary.rs
+++ b/codex-rs/common/src/config_summary.rs
@@ -12,15 +12,14 @@ pub fn create_config_summary_entries(config: &Config) -> Vec<(&'static str, Stri
         ("approval", config.approval_policy.to_string()),
         ("sandbox", summarize_sandbox_policy(&config.sandbox_policy)),
     ];
-    if config.model_provider.wire_api == WireApi::Responses
-        && config.model_family.supports_reasoning_summaries
-    {
+    if config.model_provider.wire_api == WireApi::Responses {
         let reasoning_effort = config
             .model_reasoning_effort
-            .or(config.model_family.default_reasoning_effort)
-            .map(|effort| effort.to_string())
-            .unwrap_or_else(|| "none".to_string());
-        entries.push(("reasoning effort", reasoning_effort));
+            .map(|effort| effort.to_string());
+        entries.push((
+            "reasoning effort",
+            reasoning_effort.unwrap_or_else(|| "none".to_string()),
+        ));
         entries.push((
             "reasoning summaries",
             config.model_reasoning_summary.to_string(),

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -308,7 +308,7 @@ impl ModelClient {
     /// Returns the currently configured model family.
     pub fn get_model_family(&self) -> ModelFamily {
         self.models_manager
-            .construct_model_family(&self.config.model)
+            .construct_model_family(&self.config.model, &self.config)
     }
 
     /// Returns the current reasoning effort setting.

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use crate::api_bridge::auth_provider_from_auth;
 use crate::api_bridge::map_api_error;
-use crate::openai_models::models_manager::ModelsManager;
 use codex_api::AggregateStreamExt;
 use codex_api::ChatClient as ApiChatClient;
 use codex_api::CompactClient as ApiCompactClient;
@@ -58,7 +57,7 @@ use crate::tools::spec::create_tools_json_for_responses_api;
 pub struct ModelClient {
     config: Arc<Config>,
     auth_manager: Option<Arc<AuthManager>>,
-    models_manager: Arc<ModelsManager>,
+    model_family: ModelFamily,
     otel_event_manager: OtelEventManager,
     provider: ModelProviderInfo,
     conversation_id: ConversationId,
@@ -72,7 +71,7 @@ impl ModelClient {
     pub fn new(
         config: Arc<Config>,
         auth_manager: Option<Arc<AuthManager>>,
-        models_manager: Arc<ModelsManager>,
+        model_family: ModelFamily,
         otel_event_manager: OtelEventManager,
         provider: ModelProviderInfo,
         effort: Option<ReasoningEffortConfig>,
@@ -83,7 +82,7 @@ impl ModelClient {
         Self {
             config,
             auth_manager,
-            models_manager,
+            model_family,
             otel_event_manager,
             provider,
             conversation_id,
@@ -307,8 +306,7 @@ impl ModelClient {
 
     /// Returns the currently configured model family.
     pub fn get_model_family(&self) -> ModelFamily {
-        self.models_manager
-            .construct_model_family(&self.config.model, &self.config)
+        self.model_family.clone()
     }
 
     /// Returns the current reasoning effort setting.

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use crate::api_bridge::auth_provider_from_auth;
 use crate::api_bridge::map_api_error;
+use crate::openai_models::models_manager::ModelsManager;
 use codex_api::AggregateStreamExt;
 use codex_api::ChatClient as ApiChatClient;
 use codex_api::CompactClient as ApiCompactClient;
@@ -57,6 +58,7 @@ use crate::tools::spec::create_tools_json_for_responses_api;
 pub struct ModelClient {
     config: Arc<Config>,
     auth_manager: Option<Arc<AuthManager>>,
+    models_manager: Arc<ModelsManager>,
     otel_event_manager: OtelEventManager,
     provider: ModelProviderInfo,
     conversation_id: ConversationId,
@@ -70,6 +72,7 @@ impl ModelClient {
     pub fn new(
         config: Arc<Config>,
         auth_manager: Option<Arc<AuthManager>>,
+        models_manager: Arc<ModelsManager>,
         otel_event_manager: OtelEventManager,
         provider: ModelProviderInfo,
         effort: Option<ReasoningEffortConfig>,
@@ -80,6 +83,7 @@ impl ModelClient {
         Self {
             config,
             auth_manager,
+            models_manager,
             otel_event_manager,
             provider,
             conversation_id,
@@ -90,16 +94,18 @@ impl ModelClient {
     }
 
     pub fn get_model_context_window(&self) -> Option<i64> {
-        let pct = self.config.model_family.effective_context_window_percent;
+        let model_family = self.get_model_family();
+        let effective_context_window_percent = model_family.effective_context_window_percent;
         self.config
             .model_context_window
-            .or_else(|| get_model_info(&self.config.model_family).map(|info| info.context_window))
-            .map(|w| w.saturating_mul(pct) / 100)
+            .or_else(|| get_model_info(&model_family).map(|info| info.context_window))
+            .map(|w| w.saturating_mul(effective_context_window_percent) / 100)
     }
 
     pub fn get_auto_compact_token_limit(&self) -> Option<i64> {
+        let model_family = self.get_model_family();
         self.config.model_auto_compact_token_limit.or_else(|| {
-            get_model_info(&self.config.model_family).and_then(|info| info.auto_compact_token_limit)
+            get_model_info(&model_family).and_then(|info| info.auto_compact_token_limit)
         })
     }
 
@@ -149,9 +155,8 @@ impl ModelClient {
         }
 
         let auth_manager = self.auth_manager.clone();
-        let instructions = prompt
-            .get_full_instructions(&self.config.model_family)
-            .into_owned();
+        let model_family = self.get_model_family();
+        let instructions = prompt.get_full_instructions(&model_family).into_owned();
         let tools_json = create_tools_json_for_chat_completions_api(&prompt.tools)?;
         let api_prompt = build_api_prompt(prompt, instructions, tools_json);
         let conversation_id = self.conversation_id.to_string();
@@ -204,16 +209,13 @@ impl ModelClient {
         }
 
         let auth_manager = self.auth_manager.clone();
-        let instructions = prompt
-            .get_full_instructions(&self.config.model_family)
-            .into_owned();
+        let model_family = self.get_model_family();
+        let instructions = prompt.get_full_instructions(&model_family).into_owned();
         let tools_json: Vec<Value> = create_tools_json_for_responses_api(&prompt.tools)?;
 
-        let reasoning = if self.config.model_family.supports_reasoning_summaries {
+        let reasoning = if model_family.supports_reasoning_summaries {
             Some(Reasoning {
-                effort: self
-                    .effort
-                    .or(self.config.model_family.default_reasoning_effort),
+                effort: self.effort.or(model_family.default_reasoning_effort),
                 summary: Some(self.summary),
             })
         } else {
@@ -226,15 +228,15 @@ impl ModelClient {
             vec![]
         };
 
-        let verbosity = if self.config.model_family.support_verbosity {
+        let verbosity = if model_family.support_verbosity {
             self.config
                 .model_verbosity
-                .or(self.config.model_family.default_verbosity)
+                .or(model_family.default_verbosity)
         } else {
             if self.config.model_verbosity.is_some() {
                 warn!(
                     "model_verbosity is set but ignored as the model does not support verbosity: {}",
-                    self.config.model_family.family
+                    model_family.family
                 );
             }
             None
@@ -305,7 +307,8 @@ impl ModelClient {
 
     /// Returns the currently configured model family.
     pub fn get_model_family(&self) -> ModelFamily {
-        self.config.model_family.clone()
+        self.models_manager
+            .construct_model_family(&self.config.model)
     }
 
     /// Returns the current reasoning effort setting.
@@ -342,7 +345,7 @@ impl ModelClient {
             .with_telemetry(Some(request_telemetry));
 
         let instructions = prompt
-            .get_full_instructions(&self.config.model_family)
+            .get_full_instructions(&self.get_model_family())
             .into_owned();
         let payload = ApiCompactionInput {
             model: &self.config.model,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -424,7 +424,7 @@ impl Session {
         let client = ModelClient::new(
             Arc::new(per_turn_config.clone()),
             auth_manager,
-            models_manager,
+            model_family.clone(),
             otel_event_manager,
             provider,
             session_configuration.model_reasoning_effort,
@@ -541,14 +541,12 @@ impl Session {
             });
         }
 
+        let model_family = models_manager.construct_model_family(&config.model, &config);
         // todo(aibrahim): why are we passing model here while it can change?
         let otel_event_manager = OtelEventManager::new(
             conversation_id,
             config.model.as_str(),
-            models_manager
-                .construct_model_family(&config.model, &config)
-                .slug
-                .as_str(),
+            model_family.slug.as_str(),
             auth_manager.auth().and_then(|a| a.get_account_id()),
             auth_manager.auth().and_then(|a| a.get_account_email()),
             auth_manager.auth().map(|a| a.mode),
@@ -1884,7 +1882,7 @@ async fn spawn_review_thread(
     let client = ModelClient::new(
         per_turn_config.clone(),
         auth_manager,
-        sess.services.models_manager.clone(),
+        model_family.clone(),
         otel_event_manager,
         provider,
         per_turn_config.model_reasoning_effort,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1871,11 +1871,7 @@ async fn spawn_review_thread(
         .get_otel_event_manager()
         .with_model(
             per_turn_config.model.as_str(),
-            sess.services
-                .models_manager
-                .construct_model_family(&per_turn_config.model, &per_turn_config)
-                .slug
-                .as_str(),
+            review_model_family.slug.as_str(),
         );
 
     let per_turn_config = Arc::new(per_turn_config);

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -222,6 +222,12 @@ pub struct Config {
     /// request using the Responses API.
     pub model_reasoning_summary: ReasoningSummary,
 
+    /// Optional override to force-enable reasoning summaries for the configured model.
+    pub model_supports_reasoning_summaries: Option<bool>,
+
+    /// Optional override to force reasoning summary format for the configured model.
+    pub model_reasoning_summary_format: Option<ReasoningSummaryFormat>,
+
     /// Optional verbosity control for GPT-5 models (Responses API `text.verbosity`).
     pub model_verbosity: Option<Verbosity>,
 
@@ -1110,8 +1116,8 @@ impl Config {
         if let Some(supports_reasoning_summaries) = cfg.model_supports_reasoning_summaries {
             model_family.supports_reasoning_summaries = supports_reasoning_summaries;
         }
-        if let Some(model_reasoning_summary_format) = cfg.model_reasoning_summary_format {
-            model_family.reasoning_summary_format = model_reasoning_summary_format;
+        if let Some(ref model_reasoning_summary_format) = cfg.model_reasoning_summary_format {
+            model_family.reasoning_summary_format = model_reasoning_summary_format.clone();
         }
 
         let openai_model_info = get_model_info(&model_family);
@@ -1224,6 +1230,8 @@ impl Config {
                 .model_reasoning_summary
                 .or(cfg.model_reasoning_summary)
                 .unwrap_or_default(),
+            model_supports_reasoning_summaries: cfg.model_supports_reasoning_summaries,
+            model_reasoning_summary_format: cfg.model_reasoning_summary_format.clone(),
             model_verbosity: config_profile.model_verbosity.or(cfg.model_verbosity),
             chatgpt_base_url: config_profile
                 .chatgpt_base_url
@@ -2976,6 +2984,8 @@ model_verbosity = "high"
                 show_raw_agent_reasoning: false,
                 model_reasoning_effort: Some(ReasoningEffort::High),
                 model_reasoning_summary: ReasoningSummary::Detailed,
+                model_supports_reasoning_summaries: None,
+                model_reasoning_summary_format: None,
                 model_verbosity: None,
                 chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
                 base_instructions: None,
@@ -3049,6 +3059,8 @@ model_verbosity = "high"
             show_raw_agent_reasoning: false,
             model_reasoning_effort: None,
             model_reasoning_summary: ReasoningSummary::default(),
+            model_supports_reasoning_summaries: None,
+            model_reasoning_summary_format: None,
             model_verbosity: None,
             chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
             base_instructions: None,
@@ -3137,6 +3149,8 @@ model_verbosity = "high"
             show_raw_agent_reasoning: false,
             model_reasoning_effort: None,
             model_reasoning_summary: ReasoningSummary::default(),
+            model_supports_reasoning_summaries: None,
+            model_reasoning_summary_format: None,
             model_verbosity: None,
             chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
             base_instructions: None,
@@ -3211,6 +3225,8 @@ model_verbosity = "high"
             show_raw_agent_reasoning: false,
             model_reasoning_effort: Some(ReasoningEffort::High),
             model_reasoning_summary: ReasoningSummary::Detailed,
+            model_supports_reasoning_summaries: None,
+            model_reasoning_summary_format: None,
             model_verbosity: Some(Verbosity::High),
             chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
             base_instructions: None,

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -192,6 +192,7 @@ pub struct Config {
     /// Additional filenames to try when looking for project-level docs.
     pub project_doc_fallback_filenames: Vec<String>,
 
+    // todo(aibrahim): this should be used in the overide model family
     /// Token budget applied when storing tool/function outputs in the context manager.
     pub tool_output_token_limit: Option<usize>,
 

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1112,14 +1112,7 @@ impl Config {
             .or(cfg.model)
             .unwrap_or_else(default_model);
 
-        let mut model_family = find_family_for_model(&model);
-
-        if let Some(supports_reasoning_summaries) = cfg.model_supports_reasoning_summaries {
-            model_family.supports_reasoning_summaries = supports_reasoning_summaries;
-        }
-        if let Some(ref model_reasoning_summary_format) = cfg.model_reasoning_summary_format {
-            model_family.reasoning_summary_format = model_reasoning_summary_format.clone();
-        }
+        let model_family = find_family_for_model(&model);
 
         let openai_model_info = get_model_info(&model_family);
         let model_context_window = cfg

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -192,7 +192,7 @@ pub struct Config {
     /// Additional filenames to try when looking for project-level docs.
     pub project_doc_fallback_filenames: Vec<String>,
 
-    // todo(aibrahim): this should be used in the overide model family
+    // todo(aibrahim): this should be used in the override model family
     /// Token budget applied when storing tool/function outputs in the context manager.
     pub tool_output_token_limit: Option<usize>,
 

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -27,7 +27,6 @@ use crate::model_provider_info::ModelProviderInfo;
 use crate::model_provider_info::OLLAMA_OSS_PROVIDER_ID;
 use crate::model_provider_info::built_in_model_providers;
 use crate::openai_model_info::get_model_info;
-use crate::openai_models::model_family::ModelFamily;
 use crate::openai_models::model_family::find_family_for_model;
 use crate::project_doc::DEFAULT_PROJECT_DOC_FILENAME;
 use crate::project_doc::LOCAL_PROJECT_DOC_FILENAME;
@@ -80,9 +79,6 @@ pub struct Config {
 
     /// Model used specifically for review sessions. Defaults to "gpt-5.1-codex-max".
     pub review_model: String,
-
-    // todo(aibrahim): remove this field
-    pub model_family: ModelFamily,
 
     /// Size of the context window for the model, in tokens.
     pub model_context_window: Option<i64>,
@@ -1173,7 +1169,6 @@ impl Config {
         let config = Self {
             model,
             review_model,
-            model_family,
             model_context_window,
             model_auto_compact_token_limit,
             model_provider_id,
@@ -2954,7 +2949,6 @@ model_verbosity = "high"
             Config {
                 model: "o3".to_string(),
                 review_model: OPENAI_DEFAULT_REVIEW_MODEL.to_string(),
-                model_family: find_family_for_model("o3"),
                 model_context_window: Some(200_000),
                 model_auto_compact_token_limit: Some(180_000),
                 model_provider_id: "openai".to_string(),
@@ -3028,7 +3022,6 @@ model_verbosity = "high"
         let expected_gpt3_profile_config = Config {
             model: "gpt-3.5-turbo".to_string(),
             review_model: OPENAI_DEFAULT_REVIEW_MODEL.to_string(),
-            model_family: find_family_for_model("gpt-3.5-turbo"),
             model_context_window: Some(16_385),
             model_auto_compact_token_limit: Some(14_746),
             model_provider_id: "openai-chat-completions".to_string(),
@@ -3117,7 +3110,6 @@ model_verbosity = "high"
         let expected_zdr_profile_config = Config {
             model: "o3".to_string(),
             review_model: OPENAI_DEFAULT_REVIEW_MODEL.to_string(),
-            model_family: find_family_for_model("o3"),
             model_context_window: Some(200_000),
             model_auto_compact_token_limit: Some(180_000),
             model_provider_id: "openai".to_string(),
@@ -3192,7 +3184,6 @@ model_verbosity = "high"
         let expected_gpt5_profile_config = Config {
             model: "gpt-5.1".to_string(),
             review_model: OPENAI_DEFAULT_REVIEW_MODEL.to_string(),
-            model_family: find_family_for_model("gpt-5.1"),
             model_context_window: Some(272_000),
             model_auto_compact_token_limit: Some(244_800),
             model_provider_id: "openai".to_string(),

--- a/codex-rs/core/src/openai_models/model_family.rs
+++ b/codex-rs/core/src/openai_models/model_family.rs
@@ -1,6 +1,7 @@
 use codex_protocol::config_types::Verbosity;
 use codex_protocol::openai_models::ReasoningEffort;
 
+use crate::config::Config;
 use crate::config::types::ReasoningSummaryFormat;
 use crate::tools::handlers::apply_patch::ApplyPatchToolType;
 use crate::tools::spec::ConfigShellToolType;
@@ -70,6 +71,18 @@ pub struct ModelFamily {
     pub shell_type: ConfigShellToolType,
 
     pub truncation_policy: TruncationPolicy,
+}
+
+impl ModelFamily {
+    pub fn with_config_overrides(mut self, config: &Config) -> Self {
+        if let Some(supports_reasoning_summaries) = config.model_supports_reasoning_summaries {
+            self.supports_reasoning_summaries = supports_reasoning_summaries;
+        }
+        if let Some(reasoning_summary_format) = config.model_reasoning_summary_format.as_ref() {
+            self.reasoning_summary_format = reasoning_summary_format.clone();
+        }
+        self
+    }
 }
 
 macro_rules! model_family {

--- a/codex-rs/core/src/openai_models/models_manager.rs
+++ b/codex-rs/core/src/openai_models/models_manager.rs
@@ -2,6 +2,7 @@ use codex_app_server_protocol::AuthMode;
 use codex_protocol::openai_models::ModelPreset;
 use tokio::sync::RwLock;
 
+use crate::config::Config;
 use crate::openai_models::model_family::ModelFamily;
 use crate::openai_models::model_family::find_family_for_model;
 use crate::openai_models::model_presets::builtin_model_presets;
@@ -27,7 +28,7 @@ impl ModelsManager {
         *self.available_models.write().await = models;
     }
 
-    pub fn construct_model_family(&self, model: &str) -> ModelFamily {
-        find_family_for_model(model)
+    pub fn construct_model_family(&self, model: &str, config: &Config) -> ModelFamily {
+        find_family_for_model(model).with_config_overrides(config)
     }
 }

--- a/codex-rs/core/src/openai_models/models_manager.rs
+++ b/codex-rs/core/src/openai_models/models_manager.rs
@@ -6,6 +6,7 @@ use crate::openai_models::model_family::ModelFamily;
 use crate::openai_models::model_family::find_family_for_model;
 use crate::openai_models::model_presets::builtin_model_presets;
 
+#[derive(Debug)]
 pub struct ModelsManager {
     pub available_models: RwLock<Vec<ModelPreset>>,
     pub etag: String,

--- a/codex-rs/core/src/sandboxing/assessment.rs
+++ b/codex-rs/core/src/sandboxing/assessment.rs
@@ -126,18 +126,14 @@ pub(crate) async fn assess_command(
         output_schema: Some(sandbox_assessment_schema()),
     };
 
-    let child_otel = parent_otel.with_model(
-        config.model.as_str(),
-        models_manager
-            .construct_model_family(&config.model, &config)
-            .slug
-            .as_str(),
-    );
+    let model_family = models_manager.construct_model_family(&config.model, &config);
+
+    let child_otel = parent_otel.with_model(config.model.as_str(), model_family.slug.as_str());
 
     let client = ModelClient::new(
         Arc::clone(&config),
         Some(auth_manager),
-        models_manager.clone(),
+        model_family,
         child_otel,
         provider,
         Some(SANDBOX_ASSESSMENT_REASONING_EFFORT),

--- a/codex-rs/core/src/sandboxing/assessment.rs
+++ b/codex-rs/core/src/sandboxing/assessment.rs
@@ -10,6 +10,7 @@ use crate::client::ModelClient;
 use crate::client_common::Prompt;
 use crate::client_common::ResponseEvent;
 use crate::config::Config;
+use crate::openai_models::models_manager::ModelsManager;
 use crate::protocol::SandboxPolicy;
 use askama::Template;
 use codex_otel::otel_event_manager::OtelEventManager;
@@ -46,6 +47,7 @@ pub(crate) async fn assess_command(
     auth_manager: Arc<AuthManager>,
     parent_otel: &OtelEventManager,
     conversation_id: ConversationId,
+    models_manager: Arc<ModelsManager>,
     session_source: SessionSource,
     call_id: &str,
     command: &[String],
@@ -124,12 +126,18 @@ pub(crate) async fn assess_command(
         output_schema: Some(sandbox_assessment_schema()),
     };
 
-    let child_otel =
-        parent_otel.with_model(config.model.as_str(), config.model_family.slug.as_str());
+    let child_otel = parent_otel.with_model(
+        config.model.as_str(),
+        models_manager
+            .construct_model_family(&config.model)
+            .slug
+            .as_str(),
+    );
 
     let client = ModelClient::new(
         Arc::clone(&config),
         Some(auth_manager),
+        models_manager.clone(),
         child_otel,
         provider,
         Some(SANDBOX_ASSESSMENT_REASONING_EFFORT),

--- a/codex-rs/core/src/sandboxing/assessment.rs
+++ b/codex-rs/core/src/sandboxing/assessment.rs
@@ -129,7 +129,7 @@ pub(crate) async fn assess_command(
     let child_otel = parent_otel.with_model(
         config.model.as_str(),
         models_manager
-            .construct_model_family(&config.model)
+            .construct_model_family(&config.model, &config)
             .slug
             .as_str(),
     );

--- a/codex-rs/core/src/truncate.rs
+++ b/codex-rs/core/src/truncate.rs
@@ -26,10 +26,10 @@ impl TruncationPolicy {
         }
     }
 
-    pub fn new(config: &Config) -> Self {
+    pub fn new(config: &Config, truncation_policy: TruncationPolicy) -> Self {
         let config_token_limit = config.tool_output_token_limit;
 
-        match config.model_family.truncation_policy {
+        match truncation_policy {
             TruncationPolicy::Bytes(family_bytes) => {
                 if let Some(token_limit) = config_token_limit {
                     Self::Bytes(approx_bytes_for_tokens(token_limit))

--- a/codex-rs/core/tests/chat_completions_payload.rs
+++ b/codex-rs/core/tests/chat_completions_payload.rs
@@ -72,14 +72,11 @@ async fn run_request(input: Vec<ResponseItem>) -> Value {
 
     let conversation_id = ConversationId::new();
     let models_manager = Arc::new(ModelsManager::new(Some(AuthMode::ApiKey)));
-
+    let model_family = models_manager.construct_model_family(&config.model, &config);
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
         config.model.as_str(),
-        models_manager
-            .construct_model_family(&config.model, &config)
-            .slug
-            .as_str(),
+        model_family.slug.as_str(),
         None,
         Some("test@test.com".to_string()),
         Some(AuthMode::ApiKey),
@@ -90,7 +87,7 @@ async fn run_request(input: Vec<ResponseItem>) -> Value {
     let client = ModelClient::new(
         Arc::clone(&config),
         None,
-        models_manager.clone(),
+        model_family,
         otel_event_manager,
         provider,
         effort,

--- a/codex-rs/core/tests/chat_completions_payload.rs
+++ b/codex-rs/core/tests/chat_completions_payload.rs
@@ -10,6 +10,7 @@ use codex_core::ModelProviderInfo;
 use codex_core::Prompt;
 use codex_core::ResponseItem;
 use codex_core::WireApi;
+use codex_core::openai_models::models_manager::ModelsManager;
 use codex_otel::otel_event_manager::OtelEventManager;
 use codex_protocol::ConversationId;
 use codex_protocol::models::ReasoningItemContent;
@@ -70,14 +71,18 @@ async fn run_request(input: Vec<ResponseItem>) -> Value {
     let config = Arc::new(config);
 
     let conversation_id = ConversationId::new();
+    let models_manager = Arc::new(ModelsManager::new(Some(AuthMode::ApiKey)));
 
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
         config.model.as_str(),
-        config.model_family.slug.as_str(),
+        models_manager
+            .construct_model_family(&config.model)
+            .slug
+            .as_str(),
         None,
         Some("test@test.com".to_string()),
-        Some(AuthMode::ChatGPT),
+        Some(AuthMode::ApiKey),
         false,
         "test".to_string(),
     );
@@ -85,6 +90,7 @@ async fn run_request(input: Vec<ResponseItem>) -> Value {
     let client = ModelClient::new(
         Arc::clone(&config),
         None,
+        models_manager.clone(),
         otel_event_manager,
         provider,
         effort,

--- a/codex-rs/core/tests/chat_completions_payload.rs
+++ b/codex-rs/core/tests/chat_completions_payload.rs
@@ -77,7 +77,7 @@ async fn run_request(input: Vec<ResponseItem>) -> Value {
         conversation_id,
         config.model.as_str(),
         models_manager
-            .construct_model_family(&config.model)
+            .construct_model_family(&config.model, &config)
             .slug
             .as_str(),
         None,

--- a/codex-rs/core/tests/chat_completions_sse.rs
+++ b/codex-rs/core/tests/chat_completions_sse.rs
@@ -1,4 +1,5 @@
 use assert_matches::assert_matches;
+use codex_core::openai_models::models_manager::ModelsManager;
 use std::sync::Arc;
 use tracing_test::traced_test;
 
@@ -70,14 +71,18 @@ async fn run_stream_with_bytes(sse_body: &[u8]) -> Vec<ResponseEvent> {
     let config = Arc::new(config);
 
     let conversation_id = ConversationId::new();
-
+    let auth_mode = AuthMode::ApiKey;
+    let models_manager = Arc::new(ModelsManager::new(Some(auth_mode)));
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
         config.model.as_str(),
-        config.model_family.slug.as_str(),
+        models_manager
+            .construct_model_family(&config.model)
+            .slug
+            .as_str(),
         None,
         Some("test@test.com".to_string()),
-        Some(AuthMode::ChatGPT),
+        Some(auth_mode),
         false,
         "test".to_string(),
     );
@@ -85,6 +90,7 @@ async fn run_stream_with_bytes(sse_body: &[u8]) -> Vec<ResponseEvent> {
     let client = ModelClient::new(
         Arc::clone(&config),
         None,
+        models_manager.clone(),
         otel_event_manager,
         provider,
         effort,

--- a/codex-rs/core/tests/chat_completions_sse.rs
+++ b/codex-rs/core/tests/chat_completions_sse.rs
@@ -73,13 +73,11 @@ async fn run_stream_with_bytes(sse_body: &[u8]) -> Vec<ResponseEvent> {
     let conversation_id = ConversationId::new();
     let auth_mode = AuthMode::ApiKey;
     let models_manager = Arc::new(ModelsManager::new(Some(auth_mode)));
+    let model_family = models_manager.construct_model_family(&config.model, &config);
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
         config.model.as_str(),
-        models_manager
-            .construct_model_family(&config.model, &config)
-            .slug
-            .as_str(),
+        model_family.slug.as_str(),
         None,
         Some("test@test.com".to_string()),
         Some(auth_mode),
@@ -90,7 +88,7 @@ async fn run_stream_with_bytes(sse_body: &[u8]) -> Vec<ResponseEvent> {
     let client = ModelClient::new(
         Arc::clone(&config),
         None,
-        models_manager.clone(),
+        model_family,
         otel_event_manager,
         provider,
         effort,

--- a/codex-rs/core/tests/chat_completions_sse.rs
+++ b/codex-rs/core/tests/chat_completions_sse.rs
@@ -77,7 +77,7 @@ async fn run_stream_with_bytes(sse_body: &[u8]) -> Vec<ResponseEvent> {
         conversation_id,
         config.model.as_str(),
         models_manager
-            .construct_model_family(&config.model)
+            .construct_model_family(&config.model, &config)
             .slug
             .as_str(),
         None,

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -118,6 +118,7 @@ impl TestCodexBuilder {
             config,
             codex: new_conversation.conversation,
             session_configured: new_conversation.session_configured,
+            conversation_manager: Arc::new(conversation_manager),
         })
     }
 
@@ -160,6 +161,7 @@ pub struct TestCodex {
     pub codex: Arc<CodexConversation>,
     pub session_configured: SessionConfiguredEvent,
     pub config: Config,
+    pub conversation_manager: Arc<ConversationManager>,
 }
 
 impl TestCodex {

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -8,6 +8,7 @@ use codex_core::Prompt;
 use codex_core::ResponseEvent;
 use codex_core::ResponseItem;
 use codex_core::WireApi;
+use codex_core::openai_models::models_manager::ModelsManager;
 use codex_otel::otel_event_manager::OtelEventManager;
 use codex_protocol::ConversationId;
 use codex_protocol::protocol::SessionSource;
@@ -59,14 +60,19 @@ async fn responses_stream_includes_subagent_header_on_review() {
     let config = Arc::new(config);
 
     let conversation_id = ConversationId::new();
+    let auth_mode = AuthMode::ChatGPT;
+    let models_manager = Arc::new(ModelsManager::new(Some(auth_mode)));
 
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
         config.model.as_str(),
-        config.model_family.slug.as_str(),
+        models_manager
+            .construct_model_family(&config.model)
+            .slug
+            .as_str(),
         None,
         Some("test@test.com".to_string()),
-        Some(AuthMode::ChatGPT),
+        Some(auth_mode),
         false,
         "test".to_string(),
     );
@@ -74,6 +80,7 @@ async fn responses_stream_includes_subagent_header_on_review() {
     let client = ModelClient::new(
         Arc::clone(&config),
         None,
+        models_manager.clone(),
         otel_event_manager,
         provider,
         effort,
@@ -147,14 +154,19 @@ async fn responses_stream_includes_subagent_header_on_other() {
     let config = Arc::new(config);
 
     let conversation_id = ConversationId::new();
+    let auth_mode = AuthMode::ChatGPT;
+    let models_manager = Arc::new(ModelsManager::new(Some(auth_mode)));
 
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
         config.model.as_str(),
-        config.model_family.slug.as_str(),
+        models_manager
+            .construct_model_family(&config.model)
+            .slug
+            .as_str(),
         None,
         Some("test@test.com".to_string()),
-        Some(AuthMode::ChatGPT),
+        Some(auth_mode),
         false,
         "test".to_string(),
     );
@@ -162,6 +174,7 @@ async fn responses_stream_includes_subagent_header_on_other() {
     let client = ModelClient::new(
         Arc::clone(&config),
         None,
+        models_manager.clone(),
         otel_event_manager,
         provider,
         effort,

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -8,9 +8,11 @@ use codex_core::Prompt;
 use codex_core::ResponseEvent;
 use codex_core::ResponseItem;
 use codex_core::WireApi;
+use codex_core::config::types::ReasoningSummaryFormat;
 use codex_core::openai_models::models_manager::ModelsManager;
 use codex_otel::otel_event_manager::OtelEventManager;
 use codex_protocol::ConversationId;
+use codex_protocol::config_types::ReasoningSummary;
 use codex_protocol::protocol::SessionSource;
 use core_test_support::load_default_config_for_test;
 use core_test_support::responses;
@@ -67,7 +69,7 @@ async fn responses_stream_includes_subagent_header_on_review() {
         conversation_id,
         config.model.as_str(),
         models_manager
-            .construct_model_family(&config.model)
+            .construct_model_family(&config.model, &config)
             .slug
             .as_str(),
         None,
@@ -161,7 +163,7 @@ async fn responses_stream_includes_subagent_header_on_other() {
         conversation_id,
         config.model.as_str(),
         models_manager
-            .construct_model_family(&config.model)
+            .construct_model_family(&config.model, &config)
             .slug
             .as_str(),
         None,
@@ -205,5 +207,114 @@ async fn responses_stream_includes_subagent_header_on_other() {
     assert_eq!(
         request.header("x-openai-subagent").as_deref(),
         Some("my-task")
+    );
+}
+
+#[tokio::test]
+async fn responses_respects_model_family_overrides_from_config() {
+    core_test_support::skip_if_no_network!();
+
+    let server = responses::start_mock_server().await;
+    let response_body = responses::sse(vec![
+        responses::ev_response_created("resp-1"),
+        responses::ev_completed("resp-1"),
+    ]);
+
+    let request_recorder = responses::mount_sse_once(&server, response_body).await;
+
+    let provider = ModelProviderInfo {
+        name: "mock".into(),
+        base_url: Some(format!("{}/v1", server.uri())),
+        env_key: None,
+        env_key_instructions: None,
+        experimental_bearer_token: None,
+        wire_api: WireApi::Responses,
+        query_params: None,
+        http_headers: None,
+        env_http_headers: None,
+        request_max_retries: Some(0),
+        stream_max_retries: Some(0),
+        stream_idle_timeout_ms: Some(5_000),
+        requires_openai_auth: false,
+    };
+
+    let codex_home = TempDir::new().expect("failed to create TempDir");
+    let mut config = load_default_config_for_test(&codex_home);
+    config.model = "gpt-3.5-turbo".to_string();
+    config.model_provider_id = provider.name.clone();
+    config.model_provider = provider.clone();
+    config.model_supports_reasoning_summaries = Some(true);
+    config.model_reasoning_summary_format = Some(ReasoningSummaryFormat::Experimental);
+    config.model_reasoning_summary = ReasoningSummary::Detailed;
+    let effort = config.model_reasoning_effort;
+    let summary = config.model_reasoning_summary;
+    let config = Arc::new(config);
+
+    let conversation_id = ConversationId::new();
+    let auth_mode = AuthMode::ChatGPT;
+    let models_manager = Arc::new(ModelsManager::new(Some(auth_mode)));
+
+    let otel_event_manager = OtelEventManager::new(
+        conversation_id,
+        config.model.as_str(),
+        models_manager
+            .construct_model_family(&config.model, &config)
+            .slug
+            .as_str(),
+        None,
+        Some("test@test.com".to_string()),
+        Some(auth_mode),
+        false,
+        "test".to_string(),
+    );
+
+    let client = ModelClient::new(
+        Arc::clone(&config),
+        None,
+        models_manager.clone(),
+        otel_event_manager,
+        provider,
+        effort,
+        summary,
+        conversation_id,
+        SessionSource::SubAgent(codex_protocol::protocol::SubAgentSource::Other(
+            "override-check".to_string(),
+        )),
+    );
+
+    let mut prompt = Prompt::default();
+    prompt.input = vec![ResponseItem::Message {
+        id: None,
+        role: "user".into(),
+        content: vec![ContentItem::InputText {
+            text: "hello".into(),
+        }],
+    }];
+
+    let mut stream = client.stream(&prompt).await.expect("stream failed");
+    while let Some(event) = stream.next().await {
+        if matches!(event, Ok(ResponseEvent::Completed { .. })) {
+            break;
+        }
+    }
+
+    let request = request_recorder.single_request();
+    let body = request.body_json();
+    let reasoning = body
+        .get("reasoning")
+        .and_then(|value| value.as_object())
+        .cloned();
+
+    assert!(
+        reasoning.is_some(),
+        "reasoning should be present when config enables summaries"
+    );
+
+    assert_eq!(
+        reasoning
+            .as_ref()
+            .and_then(|value| value.get("summary"))
+            .and_then(|value| value.as_str()),
+        Some("detailed")
     );
 }

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -64,14 +64,11 @@ async fn responses_stream_includes_subagent_header_on_review() {
     let conversation_id = ConversationId::new();
     let auth_mode = AuthMode::ChatGPT;
     let models_manager = Arc::new(ModelsManager::new(Some(auth_mode)));
-
+    let model_family = models_manager.construct_model_family(&config.model, &config);
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
         config.model.as_str(),
-        models_manager
-            .construct_model_family(&config.model, &config)
-            .slug
-            .as_str(),
+        model_family.slug.as_str(),
         None,
         Some("test@test.com".to_string()),
         Some(auth_mode),
@@ -82,7 +79,7 @@ async fn responses_stream_includes_subagent_header_on_review() {
     let client = ModelClient::new(
         Arc::clone(&config),
         None,
-        models_manager.clone(),
+        model_family,
         otel_event_manager,
         provider,
         effort,
@@ -158,14 +155,12 @@ async fn responses_stream_includes_subagent_header_on_other() {
     let conversation_id = ConversationId::new();
     let auth_mode = AuthMode::ChatGPT;
     let models_manager = Arc::new(ModelsManager::new(Some(auth_mode)));
+    let model_family = models_manager.construct_model_family(&config.model, &config);
 
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
         config.model.as_str(),
-        models_manager
-            .construct_model_family(&config.model, &config)
-            .slug
-            .as_str(),
+        model_family.slug.as_str(),
         None,
         Some("test@test.com".to_string()),
         Some(auth_mode),
@@ -176,7 +171,7 @@ async fn responses_stream_includes_subagent_header_on_other() {
     let client = ModelClient::new(
         Arc::clone(&config),
         None,
-        models_manager.clone(),
+        model_family,
         otel_event_manager,
         provider,
         effort,
@@ -253,14 +248,11 @@ async fn responses_respects_model_family_overrides_from_config() {
     let conversation_id = ConversationId::new();
     let auth_mode = AuthMode::ChatGPT;
     let models_manager = Arc::new(ModelsManager::new(Some(auth_mode)));
-
+    let model_family = models_manager.construct_model_family(&config.model, &config);
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
         config.model.as_str(),
-        models_manager
-            .construct_model_family(&config.model, &config)
-            .slug
-            .as_str(),
+        model_family.slug.as_str(),
         None,
         Some("test@test.com".to_string()),
         Some(auth_mode),
@@ -271,7 +263,7 @@ async fn responses_respects_model_family_overrides_from_config() {
     let client = ModelClient::new(
         Arc::clone(&config),
         None,
-        models_manager.clone(),
+        model_family,
         otel_event_manager,
         provider,
         effort,

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -1017,16 +1017,13 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
     let config = Arc::new(config);
 
     let conversation_id = ConversationId::new();
-
     let auth_mode = AuthMode::ChatGPT;
     let models_manager = Arc::new(ModelsManager::new(Some(auth_mode)));
+    let model_family = models_manager.construct_model_family(&config.model, &config);
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
         config.model.as_str(),
-        models_manager
-            .construct_model_family(&config.model, &config)
-            .slug
-            .as_str(),
+        model_family.slug.as_str(),
         None,
         Some("test@test.com".to_string()),
         Some(AuthMode::ChatGPT),
@@ -1037,7 +1034,7 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
     let client = ModelClient::new(
         Arc::clone(&config),
         None,
-        models_manager.clone(),
+        model_family,
         otel_event_manager,
         provider,
         effort,

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -1024,7 +1024,7 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
         conversation_id,
         config.model.as_str(),
         models_manager
-            .construct_model_family(&config.model)
+            .construct_model_family(&config.model, &config)
             .slug
             .as_str(),
         None,

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -16,7 +16,7 @@ use codex_core::auth::AuthCredentialsStoreMode;
 use codex_core::built_in_model_providers;
 use codex_core::error::CodexErr;
 use codex_core::features::Feature;
-use codex_core::openai_models::model_family::find_family_for_model;
+use codex_core::openai_models::models_manager::ModelsManager;
 use codex_core::protocol::EventMsg;
 use codex_core::protocol::Op;
 use codex_core::protocol::SessionSource;
@@ -1018,10 +1018,15 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
 
     let conversation_id = ConversationId::new();
 
+    let auth_mode = AuthMode::ChatGPT;
+    let models_manager = Arc::new(ModelsManager::new(Some(auth_mode)));
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
         config.model.as_str(),
-        config.model_family.slug.as_str(),
+        models_manager
+            .construct_model_family(&config.model)
+            .slug
+            .as_str(),
         None,
         Some("test@test.com".to_string()),
         Some(AuthMode::ChatGPT),
@@ -1032,6 +1037,7 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
     let client = ModelClient::new(
         Arc::clone(&config),
         None,
+        models_manager.clone(),
         otel_event_manager,
         provider,
         effort,
@@ -1378,7 +1384,6 @@ async fn context_window_error_sets_total_tokens_to_model_window() -> anyhow::Res
     let TestCodex { codex, .. } = test_codex()
         .with_config(|config| {
             config.model = "gpt-5.1".to_string();
-            config.model_family = find_family_for_model("gpt-5.1");
             config.model_context_window = Some(272_000);
         })
         .build(&server)

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -1,7 +1,6 @@
 #![allow(clippy::unwrap_used)]
 
 use codex_core::features::Feature;
-use codex_core::openai_models::model_family::find_family_for_model;
 use codex_core::protocol::AskForApproval;
 use codex_core::protocol::ENVIRONMENT_CONTEXT_OPEN_TAG;
 use codex_core::protocol::EventMsg;
@@ -73,7 +72,6 @@ async fn codex_mini_latest_tools() -> anyhow::Result<()> {
             config.user_instructions = Some("be consistent and helpful".to_string());
             config.features.disable(Feature::ApplyPatchFreeform);
             config.model = "codex-mini-latest".to_string();
-            config.model_family = find_family_for_model("codex-mini-latest")
         })
         .build(&server)
         .await?;
@@ -125,13 +123,22 @@ async fn prompt_tools_are_consistent_across_requests() -> anyhow::Result<()> {
     let req1 = mount_sse_once(&server, sse_completed("resp-1")).await;
     let req2 = mount_sse_once(&server, sse_completed("resp-2")).await;
 
-    let TestCodex { codex, config, .. } = test_codex()
+    let TestCodex {
+        codex,
+        config,
+        conversation_manager,
+        ..
+    } = test_codex()
         .with_config(|config| {
             config.user_instructions = Some("be consistent and helpful".to_string());
         })
         .build(&server)
         .await?;
-    let base_instructions = config.model_family.base_instructions.clone();
+    let base_instructions = conversation_manager
+        .get_models_manager()
+        .construct_model_family(&config.model)
+        .base_instructions
+        .clone();
 
     codex
         .submit(Op::UserInput {

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -136,7 +136,7 @@ async fn prompt_tools_are_consistent_across_requests() -> anyhow::Result<()> {
         .await?;
     let base_instructions = conversation_manager
         .get_models_manager()
-        .construct_model_family(&config.model)
+        .construct_model_family(&config.model, &config)
         .base_instructions
         .clone();
 

--- a/codex-rs/core/tests/suite/shell_serialization.rs
+++ b/codex-rs/core/tests/suite/shell_serialization.rs
@@ -103,10 +103,12 @@ fn configure_shell_model(
     output_type: ShellModelOutput,
     include_apply_patch_tool: bool,
 ) -> TestCodexBuilder {
-    let builder = match output_type {
-        ShellModelOutput::ShellCommand => builder.with_model("test-gpt-5-codex"),
-        ShellModelOutput::LocalShell => builder.with_model("codex-mini-latest"),
-        ShellModelOutput::Shell => builder.with_model("gpt-4.1"),
+    let builder = match (output_type, include_apply_patch_tool) {
+        (ShellModelOutput::ShellCommand, _) => builder.with_model("test-gpt-5-codex"),
+        (ShellModelOutput::LocalShell, true) => builder.with_model("gpt-5.1-codex"),
+        (ShellModelOutput::Shell, true) => builder.with_model("gpt-5.1-codex"),
+        (ShellModelOutput::LocalShell, false) => builder.with_model("codex-mini-latest"),
+        (ShellModelOutput::Shell, false) => builder.with_model("gpt-5"),
     };
 
     builder.with_config(move |config| {

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -26,7 +26,6 @@ use codex_core::ConversationManager;
 use codex_core::config::Config;
 use codex_core::config::edit::ConfigEditsBuilder;
 use codex_core::features::Feature;
-use codex_core::openai_models::model_family::find_family_for_model;
 use codex_core::openai_models::model_presets::HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG;
 use codex_core::openai_models::model_presets::HIDE_GPT5_1_MIGRATION_PROMPT_CONFIG;
 use codex_core::openai_models::models_manager::ModelsManager;
@@ -162,7 +161,6 @@ async fn handle_model_migration_prompt_if_needed(
                     migration_config: migration_config_key.to_string(),
                 });
                 config.model = target_model.to_string();
-                config.model_family = find_family_for_model(&target_model);
 
                 let mapped_effort = if let Some(reasoning_effort_mapping) = reasoning_effort_mapping
                     && let Some(reasoning_effort) = config.model_reasoning_effort
@@ -680,9 +678,7 @@ impl App {
             }
             AppEvent::UpdateModel(model) => {
                 self.chat_widget.set_model(&model);
-                self.config.model = model.clone();
-                let family = find_family_for_model(&model);
-                self.config.model_family = family;
+                self.config.model = model;
             }
             AppEvent::OpenReasoningPopup { model } => {
                 self.chat_widget.open_reasoning_popup(model);

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -469,6 +469,7 @@ impl ChatWidget {
             let cell = history_cell::new_reasoning_summary_block(
                 self.full_reasoning_buffer.clone(),
                 &self.config,
+                &self.models_manager,
             );
             self.add_boxed_history(cell);
         }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -465,11 +465,13 @@ impl ChatWidget {
     fn on_agent_reasoning_final(&mut self) {
         // At the end of a reasoning block, record transcript-only content.
         self.full_reasoning_buffer.push_str(&self.reasoning_buffer);
+        let model_family = self
+            .models_manager
+            .construct_model_family(&self.config.model, &self.config);
         if !self.full_reasoning_buffer.is_empty() {
             let cell = history_cell::new_reasoning_summary_block(
                 self.full_reasoning_buffer.clone(),
-                &self.config,
-                &self.models_manager,
+                &model_family,
             );
             self.add_boxed_history(cell);
         }

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -27,7 +27,7 @@ use codex_common::format_env_display::format_env_display;
 use codex_core::config::Config;
 use codex_core::config::types::McpServerTransportConfig;
 use codex_core::config::types::ReasoningSummaryFormat;
-use codex_core::openai_models::models_manager::ModelsManager;
+use codex_core::openai_models::model_family::ModelFamily;
 use codex_core::protocol::FileChange;
 use codex_core::protocol::McpAuthStatus;
 use codex_core::protocol::McpInvocation;
@@ -1407,10 +1407,8 @@ pub(crate) fn new_view_image_tool_call(path: PathBuf, cwd: &Path) -> PlainHistor
 
 pub(crate) fn new_reasoning_summary_block(
     full_reasoning_buffer: String,
-    config: &Config,
-    models_manager: &ModelsManager,
+    model_family: &ModelFamily,
 ) -> Box<dyn HistoryCell> {
-    let model_family = models_manager.construct_model_family(&config.model, config);
     if model_family.reasoning_summary_format == ReasoningSummaryFormat::Experimental {
         // Experimental format is following:
         // ** header **
@@ -1506,6 +1504,7 @@ mod tests {
     use codex_core::config::ConfigToml;
     use codex_core::config::types::McpServerConfig;
     use codex_core::config::types::McpServerTransportConfig;
+    use codex_core::openai_models::models_manager::ModelsManager;
     use codex_core::protocol::McpAuthStatus;
     use codex_login::AuthMode;
     use codex_protocol::parse_command::ParsedCommand;
@@ -2313,11 +2312,10 @@ mod tests {
     fn reasoning_summary_block() {
         let config = test_config();
         let models_manager = Arc::new(ModelsManager::new(Some(AuthMode::ApiKey)));
-
+        let model_family = models_manager.construct_model_family(&config.model, &config);
         let cell = new_reasoning_summary_block(
             "**High level reasoning**\n\nDetailed reasoning goes here.".to_string(),
-            &config,
-            &models_manager,
+            &model_family,
         );
 
         let rendered_display = render_lines(&cell.display_lines(80));
@@ -2331,12 +2329,9 @@ mod tests {
     fn reasoning_summary_block_returns_reasoning_cell_when_feature_disabled() {
         let config = test_config();
         let models_manager = Arc::new(ModelsManager::new(Some(AuthMode::ApiKey)));
-
-        let cell = new_reasoning_summary_block(
-            "Detailed reasoning goes here.".to_string(),
-            &config,
-            &models_manager,
-        );
+        let model_family = models_manager.construct_model_family(&config.model, &config);
+        let cell =
+            new_reasoning_summary_block("Detailed reasoning goes here.".to_string(), &model_family);
 
         let rendered = render_transcript(cell.as_ref());
         assert_eq!(rendered, vec!["• Detailed reasoning goes here."]);
@@ -2358,8 +2353,7 @@ mod tests {
 
         let cell = new_reasoning_summary_block(
             "**High level reasoning**\n\nDetailed reasoning goes here.".to_string(),
-            &config,
-            &models_manager,
+            &model_family,
         );
 
         let rendered_display = render_lines(&cell.display_lines(80));
@@ -2370,11 +2364,10 @@ mod tests {
     fn reasoning_summary_block_falls_back_when_header_is_missing() {
         let config = test_config();
         let models_manager = Arc::new(ModelsManager::new(Some(AuthMode::ApiKey)));
-
+        let model_family = models_manager.construct_model_family(&config.model, &config);
         let cell = new_reasoning_summary_block(
             "**High level reasoning without closing".to_string(),
-            &config,
-            &models_manager,
+            &model_family,
         );
 
         let rendered = render_transcript(cell.as_ref());
@@ -2385,11 +2378,10 @@ mod tests {
     fn reasoning_summary_block_falls_back_when_summary_is_missing() {
         let config = test_config();
         let models_manager = Arc::new(ModelsManager::new(Some(AuthMode::ApiKey)));
-
+        let model_family = models_manager.construct_model_family(&config.model, &config);
         let cell = new_reasoning_summary_block(
             "**High level reasoning without closing**".to_string(),
-            &config,
-            &models_manager,
+            &model_family,
         );
 
         let rendered = render_transcript(cell.as_ref());
@@ -2397,8 +2389,7 @@ mod tests {
 
         let cell = new_reasoning_summary_block(
             "**High level reasoning without closing**\n\n  ".to_string(),
-            &config,
-            &models_manager,
+            &model_family,
         );
 
         let rendered = render_transcript(cell.as_ref());
@@ -2409,11 +2400,10 @@ mod tests {
     fn reasoning_summary_block_splits_header_and_summary_when_present() {
         let config = test_config();
         let models_manager = Arc::new(ModelsManager::new(Some(AuthMode::ApiKey)));
-
+        let model_family = models_manager.construct_model_family(&config.model, &config);
         let cell = new_reasoning_summary_block(
             "**High level plan**\n\nWe should fix the bug next.".to_string(),
-            &config,
-            &models_manager,
+            &model_family,
         );
 
         let rendered_display = render_lines(&cell.display_lines(80));

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -27,6 +27,7 @@ use codex_common::format_env_display::format_env_display;
 use codex_core::config::Config;
 use codex_core::config::types::McpServerTransportConfig;
 use codex_core::config::types::ReasoningSummaryFormat;
+use codex_core::openai_models::models_manager::ModelsManager;
 use codex_core::protocol::FileChange;
 use codex_core::protocol::McpAuthStatus;
 use codex_core::protocol::McpInvocation;
@@ -1407,8 +1408,10 @@ pub(crate) fn new_view_image_tool_call(path: PathBuf, cwd: &Path) -> PlainHistor
 pub(crate) fn new_reasoning_summary_block(
     full_reasoning_buffer: String,
     config: &Config,
+    models_manager: &ModelsManager,
 ) -> Box<dyn HistoryCell> {
-    if config.model_family.reasoning_summary_format == ReasoningSummaryFormat::Experimental {
+    let model_family = models_manager.construct_model_family(&config.model);
+    if model_family.reasoning_summary_format == ReasoningSummaryFormat::Experimental {
         // Experimental format is following:
         // ** header **
         //
@@ -1504,11 +1507,13 @@ mod tests {
     use codex_core::config::types::McpServerConfig;
     use codex_core::config::types::McpServerTransportConfig;
     use codex_core::protocol::McpAuthStatus;
+    use codex_login::AuthMode;
     use codex_protocol::parse_command::ParsedCommand;
     use dirs::home_dir;
     use pretty_assertions::assert_eq;
     use serde_json::json;
     use std::collections::HashMap;
+    use std::sync::Arc;
 
     use codex_core::protocol::ExecCommandSource;
     use mcp_types::CallToolResult;
@@ -2306,12 +2311,13 @@ mod tests {
     }
     #[test]
     fn reasoning_summary_block() {
-        let mut config = test_config();
-        config.model_family.reasoning_summary_format = ReasoningSummaryFormat::Experimental;
+        let config = test_config();
+        let models_manager = Arc::new(ModelsManager::new(Some(AuthMode::ApiKey)));
 
         let cell = new_reasoning_summary_block(
             "**High level reasoning**\n\nDetailed reasoning goes here.".to_string(),
             &config,
+            &models_manager,
         );
 
         let rendered_display = render_lines(&cell.display_lines(80));
@@ -2323,11 +2329,14 @@ mod tests {
 
     #[test]
     fn reasoning_summary_block_returns_reasoning_cell_when_feature_disabled() {
-        let mut config = test_config();
-        config.model_family.reasoning_summary_format = ReasoningSummaryFormat::Experimental;
+        let config = test_config();
+        let models_manager = Arc::new(ModelsManager::new(Some(AuthMode::ApiKey)));
 
-        let cell =
-            new_reasoning_summary_block("Detailed reasoning goes here.".to_string(), &config);
+        let cell = new_reasoning_summary_block(
+            "Detailed reasoning goes here.".to_string(),
+            &config,
+            &models_manager,
+        );
 
         let rendered = render_transcript(cell.as_ref());
         assert_eq!(rendered, vec!["• Detailed reasoning goes here."]);
@@ -2335,12 +2344,13 @@ mod tests {
 
     #[test]
     fn reasoning_summary_block_falls_back_when_header_is_missing() {
-        let mut config = test_config();
-        config.model_family.reasoning_summary_format = ReasoningSummaryFormat::Experimental;
+        let config = test_config();
+        let models_manager = Arc::new(ModelsManager::new(Some(AuthMode::ApiKey)));
 
         let cell = new_reasoning_summary_block(
             "**High level reasoning without closing".to_string(),
             &config,
+            &models_manager,
         );
 
         let rendered = render_transcript(cell.as_ref());
@@ -2349,12 +2359,13 @@ mod tests {
 
     #[test]
     fn reasoning_summary_block_falls_back_when_summary_is_missing() {
-        let mut config = test_config();
-        config.model_family.reasoning_summary_format = ReasoningSummaryFormat::Experimental;
+        let config = test_config();
+        let models_manager = Arc::new(ModelsManager::new(Some(AuthMode::ApiKey)));
 
         let cell = new_reasoning_summary_block(
             "**High level reasoning without closing**".to_string(),
             &config,
+            &models_manager,
         );
 
         let rendered = render_transcript(cell.as_ref());
@@ -2363,6 +2374,7 @@ mod tests {
         let cell = new_reasoning_summary_block(
             "**High level reasoning without closing**\n\n  ".to_string(),
             &config,
+            &models_manager,
         );
 
         let rendered = render_transcript(cell.as_ref());
@@ -2371,12 +2383,13 @@ mod tests {
 
     #[test]
     fn reasoning_summary_block_splits_header_and_summary_when_present() {
-        let mut config = test_config();
-        config.model_family.reasoning_summary_format = ReasoningSummaryFormat::Experimental;
+        let config = test_config();
+        let models_manager = Arc::new(ModelsManager::new(Some(AuthMode::ApiKey)));
 
         let cell = new_reasoning_summary_block(
             "**High level plan**\n\nWe should fix the bug next.".to_string(),
             &config,
+            &models_manager,
         );
 
         let rendered_display = render_lines(&cell.display_lines(80));


### PR DESCRIPTION
- Remove `model_family` from `config`
- Make sure to still override config elements related to `model_family` like supporting reasoning