### PR TITLE
fix: prevent hang when pasting special files (issue #7683)

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -259,15 +259,15 @@ impl ChatComposer {
 
         // normalize_pasted_path already handles Windows → WSL path conversion,
         // so we can directly try to read the image dimensions.
-        match image::image_dimensions(&path_buf) {
-            Ok((w, h)) => {
+        match crate::clipboard_paste::safe_image_dimensions(&path_buf) {
+            Some((w, h)) => {
                 tracing::info!("OK: {pasted}");
                 let format_label = pasted_image_format(&path_buf).label();
                 self.attach_image(path_buf, w, h, format_label);
                 true
             }
-            Err(err) => {
-                tracing::trace!("ERR: {err}");
+            None => {
+                tracing::trace!("ERR: could not read dimensions for {pasted}");
                 false
             }
         }
@@ -668,7 +668,7 @@ impl ChatComposer {
                 if is_image {
                     // Determine dimensions; if that fails fall back to normal path insertion.
                     let path_buf = PathBuf::from(&sel_path);
-                    if let Ok((w, h)) = image::image_dimensions(&path_buf) {
+                    if let Some((w, h)) = crate::clipboard_paste::safe_image_dimensions(&path_buf) {
                         // Remove the current @token (mirror logic from insert_selected_path without inserting text)
                         // using the flat text and byte-offset cursor API.
                         let cursor_offset = self.textarea.cursor();

--- a/codex-rs/tui/src/clipboard_paste.rs
+++ b/codex-rs/tui/src/clipboard_paste.rs
@@ -353,6 +353,16 @@ pub fn pasted_image_format(path: &Path) -> EncodedImageFormat {
     }
 }
 
+/// Safely attempt to get image dimensions, avoiding hangs on special files (like FIFOs).
+pub fn safe_image_dimensions(path: &Path) -> Option<(u32, u32)> {
+    // Ensure it's a regular file (or symlink to one) before opening.
+    // metadata() follows symlinks, which is what we want.
+    match std::fs::metadata(path) {
+        Ok(meta) if meta.is_file() => image::image_dimensions(path).ok(),
+        _ => None,
+    }
+}
+
 #[cfg(test)]
 mod pasted_paths_tests {
     use super::*;

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -41,7 +41,7 @@ mod ascii_animation;
 mod bottom_pane;
 mod chatwidget;
 mod cli;
-mod clipboard_paste;
+pub(crate) mod clipboard_paste;
 mod color;
 pub mod custom_terminal;
 mod diff_render;


### PR DESCRIPTION
This PR fixes a bug where the application would hang if a user pasted a path to a special file (like /dev/tty0 or a named pipe) into the chat composer.

The issue was caused by image::image_dimensions attempting to read from these special files, which can block indefinitely.

Fixes #7683

## Changes
* Added `safe_image_dimensions` helper in `tui/src/clipboard_paste.rs`
    * This function checks std::fs::metadata to ensure the path is a regular file (or symlink to one) before calling image::image_dimensions.
* Updated ChatComposer (`tui/src/bottom_pane/chat_composer.rs`) to use `safe_image_dimensions` in:
    * `handle_paste_image_path`: When handling pasted text. 
    * `handle_key_event_with_file_popup`: When selecting a file from the search popup.

## Verification
* Reproduction Test: Created a local reproduction test using a named pipe (FIFO).
    * Confirmed that calling image::image_dimensions directly on the FIFO causes a hang (timeout).
    * Confirmed that using the new safe_image_dimensions check returns None immediately, preventing the hang.
* Manual Testing: Verified that pasting normal image paths still works as expected.