### PR TITLE
Added deprecation notice for "chat" wire_api

### DIFF
--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -48,6 +48,7 @@ pub mod token_data;
 mod truncate;
 mod unified_exec;
 mod user_instructions;
+pub use model_provider_info::CHAT_WIRE_API_DEPRECATION_SUMMARY;
 pub use model_provider_info::DEFAULT_LMSTUDIO_PORT;
 pub use model_provider_info::DEFAULT_OLLAMA_PORT;
 pub use model_provider_info::LMSTUDIO_OSS_PROVIDER_ID;

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -26,6 +26,7 @@ const DEFAULT_REQUEST_MAX_RETRIES: u64 = 4;
 const MAX_STREAM_MAX_RETRIES: u64 = 100;
 /// Hard cap for user-configured `request_max_retries`.
 const MAX_REQUEST_MAX_RETRIES: u64 = 100;
+pub const CHAT_WIRE_API_DEPRECATION_SUMMARY: &str = r#"Support for the "chat" wire API is deprecated and will soon be removed. Update your model provider definition in config.toml to use wire_api = "responses"."#;
 
 /// Wire protocol that the provider speaks. Most third-party services only
 /// implement the classic OpenAI Chat Completions JSON schema, whereas OpenAI


### PR DESCRIPTION
This PR adds a deprecation notice that appears once per invocation of codex (not per conversation) when a conversation is started using a custom model provider configured with the "chat" wire_api. We have [announced](https://github.com/openai/codex/discussions/7782) that this feature is deprecated and will be removed in early Feb 2026, so we want to notify users of this fact.

The deprecation notice was added in a way that works with the non-interactive "codex exec", the TUI, and with the extension. Screen shots of each are below.

<img width="1000" height="89" alt="image" src="https://github.com/user-attachments/assets/72cc08bb-d158-4a89-b3c8-7a896abd016f" />

<img width="1000" height="38" alt="Screenshot 2025-12-11 at 2 22 29 PM" src="https://github.com/user-attachments/assets/7b2128ca-9afc-48be-9ce1-2ce81bc00fcb" />

<img width="479" height="106" alt="Screenshot 2025-12-11 at 2 21 26 PM" src="https://github.com/user-attachments/assets/858ec1cc-ebfc-4c99-b22b-63015154d752" />
