### PR TITLE
fix(windows) update shell_command parameters

### DIFF
--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -41,7 +41,10 @@ impl Shell {
                 ]
             }
             ShellType::PowerShell => {
-                let mut args = vec![self.shell_path.to_string_lossy().to_string()];
+                let mut args = vec![
+                    self.shell_path.to_string_lossy().to_string(),
+                    "-NoLogo".to_string(),
+                ];
                 if !use_login_shell {
                     args.push("-NoProfile".to_string());
                 }

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -445,11 +445,17 @@ mod tests {
         };
         assert_eq!(
             test_powershell_shell.derive_exec_args("echo hello", false),
-            vec!["pwsh.exe", "-NoProfile", "-Command", "echo hello"]
+            vec![
+                "pwsh.exe",
+                "-NoLogo",
+                "-NoProfile",
+                "-Command",
+                "echo hello"
+            ]
         );
         assert_eq!(
             test_powershell_shell.derive_exec_args("echo hello", true),
-            vec!["pwsh.exe", "-Command", "echo hello"]
+            vec!["pwsh.exe", "-NoLogo", "-Command", "echo hello"]
         );
     }
 

--- a/codex-rs/core/src/tools/handlers/unified_exec.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec.rs
@@ -309,8 +309,9 @@ mod tests {
 
         let command = get_command(&args);
 
-        assert_eq!(command.len(), 3);
-        assert_eq!(command[2], "echo hello");
+        let expected_command_len = if cfg!(windows) { 4 } else { 3 };
+        assert_eq!(command.len(), expected_command_len);
+        assert_eq!(command.last().unwrap(), "echo hello");
     }
 
     #[test]
@@ -338,7 +339,7 @@ mod tests {
 
         let command = get_command(&args);
 
-        assert_eq!(command[2], "echo hello");
+        assert_eq!(command.last().unwrap(), "echo hello");
     }
 
     #[test]


### PR DESCRIPTION
Fixes #7649 

## Summary
When we were originally looking at this invocation, testing and docs indicated that `-Command` implied `-NoLogo`. However, we're seeing user reports indicating this is not always the case. Let's add it to be explicit.

## Testing
- [x] Updated tests
- [x] Tested locally on windows