### PR TITLE
[app-server] Make sure that config writes preserve comments & order or configs

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -901,6 +901,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "toml",
+ "toml_edit",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/codex-rs/app-server/Cargo.toml
+++ b/codex-rs/app-server/Cargo.toml
@@ -34,6 +34,7 @@ sha2 = { workspace = true }
 mcp-types = { workspace = true }
 tempfile = { workspace = true }
 toml = { workspace = true }
+toml_edit = { workspace = true }
 tokio = { workspace = true, features = [
     "io-std",
     "macros",

--- a/codex-rs/app-server/src/config_api.rs
+++ b/codex-rs/app-server/src/config_api.rs
@@ -190,7 +190,7 @@ impl ConfigApi {
             )
         })?;
 
-        let updated_layers = layers.clone().with_user_config(user_config.clone());
+        let updated_layers = layers.with_user_config(user_config.clone());
         let effective = updated_layers.effective_config();
         validate_config(&effective).map_err(|err| {
             config_write_error(
@@ -772,6 +772,7 @@ fn config_write_error(code: ConfigWriteErrorCode, message: impl Into<String>) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    use anyhow::Result;
     use pretty_assertions::assert_eq;
     use tempfile::tempdir;
 
@@ -825,7 +826,7 @@ X-Doc = "42"
     }
 
     #[tokio::test]
-    async fn write_value_preserves_comments_and_order() {
+    async fn write_value_preserves_comments_and_order() -> Result<()> {
         let tmp = tempdir().expect("tempdir");
         let original = r#"# Codex user configuration
 model = "gpt-5"
@@ -838,7 +839,7 @@ hide_full_access_warning = true
 [features]
 unified_exec = true
 "#;
-        std::fs::write(tmp.path().join(CONFIG_FILE_NAME), original).unwrap();
+        std::fs::write(tmp.path().join(CONFIG_FILE_NAME), original)?;
 
         let api = ConfigApi::new(tmp.path().to_path_buf(), vec![]);
         api.write_value(ConfigValueWriteParams {
@@ -866,6 +867,7 @@ unified_exec = true
 remote_compaction = true
 "#;
         assert_eq!(updated, expected);
+        Ok(())
     }
 
     #[tokio::test]

--- a/codex-rs/core/src/config/edit.rs
+++ b/codex-rs/core/src/config/edit.rs
@@ -555,7 +555,10 @@ impl ConfigEditsBuilder {
         self
     }
 
-    pub fn with_edits(mut self, edits: Vec<ConfigEdit>) -> Self {
+    pub fn with_edits<I>(mut self, edits: I) -> Self
+    where
+        I: IntoIterator<Item = ConfigEdit>,
+    {
         self.edits.extend(edits);
         self
     }


### PR DESCRIPTION
Make sure that config writes preserve comments and order of configs by utilizing the ConfigEditsBuilder in core.

Tested by running a real example and made sure that nothing in the config file changes other than the configs to edit. 