### PR TITLE
fix: use PowerShell to parse PowerShell

### DIFF
--- a/codex-rs/core/src/command_safety/powershell_parser.ps1
+++ b/codex-rs/core/src/command_safety/powershell_parser.ps1
@@ -1,0 +1,201 @@
+$ErrorActionPreference = 'Stop'
+
+$payload = $env:CODEX_POWERSHELL_PAYLOAD
+if ([string]::IsNullOrEmpty($payload)) {
+    Write-Output '{"status":"parse_failed"}'
+    exit 0
+}
+
+try {
+    $source =
+        [System.Text.Encoding]::Unicode.GetString(
+            [System.Convert]::FromBase64String($payload)
+        )
+} catch {
+    Write-Output '{"status":"parse_failed"}'
+    exit 0
+}
+
+$tokens = $null
+$errors = $null
+
+$ast = $null
+try {
+    $ast = [System.Management.Automation.Language.Parser]::ParseInput(
+        $source,
+        [ref]$tokens,
+        [ref]$errors
+    )
+} catch {
+    Write-Output '{"status":"parse_failed"}'
+    exit 0
+}
+
+if ($errors.Count -gt 0) {
+    Write-Output '{"status":"parse_errors"}'
+    exit 0
+}
+
+function Convert-CommandElement {
+    param($element)
+
+    if ($element -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+        return @($element.Value)
+    }
+
+    if ($element -is [System.Management.Automation.Language.ExpandableStringExpressionAst]) {
+        if ($element.NestedExpressions.Count -gt 0) {
+            return $null
+        }
+        return @($element.Value)
+    }
+
+    if ($element -is [System.Management.Automation.Language.ConstantExpressionAst]) {
+        return @($element.Value.ToString())
+    }
+
+    if ($element -is [System.Management.Automation.Language.CommandParameterAst]) {
+        if ($element.Argument -eq $null) {
+            return @('-' + $element.ParameterName)
+        }
+
+        if ($element.Argument -is [System.Management.Automation.Language.StringConstantExpressionAst]) {
+            return @('-' + $element.ParameterName, $element.Argument.Value)
+        }
+
+        if ($element.Argument -is [System.Management.Automation.Language.ConstantExpressionAst]) {
+            return @('-' + $element.ParameterName, $element.Argument.Value.ToString())
+        }
+
+        return $null
+    }
+
+    return $null
+}
+
+function Convert-PipelineElement {
+    param($element)
+
+    if ($element -is [System.Management.Automation.Language.CommandAst]) {
+        if ($element.Redirections.Count -gt 0) {
+            return $null
+        }
+
+        if (
+            $element.InvocationOperator -ne $null -and
+            $element.InvocationOperator -ne [System.Management.Automation.Language.TokenKind]::Unknown
+        ) {
+            return $null
+        }
+
+        $parts = @()
+        foreach ($commandElement in $element.CommandElements) {
+            $converted = Convert-CommandElement $commandElement
+            if ($converted -eq $null) {
+                return $null
+            }
+            $parts += $converted
+        }
+        return $parts
+    }
+
+    if ($element -is [System.Management.Automation.Language.CommandExpressionAst]) {
+        if ($element.Redirections.Count -gt 0) {
+            return $null
+        }
+
+        if ($element.Expression -is [System.Management.Automation.Language.ParenExpressionAst]) {
+            $innerPipeline = $element.Expression.Pipeline
+            if ($innerPipeline -and $innerPipeline.PipelineElements.Count -eq 1) {
+                return Convert-PipelineElement $innerPipeline.PipelineElements[0]
+            }
+        }
+
+        return $null
+    }
+
+    return $null
+}
+
+function Add-CommandsFromPipelineAst {
+    param($pipeline, $commands)
+
+    if ($pipeline.PipelineElements.Count -eq 0) {
+        return $false
+    }
+
+    foreach ($element in $pipeline.PipelineElements) {
+        $words = Convert-PipelineElement $element
+        if ($words -eq $null -or $words.Count -eq 0) {
+            return $false
+        }
+        $null = $commands.Add($words)
+    }
+
+    return $true
+}
+
+function Add-CommandsFromPipelineChain {
+    param($chain, $commands)
+
+    if (-not (Add-CommandsFromPipelineBase $chain.LhsPipelineChain $commands)) {
+        return $false
+    }
+
+    if (-not (Add-CommandsFromPipelineAst $chain.RhsPipeline $commands)) {
+        return $false
+    }
+
+    return $true
+}
+
+function Add-CommandsFromPipelineBase {
+    param($pipeline, $commands)
+
+    if ($pipeline -is [System.Management.Automation.Language.PipelineAst]) {
+        return Add-CommandsFromPipelineAst $pipeline $commands
+    }
+
+    if ($pipeline -is [System.Management.Automation.Language.PipelineChainAst]) {
+        return Add-CommandsFromPipelineChain $pipeline $commands
+    }
+
+    return $false
+}
+
+$commands = [System.Collections.ArrayList]::new()
+
+foreach ($statement in $ast.EndBlock.Statements) {
+    if (-not (Add-CommandsFromPipelineBase $statement $commands)) {
+        $commands = $null
+        break
+    }
+}
+
+if ($commands -ne $null) {
+    $normalized = [System.Collections.ArrayList]::new()
+    foreach ($cmd in $commands) {
+        if ($cmd -is [string]) {
+            $null = $normalized.Add(@($cmd))
+            continue
+        }
+
+        if ($cmd -is [System.Array] -or $cmd -is [System.Collections.IEnumerable]) {
+            $null = $normalized.Add(@($cmd))
+            continue
+        }
+
+        $normalized = $null
+        break
+    }
+
+    $commands = $normalized
+}
+
+$result = if ($commands -eq $null) {
+    @{ status = 'unsupported' }
+} else {
+    @{ status = 'ok'; commands = $commands }
+}
+
+,$result | ConvertTo-Json -Depth 3

