### PR TITLE
docs(app-server): align approval responses with schema

### DIFF
--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -334,14 +334,14 @@ When an upstream HTTP status is available (for example, from the Responses API o
 Certain actions (shell commands or modifying files) may require explicit user approval depending on the user's config. When `turn/start` is used, the app-server drives an approval flow by sending a server-initiated JSON-RPC request to the client. The client must respond to tell Codex whether to proceed. UIs should present these requests inline with the active turn so users can review the proposed command or diff before choosing.
 
 - Requests include `threadId` and `turnId`—use them to scope UI state to the active conversation.
-- Respond with a single `{ "decision": "accept" | "decline" }` payload (plus optional `acceptSettings` on command executions). The server resumes or declines the work and ends the item with `item/completed`.
+- Respond with a single `{ "decision": "accept" | "acceptForSession" | "acceptWithExecpolicyAmendment" | "decline" | "cancel" }` payload (include `execpolicyAmendment` when using `acceptWithExecpolicyAmendment`). The server resumes or declines the work and ends the item with `item/completed`.
 
 ### Command execution approvals
 
 Order of messages:
 1. `item/started` — shows the pending `commandExecution` item with `command`, `cwd`, and other fields so you can render the proposed action.
 2. `item/commandExecution/requestApproval` (request) — carries the same `itemId`, `threadId`, `turnId`, optionally `reason` or `risk`, plus `parsedCmd` for friendly display.
-3. Client response — `{ "decision": "accept", "acceptSettings": { "forSession": false } }` or `{ "decision": "decline" }`.
+3. Client response — for example `{ "decision": "accept" }`, `{ "decision": "acceptForSession" }`, `{ "decision": "acceptWithExecpolicyAmendment", "execpolicyAmendment": { ... } }`, or `{ "decision": "decline" }`.
 4. `item/completed` — final `commandExecution` item with `status: "completed" | "failed" | "declined"` and execution output. Render this as the authoritative result.
 
 ### File change approvals


### PR DESCRIPTION
Remove legacy `acceptSettings.forSession` example and document current approval decisions (accept/acceptForSession/acceptWithExecpolicyAmendment/decline/cancel). Schema shifted in 0a32acaa2 (2025-12-08, PR #7747) when `accept_settings` was merged into `ApprovalDecision`.

