### PR TITLE
Inject SKILL.md when it's explicitly mentioned.

### DIFF
--- a/codex-rs/core/src/event_mapping.rs
+++ b/codex-rs/core/src/event_mapping.rs
@@ -205,7 +205,7 @@ mod tests {
                 id: None,
                 role: "user".to_string(),
                 content: vec![ContentItem::InputText {
-                    text: "<SKILL name=\"demo\" path=\"skills/demo/SKILL.md\">\nbody\n</SKILL>"
+                    text: "<skill>\n<name>demo</name>\n<path>skills/demo/SKILL.md</path>\nbody\n</skill>"
                         .to_string(),
                 }],
             },

--- a/codex-rs/core/src/event_mapping.rs
+++ b/codex-rs/core/src/event_mapping.rs
@@ -13,6 +13,7 @@ use codex_protocol::user_input::UserInput;
 use tracing::warn;
 use uuid::Uuid;
 
+use crate::user_instructions::SkillInstructions;
 use crate::user_instructions::UserInstructions;
 use crate::user_shell_command::is_user_shell_command_text;
 
@@ -23,7 +24,9 @@ fn is_session_prefix(text: &str) -> bool {
 }
 
 fn parse_user_message(message: &[ContentItem]) -> Option<UserMessageItem> {
-    if UserInstructions::is_user_instructions(message) {
+    if UserInstructions::is_user_instructions(message)
+        || SkillInstructions::is_skill_instructions(message)
+    {
         return None;
     }
 

--- a/codex-rs/core/src/event_mapping.rs
+++ b/codex-rs/core/src/event_mapping.rs
@@ -201,14 +201,22 @@ mod tests {
                     text: "# AGENTS.md instructions for test_directory\n\n<INSTRUCTIONS>\ntest_text\n</INSTRUCTIONS>".to_string(),
                 }],
             },
