### PR TITLE
fix: update URLs to use HTTPS in model migration prompts

### DIFF
--- a/codex-rs/tui/src/model_migration.rs
+++ b/codex-rs/tui/src/model_migration.rs
@@ -292,7 +292,7 @@ fn gpt_5_1_codex_max_migration_copy() -> ModelMigrationCopy {
             ),
             Line::from(vec![
                 "Learn more at ".into(),
-                "www.openai.com/index/gpt-5-1-codex-max".cyan().underlined(),
+                "https://openai.com/index/gpt-5-1-codex-max/".cyan().underlined(),
                 ".".into(),
             ]),
         ],
@@ -312,7 +312,7 @@ fn gpt5_migration_copy() -> ModelMigrationCopy {
             ),
             Line::from(vec![
                 "Learn more at ".into(),
-                "www.openai.com/index/gpt-5-1".cyan().underlined(),
+                "https://openai.com/index/gpt-5-1/".cyan().underlined(),
                 ".".into(),
             ]),
             Line::from(vec!["Press enter to continue".dim()]),

--- a/codex-rs/tui/src/model_migration.rs
+++ b/codex-rs/tui/src/model_migration.rs
@@ -292,7 +292,9 @@ fn gpt_5_1_codex_max_migration_copy() -> ModelMigrationCopy {
             ),
             Line::from(vec![
                 "Learn more at ".into(),
-                "https://openai.com/index/gpt-5-1-codex-max/".cyan().underlined(),
+                "https://openai.com/index/gpt-5-1-codex-max/"
+                    .cyan()
+                    .underlined(),
                 ".".into(),
             ]),
         ],

--- a/codex-rs/tui/src/snapshots/codex_tui__model_migration__tests__model_migration_prompt.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__model_migration__tests__model_migration_prompt.snap
@@ -9,7 +9,7 @@ expression: terminal.backend()
   than its predecessors and capable of long-running
   project-scale work.
 
-  Learn more at www.openai.com/index/gpt-5-1-codex-max.
+  Learn more at https://openai.com/index/gpt-5-1-codex-max/.
 
   Choose how you'd like Codex to proceed.
 

--- a/codex-rs/tui/src/snapshots/codex_tui__model_migration__tests__model_migration_prompt_gpt5_codex.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__model_migration__tests__model_migration_prompt_gpt5_codex.snap
@@ -10,6 +10,6 @@ expression: terminal.backend()
   You can continue using legacy models by specifying them
   directly with the -m option or in your config.toml.
 
-  Learn more at www.openai.com/index/gpt-5-1.
+  Learn more at https://openai.com/index/gpt-5-1/.
 
   Press enter to continue

--- a/codex-rs/tui/src/snapshots/codex_tui__model_migration__tests__model_migration_prompt_gpt5_codex_mini.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__model_migration__tests__model_migration_prompt_gpt5_codex_mini.snap
@@ -10,6 +10,6 @@ expression: terminal.backend()
   You can continue using legacy models by specifying them
   directly with the -m option or in your config.toml.
 
-  Learn more at www.openai.com/index/gpt-5-1.
+  Learn more at https://openai.com/index/gpt-5-1/.
 
   Press enter to continue

--- a/codex-rs/tui/src/snapshots/codex_tui__model_migration__tests__model_migration_prompt_gpt5_family.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__model_migration__tests__model_migration_prompt_gpt5_family.snap
@@ -10,6 +10,6 @@ expression: terminal.backend()
   You can continue using legacy models by specifying them
   directly with the -m option or in your config.toml.
 
-  Learn more at www.openai.com/index/gpt-5-1.
+  Learn more at https://openai.com/index/gpt-5-1/.
 
   Press enter to continue


### PR DESCRIPTION
Update URLs to use HTTPS in model migration prompts

Closes #6685