### PR TITLE
fix: refine the warning message and docs for deprecated tools config

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -517,7 +517,7 @@ impl Session {
 
         for (alias, feature) in session_configuration.features.legacy_feature_usages() {
             let canonical = feature.key();
-            let summary = format!("`{alias}` is deprecated. Use `{canonical}` instead.");
+            let summary = format!("`{alias}` is deprecated. Use `[features].{canonical}` instead.");
             let details = if alias == canonical {
                 None
             } else {

--- a/codex-rs/core/tests/suite/deprecation_notice.rs
+++ b/codex-rs/core/tests/suite/deprecation_notice.rs
@@ -36,7 +36,7 @@ async fn emits_deprecation_notice_for_legacy_feature_flag() -> anyhow::Result<()
     let DeprecationNoticeEvent { summary, details } = notice;
     assert_eq!(
         summary,
-        "`use_experimental_unified_exec_tool` is deprecated. Use `unified_exec` instead."
+        "`use_experimental_unified_exec_tool` is deprecated. Use `[features].unified_exec` instead."
             .to_string(),
     );
     assert_eq!(

--- a/docs/config.md
+++ b/docs/config.md
@@ -349,6 +349,8 @@ Though using this option may also be necessary if you try to use Codex in enviro
 
 ### tools.\*
 
+These `[tools]` configuration options are deprecated. Use `[features]` instead (see [Feature flags](#feature-flags)).
+
 Use the optional `[tools]` table to toggle built-in tools that the agent may call. `web_search` stays off unless you opt in, while `view_image` is now enabled by default:
 
 ```toml
@@ -356,8 +358,6 @@ Use the optional `[tools]` table to toggle built-in tools that the agent may cal
 web_search = true   # allow Codex to issue first-party web searches without prompting you (deprecated)
 view_image = false  # disable image uploads (they're enabled by default)
 ```
-
-`web_search` is deprecated; use the `web_search_request` feature flag instead.
 
 The `view_image` toggle is useful when you want to include screenshots or diagrams from your repo without pasting them manually. Codex still respects sandboxing: it can only attach files inside the workspace roots you allow.
 


### PR DESCRIPTION
Issue #7661 revealed that users are confused by deprecation warnings like:
> `tools.web_search` is deprecated. Use `web_search_request` instead.

This message misleadingly suggests renaming the config key from `web_search` to `web_search_request`, when the actual required change is to **move and rename the configuration from the `[tools]` section to the `[features]` section**.

This PR clarifies the warning messages and documentation to make it clear that deprecated `[tools]` configurations should be moved to `[features]`.  Changes made:
- Updated deprecation warning format in `codex-rs/core/src/codex.rs:520` to include `[features].` prefix
- Updated corresponding test expectations in `codex-rs/core/tests/suite/deprecation_notice.rs:39`
- Improved documentation in `docs/config.md` to clarify upfront that `[tools]` options are deprecated in favor of `[features]`