-        ResponseItem::Message {
-            id: None,
-            role: "user".to_string(),
-            content: vec![ContentItem::InputText {
-                text: "<user_shell_command>echo 42</user_shell_command>".to_string(),
-            }],
-        },
-    ];
+            ResponseItem::Message {
+                id: None,
+                role: "user".to_string(),
+                content: vec![ContentItem::InputText {
+                    text: "<SKILL name=\"demo\" path=\"skills/demo/SKILL.md\">\nbody\n</SKILL>"
+                        .to_string(),
+                }],
+            },
+            ResponseItem::Message {
+                id: None,
+                role: "user".to_string(),
+                content: vec![ContentItem::InputText {
+                    text: "<user_shell_command>echo 42</user_shell_command>".to_string(),
+                }],
+            },
+        ];
 
         for item in items {
             let turn_item = parse_turn_item(&item);

--- a/codex-rs/core/src/project_doc.rs
+++ b/codex-rs/core/src/project_doc.rs
@@ -239,6 +239,7 @@ mod tests {
     use super::*;
     use crate::config::ConfigOverrides;
     use crate::config::ConfigToml;
+    use crate::skills::load_skills;
     use std::fs;
     use std::path::PathBuf;
     use tempfile::TempDir;
@@ -505,9 +506,13 @@ mod tests {
             "extract from pdfs",
         );
 
-        let res = get_user_instructions(&cfg, None)
-            .await
-            .expect("instructions expected");
+        let skills = load_skills(&cfg);
+        let res = get_user_instructions(
+            &cfg,
+            skills.errors.is_empty().then_some(skills.skills.as_slice()),
+        )
+        .await
+        .expect("instructions expected");
         let expected_path = dunce::canonicalize(
             cfg.codex_home
                 .join("skills/pdf-processing/SKILL.md")
@@ -528,9 +533,13 @@ mod tests {
         let cfg = make_config(&tmp, 4096, None);
         create_skill(cfg.codex_home.clone(), "linting", "run clippy");
 
-        let res = get_user_instructions(&cfg, None)
-            .await
-            .expect("instructions expected");
+        let skills = load_skills(&cfg);
+        let res = get_user_instructions(
+            &cfg,
+            skills.errors.is_empty().then_some(skills.skills.as_slice()),
+        )
+        .await
+        .expect("instructions expected");
         let expected_path =
             dunce::canonicalize(cfg.codex_home.join("skills/linting/SKILL.md").as_path())
                 .unwrap_or_else(|_| cfg.codex_home.join("skills/linting/SKILL.md"));

--- a/codex-rs/core/src/skills/injection.rs
+++ b/codex-rs/core/src/skills/injection.rs
@@ -1,0 +1,78 @@
+use std::collections::HashSet;
+
+use crate::skills::SkillLoadOutcome;
+use crate::skills::SkillMetadata;
+use crate::user_instructions::SkillInstructions;
+use codex_protocol::models::ResponseItem;
+use codex_protocol::user_input::UserInput;
+use tokio::fs;
+
+#[derive(Debug, Default)]
+pub(crate) struct SkillInjections {
+    pub(crate) items: Vec<ResponseItem>,
+    pub(crate) warnings: Vec<String>,
+}
+
+pub(crate) async fn build_skill_injections(
+    inputs: &[UserInput],
+    skills: Option<&SkillLoadOutcome>,
+) -> SkillInjections {
+    if inputs.is_empty() {
+        return SkillInjections::default();
+    }
+
+    let Some(outcome) = skills else {
+        return SkillInjections::default();
+    };
+
+    let mentioned_skills = collect_explicit_skill_mentions(inputs, &outcome.skills);
+    if mentioned_skills.is_empty() {
+        return SkillInjections::default();
+    }
+
+    let mut result = SkillInjections {
+        items: Vec::with_capacity(mentioned_skills.len()),
+        warnings: Vec::new(),
+    };
+
+    for skill in mentioned_skills {
+        match fs::read_to_string(&skill.path).await {
+            Ok(contents) => {
+                result.items.push(ResponseItem::from(SkillInstructions {
+                    name: skill.name,
+                    path: skill.path.to_string_lossy().into_owned(),
+                    contents,
+                }));
+            }
+            Err(err) => {
+                let message = format!(
+                    "Failed to load skill {} at {}: {err:#}",
+                    skill.name,
+                    skill.path.display()
+                );
+                result.warnings.push(message);
+            }
+        }
+    }
+
+    result
+}
+
+fn collect_explicit_skill_mentions(
+    inputs: &[UserInput],
+    skills: &[SkillMetadata],
+) -> Vec<SkillMetadata> {
+    let mut selected: Vec<SkillMetadata> = Vec::new();
+    let mut seen: HashSet<String> = HashSet::new();
+
+    for input in inputs {
+        if let UserInput::Skill { name, path } = input
+            && seen.insert(name.clone())
+            && let Some(skill) = skills.iter().find(|s| s.name == *name && s.path == *path)
+        {
+            selected.push(skill.clone());
+        }
+    }
+
+    selected
+}

--- a/codex-rs/core/src/skills/mod.rs
+++ b/codex-rs/core/src/skills/mod.rs
@@ -1,7 +1,10 @@
+pub mod injection;
 pub mod loader;
 pub mod model;
 pub mod render;
 
+pub(crate) use injection::SkillInjections;
+pub(crate) use injection::build_skill_injections;
 pub use loader::load_skills;
 pub use model::SkillError;
 pub use model::SkillLoadOutcome;

--- a/codex-rs/core/src/state/service.rs
+++ b/codex-rs/core/src/state/service.rs
@@ -4,6 +4,7 @@ use crate::AuthManager;
 use crate::RolloutRecorder;
 use crate::mcp_connection_manager::McpConnectionManager;
 use crate::openai_models::models_manager::ModelsManager;
+use crate::skills::SkillLoadOutcome;
 use crate::tools::sandboxing::ApprovalStore;
 use crate::unified_exec::UnifiedExecSessionManager;
 use crate::user_notification::UserNotifier;
@@ -24,4 +25,5 @@ pub(crate) struct SessionServices {
     pub(crate) models_manager: Arc<ModelsManager>,
     pub(crate) otel_event_manager: OtelEventManager,
     pub(crate) tool_approvals: Mutex<ApprovalStore>,
+    pub(crate) skills: Option<SkillLoadOutcome>,
 }

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -7,6 +7,7 @@ use crate::context_manager::ContextManager;
 use crate::protocol::RateLimitSnapshot;
 use crate::protocol::TokenUsage;
 use crate::protocol::TokenUsageInfo;
+use crate::skills::SkillMetadata;
 use crate::truncate::TruncationPolicy;
 
 /// Persistent, session-scoped state previously stored directly on `Session`.
@@ -14,16 +15,21 @@ pub(crate) struct SessionState {
     pub(crate) session_configuration: SessionConfiguration,
     pub(crate) history: ContextManager,
     pub(crate) latest_rate_limits: Option<RateLimitSnapshot>,
+    pub(crate) skills: Option<Vec<SkillMetadata>>,
 }
 
 impl SessionState {
     /// Create a new session state mirroring previous `State::default()` semantics.
-    pub(crate) fn new(session_configuration: SessionConfiguration) -> Self {
+    pub(crate) fn new(
+        session_configuration: SessionConfiguration,
+        skills: Option<Vec<SkillMetadata>>,
+    ) -> Self {
         let history = ContextManager::new();
         Self {
             session_configuration,
             history,
             latest_rate_limits: None,
+            skills,
         }
     }
 

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -7,7 +7,6 @@ use crate::context_manager::ContextManager;
 use crate::protocol::RateLimitSnapshot;
 use crate::protocol::TokenUsage;
 use crate::protocol::TokenUsageInfo;
-use crate::skills::SkillLoadOutcome;
 use crate::truncate::TruncationPolicy;
 
 /// Persistent, session-scoped state previously stored directly on `Session`.
@@ -15,21 +14,16 @@ pub(crate) struct SessionState {
     pub(crate) session_configuration: SessionConfiguration,
     pub(crate) history: ContextManager,
     pub(crate) latest_rate_limits: Option<RateLimitSnapshot>,
-    pub(crate) skills: Option<SkillLoadOutcome>,
 }
 
 impl SessionState {
     /// Create a new session state mirroring previous `State::default()` semantics.
-    pub(crate) fn new(
-        session_configuration: SessionConfiguration,
-        skills: Option<SkillLoadOutcome>,
-    ) -> Self {
+    pub(crate) fn new(session_configuration: SessionConfiguration) -> Self {
         let history = ContextManager::new();
         Self {
             session_configuration,
             history,
             latest_rate_limits: None,
-            skills,
         }
     }
 

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -7,7 +7,7 @@ use crate::context_manager::ContextManager;
 use crate::protocol::RateLimitSnapshot;
 use crate::protocol::TokenUsage;
 use crate::protocol::TokenUsageInfo;
-use crate::skills::SkillMetadata;
+use crate::skills::SkillLoadOutcome;
 use crate::truncate::TruncationPolicy;
 
 /// Persistent, session-scoped state previously stored directly on `Session`.
@@ -15,14 +15,14 @@ pub(crate) struct SessionState {
     pub(crate) session_configuration: SessionConfiguration,
     pub(crate) history: ContextManager,
     pub(crate) latest_rate_limits: Option<RateLimitSnapshot>,
-    pub(crate) skills: Option<Vec<SkillMetadata>>,
+    pub(crate) skills: Option<SkillLoadOutcome>,
 }
 
 impl SessionState {
     /// Create a new session state mirroring previous `State::default()` semantics.
     pub(crate) fn new(
         session_configuration: SessionConfiguration,
-        skills: Option<Vec<SkillMetadata>>,
+        skills: Option<SkillLoadOutcome>,
     ) -> Self {
         let history = ContextManager::new();
         Self {

--- a/codex-rs/core/src/user_instructions.rs
+++ b/codex-rs/core/src/user_instructions.rs
@@ -6,7 +6,7 @@ use codex_protocol::models::ResponseItem;
 
 pub const USER_INSTRUCTIONS_OPEN_TAG_LEGACY: &str = "<user_instructions>";
 pub const USER_INSTRUCTIONS_PREFIX: &str = "# AGENTS.md instructions for ";
-pub const SKILL_INSTRUCTIONS_PREFIX: &str = "<SKILL";
+pub const SKILL_INSTRUCTIONS_PREFIX: &str = "<skill";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename = "user_instructions", rename_all = "snake_case")]
@@ -67,10 +67,8 @@ impl From<SkillInstructions> for ResponseItem {
             role: "user".to_string(),
             content: vec![ContentItem::InputText {
                 text: format!(
-                    "<SKILL name=\"{name}\" path=\"{path}\">\n{contents}\n</SKILL>",
-                    name = si.name,
-                    path = si.path,
-                    contents = si.contents
+                    "<skill>\n<name>{}</name>\n<path>{}</path>\n{}\n</skill>",
+                    si.name, si.path, si.contents
                 ),
             }],
         }
@@ -174,7 +172,7 @@ mod tests {
 
         assert_eq!(
             text,
-            "<SKILL name=\"demo-skill\" path=\"skills/demo/SKILL.md\">\nbody\n</SKILL>",
+            "<skill>\n<name>demo-skill</name>\n<path>skills/demo/SKILL.md</path>\nbody\n</skill>",
         );
     }
 
@@ -182,7 +180,7 @@ mod tests {
     fn test_is_skill_instructions() {
         assert!(SkillInstructions::is_skill_instructions(&[
             ContentItem::InputText {
-                text: "<SKILL name=\"demo-skill\" path=\"skills/demo/SKILL.md\">\nbody\n</SKILL>"
+                text: "<skill>\n<name>demo-skill</name>\n<path>skills/demo/SKILL.md</path>\nbody\n</skill>"
                     .to_string(),
             }
         ]));

--- a/codex-rs/core/src/user_instructions.rs
+++ b/codex-rs/core/src/user_instructions.rs
@@ -6,6 +6,7 @@ use codex_protocol::models::ResponseItem;
 
 pub const USER_INSTRUCTIONS_OPEN_TAG_LEGACY: &str = "<user_instructions>";
 pub const USER_INSTRUCTIONS_PREFIX: &str = "# AGENTS.md instructions for ";
+pub const SKILL_INSTRUCTIONS_PREFIX: &str = "# SKILL.md instructions for ";
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename = "user_instructions", rename_all = "snake_case")]
@@ -35,6 +36,41 @@ impl From<UserInstructions> for ResponseItem {
                     "{USER_INSTRUCTIONS_PREFIX}{directory}\n\n<INSTRUCTIONS>\n{contents}\n</INSTRUCTIONS>",
                     directory = ui.directory,
                     contents = ui.text
+                ),
+            }],
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(rename = "skill_instructions", rename_all = "snake_case")]
+pub(crate) struct SkillInstructions {
+    pub name: String,
+    pub path: String,
+    pub contents: String,
+}
+
+impl SkillInstructions {
+    pub fn is_skill_instructions(message: &[ContentItem]) -> bool {
+        if let [ContentItem::InputText { text }] = message {
+            text.starts_with(SKILL_INSTRUCTIONS_PREFIX)
+        } else {
+            false
+        }
+    }
+}
+
+impl From<SkillInstructions> for ResponseItem {
+    fn from(si: SkillInstructions) -> Self {
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: format!(
+                    "{SKILL_INSTRUCTIONS_PREFIX}{name}\nPath: {path}\n\n<SKILL>\n{contents}\n</SKILL>",
+                    name = si.name,
+                    path = si.path,
+                    contents = si.contents
                 ),
             }],
         }

--- a/codex-rs/core/tests/common/test_codex.rs
+++ b/codex-rs/core/tests/common/test_codex.rs
@@ -236,33 +236,6 @@ impl TestCodex {
         .await;
         Ok(())
     }
-
-    pub async fn submit_items(
-        &self,
-        items: Vec<UserInput>,
-        approval_policy: AskForApproval,
-        sandbox_policy: SandboxPolicy,
-    ) -> Result<()> {
-        let session_model = self.session_configured.model.clone();
-        self.codex
-            .submit(Op::UserTurn {
-                items,
-                final_output_json_schema: None,
-                cwd: self.cwd.path().to_path_buf(),
-                approval_policy,
-                sandbox_policy,
-                model: session_model,
-                effort: None,
-                summary: ReasoningSummary::Auto,
-            })
-            .await?;
-
-        wait_for_event(&self.codex, |event| {
-            matches!(event, EventMsg::TaskComplete(_))
-        })
-        .await;
-        Ok(())
-    }
 }
 
 pub struct TestCodexHarness {

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -50,6 +50,7 @@ mod seatbelt;
 mod shell_command;
 mod shell_serialization;
 mod shell_snapshot;
+mod skills;
 mod stream_error_allows_next_turn;
 mod stream_no_completed;
 mod text_encoding_fix;

--- a/codex-rs/core/tests/suite/skills.rs
+++ b/codex-rs/core/tests/suite/skills.rs
@@ -4,7 +4,9 @@
 use anyhow::Result;
 use codex_core::features::Feature;
 use codex_core::protocol::AskForApproval;
+use codex_core::protocol::Op;
 use codex_core::protocol::SandboxPolicy;
+use codex_core::protocol::SkillLoadOutcomeInfo;
 use codex_protocol::user_input::UserInput;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
@@ -42,6 +44,7 @@ async fn user_turn_includes_skill_instructions() -> Result<()> {
     let test = builder.build(&server).await?;
 
     let skill_path = test.codex_home_path().join("skills/demo/SKILL.md");
+    let skill_path = std::fs::canonicalize(skill_path)?;
 
     let mock = mount_sse_once(
         &server,
@@ -53,31 +56,80 @@ async fn user_turn_includes_skill_instructions() -> Result<()> {
     )
     .await;
 
-    test.submit_items(
-        vec![
-            UserInput::Text {
-                text: "please use $demo".to_string(),
-            },
-            UserInput::Skill {
-                name: "demo".to_string(),
-                path: skill_path.clone(),
-            },
-        ],
-        AskForApproval::Never,
-        SandboxPolicy::DangerFullAccess,
-    )
-    .await?;
+    let session_model = test.session_configured.model.clone();
+    test.codex
+        .submit(Op::UserTurn {
+            items: vec![
+                UserInput::Text {
+                    text: "please use $demo".to_string(),
+                },
+                UserInput::Skill {
+                    name: "demo".to_string(),
+                    path: skill_path.clone(),
+                },
+            ],
+            final_output_json_schema: None,
+            cwd: test.cwd_path().to_path_buf(),
+            approval_policy: AskForApproval::Never,
+            sandbox_policy: SandboxPolicy::DangerFullAccess,
+            model: session_model,
+            effort: None,
+            summary: codex_protocol::config_types::ReasoningSummary::Auto,
+        })
+        .await?;
+
+    core_test_support::wait_for_event(test.codex.as_ref(), |event| {
+        matches!(event, codex_core::protocol::EventMsg::TaskComplete(_))
+    })
+    .await;
 
     let request = mock.single_request();
     let user_texts = request.message_input_texts("user");
     let skill_path_str = skill_path.to_string_lossy();
     assert!(
         user_texts.iter().any(|text| {
-            text.contains("<SKILL name=\"demo\"")
+            text.contains("<skill>\n<name>demo</name>")
+                && text.contains("<path>")
                 && text.contains(skill_body)
                 && text.contains(skill_path_str.as_ref())
         }),
         "expected skill instructions in user input, got {user_texts:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn skill_load_errors_surface_in_session_configured() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let mut builder = test_codex()
+        .with_config(|cfg| {
+            cfg.features.enable(Feature::Skills);
+        })
+        .with_pre_build_hook(|home| {
+            let skill_dir = home.join("skills").join("broken");
+            fs::create_dir_all(&skill_dir).unwrap();
+            fs::write(skill_dir.join("SKILL.md"), "not yaml").unwrap();
+        });
+    let test = builder.build(&server).await?;
+
+    let SkillLoadOutcomeInfo { skills, errors } = test
+        .session_configured
+        .skill_load_outcome
+        .as_ref()
+        .expect("skill outcome present");
+
+    assert!(
+        skills.is_empty(),
+        "expected no skills loaded, got {skills:?}"
+    );
+    assert_eq!(errors.len(), 1, "expected one load error");
+    let error_path = errors[0].path.to_string_lossy();
+    assert!(
+        error_path.ends_with("skills/broken/SKILL.md"),
+        "unexpected error path: {error_path}"
     );
 
     Ok(())

--- a/codex-rs/core/tests/suite/skills.rs
+++ b/codex-rs/core/tests/suite/skills.rs
@@ -1,0 +1,84 @@
+#![cfg(not(target_os = "windows"))]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use anyhow::Result;
+use codex_core::features::Feature;
+use codex_core::protocol::AskForApproval;
+use codex_core::protocol::SandboxPolicy;
+use codex_protocol::user_input::UserInput;
+use core_test_support::responses::ev_assistant_message;
+use core_test_support::responses::ev_completed;
+use core_test_support::responses::ev_response_created;
+use core_test_support::responses::mount_sse_once;
+use core_test_support::responses::sse;
+use core_test_support::responses::start_mock_server;
+use core_test_support::skip_if_no_network;
+use core_test_support::test_codex::test_codex;
+use std::fs;
+use std::path::Path;
+
+fn write_skill(home: &Path, name: &str, description: &str, body: &str) -> std::path::PathBuf {
+    let skill_dir = home.join("skills").join(name);
+    fs::create_dir_all(&skill_dir).unwrap();
+    let contents = format!("---\nname: {name}\ndescription: {description}\n---\n\n{body}\n");
+    let path = skill_dir.join("SKILL.md");
+    fs::write(&path, contents).unwrap();
+    path
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn user_turn_includes_skill_instructions() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let skill_body = "skill body";
+    let mut builder = test_codex()
+        .with_config(|cfg| {
+            cfg.features.enable(Feature::Skills);
+        })
+        .with_pre_build_hook(|home| {
+            write_skill(home, "demo", "demo skill", skill_body);
+        });
+    let test = builder.build(&server).await?;
+
+    let skill_path = test.codex_home_path().join("skills/demo/SKILL.md");
+
+    let mock = mount_sse_once(
+        &server,
+        sse(vec![
+            ev_response_created("resp-1"),
+            ev_assistant_message("msg-1", "done"),
+            ev_completed("resp-1"),
+        ]),
+    )
+    .await;
+
+    test.submit_items(
+        vec![
+            UserInput::Text {
+                text: "please use $demo".to_string(),
+            },
+            UserInput::Skill {
+                name: "demo".to_string(),
+                path: skill_path.clone(),
+            },
+        ],
+        AskForApproval::Never,
+        SandboxPolicy::DangerFullAccess,
+    )
+    .await?;
+
+    let request = mock.single_request();
+    let user_texts = request.message_input_texts("user");
+    let skill_path_str = skill_path.to_string_lossy();
+    assert!(
+        user_texts.iter().any(|text| {
+            text.contains("<SKILL name=\"demo\"")
+                && text.contains(skill_body)
+                && text.contains(skill_path_str.as_ref())
+        }),
+        "expected skill instructions in user input, got {user_texts:?}"
+    );
+
+    Ok(())
+}

--- a/codex-rs/exec/tests/event_processor_with_json_output.rs
+++ b/codex-rs/exec/tests/event_processor_with_json_output.rs
@@ -83,6 +83,7 @@ fn session_configured_produces_thread_started_event() {
             history_log_id: 0,
             history_entry_count: 0,
             initial_messages: None,
+            skill_load_outcome: None,
             rollout_path,
         }),
     );

--- a/codex-rs/mcp-server/src/outgoing_message.rs
+++ b/codex-rs/mcp-server/src/outgoing_message.rs
@@ -266,6 +266,7 @@ mod tests {
                 history_log_id: 1,
                 history_entry_count: 1000,
                 initial_messages: None,
+                skill_load_outcome: None,
                 rollout_path: rollout_file.path().to_path_buf(),
             }),
         };
@@ -305,6 +306,7 @@ mod tests {
             history_log_id: 1,
             history_entry_count: 1000,
             initial_messages: None,
+            skill_load_outcome: None,
             rollout_path: rollout_file.path().to_path_buf(),
         };
         let event = Event {

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -311,6 +311,9 @@ impl From<Vec<UserInput>> for ResponseInputItem {
                             }
                         }
                     },
+                    UserInput::Skill { .. } => ContentItem::InputText {
+                        text: String::new(),
+                    },
                 })
                 .collect::<Vec<ContentItem>>(),
         }

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -281,39 +281,37 @@ impl From<Vec<UserInput>> for ResponseInputItem {
             role: "user".to_string(),
             content: items
                 .into_iter()
-                .map(|c| match c {
-                    UserInput::Text { text } => ContentItem::InputText { text },
-                    UserInput::Image { image_url } => ContentItem::InputImage { image_url },
+                .filter_map(|c| match c {
+                    UserInput::Text { text } => Some(ContentItem::InputText { text }),
+                    UserInput::Image { image_url } => Some(ContentItem::InputImage { image_url }),
                     UserInput::LocalImage { path } => match load_and_resize_to_fit(&path) {
-                        Ok(image) => ContentItem::InputImage {
+                        Ok(image) => Some(ContentItem::InputImage {
                             image_url: image.into_data_url(),
-                        },
+                        }),
                         Err(err) => {
                             if matches!(&err, ImageProcessingError::Read { .. }) {
-                                local_image_error_placeholder(&path, &err)
+                                Some(local_image_error_placeholder(&path, &err))
                             } else if err.is_invalid_image() {
-                                invalid_image_error_placeholder(&path, &err)
+                                Some(invalid_image_error_placeholder(&path, &err))
                             } else {
                                 let Some(mime_guess) = mime_guess::from_path(&path).first() else {
-                                    return local_image_error_placeholder(
+                                    return Some(local_image_error_placeholder(
                                         &path,
                                         "unsupported MIME type (unknown)",
-                                    );
+                                    ));
                                 };
                                 let mime = mime_guess.essence_str().to_owned();
                                 if !mime.starts_with("image/") {
-                                    return local_image_error_placeholder(
+                                    return Some(local_image_error_placeholder(
                                         &path,
                                         format!("unsupported MIME type `{mime}`"),
-                                    );
+                                    ));
                                 }
-                                unsupported_image_error_placeholder(&path, &mime)
+                                Some(unsupported_image_error_placeholder(&path, &mime))
                             }
                         }
                     },
-                    UserInput::Skill { .. } => ContentItem::InputText {
-                        text: String::new(),
-                    },
+                    UserInput::Skill { .. } => None, // Skill bodies are injected later in core
                 })
                 .collect::<Vec<ContentItem>>(),
         }

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -1613,6 +1613,25 @@ pub struct ListCustomPromptsResponseEvent {
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS)]
+pub struct SkillInfo {
+    pub name: String,
+    pub description: String,
+    pub path: PathBuf,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS)]
+pub struct SkillErrorInfo {
+    pub path: PathBuf,
+    pub message: String,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS, Default)]
+pub struct SkillLoadOutcomeInfo {
+    pub skills: Vec<SkillInfo>,
+    pub errors: Vec<SkillErrorInfo>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS)]
 pub struct SessionConfiguredEvent {
     /// Name left as session_id instead of conversation_id for backwards compatibility.
     pub session_id: ConversationId,
@@ -1646,6 +1665,9 @@ pub struct SessionConfiguredEvent {
     /// When present, UIs can use these to seed the history.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub initial_messages: Option<Vec<EventMsg>>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skill_load_outcome: Option<SkillLoadOutcomeInfo>,
 
     pub rollout_path: PathBuf,
 }
@@ -1774,6 +1796,7 @@ mod tests {
                 history_log_id: 0,
                 history_entry_count: 0,
                 initial_messages: None,
+                skill_load_outcome: None,
                 rollout_path: rollout_file.path().to_path_buf(),
             }),
         };

