### PR TITLE
chore: persist comments in edit

### DIFF
--- a/codex-rs/core/src/config/edit.rs
+++ b/codex-rs/core/src/config/edit.rs
@@ -1168,7 +1168,7 @@ foo = { command = "cmd" } # keep me
         let contents =
             std::fs::read_to_string(codex_home.join(CONFIG_TOML_FILE)).expect("read config");
         let expected = r#"[mcp_servers]
-foo = { command = "cmd", enabled = false } # keep me
+foo = { command = "cmd" , enabled = false } # keep me
 "#;
         assert_eq!(contents, expected);
     }
@@ -1210,7 +1210,7 @@ foo = { command = "cmd", args = ["--flag"] } # keep me
         let contents =
             std::fs::read_to_string(codex_home.join(CONFIG_TOML_FILE)).expect("read config");
         let expected = r#"[mcp_servers]
-foo = { command = "cmd" } # keep me
+foo = { command = "cmd"} # keep me
 "#;
         assert_eq!(contents, expected);
     }
@@ -1254,7 +1254,7 @@ foo = { command = "cmd" }
             std::fs::read_to_string(codex_home.join(CONFIG_TOML_FILE)).expect("read config");
         let expected = r#"[mcp_servers]
 # keep me
-foo = { command = "cmd", enabled = false }
+foo = { command = "cmd" , enabled = false }
 "#;
         assert_eq!(contents, expected);
     }

--- a/codex-rs/core/src/config/service.rs
+++ b/codex-rs/core/src/config/service.rs
@@ -936,7 +936,7 @@ remote_compaction = true
     #[tokio::test]
     async fn upsert_merges_tables_replace_overwrites() -> Result<()> {
         let tmp = tempdir().expect("tempdir");
-        let path = tmp.path().join(CONFIG_FILE_NAME);
+        let path = tmp.path().join(CONFIG_TOML_FILE);
         let base = r#"[mcp_servers.linear]
 bearer_token_env_var = "TOKEN"
 name = "linear"
@@ -949,7 +949,7 @@ existing = "keep"
 alpha = "a"
 "#;
 
-        let overlay = json!({
+        let overlay = serde_json::json!({
             "bearer_token_env_var": "NEW_TOKEN",
             "http_headers": {
                 "alpha": "updated",
@@ -961,16 +961,17 @@ alpha = "a"
 
         std::fs::write(&path, base)?;
 
-        let api = ConfigApi::new(tmp.path().to_path_buf(), vec![]);
-        api.write_value(ConfigValueWriteParams {
-            file_path: Some(path.display().to_string()),
-            key_path: "mcp_servers.linear".to_string(),
-            value: overlay.clone(),
-            merge_strategy: MergeStrategy::Upsert,
-            expected_version: None,
-        })
-        .await
-        .expect("upsert succeeds");
+        let service = ConfigService::new(tmp.path().to_path_buf(), vec![]);
+        service
+            .write_value(ConfigValueWriteParams {
+                file_path: Some(path.display().to_string()),
+                key_path: "mcp_servers.linear".to_string(),
+                value: overlay.clone(),
+                merge_strategy: MergeStrategy::Upsert,
+                expected_version: None,
+            })
+            .await
+            .expect("upsert succeeds");
 
         let upserted: TomlValue = toml::from_str(&std::fs::read_to_string(&path)?)?;
         let expected_upsert: TomlValue = toml::from_str(
@@ -991,15 +992,16 @@ beta = "b"
 
         std::fs::write(&path, base)?;
 
-        api.write_value(ConfigValueWriteParams {
-            file_path: Some(path.display().to_string()),
-            key_path: "mcp_servers.linear".to_string(),
-            value: overlay,
-            merge_strategy: MergeStrategy::Replace,
-            expected_version: None,
-        })
-        .await
-        .expect("replace succeeds");
+        service
+            .write_value(ConfigValueWriteParams {
+                file_path: Some(path.display().to_string()),
+                key_path: "mcp_servers.linear".to_string(),
+                value: overlay,
+                merge_strategy: MergeStrategy::Replace,
+                expected_version: None,
+            })
+            .await
+            .expect("replace succeeds");
 
         let replaced: TomlValue = toml::from_str(&std::fs::read_to_string(&path)?)?;
         let expected_replace: TomlValue = toml::from_str(


### PR DESCRIPTION
This PR makes sure that inline comment is preserved for mcp server config and arbitrary key/value setPath config.
