### PR TITLE
Fix Nix cargo output hashes for rmcp and filedescriptor

### DIFF
--- a/codex-rs/default.nix
+++ b/codex-rs/default.nix
@@ -22,7 +22,6 @@ rustPlatform.buildRustPackage (_: {
   cargoLock.outputHashes = {
     "ratatui-0.29.0" = "sha256-HBvT5c8GsiCxMffNjJGLmHnvG77A6cqEL+1ARurBXho=";
     "crossterm-0.28.1" = "sha256-6qCtfSMuXACKFb9ATID39XyFDIEMFDmbx6SSmNe+728=";
-    "rmcp-0.9.0" = "sha256-0iPrpf0Ha/facO3p5e0hUKHBqGp/iS+C+OdS+pRKMOU=";
   };
 
   meta = with lib; {

--- a/codex-rs/default.nix
+++ b/codex-rs/default.nix
@@ -22,6 +22,7 @@ rustPlatform.buildRustPackage (_: {
   cargoLock.outputHashes = {
     "ratatui-0.29.0" = "sha256-HBvT5c8GsiCxMffNjJGLmHnvG77A6cqEL+1ARurBXho=";
     "crossterm-0.28.1" = "sha256-6qCtfSMuXACKFb9ATID39XyFDIEMFDmbx6SSmNe+728=";
+    "filedescriptor-0.8.3" = "sha256-juXYvQWnzJ2SA0CzQU2+D0kOcLu4jLlX29f14vCYtfQ=";
   };
 
   meta = with lib; {

--- a/codex-rs/default.nix
+++ b/codex-rs/default.nix
@@ -22,7 +22,7 @@ rustPlatform.buildRustPackage (_: {
   cargoLock.outputHashes = {
     "ratatui-0.29.0" = "sha256-HBvT5c8GsiCxMffNjJGLmHnvG77A6cqEL+1ARurBXho=";
     "crossterm-0.28.1" = "sha256-6qCtfSMuXACKFb9ATID39XyFDIEMFDmbx6SSmNe+728=";
-    "filedescriptor-0.8.3" = "sha256-juXYvQWnzJ2SA0CzQU2+D0kOcLu4jLlX29f14vCYtfQ=";
+    "filedescriptor-0.8.3" = "sha256-aIbzfHYjPDzWSZrgbauezGzg6lm3frhyBbU01gTQpaE=";
   };
 
   meta = with lib; {


### PR DESCRIPTION
Fixes #7759:

- Drop the stale `rmcp` entry from `codex-rs/default.nix`’s `cargoLock.outputHashes` since the crate now comes from crates.io and no longer needs a git hash.
- Add the missing hash for the filedescriptor-0.8.3 git dependency (from `pakrym/wezterm`) so `buildRustPackage` can vendor it.