--- a/codex-rs/protocol/src/user_input.rs
+++ b/codex-rs/protocol/src/user_input.rs
@@ -21,4 +21,10 @@ pub enum UserInput {
     LocalImage {
         path: std::path::PathBuf,
     },
+
+    /// Skill selected by the user (name + path to SKILL.md).
+    Skill {
+        name: String,
+        path: std::path::PathBuf,
+    },
 }

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -25,6 +25,7 @@ use codex_core::AuthManager;
 use codex_core::ConversationManager;
 use codex_core::config::Config;
 use codex_core::config::edit::ConfigEditsBuilder;
+#[cfg(target_os = "windows")]
 use codex_core::features::Feature;
 use codex_core::openai_models::model_presets::HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG;
 use codex_core::openai_models::model_presets::HIDE_GPT5_1_MIGRATION_PROMPT_CONFIG;
@@ -33,9 +34,9 @@ use codex_core::protocol::EventMsg;
 use codex_core::protocol::FinalOutput;
 use codex_core::protocol::Op;
 use codex_core::protocol::SessionSource;
+use codex_core::protocol::SkillLoadOutcomeInfo;
 use codex_core::protocol::TokenUsage;
-use codex_core::skills::load_skills;
-use codex_core::skills::model::SkillMetadata;
+use codex_core::skills::SkillError;
 use codex_protocol::ConversationId;
 use codex_protocol::openai_models::ModelPreset;
 use codex_protocol::openai_models::ModelUpgrade;
