### PR TITLE
file-search: ignore parent gitignore rules

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1287,8 +1287,10 @@ dependencies = [
  "clap",
  "ignore",
  "nucleo-matcher",
+ "pretty_assertions",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/codex-rs/file-search/Cargo.toml
+++ b/codex-rs/file-search/Cargo.toml
@@ -20,3 +20,7 @@ nucleo-matcher = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }
+tempfile = { workspace = true }

--- a/codex-rs/file-search/src/lib.rs
+++ b/codex-rs/file-search/src/lib.rs
@@ -162,14 +162,15 @@ pub fn run(
         // Follow symlinks to search their contents.
         .follow_links(true)
         // Don't require git to be present to apply to apply git-related ignore rules.
-        .require_git(false);
+        .require_git(false)
+        // Don't let ignore rules "leak" from parent directories above the search root.
+        .parents(false);
     if !respect_gitignore {
         walk_builder
             .git_ignore(false)
             .git_global(false)
             .git_exclude(false)
-            .ignore(false)
-            .parents(false);
+            .ignore(false);
     }
 
     if !exclude.is_empty() {

--- a/codex-rs/file-search/tests/ignore_parent_gitignore.rs
+++ b/codex-rs/file-search/tests/ignore_parent_gitignore.rs
@@ -1,0 +1,63 @@
+use codex_file_search as file_search;
+use pretty_assertions::assert_eq;
+use std::num::NonZero;
+
+#[test]
+fn ignores_do_not_apply_from_parent_directories() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+
+    let parent = temp.path();
+    std::fs::write(parent.join(".gitignore"), "child/\n")?;
+
+    let child = parent.join("child");
+    std::fs::create_dir_all(&child)?;
+    std::fs::write(child.join("needle-visible.txt"), "ok")?;
+
+    let limit = NonZero::new(50).unwrap();
+    let threads = NonZero::new(2).unwrap();
+
+    let res = file_search::run(
+        "needle",
+        limit,
+        &child,
+        Vec::new(),
+        threads,
+        Default::default(),
+        false,
+        true,
+    )?;
+
+    let paths: Vec<String> = res.matches.into_iter().map(|m| m.path).collect();
+    assert_eq!(paths, vec!["needle-visible.txt"]);
+
+    Ok(())
+}
+
+#[test]
+fn gitignore_inside_root_is_still_respected() -> anyhow::Result<()> {
+    let temp = tempfile::tempdir()?;
+    let root = temp.path();
+
+    std::fs::write(root.join(".gitignore"), "needle-ignored.txt\n")?;
+    std::fs::write(root.join("needle-visible.txt"), "ok")?;
+    std::fs::write(root.join("needle-ignored.txt"), "ok")?;
+
+    let limit = NonZero::new(50).unwrap();
+    let threads = NonZero::new(2).unwrap();
+
+    let res = file_search::run(
+        "needle",
+        limit,
+        root,
+        Vec::new(),
+        threads,
+        Default::default(),
+        false,
+        true,
+    )?;
+
+    let paths: Vec<String> = res.matches.into_iter().map(|m| m.path).collect();
+    assert_eq!(paths, vec!["needle-visible.txt"]);
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes a file-search behavior where ignore rules from parent directories above the search root could incorrectly exclude results.

- Always set WalkBuilder::parents(false) so ignore rules don’t leak from above the search root
- Adds regression tests verifying parent .gitignore does not apply, while root .gitignore still does

<img width="470" height="228" alt="image" src="https://github.com/user-attachments/assets/7f6c24f8-c884-4ae7-879e-dfc62eb55fb3" />
