### PR TITLE
add --branch to codex cloud exec

### DIFF
--- a/codex-rs/cloud-tasks/src/cli.rs
+++ b/codex-rs/cloud-tasks/src/cli.rs
@@ -28,6 +28,10 @@ pub struct ExecCommand {
     #[arg(long = "env", value_name = "ENV_ID")]
     pub environment: String,
 
+    /// Git branch to run in Codex Cloud.
+    #[arg(long = "branch", value_name = "BRANCH", default_value = "main")]
+    pub branch: String,
+
     /// Number of assistant attempts (best-of-N).
     #[arg(
         long = "attempts",

--- a/codex-rs/cloud-tasks/src/lib.rs
+++ b/codex-rs/cloud-tasks/src/lib.rs
@@ -101,6 +101,7 @@ async fn run_exec_command(args: crate::cli::ExecCommand) -> anyhow::Result<()> {
     let crate::cli::ExecCommand {
         query,
         environment,
+        branch,
         attempts,
     } = args;
     let ctx = init_backend("codex_cloud_tasks_exec").await?;
@@ -110,7 +111,7 @@ async fn run_exec_command(args: crate::cli::ExecCommand) -> anyhow::Result<()> {
         &*ctx.backend,
         &env_id,
         &prompt,
-        "main",
+        &branch,
         false,
         attempts,
     )


### PR DESCRIPTION
Adds `--branch` to `codex cloud exec` to set base branch.