### PR TITLE
fix: ensure accept_elicitation_for_prompt_rule() test passes locally

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -412,14 +412,6 @@ jobs:
       - name: Install DotSlash
         uses: facebook/install-dotslash@v2
 
-      - name: Pre-fetch DotSlash artifacts
-        # The Bash wrapper is not available on Windows.
-        if: ${{ !startsWith(matrix.runner, 'windows') }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          dotslash -- fetch exec-server/tests/suite/bash
-
       - uses: dtolnay/rust-toolchain@1.90
         with:
           targets: ${{ matrix.target }}

--- a/codex-rs/exec-server/tests/suite/list_tools.rs
+++ b/codex-rs/exec-server/tests/suite/list_tools.rs
@@ -22,7 +22,9 @@ async fn list_tools() -> Result<()> {
         policy_dir.join("default.codexpolicy"),
         r#"prefix_rule(pattern=["ls"], decision="prompt")"#,
     )?;
-    let transport = create_transport(codex_home.path())?;
+    let dotslash_cache_temp_dir = TempDir::new()?;
+    let dotslash_cache = dotslash_cache_temp_dir.path();
+    let transport = create_transport(codex_home.path(), dotslash_cache).await?;
 
     let service = ().serve(transport).await?;
     let tools = service.list_tools(Default::default()).await?.tools;


### PR DESCRIPTION
When I originally introduced `accept_elicitation_for_prompt_rule()` in https://github.com/openai/codex/pull/7617, it worked for me locally because I had run `codex-rs/exec-server/tests/suite/bash` once myself, which had the side-effect of installing the corresponding DotSlash artifact.

In CI, I added explicit logic to do this as part of `.github/workflows/rust-ci.yml`, which meant the test also passed in CI, but this logic should have been done as part of the test so that it would work locally for devs who had not installed the DotSlash artifact for `codex-rs/exec-server/tests/suite/bash` before. This PR updates the test to do this (and deletes the setup logic from `rust-ci.yml`), creating a new `DOTSLASH_CACHE` in a temp directory so that this is handled independently for each test.

While here, also added a check to ensure that the `codex` binary has been built prior to running the test, as we have to ensure it is symlinked as `codex-linux-sandbox` on Linux in order for the integration test to work on that platform.