### PR TITLE
feat: support mcp in-session login

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -887,6 +887,7 @@ dependencies = [
  "codex-file-search",
  "codex-login",
  "codex-protocol",
+ "codex-rmcp-client",
  "codex-utils-json-to-toml",
  "core_test_support",
  "mcp-types",

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -529,6 +529,7 @@ server_notification_definitions! {
     CommandExecutionOutputDelta => "item/commandExecution/outputDelta" (v2::CommandExecutionOutputDeltaNotification),
     FileChangeOutputDelta => "item/fileChange/outputDelta" (v2::FileChangeOutputDeltaNotification),
     McpToolCallProgress => "item/mcpToolCall/progress" (v2::McpToolCallProgressNotification),
+    McpServerOauthLoginCompleted => "mcpServer/oauthLogin/completed" (v2::McpServerOauthLoginCompletedNotification),
     AccountUpdated => "account/updated" (v2::AccountUpdatedNotification),
     AccountRateLimitsUpdated => "account/rateLimits/updated" (v2::AccountRateLimitsUpdatedNotification),
     ReasoningSummaryTextDelta => "item/reasoning/summaryTextDelta" (v2::ReasoningSummaryTextDeltaNotification),

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -139,7 +139,7 @@ client_request_definitions! {
         response: v2::ModelListResponse,
     },
 
-    McpServerOauthLogin => "mcpServer/oauthLogin" {
+    McpServerOauthLogin => "mcpServer/oauth/login" {
         params: v2::McpServerOauthLoginParams,
         response: v2::McpServerOauthLoginResponse,
     },

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -139,6 +139,11 @@ client_request_definitions! {
         response: v2::ModelListResponse,
     },
 
+    McpServerOauthLogin => "mcpServer/oauthLogin" {
+        params: v2::McpServerOauthLoginParams,
+        response: v2::McpServerOauthLoginResponse,
+    },
+
     McpServersList => "mcpServers/list" {
         params: v2::ListMcpServersParams,
         response: v2::ListMcpServersResponse,

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -691,6 +691,23 @@ pub struct ListMcpServersResponse {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
+pub struct McpServerOauthLoginParams {
+    pub name: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub scopes: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct McpServerOauthLoginResponse {
+    pub authorization_url: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct FeedbackUploadParams {
     pub classification: String,
     pub reason: Option<String>,

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -696,6 +696,9 @@ pub struct McpServerOauthLoginParams {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub scopes: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub timeout_secs: Option<i64>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
@@ -1482,6 +1485,17 @@ pub struct McpToolCallProgressNotification {
     pub turn_id: String,
     pub item_id: String,
     pub message: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct McpServerOauthLoginCompletedNotification {
+    pub name: String,
+    pub success: bool,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub error: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]

--- a/codex-rs/app-server/Cargo.toml
+++ b/codex-rs/app-server/Cargo.toml
@@ -26,6 +26,7 @@ codex-login = { workspace = true }
 codex-protocol = { workspace = true }
 codex-app-server-protocol = { workspace = true }
 codex-feedback = { workspace = true }
+codex-rmcp-client = { workspace = true }
 codex-utils-json-to-toml = { workspace = true }
 chrono = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -59,6 +59,7 @@ impl MessageProcessor {
             outgoing.clone(),
             codex_linux_sandbox_exe,
             Arc::clone(&config),
+            cli_overrides.clone(),
             feedback,
         );
         let config_api = ConfigApi::new(config.codex_home.clone(), cli_overrides);

--- a/codex-rs/rmcp-client/src/lib.rs
+++ b/codex-rs/rmcp-client/src/lib.rs
@@ -17,6 +17,7 @@ pub use oauth::delete_oauth_tokens;
 pub(crate) use oauth::load_oauth_tokens;
 pub use oauth::save_oauth_tokens;
 pub use perform_oauth_login::perform_oauth_login;
+pub use perform_oauth_login::perform_oauth_login_return_url;
 pub use rmcp::model::ElicitationAction;
 pub use rmcp_client::Elicitation;
 pub use rmcp_client::ElicitationResponse;

--- a/codex-rs/rmcp-client/src/lib.rs
+++ b/codex-rs/rmcp-client/src/lib.rs
@@ -16,6 +16,7 @@ pub use oauth::WrappedOAuthTokenResponse;
 pub use oauth::delete_oauth_tokens;
 pub(crate) use oauth::load_oauth_tokens;
 pub use oauth::save_oauth_tokens;
+pub use perform_oauth_login::OauthLoginHandle;
 pub use perform_oauth_login::perform_oauth_login;
 pub use perform_oauth_login::perform_oauth_login_return_url;
 pub use rmcp::model::ElicitationAction;

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -40,70 +40,44 @@ pub async fn perform_oauth_login(
     env_http_headers: Option<HashMap<String, String>>,
     scopes: &[String],
 ) -> Result<()> {
-    let server = Arc::new(Server::http("127.0.0.1:0").map_err(|err| anyhow!(err))?);
-    let guard = CallbackServerGuard {
-        server: Arc::clone(&server),
-    };
+    OauthLoginFlow::new(
+        server_name,
+        server_url,
+        store_mode,
+        http_headers,
+        env_http_headers,
+        scopes,
+        true,
+    )
+    .await?
+    .finish()
+    .await
+}
 
-    let redirect_uri = match server.server_addr() {
-        tiny_http::ListenAddr::IP(std::net::SocketAddr::V4(addr)) => {
-            format!("http://{}:{}/callback", addr.ip(), addr.port())
-        }
-        tiny_http::ListenAddr::IP(std::net::SocketAddr::V6(addr)) => {
-            format!("http://[{}]:{}/callback", addr.ip(), addr.port())
-        }
-        #[cfg(not(target_os = "windows"))]
-        _ => return Err(anyhow!("unable to determine callback address")),
-    };
+pub async fn perform_oauth_login_return_url(
+    server_name: &str,
+    server_url: &str,
+    store_mode: OAuthCredentialsStoreMode,
+    http_headers: Option<HashMap<String, String>>,
+    env_http_headers: Option<HashMap<String, String>>,
+    scopes: &[String],
+) -> Result<String> {
+    let flow = OauthLoginFlow::new(
+        server_name,
+        server_url,
+        store_mode,
+        http_headers,
+        env_http_headers,
+        scopes,
+        false,
+    )
+    .await?;
 
-    let (tx, rx) = oneshot::channel();
-    spawn_callback_server(server, tx);
+    let auth_url = flow.authorization_url();
+    let server_name_for_logging = flow.server_name.clone();
+    flow.spawn(server_name_for_logging);
 
-    let default_headers = build_default_headers(http_headers, env_http_headers)?;
-    let http_client = apply_default_headers(ClientBuilder::new(), &default_headers).build()?;
-
-    let mut oauth_state = OAuthState::new(server_url, Some(http_client)).await?;
-    let scope_refs: Vec<&str> = scopes.iter().map(String::as_str).collect();
-    oauth_state
-        .start_authorization(&scope_refs, &redirect_uri, Some("Codex"))
-        .await?;
-    let auth_url = oauth_state.get_authorization_url().await?;
-
-    println!("Authorize `{server_name}` by opening this URL in your browser:\n{auth_url}\n");
-
-    if webbrowser::open(&auth_url).is_err() {
-        println!("(Browser launch failed; please copy the URL above manually.)");
-    }
-
-    let (code, csrf_state) = timeout(Duration::from_secs(300), rx)
-        .await
-        .context("timed out waiting for OAuth callback")?
-        .context("OAuth callback was cancelled")?;
-
-    oauth_state
-        .handle_callback(&code, &csrf_state)
-        .await
-        .context("failed to handle OAuth callback")?;
-
-    let (client_id, credentials_opt) = oauth_state
-        .get_credentials()
-        .await
-        .context("failed to retrieve OAuth credentials")?;
-    let credentials =
-        credentials_opt.ok_or_else(|| anyhow!("OAuth provider did not return credentials"))?;
-
-    let expires_at = compute_expires_at_millis(&credentials);
-    let stored = StoredOAuthTokens {
-        server_name: server_name.to_string(),
-        url: server_url.to_string(),
-        client_id,
-        token_response: WrappedOAuthTokenResponse(credentials),
-        expires_at,
-    };
-    save_oauth_tokens(server_name, &stored, store_mode)?;
-
-    drop(guard);
-    Ok(())
+    Ok(auth_url)
 }
 
 fn spawn_callback_server(server: Arc<Server>, tx: oneshot::Sender<(String, String)>) {
@@ -159,4 +133,135 @@ fn parse_oauth_callback(path: &str) -> Option<OauthCallbackResult> {
         code: code?,
         state: state?,
     })
+}
+
+struct OauthLoginFlow {
+    auth_url: String,
+    oauth_state: OAuthState,
+    rx: oneshot::Receiver<(String, String)>,
+    guard: CallbackServerGuard,
+    server_name: String,
+    server_url: String,
+    store_mode: OAuthCredentialsStoreMode,
+    launch_browser: bool,
+}
+
+impl OauthLoginFlow {
+    async fn new(
+        server_name: &str,
+        server_url: &str,
+        store_mode: OAuthCredentialsStoreMode,
+        http_headers: Option<HashMap<String, String>>,
+        env_http_headers: Option<HashMap<String, String>>,
+        scopes: &[String],
+        launch_browser: bool,
+    ) -> Result<Self> {
+        let server = Arc::new(Server::http("127.0.0.1:0").map_err(|err| anyhow!(err))?);
+        let guard = CallbackServerGuard {
+            server: Arc::clone(&server),
+        };
+
+        let redirect_uri = match server.server_addr() {
+            tiny_http::ListenAddr::IP(std::net::SocketAddr::V4(addr)) => {
+                let ip = addr.ip();
+                let port = addr.port();
+                format!("http://{ip}:{port}/callback")
+            }
+            tiny_http::ListenAddr::IP(std::net::SocketAddr::V6(addr)) => {
+                let ip = addr.ip();
+                let port = addr.port();
+                format!("http://[{ip}]:{port}/callback")
+            }
+            #[cfg(not(target_os = "windows"))]
+            _ => return Err(anyhow!("unable to determine callback address")),
+        };
+
+        let (tx, rx) = oneshot::channel();
+        spawn_callback_server(server, tx);
+
+        let default_headers = build_default_headers(http_headers, env_http_headers)?;
+        let http_client = apply_default_headers(ClientBuilder::new(), &default_headers).build()?;
+
+        let mut oauth_state = OAuthState::new(server_url, Some(http_client)).await?;
+        let scope_refs: Vec<&str> = scopes.iter().map(String::as_str).collect();
+        oauth_state
+            .start_authorization(&scope_refs, &redirect_uri, Some("Codex"))
+            .await?;
+        let auth_url = oauth_state.get_authorization_url().await?;
+
+        Ok(Self {
+            auth_url,
+            oauth_state,
+            rx,
+            guard,
+            server_name: server_name.to_string(),
+            server_url: server_url.to_string(),
+            store_mode,
+            launch_browser,
+        })
+    }
+
+    fn authorization_url(&self) -> String {
+        self.auth_url.clone()
+    }
+
+    async fn finish(mut self) -> Result<()> {
+        if self.launch_browser {
+            let server_name = &self.server_name;
+            let auth_url = &self.auth_url;
+            println!(
+                "Authorize `{server_name}` by opening this URL in your browser:\n{auth_url}\n"
+            );
+
+            if webbrowser::open(auth_url).is_err() {
+                println!("(Browser launch failed; please copy the URL above manually.)");
+            }
+        }
+
+        let result = async {
+            let (code, csrf_state) = timeout(Duration::from_secs(300), &mut self.rx)
+                .await
+                .context("timed out waiting for OAuth callback")?
+                .context("OAuth callback was cancelled")?;
+
+            self.oauth_state
+                .handle_callback(&code, &csrf_state)
+                .await
+                .context("failed to handle OAuth callback")?;
+
+            let (client_id, credentials_opt) = self
+                .oauth_state
+                .get_credentials()
+                .await
+                .context("failed to retrieve OAuth credentials")?;
+            let credentials = credentials_opt
+                .ok_or_else(|| anyhow!("OAuth provider did not return credentials"))?;
+
+            let expires_at = compute_expires_at_millis(&credentials);
+            let stored = StoredOAuthTokens {
+                server_name: self.server_name.clone(),
+                url: self.server_url.clone(),
+                client_id,
+                token_response: WrappedOAuthTokenResponse(credentials),
+                expires_at,
+            };
+            save_oauth_tokens(&self.server_name, &stored, self.store_mode)?;
+
+            Ok(())
+        }
+        .await;
+
+        drop(self.guard);
+        result
+    }
+
+    fn spawn(self, server_name_for_logging: String) {
+        tokio::spawn(async move {
+            if let Err(err) = self.finish().await {
+                eprintln!(
+                    "Failed to complete OAuth login for '{server_name_for_logging}': {err:#}"
+                );
+            }
+        });
+    }
 }


### PR DESCRIPTION
### Summary
* Added `mcpServer/oauthLogin` in app server for supporting in session MCP server login
* Added `McpServerOauthLoginParams` and `McpServerOauthLoginResponse` to support above method with response returning the auth URL for consumer to open browser or display accordingly.
* Added `McpServerOauthLoginCompletedNotification` which the app server would emit on MCP server login success or failure (i.e. timeout).
* Refactored rmcp-client oath_login to have the ability on starting a auth server which the codex_message_processor uses for in-session auth. 