### PR TITLE
Prompts: prevent GPT-5.1/5.2 from ending turns after tool preambles

### DIFF
--- a/codex-rs/core/gpt_5_1_prompt.md
+++ b/codex-rs/core/gpt_5_1_prompt.md
@@ -38,7 +38,7 @@ You'll work for stretches with tool calls — it's critical to keep the user upd
 
 Frequency & Length:
 - Send short updates (1–2 sentences) whenever there is a meaningful, important insight you need to share with the user to keep them informed.
-- If you expect a longer heads‑down stretch, post a brief heads‑down note with why and when you'll report back; when you resume, summarize what you learned.
+- If you expect a longer heads‑down stretch, post a brief heads‑down note (why), then immediately continue with tool calls; do NOT end the turn after the note.
 - Only the initial plan, plan updates, and final recap can be longer, with multiple bullets and paragraphs
 
 Tone:
@@ -59,6 +59,13 @@ Content:
 - “Finished poking at the DB gateway. I will now chase down error handling.”
 - “Alright, build pipeline order is interesting. Checking how it reports failures.”
 - “Spotted a clever caching util; now hunting where it gets used.”
+
+**Critical:** Do not leave dangling updates.
+
+- If you say you're about to run a command or apply a patch, immediately do it by emitting the tool call in the same response.
+- Never end the turn right after a preamble like “Next, I’ll …” or “I will now …”.
+- If approval/escalation is needed, request it via the tool call mechanism (do not ask in chat and wait).
+
 
 ## Planning
 

--- a/codex-rs/core/gpt_5_2_prompt.md
+++ b/codex-rs/core/gpt_5_2_prompt.md
@@ -38,7 +38,7 @@ You'll work for stretches with tool calls — it's critical to keep the user upd
 
 Frequency & Length:
 - Send short updates (1–2 sentences) whenever there is a meaningful, important insight you need to share with the user to keep them informed.
-- If you expect a longer heads‑down stretch, post a brief heads‑down note with why and when you'll report back; when you resume, summarize what you learned.
+- If you expect a longer heads‑down stretch, post a brief heads‑down note (why), then immediately continue with tool calls; do NOT end the turn after the note.
 - Only the initial plan, plan updates, and final recap can be longer, with multiple bullets and paragraphs
 
 Tone:
@@ -59,6 +59,13 @@ Content:
 - “Finished poking at the DB gateway. I will now chase down error handling.”
 - “Alright, build pipeline order is interesting. Checking how it reports failures.”
 - “Spotted a clever caching util; now hunting where it gets used.”
+
+**Critical:** Do not leave dangling updates.
+
+- If you say you're about to run a command or apply a patch, immediately do it by emitting the tool call in the same response.
+- Never end the turn right after a preamble like “Next, I’ll …” or “I will now …”.
+- If approval/escalation is needed, request it via the tool call mechanism (do not ask in chat and wait).
+
 
 ## Planning
 


### PR DESCRIPTION
## Summary
With `gpt-5.2` (especially at higher reasoning effort), Codex CLI can emit a short progress/preamble message (e.g. “Next, I’ll …”) and then yield back to the user without emitting any tool calls. Because the CLI only continues an agent turn when tool calls are emitted, this stalls multi-step work and forces manual “continue” nudges.

This PR updates the GPT-5.2 (and GPT-5.1 for parity) system prompts to explicitly forbid “dangling” preambles and require issuing tool calls in the same assistant turn.

## Problem
Observed behavior:
- The agent prints a preamble like “Ok, now I’ll run … / Next, I’ll …”
- No tool call follows
- The turn ends and control returns to the user mid-task

Expected:
- If the agent says it will run a command/apply a patch, it should immediately emit the tool call(s) in the same response (or ask the user directly if input/approval is required).

## Root cause (why this happens)
Codex CLI’s agent loop continues a turn only when the model emits tool calls. Pure text updates are treated as “end of turn”.

The current GPT-5.x prompt strongly encourages short “next I’ll …” style progress updates, but doesn’t clearly state that such preambles must not be a standalone turn. `gpt-5.2` sometimes treats the preamble as a separate phase and stops before emitting tool calls.

This appears consistent with a broader class of similar “agent stops while it still has a plan” issues, and matches recent reports specifically for `v0.71.0` + GPT‑5.2.

## Changes
- `codex-rs/core/gpt_5_2_prompt.md`: clarify “heads-down” guidance and add an explicit rule to avoid standalone preambles and to emit tool calls immediately in the same response.
- `codex-rs/core/gpt_5_1_prompt.md`: mirror the same clarification to keep behavior consistent across GPT-5.1 and GPT-5.2.

## Related issues
Fixes #7900  
Related: #5264, #6277

## Test plan
N/A (prompt-only change)

## Notes
- If you don’t want auto-closing, use “Addresses #7900” instead of “Fixes #7900”.
