### PR TITLE
exec-server: additional context for errors

### DIFF
--- a/codex-rs/exec-server/src/posix/escalate_client.rs
+++ b/codex-rs/exec-server/src/posix/escalate_client.rs
@@ -51,7 +51,10 @@ pub(crate) async fn run(file: String, argv: Vec<String>) -> anyhow::Result<i32> 
         })
         .await
         .context("failed to send EscalateRequest")?;
-    let message = client.receive::<EscalateResponse>().await?;
+    let message = client
+        .receive::<EscalateResponse>()
+        .await
+        .context("failed to receive EscalateResponse")?;
     match message.action {
         EscalateAction::Escalate => {
             // TODO: maybe we should send ALL open FDs (except the escalate client)?

--- a/codex-rs/exec-server/tests/suite/accept_elicitation.rs
+++ b/codex-rs/exec-server/tests/suite/accept_elicitation.rs
@@ -104,6 +104,7 @@ prefix_rule(
             name: Cow::Borrowed("shell"),
             arguments: Some(object(json!(
                 {
+                    "login": false,
                     "command": "git init .",
                     "workdir": project_root_path.to_string_lossy(),
                 }


### PR DESCRIPTION
Add a .context() on some exec-server errors for debugging CI flakes.

Also, "login": false in the test to make the test not affected by user profile.