### PR TITLE
Sign two additional exes for Windows

### DIFF
--- a/.github/actions/windows-code-sign/action.yml
+++ b/.github/actions/windows-code-sign/action.yml
@@ -53,3 +53,5 @@ runs:
         files: |
           ${{ github.workspace }}/codex-rs/target/${{ inputs.target }}/release/codex.exe
           ${{ github.workspace }}/codex-rs/target/${{ inputs.target }}/release/codex-responses-api-proxy.exe
+          ${{ github.workspace }}/codex-rs/target/${{ inputs.target }}/release/codex-windows-sandbox-setup.exe
+          ${{ github.workspace }}/codex-rs/target/${{ inputs.target }}/release/codex-command-runner.exe

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -101,7 +101,7 @@ jobs:
           sudo apt-get install -y musl-tools pkg-config
 
       - name: Cargo build
-        run: cargo build --target ${{ matrix.target }} --release --bin codex --bin codex-responses-api-proxy
+        run: cargo build --target ${{ matrix.target }} --release --bin codex --bin codex-responses-api-proxy --bin codex-windows-sandbox-setup --bin codex-command-runner
 
       - if: ${{ contains(matrix.target, 'linux') }}
         name: Cosign Linux artifacts

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -101,7 +101,12 @@ jobs:
           sudo apt-get install -y musl-tools pkg-config
 
       - name: Cargo build
-        run: cargo build --target ${{ matrix.target }} --release --bin codex --bin codex-responses-api-proxy --bin codex-windows-sandbox-setup --bin codex-command-runner
+        run: |
+          if [[ "${{ contains(matrix.target, 'windows') }}" == 'true' ]]; then
+            cargo build --target ${{ matrix.target }} --release --bin codex --bin codex-responses-api-proxy --bin codex-windows-sandbox-setup --bin codex-command-runner
+          else
+            cargo build --target ${{ matrix.target }} --release --bin codex --bin codex-responses-api-proxy
+          fi
 
       - if: ${{ contains(matrix.target, 'linux') }}
         name: Cosign Linux artifacts


### PR DESCRIPTION
The elevated sandbox ships two exes
* one for elevated setup of the sandbox
* one to actually run commands under the sandbox user.

This PR adds them to the windows signing step