### PR TITLE
[core] type the model name

### DIFF
--- a/codex-rs/core/src/openai_models/model_presets.rs
+++ b/codex-rs/core/src/openai_models/model_presets.rs
@@ -1,4 +1,5 @@
 use codex_app_server_protocol::AuthMode;
+use codex_protocol::openai_models::ModelName;
 use codex_protocol::openai_models::ModelPreset;
 use codex_protocol::openai_models::ModelUpgrade;
 use codex_protocol::openai_models::ReasoningEffort;
@@ -9,15 +10,36 @@ pub const HIDE_GPT5_1_MIGRATION_PROMPT_CONFIG: &str = "hide_gpt5_1_migration_pro
 pub const HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG: &str =
     "hide_gpt-5.1-codex-max_migration_prompt";
 
+fn make_preset(
+    name: ModelName,
+    description: &str,
+    default_reasoning_effort: ReasoningEffort,
+    supported_reasoning_efforts: Vec<ReasoningEffortPreset>,
+    is_default: bool,
+    upgrade: Option<ModelUpgrade>,
+    show_in_picker: bool,
+) -> ModelPreset {
+    let slug = name.as_str().to_string();
+    ModelPreset {
+        id: slug.clone(),
+        model: slug.clone(),
+        display_name: slug,
+        description: description.to_string(),
+        default_reasoning_effort,
+        supported_reasoning_efforts,
+        is_default,
+        upgrade,
+        show_in_picker,
+    }
+}
+
 static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
     vec![
-        ModelPreset {
-            id: "gpt-5.1-codex-max".to_string(),
-            model: "gpt-5.1-codex-max".to_string(),
-            display_name: "gpt-5.1-codex-max".to_string(),
-            description: "Latest Codex-optimized flagship for deep and fast reasoning.".to_string(),
-            default_reasoning_effort: ReasoningEffort::Medium,
-            supported_reasoning_efforts: vec![
+        make_preset(
+            ModelName::Gpt51CodexMax,
+            "Latest Codex-optimized flagship for deep and fast reasoning.",
+            ReasoningEffort::Medium,
+            vec![
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::Low,
                     description: "Fast responses with lighter reasoning".to_string(),
@@ -35,17 +57,15 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                     description: "Extra high reasoning depth for complex problems".to_string(),
                 },
             ],
-            is_default: true,
-            upgrade: None,
-            show_in_picker: true,
-        },
-        ModelPreset {
-            id: "gpt-5.1-codex".to_string(),
-            model: "gpt-5.1-codex".to_string(),
-            display_name: "gpt-5.1-codex".to_string(),
-            description: "Optimized for codex.".to_string(),
-            default_reasoning_effort: ReasoningEffort::Medium,
-            supported_reasoning_efforts: vec![
+            true,
+            None,
+            true,
+        ),
+        make_preset(
+            ModelName::Gpt51Codex,
+            "Optimized for codex.",
+            ReasoningEffort::Medium,
+            vec![
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::Low,
                     description: "Fastest responses with limited reasoning".to_string(),
@@ -60,21 +80,19 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                         .to_string(),
                 },
             ],
-            is_default: false,
-            upgrade: Some(ModelUpgrade {
-                id: "gpt-5.1-codex-max".to_string(),
+            false,
+            Some(ModelUpgrade {
+                id: ModelName::Gpt51CodexMax.as_str().to_string(),
                 reasoning_effort_mapping: None,
                 migration_config_key: HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG.to_string(),
             }),
-            show_in_picker: true,
-        },
-        ModelPreset {
-            id: "gpt-5.1-codex-mini".to_string(),
-            model: "gpt-5.1-codex-mini".to_string(),
-            display_name: "gpt-5.1-codex-mini".to_string(),
-            description: "Optimized for codex. Cheaper, faster, but less capable.".to_string(),
-            default_reasoning_effort: ReasoningEffort::Medium,
-            supported_reasoning_efforts: vec![
+            true,
+        ),
+        make_preset(
+            ModelName::Gpt51CodexMini,
+            "Optimized for codex. Cheaper, faster, but less capable.",
+            ReasoningEffort::Medium,
+            vec![
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::Medium,
                     description: "Dynamically adjusts reasoning based on the task".to_string(),
@@ -85,21 +103,19 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                         .to_string(),
                 },
             ],
-            is_default: false,
-            upgrade: Some(ModelUpgrade {
-                id: "gpt-5.1-codex-max".to_string(),
+            false,
+            Some(ModelUpgrade {
+                id: ModelName::Gpt51CodexMax.as_str().to_string(),
                 reasoning_effort_mapping: None,
                 migration_config_key: HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG.to_string(),
             }),
-            show_in_picker: true,
-        },
-        ModelPreset {
-            id: "gpt-5.1".to_string(),
-            model: "gpt-5.1".to_string(),
-            display_name: "gpt-5.1".to_string(),
-            description: "Broad world knowledge with strong general reasoning.".to_string(),
-            default_reasoning_effort: ReasoningEffort::Medium,
-            supported_reasoning_efforts: vec![
+            true,
+        ),
+        make_preset(
+            ModelName::Gpt51,
+            "Broad world knowledge with strong general reasoning.",
+            ReasoningEffort::Medium,
+            vec![
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::Low,
                     description: "Balances speed with some reasoning; useful for straightforward queries and short explanations".to_string(),
@@ -113,22 +129,20 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                     description: "Maximizes reasoning depth for complex or ambiguous problems".to_string(),
                 },
             ],
-            is_default: false,
-            upgrade: Some(ModelUpgrade {
-                id: "gpt-5.1-codex-max".to_string(),
+            false,
+            Some(ModelUpgrade {
+                id: ModelName::Gpt51CodexMax.as_str().to_string(),
                 reasoning_effort_mapping: None,
                 migration_config_key: HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG.to_string(),
             }),
-            show_in_picker: true,
-        },
+            true,
+        ),
         // Deprecated models.
-        ModelPreset {
-            id: "gpt-5-codex".to_string(),
-            model: "gpt-5-codex".to_string(),
-            display_name: "gpt-5-codex".to_string(),
-            description: "Optimized for codex.".to_string(),
-            default_reasoning_effort: ReasoningEffort::Medium,
-            supported_reasoning_efforts: vec![
+        make_preset(
+            ModelName::Gpt5Codex,
+            "Optimized for codex.",
+            ReasoningEffort::Medium,
+            vec![
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::Low,
                     description: "Fastest responses with limited reasoning".to_string(),
@@ -142,21 +156,19 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                     description: "Maximizes reasoning depth for complex or ambiguous problems".to_string(),
                 },
             ],
-            is_default: false,
-            upgrade: Some(ModelUpgrade {
-                id: "gpt-5.1-codex-max".to_string(),
+            false,
+            Some(ModelUpgrade {
+                id: ModelName::Gpt51CodexMax.as_str().to_string(),
                 reasoning_effort_mapping: None,
                 migration_config_key: HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG.to_string(),
             }),
-            show_in_picker: false,
-        },
-        ModelPreset {
-            id: "gpt-5-codex-mini".to_string(),
-            model: "gpt-5-codex-mini".to_string(),
-            display_name: "gpt-5-codex-mini".to_string(),
-            description: "Optimized for codex. Cheaper, faster, but less capable.".to_string(),
-            default_reasoning_effort: ReasoningEffort::Medium,
-            supported_reasoning_efforts: vec![
+            false,
+        ),
+        make_preset(
+            ModelName::Gpt5CodexMini,
+            "Optimized for codex. Cheaper, faster, but less capable.",
+            ReasoningEffort::Medium,
+            vec![
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::Medium,
                     description: "Dynamically adjusts reasoning based on the task".to_string(),
@@ -166,21 +178,19 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                     description: "Maximizes reasoning depth for complex or ambiguous problems".to_string(),
                 },
             ],
-            is_default: false,
-            upgrade: Some(ModelUpgrade {
-                id: "gpt-5.1-codex-mini".to_string(),
+            false,
+            Some(ModelUpgrade {
+                id: ModelName::Gpt51CodexMini.as_str().to_string(),
                 reasoning_effort_mapping: None,
                 migration_config_key: HIDE_GPT5_1_MIGRATION_PROMPT_CONFIG.to_string(),
             }),
-            show_in_picker: false,
-        },
-        ModelPreset {
-            id: "gpt-5".to_string(),
-            model: "gpt-5".to_string(),
-            display_name: "gpt-5".to_string(),
-            description: "Broad world knowledge with strong general reasoning.".to_string(),
-            default_reasoning_effort: ReasoningEffort::Medium,
-            supported_reasoning_efforts: vec![
+            false,
+        ),
+        make_preset(
+            ModelName::Gpt5,
+            "Broad world knowledge with strong general reasoning.",
+            ReasoningEffort::Medium,
+            vec![
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::Minimal,
                     description: "Fastest responses with little reasoning".to_string(),
@@ -198,14 +208,14 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                     description: "Maximizes reasoning depth for complex or ambiguous problems".to_string(),
                 },
             ],
-            is_default: false,
-            upgrade: Some(ModelUpgrade {
-                id: "gpt-5.1-codex-max".to_string(),
+            false,
+            Some(ModelUpgrade {
+                id: ModelName::Gpt51CodexMax.as_str().to_string(),
                 reasoning_effort_mapping: None,
                 migration_config_key: HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG.to_string(),
             }),
-            show_in_picker: false,
-        },
+            false,
+        ),
     ]
 });
 

--- a/codex-rs/core/src/openai_models/model_presets.rs
+++ b/codex-rs/core/src/openai_models/model_presets.rs
@@ -10,15 +10,26 @@ pub const HIDE_GPT5_1_MIGRATION_PROMPT_CONFIG: &str = "hide_gpt5_1_migration_pro
 pub const HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG: &str =
     "hide_gpt-5.1-codex-max_migration_prompt";
 
-fn make_preset(
+struct ModelPresetArgs {
     name: ModelName,
-    description: &str,
+    description: &'static str,
     default_reasoning_effort: ReasoningEffort,
     supported_reasoning_efforts: Vec<ReasoningEffortPreset>,
     is_default: bool,
     upgrade: Option<ModelUpgrade>,
     show_in_picker: bool,
-) -> ModelPreset {
+}
+
+fn make_preset(args: ModelPresetArgs) -> ModelPreset {
+    let ModelPresetArgs {
+        name,
+        description,
+        default_reasoning_effort,
+        supported_reasoning_efforts,
+        is_default,
+        upgrade,
+        show_in_picker,
+    } = args;
     let slug = name.as_str().to_string();
     ModelPreset {
         id: slug.clone(),
@@ -35,11 +46,11 @@ fn make_preset(
 
 static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
     vec![
-        make_preset(
-            ModelName::Gpt51CodexMax,
-            "Latest Codex-optimized flagship for deep and fast reasoning.",
-            ReasoningEffort::Medium,
-            vec![
+        make_preset(ModelPresetArgs {
+            name: ModelName::Gpt51CodexMax,
+            description: "Latest Codex-optimized flagship for deep and fast reasoning.",
+            default_reasoning_effort: ReasoningEffort::Medium,
+            supported_reasoning_efforts: vec![
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::Low,
                     description: "Fast responses with lighter reasoning".to_string(),
@@ -57,15 +68,15 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                     description: "Extra high reasoning depth for complex problems".to_string(),
                 },
             ],
-            true,
-            None,
-            true,
-        ),
-        make_preset(
-            ModelName::Gpt51Codex,
-            "Optimized for codex.",
-            ReasoningEffort::Medium,
-            vec![
+            is_default: true,
+            upgrade: None,
+            show_in_picker: true,
+        }),
+        make_preset(ModelPresetArgs {
+            name: ModelName::Gpt51Codex,
+            description: "Optimized for codex.",
+            default_reasoning_effort: ReasoningEffort::Medium,
+            supported_reasoning_efforts: vec![
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::Low,
                     description: "Fastest responses with limited reasoning".to_string(),
@@ -80,19 +91,19 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                         .to_string(),
                 },
             ],
-            false,
-            Some(ModelUpgrade {
+            is_default: false,
+            upgrade: Some(ModelUpgrade {
                 id: ModelName::Gpt51CodexMax.as_str().to_string(),
                 reasoning_effort_mapping: None,
                 migration_config_key: HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG.to_string(),
             }),
-            true,
-        ),
-        make_preset(
-            ModelName::Gpt51CodexMini,
-            "Optimized for codex. Cheaper, faster, but less capable.",
-            ReasoningEffort::Medium,
-            vec![
+            show_in_picker: true,
+        }),
+        make_preset(ModelPresetArgs {
+            name: ModelName::Gpt51CodexMini,
+            description: "Optimized for codex. Cheaper, faster, but less capable.",
+            default_reasoning_effort: ReasoningEffort::Medium,
+            supported_reasoning_efforts: vec![
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::Medium,
                     description: "Dynamically adjusts reasoning based on the task".to_string(),
@@ -103,19 +114,19 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                         .to_string(),
                 },
             ],
-            false,
-            Some(ModelUpgrade {
+            is_default: false,
+            upgrade: Some(ModelUpgrade {
                 id: ModelName::Gpt51CodexMax.as_str().to_string(),
                 reasoning_effort_mapping: None,
                 migration_config_key: HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG.to_string(),
             }),
-            true,
-        ),
-        make_preset(
-            ModelName::Gpt51,
-            "Broad world knowledge with strong general reasoning.",
-            ReasoningEffort::Medium,
-            vec![
+            show_in_picker: true,
+        }),
+        make_preset(ModelPresetArgs {
+            name: ModelName::Gpt51,
+            description: "Broad world knowledge with strong general reasoning.",
+            default_reasoning_effort: ReasoningEffort::Medium,
+            supported_reasoning_efforts: vec![
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::Low,
                     description: "Balances speed with some reasoning; useful for straightforward queries and short explanations".to_string(),
@@ -129,20 +140,20 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                     description: "Maximizes reasoning depth for complex or ambiguous problems".to_string(),
                 },
             ],
-            false,
-            Some(ModelUpgrade {
+            is_default: false,
+            upgrade: Some(ModelUpgrade {
                 id: ModelName::Gpt51CodexMax.as_str().to_string(),
                 reasoning_effort_mapping: None,
                 migration_config_key: HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG.to_string(),
             }),
-            true,
-        ),
+            show_in_picker: true,
+        }),
         // Deprecated models.
-        make_preset(
-            ModelName::Gpt5Codex,
-            "Optimized for codex.",
-            ReasoningEffort::Medium,
-            vec![
+        make_preset(ModelPresetArgs {
+            name: ModelName::Gpt5Codex,
+            description: "Optimized for codex.",
+            default_reasoning_effort: ReasoningEffort::Medium,
+            supported_reasoning_efforts: vec![
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::Low,
                     description: "Fastest responses with limited reasoning".to_string(),
@@ -156,19 +167,19 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                     description: "Maximizes reasoning depth for complex or ambiguous problems".to_string(),
                 },
             ],
-            false,
-            Some(ModelUpgrade {
+            is_default: false,
+            upgrade: Some(ModelUpgrade {
                 id: ModelName::Gpt51CodexMax.as_str().to_string(),
                 reasoning_effort_mapping: None,
                 migration_config_key: HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG.to_string(),
             }),
-            false,
-        ),
-        make_preset(
-            ModelName::Gpt5CodexMini,
-            "Optimized for codex. Cheaper, faster, but less capable.",
-            ReasoningEffort::Medium,
-            vec![
+            show_in_picker: false,
+        }),
+        make_preset(ModelPresetArgs {
+            name: ModelName::Gpt5CodexMini,
+            description: "Optimized for codex. Cheaper, faster, but less capable.",
+            default_reasoning_effort: ReasoningEffort::Medium,
+            supported_reasoning_efforts: vec![
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::Medium,
                     description: "Dynamically adjusts reasoning based on the task".to_string(),
@@ -178,19 +189,19 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                     description: "Maximizes reasoning depth for complex or ambiguous problems".to_string(),
                 },
             ],
-            false,
-            Some(ModelUpgrade {
+            is_default: false,
+            upgrade: Some(ModelUpgrade {
                 id: ModelName::Gpt51CodexMini.as_str().to_string(),
                 reasoning_effort_mapping: None,
                 migration_config_key: HIDE_GPT5_1_MIGRATION_PROMPT_CONFIG.to_string(),
             }),
-            false,
-        ),
-        make_preset(
-            ModelName::Gpt5,
-            "Broad world knowledge with strong general reasoning.",
-            ReasoningEffort::Medium,
-            vec![
+            show_in_picker: false,
+        }),
+        make_preset(ModelPresetArgs {
+            name: ModelName::Gpt5,
+            description: "Broad world knowledge with strong general reasoning.",
+            default_reasoning_effort: ReasoningEffort::Medium,
+            supported_reasoning_efforts: vec![
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::Minimal,
                     description: "Fastest responses with little reasoning".to_string(),
@@ -208,14 +219,14 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                     description: "Maximizes reasoning depth for complex or ambiguous problems".to_string(),
                 },
             ],
-            false,
-            Some(ModelUpgrade {
+            is_default: false,
+            upgrade: Some(ModelUpgrade {
                 id: ModelName::Gpt51CodexMax.as_str().to_string(),
                 reasoning_effort_mapping: None,
                 migration_config_key: HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG.to_string(),
             }),
-            false,
-        ),
+            show_in_picker: false,
+        }),
     ]
 });
 

--- a/codex-rs/protocol/src/openai_models.rs
+++ b/codex-rs/protocol/src/openai_models.rs
@@ -7,6 +7,31 @@ use strum_macros::Display;
 use strum_macros::EnumIter;
 use ts_rs::TS;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum ModelName {
+    Gpt51CodexMax,
+    Gpt51Codex,
+    Gpt51CodexMini,
+    Gpt51,
+    Gpt5Codex,
+    Gpt5CodexMini,
+    Gpt5,
+}
+
+impl ModelName {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Gpt51CodexMax => "gpt-5.1-codex-max",
+            Self::Gpt51Codex => "gpt-5.1-codex",
+            Self::Gpt51CodexMini => "gpt-5.1-codex-mini",
+            Self::Gpt51 => "gpt-5.1",
+            Self::Gpt5Codex => "gpt-5-codex",
+            Self::Gpt5CodexMini => "gpt-5-codex-mini",
+            Self::Gpt5 => "gpt-5",
+        }
+    }
+}
+
 /// See https://platform.openai.com/docs/guides/reasoning?api-mode=responses#get-started-with-reasoning
 #[derive(
     Debug,


### PR DESCRIPTION
Make the model name in model preset a typed enum. This allows client also get typed model names.

tested by calling `model/list` in app server.