### PR TITLE
docs: fix FAQ default sandbox description

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,7 +22,7 @@ Yes. [`codex exec`](./exec.md) runs Codex in non-interactive mode with streaming
 
 ### How do I stop Codex from editing my files?
 
-By default, Codex can modify files in your current working directory (Auto mode). To prevent edits, run `codex` in read-only mode with the CLI flag `--sandbox read-only`. Alternatively, you can change the approval level mid-conversation with `/approvals`.
+New workspaces start in the **Read Only** preset, so Codex inspects files but asks before touching anything. Once you explicitly trust a directory (for example via the onboarding prompt or `/approvals` → "Trust this directory"), Codex will switch to the Agent/Auto preset for that repo and can edit inside the workspace. To keep it hands-off, relock the session with `/approvals` → "Read Only" or launch Codex with `--sandbox read-only` (optionally combine with `--ask-for-approval never` for silent CI runs).
 
 ### How do I connect Codex to MCP servers?
 


### PR DESCRIPTION
## Summary\n- fix the FAQ entry about preventing edits so it accurately states that new workspaces default to Read Only until trusted\n- document how to relock a trusted repo via /approvals or the --sandbox read-only flag (with CI combo hint for --ask-for-approval never)\n\n## Testing\n- not run (docs change)