### PR TITLE
feat: update sandbox policy to allow TTY

### DIFF
--- a/codex-rs/core/src/seatbelt_base_policy.sbpl
+++ b/codex-rs/core/src/seatbelt_base_policy.sbpl
@@ -102,3 +102,6 @@
   (require-all
     (regex #"^/dev/ttys[0-9]+")
     (extension "com.apple.sandbox.pty")))
+; PTYs created before entering seatbelt may lack the extension; allow ioctl
+; on those slave ttys so interactive shells detect a TTY and remain functional.
+(allow file-ioctl (regex #"^/dev/ttys[0-9]+"))


### PR DESCRIPTION
**Change**: Seatbelt now allows file-ioctl on /dev/ttys[0-9]+ even without the sandbox extension so pre-created PTYs remain interactive (Python REPL, shells).

**Risk**: A seatbelted process that already holds a PTY fd (including one it shouldn’t) could issue tty ioctls like TIOCSTI or termios changes on that fd. This doesn’t allow opening new PTYs or reading/writing them; it only broadens ioctl capability on existing fds.

**Why acceptable**: We already hand the child its PTY for interactive use; restoring ioctls is required for isatty() and prompts to work. The attack requires being given or inheriting a sensitive PTY fd; by design we don’t hand untrusted processes other users’ PTYs (we don't hand them any PTYs actually), so the practical exposure is limited to the PTY intentionally allocated for the session.

**Validation**:
Running
```
start a python interpreter and keep it running
```
Followed by:
* `calculate 1+1 using it` -> works as expected
* `Use this Python session to run the command just fix in /Users/jif/code/codex/codex-rs` -> does not work as expected