### PR TITLE
make `model` optional in config

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1885,7 +1885,7 @@ impl CodexMessageProcessor {
 
     async fn list_models(&self, request_id: RequestId, params: ModelListParams) {
         let ModelListParams { limit, cursor } = params;
-        let models = supported_models(self.conversation_manager.clone()).await;
+        let models = supported_models(self.conversation_manager.clone(), &self.config).await;
         let total = models.len();
 
         if total == 0 {
@@ -2796,7 +2796,7 @@ impl CodexMessageProcessor {
         })?;
 
         let mut config = self.config.as_ref().clone();
-        config.model = self.config.review_model.clone();
+        config.model = Some(self.config.review_model.clone());
 
         let NewConversation {
             conversation_id,

--- a/codex-rs/app-server/src/models.rs
+++ b/codex-rs/app-server/src/models.rs
@@ -3,12 +3,16 @@ use std::sync::Arc;
 use codex_app_server_protocol::Model;
 use codex_app_server_protocol::ReasoningEffortOption;
 use codex_core::ConversationManager;
+use codex_core::config::Config;
 use codex_protocol::openai_models::ModelPreset;
 use codex_protocol::openai_models::ReasoningEffortPreset;
 
-pub async fn supported_models(conversation_manager: Arc<ConversationManager>) -> Vec<Model> {
+pub async fn supported_models(
+    conversation_manager: Arc<ConversationManager>,
+    config: &Config,
+) -> Vec<Model> {
     conversation_manager
-        .list_models()
+        .list_models(config)
         .await
         .into_iter()
         .map(model_from_preset)

--- a/codex-rs/app-server/tests/common/lib.rs
+++ b/codex-rs/app-server/tests/common/lib.rs
@@ -1,6 +1,7 @@
 mod auth_fixtures;
 mod mcp_process;
 mod mock_model_server;
+mod models_cache;
 mod responses;
 mod rollout;
 
@@ -14,6 +15,8 @@ pub use core_test_support::format_with_current_shell_display;
 pub use mcp_process::McpProcess;
 pub use mock_model_server::create_mock_chat_completions_server;
 pub use mock_model_server::create_mock_chat_completions_server_unchecked;
+pub use models_cache::write_models_cache;
+pub use models_cache::write_models_cache_with_models;
 pub use responses::create_apply_patch_sse_response;
 pub use responses::create_exec_command_sse_response;
 pub use responses::create_final_assistant_message_sse_response;

--- a/codex-rs/app-server/tests/common/models_cache.rs
+++ b/codex-rs/app-server/tests/common/models_cache.rs
@@ -1,0 +1,74 @@
+use chrono::DateTime;
+use chrono::Utc;
+use codex_core::openai_models::model_presets::all_model_presets;
+use codex_protocol::openai_models::ClientVersion;
+use codex_protocol::openai_models::ConfigShellToolType;
+use codex_protocol::openai_models::ModelInfo;
+use codex_protocol::openai_models::ModelPreset;
+use codex_protocol::openai_models::ModelVisibility;
+use serde_json::json;
+use std::path::Path;
+
+/// Convert a ModelPreset to ModelInfo for cache storage.
+fn preset_to_info(preset: &ModelPreset, priority: i32) -> ModelInfo {
+    ModelInfo {
+        slug: preset.id.clone(),
+        display_name: preset.display_name.clone(),
+        description: Some(preset.description.clone()),
+        default_reasoning_level: preset.default_reasoning_effort,
+        supported_reasoning_levels: preset.supported_reasoning_efforts.clone(),
+        shell_type: ConfigShellToolType::ShellCommand,
+        visibility: if preset.show_in_picker {
+            ModelVisibility::List
+        } else {
+            ModelVisibility::Hide
+        },
+        minimal_client_version: ClientVersion(0, 1, 0),
+        supported_in_api: true,
+        priority,
+        upgrade: preset.upgrade.as_ref().map(|u| u.id.clone()),
+        base_instructions: None,
+    }
+}
+
+/// Write a models_cache.json file to the codex home directory.
+/// This prevents ModelsManager from making network requests to refresh models.
+/// The cache will be treated as fresh (within TTL) and used instead of fetching from the network.
+/// Uses the built-in model presets from ModelsManager, converted to ModelInfo format.
+pub fn write_models_cache(codex_home: &Path) -> std::io::Result<()> {
+    // Get all presets and filter for show_in_picker (same as builtin_model_presets does)
+    let presets: Vec<&ModelPreset> = all_model_presets()
+        .iter()
+        .filter(|preset| preset.show_in_picker)
+        .collect();
+    // Convert presets to ModelInfo, assigning priorities (higher = earlier in list)
+    // Priority is used for sorting, so first model gets highest priority
+    let models: Vec<ModelInfo> = presets
+        .iter()
+        .enumerate()
+        .map(|(idx, preset)| {
+            // Higher priority = earlier in list, so reverse the index
+            let priority = (presets.len() - idx) as i32;
+            preset_to_info(preset, priority)
+        })
+        .collect();
+
+    write_models_cache_with_models(codex_home, models)
+}
+
+/// Write a models_cache.json file with specific models.
+/// Useful when tests need specific models to be available.
+pub fn write_models_cache_with_models(
+    codex_home: &Path,
+    models: Vec<ModelInfo>,
+) -> std::io::Result<()> {
+    let cache_path = codex_home.join("models_cache.json");
+    // DateTime<Utc> serializes to RFC3339 format by default with serde
+    let fetched_at: DateTime<Utc> = Utc::now();
+    let cache = json!({
+        "fetched_at": fetched_at,
+        "etag": null,
+        "models": models
+    });
+    std::fs::write(cache_path, serde_json::to_string_pretty(&cache)?)
+}

--- a/codex-rs/app-server/tests/suite/v2/model_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/model_list.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use anyhow::anyhow;
 use app_test_support::McpProcess;
 use app_test_support::to_response;
+use app_test_support::write_models_cache;
 use codex_app_server_protocol::JSONRPCError;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::Model;
@@ -22,6 +23,7 @@ const INVALID_REQUEST_ERROR_CODE: i64 = -32600;
 #[tokio::test]
 async fn list_models_returns_all_models_with_large_limit() -> Result<()> {
     let codex_home = TempDir::new()?;
+    write_models_cache(codex_home.path())?;
     let mut mcp = McpProcess::new(codex_home.path()).await?;
 
     timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
@@ -151,6 +153,7 @@ async fn list_models_returns_all_models_with_large_limit() -> Result<()> {
 #[tokio::test]
 async fn list_models_pagination_works() -> Result<()> {
     let codex_home = TempDir::new()?;
+    write_models_cache(codex_home.path())?;
     let mut mcp = McpProcess::new(codex_home.path()).await?;
 
     timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
@@ -248,6 +251,7 @@ async fn list_models_pagination_works() -> Result<()> {
 #[tokio::test]
 async fn list_models_rejects_invalid_cursor() -> Result<()> {
     let codex_home = TempDir::new()?;
+    write_models_cache(codex_home.path())?;
     let mut mcp = McpProcess::new(codex_home.path()).await?;
 
     timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;

--- a/codex-rs/common/src/config_summary.rs
+++ b/codex-rs/common/src/config_summary.rs
@@ -4,10 +4,10 @@ use codex_core::config::Config;
 use crate::sandbox_summary::summarize_sandbox_policy;
 
 /// Build a list of key/value pairs summarizing the effective configuration.
-pub fn create_config_summary_entries(config: &Config) -> Vec<(&'static str, String)> {
+pub fn create_config_summary_entries(config: &Config, model: &str) -> Vec<(&'static str, String)> {
     let mut entries = vec![
         ("workdir", config.cwd.display().to_string()),
-        ("model", config.model.clone()),
+        ("model", model.to_string()),
         ("provider", config.model_provider_id.clone()),
         ("approval", config.approval_policy.to_string()),
         ("sandbox", summarize_sandbox_policy(&config.sandbox_policy)),

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -166,7 +166,7 @@ impl ModelClient {
 
             let stream_result = client
                 .stream_prompt(
-                    &self.config.model,
+                    &self.get_model(),
                     &api_prompt,
                     Some(conversation_id.clone()),
                     Some(session_source.clone()),
@@ -260,7 +260,7 @@ impl ModelClient {
             };
 
             let stream_result = client
-                .stream_prompt(&self.config.model, &api_prompt, options)
+                .stream_prompt(&self.get_model(), &api_prompt, options)
                 .await;
 
             match stream_result {
@@ -292,7 +292,7 @@ impl ModelClient {
 
     /// Returns the currently configured model slug.
     pub fn get_model(&self) -> String {
-        self.config.model.clone()
+        self.get_model_family().get_model_slug().to_string()
     }
 
     /// Returns the currently configured model family.
@@ -337,7 +337,7 @@ impl ModelClient {
             .get_full_instructions(&self.get_model_family())
             .into_owned();
         let payload = ApiCompactionInput {
-            model: &self.config.model,
+            model: &self.get_model(),
             input: &prompt.input,
             instructions: &instructions,
         };

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -59,7 +59,6 @@ pub mod edit;
 pub mod profile;
 pub mod types;
 
-pub const OPENAI_DEFAULT_MODEL: &str = "gpt-5.1-codex-max";
 const OPENAI_DEFAULT_REVIEW_MODEL: &str = "gpt-5.1-codex-max";
 
 /// Maximum number of bytes of the documentation that will be embedded. Larger
@@ -73,7 +72,7 @@ pub const CONFIG_TOML_FILE: &str = "config.toml";
 #[derive(Debug, Clone, PartialEq)]
 pub struct Config {
     /// Optional override of model selection.
-    pub model: String,
+    pub model: Option<String>,
 
     /// Model used specifically for review sessions. Defaults to "gpt-5.1-codex-max".
     pub review_model: String,
@@ -1108,11 +1107,7 @@ impl Config {
 
         let forced_login_method = cfg.forced_login_method;
 
-        // todo(aibrahim): make model optional
-        let model = model
-            .or(config_profile.model)
-            .or(cfg.model)
-            .unwrap_or_else(default_model);
+        let model = model.or(config_profile.model).or(cfg.model);
 
         let compact_prompt = compact_prompt.or(cfg.compact_prompt).and_then(|value| {
             let trimmed = value.trim();
@@ -1311,10 +1306,6 @@ impl Config {
         }
         self.forced_auto_mode_downgraded_on_windows = !value;
     }
-}
-
-fn default_model() -> String {
-    OPENAI_DEFAULT_MODEL.to_string()
 }
 
 fn default_review_model() -> String {
@@ -2940,7 +2931,7 @@ model_verbosity = "high"
         )?;
         assert_eq!(
             Config {
-                model: "o3".to_string(),
+                model: Some("o3".to_string()),
                 review_model: OPENAI_DEFAULT_REVIEW_MODEL.to_string(),
                 model_context_window: None,
                 model_auto_compact_token_limit: None,
@@ -3014,7 +3005,7 @@ model_verbosity = "high"
             fixture.codex_home(),
         )?;
         let expected_gpt3_profile_config = Config {
-            model: "gpt-3.5-turbo".to_string(),
+            model: Some("gpt-3.5-turbo".to_string()),
             review_model: OPENAI_DEFAULT_REVIEW_MODEL.to_string(),
             model_context_window: None,
             model_auto_compact_token_limit: None,
@@ -3103,7 +3094,7 @@ model_verbosity = "high"
             fixture.codex_home(),
         )?;
         let expected_zdr_profile_config = Config {
-            model: "o3".to_string(),
+            model: Some("o3".to_string()),
             review_model: OPENAI_DEFAULT_REVIEW_MODEL.to_string(),
             model_context_window: None,
             model_auto_compact_token_limit: None,
@@ -3178,7 +3169,7 @@ model_verbosity = "high"
             fixture.codex_home(),
         )?;
         let expected_gpt5_profile_config = Config {
-            model: "gpt-5.1".to_string(),
+            model: Some("gpt-5.1".to_string()),
             review_model: OPENAI_DEFAULT_REVIEW_MODEL.to_string(),
             model_context_window: None,
             model_auto_compact_token_limit: None,

--- a/codex-rs/core/src/conversation_manager.rs
+++ b/codex-rs/core/src/conversation_manager.rs
@@ -1,5 +1,7 @@
 use crate::AuthManager;
 use crate::CodexAuth;
+#[cfg(any(test, feature = "test-support"))]
+use crate::ModelProviderInfo;
 use crate::codex::Codex;
 use crate::codex::CodexSpawnOk;
 use crate::codex::INITIAL_SUBMIT_ID;
@@ -54,11 +56,14 @@ impl ConversationManager {
     #[cfg(any(test, feature = "test-support"))]
     /// Construct with a dummy AuthManager containing the provided CodexAuth.
     /// Used for integration tests: should not be used by ordinary business logic.
-    pub fn with_auth(auth: CodexAuth) -> Self {
-        Self::new(
-            crate::AuthManager::from_auth_for_testing(auth),
-            SessionSource::Exec,
-        )
+    pub fn with_models_provider(auth: CodexAuth, provider: ModelProviderInfo) -> Self {
+        let auth_manager = crate::AuthManager::from_auth_for_testing(auth);
+        Self {
+            conversations: Arc::new(RwLock::new(HashMap::new())),
+            auth_manager: auth_manager.clone(),
+            session_source: SessionSource::Exec,
+            models_manager: Arc::new(ModelsManager::with_provider(auth_manager, provider)),
+        }
     }
 
     pub fn session_source(&self) -> SessionSource {
@@ -213,8 +218,8 @@ impl ConversationManager {
         self.finalize_spawn(codex, conversation_id).await
     }
 
-    pub async fn list_models(&self) -> Vec<ModelPreset> {
-        self.models_manager.list_models().await
+    pub async fn list_models(&self, config: &Config) -> Vec<ModelPreset> {
+        self.models_manager.list_models(config).await
     }
 
     pub fn get_models_manager(&self) -> Arc<ModelsManager> {

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -208,6 +208,45 @@ impl ModelProviderInfo {
             .map(Duration::from_millis)
             .unwrap_or(Duration::from_millis(DEFAULT_STREAM_IDLE_TIMEOUT_MS))
     }
+    pub fn create_openai_provider() -> ModelProviderInfo {
+        ModelProviderInfo {
+            name: "OpenAI".into(),
+            // Allow users to override the default OpenAI endpoint by
+            // exporting `OPENAI_BASE_URL`. This is useful when pointing
+            // Codex at a proxy, mock server, or Azure-style deployment
+            // without requiring a full TOML override for the built-in
+            // OpenAI provider.
+            base_url: std::env::var("OPENAI_BASE_URL")
+                .ok()
+                .filter(|v| !v.trim().is_empty()),
+            env_key: None,
+            env_key_instructions: None,
+            experimental_bearer_token: None,
+            wire_api: WireApi::Responses,
+            query_params: None,
+            http_headers: Some(
+                [("version".to_string(), env!("CARGO_PKG_VERSION").to_string())]
+                    .into_iter()
+                    .collect(),
+            ),
+            env_http_headers: Some(
+                [
+                    (
+                        "OpenAI-Organization".to_string(),
+                        "OPENAI_ORGANIZATION".to_string(),
+                    ),
+                    ("OpenAI-Project".to_string(), "OPENAI_PROJECT".to_string()),
+                ]
+                .into_iter()
+                .collect(),
+            ),
+            // Use global defaults for retry/timeout unless overridden in config.toml.
+            request_max_retries: None,
+            stream_max_retries: None,
+            stream_idle_timeout_ms: None,
+            requires_openai_auth: true,
+        }
+    }
 }
 
 pub const DEFAULT_LMSTUDIO_PORT: u16 = 1234;
@@ -225,46 +264,7 @@ pub fn built_in_model_providers() -> HashMap<String, ModelProviderInfo> {
     // open source ("oss") providers by default. Users are encouraged to add to
     // `model_providers` in config.toml to add their own providers.
     [
-        (
-            "openai",
-            P {
-                name: "OpenAI".into(),
-                // Allow users to override the default OpenAI endpoint by
-                // exporting `OPENAI_BASE_URL`. This is useful when pointing
-                // Codex at a proxy, mock server, or Azure-style deployment
-                // without requiring a full TOML override for the built-in
-                // OpenAI provider.
-                base_url: std::env::var("OPENAI_BASE_URL")
-                    .ok()
-                    .filter(|v| !v.trim().is_empty()),
-                env_key: None,
-                env_key_instructions: None,
-                experimental_bearer_token: None,
-                wire_api: WireApi::Responses,
-                query_params: None,
-                http_headers: Some(
-                    [("version".to_string(), env!("CARGO_PKG_VERSION").to_string())]
-                        .into_iter()
-                        .collect(),
-                ),
-                env_http_headers: Some(
-                    [
-                        (
-                            "OpenAI-Organization".to_string(),
-                            "OPENAI_ORGANIZATION".to_string(),
-                        ),
-                        ("OpenAI-Project".to_string(), "OPENAI_PROJECT".to_string()),
-                    ]
-                    .into_iter()
-                    .collect(),
-                ),
-                // Use global defaults for retry/timeout unless overridden in config.toml.
-                request_max_retries: None,
-                stream_max_retries: None,
-                stream_idle_timeout_ms: None,
-                requires_openai_auth: true,
-            },
-        ),
+        ("openai", P::create_openai_provider()),
         (
             OLLAMA_OSS_PROVIDER_ID,
             create_oss_provider(DEFAULT_OLLAMA_PORT, WireApi::Chat),

--- a/codex-rs/core/src/openai_models/model_family.rs
+++ b/codex-rs/core/src/openai_models/model_family.rs
@@ -116,6 +116,10 @@ impl ModelFamily {
     const fn default_auto_compact_limit(context_window: i64) -> i64 {
         (context_window * 9) / 10
     }
+
+    pub fn get_model_slug(&self) -> &str {
+        &self.slug
+    }
 }
 
 macro_rules! model_family {

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -92,6 +92,8 @@ async fn start_review_conversation(
 
     // Set explicit review rubric for the sub-agent
     sub_agent_config.base_instructions = Some(crate::REVIEW_PROMPT.to_string());
+
+    sub_agent_config.model = Some(config.review_model.clone());
     (run_codex_conversation_one_shot(
         sub_agent_config,
         session.auth_manager(),

--- a/codex-rs/core/tests/chat_completions_payload.rs
+++ b/codex-rs/core/tests/chat_completions_payload.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::expect_used)]
+
 use std::sync::Arc;
 
 use codex_app_server_protocol::AuthMode;
@@ -71,10 +73,11 @@ async fn run_request(input: Vec<ResponseItem>) -> Value {
     let config = Arc::new(config);
 
     let conversation_id = ConversationId::new();
-    let model_family = ModelsManager::construct_model_family_offline(&config.model, &config);
+    let model = ModelsManager::get_model_offline(config.model.as_deref());
+    let model_family = ModelsManager::construct_model_family_offline(model.as_str(), &config);
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
-        config.model.as_str(),
+        model.as_str(),
         model_family.slug.as_str(),
         None,
         Some("test@test.com".to_string()),
@@ -108,11 +111,15 @@ async fn run_request(input: Vec<ResponseItem>) -> Value {
         }
     }
 
-    let requests = match server.received_requests().await {
-        Some(reqs) => reqs,
-        None => panic!("request not made"),
-    };
-    match requests[0].body_json() {
+    let all_requests = server.received_requests().await.expect("received requests");
+    let requests: Vec<_> = all_requests
+        .iter()
+        .filter(|req| req.method == "POST" && req.url.path().ends_with("/chat/completions"))
+        .collect();
+    let request = requests
+        .first()
+        .unwrap_or_else(|| panic!("expected POST request to /chat/completions"));
+    match request.body_json() {
         Ok(v) => v,
         Err(e) => panic!("invalid json body: {e}"),
     }

--- a/codex-rs/core/tests/chat_completions_sse.rs
+++ b/codex-rs/core/tests/chat_completions_sse.rs
@@ -74,10 +74,11 @@ async fn run_stream_with_bytes(sse_body: &[u8]) -> Vec<ResponseEvent> {
     let conversation_id = ConversationId::new();
     let auth_manager = AuthManager::from_auth_for_testing(CodexAuth::from_api_key("Test API Key"));
     let auth_mode = auth_manager.get_auth_mode();
-    let model_family = ModelsManager::construct_model_family_offline(&config.model, &config);
+    let model = ModelsManager::get_model_offline(config.model.as_deref());
+    let model_family = ModelsManager::construct_model_family_offline(model.as_str(), &config);
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
-        config.model.as_str(),
+        model.as_str(),
         model_family.slug.as_str(),
         None,
         Some("test@test.com".to_string()),

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -61,14 +61,16 @@ async fn responses_stream_includes_subagent_header_on_review() {
     config.model_provider = provider.clone();
     let effort = config.model_reasoning_effort;
     let summary = config.model_reasoning_summary;
+    let model = ModelsManager::get_model_offline(config.model.as_deref());
+    config.model = Some(model.clone());
     let config = Arc::new(config);
 
     let conversation_id = ConversationId::new();
     let auth_mode = AuthMode::ChatGPT;
-    let model_family = ModelsManager::construct_model_family_offline(&config.model, &config);
+    let model_family = ModelsManager::construct_model_family_offline(model.as_str(), &config);
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
-        config.model.as_str(),
+        model.as_str(),
         model_family.slug.as_str(),
         None,
         Some("test@test.com".to_string()),
@@ -151,15 +153,17 @@ async fn responses_stream_includes_subagent_header_on_other() {
     config.model_provider = provider.clone();
     let effort = config.model_reasoning_effort;
     let summary = config.model_reasoning_summary;
+    let model = ModelsManager::get_model_offline(config.model.as_deref());
+    config.model = Some(model.clone());
     let config = Arc::new(config);
 
     let conversation_id = ConversationId::new();
     let auth_mode = AuthMode::ChatGPT;
-    let model_family = ModelsManager::construct_model_family_offline(&config.model, &config);
+    let model_family = ModelsManager::construct_model_family_offline(model.as_str(), &config);
 
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
-        config.model.as_str(),
+        model.as_str(),
         model_family.slug.as_str(),
         None,
         Some("test@test.com".to_string()),
@@ -235,7 +239,7 @@ async fn responses_respects_model_family_overrides_from_config() {
 
     let codex_home = TempDir::new().expect("failed to create TempDir");
     let mut config = load_default_config_for_test(&codex_home);
-    config.model = "gpt-3.5-turbo".to_string();
+    config.model = Some("gpt-3.5-turbo".to_string());
     config.model_provider_id = provider.name.clone();
     config.model_provider = provider.clone();
     config.model_supports_reasoning_summaries = Some(true);
@@ -243,15 +247,16 @@ async fn responses_respects_model_family_overrides_from_config() {
     config.model_reasoning_summary = ReasoningSummary::Detailed;
     let effort = config.model_reasoning_effort;
     let summary = config.model_reasoning_summary;
+    let model = config.model.clone().expect("model configured");
     let config = Arc::new(config);
 
     let conversation_id = ConversationId::new();
     let auth_mode =
         AuthManager::from_auth_for_testing(CodexAuth::from_api_key("Test API Key")).get_auth_mode();
-    let model_family = ModelsManager::construct_model_family_offline(&config.model, &config);
+    let model_family = ModelsManager::construct_model_family_offline(model.as_str(), &config);
     let otel_event_manager = OtelEventManager::new(
         conversation_id,
-        config.model.as_str(),
+        model.as_str(),
         model_family.slug.as_str(),
         None,
         Some("test@test.com".to_string()),

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -28,6 +28,7 @@ use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_completed_with_tokens;
 use core_test_support::responses::ev_function_call;
+use core_test_support::responses::get_responses_requests;
 use core_test_support::responses::mount_compact_json_once;
 use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::mount_sse_once_match;
@@ -135,7 +136,10 @@ async fn summarize_context_three_requests_and_instructions() {
     config.model_provider = model_provider;
     set_test_compact_prompt(&mut config);
     config.model_auto_compact_token_limit = Some(200_000);
-    let conversation_manager = ConversationManager::with_auth(CodexAuth::from_api_key("dummy"));
+    let conversation_manager = ConversationManager::with_models_provider(
+        CodexAuth::from_api_key("dummy"),
+        config.model_provider.clone(),
+    );
     let NewConversation {
         conversation: codex,
         session_configured,
@@ -329,7 +333,10 @@ async fn manual_compact_uses_custom_prompt() {
     config.model_provider = model_provider;
     config.compact_prompt = Some(custom_prompt.to_string());
 
-    let conversation_manager = ConversationManager::with_auth(CodexAuth::from_api_key("dummy"));
+    let conversation_manager = ConversationManager::with_models_provider(
+        CodexAuth::from_api_key("dummy"),
+        config.model_provider.clone(),
+    );
     let codex = conversation_manager
         .new_conversation(config)
         .await
@@ -344,7 +351,7 @@ async fn manual_compact_uses_custom_prompt() {
     assert_eq!(message, COMPACT_WARNING_MESSAGE);
     wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
 
-    let requests = server.received_requests().await.expect("collect requests");
+    let requests = get_responses_requests(&server).await;
     let body = requests
         .iter()
         .find_map(|req| req.body_json::<serde_json::Value>().ok())
@@ -409,7 +416,10 @@ async fn manual_compact_emits_api_and_local_token_usage_events() {
     config.model_provider = model_provider;
     set_test_compact_prompt(&mut config);
 
-    let conversation_manager = ConversationManager::with_auth(CodexAuth::from_api_key("dummy"));
+    let conversation_manager = ConversationManager::with_models_provider(
+        CodexAuth::from_api_key("dummy"),
+        config.model_provider.clone(),
+    );
     let NewConversation {
         conversation: codex,
         ..
@@ -570,7 +580,7 @@ async fn multiple_auto_compact_per_task_runs_after_token_limit_hit() {
     wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
 
     // collect the requests payloads from the model
-    let requests_payloads = server.received_requests().await.unwrap();
+    let requests_payloads = get_responses_requests(&server).await;
 
     let body = requests_payloads[0]
         .body_json::<serde_json::Value>()
@@ -1050,7 +1060,10 @@ async fn auto_compact_runs_after_token_limit_hit() {
     config.model_provider = model_provider;
     set_test_compact_prompt(&mut config);
     config.model_auto_compact_token_limit = Some(200_000);
-    let conversation_manager = ConversationManager::with_auth(CodexAuth::from_api_key("dummy"));
+    let conversation_manager = ConversationManager::with_models_provider(
+        CodexAuth::from_api_key("dummy"),
+        config.model_provider.clone(),
+    );
     let codex = conversation_manager
         .new_conversation(config)
         .await
@@ -1090,7 +1103,7 @@ async fn auto_compact_runs_after_token_limit_hit() {
 
     wait_for_event(&codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
 
-    let requests = server.received_requests().await.unwrap();
+    let requests = get_responses_requests(&server).await;
     assert_eq!(
         requests.len(),
         5,
@@ -1295,7 +1308,10 @@ async fn auto_compact_persists_rollout_entries() {
     let mut config = load_default_config_for_test(&home);
     config.model_provider = model_provider;
     set_test_compact_prompt(&mut config);
-    let conversation_manager = ConversationManager::with_auth(CodexAuth::from_api_key("dummy"));
+    let conversation_manager = ConversationManager::with_models_provider(
+        CodexAuth::from_api_key("dummy"),
+        config.model_provider.clone(),
+    );
     let NewConversation {
         conversation: codex,
         session_configured,
@@ -1397,11 +1413,14 @@ async fn manual_compact_retries_after_context_window_error() {
     config.model_provider = model_provider;
     set_test_compact_prompt(&mut config);
     config.model_auto_compact_token_limit = Some(200_000);
-    let codex = ConversationManager::with_auth(CodexAuth::from_api_key("dummy"))
-        .new_conversation(config)
-        .await
-        .unwrap()
-        .conversation;
+    let codex = ConversationManager::with_models_provider(
+        CodexAuth::from_api_key("dummy"),
+        config.model_provider.clone(),
+    )
+    .new_conversation(config)
+    .await
+    .unwrap()
+    .conversation;
 
     codex
         .submit(Op::UserInput {
@@ -1529,11 +1548,14 @@ async fn manual_compact_twice_preserves_latest_user_messages() {
     let mut config = load_default_config_for_test(&home);
     config.model_provider = model_provider;
     set_test_compact_prompt(&mut config);
-    let codex = ConversationManager::with_auth(CodexAuth::from_api_key("dummy"))
-        .new_conversation(config)
-        .await
-        .unwrap()
-        .conversation;
+    let codex = ConversationManager::with_models_provider(
+        CodexAuth::from_api_key("dummy"),
+        config.model_provider.clone(),
+    )
+    .new_conversation(config)
+    .await
+    .unwrap()
+    .conversation;
 
     codex
         .submit(Op::UserInput {
@@ -1731,7 +1753,10 @@ async fn auto_compact_allows_multiple_attempts_when_interleaved_with_other_turn_
     config.model_provider = model_provider;
     set_test_compact_prompt(&mut config);
     config.model_auto_compact_token_limit = Some(200);
-    let conversation_manager = ConversationManager::with_auth(CodexAuth::from_api_key("dummy"));
+    let conversation_manager = ConversationManager::with_models_provider(
+        CodexAuth::from_api_key("dummy"),
+        config.model_provider.clone(),
+    );
     let codex = conversation_manager
         .new_conversation(config)
         .await
@@ -1771,10 +1796,8 @@ async fn auto_compact_allows_multiple_attempts_when_interleaved_with_other_turn_
         "auto compact should not emit task lifecycle events"
     );
 
-    let request_bodies: Vec<String> = server
-        .received_requests()
-        .await
-        .unwrap()
+    let requests = get_responses_requests(&server).await;
+    let request_bodies: Vec<String> = requests
         .into_iter()
         .map(|request| String::from_utf8(request.body).unwrap_or_default())
         .collect();
@@ -1845,11 +1868,14 @@ async fn auto_compact_triggers_after_function_call_over_95_percent_usage() {
     config.model_context_window = Some(context_window);
     config.model_auto_compact_token_limit = Some(limit);
 
-    let codex = ConversationManager::with_auth(CodexAuth::from_api_key("dummy"))
-        .new_conversation(config)
-        .await
-        .unwrap()
-        .conversation;
+    let codex = ConversationManager::with_models_provider(
+        CodexAuth::from_api_key("dummy"),
+        config.model_provider.clone(),
+    )
+    .new_conversation(config)
+    .await
+    .unwrap()
+    .conversation;
 
     codex
         .submit(Op::UserInput {

--- a/codex-rs/core/tests/suite/fork_conversation.rs
+++ b/codex-rs/core/tests/suite/fork_conversation.rs
@@ -55,7 +55,10 @@ async fn fork_conversation_twice_drops_to_first_message() {
     config.model_provider = model_provider.clone();
     let config_for_fork = config.clone();
 
-    let conversation_manager = ConversationManager::with_auth(CodexAuth::from_api_key("dummy"));
+    let conversation_manager = ConversationManager::with_models_provider(
+        CodexAuth::from_api_key("dummy"),
+        config.model_provider.clone(),
+    );
     let NewConversation {
         conversation: codex,
         ..

--- a/codex-rs/core/tests/suite/list_models.rs
+++ b/codex-rs/core/tests/suite/list_models.rs
@@ -1,15 +1,23 @@
 use anyhow::Result;
 use codex_core::CodexAuth;
 use codex_core::ConversationManager;
+use codex_core::built_in_model_providers;
 use codex_protocol::openai_models::ModelPreset;
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::openai_models::ReasoningEffortPreset;
+use core_test_support::load_default_config_for_test;
 use pretty_assertions::assert_eq;
+use tempfile::tempdir;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn list_models_returns_api_key_models() -> Result<()> {
-    let manager = ConversationManager::with_auth(CodexAuth::from_api_key("sk-test"));
-    let models = manager.list_models().await;
+    let codex_home = tempdir()?;
+    let config = load_default_config_for_test(&codex_home);
+    let manager = ConversationManager::with_models_provider(
+        CodexAuth::from_api_key("sk-test"),
+        built_in_model_providers()["openai"].clone(),
+    );
+    let models = manager.list_models(&config).await;
 
     let expected_models = expected_models_for_api_key();
     assert_eq!(expected_models, models);
@@ -19,9 +27,13 @@ async fn list_models_returns_api_key_models() -> Result<()> {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn list_models_returns_chatgpt_models() -> Result<()> {
-    let manager =
-        ConversationManager::with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing());
-    let models = manager.list_models().await;
+    let codex_home = tempdir()?;
+    let config = load_default_config_for_test(&codex_home);
+    let manager = ConversationManager::with_models_provider(
+        CodexAuth::create_dummy_chatgpt_auth_for_testing(),
+        built_in_model_providers()["openai"].clone(),
+    );
+    let models = manager.list_models(&config).await;
 
     let expected_models = expected_models_for_chatgpt();
     assert_eq!(expected_models, models);

--- a/codex-rs/core/tests/suite/model_overrides.rs
+++ b/codex-rs/core/tests/suite/model_overrides.rs
@@ -20,10 +20,12 @@ async fn override_turn_context_does_not_persist_when_config_exists() {
         .expect("seed config.toml");
 
     let mut config = load_default_config_for_test(&codex_home);
-    config.model = "gpt-4o".to_string();
+    config.model = Some("gpt-4o".to_string());
 
-    let conversation_manager =
-        ConversationManager::with_auth(CodexAuth::from_api_key("Test API Key"));
+    let conversation_manager = ConversationManager::with_models_provider(
+        CodexAuth::from_api_key("Test API Key"),
+        config.model_provider.clone(),
+    );
     let codex = conversation_manager
         .new_conversation(config)
         .await
@@ -62,8 +64,10 @@ async fn override_turn_context_does_not_create_config_file() {
 
     let config = load_default_config_for_test(&codex_home);
 
-    let conversation_manager =
-        ConversationManager::with_auth(CodexAuth::from_api_key("Test API Key"));
+    let conversation_manager = ConversationManager::with_models_provider(
+        CodexAuth::from_api_key("Test API Key"),
+        config.model_provider.clone(),
+    );
     let codex = conversation_manager
         .new_conversation(config)
         .await

--- a/codex-rs/core/tests/suite/resume_warning.rs
+++ b/codex-rs/core/tests/suite/resume_warning.rs
@@ -4,6 +4,7 @@ use codex_core::AuthManager;
 use codex_core::CodexAuth;
 use codex_core::ConversationManager;
 use codex_core::NewConversation;
+use codex_core::built_in_model_providers;
 use codex_core::protocol::EventMsg;
 use codex_core::protocol::InitialHistory;
 use codex_core::protocol::ResumedHistory;
@@ -16,7 +17,11 @@ use core_test_support::load_default_config_for_test;
 use core_test_support::wait_for_event;
 use tempfile::TempDir;
 
-fn resume_history(config: &codex_core::config::Config, previous_model: &str, rollout_path: &std::path::Path) -> InitialHistory {
+fn resume_history(
+    config: &codex_core::config::Config,
+    previous_model: &str,
+    rollout_path: &std::path::Path,
+) -> InitialHistory {
     let turn_ctx = TurnContextItem {
         cwd: config.cwd.clone(),
         approval_policy: config.approval_policy,
@@ -38,7 +43,7 @@ async fn emits_warning_when_resumed_model_differs() {
     // Arrange a config with a current model and a prior rollout recorded under a different model.
     let home = TempDir::new().expect("tempdir");
     let mut config = load_default_config_for_test(&home);
-    config.model = "current-model".to_string();
+    config.model = Some("current-model".to_string());
     // Ensure cwd is absolute (the helper sets it to the temp dir already).
     assert!(config.cwd.is_absolute());
 
@@ -47,7 +52,10 @@ async fn emits_warning_when_resumed_model_differs() {
 
     let initial_history = resume_history(&config, "previous-model", &rollout_path);
 
-    let conversation_manager = ConversationManager::with_auth(CodexAuth::from_api_key("test"));
+    let conversation_manager = ConversationManager::with_models_provider(
+        CodexAuth::from_api_key("test"),
+        config.model_provider.clone(),
+    );
     let auth_manager = AuthManager::from_auth_for_testing(CodexAuth::from_api_key("test"));
 
     // Act: resume the conversation.

--- a/codex-rs/core/tests/suite/rmcp_client.rs
+++ b/codex-rs/core/tests/suite/rmcp_client.rs
@@ -487,9 +487,13 @@ async fn stdio_image_completions_round_trip() -> anyhow::Result<()> {
 
     // Chat Completions assertion: the second POST should include a tool role message
     // with an array `content` containing an item with the expected data URL.
-    let requests = server.received_requests().await.expect("requests captured");
+    let all_requests = server.received_requests().await.expect("requests captured");
+    let requests: Vec<_> = all_requests
+        .iter()
+        .filter(|req| req.method == "POST" && req.url.path().ends_with("/chat/completions"))
+        .collect();
     assert!(requests.len() >= 2, "expected two chat completion calls");
-    let second = &requests[1];
+    let second = requests[1];
     let body: Value = serde_json::from_slice(&second.body)?;
     let messages = body
         .get("messages")

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -18,6 +18,7 @@ use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
 use core_test_support::responses::ev_response_created;
+use core_test_support::responses::get_responses_request_bodies;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
@@ -1240,10 +1241,7 @@ async fn exec_command_reports_chunk_and_exit_metadata() -> Result<()> {
     let requests = server.received_requests().await.expect("recorded requests");
     assert!(!requests.is_empty(), "expected at least one POST request");
 
-    let bodies = requests
-        .iter()
-        .map(|req| req.body_json::<Value>().expect("request json"))
-        .collect::<Vec<_>>();
+    let bodies = get_responses_request_bodies(&server).await;
 
     let outputs = collect_tool_outputs(&bodies)?;
     let metadata = outputs
@@ -1347,10 +1345,7 @@ async fn unified_exec_respects_early_exit_notifications() -> Result<()> {
     let requests = server.received_requests().await.expect("recorded requests");
     assert!(!requests.is_empty(), "expected at least one POST request");
 
-    let bodies = requests
-        .iter()
-        .map(|req| req.body_json::<Value>().expect("request json"))
-        .collect::<Vec<_>>();
+    let bodies = get_responses_request_bodies(&server).await;
 
     let outputs = collect_tool_outputs(&bodies)?;
     let output = outputs
@@ -1475,10 +1470,7 @@ async fn write_stdin_returns_exit_metadata_and_clears_session() -> Result<()> {
     let requests = server.received_requests().await.expect("recorded requests");
     assert!(!requests.is_empty(), "expected at least one POST request");
 
-    let bodies = requests
-        .iter()
-        .map(|req| req.body_json::<Value>().expect("request json"))
-        .collect::<Vec<_>>();
+    let bodies = get_responses_request_bodies(&server).await;
 
     let outputs = collect_tool_outputs(&bodies)?;
 
@@ -1727,10 +1719,7 @@ async fn unified_exec_reuses_session_via_stdin() -> Result<()> {
     let requests = server.received_requests().await.expect("recorded requests");
     assert!(!requests.is_empty(), "expected at least one POST request");
 
-    let bodies = requests
-        .iter()
-        .map(|req| req.body_json::<Value>().expect("request json"))
-        .collect::<Vec<_>>();
+    let bodies = get_responses_request_bodies(&server).await;
 
     let outputs = collect_tool_outputs(&bodies)?;
 
@@ -1864,10 +1853,7 @@ PY
     let requests = server.received_requests().await.expect("recorded requests");
     assert!(!requests.is_empty(), "expected at least one POST request");
 
-    let bodies = requests
-        .iter()
-        .map(|req| req.body_json::<Value>().expect("request json"))
-        .collect::<Vec<_>>();
+    let bodies = get_responses_request_bodies(&server).await;
 
     let outputs = collect_tool_outputs(&bodies)?;
 
@@ -1976,10 +1962,7 @@ async fn unified_exec_timeout_and_followup_poll() -> Result<()> {
     let requests = server.received_requests().await.expect("recorded requests");
     assert!(!requests.is_empty(), "expected at least one POST request");
 
-    let bodies = requests
-        .iter()
-        .map(|req| req.body_json::<Value>().expect("request json"))
-        .collect::<Vec<_>>();
+    let bodies = get_responses_request_bodies(&server).await;
 
     let outputs = collect_tool_outputs(&bodies)?;
 
@@ -2065,10 +2048,7 @@ PY
     let requests = server.received_requests().await.expect("recorded requests");
     assert!(!requests.is_empty(), "expected at least one POST request");
 
-    let bodies = requests
-        .iter()
-        .map(|req| req.body_json::<Value>().expect("request json"))
-        .collect::<Vec<_>>();
+    let bodies = get_responses_request_bodies(&server).await;
 
     let outputs = collect_tool_outputs(&bodies)?;
     let large_output = outputs.get(call_id).expect("missing large output summary");
@@ -2145,10 +2125,7 @@ async fn unified_exec_runs_under_sandbox() -> Result<()> {
     let requests = server.received_requests().await.expect("recorded requests");
     assert!(!requests.is_empty(), "expected at least one POST request");
 
-    let bodies = requests
-        .iter()
-        .map(|req| req.body_json::<Value>().expect("request json"))
-        .collect::<Vec<_>>();
+    let bodies = get_responses_request_bodies(&server).await;
 
     let outputs = collect_tool_outputs(&bodies)?;
     let output = outputs.get(call_id).expect("missing output");
@@ -2246,10 +2223,7 @@ async fn unified_exec_python_prompt_under_seatbelt() -> Result<()> {
     let requests = server.received_requests().await.expect("recorded requests");
     assert!(!requests.is_empty(), "expected at least one POST request");
 
-    let bodies = requests
-        .iter()
-        .map(|req| req.body_json::<Value>().expect("request json"))
-        .collect::<Vec<_>>();
+    let bodies = get_responses_request_bodies(&server).await;
 
     let outputs = collect_tool_outputs(&bodies)?;
     let startup_output = outputs
@@ -2339,10 +2313,7 @@ async fn unified_exec_runs_on_all_platforms() -> Result<()> {
     let requests = server.received_requests().await.expect("recorded requests");
     assert!(!requests.is_empty(), "expected at least one POST request");
 
-    let bodies = requests
-        .iter()
-        .map(|req| req.body_json::<Value>().expect("request json"))
-        .collect::<Vec<_>>();
+    let bodies = get_responses_request_bodies(&server).await;
 
     let outputs = collect_tool_outputs(&bodies)?;
     let output = outputs.get(call_id).expect("missing output");

--- a/codex-rs/core/tests/suite/user_shell_cmd.rs
+++ b/codex-rs/core/tests/suite/user_shell_cmd.rs
@@ -42,8 +42,10 @@ async fn user_shell_cmd_ls_and_cat_in_temp_dir() {
     let mut config = load_default_config_for_test(&codex_home);
     config.cwd = cwd.path().to_path_buf();
 
-    let conversation_manager =
-        ConversationManager::with_auth(codex_core::CodexAuth::from_api_key("dummy"));
+    let conversation_manager = ConversationManager::with_models_provider(
+        codex_core::CodexAuth::from_api_key("dummy"),
+        config.model_provider.clone(),
+    );
     let NewConversation {
         conversation: codex,
         ..
@@ -99,8 +101,10 @@ async fn user_shell_cmd_can_be_interrupted() {
     // Set up isolated config and conversation.
     let codex_home = TempDir::new().unwrap();
     let config = load_default_config_for_test(&codex_home);
-    let conversation_manager =
-        ConversationManager::with_auth(codex_core::CodexAuth::from_api_key("dummy"));
+    let conversation_manager = ConversationManager::with_models_provider(
+        codex_core::CodexAuth::from_api_key("dummy"),
+        config.model_provider.clone(),
+    );
     let NewConversation {
         conversation: codex,
         ..

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -140,7 +140,8 @@ impl EventProcessor for EventProcessorWithHumanOutput {
             VERSION
         );
 
-        let mut entries = create_config_summary_entries(config);
+        let mut entries =
+            create_config_summary_entries(config, session_configured_event.model.as_str());
         entries.push((
             "session id",
             session_configured_event.session_id.to_string(),

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -263,7 +263,6 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
     let default_cwd = config.cwd.to_path_buf();
     let default_approval_policy = config.approval_policy;
     let default_sandbox_policy = config.sandbox_policy.clone();
-    let default_model = config.model.clone();
     let default_effort = config.model_reasoning_effort;
     let default_summary = config.model_reasoning_summary;
 
@@ -278,6 +277,10 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         config.cli_auth_credentials_store_mode,
     );
     let conversation_manager = ConversationManager::new(auth_manager.clone(), SessionSource::Exec);
+    let default_model = conversation_manager
+        .get_models_manager()
+        .get_model(&config.model, &config)
+        .await;
 
     // Handle resume subcommand by resolving a rollout path and using explicit resume API.
     let NewConversation {

--- a/codex-rs/lmstudio/src/lib.rs
+++ b/codex-rs/lmstudio/src/lib.rs
@@ -11,7 +11,10 @@ pub const DEFAULT_OSS_MODEL: &str = "openai/gpt-oss-20b";
 /// - Ensures a local LM Studio server is reachable.
 /// - Checks if the model exists locally and downloads it if missing.
 pub async fn ensure_oss_ready(config: &Config) -> std::io::Result<()> {
-    let model: &str = config.model.as_ref();
+    let model = match config.model.as_ref() {
+        Some(model) => model,
+        None => DEFAULT_OSS_MODEL,
+    };
 
     // Verify local LM Studio is reachable.
     let lmstudio_client = LMStudioClient::try_from_provider(config).await?;

--- a/codex-rs/ollama/src/lib.rs
+++ b/codex-rs/ollama/src/lib.rs
@@ -19,7 +19,10 @@ pub const DEFAULT_OSS_MODEL: &str = "gpt-oss:20b";
 /// - Checks if the model exists locally and pulls it if missing.
 pub async fn ensure_oss_ready(config: &Config) -> std::io::Result<()> {
     // Only download when the requested model is the default OSS model (or when -m is not provided).
-    let model = config.model.as_ref();
+    let model = match config.model.as_ref() {
+        Some(model) => model,
+        None => DEFAULT_OSS_MODEL,
+    };
 
     // Verify local Ollama is reachable.
     let ollama_client = crate::OllamaClient::try_from_oss_provider(config).await?;

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -338,9 +338,10 @@ impl App {
     ) {
         let conv = new_conv.conversation;
         let session_configured = new_conv.session_configured;
+        let model_family = self.chat_widget.get_model_family();
         let init = crate::chatwidget::ChatWidgetInit {
             config: cfg,
-            model_family: self.chat_widget.get_model_family(),
+            model_family: model_family.clone(),
             frame_requester: tui.frame_requester(),
             app_event_tx: self.app_event_tx.clone(),
             initial_prompt: None,
@@ -354,6 +355,7 @@ impl App {
         };
         self.chat_widget =
             crate::chatwidget::ChatWidget::new_from_existing(init, conv, session_configured);
+        self.current_model = model_family.get_model_slug().to_string();
         // Trim transcript up to the selected user message and re-render it.
         self.trim_transcript_for_backtrack(nth_user_message);
         self.render_transcript_once(tui);

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -75,6 +75,7 @@ fn set_windows_sandbox_enabled(enabled: bool) {
 
 fn test_config() -> Config {
     // Use base defaults to avoid depending on host state.
+
     Config::load_from_base_config_with_overrides(
         ConfigToml::default(),
         ConfigOverrides::default(),
@@ -346,10 +347,12 @@ async fn helpers_are_available_and_do_not_panic() {
     let (tx_raw, _rx) = unbounded_channel::<AppEvent>();
     let tx = AppEventSender::new(tx_raw);
     let cfg = test_config();
-    let model_family = ModelsManager::construct_model_family_offline(&cfg.model, &cfg);
-    let conversation_manager = Arc::new(ConversationManager::with_auth(CodexAuth::from_api_key(
-        "test",
-    )));
+    let resolved_model = ModelsManager::get_model_offline(cfg.model.as_deref());
+    let model_family = ModelsManager::construct_model_family_offline(&resolved_model, &cfg);
+    let conversation_manager = Arc::new(ConversationManager::with_models_provider(
+        CodexAuth::from_api_key("test"),
+        cfg.model_provider.clone(),
+    ));
     let auth_manager = AuthManager::from_auth_for_testing(CodexAuth::from_api_key("test"));
     let init = ChatWidgetInit {
         config: cfg,
@@ -382,8 +385,11 @@ fn make_chatwidget_manual(
     let app_event_tx = AppEventSender::new(tx_raw);
     let (op_tx, op_rx) = unbounded_channel::<Op>();
     let mut cfg = test_config();
+    let resolved_model = model_override
+        .map(str::to_owned)
+        .unwrap_or_else(|| ModelsManager::get_model_offline(cfg.model.as_deref()));
     if let Some(model) = model_override {
-        cfg.model = model.to_string();
+        cfg.model = Some(model.to_string());
     }
     let bottom = BottomPane::new(BottomPaneParams {
         app_event_tx: app_event_tx.clone(),
@@ -402,10 +408,10 @@ fn make_chatwidget_manual(
         bottom_pane: bottom,
         active_cell: None,
         config: cfg.clone(),
-        model_family: ModelsManager::construct_model_family_offline(&cfg.model, &cfg),
+        model_family: ModelsManager::construct_model_family_offline(&resolved_model, &cfg),
         auth_manager: auth_manager.clone(),
         models_manager: Arc::new(ModelsManager::new(auth_manager)),
-        session_header: SessionHeader::new(cfg.model),
+        session_header: SessionHeader::new(resolved_model.clone()),
         initial_user_message: None,
         token_info: None,
         rate_limit_snapshot: None,
@@ -650,10 +656,9 @@ fn rate_limit_snapshot_updates_and_retains_plan_type() {
 
 #[test]
 fn rate_limit_switch_prompt_skips_when_on_lower_cost_model() {
-    let (mut chat, _, _) = make_chatwidget_manual(None);
+    let (mut chat, _, _) = make_chatwidget_manual(Some(NUDGE_MODEL_SLUG));
     chat.auth_manager =
         AuthManager::from_auth_for_testing(CodexAuth::create_dummy_chatgpt_auth_for_testing());
-    chat.config.model = NUDGE_MODEL_SLUG.to_string();
 
     chat.on_rate_limit_snapshot(Some(snapshot(95.0)));
 
@@ -666,8 +671,7 @@ fn rate_limit_switch_prompt_skips_when_on_lower_cost_model() {
 #[test]
 fn rate_limit_switch_prompt_shows_once_per_session() {
     let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
-    let (mut chat, _, _) = make_chatwidget_manual(None);
-    chat.config.model = "gpt-5".to_string();
+    let (mut chat, _, _) = make_chatwidget_manual(Some("gpt-5"));
     chat.auth_manager = AuthManager::from_auth_for_testing(auth);
 
     chat.on_rate_limit_snapshot(Some(snapshot(90.0)));
@@ -691,8 +695,7 @@ fn rate_limit_switch_prompt_shows_once_per_session() {
 #[test]
 fn rate_limit_switch_prompt_respects_hidden_notice() {
     let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
-    let (mut chat, _, _) = make_chatwidget_manual(None);
-    chat.config.model = "gpt-5".to_string();
+    let (mut chat, _, _) = make_chatwidget_manual(Some("gpt-5"));
     chat.auth_manager = AuthManager::from_auth_for_testing(auth);
     chat.config.notices.hide_rate_limit_model_nudge = Some(true);
 
@@ -707,8 +710,7 @@ fn rate_limit_switch_prompt_respects_hidden_notice() {
 #[test]
 fn rate_limit_switch_prompt_defers_until_task_complete() {
     let auth = CodexAuth::create_dummy_chatgpt_auth_for_testing();
-    let (mut chat, _, _) = make_chatwidget_manual(None);
-    chat.config.model = "gpt-5".to_string();
+    let (mut chat, _, _) = make_chatwidget_manual(Some("gpt-5"));
     chat.auth_manager = AuthManager::from_auth_for_testing(auth);
 
     chat.bottom_pane.set_task_running(true);
@@ -728,10 +730,9 @@ fn rate_limit_switch_prompt_defers_until_task_complete() {
 
 #[test]
 fn rate_limit_switch_prompt_popup_snapshot() {
-    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None);
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5"));
     chat.auth_manager =
         AuthManager::from_auth_for_testing(CodexAuth::create_dummy_chatgpt_auth_for_testing());
-    chat.config.model = "gpt-5".to_string();
 
     chat.on_rate_limit_snapshot(Some(snapshot(92.0)));
     chat.maybe_show_pending_rate_limit_prompt();
@@ -1774,9 +1775,7 @@ fn render_bottom_popup(chat: &ChatWidget, width: u16) -> String {
 
 #[test]
 fn model_selection_popup_snapshot() {
-    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None);
-
-    chat.config.model = "gpt-5-codex".to_string();
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5-codex"));
     chat.open_model_popup();
 
     let popup = render_bottom_popup(&chat, 80);
@@ -1879,10 +1878,9 @@ fn startup_prompts_for_windows_sandbox_when_agent_requested() {
 
 #[test]
 fn model_reasoning_selection_popup_snapshot() {
-    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None);
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.1-codex-max"));
 
     set_chatgpt_auth(&mut chat);
-    chat.config.model = "gpt-5.1-codex-max".to_string();
     chat.config.model_reasoning_effort = Some(ReasoningEffortConfig::High);
 
     let preset = get_available_model(&chat, "gpt-5.1-codex-max");
@@ -1894,10 +1892,9 @@ fn model_reasoning_selection_popup_snapshot() {
 
 #[test]
 fn model_reasoning_selection_popup_extra_high_warning_snapshot() {
-    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None);
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.1-codex-max"));
 
     set_chatgpt_auth(&mut chat);
-    chat.config.model = "gpt-5.1-codex-max".to_string();
     chat.config.model_reasoning_effort = Some(ReasoningEffortConfig::XHigh);
 
     let preset = get_available_model(&chat, "gpt-5.1-codex-max");
@@ -1909,10 +1906,9 @@ fn model_reasoning_selection_popup_extra_high_warning_snapshot() {
 
 #[test]
 fn reasoning_popup_shows_extra_high_with_space() {
-    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None);
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.1-codex-max"));
 
     set_chatgpt_auth(&mut chat);
-    chat.config.model = "gpt-5.1-codex-max".to_string();
 
     let preset = get_available_model(&chat, "gpt-5.1-codex-max");
     chat.open_reasoning_popup(preset);
@@ -1992,9 +1988,7 @@ fn feedback_upload_consent_popup_snapshot() {
 
 #[test]
 fn reasoning_popup_escape_returns_to_model_popup() {
-    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None);
-
-    chat.config.model = "gpt-5.1".to_string();
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5.1"));
     chat.open_model_popup();
 
     let preset = get_available_model(&chat, "gpt-5.1-codex");

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -621,6 +621,7 @@ impl HistoryCell for SessionInfoCell {
 
 pub(crate) fn new_session_info(
     config: &Config,
+    requested_model: &str,
     event: SessionConfiguredEvent,
     is_first_event: bool,
 ) -> SessionInfoCell {
@@ -679,10 +680,10 @@ pub(crate) fn new_session_info(
         {
             parts.push(Box::new(tooltips));
         }
-        if config.model != model {
+        if requested_model != model {
             let lines = vec![
                 "model changed:".magenta().bold().into(),
-                format!("requested: {}", config.model).into(),
+                format!("requested: {requested_model}").into(),
                 format!("used: {model}").into(),
             ];
             parts.push(Box::new(PlainHistoryCell { lines }));
@@ -2321,10 +2322,7 @@ mod tests {
     }
     #[test]
     fn reasoning_summary_block() {
-        let config = test_config();
-        let reasoning_format =
-            ModelsManager::construct_model_family_offline(&config.model, &config)
-                .reasoning_summary_format;
+        let reasoning_format = ReasoningSummaryFormat::Experimental;
         let cell = new_reasoning_summary_block(
             "**High level reasoning**\n\nDetailed reasoning goes here.".to_string(),
             reasoning_format,
@@ -2339,10 +2337,7 @@ mod tests {
 
     #[test]
     fn reasoning_summary_block_returns_reasoning_cell_when_feature_disabled() {
-        let config = test_config();
-        let reasoning_format =
-            ModelsManager::construct_model_family_offline(&config.model, &config)
-                .reasoning_summary_format;
+        let reasoning_format = ReasoningSummaryFormat::Experimental;
         let cell = new_reasoning_summary_block(
             "Detailed reasoning goes here.".to_string(),
             reasoning_format,
@@ -2355,10 +2350,11 @@ mod tests {
     #[test]
     fn reasoning_summary_block_respects_config_overrides() {
         let mut config = test_config();
-        config.model = "gpt-3.5-turbo".to_string();
+        config.model = Some("gpt-3.5-turbo".to_string());
         config.model_supports_reasoning_summaries = Some(true);
         config.model_reasoning_summary_format = Some(ReasoningSummaryFormat::Experimental);
-        let model_family = ModelsManager::construct_model_family_offline(&config.model, &config);
+        let model_family =
+            ModelsManager::construct_model_family_offline(&config.model.clone().unwrap(), &config);
         assert_eq!(
             model_family.reasoning_summary_format,
             ReasoningSummaryFormat::Experimental
@@ -2375,10 +2371,7 @@ mod tests {
 
     #[test]
     fn reasoning_summary_block_falls_back_when_header_is_missing() {
-        let config = test_config();
-        let reasoning_format =
-            ModelsManager::construct_model_family_offline(&config.model, &config)
-                .reasoning_summary_format;
+        let reasoning_format = ReasoningSummaryFormat::Experimental;
         let cell = new_reasoning_summary_block(
             "**High level reasoning without closing".to_string(),
             reasoning_format,
@@ -2390,10 +2383,7 @@ mod tests {
 
     #[test]
     fn reasoning_summary_block_falls_back_when_summary_is_missing() {
-        let config = test_config();
-        let reasoning_format =
-            ModelsManager::construct_model_family_offline(&config.model, &config)
-                .reasoning_summary_format;
+        let reasoning_format = ReasoningSummaryFormat::Experimental;
         let cell = new_reasoning_summary_block(
             "**High level reasoning without closing**".to_string(),
             reasoning_format.clone(),
@@ -2413,10 +2403,7 @@ mod tests {
 
     #[test]
     fn reasoning_summary_block_splits_header_and_summary_when_present() {
-        let config = test_config();
-        let reasoning_format =
-            ModelsManager::construct_model_family_offline(&config.model, &config)
-                .reasoning_summary_format;
+        let reasoning_format = ReasoningSummaryFormat::Experimental;
         let cell = new_reasoning_summary_block(
             "**High level plan**\n\nWe should fix the bug next.".to_string(),
             reasoning_format,

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -78,6 +78,7 @@ pub(crate) fn new_status_output(
     rate_limits: Option<&RateLimitSnapshotDisplay>,
     plan_type: Option<PlanType>,
     now: DateTime<Local>,
+    model_name: &str,
 ) -> CompositeHistoryCell {
     let command = PlainHistoryCell::new(vec!["/status".magenta().into()]);
     let card = StatusHistoryCell::new(
@@ -90,6 +91,7 @@ pub(crate) fn new_status_output(
         rate_limits,
         plan_type,
         now,
+        model_name,
     );
 
     CompositeHistoryCell::new(vec![Box::new(command), Box::new(card)])
@@ -107,9 +109,10 @@ impl StatusHistoryCell {
         rate_limits: Option<&RateLimitSnapshotDisplay>,
         plan_type: Option<PlanType>,
         now: DateTime<Local>,
+        model_name: &str,
     ) -> Self {
-        let config_entries = create_config_summary_entries(config);
-        let (model_name, model_details) = compose_model_display(config, &config_entries);
+        let config_entries = create_config_summary_entries(config, model_name);
+        let (model_name, model_details) = compose_model_display(model_name, &config_entries);
         let approval = config_entries
             .iter()
             .find(|(k, _)| *k == "approval")

--- a/codex-rs/tui/src/status/helpers.rs
+++ b/codex-rs/tui/src/status/helpers.rs
@@ -17,7 +17,7 @@ fn normalize_agents_display_path(path: &Path) -> String {
 }
 
 pub(crate) fn compose_model_display(
-    config: &Config,
+    model_name: &str,
     entries: &[(&str, String)],
 ) -> (String, Vec<String>) {
     let mut details: Vec<String> = Vec::new();
@@ -33,7 +33,7 @@ pub(crate) fn compose_model_display(
         }
     }
 
-    (config.model.clone(), details)
+    (model_name.to_string(), details)
 }
 
 pub(crate) fn compose_agents_summary(config: &Config) -> String {


### PR DESCRIPTION
- Make Config.model optional and centralize default-selection logic in ModelsManager, including a default_model helper (with codex-auto-balanced when available) so sessions now carry an explicit chosen model separate from the base config.
- Resolve `model` once in `core` and `tui` from config. Then store the state of it on other structs.
- Move refreshing models to be before resolving the default model