### PR TITLE
fix(tui): show xhigh reasoning warning for gpt-5.2

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2395,7 +2395,8 @@ impl ChatWidget {
             format!("⚠ {effort_label} reasoning effort can quickly consume Plus plan rate limits.")
         });
         let warn_for_model = preset.model.starts_with("gpt-5.1-codex")
-            || preset.model.starts_with("gpt-5.1-codex-max");
+            || preset.model.starts_with("gpt-5.1-codex-max")
+            || preset.model.starts_with("gpt-5.2");
 
         struct EffortChoice {
             stored: Option<ReasoningEffortConfig>,

--- a/codex-rs/tui2/src/chatwidget.rs
+++ b/codex-rs/tui2/src/chatwidget.rs
@@ -2379,7 +2379,8 @@ impl ChatWidget {
             format!("⚠ {effort_label} reasoning effort can quickly consume Plus plan rate limits.")
         });
         let warn_for_model = preset.model.starts_with("gpt-5.1-codex")
-            || preset.model.starts_with("gpt-5.1-codex-max");
+            || preset.model.starts_with("gpt-5.1-codex-max")
+            || preset.model.starts_with("gpt-5.2");
 
         struct EffortChoice {
             stored: Option<ReasoningEffortConfig>,


### PR DESCRIPTION
## Notes
- Extend reasoning-effort popup warning eligibility to gpt-5.2* models for the Extra High (xhigh) option.

## Revisions
- R2: Remove unnecessary tests and snapshots
- R1: initial

## Testing
- `just fix`, `cargo test -p codex-tui`, and `cargo test -p codex-tui2`
- Manual testing

**Before**:
<img width="864" height="162" alt="image" src="https://github.com/user-attachments/assets/d12a8f11-3ba5-4c31-9ae9-096a408b4971" />

**After** (consistent with GPT 5.1 Codex Max):
<img width="864" height="156" alt="image" src="https://github.com/user-attachments/assets/29c0ea7a-c68e-4fac-b10f-15a420ae5953" />

<img width="684" height="154" alt="image" src="https://github.com/user-attachments/assets/b562b8b6-6e63-4dc2-8344-5c7f9a9b6263" />

