### PR TITLE
fix: omit reasoning summary when ReasoningSummary::None

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -206,7 +206,11 @@ impl ModelClient {
         let reasoning = if model_family.supports_reasoning_summaries {
             Some(Reasoning {
                 effort: self.effort.or(model_family.default_reasoning_effort),
-                summary: Some(self.summary),
+                summary: if self.summary == ReasoningSummaryConfig::None {
+                    None
+                } else {
+                    Some(self.summary)
+                },
             })
         } else {
             None


### PR DESCRIPTION
```
{
  "error": {
    "message": "Invalid value: 'none'. Supported values are: 'concise', 'detailed', and 'auto'.",
    "type": "invalid_request_error",
    "param": "reasoning.summary",
    "code": "invalid_value"
  }
}
```