### PR TITLE
fix: remove inaccurate `#[allow(dead_code)]` marker

### DIFF
--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -99,7 +99,6 @@ pub struct ModelProviderInfo {
 }
 
 impl ModelProviderInfo {
-    #[allow(dead_code)]
     fn build_header_map(&self) -> crate::error::Result<HeaderMap> {
         let mut headers = HeaderMap::new();
         if let Some(extra) = &self.http_headers {


### PR DESCRIPTION
Me reading this clippy warning:

<img width="263" height="191" alt="image" src="https://github.com/user-attachments/assets/3a936a17-f91d-47bc-a08a-cafb154e9e32" />
