### PR TITLE
Changed default wrap algorithm from OptimalFit to FirstFit

### DIFF
--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1664,8 +1664,8 @@ mod tests {
         assert_eq!(
             rendered,
             vec![
-                "✔ You approved codex".to_string(),
-                "  to run echo something".to_string(),
+                "✔ You approved codex to".to_string(),
+                "  run echo something".to_string(),
                 "  really long to ensure".to_string(),
                 "  wrapping happens this".to_string(),
                 "  time".to_string(),

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -595,8 +595,8 @@ mod tests {
             lines,
             vec![
                 "- outer item with".to_string(),
-                "  several words".to_string(),
-                "  to wrap".to_string(),
+                "  several words to".to_string(),
+                "  wrap".to_string(),
                 "    - inner item".to_string(),
                 "      that also".to_string(),
                 "      needs wrapping".to_string(),

--- a/codex-rs/tui/src/wrapping.rs
+++ b/codex-rs/tui/src/wrapping.rs
@@ -636,11 +636,11 @@ mod tests {
         let joined: String = wrapped.iter().map(ToString::to_string).join("\n");
         assert_eq!(
             joined,
-            r#"Years passed, and Willowmere thrived
-in peace and friendship. Mira’s herb
-garden flourished with both ordinary and
-enchanted plants, and travelers spoke
-of the kindness of the woman who tended
+            r#"Years passed, and Willowmere thrived in
+peace and friendship. Mira’s herb garden
+flourished with both ordinary and
+enchanted plants, and travelers spoke of
+the kindness of the woman who tended
 them."#
         );
     }

--- a/codex-rs/tui/src/wrapping.rs
+++ b/codex-rs/tui/src/wrapping.rs
@@ -3,7 +3,6 @@ use ratatui::text::Span;
 use std::borrow::Cow;
 use std::ops::Range;
 use textwrap::Options;
-use textwrap::wrap_algorithms::Penalties;
 
 use crate::render::line_utils::push_owned_lines;
 
@@ -92,11 +91,7 @@ impl<'a> RtOptions<'a> {
             subsequent_indent: Line::default(),
             break_words: true,
             word_separator: textwrap::WordSeparator::new(),
-            wrap_algorithm: textwrap::WrapAlgorithm::OptimalFit(Penalties {
-                // ~infinite overflow penalty, we never want to overflow a line.
-                overflow_penalty: usize::MAX / 4,
-                ..Default::default()
-            }),
+            wrap_algorithm: textwrap::WrapAlgorithm::FirstFit,
             word_splitter: textwrap::WordSplitter::HyphenSplitter,
         }
     }

--- a/codex-rs/tui2/src/history_cell.rs
+++ b/codex-rs/tui2/src/history_cell.rs
@@ -1664,8 +1664,8 @@ mod tests {
         assert_eq!(
             rendered,
             vec![
-                "✔ You approved codex".to_string(),
-                "  to run echo something".to_string(),
+                "✔ You approved codex to".to_string(),
+                "  run echo something".to_string(),
                 "  really long to ensure".to_string(),
                 "  wrapping happens this".to_string(),
                 "  time".to_string(),

--- a/codex-rs/tui2/src/markdown_render.rs
+++ b/codex-rs/tui2/src/markdown_render.rs
@@ -595,8 +595,8 @@ mod tests {
             lines,
             vec![
                 "- outer item with".to_string(),
-                "  several words".to_string(),
-                "  to wrap".to_string(),
+                "  several words to".to_string(),
+                "  wrap".to_string(),
                 "    - inner item".to_string(),
                 "      that also".to_string(),
                 "      needs wrapping".to_string(),

--- a/codex-rs/tui2/src/wrapping.rs
+++ b/codex-rs/tui2/src/wrapping.rs
@@ -636,11 +636,11 @@ mod tests {
         let joined: String = wrapped.iter().map(ToString::to_string).join("\n");
         assert_eq!(
             joined,
-            r#"Years passed, and Willowmere thrived
-in peace and friendship. Mira’s herb
-garden flourished with both ordinary and
-enchanted plants, and travelers spoke
-of the kindness of the woman who tended
+            r#"Years passed, and Willowmere thrived in
+peace and friendship. Mira’s herb garden
+flourished with both ordinary and
+enchanted plants, and travelers spoke of
+the kindness of the woman who tended
 them."#
         );
     }

--- a/codex-rs/tui2/src/wrapping.rs
+++ b/codex-rs/tui2/src/wrapping.rs
@@ -3,7 +3,6 @@ use ratatui::text::Span;
 use std::borrow::Cow;
 use std::ops::Range;
 use textwrap::Options;
-use textwrap::wrap_algorithms::Penalties;
 
 use crate::render::line_utils::push_owned_lines;
 
@@ -92,11 +91,7 @@ impl<'a> RtOptions<'a> {
             subsequent_indent: Line::default(),
             break_words: true,
             word_separator: textwrap::WordSeparator::new(),
-            wrap_algorithm: textwrap::WrapAlgorithm::OptimalFit(Penalties {
-                // ~infinite overflow penalty, we never want to overflow a line.
-                overflow_penalty: usize::MAX / 4,
-                ..Default::default()
-            }),
+            wrap_algorithm: textwrap::WrapAlgorithm::FirstFit,
             word_splitter: textwrap::WordSplitter::HyphenSplitter,
         }
     }


### PR DESCRIPTION
Codex identified this as the cause of a reported hang: https://github.com/openai/codex/issues/7822. Apparently, the wrapping algorithm we're using has known issues and bad worst-case behaviors when OptimalFit is used on certain strings. It recommended switching to FirstFit instead.
