### PR TITLE
fix: disable shimmer animation when auth URL is present (#7646)

### DIFF
--- a/codex-rs/tui/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui/src/onboarding/onboarding_screen.rs
@@ -265,6 +265,7 @@ impl WidgetRef for &OnboardingScreen {
 
         // Check if any active step requires animation suppression (e.g. Auth with URL visible)
         for step in self.current_steps() {
+            #[allow(clippy::collapsible_if)]
             if let Step::Auth(auth_widget) = step {
                 if auth_widget.should_suppress_animations() {
                     self.suppress_animations.store(true, Ordering::Relaxed);

--- a/codex-rs/tui/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui/src/onboarding/onboarding_screen.rs
@@ -26,6 +26,7 @@ use crate::tui::TuiEvent;
 use color_eyre::eyre::Result;
 use std::sync::Arc;
 use std::sync::RwLock;
+use std::sync::atomic::AtomicBool;
 
 #[allow(clippy::large_enum_variant)]
 enum Step {
@@ -85,10 +86,12 @@ impl OnboardingScreen {
         let codex_home = config.codex_home;
         let cli_auth_credentials_store_mode = config.cli_auth_credentials_store_mode;
         let mut steps: Vec<Step> = Vec::new();
+        let suppress_animations = Arc::new(AtomicBool::new(false));
         steps.push(Step::Welcome(WelcomeWidget::new(
             !matches!(login_status, LoginStatus::NotAuthenticated),
             tui.frame_requester(),
             config.animations,
+            suppress_animations.clone(),
         )));
         if show_login_screen {
             let highlighted_mode = match forced_login_method {
@@ -107,6 +110,7 @@ impl OnboardingScreen {
                 forced_chatgpt_workspace_id,
                 forced_login_method,
                 animations_enabled: config.animations,
+                suppress_animations: suppress_animations.clone(),
             }))
         }
         let is_git_repo = get_git_repo_root(&cwd).is_some();

--- a/codex-rs/tui/src/tui/frame_requester.rs
+++ b/codex-rs/tui/src/tui/frame_requester.rs
@@ -63,6 +63,17 @@ impl FrameRequester {
             frame_schedule_tx: tx,
         }
     }
+
+    /// Create a spy frame requester that exposes the receiver for verification.
+    pub(crate) fn test_spy() -> (Self, mpsc::UnboundedReceiver<Instant>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (
+            FrameRequester {
+                frame_schedule_tx: tx,
+            },
+            rx,
+        )
+    }
 }
 
 /// A scheduler for coalescing frame draw requests and notifying the TUI event loop.


### PR DESCRIPTION
This PR fixes issue #7646 where the shimmer animation on the 'Continue in Browser' screen prevented copying the authentication URL in SSH sessions.

## Changes
- Modified `tui/src/onboarding/auth.rs` to disable the shimmer animation when the auth URL is displayed.
- Implemented a shared `suppress_animations` flag in `OnboardingScreen` to stop the `WelcomeWidget` animation from triggering redraws when the auth link is visible.
- Added a regression test `shimmer_disabled_when_url_present` to verify the fix.

## Verification
- Ran the new regression test successfully.
- Verified that the animation stops and the screen becomes static when the URL is shown.


https://github.com/user-attachments/assets/41de7a00-731d-49dc-a0b4-88bc1c5b3d3f

