### PR TITLE
fix: preserve arg0 for PTY sandbox commands without relying on PATH

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1663,6 +1663,8 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "portable-pty",
+ "pretty_assertions",
+ "tempfile",
  "tokio",
 ]
 

--- a/codex-rs/utils/pty/Cargo.toml
+++ b/codex-rs/utils/pty/Cargo.toml
@@ -10,4 +10,8 @@ workspace = true
 [dependencies]
 anyhow = { workspace = true }
 portable-pty = { workspace = true }
-tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync"] }
+tempfile = { workspace = true }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "sync", "time"] }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }

--- a/codex-rs/utils/pty/tests/arg0.rs
+++ b/codex-rs/utils/pty/tests/arg0.rs
@@ -1,0 +1,58 @@
+#[cfg(unix)]
+use std::collections::HashMap;
+#[cfg(unix)]
+use std::time::Duration;
+
+#[cfg(unix)]
+use pretty_assertions::assert_eq;
+#[cfg(unix)]
+use tokio::sync::broadcast::error::RecvError;
+
+#[cfg(unix)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn spawn_pty_preserves_arg0_without_path_lookup() -> anyhow::Result<()> {
+    let cwd = std::env::current_dir()?;
+    let mut env = HashMap::new();
+    env.insert("PATH".to_string(), "/usr/bin:/bin".to_string());
+
+    let arg0 = Some("codex-linux-sandbox".to_string());
+    let args = vec!["-c".to_string(), "echo $0".to_string()];
+
+    let spawned = codex_utils_pty::spawn_pty_process("/bin/sh", &args, &cwd, &env, &arg0).await?;
+
+    let mut output_rx = spawned.output_rx;
+    let mut exit_rx = spawned.exit_rx;
+    let mut collected = Vec::new();
+
+    let exit_code = loop {
+        tokio::select! {
+            exit_code = &mut exit_rx => break exit_code?,
+            chunk = output_rx.recv() => match chunk {
+                Ok(chunk) => collected.extend_from_slice(&chunk),
+                Err(RecvError::Lagged(_)) => continue,
+                Err(RecvError::Closed) => break -1,
+            }
+        }
+    };
+    assert_eq!(exit_code, 0);
+
+    loop {
+        match tokio::time::timeout(Duration::from_millis(25), output_rx.recv()).await {
+            Ok(Ok(chunk)) => collected.extend_from_slice(&chunk),
+            Ok(Err(RecvError::Lagged(_))) => continue,
+            Ok(Err(RecvError::Closed)) | Err(_) => break,
+        }
+    }
+
+    let output = String::from_utf8_lossy(&collected);
+    assert!(
+        output.contains("codex-linux-sandbox"),
+        "expected argv0 to include codex-linux-sandbox, got {output:?}"
+    );
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+#[test]
+fn spawn_pty_preserves_arg0_without_path_lookup() {}


### PR DESCRIPTION
Unified exec PTY sessions under Seccomp were using arg0 as the program when spawning the PTY. For the `codex-linux-sandbox` case, this meant we were actually executing codex-linux-sandbox via `PATH` lookup instead of the configured `codex_linux_sandbox_exe` path.

**Fix:**
On Unix, creates a temporary directory, symlinks the real program to a filename derived from arg0 (i.e. `codex-linux-sandbox`), and uses that symlink as the command in CommandBuilder. 

This preserves argv[0] for dispatch while always executing the configured program path, and falls back to the old behavior when program is not absolute or arg0 is unset.