### PR TITLE
fix: restore MCP startup progress messages in TUI (fixes #7827)

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -771,15 +771,13 @@ impl Session {
             state.session_configuration = session_configuration.clone();
             (session_configuration, sandbox_policy_changed)
         };
+        let per_turn_config = Self::build_per_turn_config(&session_configuration);
 
         if sandbox_policy_changed {
             let sandbox_state = SandboxState {
-                sandbox_policy: session_configuration.sandbox_policy.clone(),
-                codex_linux_sandbox_exe: session_configuration
-                    .original_config_do_not_use
-                    .codex_linux_sandbox_exe
-                    .clone(),
-                sandbox_cwd: session_configuration.cwd.clone(),
+                sandbox_policy: per_turn_config.sandbox_policy.clone(),
+                codex_linux_sandbox_exe: per_turn_config.codex_linux_sandbox_exe.clone(),
+                sandbox_cwd: per_turn_config.cwd.clone(),
             };
             if let Err(e) = self
                 .services
@@ -793,7 +791,6 @@ impl Session {
             }
         }
 
-        let per_turn_config = Self::build_per_turn_config(&session_configuration);
         let model_family = self
             .services
             .models_manager

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -183,20 +183,17 @@ struct ManagedClient {
 }
 
 impl ManagedClient {
-    async fn notify_sandbox_state(&self, sandbox_state: &SandboxState) -> Result<()> {
+    async fn notify_sandbox_state_change(&self, sandbox_state: &SandboxState) -> Result<()> {
         if !self.server_supports_sandbox_state_capability {
             return Ok(());
         }
+
         self.client
             .send_custom_notification(
                 MCP_SANDBOX_STATE_NOTIFICATION,
                 Some(serde_json::to_value(sandbox_state)?),
             )
             .await
-    }
-
-    async fn notify_sandbox_state_change(&self, sandbox_state: &SandboxState) -> Result<()> {
-        self.notify_sandbox_state(sandbox_state).await
     }
 }
 

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -182,6 +182,20 @@ struct ManagedClient {
     server_supports_sandbox_state_capability: bool,
 }
 
+impl ManagedClient {
+    async fn notify_sandbox_state(&self, sandbox_state: &SandboxState) -> Result<()> {
+        if !self.server_supports_sandbox_state_capability {
+            return Ok(());
+        }
+        self.client
+            .send_custom_notification(
+                MCP_SANDBOX_STATE_NOTIFICATION,
+                Some(serde_json::to_value(sandbox_state)?),
+            )
+            .await
+    }
+}
+
 #[derive(Clone)]
 struct AsyncManagedClient {
     client: Shared<BoxFuture<'static, Result<ManagedClient, StartupOutcomeError>>>,
@@ -228,21 +242,6 @@ impl AsyncManagedClient {
     async fn client(&self) -> Result<ManagedClient, StartupOutcomeError> {
         self.client.clone().await
     }
-
-    async fn notify_sandbox_state_change(&self, sandbox_state: &SandboxState) -> Result<()> {
-        let managed = self.client().await?;
-        if !managed.server_supports_sandbox_state_capability {
-            return Ok(());
-        }
-
-        managed
-            .client
-            .send_custom_notification(
-                MCP_SANDBOX_STATE_NOTIFICATION,
-                Some(serde_json::to_value(sandbox_state)?),
-            )
-            .await
-    }
 }
 
 pub const MCP_SANDBOX_STATE_CAPABILITY: &str = "codex/sandbox-state";
@@ -274,6 +273,7 @@ impl McpConnectionManager {
         auth_entries: HashMap<String, McpAuthStatusEntry>,
         tx_event: Sender<Event>,
         cancel_token: CancellationToken,
+        sandbox_state: SandboxState,
     ) {
         if cancel_token.is_cancelled() {
             return;
@@ -302,13 +302,23 @@ impl McpConnectionManager {
             clients.insert(server_name.clone(), async_managed_client.clone());
             let tx_event = tx_event.clone();
             let auth_entry = auth_entries.get(&server_name).cloned();
+            let sandbox_state = sandbox_state.clone();
             join_set.spawn(async move {
                 let outcome = async_managed_client.client().await;
                 if cancel_token.is_cancelled() {
                     return (server_name, Err(StartupOutcomeError::Cancelled));
                 }
                 let status = match &outcome {
-                    Ok(_) => McpStartupStatus::Ready,
+                    Ok(managed_client) => {
+                        // Send sandbox state notification immediately after Ready
+                        if let Err(e) = managed_client.notify_sandbox_state(&sandbox_state).await {
+                            warn!(
+                                "Failed to notify sandbox state to MCP server {}: {e:#}",
+                                server_name
+                            );
+                        }
+                        McpStartupStatus::Ready
+                    }
                     Err(error) => {
                         let error_str = mcp_init_error_display(
                             server_name.as_str(),
@@ -603,34 +613,6 @@ impl McpConnectionManager {
             .await
             .get(tool_name)
             .map(|tool| (tool.server_name.clone(), tool.tool_name.clone()))
-    }
-
-    pub async fn notify_sandbox_state_change(&self, sandbox_state: &SandboxState) -> Result<()> {
-        let mut join_set = JoinSet::new();
-
-        for async_managed_client in self.clients.values() {
-            let sandbox_state = sandbox_state.clone();
-            let async_managed_client = async_managed_client.clone();
-            join_set.spawn(async move {
-                async_managed_client
-                    .notify_sandbox_state_change(&sandbox_state)
-                    .await
-            });
-        }
-
-        while let Some(join_res) = join_set.join_next().await {
-            match join_res {
-                Ok(Ok(())) => {}
-                Ok(Err(err)) => {
-                    warn!("Failed to notify sandbox state change to MCP server: {err:#}");
-                }
-                Err(err) => {
-                    warn!("Task panic when notifying sandbox state change to MCP server: {err:#}");
-                }
-            }
-        }
-
-        Ok(())
     }
 }
 

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -273,7 +273,7 @@ impl McpConnectionManager {
         auth_entries: HashMap<String, McpAuthStatusEntry>,
         tx_event: Sender<Event>,
         cancel_token: CancellationToken,
-        sandbox_state: SandboxState,
+        initial_sandbox_state: SandboxState,
     ) {
         if cancel_token.is_cancelled() {
             return;
@@ -313,8 +313,7 @@ impl McpConnectionManager {
                         // Send sandbox state notification immediately after Ready
                         if let Err(e) = managed_client.notify_sandbox_state(&sandbox_state).await {
                             warn!(
-                                "Failed to notify sandbox state to MCP server {}: {e:#}",
-                                server_name
+                                "Failed to notify sandbox state to MCP server {server_name}: {e:#}",
                             );
                         }
                         McpStartupStatus::Ready

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -626,7 +626,6 @@ impl McpConnectionManager {
             .map(|tool| (tool.server_name.clone(), tool.tool_name.clone()))
     }
 
-    #[allow(dead_code)]
     pub async fn notify_sandbox_state_change(&self, sandbox_state: &SandboxState) -> Result<()> {
         let mut join_set = JoinSet::new();
 

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__mcp_startup_header_booting.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__mcp_startup_header_booting.snap
@@ -1,0 +1,11 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: terminal.backend()
+---
+"                                                                                "
+"• Booting MCP server: alpha (0s • esc to interrupt)                             "
+"                                                                                "
+"                                                                                "
+"› Ask Codex to do anything                                                      "
+"                                                                                "
+"  100% context left · ? for shortcuts                                           "

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -27,6 +27,8 @@ use codex_core::protocol::ExecCommandSource;
 use codex_core::protocol::ExecPolicyAmendment;
 use codex_core::protocol::ExitedReviewModeEvent;
 use codex_core::protocol::FileChange;
+use codex_core::protocol::McpStartupStatus;
+use codex_core::protocol::McpStartupUpdateEvent;
 use codex_core::protocol::Op;
 use codex_core::protocol::PatchApplyBeginEvent;
 use codex_core::protocol::PatchApplyEndEvent;
@@ -2427,6 +2429,28 @@ fn status_widget_active_snapshot() {
         .draw(|f| chat.render(f.area(), f.buffer_mut()))
         .expect("draw status widget");
     assert_snapshot!("status_widget_active", terminal.backend());
+}
+
+#[test]
+fn mcp_startup_header_booting_snapshot() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None);
+    chat.show_welcome_banner = false;
+
+    chat.handle_codex_event(Event {
+        id: "mcp-1".into(),
+        msg: EventMsg::McpStartupUpdate(McpStartupUpdateEvent {
+            server: "alpha".into(),
+            status: McpStartupStatus::Starting,
+        }),
+    });
+
+    let height = chat.desired_height(80);
+    let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, height))
+        .expect("create terminal");
+    terminal
+        .draw(|f| chat.render(f.area(), f.buffer_mut()))
+        .expect("draw chat widget");
+    assert_snapshot!("mcp_startup_header_booting", terminal.backend());
 }
 
 #[test]


### PR DESCRIPTION
## Problem

The introduction of `notify_sandbox_state_change()` in #7112 caused a regression where the blocking call in `Session::new()` waits for all MCP servers to fully initialize before returning. This prevents the TUI event loop from starting, resulting in `McpStartupUpdateEvent` messages being emitted but never consumed or displayed. As a result, the app appears to hang during startup, and users do not see the expected "Booting MCP server: {name}" status line.

Issue: [#7827](https://github.com/openai/codex/issues/7827)

## Solution
This change moves sandbox state notification into each MCP server's background initialization task. The notification is sent immediately after the server transitions to the Ready state. This approach:
- Avoids blocking `Session::new()`, allowing the TUI event loop to start promptly.
- Ensures each MCP server receives its sandbox state before handling any tool calls.
- Restores the display of "Booting MCP server" status lines during startup.

## Key Changes
- Added `ManagedClient::notify_sandbox_state()` method.
- Passed sandbox_state to `McpConnectionManager::initialize()`.
- Sends sandbox state notification in the background task after the server reaches Ready status.
- Removed blocking notify_sandbox_state_change() methods.
- Added a chatwidget snapshot test for the "Booting MCP server" status line.

## Regression Details

Regression was bisected to #7112, which introduced the blocking behavior.