### PR TITLE
fix: OTEL HTTP exporter panic and mTLS support

### DIFF
--- a/codex-rs/otel/Cargo.toml
+++ b/codex-rs/otel/Cargo.toml
@@ -29,7 +29,7 @@ opentelemetry-otlp = { workspace = true, features = [
     "http-proto",
     "http-json",
     "logs",
-    "reqwest",
+    "reqwest-blocking-client",
     "reqwest-rustls",
     "tls",
     "tls-roots",
@@ -40,7 +40,7 @@ opentelemetry_sdk = { workspace = true, features = [
     "rt-tokio",
 ], optional = true }
 http = { workspace = true }
-reqwest = { workspace = true }
+reqwest = { workspace = true, features = ["blocking", "rustls-tls"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 strum_macros = { workspace = true }


### PR DESCRIPTION
This fixes two issues with the OTEL HTTP exporter:

1. **Runtime panic with async reqwest client**

The `opentelemetry_sdk` `BatchLogProcessor` spawns a dedicated OS thread that uses `futures_executor::block_on()` rather than tokio's runtime. When the async reqwest client's timeout mechanism calls `tokio::time::sleep()`, it panics with "there is no reactor running, must be called from the context of a Tokio 1.x runtime".

The fix is to use `reqwest::blocking::Client` instead, which doesn't depend on tokio for timeouts. However, the blocking client creates its own internal tokio runtime during construction, which would panic if built from within an async context. We wrap the construction in `tokio::task::block_in_place()` to handle this.

2. **mTLS certificate handling**

The HTTP client wasn't properly configured for mTLS, matching the fixes previously done for the model provider client:

- Added `.tls_built_in_root_certs(false)` when using a custom CA certificate to ensure only our CA is trusted
- Added `.https_only(true)` when using client identity
- Added `rustls-tls` feature to ensure rustls is used (required for `Identity::from_pem()` to work correctly)