### PR TITLE
[app-server-protocol] Add types for config

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -4,6 +4,7 @@ use std::path::PathBuf;
 use crate::protocol::common::AuthMode;
 use codex_protocol::account::PlanType;
 use codex_protocol::approvals::ExecPolicyAmendment as CoreExecPolicyAmendment;
+use codex_protocol::config_types::ForcedLoginMethod;
 use codex_protocol::config_types::ReasoningSummary;
 use codex_protocol::config_types::Verbosity;
 use codex_protocol::items::AgentMessageContent as CoreAgentMessageContent;
@@ -178,6 +179,32 @@ pub struct SandboxWorkspaceWrite {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "snake_case")]
 #[ts(export_to = "v2/")]
+pub struct Tools {
+    pub web_search: Option<bool>,
+    pub view_image: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "snake_case")]
+#[ts(export_to = "v2/")]
+pub struct Profile {
+    pub model: Option<String>,
+    pub model_provider: Option<String>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_approval_policy",
+        serialize_with = "serialize_approval_policy"
+    )]
+    pub approval_policy: Option<AskForApproval>,
+    pub model_reasoning_effort: Option<ReasoningEffort>,
+    pub model_reasoning_summary: Option<ReasoningSummary>,
+    pub model_verbosity: Option<Verbosity>,
+    pub chatgpt_base_url: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "snake_case")]
+#[ts(export_to = "v2/")]
 pub struct Config {
     pub model: Option<String>,
     pub review_model: Option<String>,
@@ -197,6 +224,12 @@ pub struct Config {
     )]
     pub sandbox_mode: Option<SandboxMode>,
     pub sandbox_workspace_write: Option<SandboxWorkspaceWrite>,
