### PR TITLE
fix: drop stale filedescriptor output hash for nix

### DIFF
--- a/codex-rs/default.nix
+++ b/codex-rs/default.nix
@@ -22,7 +22,6 @@ rustPlatform.buildRustPackage (_: {
   cargoLock.outputHashes = {
     "ratatui-0.29.0" = "sha256-HBvT5c8GsiCxMffNjJGLmHnvG77A6cqEL+1ARurBXho=";
     "crossterm-0.28.1" = "sha256-6qCtfSMuXACKFb9ATID39XyFDIEMFDmbx6SSmNe+728=";
-    "filedescriptor-0.8.3" = "sha256-aIbzfHYjPDzWSZrgbauezGzg6lm3frhyBbU01gTQpaE=";
   };
 
   meta = with lib; {


### PR DESCRIPTION
Fixes: #7863 

- Remove the `filedescriptor-0.8.3` entry from `codex-rs/default.nix` output hashes because the crate now comes from crates.io.