### PR TITLE
docs: point dev checks to just

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -25,7 +25,7 @@ If you want to add a new feature or change the behavior of an existing one, plea
 
 - Fill in the PR template (or include similar information) - **What? Why? How?**
 - Include a link to a bug report or enhancement request in the issue tracker
-- Run **all** checks locally (`cargo test && cargo clippy --tests && cargo fmt -- --config imports_granularity=Item`). CI failures that could have been caught locally slow down the process.
+- Run **all** checks locally. Use the root `just` helpers so you stay consistent with the rest of the workspace: `just fmt`, `just fix -p <crate>` for the crate you touched, and the relevant tests (e.g., `cargo test -p codex-tui` or `just test` if you need a full sweep). CI failures that could have been caught locally slow down the process.
 - Make sure your branch is up-to-date with `main` and that you have resolved merge conflicts.
 - Mark the PR as **Ready for review** only when you believe it is in a merge-able state.
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -31,10 +31,11 @@ cargo build
 # Launch the TUI with a sample prompt.
 cargo run --bin codex -- "explain this codebase to me"
 
-# After making changes, ensure the code is clean.
-cargo fmt -- --config imports_granularity=Item
-cargo clippy --tests
+# After making changes, use the root justfile helpers (they default to codex-rs):
+just fmt
+just fix -p <crate-you-touched>
 
-# Run the tests.
-cargo test
+# Run the relevant tests (project-specific is fastest), for example:
+cargo test -p codex-tui
+just test  # if you need a full sweep
 ```

--- a/docs/install.md
+++ b/docs/install.md
@@ -24,6 +24,10 @@ curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 source "$HOME/.cargo/env"
 rustup component add rustfmt
 rustup component add clippy
+# Install helper tools used by the workspace justfile:
+cargo install just
+# Optional: install nextest for the `just test` helper (or use `cargo test --all-features` as a fallback)
+cargo install cargo-nextest
 
 # Build Codex.
 cargo build
@@ -37,5 +41,8 @@ just fix -p <crate-you-touched>
 
 # Run the relevant tests (project-specific is fastest), for example:
 cargo test -p codex-tui
-just test  # if you need a full sweep
+# If you have cargo-nextest installed, `just test` runs the full suite:
+just test
+# Otherwise, fall back to:
+cargo test --all-features
 ```


### PR DESCRIPTION
Update install and contributing guides to use the root justfile helpers (`just fmt`, `just fix -p <crate>`, and targeted tests) instead of the older cargo fmt/clippy/test instructions that have been in place since 459363e17b. This matches the justfile relocation to the repo root in 952d6c946 and the current lint/test workflow for CI (see `.github/workflows/rust-ci.yml`).
