### PR TITLE
Fix misleading 'maximize' high effort description on xhigh models

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/model_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/model_list.rs
@@ -64,7 +64,7 @@ async fn list_models_returns_all_models_with_large_limit() -> Result<()> {
                 },
                 ReasoningEffortOption {
                     reasoning_effort: ReasoningEffort::High,
-                    description: "Maximizes reasoning depth for complex problems".to_string(),
+                    description: "Greater reasoning depth for complex problems".to_string(),
                 },
                 ReasoningEffortOption {
                     reasoning_effort: ReasoningEffort::XHigh,
@@ -136,7 +136,7 @@ async fn list_models_returns_all_models_with_large_limit() -> Result<()> {
                 },
                 ReasoningEffortOption {
                     reasoning_effort: ReasoningEffort::High,
-                    description: "Maximizes reasoning depth for complex or ambiguous problems"
+                    description: "Greater reasoning depth for complex or ambiguous problems"
                         .to_string(),
                 },
                 ReasoningEffortOption {

--- a/codex-rs/core/src/openai_models/model_presets.rs
+++ b/codex-rs/core/src/openai_models/model_presets.rs
@@ -28,7 +28,7 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                 },
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::High,
-                    description: "Maximizes reasoning depth for complex problems".to_string(),
+                    description: "Greater reasoning depth for complex problems".to_string(),
                 },
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::XHigh,
@@ -110,7 +110,7 @@ static PRESETS: Lazy<Vec<ModelPreset>> = Lazy::new(|| {
                 },
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::High,
-                    description: "Maximizes reasoning depth for complex or ambiguous problems".to_string(),
+                    description: "Greater reasoning depth for complex or ambiguous problems".to_string(),
                 },
                 ReasoningEffortPreset {
                     effort: ReasoningEffort::XHigh,

--- a/codex-rs/core/tests/suite/list_models.rs
+++ b/codex-rs/core/tests/suite/list_models.rs
@@ -79,7 +79,7 @@ fn gpt_5_1_codex_max() -> ModelPreset {
             ),
             effort(
                 ReasoningEffort::High,
-                "Maximizes reasoning depth for complex problems",
+                "Greater reasoning depth for complex problems",
             ),
             effort(
                 ReasoningEffort::XHigh,
@@ -160,7 +160,7 @@ fn robin() -> ModelPreset {
             ),
             effort(
                 ReasoningEffort::High,
-                "Maximizes reasoning depth for complex or ambiguous problems",
+                "Greater reasoning depth for complex or ambiguous problems",
             ),
             effort(
                 ReasoningEffort::XHigh,

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_reasoning_selection_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_reasoning_selection_popup.snap
@@ -6,7 +6,7 @@ expression: popup
 
   1. Low               Fast responses with lighter reasoning
   2. Medium (default)  Balances speed and reasoning depth for everyday tasks
-› 3. High (current)    Maximizes reasoning depth for complex problems
+› 3. High (current)    Greater reasoning depth for complex problems
   4. Extra high        Extra high reasoning depth for complex problems
 
   Press enter to confirm or esc to go back

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_reasoning_selection_popup_extra_high_warning.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_reasoning_selection_popup_extra_high_warning.snap
@@ -8,7 +8,7 @@ expression: popup
   1. Low                   Fast responses with lighter reasoning
   2. Medium (default)      Balances speed and reasoning depth for everyday
                            tasks
-  3. High                  Maximizes reasoning depth for complex problems
+  3. High                  Greater reasoning depth for complex problems
 › 4. Extra high (current)  Extra high reasoning depth for complex problems
                            ⚠ Extra high reasoning effort can quickly consume
                            Plus plan rate limits.

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1931,7 +1931,7 @@ fn single_reasoning_option_skips_selection() {
 
     let single_effort = vec![ReasoningEffortPreset {
         effort: ReasoningEffortConfig::High,
-        description: "Maximizes reasoning depth for complex or ambiguous problems".to_string(),
+        description: "Greater reasoning depth for complex or ambiguous problems".to_string(),
     }];
     let preset = ModelPreset {
         id: "model-with-single-reasoning".to_string(),

--- a/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__model_reasoning_selection_popup.snap
+++ b/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__model_reasoning_selection_popup.snap
@@ -6,7 +6,7 @@ expression: popup
 
   1. Low               Fast responses with lighter reasoning
   2. Medium (default)  Balances speed and reasoning depth for everyday tasks
-› 3. High (current)    Maximizes reasoning depth for complex problems
+› 3. High (current)    Greater reasoning depth for complex problems
   4. Extra high        Extra high reasoning depth for complex problems
 
   Press enter to confirm or esc to go back

--- a/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__model_reasoning_selection_popup_extra_high_warning.snap
+++ b/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__model_reasoning_selection_popup_extra_high_warning.snap
@@ -7,7 +7,7 @@ expression: popup
   1. Low                   Fast responses with lighter reasoning
   2. Medium (default)      Balances speed and reasoning depth for everyday
                            tasks
-  3. High                  Maximizes reasoning depth for complex problems
+  3. High                  Greater reasoning depth for complex problems
 › 4. Extra high (current)  Extra high reasoning depth for complex problems
                            ⚠ Extra high reasoning effort can quickly consume
                            Plus plan rate limits.

--- a/codex-rs/tui2/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_reasoning_selection_popup.snap
+++ b/codex-rs/tui2/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_reasoning_selection_popup.snap
@@ -6,7 +6,7 @@ expression: popup
 
   1. Low               Fast responses with lighter reasoning
   2. Medium (default)  Balances speed and reasoning depth for everyday tasks
-› 3. High (current)    Maximizes reasoning depth for complex problems
+› 3. High (current)    Greater reasoning depth for complex problems
   4. Extra high        Extra high reasoning depth for complex problems
 
   Press enter to confirm or esc to go back

--- a/codex-rs/tui2/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_reasoning_selection_popup_extra_high_warning.snap
+++ b/codex-rs/tui2/src/chatwidget/snapshots/codex_tui__chatwidget__tests__model_reasoning_selection_popup_extra_high_warning.snap
@@ -8,7 +8,7 @@ expression: popup
   1. Low                   Fast responses with lighter reasoning
   2. Medium (default)      Balances speed and reasoning depth for everyday
                            tasks
-  3. High                  Maximizes reasoning depth for complex problems
+  3. High                  Greater reasoning depth for complex problems
 › 4. Extra high (current)  Extra high reasoning depth for complex problems
                            ⚠ Extra high reasoning effort can quickly consume
                            Plus plan rate limits.


### PR DESCRIPTION
## Notes
- switch misleading High reasoning effort descriptions from "Maximizes reasoning depth" to "Higher reasoning depth" across models with xhigh reasoning. Affects GPT-5.1 Codex Max and Robin
- refresh model list fixtures and chatwidget snapshots to match new copy

## Revision
- R2: Change 'Higher' to 'Greater'
- R1: Initial

## Testing

<img width="583" height="142" alt="image" src="https://github.com/user-attachments/assets/1ddd8971-7841-4cb3-b9ba-91095a7435d2" />

<img width="838" height="142" alt="image" src="https://github.com/user-attachments/assets/79aaedbf-7624-4695-b822-93dea7d6a800" />
