### PR TITLE
Revert "Revert "feat: windows codesign with Azure trusted signing""

### DIFF
--- a/.github/actions/windows-code-sign/action.yml
+++ b/.github/actions/windows-code-sign/action.yml
@@ -1,0 +1,54 @@
+name: windows-code-sign
+description: Sign Windows binaries with Azure Trusted Signing.
+inputs:
+  target:
+    description: Target triple for the artifacts to sign.
+    required: true
+  client-id:
+    description: Azure Trusted Signing client ID.
+    required: true
+  tenant-id:
+    description: Azure tenant ID for Trusted Signing.
+    required: true
+  subscription-id:
+    description: Azure subscription ID for Trusted Signing.
+    required: true
+  endpoint:
+    description: Azure Trusted Signing endpoint.
+    required: true
+  account-name:
+    description: Azure Trusted Signing account name.
+    required: true
+  certificate-profile-name:
+    description: Certificate profile name for signing.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Azure login for Trusted Signing (OIDC)
+      uses: azure/login@v2
+      with:
+        client-id: ${{ inputs.client-id }}
+        tenant-id: ${{ inputs.tenant-id }}
+        subscription-id: ${{ inputs.subscription-id }}
+
+    - name: Sign Windows binaries with Azure Trusted Signing
+      uses: azure/trusted-signing-action@v0
+      with:
+        endpoint: ${{ inputs.endpoint }}
+        trusted-signing-account-name: ${{ inputs.account-name }}
+        certificate-profile-name: ${{ inputs.certificate-profile-name }}
+        exclude-environment-credential: true
+        exclude-workload-identity-credential: true
+        exclude-managed-identity-credential: true
+        exclude-shared-token-cache-credential: true
+        exclude-visual-studio-credential: true
+        exclude-visual-studio-code-credential: true
+        exclude-azure-cli-credential: false
+        exclude-azure-powershell-credential: true
+        exclude-azure-developer-cli-credential: true
+        exclude-interactive-browser-credential: true
+        files: |
+          ${{ github.workspace }}/codex-rs/target/${{ inputs.target }}/release/codex.exe
+          ${{ github.workspace }}/codex-rs/target/${{ inputs.target }}/release/codex-responses-api-proxy.exe

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -110,6 +110,18 @@ jobs:
           target: ${{ matrix.target }}
           artifacts-dir: ${{ github.workspace }}/codex-rs/target/${{ matrix.target }}/release
 
+      - if: ${{ contains(matrix.target, 'windows') }}
+        name: Sign Windows binaries with Azure Trusted Signing
+        uses: ./.github/actions/windows-code-sign
+        with:
+          target: ${{ matrix.target }}
+          client-id: ${{ secrets.AZURE_TRUSTED_SIGNING_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TRUSTED_SIGNING_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_TRUSTED_SIGNING_SUBSCRIPTION_ID }}
+          endpoint: ${{ secrets.AZURE_TRUSTED_SIGNING_ENDPOINT }}
+          account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
+          certificate-profile-name: ${{ secrets.AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME }}
+
       - if: ${{ matrix.runner == 'macos-15-xlarge' }}
         name: Configure Apple code signing
         shell: bash


### PR DESCRIPTION
Reverts openai/codex#7753

Updated the tag ref matching at https://github.com/openai/openai/pull/594858 so that release with tag change can be picked up correctly. 