--- a/codex-rs/core/src/powershell.rs
+++ b/codex-rs/core/src/powershell.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-#[cfg(windows)]
+#[cfg(any(windows, test))]
 use codex_utils_absolute_path::AbsolutePathBuf;
 
 use crate::shell::ShellType;
@@ -57,7 +57,7 @@ pub(crate) fn try_find_powershellish_executable_blocking() -> Option<AbsolutePat
 }
 
 /// This function attempts to find a powershell.exe executable on the system.
-#[cfg(windows)]
+#[cfg(any(windows, test))]
 pub(crate) fn try_find_powershell_executable_blocking() -> Option<AbsolutePathBuf> {
     try_find_powershellish_executable_in_path(&["powershell.exe"])
 }
@@ -72,7 +72,7 @@ pub(crate) fn try_find_powershell_executable_blocking() -> Option<AbsolutePathBu
 /// pwsh.exe must be installed separately by the user. And even when the user
 /// has installed pwsh.exe, it may not be available in the system PATH, in which
 /// case we attempt to locate it via other means.
-#[cfg(windows)]
+#[cfg(any(windows, test))]
 pub(crate) fn try_find_pwsh_executable_blocking() -> Option<AbsolutePathBuf> {
     if let Some(ps_home) = std::process::Command::new("cmd")
         .args(["/C", "pwsh", "-NoProfile", "-Command", "$PSHOME"])
@@ -99,7 +99,7 @@ pub(crate) fn try_find_pwsh_executable_blocking() -> Option<AbsolutePathBuf> {
     try_find_powershellish_executable_in_path(&["pwsh.exe"])
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, test))]
 fn try_find_powershellish_executable_in_path(candidates: &[&str]) -> Option<AbsolutePathBuf> {
     for candidate in candidates {
         let Ok(resolved_path) = which::which(candidate) else {
@@ -120,7 +120,7 @@ fn try_find_powershellish_executable_in_path(candidates: &[&str]) -> Option<Abso
     None
 }
 
-#[cfg(windows)]
+#[cfg(any(windows, test))]
 fn is_powershellish_executable_available(powershell_or_pwsh_exe: &std::path::Path) -> bool {
     // This test works for both powershell.exe and pwsh.exe.
     std::process::Command::new(powershell_or_pwsh_exe)

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -303,6 +303,8 @@ mod tests {
     use crate::codex::make_session_and_context;
     use crate::exec_env::create_env;
     use crate::is_safe_command::is_known_safe_command;
+    use crate::powershell::try_find_powershell_executable_blocking;
+    use crate::powershell::try_find_pwsh_executable_blocking;
     use crate::sandboxing::SandboxPermissions;
     use crate::shell::Shell;
     use crate::shell::ShellType;
@@ -328,12 +330,23 @@ mod tests {
         };
         assert_safe(&zsh_shell, "ls -la");
 
-        let powershell = Shell {
-            shell_type: ShellType::PowerShell,
-            shell_path: PathBuf::from("pwsh.exe"),
-            shell_snapshot: None,
-        };
-        assert_safe(&powershell, "ls -Name");
+        if let Some(path) = try_find_powershell_executable_blocking() {
+            let powershell = Shell {
+                shell_type: ShellType::PowerShell,
+                shell_path: path.to_path_buf(),
+                shell_snapshot: None,
+            };
+            assert_safe(&powershell, "ls -Name");
+        }
+
+        if let Some(path) = try_find_pwsh_executable_blocking() {
+            let pwsh = Shell {
+                shell_type: ShellType::PowerShell,
+                shell_path: path.to_path_buf(),
+                shell_snapshot: None,
+            };
+            assert_safe(&pwsh, "ls -Name");
+        }
     }
 
     fn assert_safe(shell: &Shell, command: &str) {


### PR DESCRIPTION
Previous to this PR, we used a hand-rolled PowerShell parser in `windows_safe_commands.rs` to take a `&str` of PowerShell script see if it is equivalent to a list of `execvp(3)` invocations, and if so, we then test each using `is_safe_powershell_command()` to determine if the overall command is safe:

https://github.com/openai/codex/blob/6e6338aa876bb4258abe25b02ac6417b8ea9dff0/codex-rs/core/src/command_safety/windows_safe_commands.rs#L89-L98

Unfortunately, our PowerShell parser did not recognize `@(...)` as a special construct, so it was treated as an ordinary token. This meant that the following would erroneously be considered "safe:"

```powershell
ls @(calc.exe)
```

The fix introduced in this PR is to do something comparable what we do for Bash/Zsh, which is to use a "proper" parser to derive the list of `execvp(3)` calls. For Bash/Zsh, we rely on https://crates.io/crates/tree-sitter-bash, but there does not appear to be a crate of comparable quality for parsing PowerShell statically (https://github.com/airbus-cert/tree-sitter-powershell/ is the best thing I found).

Instead, in this PR, we use a PowerShell script to parse the input PowerShell program to produce the AST.