### PR TITLE
chore: refactor to move Arc<RwLock> concern outside exec_policy_for

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -11,6 +11,7 @@ use crate::compact;
 use crate::compact::run_inline_auto_compact_task;
 use crate::compact::should_use_remote_compact_task;
 use crate::compact_remote::run_inline_remote_auto_compact_task;
+use crate::exec_policy::load_exec_policy_for_features;
 use crate::features::Feature;
 use crate::features::Features;
 use crate::openai_models::models_manager::ModelsManager;
@@ -174,9 +175,10 @@ impl Codex {
 
         let user_instructions = get_user_instructions(&config).await;
 
-        let exec_policy = crate::exec_policy::exec_policy_for(&config.features, &config.codex_home)
+        let exec_policy = load_exec_policy_for_features(&config.features, &config.codex_home)
             .await
             .map_err(|err| CodexErr::Fatal(format!("failed to load execpolicy: {err}")))?;
+        let exec_policy = Arc::new(RwLock::new(exec_policy));
 
         let config = Arc::new(config);
 


### PR DESCRIPTION
The caller should decide whether wrapping the policy in `Arc<RwLock>` is necessary. This should make https://github.com/openai/codex/pull/7609 a bit smoother.

- `exec_policy_for()` -> `load_exec_policy_for_features()`
- introduce `load_exec_policy()` that does not take `Features` as an arg
- both return `Result<Policy, ExecPolicyError>` instead of Result<Arc<RwLock<Policy>>, ExecPolicyError>`

This simplifies the tests as they have no need for `Arc<RwLock>`.