### PR TITLE
docs: Remove experimental_use_rmcp_client from config

### DIFF
--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -229,9 +229,6 @@ enable_experimental_windows_sandbox = false
 # Use experimental unified exec tool. Default: false
 experimental_use_unified_exec_tool = false
 
-# Use experimental Rust MCP client (enables OAuth for HTTP MCP). Default: false
-experimental_use_rmcp_client = false
-
 # Include apply_patch via freeform editing path (affects default tool set). Default: false
 experimental_use_freeform_apply_patch = false
 
@@ -320,7 +317,6 @@ experimental_use_freeform_apply_patch = false
 # experimental_compact_prompt_file = "compact_prompt.txt"
 # include_apply_patch_tool = false
 # experimental_use_unified_exec_tool = false
-# experimental_use_rmcp_client = false
 # experimental_use_freeform_apply_patch = false
 # experimental_sandbox_command_assessment = false
 # tools_web_search = false

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -226,9 +226,6 @@ enable_experimental_windows_sandbox = false
 # Experimental toggles (legacy; prefer [features])
 ################################################################################
 
-# Use experimental unified exec tool. Default: false
-experimental_use_unified_exec_tool = false
-
 # Include apply_patch via freeform editing path (affects default tool set). Default: false
 experimental_use_freeform_apply_patch = false
 
@@ -316,7 +313,6 @@ experimental_use_freeform_apply_patch = false
 # chatgpt_base_url = "https://chatgpt.com/backend-api/"
 # experimental_compact_prompt_file = "compact_prompt.txt"
 # include_apply_patch_tool = false
-# experimental_use_unified_exec_tool = false
 # experimental_use_freeform_apply_patch = false
 # experimental_sandbox_command_assessment = false
 # tools_web_search = false


### PR DESCRIPTION
Removed experimental Rust MCP client option from config.