@@ -86,6 +87,17 @@ fn session_summary(
         usage_line,
         resume_command,
     })
+}
+
+fn skill_errors_from_outcome(outcome: &SkillLoadOutcomeInfo) -> Vec<SkillError> {
+    outcome
+        .errors
+        .iter()
+        .map(|err| SkillError {
+            path: err.path.clone(),
+            message: err.message.clone(),
+        })
+        .collect()
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -235,8 +247,6 @@ pub(crate) struct App {
 
     // One-shot suppression of the next world-writable scan after user confirmation.
     skip_world_writable_scan_once: bool,
-
-    pub(crate) skills: Option<Vec<SkillMetadata>>,
 }
 
 impl App {
@@ -281,26 +291,6 @@ impl App {
             return Ok(exit_info);
         }
 
-        let skills_outcome = load_skills(&config);
-        if !skills_outcome.errors.is_empty() {
-            match run_skill_error_prompt(tui, &skills_outcome.errors).await {
-                SkillErrorPromptOutcome::Exit => {
-                    return Ok(AppExitInfo {
-                        token_usage: TokenUsage::default(),
-                        conversation_id: None,
-                        update_action: None,
-                    });
-                }
-                SkillErrorPromptOutcome::Continue => {}
-            }
-        }
-
-        let skills = if config.features.enabled(Feature::Skills) {
-            Some(skills_outcome.skills.clone())
-        } else {
-            None
-        };
-
         let enhanced_keys_supported = tui.enhanced_keys_supported();
         let model_family = conversation_manager
             .get_models_manager()
@@ -318,7 +308,6 @@ impl App {
                     auth_manager: auth_manager.clone(),
                     models_manager: conversation_manager.get_models_manager(),
                     feedback: feedback.clone(),
-                    skills: skills.clone(),
                     is_first_run,
                     model_family,
                 };
@@ -345,7 +334,6 @@ impl App {
                     auth_manager: auth_manager.clone(),
                     models_manager: conversation_manager.get_models_manager(),
                     feedback: feedback.clone(),
-                    skills: skills.clone(),
                     is_first_run,
                     model_family,
                 };
@@ -382,7 +370,6 @@ impl App {
             pending_update_action: None,
             suppress_shutdown_complete: false,
             skip_world_writable_scan_once: false,
-            skills,
         };
 
         // On startup, if Agent mode (workspace-write) or ReadOnly is active, warn about world-writable dirs on Windows.
@@ -508,7 +495,6 @@ impl App {
                     auth_manager: self.auth_manager.clone(),
                     models_manager: self.server.get_models_manager(),
                     feedback: self.feedback.clone(),
-                    skills: self.skills.clone(),
                     is_first_run: false,
                     model_family,
                 };
@@ -558,7 +544,6 @@ impl App {
                                     auth_manager: self.auth_manager.clone(),
                                     models_manager: self.server.get_models_manager(),
                                     feedback: self.feedback.clone(),
-                                    skills: self.skills.clone(),
                                     is_first_run: false,
                                     model_family: model_family.clone(),
                                 };
@@ -648,6 +633,19 @@ impl App {
                 {
                     self.suppress_shutdown_complete = false;
                     return Ok(true);
+                }
+                if let EventMsg::SessionConfigured(cfg) = &event.msg
+                    && let Some(outcome) = cfg.skill_load_outcome.as_ref()
+                    && !outcome.errors.is_empty()
+                {
+                    let errors = skill_errors_from_outcome(outcome);
+                    match run_skill_error_prompt(tui, &errors).await {
+                        SkillErrorPromptOutcome::Exit => {
+                            self.chat_widget.submit_op(Op::Shutdown);
+                            return Ok(false);
+                        }
+                        SkillErrorPromptOutcome::Continue => {}
+                    }
                 }
                 self.chat_widget.handle_codex_event(event);
             }
@@ -1193,7 +1191,6 @@ mod tests {
             pending_update_action: None,
             suppress_shutdown_complete: false,
             skip_world_writable_scan_once: false,
-            skills: None,
         }
     }
 
@@ -1231,7 +1228,6 @@ mod tests {
                 pending_update_action: None,
                 suppress_shutdown_complete: false,
                 skip_world_writable_scan_once: false,
-                skills: None,
             },
             rx,
             op_rx,
@@ -1339,6 +1335,7 @@ mod tests {
                 history_log_id: 0,
                 history_entry_count: 0,
                 initial_messages: None,
+                skill_load_outcome: None,
                 rollout_path: PathBuf::new(),
             };
             Arc::new(new_session_info(
@@ -1393,6 +1390,7 @@ mod tests {
             history_log_id: 0,
             history_entry_count: 0,
             initial_messages: None,
+            skill_load_outcome: None,
             rollout_path: PathBuf::new(),
         };
 

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -349,7 +349,6 @@ impl App {
             auth_manager: self.auth_manager.clone(),
             models_manager: self.server.get_models_manager(),
             feedback: self.feedback.clone(),
-            skills: self.skills.clone(),
             is_first_run: false,
         };
         self.chat_widget =

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -801,6 +801,10 @@ impl ChatComposer {
         self.skills.as_ref().is_some_and(|s| !s.is_empty())
     }
 
+    pub fn skills(&self) -> Option<&Vec<SkillMetadata>> {
+        self.skills.as_ref()
+    }
+
     /// Extract a token prefixed with `prefix` under the cursor, if any.
     ///
     /// The returned string **does not** include the prefix.

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -131,8 +131,17 @@ impl BottomPane {
         }
     }
 
+    pub fn set_skills(&mut self, skills: Option<Vec<SkillMetadata>>) {
+        self.composer.set_skill_mentions(skills);
+        self.request_redraw();
+    }
+
     pub fn status_widget(&self) -> Option<&StatusIndicatorWidget> {
         self.status.as_ref()
+    }
+
+    pub fn skills(&self) -> Option<&Vec<SkillMetadata>> {
+        self.composer.skills()
     }
 
     #[cfg(test)]

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -44,6 +44,7 @@ use codex_core::protocol::PatchApplyBeginEvent;
 use codex_core::protocol::RateLimitSnapshot;
 use codex_core::protocol::ReviewRequest;
 use codex_core::protocol::ReviewTarget;
+use codex_core::protocol::SkillLoadOutcomeInfo;
 use codex_core::protocol::StreamErrorEvent;
 use codex_core::protocol::TaskCompleteEvent;
 use codex_core::protocol::TokenUsage;
@@ -260,7 +261,6 @@ pub(crate) struct ChatWidgetInit {
     pub(crate) auth_manager: Arc<AuthManager>,
     pub(crate) models_manager: Arc<ModelsManager>,
     pub(crate) feedback: codex_feedback::CodexFeedback,
-    pub(crate) skills: Option<Vec<SkillMetadata>>,
     pub(crate) is_first_run: bool,
     pub(crate) model_family: ModelFamily,
 }
@@ -389,6 +389,7 @@ impl ChatWidget {
     fn on_session_configured(&mut self, event: codex_core::protocol::SessionConfiguredEvent) {
         self.bottom_pane
             .set_history_metadata(event.history_log_id, event.history_entry_count);
+        self.set_skills_from_outcome(event.skill_load_outcome.as_ref());
         self.conversation_id = Some(event.session_id);
         self.current_rollout_path = Some(event.rollout_path.clone());
         let initial_messages = event.initial_messages.clone();
@@ -410,6 +411,11 @@ impl ChatWidget {
         if !self.suppress_session_configured_redraw {
             self.request_redraw();
         }
+    }
+
+    fn set_skills_from_outcome(&mut self, outcome: Option<&SkillLoadOutcomeInfo>) {
+        let skills = outcome.map(skills_from_outcome);
+        self.bottom_pane.set_skills(skills);
     }
 
     pub(crate) fn open_feedback_note(
@@ -1259,7 +1265,6 @@ impl ChatWidget {
             auth_manager,
             models_manager,
             feedback,
-            skills,
             is_first_run,
             model_family,
         } = common;
@@ -1279,7 +1284,7 @@ impl ChatWidget {
                 placeholder_text: placeholder,
                 disable_paste_burst: config.disable_paste_burst,
                 animations_enabled: config.animations,
-                skills,
+                skills: None,
             }),
             active_cell: None,
             config: config.clone(),
@@ -1342,7 +1347,6 @@ impl ChatWidget {
             auth_manager,
             models_manager,
             feedback,
-            skills,
             model_family,
             ..
         } = common;
@@ -1364,7 +1368,7 @@ impl ChatWidget {
                 placeholder_text: placeholder,
                 disable_paste_burst: config.disable_paste_burst,
                 animations_enabled: config.animations,
-                skills,
+                skills: None,
             }),
             active_cell: None,
             config: config.clone(),
@@ -1729,6 +1733,16 @@ impl ChatWidget {
 
         for path in image_paths {
             items.push(UserInput::LocalImage { path });
+        }
+
+        if let Some(skills) = self.bottom_pane.skills() {
+            let skill_mentions = find_skill_mentions(&text, skills);
+            for skill in skill_mentions {
+                items.push(UserInput::Skill {
+                    name: skill.name.clone(),
+                    path: skill.path.clone(),
+                });
+            }
         }
 
         self.codex_op_tx
@@ -3448,6 +3462,34 @@ pub(crate) fn show_review_commit_picker_with_entries(
         search_placeholder: Some("Type to search commits".to_string()),
         ..Default::default()
     });
+}
+
+fn skills_from_outcome(outcome: &SkillLoadOutcomeInfo) -> Vec<SkillMetadata> {
+    outcome
+        .skills
+        .iter()
+        .map(|skill| SkillMetadata {
+            name: skill.name.clone(),
+            description: skill.description.clone(),
+            path: skill.path.clone(),
+        })
+        .collect()
+}
+
+fn find_skill_mentions(text: &str, skills: &[SkillMetadata]) -> Vec<SkillMetadata> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut matches: Vec<SkillMetadata> = Vec::new();
+    for skill in skills {
+        if seen.contains(&skill.name) {
+            continue;
+        }
+        let needle = format!("${}", skill.name);
+        if text.contains(&needle) {
+            seen.insert(skill.name.clone());
+            matches.push(skill.clone());
+        }
+    }
+    matches
 }
 
 #[cfg(test)]

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -121,6 +121,7 @@ fn resumed_initial_messages_render_history() {
                 message: "assistant reply".to_string(),
             }),
         ]),
+        skill_load_outcome: None,
         rollout_path: rollout_file.path().to_path_buf(),
     };
 
@@ -361,7 +362,6 @@ async fn helpers_are_available_and_do_not_panic() {
         auth_manager,
         models_manager: conversation_manager.get_models_manager(),
         feedback: codex_feedback::CodexFeedback::new(),
-        skills: None,
         is_first_run: true,
         model_family,
     };


### PR DESCRIPTION
1. Skills load once in core at session start; the cached outcome  is reused across core and surfaced to TUI via SessionConfigured.
2. TUI detects explicit skill selections, and core injects the matching SKILL.md content into the turn when a selected skill is present.
