### PR TITLE
fix: remove outdated prompt guidance for non-codex models

### DIFF
--- a/codex-rs/core/gpt_5_1_prompt.md
+++ b/codex-rs/core/gpt_5_1_prompt.md
@@ -319,7 +319,6 @@ For casual greetings, acknowledgements, or other one-off conversational messages
 When using the shell, you must adhere to the following guidelines:
 
 - When searching for text or files, prefer using `rg` or `rg --files` respectively because `rg` is much faster than alternatives like `grep`. (If the `rg` command is not found, then use alternatives.)
-- Read files in chunks with a max chunk size of 250 lines. Do not use python scripts to attempt to output larger chunks of a file. Command line output will be truncated after 10 kilobytes or 256 lines of output, regardless of the command used.
 
 ## apply_patch
 

--- a/codex-rs/core/prompt.md
+++ b/codex-rs/core/prompt.md
@@ -297,7 +297,6 @@ For casual greetings, acknowledgements, or other one-off conversational messages
 When using the shell, you must adhere to the following guidelines:
 
 - When searching for text or files, prefer using `rg` or `rg --files` respectively because `rg` is much faster than alternatives like `grep`. (If the `rg` command is not found, then use alternatives.)
-- Read files in chunks with a max chunk size of 250 lines. Do not use python scripts to attempt to output larger chunks of a file. Command line output will be truncated after 10 kilobytes or 256 lines of output, regardless of the command used.
 
 ## `update_plan`
 


### PR DESCRIPTION
Removing guidance from the non-codex prompts that is outdated now that `tool_output_token_limit` is user-configurable. 

Addresses https://github.com/openai/codex/issues/7867