+    pub forced_chatgpt_workspace_id: Option<String>,
+    pub forced_login_method: Option<ForcedLoginMethod>,
+    pub tools: Option<Tools>,
+    pub profile: Option<String>,
+    #[serde(default)]
+    pub profiles: HashMap<String, Profile>,
     pub instructions: Option<String>,
     pub developer_instructions: Option<String>,
     pub compact_prompt: Option<String>,

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -163,7 +163,7 @@ pub enum ConfigLayerName {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema, TS)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct SandboxWorkspaceWrite {
     #[serde(default)]
@@ -177,17 +177,17 @@ pub struct SandboxWorkspaceWrite {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
-pub struct Tools {
+pub struct ToolsV2 {
     pub web_search: Option<bool>,
     pub view_image: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
-pub struct Profile {
+pub struct ProfileV2 {
     pub model: Option<String>,
     pub model_provider: Option<String>,
     #[serde(
@@ -203,7 +203,7 @@ pub struct Profile {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct Config {
     pub model: Option<String>,
@@ -226,10 +226,10 @@ pub struct Config {
     pub sandbox_workspace_write: Option<SandboxWorkspaceWrite>,
     pub forced_chatgpt_workspace_id: Option<String>,
     pub forced_login_method: Option<ForcedLoginMethod>,
-    pub tools: Option<Tools>,
+    pub tools: Option<ToolsV2>,
     pub profile: Option<String>,
     #[serde(default)]
-    pub profiles: HashMap<String, Profile>,
+    pub profiles: HashMap<String, ProfileV2>,
     pub instructions: Option<String>,
     pub developer_instructions: Option<String>,
     pub compact_prompt: Option<String>,
@@ -1825,6 +1825,25 @@ mod tests {
                 id: "search-1".to_string(),
                 query: "docs".to_string(),
             }
+        );
+    }
+
+    #[test]
+    fn config_tools_deserializes_with_snake_case_keys() {
+        let config: Config = serde_json::from_value(json!({
+            "tools": {
+                "web_search": true,
+                "view_image": false
+            }
+        }))
+        .unwrap();
+
+        assert_eq!(
+            config.tools,
+            Some(Tools {
+                web_search: Some(true),
+                view_image: Some(false),
+            })
         );
     }
 

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -163,102 +163,80 @@ pub enum ConfigLayerName {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema, TS)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 #[ts(export_to = "v2/")]
 pub struct SandboxWorkspaceWrite {
-    #[serde(default, alias = "writable_roots")]
+    #[serde(default)]
     pub writable_roots: Vec<PathBuf>,
-    #[serde(default, alias = "network_access")]
+    #[serde(default)]
     pub network_access: bool,
-    #[serde(default, alias = "exclude_tmpdir_env_var")]
+    #[serde(default)]
     pub exclude_tmpdir_env_var: bool,
-    #[serde(default, alias = "exclude_slash_tmp")]
+    #[serde(default)]
     pub exclude_slash_tmp: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 #[ts(export_to = "v2/")]
 pub struct ToolsV2 {
-    #[serde(alias = "web_search")]
     pub web_search: Option<bool>,
-    #[serde(alias = "view_image")]
     pub view_image: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 #[ts(export_to = "v2/")]
 pub struct ProfileV2 {
     pub model: Option<String>,
-    #[serde(alias = "model_provider")]
     pub model_provider: Option<String>,
     #[serde(
         default,
         deserialize_with = "deserialize_approval_policy",
-        serialize_with = "serialize_approval_policy",
-        alias = "approval_policy"
+        serialize_with = "serialize_approval_policy"
     )]
     pub approval_policy: Option<AskForApproval>,
-    #[serde(alias = "model_reasoning_effort")]
     pub model_reasoning_effort: Option<ReasoningEffort>,
-    #[serde(alias = "model_reasoning_summary")]
     pub model_reasoning_summary: Option<ReasoningSummary>,
-    #[serde(alias = "model_verbosity")]
     pub model_verbosity: Option<Verbosity>,
-    #[serde(alias = "chatgpt_base_url")]
     pub chatgpt_base_url: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
-#[serde(rename_all = "camelCase")]
+#[serde(rename_all = "snake_case")]
 #[ts(export_to = "v2/")]
 pub struct Config {
     pub model: Option<String>,
-    #[serde(alias = "review_model")]
     pub review_model: Option<String>,
-    #[serde(alias = "model_context_window")]
     pub model_context_window: Option<i64>,
-    #[serde(alias = "model_auto_compact_token_limit")]
     pub model_auto_compact_token_limit: Option<i64>,
-    #[serde(alias = "model_provider")]
     pub model_provider: Option<String>,
     #[serde(
         default,
         deserialize_with = "deserialize_approval_policy",
-        serialize_with = "serialize_approval_policy",
-        alias = "approval_policy"
+        serialize_with = "serialize_approval_policy"
     )]
     pub approval_policy: Option<AskForApproval>,
     #[serde(
         default,
         deserialize_with = "deserialize_sandbox_mode",
-        serialize_with = "serialize_sandbox_mode",
-        alias = "sandbox_mode"
+        serialize_with = "serialize_sandbox_mode"
     )]
     pub sandbox_mode: Option<SandboxMode>,
-    #[serde(alias = "sandbox_workspace_write")]
     pub sandbox_workspace_write: Option<SandboxWorkspaceWrite>,
-    #[serde(alias = "forced_chatgpt_workspace_id")]
     pub forced_chatgpt_workspace_id: Option<String>,
-    #[serde(alias = "forced_login_method")]
     pub forced_login_method: Option<ForcedLoginMethod>,
     pub tools: Option<ToolsV2>,
     pub profile: Option<String>,
     #[serde(default)]
     pub profiles: HashMap<String, ProfileV2>,
     pub instructions: Option<String>,
-    #[serde(alias = "developer_instructions")]
     pub developer_instructions: Option<String>,
-    #[serde(alias = "compact_prompt")]
     pub compact_prompt: Option<String>,
-    #[serde(alias = "model_reasoning_effort")]
     pub model_reasoning_effort: Option<ReasoningEffort>,
-    #[serde(alias = "model_reasoning_summary")]
     pub model_reasoning_summary: Option<ReasoningSummary>,
-    #[serde(alias = "model_verbosity")]
     pub model_verbosity: Option<Verbosity>,
-    #[serde(default, flatten, deserialize_with = "deserialize_additional")]
+    #[serde(default, flatten)]
     pub additional: HashMap<String, JsonValue>,
 }
 
@@ -299,38 +277,6 @@ where
         .as_ref()
         .map(|mode| mode.to_core())
         .serialize(serializer)
-}
-
-fn deserialize_additional<'de, D>(deserializer: D) -> Result<HashMap<String, JsonValue>, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    let raw = HashMap::<String, JsonValue>::deserialize(deserializer)?;
-    Ok(raw
-        .into_iter()
-        .map(|(key, value)| (snake_to_camel(&key), value))
-        .collect())
-}
-
-fn snake_to_camel(input: &str) -> String {
-    let mut output = String::with_capacity(input.len());
-    let mut upper_next = false;
-
-    for ch in input.chars() {
-        if ch == '_' {
-            upper_next = true;
-            continue;
-        }
-
-        if upper_next {
-            output.push(ch.to_ascii_uppercase());
-            upper_next = false;
-        } else {
-            output.push(ch);
-        }
-    }
-
-    output
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
@@ -1879,25 +1825,6 @@ mod tests {
                 id: "search-1".to_string(),
                 query: "docs".to_string(),
             }
-        );
-    }
-
-    #[test]
-    fn config_tools_deserializes_with_snake_case_keys() {
-        let config: Config = serde_json::from_value(json!({
-            "tools": {
-                "web_search": true,
-                "view_image": false
-            }
-        }))
-        .unwrap();
-
-        assert_eq!(
-            config.tools,
-            Some(ToolsV2 {
-                web_search: Some(true),
-                view_image: Some(false),
-            })
         );
     }
 


### PR DESCRIPTION
Currently the config returned by `config/read` in untyped. Add types so it's easier for client to parse the config. Since currently configs are all defined in snake case we'll keep that instead of using camel case like the rest of V2.

Sample output by testing using the app server test client:
```
{
<   "id": "f28449f4-b015-459b-b07b-eef06980165d",
<   "result": {
<     "config": {
<       "approvalPolicy": null,
<       "compactPrompt": null,
<       "developerInstructions": null,
<       "features": {
<         "experimental_use_rmcp_client": true
<       },
<       "forcedChatgptWorkspaceId": null,
<       "forcedLoginMethod": null,
<       "instructions": null,
<       "model": "gpt-5.1-codex-max",
<       "modelAutoCompactTokenLimit": null,
<       "modelContextWindow": null,
<       "modelProvider": null,
<       "modelReasoningEffort": null,
<       "modelReasoningSummary": null,
<       "modelVerbosity": null,
<       "model_providers": {
<         "local": {
<           "base_url": "http://localhost:8061/api/codex",
<           "env_http_headers": {
<             "ChatGPT-Account-ID": "OPENAI_ACCOUNT_ID"
<           },
<           "env_key": "CHATGPT_TOKEN_STAGING",
<           "name": "local",
<           "wire_api": "responses"
<         }
<       },
<       "model_reasoning_effort": "medium",
<       "notice": {
<         "hide_gpt-5.1-codex-max_migration_prompt": true,
<         "hide_gpt5_1_migration_prompt": true
<       },
<       "profile": null,
<       "profiles": {},
<       "projects": {
<         "/Users/celia/code": {
<           "trust_level": "trusted"
<         },
<         "/Users/celia/code/codex": {
<           "trust_level": "trusted"
<         },
<         "/Users/celia/code/openai": {
<           "trust_level": "trusted"
<         }
<       },
<       "reviewModel": null,
<       "sandboxMode": null,
<       "sandboxWorkspaceWrite": null,
<       "tools": {
<         "viewImage": null,
<         "webSearch": null
<       }
<     },
<     "origins": {
<       "features.experimental_use_rmcp_client": {
<         "name": "user",
<         "source": "/Users/celia/.codex/config.toml",
<         "version": "sha256:a1d8eaedb5d9db5dfdfa69f30fa9df2efec66bb4dd46aa67f149fcc67cd0711c"
<       },
<       "model": {
<         "name": "user",
<         "source": "/Users/celia/.codex/config.toml",
<         "version": "sha256:a1d8eaedb5d9db5dfdfa69f30fa9df2efec66bb4dd46aa67f149fcc67cd0711c"
<       },
<       "model_providers.local.base_url": {
<         "name": "user",
<         "source": "/Users/celia/.codex/config.toml",
<         "version": "sha256:a1d8eaedb5d9db5dfdfa69f30fa9df2efec66bb4dd46aa67f149fcc67cd0711c"
<       },
<       "model_providers.local.env_http_headers.ChatGPT-Account-ID": {
<         "name": "user",
<         "source": "/Users/celia/.codex/config.toml",
<         "version": "sha256:a1d8eaedb5d9db5dfdfa69f30fa9df2efec66bb4dd46aa67f149fcc67cd0711c"
<       },
<       "model_providers.local.env_key": {
<         "name": "user",
<         "source": "/Users/celia/.codex/config.toml",
<         "version": "sha256:a1d8eaedb5d9db5dfdfa69f30fa9df2efec66bb4dd46aa67f149fcc67cd0711c"
<       },
<       "model_providers.local.name": {
<         "name": "user",
<         "source": "/Users/celia/.codex/config.toml",
<         "version": "sha256:a1d8eaedb5d9db5dfdfa69f30fa9df2efec66bb4dd46aa67f149fcc67cd0711c"
<       },
<       "model_providers.local.wire_api": {
<         "name": "user",
<         "source": "/Users/celia/.codex/config.toml",
<         "version": "sha256:a1d8eaedb5d9db5dfdfa69f30fa9df2efec66bb4dd46aa67f149fcc67cd0711c"
<       },
<       "model_reasoning_effort": {
<         "name": "user",
<         "source": "/Users/celia/.codex/config.toml",
<         "version": "sha256:a1d8eaedb5d9db5dfdfa69f30fa9df2efec66bb4dd46aa67f149fcc67cd0711c"
<       },
<       "notice.hide_gpt-5.1-codex-max_migration_prompt": {
<         "name": "user",
<         "source": "/Users/celia/.codex/config.toml",
<         "version": "sha256:a1d8eaedb5d9db5dfdfa69f30fa9df2efec66bb4dd46aa67f149fcc67cd0711c"
<       },
<       "notice.hide_gpt5_1_migration_prompt": {
<         "name": "user",
<         "source": "/Users/celia/.codex/config.toml",
<         "version": "sha256:a1d8eaedb5d9db5dfdfa69f30fa9df2efec66bb4dd46aa67f149fcc67cd0711c"
<       },
<       "projects./Users/celia/code.trust_level": {
<         "name": "user",
<         "source": "/Users/celia/.codex/config.toml",
<         "version": "sha256:a1d8eaedb5d9db5dfdfa69f30fa9df2efec66bb4dd46aa67f149fcc67cd0711c"
<       },
<       "projects./Users/celia/code/codex.trust_level": {
<         "name": "user",
<         "source": "/Users/celia/.codex/config.toml",
<         "version": "sha256:a1d8eaedb5d9db5dfdfa69f30fa9df2efec66bb4dd46aa67f149fcc67cd0711c"
<       },
<       "projects./Users/celia/code/openai.trust_level": {
<         "name": "user",
<         "source": "/Users/celia/.codex/config.toml",
<         "version": "sha256:a1d8eaedb5d9db5dfdfa69f30fa9df2efec66bb4dd46aa67f149fcc67cd0711c"
<       },
<       "tools.web_search": {
<         "name": "user",
<         "source": "/Users/celia/.codex/config.toml",
<         "version": "sha256:a1d8eaedb5d9db5dfdfa69f30fa9df2efec66bb4dd46aa67f149fcc67cd0711c"
<       }
<     }
<   }
< }
```