### PR TITLE
Sync tui2 with tui and keep dual-run glue

### DIFF
--- a/codex-rs/tui2/Cargo.toml
+++ b/codex-rs/tui2/Cargo.toml
@@ -4,17 +4,18 @@ version.workspace = true
 edition.workspace = true
 license.workspace = true
 
-[lib]
-name = "codex_tui2"
-path = "src/lib.rs"
-
 [[bin]]
 name = "codex-tui2"
 path = "src/main.rs"
 
+[lib]
+name = "codex_tui2"
+path = "src/lib.rs"
+
 [features]
-# Keep feature surface aligned with codex-tui while tui2 evolves separately.
+# Enable vt100-based tests (emulator) when running with `--features vt100-tests`.
 vt100-tests = []
+# Gate verbose debug logging inside the TUI implementation.
 debug-logs = []
 
 [lints]

--- a/codex-rs/tui2/src/app.rs
+++ b/codex-rs/tui2/src/app.rs
@@ -8,7 +8,7 @@ use crate::exec_command::strip_bash_lc_and_escape;
 use crate::file_search::FileSearchManager;
 use crate::history_cell::HistoryCell;
 use crate::model_migration::ModelMigrationOutcome;
-use crate::model_migration::migration_copy_for_config;
+use crate::model_migration::migration_copy_for_models;
 use crate::model_migration::run_model_migration_prompt;
 use crate::pager_overlay::Overlay;
 use crate::render::highlight::highlight_bash_to_lines;
@@ -20,11 +20,11 @@ use crate::tui;
 use crate::tui::TuiEvent;
 use crate::update_action::UpdateAction;
 use codex_ansi_escape::ansi_escape_line;
-use codex_app_server_protocol::AuthMode;
 use codex_core::AuthManager;
 use codex_core::ConversationManager;
 use codex_core::config::Config;
 use codex_core::config::edit::ConfigEditsBuilder;
+#[cfg(target_os = "windows")]
 use codex_core::features::Feature;
 use codex_core::openai_models::model_presets::HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG;
 use codex_core::openai_models::model_presets::HIDE_GPT5_1_MIGRATION_PROMPT_CONFIG;
@@ -33,9 +33,9 @@ use codex_core::protocol::EventMsg;
 use codex_core::protocol::FinalOutput;
 use codex_core::protocol::Op;
 use codex_core::protocol::SessionSource;
+use codex_core::protocol::SkillLoadOutcomeInfo;
 use codex_core::protocol::TokenUsage;
-use codex_core::skills::load_skills;
-use codex_core::skills::model::SkillMetadata;
+use codex_core::skills::SkillError;
 use codex_protocol::ConversationId;
 use codex_protocol::openai_models::ModelPreset;
 use codex_protocol::openai_models::ModelUpgrade;
@@ -49,6 +49,7 @@ use ratatui::style::Stylize;
 use ratatui::text::Line;
 use ratatui::widgets::Paragraph;
 use ratatui::widgets::Wrap;
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
@@ -60,9 +61,6 @@ use tokio::sync::mpsc::unbounded_channel;
 
 #[cfg(not(debug_assertions))]
 use crate::history_cell::UpdateAvailableHistoryCell;
-
-const GPT_5_1_MIGRATION_AUTH_MODES: [AuthMode; 2] = [AuthMode::ChatGPT, AuthMode::ApiKey];
-const GPT_5_1_CODEX_MIGRATION_AUTH_MODES: [AuthMode; 2] = [AuthMode::ChatGPT, AuthMode::ApiKey];
 
 #[derive(Debug, Clone)]
 pub struct AppExitInfo {
@@ -98,6 +96,17 @@ fn session_summary(
     })
 }
 
+fn skill_errors_from_outcome(outcome: &SkillLoadOutcomeInfo) -> Vec<SkillError> {
+    outcome
+        .errors
+        .iter()
+        .map(|err| SkillError {
+            path: err.path.clone(),
+            message: err.message.clone(),
+        })
+        .collect()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct SessionSummary {
     usage_line: String,
@@ -107,26 +116,46 @@ struct SessionSummary {
 fn should_show_model_migration_prompt(
     current_model: &str,
     target_model: &str,
-    hide_prompt_flag: Option<bool>,
-    available_models: Vec<ModelPreset>,
+    seen_migrations: &BTreeMap<String, String>,
+    available_models: &[ModelPreset],
 ) -> bool {
-    if target_model == current_model || hide_prompt_flag.unwrap_or(false) {
+    if target_model == current_model {
         return false;
     }
 
-    available_models
+    if let Some(seen_target) = seen_migrations.get(current_model)
+        && seen_target == target_model
+    {
+        return false;
+    }
+
+    if available_models
         .iter()
-        .filter(|preset| preset.upgrade.is_some())
-        .any(|preset| preset.model == current_model)
+        .any(|preset| preset.model == current_model && preset.upgrade.is_some())
+    {
+        return true;
+    }
+
+    if available_models
+        .iter()
+        .any(|preset| preset.upgrade.as_ref().map(|u| u.id.as_str()) == Some(target_model))
+    {
+        return true;
+    }
+
+    false
 }
 
-fn migration_prompt_hidden(config: &Config, migration_config_key: &str) -> Option<bool> {
+fn migration_prompt_hidden(config: &Config, migration_config_key: &str) -> bool {
     match migration_config_key {
-        HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG => {
-            config.notices.hide_gpt_5_1_codex_max_migration_prompt
+        HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG => config
+            .notices
+            .hide_gpt_5_1_codex_max_migration_prompt
+            .unwrap_or(false),
+        HIDE_GPT5_1_MIGRATION_PROMPT_CONFIG => {
+            config.notices.hide_gpt5_1_migration_prompt.unwrap_or(false)
         }
-        HIDE_GPT5_1_MIGRATION_PROMPT_CONFIG => config.notices.hide_gpt5_1_migration_prompt,
-        _ => None,
+        _ => false,
     }
 }
 
@@ -135,7 +164,6 @@ async fn handle_model_migration_prompt_if_needed(
     config: &mut Config,
     model: &str,
     app_event_tx: &AppEventSender,
-    auth_mode: Option<AuthMode>,
     models_manager: Arc<ModelsManager>,
 ) -> Option<AppExitInfo> {
     let available_models = models_manager.list_models(config).await;
@@ -150,26 +178,52 @@ async fn handle_model_migration_prompt_if_needed(
         migration_config_key,
     }) = upgrade
     {
-        if !migration_prompt_allows_auth_mode(auth_mode, migration_config_key.as_str()) {
+        if migration_prompt_hidden(config, migration_config_key.as_str()) {
             return None;
         }
 
         let target_model = target_model.to_string();
-        let hide_prompt_flag = migration_prompt_hidden(config, migration_config_key.as_str());
         if !should_show_model_migration_prompt(
             model,
             &target_model,
-            hide_prompt_flag,
-            available_models.clone(),
+            &config.notices.model_migrations,
+            &available_models,
         ) {
             return None;
         }
 
-        let prompt_copy = migration_copy_for_config(migration_config_key.as_str());
+        let current_preset = available_models.iter().find(|preset| preset.model == model);
+        let target_preset = available_models
+            .iter()
+            .find(|preset| preset.model == target_model);
+        let target_display_name = target_preset
+            .map(|preset| preset.display_name.clone())
+            .unwrap_or_else(|| target_model.clone());
+        let heading_label = if target_display_name == model {
+            target_model.clone()
+        } else {
+            target_display_name.clone()
+        };
+        let target_description = target_preset.and_then(|preset| {
+            if preset.description.is_empty() {
+                None
+            } else {
+                Some(preset.description.clone())
+            }
+        });
+        let can_opt_out = current_preset.is_some();
+        let prompt_copy = migration_copy_for_models(
+            model,
+            &target_model,
+            heading_label,
+            target_description,
+            can_opt_out,
+        );
         match run_model_migration_prompt(tui, prompt_copy).await {
             ModelMigrationOutcome::Accepted => {
                 app_event_tx.send(AppEvent::PersistModelMigrationPromptAcknowledged {
-                    migration_config: migration_config_key.to_string(),
+                    from_model: model.to_string(),
+                    to_model: target_model.clone(),
                 });
                 config.model = Some(target_model.clone());
 
@@ -195,7 +249,8 @@ async fn handle_model_migration_prompt_if_needed(
             }
             ModelMigrationOutcome::Rejected => {
                 app_event_tx.send(AppEvent::PersistModelMigrationPromptAcknowledged {
-                    migration_config: migration_config_key.to_string(),
+                    from_model: model.to_string(),
+                    to_model: target_model.clone(),
                 });
             }
             ModelMigrationOutcome::Exit => {
@@ -247,8 +302,6 @@ pub(crate) struct App {
 
     // One-shot suppression of the next world-writable scan after user confirmation.
     skip_world_writable_scan_once: bool,
-
-    pub(crate) skills: Option<Vec<SkillMetadata>>,
 }
 
 impl App {
@@ -276,7 +329,6 @@ impl App {
         let (app_event_tx, mut app_event_rx) = unbounded_channel();
         let app_event_tx = AppEventSender::new(app_event_tx);
 
-        let auth_mode = auth_manager.auth().map(|auth| auth.mode);
         let conversation_manager = Arc::new(ConversationManager::new(
             auth_manager.clone(),
             SessionSource::Cli,
@@ -290,7 +342,6 @@ impl App {
             &mut config,
             model.as_str(),
             &app_event_tx,
-            auth_mode,
             conversation_manager.get_models_manager(),
         )
         .await;
@@ -300,26 +351,6 @@ impl App {
         if let Some(updated_model) = config.model.clone() {
             model = updated_model;
         }
-
-        let skills_outcome = load_skills(&config);
-        if !skills_outcome.errors.is_empty() {
-            match run_skill_error_prompt(tui, &skills_outcome.errors).await {
-                SkillErrorPromptOutcome::Exit => {
-                    return Ok(AppExitInfo {
-                        token_usage: TokenUsage::default(),
-                        conversation_id: None,
-                        update_action: None,
-                    });
-                }
-                SkillErrorPromptOutcome::Continue => {}
-            }
-        }
-
-        let skills = if config.features.enabled(Feature::Skills) {
-            Some(skills_outcome.skills.clone())
-        } else {
-            None
-        };
 
         let enhanced_keys_supported = tui.enhanced_keys_supported();
         let model_family = conversation_manager
@@ -338,7 +369,6 @@ impl App {
                     auth_manager: auth_manager.clone(),
                     models_manager: conversation_manager.get_models_manager(),
                     feedback: feedback.clone(),
-                    skills: skills.clone(),
                     is_first_run,
                     model_family: model_family.clone(),
                 };
@@ -365,7 +395,6 @@ impl App {
                     auth_manager: auth_manager.clone(),
                     models_manager: conversation_manager.get_models_manager(),
                     feedback: feedback.clone(),
-                    skills: skills.clone(),
                     is_first_run,
                     model_family: model_family.clone(),
                 };
@@ -403,7 +432,6 @@ impl App {
             pending_update_action: None,
             suppress_shutdown_complete: false,
             skip_world_writable_scan_once: false,
-            skills,
         };
 
         // On startup, if Agent mode (workspace-write) or ReadOnly is active, warn about world-writable dirs on Windows.
@@ -529,7 +557,6 @@ impl App {
                     auth_manager: self.auth_manager.clone(),
                     models_manager: self.server.get_models_manager(),
                     feedback: self.feedback.clone(),
-                    skills: self.skills.clone(),
                     is_first_run: false,
                     model_family: model_family.clone(),
                 };
@@ -580,7 +607,6 @@ impl App {
                                     auth_manager: self.auth_manager.clone(),
                                     models_manager: self.server.get_models_manager(),
                                     feedback: self.feedback.clone(),
-                                    skills: self.skills.clone(),
                                     is_first_run: false,
                                     model_family: model_family.clone(),
                                 };
@@ -671,6 +697,19 @@ impl App {
                 {
                     self.suppress_shutdown_complete = false;
                     return Ok(true);
+                }
+                if let EventMsg::SessionConfigured(cfg) = &event.msg
+                    && let Some(outcome) = cfg.skill_load_outcome.as_ref()
+                    && !outcome.errors.is_empty()
+                {
+                    let errors = skill_errors_from_outcome(outcome);
+                    match run_skill_error_prompt(tui, &errors).await {
+                        SkillErrorPromptOutcome::Exit => {
+                            self.chat_widget.submit_op(Op::Shutdown);
+                            return Ok(false);
+                        }
+                        SkillErrorPromptOutcome::Continue => {}
+                    }
                 }
                 self.chat_widget.handle_codex_event(event);
             }
@@ -960,13 +999,19 @@ impl App {
                     ));
                 }
             }
-            AppEvent::PersistModelMigrationPromptAcknowledged { migration_config } => {
+            AppEvent::PersistModelMigrationPromptAcknowledged {
+                from_model,
+                to_model,
+            } => {
                 if let Err(err) = ConfigEditsBuilder::new(&self.config.codex_home)
-                    .set_hide_model_migration_prompt(&migration_config, true)
+                    .record_model_migration_seen(from_model.as_str(), to_model.as_str())
                     .apply()
                     .await
                 {
-                    tracing::error!(error = %err, "failed to persist model migration prompt acknowledgement");
+                    tracing::error!(
+                        error = %err,
+                        "failed to persist model migration prompt acknowledgement"
+                    );
                     self.chat_widget.add_error_message(format!(
                         "Failed to save model migration prompt preference: {err}"
                     ));
@@ -1140,28 +1185,6 @@ impl App {
     }
 }
 
-fn migration_prompt_allowed_auth_modes(migration_config_key: &str) -> Option<&'static [AuthMode]> {
-    match migration_config_key {
-        HIDE_GPT5_1_MIGRATION_PROMPT_CONFIG => Some(&GPT_5_1_MIGRATION_AUTH_MODES),
-        HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG => Some(&GPT_5_1_CODEX_MIGRATION_AUTH_MODES),
-        _ => None,
-    }
-}
-
-fn migration_prompt_allows_auth_mode(
-    auth_mode: Option<AuthMode>,
-    migration_config_key: &str,
-) -> bool {
-    if let Some(allowed_modes) = migration_prompt_allowed_auth_modes(migration_config_key) {
-        match auth_mode {
-            None => true,
-            Some(mode) => allowed_modes.contains(&mode),
-        }
-    } else {
-        auth_mode != Some(AuthMode::ApiKey)
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1219,7 +1242,6 @@ mod tests {
             pending_update_action: None,
             suppress_shutdown_complete: false,
             skip_world_writable_scan_once: false,
-            skills: None,
         }
     }
 
@@ -1260,7 +1282,6 @@ mod tests {
                 pending_update_action: None,
                 suppress_shutdown_complete: false,
                 skip_world_writable_scan_once: false,
-                skills: None,
             },
             rx,
             op_rx,
@@ -1273,51 +1294,54 @@ mod tests {
 
     #[test]
     fn model_migration_prompt_only_shows_for_deprecated_models() {
+        let seen = BTreeMap::new();
         assert!(should_show_model_migration_prompt(
             "gpt-5",
             "gpt-5.1",
-            None,
-            all_model_presets()
+            &seen,
+            &all_model_presets()
         ));
         assert!(should_show_model_migration_prompt(
             "gpt-5-codex",
             "gpt-5.1-codex",
-            None,
-            all_model_presets()
+            &seen,
+            &all_model_presets()
         ));
         assert!(should_show_model_migration_prompt(
             "gpt-5-codex-mini",
             "gpt-5.1-codex-mini",
-            None,
-            all_model_presets()
+            &seen,
+            &all_model_presets()
         ));
         assert!(should_show_model_migration_prompt(
             "gpt-5.1-codex",
             "gpt-5.1-codex-max",
-            None,
-            all_model_presets()
+            &seen,
+            &all_model_presets()
         ));
         assert!(!should_show_model_migration_prompt(
             "gpt-5.1-codex",
             "gpt-5.1-codex",
-            None,
-            all_model_presets()
+            &seen,
+            &all_model_presets()
         ));
     }
 
     #[test]
     fn model_migration_prompt_respects_hide_flag_and_self_target() {
+        let mut seen = BTreeMap::new();
+        seen.insert("gpt-5".to_string(), "gpt-5.1".to_string());
         assert!(!should_show_model_migration_prompt(
             "gpt-5",
             "gpt-5.1",
-            Some(true),
-            all_model_presets()
+            &seen,
+            &all_model_presets()
         ));
         assert!(!should_show_model_migration_prompt(
             "gpt-5.1",
             "gpt-5.1",
-            None,
-            all_model_presets()
+            &seen,
+            &all_model_presets()
         ));
     }
 
@@ -1470,41 +1494,5 @@ mod tests {
             summary.resume_command,
             Some("codex resume 123e4567-e89b-12d3-a456-426614174000".to_string())
         );
-    }
-
-    #[test]
-    fn gpt5_migration_allows_api_key_and_chatgpt() {
-        assert!(migration_prompt_allows_auth_mode(
-            Some(AuthMode::ApiKey),
-            HIDE_GPT5_1_MIGRATION_PROMPT_CONFIG,
-        ));
-        assert!(migration_prompt_allows_auth_mode(
-            Some(AuthMode::ChatGPT),
-            HIDE_GPT5_1_MIGRATION_PROMPT_CONFIG,
-        ));
-    }
-
-    #[test]
-    fn gpt_5_1_codex_max_migration_limits_to_chatgpt() {
-        assert!(migration_prompt_allows_auth_mode(
-            Some(AuthMode::ChatGPT),
-            HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG,
-        ));
-        assert!(migration_prompt_allows_auth_mode(
-            Some(AuthMode::ApiKey),
-            HIDE_GPT_5_1_CODEX_MAX_MIGRATION_PROMPT_CONFIG,
-        ));
-    }
-
-    #[test]
-    fn other_migrations_block_api_key() {
-        assert!(!migration_prompt_allows_auth_mode(
-            Some(AuthMode::ApiKey),
-            "unknown"
-        ));
-        assert!(migration_prompt_allows_auth_mode(
-            Some(AuthMode::ChatGPT),
-            "unknown"
-        ));
     }
 }

--- a/codex-rs/tui2/src/app_backtrack.rs
+++ b/codex-rs/tui2/src/app_backtrack.rs
@@ -350,7 +350,6 @@ impl App {
             auth_manager: self.auth_manager.clone(),
             models_manager: self.server.get_models_manager(),
             feedback: self.feedback.clone(),
-            skills: self.skills.clone(),
             is_first_run: false,
         };
         self.chat_widget =

--- a/codex-rs/tui2/src/app_event.rs
+++ b/codex-rs/tui2/src/app_event.rs
@@ -139,7 +139,8 @@ pub(crate) enum AppEvent {
 
     /// Persist the acknowledgement flag for the model migration prompt.
     PersistModelMigrationPromptAcknowledged {
-        migration_config: String,
+        from_model: String,
+        to_model: String,
     },
 
     /// Skip the next world-writable scan (one-shot) after a user-confirmed continue.

--- a/codex-rs/tui2/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui2/src/bottom_pane/command_popup.rs
@@ -373,4 +373,23 @@ mod tests {
         let description = rows.first().and_then(|row| row.description.as_deref());
         assert_eq!(description, Some("send saved prompt"));
     }
+
+    #[test]
+    fn fuzzy_filter_matches_subsequence_for_ac() {
+        let mut popup = CommandPopup::new(Vec::new(), false);
+        popup.on_composer_text_change("/ac".to_string());
+
+        let cmds: Vec<&str> = popup
+            .filtered_items()
+            .into_iter()
+            .filter_map(|item| match item {
+                CommandItem::Builtin(cmd) => Some(cmd.command()),
+                CommandItem::UserPrompt(_) => None,
+            })
+            .collect();
+        assert!(
+            cmds.contains(&"compact") && cmds.contains(&"feedback"),
+            "expected fuzzy search for '/ac' to include compact and feedback, got {cmds:?}"
+        );
+    }
 }

--- a/codex-rs/tui2/src/bottom_pane/list_selection_view.rs
+++ b/codex-rs/tui2/src/bottom_pane/list_selection_view.rs
@@ -40,6 +40,7 @@ pub(crate) struct SelectionItem {
     pub description: Option<String>,
     pub selected_description: Option<String>,
     pub is_current: bool,
+    pub is_default: bool,
     pub actions: Vec<SelectionAction>,
     pub dismiss_on_select: bool,
     pub search_value: Option<String>,
@@ -187,11 +188,14 @@ impl ListSelectionView {
                     let is_selected = self.state.selected_idx == Some(visible_idx);
                     let prefix = if is_selected { '›' } else { ' ' };
                     let name = item.name.as_str();
-                    let name_with_marker = if item.is_current {
-                        format!("{name} (current)")
+                    let marker = if item.is_current {
+                        " (current)"
+                    } else if item.is_default {
+                        " (default)"
                     } else {
-                        item.name.clone()
+                        ""
                     };
+                    let name_with_marker = format!("{name}{marker}");
                     let n = visible_idx + 1;
                     let wrap_prefix = if self.is_searchable {
                         // The number keys don't work when search is enabled (since we let the

--- a/codex-rs/tui2/src/bottom_pane/mod.rs
+++ b/codex-rs/tui2/src/bottom_pane/mod.rs
@@ -131,8 +131,17 @@ impl BottomPane {
         }
     }
 
+    pub fn set_skills(&mut self, skills: Option<Vec<SkillMetadata>>) {
+        self.composer.set_skill_mentions(skills);
+        self.request_redraw();
+    }
+
     pub fn status_widget(&self) -> Option<&StatusIndicatorWidget> {
         self.status.as_ref()
+    }
+
+    pub fn skills(&self) -> Option<&Vec<SkillMetadata>> {
+        self.composer.skills()
     }
 
     #[cfg(test)]

--- a/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__mcp_startup_header_booting.snap
+++ b/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__mcp_startup_header_booting.snap
@@ -1,0 +1,11 @@
+---
+source: tui2/src/chatwidget/tests.rs
+expression: terminal.backend()
+---
+"                                                                                "
+"• Booting MCP server: alpha (0s • esc to interrupt)                             "
+"                                                                                "
+"                                                                                "
+"› Ask Codex to do anything                                                      "
+"                                                                                "
+"  100% context left · ? for shortcuts                                           "

--- a/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__model_selection_popup.snap
+++ b/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__model_selection_popup.snap
@@ -5,13 +5,14 @@ expression: popup
   Select Model and Effort
   Access legacy models by running codex -m <model_name> or in your config.toml
 
-› 1. gpt-5.1-codex-max   Latest Codex-optimized flagship for deep and fast
-                         reasoning.
-  2. gpt-5.1-codex       Optimized for codex.
-  3. gpt-5.1-codex-mini  Optimized for codex. Cheaper, faster, but less
-                         capable.
-  4. gpt-5.2             Latest frontier model with improvements across
-                         knowledge, reasoning and coding
-  5. gpt-5.1             Broad world knowledge with strong general reasoning.
+› 1. gpt-5.1-codex-max (default)  Latest Codex-optimized flagship for deep and
+                                  fast reasoning.
+  2. gpt-5.1-codex                Optimized for codex.
+  3. gpt-5.1-codex-mini           Optimized for codex. Cheaper, faster, but
+                                  less capable.
+  4. gpt-5.2                      Latest frontier model with improvements
+                                  across knowledge, reasoning and coding
+  5. gpt-5.1                      Broad world knowledge with strong general
+                                  reasoning.
 
   Press enter to select reasoning effort, or esc to dismiss.

--- a/codex-rs/tui2/src/chatwidget/tests.rs
+++ b/codex-rs/tui2/src/chatwidget/tests.rs
@@ -27,6 +27,8 @@ use codex_core::protocol::ExecCommandSource;
 use codex_core::protocol::ExecPolicyAmendment;
 use codex_core::protocol::ExitedReviewModeEvent;
 use codex_core::protocol::FileChange;
+use codex_core::protocol::McpStartupStatus;
+use codex_core::protocol::McpStartupUpdateEvent;
 use codex_core::protocol::Op;
 use codex_core::protocol::PatchApplyBeginEvent;
 use codex_core::protocol::PatchApplyEndEvent;
@@ -366,7 +368,6 @@ async fn helpers_are_available_and_do_not_panic() {
         auth_manager,
         models_manager: conversation_manager.get_models_manager(),
         feedback: codex_feedback::CodexFeedback::new(),
-        skills: None,
         is_first_run: true,
         model_family,
     };
@@ -1932,7 +1933,7 @@ fn single_reasoning_option_skips_selection() {
 
     let single_effort = vec![ReasoningEffortPreset {
         effort: ReasoningEffortConfig::High,
-        description: "Maximizes reasoning depth for complex or ambiguous problems".to_string(),
+        description: "Greater reasoning depth for complex or ambiguous problems".to_string(),
     }];
     let preset = ModelPreset {
         id: "model-with-single-reasoning".to_string(),
@@ -2417,6 +2418,28 @@ fn status_widget_active_snapshot() {
         .draw(|f| chat.render(f.area(), f.buffer_mut()))
         .expect("draw status widget");
     assert_snapshot!("status_widget_active", terminal.backend());
+}
+
+#[test]
+fn mcp_startup_header_booting_snapshot() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None);
+    chat.show_welcome_banner = false;
+
+    chat.handle_codex_event(Event {
+        id: "mcp-1".into(),
+        msg: EventMsg::McpStartupUpdate(McpStartupUpdateEvent {
+            server: "alpha".into(),
+            status: McpStartupStatus::Starting,
+        }),
+    });
+
+    let height = chat.desired_height(80);
+    let mut terminal = ratatui::Terminal::new(ratatui::backend::TestBackend::new(80, height))
+        .expect("create terminal");
+    terminal
+        .draw(|f| chat.render(f.area(), f.buffer_mut()))
+        .expect("draw chat widget");
+    assert_snapshot!("mcp_startup_header_booting", terminal.backend());
 }
 
 #[test]

--- a/codex-rs/tui2/src/lib.rs
+++ b/codex-rs/tui2/src/lib.rs
@@ -58,6 +58,7 @@ mod markdown;
 mod markdown_render;
 mod markdown_stream;
 mod model_migration;
+mod notifications;
 pub mod onboarding;
 mod oss_selection;
 mod pager_overlay;
@@ -269,6 +270,7 @@ pub async fn run_main(
     let file_layer = tracing_subscriber::fmt::layer()
         .with_writer(non_blocking)
         .with_target(false)
+        .with_ansi(false)
         .with_span_events(tracing_subscriber::fmt::format::FmtSpan::CLOSE)
         .with_filter(env_filter());
 

--- a/codex-rs/tui2/src/notifications/mod.rs
+++ b/codex-rs/tui2/src/notifications/mod.rs
@@ -1,0 +1,139 @@
+mod osc9;
+mod windows_toast;
+
+use std::env;
+use std::io;
+
+use codex_core::env::is_wsl;
+use osc9::Osc9Backend;
+use windows_toast::WindowsToastBackend;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NotificationBackendKind {
+    Osc9,
+    WindowsToast,
+}
+
+#[derive(Debug)]
+pub enum DesktopNotificationBackend {
+    Osc9(Osc9Backend),
+    WindowsToast(WindowsToastBackend),
+}
+
+impl DesktopNotificationBackend {
+    pub fn osc9() -> Self {
+        Self::Osc9(Osc9Backend)
+    }
+
+    pub fn windows_toast() -> Self {
+        Self::WindowsToast(WindowsToastBackend::default())
+    }
+
+    pub fn kind(&self) -> NotificationBackendKind {
+        match self {
+            DesktopNotificationBackend::Osc9(_) => NotificationBackendKind::Osc9,
+            DesktopNotificationBackend::WindowsToast(_) => NotificationBackendKind::WindowsToast,
+        }
+    }
+
+    pub fn notify(&mut self, message: &str) -> io::Result<()> {
+        match self {
+            DesktopNotificationBackend::Osc9(backend) => backend.notify(message),
+            DesktopNotificationBackend::WindowsToast(backend) => backend.notify(message),
+        }
+    }
+}
+
+pub fn detect_backend() -> DesktopNotificationBackend {
+    if should_use_windows_toasts() {
+        tracing::info!(
+            "Windows Terminal session detected under WSL; using Windows toast notifications"
+        );
+        DesktopNotificationBackend::windows_toast()
+    } else {
+        DesktopNotificationBackend::osc9()
+    }
+}
+
+fn should_use_windows_toasts() -> bool {
+    is_wsl() && env::var_os("WT_SESSION").is_some()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NotificationBackendKind;
+    use super::detect_backend;
+    use serial_test::serial;
+    use std::ffi::OsString;
+
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<OsString>,
+    }
+
+    impl EnvVarGuard {
+        fn set(key: &'static str, value: &str) -> Self {
+            let original = std::env::var_os(key);
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, original }
+        }
+
+        fn remove(key: &'static str) -> Self {
+            let original = std::env::var_os(key);
+            unsafe {
+                std::env::remove_var(key);
+            }
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                match &self.original {
+                    Some(value) => std::env::set_var(self.key, value),
+                    None => std::env::remove_var(self.key),
+                }
+            }
+        }
+    }
+
+    #[test]
+    #[serial]
+    fn defaults_to_osc9_outside_wsl() {
+        let _wsl_guard = EnvVarGuard::remove("WSL_DISTRO_NAME");
+        let _wt_guard = EnvVarGuard::remove("WT_SESSION");
+        assert_eq!(detect_backend().kind(), NotificationBackendKind::Osc9);
+    }
+
+    #[test]
+    #[serial]
+    fn waits_for_windows_terminal() {
+        let _wsl_guard = EnvVarGuard::set("WSL_DISTRO_NAME", "Ubuntu");
+        let _wt_guard = EnvVarGuard::remove("WT_SESSION");
+        assert_eq!(detect_backend().kind(), NotificationBackendKind::Osc9);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    #[serial]
+    fn selects_windows_toast_in_wsl_windows_terminal() {
+        let _wsl_guard = EnvVarGuard::set("WSL_DISTRO_NAME", "Ubuntu");
+        let _wt_guard = EnvVarGuard::set("WT_SESSION", "abc");
+        assert_eq!(
+            detect_backend().kind(),
+            NotificationBackendKind::WindowsToast
+        );
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    #[test]
+    #[serial]
+    fn stays_on_osc9_outside_linux_even_with_wsl_env() {
+        let _wsl_guard = EnvVarGuard::set("WSL_DISTRO_NAME", "Ubuntu");
+        let _wt_guard = EnvVarGuard::set("WT_SESSION", "abc");
+        assert_eq!(detect_backend().kind(), NotificationBackendKind::Osc9);
+    }
+}

--- a/codex-rs/tui2/src/notifications/osc9.rs
+++ b/codex-rs/tui2/src/notifications/osc9.rs
@@ -1,0 +1,37 @@
+use std::fmt;
+use std::io;
+use std::io::stdout;
+
+use crossterm::Command;
+use ratatui::crossterm::execute;
+
+#[derive(Debug, Default)]
+pub struct Osc9Backend;
+
+impl Osc9Backend {
+    pub fn notify(&mut self, message: &str) -> io::Result<()> {
+        execute!(stdout(), PostNotification(message.to_string()))
+    }
+}
+
+/// Command that emits an OSC 9 desktop notification with a message.
+#[derive(Debug, Clone)]
+pub struct PostNotification(pub String);
+
+impl Command for PostNotification {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        write!(f, "\x1b]9;{}\x07", self.0)
+    }
+
+    #[cfg(windows)]
+    fn execute_winapi(&self) -> io::Result<()> {
+        Err(std::io::Error::other(
+            "tried to execute PostNotification using WinAPI; use ANSI instead",
+        ))
+    }
+
+    #[cfg(windows)]
+    fn is_ansi_code_supported(&self) -> bool {
+        true
+    }
+}

--- a/codex-rs/tui2/src/notifications/windows_toast.rs
+++ b/codex-rs/tui2/src/notifications/windows_toast.rs
@@ -1,0 +1,128 @@
+use std::io;
+use std::process::Command;
+use std::process::Stdio;
+
+use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
+
+const APP_ID: &str = "Codex";
+const POWERSHELL_EXE: &str = "powershell.exe";
+
+#[derive(Debug)]
+pub struct WindowsToastBackend {
+    encoded_title: String,
+}
+
+impl WindowsToastBackend {
+    pub fn notify(&mut self, message: &str) -> io::Result<()> {
+        let encoded_body = encode_argument(message);
+        let encoded_command = build_encoded_command(&self.encoded_title, &encoded_body);
+        spawn_powershell(encoded_command)
+    }
+}
+
+impl Default for WindowsToastBackend {
+    fn default() -> Self {
+        WindowsToastBackend {
+            encoded_title: encode_argument(APP_ID),
+        }
+    }
+}
+
+fn spawn_powershell(encoded_command: String) -> io::Result<()> {
+    let mut command = Command::new(POWERSHELL_EXE);
+    command
+        .arg("-NoProfile")
+        .arg("-NoLogo")
+        .arg("-EncodedCommand")
+        .arg(encoded_command)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    let status = command.status()?;
+    if status.success() {
+        Ok(())
+    } else {
+        Err(io::Error::other(format!(
+            "{POWERSHELL_EXE} exited with status {status}"
+        )))
+    }
+}
+
+fn build_encoded_command(encoded_title: &str, encoded_body: &str) -> String {
+    let script = build_ps_script(encoded_title, encoded_body);
+    encode_script_for_powershell(&script)
+}
+
+fn build_ps_script(encoded_title: &str, encoded_body: &str) -> String {
+    format!(
+        r#"
+$encoding = [System.Text.Encoding]::UTF8
+$titleText = $encoding.GetString([System.Convert]::FromBase64String("{encoded_title}"))
+$bodyText = $encoding.GetString([System.Convert]::FromBase64String("{encoded_body}"))
+[Windows.UI.Notifications.ToastNotificationManager, Windows.UI.Notifications, ContentType = WindowsRuntime] | Out-Null
+$doc = [Windows.UI.Notifications.ToastNotificationManager]::GetTemplateContent([Windows.UI.Notifications.ToastTemplateType]::ToastText02)
+$textNodes = $doc.GetElementsByTagName("text")
+$textNodes.Item(0).AppendChild($doc.CreateTextNode($titleText)) | Out-Null
+$textNodes.Item(1).AppendChild($doc.CreateTextNode($bodyText)) | Out-Null
+$toast = [Windows.UI.Notifications.ToastNotification]::new($doc)
+[Windows.UI.Notifications.ToastNotificationManager]::CreateToastNotifier('Codex').Show($toast)
+"#,
+    )
+}
+
+fn encode_script_for_powershell(script: &str) -> String {
+    let mut wide: Vec<u8> = Vec::with_capacity((script.len() + 1) * 2);
+    for unit in script.encode_utf16() {
+        let bytes = unit.to_le_bytes();
+        wide.extend_from_slice(&bytes);
+    }
+    BASE64.encode(wide)
+}
+
+fn encode_argument(value: &str) -> String {
+    BASE64.encode(escape_for_xml(value))
+}
+
+pub fn escape_for_xml(input: &str) -> String {
+    let mut escaped = String::with_capacity(input.len());
+    for ch in input.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::encode_script_for_powershell;
+    use super::escape_for_xml;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn escapes_xml_entities() {
+        assert_eq!(escape_for_xml("5 > 3"), "5 &gt; 3");
+        assert_eq!(escape_for_xml("a & b"), "a &amp; b");
+        assert_eq!(escape_for_xml("<tag>"), "&lt;tag&gt;");
+        assert_eq!(escape_for_xml("\"quoted\""), "&quot;quoted&quot;");
+        assert_eq!(escape_for_xml("single 'quote'"), "single &apos;quote&apos;");
+    }
+
+    #[test]
+    fn leaves_safe_text_unmodified() {
+        assert_eq!(escape_for_xml("codex"), "codex");
+        assert_eq!(escape_for_xml("multi word text"), "multi word text");
+    }
+
+    #[test]
+    fn encodes_utf16le_for_powershell() {
+        assert_eq!(encode_script_for_powershell("A"), "QQA=");
+    }
+}

--- a/codex-rs/tui2/src/snapshots/codex_tui2__model_migration__tests__model_migration_prompt.snap
+++ b/codex-rs/tui2/src/snapshots/codex_tui2__model_migration__tests__model_migration_prompt.snap
@@ -2,14 +2,15 @@
 source: tui2/src/model_migration.rs
 expression: terminal.backend()
 ---
-> Codex just got an upgrade. Introducing gpt-5.1-codex-max
+> Try gpt-5.1-codex-max
 
-  Codex is now powered by gpt-5.1-codex-max, our latest
-  frontier agentic coding model. It is smarter and faster
-  than its predecessors and capable of long-running
-  project-scale work.
+  We recommend switching from gpt-5.1-codex-mini to
+  gpt-5.1-codex-max.
 
-  Learn more at https://openai.com/index/gpt-5-1-codex-max/.
+  Latest Codex-optimized flagship for deep and fast
+  reasoning.
+
+  You can continue using gpt-5.1-codex-mini if you prefer.
 
   Choose how you'd like Codex to proceed.
 

--- a/codex-rs/tui2/src/snapshots/codex_tui2__model_migration__tests__model_migration_prompt_gpt5_codex.snap
+++ b/codex-rs/tui2/src/snapshots/codex_tui2__model_migration__tests__model_migration_prompt_gpt5_codex.snap
@@ -2,14 +2,12 @@
 source: tui2/src/model_migration.rs
 expression: terminal.backend()
 ---
-> Introducing our gpt-5.1 models
+> Try gpt-5.1-codex-max
 
-  We've upgraded our family of models supported in Codex to
-  gpt-5.1, gpt-5.1-codex and gpt-5.1-codex-mini.
+  We recommend switching from gpt-5-codex to
+  gpt-5.1-codex-max.
 
-  You can continue using legacy models by specifying them
-  directly with the -m option or in your config.toml.
-
-  Learn more at https://openai.com/index/gpt-5-1/.
+  Latest Codex-optimized flagship for deep and fast
+  reasoning.
 
   Press enter to continue

--- a/codex-rs/tui2/src/snapshots/codex_tui2__model_migration__tests__model_migration_prompt_gpt5_codex_mini.snap
+++ b/codex-rs/tui2/src/snapshots/codex_tui2__model_migration__tests__model_migration_prompt_gpt5_codex_mini.snap
@@ -2,14 +2,11 @@
 source: tui2/src/model_migration.rs
 expression: terminal.backend()
 ---
-> Introducing our gpt-5.1 models
+> Try gpt-5.1-codex-mini
 
-  We've upgraded our family of models supported in Codex to
-  gpt-5.1, gpt-5.1-codex and gpt-5.1-codex-mini.
+  We recommend switching from gpt-5-codex-mini to
+  gpt-5.1-codex-mini.
 
-  You can continue using legacy models by specifying them
-  directly with the -m option or in your config.toml.
-
-  Learn more at https://openai.com/index/gpt-5-1/.
+  Optimized for codex. Cheaper, faster, but less capable.
 
   Press enter to continue

--- a/codex-rs/tui2/src/snapshots/codex_tui2__model_migration__tests__model_migration_prompt_gpt5_family.snap
+++ b/codex-rs/tui2/src/snapshots/codex_tui2__model_migration__tests__model_migration_prompt_gpt5_family.snap
@@ -2,14 +2,10 @@
 source: tui2/src/model_migration.rs
 expression: terminal.backend()
 ---
-> Introducing our gpt-5.1 models
+> Try gpt-5.1
 
-  We've upgraded our family of models supported in Codex to
-  gpt-5.1, gpt-5.1-codex and gpt-5.1-codex-mini.
+  We recommend switching from gpt-5 to gpt-5.1.
 
-  You can continue using legacy models by specifying them
-  directly with the -m option or in your config.toml.
-
-  Learn more at https://openai.com/index/gpt-5-1/.
+  Broad world knowledge with strong general reasoning.
 
   Press enter to continue

--- a/codex-rs/tui2/styles.md
+++ b/codex-rs/tui2/styles.md
@@ -1,0 +1,21 @@
+# Headers, primary, and secondary text
+
+- **Headers:** Use `bold`. For markdown with various header levels, leave in the `#` signs.
+- **Primary text:** Default.
+- **Secondary text:** Use `dim`.
+
+# Foreground colors
+
+- **Default:** Most of the time, just use the default foreground color. `reset` can help get it back.
+- **User input tips, selection, and status indicators:** Use ANSI `cyan`.
+- **Success and additions:** Use ANSI `green`.
+- **Errors, failures and deletions:** Use ANSI `red`.
+- **Codex:** Use ANSI `magenta`.
+
+# Avoid
+
+- Avoid custom colors because there's no guarantee that they'll contrast well or look good in various terminal color themes. (`shimmer.rs` is an exception that works well because we take the default colors and just adjust their levels.)
+- Avoid ANSI `black` & `white` as foreground colors because the default terminal theme color will do a better job. (Use `reset` if you need to in order to get those.) The exception is if you need contrast rendering over a manually colored background.
+- Avoid ANSI `blue` and `yellow` because for now the style guide doesn't use them. Prefer a foreground color mentioned above.
+
+(There are some rules to try to catch this in `clippy.toml`.)

--- a/codex-rs/tui2/tests/all.rs
+++ b/codex-rs/tui2/tests/all.rs
@@ -1,0 +1,6 @@
+// Single integration test binary that aggregates all test modules.
+// The submodules live in `tests/suite/`.
+#[cfg(feature = "vt100-tests")]
+mod test_backend;
+
+mod suite;

--- a/codex-rs/tui2/tests/fixtures/oss-story.jsonl
+++ b/codex-rs/tui2/tests/fixtures/oss-story.jsonl
@@ -1,0 +1,8041 @@
+{"ts":"2025-08-10T03:12:26.500Z","dir":"meta","kind":"session_start","cwd":"/Users/easong/code/codex/codex-rs","model":"gpt-oss:20b","model_provider_id":"oss","model_provider_name":"gpt-oss"}
+{"ts":"2025-08-10T03:12:26.500Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:26.502Z","dir":"to_tui","kind":"log_line","line":"[INFO codex_core::codex] resume_path: None"}
+{"ts":"2025-08-10T03:12:26.502Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:26.519Z","dir":"to_tui","kind":"codex_event","payload":{"id":"0","msg":{"type":"session_configured","session_id":"8f7c4ac2-6141-42da-b4d5-7032a8e8df3b","model":"gpt-oss:20b","history_log_id":2532619,"history_entry_count":355}}}
+{"ts":"2025-08-10T03:12:26.520Z","dir":"to_tui","kind":"insert_history","lines":9}
+{"ts":"2025-08-10T03:12:26.520Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:26.520Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:26.522Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:28.561Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('h'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:12:28.563Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:28.564Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:28.650Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('h'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:12:28.676Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('e'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:12:28.676Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:28.678Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:28.748Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('e'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:12:28.810Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('l'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:12:28.810Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:28.812Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:28.868Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('l'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:12:28.947Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('l'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:12:28.947Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:28.949Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:29.007Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('l'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:12:29.102Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('o'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:12:29.103Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:29.107Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:29.151Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('o'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:12:29.189Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Enter, modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:12:29.189Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:29.190Z","dir":"to_tui","kind":"insert_history","lines":3}
+{"ts":"2025-08-10T03:12:29.190Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:29.192Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:29.191Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"task_started"}}}
+{"ts":"2025-08-10T03:12:29.291Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:29.291Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:29.291Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:29.293Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:29.396Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:29.398Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:29.501Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:29.503Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:29.606Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:29.608Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:29.708Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:29.709Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:29.812Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:29.813Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:29.913Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:29.915Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:30.018Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:30.020Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:30.119Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:30.120Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:30.219Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:30.220Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:30.320Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:30.321Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:30.420Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:30.421Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:30.523Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:30.524Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:30.626Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:30.627Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:30.726Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:30.727Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:30.826Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:30.827Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:30.926Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:30.927Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:31.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:31.028Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:31.127Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:31.129Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:31.231Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:31.232Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:31.334Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:31.335Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:31.436Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:31.437Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:31.536Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:31.537Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:31.637Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:31.638Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:31.737Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:31.738Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:31.837Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:31.838Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:31.938Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:31.939Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:32.039Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:32.040Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:32.142Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:32.144Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:32.244Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:32.246Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:32.345Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:32.346Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:32.445Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:32.446Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:32.545Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:32.547Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:32.650Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:32.651Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:32.750Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:32.752Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:32.854Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:32.855Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:32.959Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:32.960Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:33.063Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:33.065Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:33.166Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:33.167Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:33.271Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:33.272Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:33.377Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:33.378Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:33.478Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:33.480Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:33.583Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:33.585Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:33.688Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:33.690Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:33.792Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:33.794Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:33.895Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:33.897Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:34.000Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:34.002Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:34.105Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:34.107Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:34.211Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:34.212Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:34.312Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:34.313Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:34.417Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:34.418Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:34.524Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:34.525Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:34.629Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:34.630Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:34.731Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:34.732Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:34.836Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:34.837Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:34.937Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:34.938Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:35.038Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:35.039Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:35.143Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:35.144Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:35.246Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:35.247Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:35.347Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:35.348Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:35.452Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:35.453Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:35.557Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:35.558Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:35.662Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:35.663Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:35.763Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:35.765Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:35.868Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:35.870Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:35.970Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:35.972Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:36.071Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:36.073Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:36.174Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:36.175Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:36.279Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:36.280Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:36.384Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:36.385Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:36.489Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:36.491Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:36.593Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:36.595Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:36.699Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:36.700Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:36.804Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:36.805Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:36.909Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:36.910Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:37.011Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:37.012Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:37.116Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:37.117Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:37.221Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:37.222Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:37.322Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:37.324Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:37.427Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:37.429Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:37.533Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:37.534Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:37.638Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:37.639Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:37.742Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:37.743Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:37.842Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:37.844Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:37.948Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:37.950Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:38.049Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:38.050Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:38.154Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:38.155Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:38.259Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:38.260Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:38.364Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:38.365Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:38.466Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:38.468Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:38.571Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:38.573Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:38.676Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:38.678Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:38.781Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:38.783Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:38.887Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:38.888Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:38.988Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:38.990Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:39.092Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:39.094Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:39.197Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:39.199Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:39.300Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:39.301Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:39.405Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:39.406Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:39.509Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:39.510Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:39.609Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:39.610Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:39.714Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:39.716Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:39.819Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:39.821Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:39.924Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:39.926Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:40.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:40.027Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:40.132Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:40.133Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:40.236Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:40.237Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:40.338Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:40.339Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:40.443Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:40.445Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:40.545Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:40.547Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:40.650Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:40.652Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:40.756Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:40.757Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:40.859Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:40.861Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:40.964Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:40.966Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:41.066Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:41.067Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:41.168Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:41.169Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:41.273Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:41.275Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:41.378Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:41.379Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:41.479Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:41.480Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:41.584Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:41.585Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:41.689Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:41.690Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:41.794Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:41.795Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:41.899Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:41.901Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:42.004Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:42.006Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:42.105Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:42.106Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:42.209Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:42.210Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:42.312Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:42.313Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:42.417Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:42.418Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:42.521Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:42.523Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:42.626Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:42.628Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:42.729Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:42.730Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:42.829Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:42.831Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:42.934Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:42.936Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:43.039Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:43.041Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:43.142Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:43.144Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:43.247Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:43.249Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:43.352Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:43.354Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:43.457Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:43.459Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:43.559Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:43.560Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:43.659Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:43.660Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:43.762Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:43.763Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:43.867Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:43.869Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:43.972Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:43.974Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:44.077Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:44.079Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:44.182Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:44.184Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:44.287Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:44.289Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:44.392Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:44.394Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:44.497Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:44.499Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:44.603Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:44.604Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:44.708Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:44.709Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:44.809Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:44.810Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:44.911Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:44.913Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:45.015Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:45.016Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:45.120Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:45.121Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:45.221Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:45.223Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:45.328Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:45.329Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:45.429Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:45.430Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:45.529Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:45.530Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:45.634Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:45.635Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:45.739Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:45.742Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:45.844Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:45.845Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:45.949Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:45.950Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:46.054Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:46.055Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:46.159Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:46.161Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:46.262Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:46.263Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:46.367Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:46.369Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:46.472Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:46.474Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:46.576Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:46.577Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:46.679Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:46.680Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:46.784Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:46.785Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:46.887Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:46.889Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:46.989Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:46.991Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:47.095Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:47.096Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:47.200Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:47.201Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:47.305Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:47.306Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:47.409Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:47.410Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:47.513Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:47.515Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:47.618Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:47.620Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:47.720Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:47.722Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:47.821Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:47.823Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:47.926Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:47.927Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:48.031Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:48.032Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:48.136Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:48.137Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:48.241Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:48.242Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:48.342Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:48.344Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:48.443Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:48.444Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:48.548Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:48.549Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:48.653Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:48.654Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:48.758Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:48.759Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:48.859Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:48.860Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:48.959Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:48.960Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:49.064Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:49.065Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:49.169Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:49.170Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:49.274Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:49.276Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:49.376Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:49.377Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:49.481Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:49.482Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:49.586Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:49.587Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:49.691Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:49.692Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:49.796Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:49.797Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:49.901Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:49.902Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:50.004Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.005Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:50.107Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.108Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:50.208Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.210Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:50.312Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.313Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:50.417Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.418Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:50.523Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.524Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:50.628Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.629Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:50.731Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.733Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:50.836Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.837Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:50.921Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":"The"}}}
+{"ts":"2025-08-10T03:12:50.921Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.921Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:12:50.921Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.921Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.923Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:50.937Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.947Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" user"}}}
+{"ts":"2025-08-10T03:12:50.973Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" says"}}}
+{"ts":"2025-08-10T03:12:50.990Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.990Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.990Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.990Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.992Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:50.999Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":":"}}}
+{"ts":"2025-08-10T03:12:50.999Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:50.999Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.000Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.026Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" \""}}}
+{"ts":"2025-08-10T03:12:51.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.027Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.042Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.044Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.052Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":"hello"}}}
+{"ts":"2025-08-10T03:12:51.052Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.052Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.053Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.079Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":"\"."}}}
+{"ts":"2025-08-10T03:12:51.079Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.079Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.080Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.105Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" So"}}}
+{"ts":"2025-08-10T03:12:51.105Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.105Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.106Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.131Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" they've"}}}
+{"ts":"2025-08-10T03:12:51.131Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.131Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.133Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.143Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.144Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.158Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" greeted"}}}
+{"ts":"2025-08-10T03:12:51.158Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.158Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.159Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.184Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:12:51.184Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.184Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.185Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.210Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" assistant"}}}
+{"ts":"2025-08-10T03:12:51.210Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.210Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.212Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.237Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:12:51.237Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.237Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.238Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.248Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.249Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.263Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" Probably"}}}
+{"ts":"2025-08-10T03:12:51.263Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.263Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.265Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.289Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" user"}}}
+{"ts":"2025-08-10T03:12:51.289Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.289Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.291Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.316Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" is"}}}
+{"ts":"2025-08-10T03:12:51.316Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.316Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.317Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.342Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" not"}}}
+{"ts":"2025-08-10T03:12:51.342Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.342Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.343Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.349Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.351Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.368Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" asking"}}}
+{"ts":"2025-08-10T03:12:51.368Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.368Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.369Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.395Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:12:51.395Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.395Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.396Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.421Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" question"}}}
+{"ts":"2025-08-10T03:12:51.421Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.421Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.423Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.447Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:12:51.447Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.447Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.448Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.454Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.456Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.474Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" Maybe"}}}
+{"ts":"2025-08-10T03:12:51.474Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.474Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.475Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.500Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" expecting"}}}
+{"ts":"2025-08-10T03:12:51.500Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.500Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.501Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.526Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" acknowledgment"}}}
+{"ts":"2025-08-10T03:12:51.526Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.526Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.528Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.553Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:12:51.553Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.553Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.554Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.559Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.561Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.579Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" They"}}}
+{"ts":"2025-08-10T03:12:51.579Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.579Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.580Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.606Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" might"}}}
+{"ts":"2025-08-10T03:12:51.606Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.606Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.607Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.632Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" want"}}}
+{"ts":"2025-08-10T03:12:51.632Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.632Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.633Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.659Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:12:51.659Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.659Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.660Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.662Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.663Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.685Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" reply"}}}
+{"ts":"2025-08-10T03:12:51.685Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.685Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.687Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.712Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" like"}}}
+{"ts":"2025-08-10T03:12:51.712Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.712Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.713Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.738Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" \""}}}
+{"ts":"2025-08-10T03:12:51.738Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.738Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.739Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.765Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.765Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":"Hello"}}}
+{"ts":"2025-08-10T03:12:51.765Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.765Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.766Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.791Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":"\""}}}
+{"ts":"2025-08-10T03:12:51.791Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.791Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.792Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.817Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" or"}}}
+{"ts":"2025-08-10T03:12:51.817Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.817Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.818Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.843Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" ask"}}}
+{"ts":"2025-08-10T03:12:51.843Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.843Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.845Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.870Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" if"}}}
+{"ts":"2025-08-10T03:12:51.870Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.870Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.870Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.871Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.896Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" something"}}}
+{"ts":"2025-08-10T03:12:51.896Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.896Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.897Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.922Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:12:51.922Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.922Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.923Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.948Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" As"}}}
+{"ts":"2025-08-10T03:12:51.948Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.948Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.949Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:51.974Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.974Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" per"}}}
+{"ts":"2025-08-10T03:12:51.974Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.974Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:51.975Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.000Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" user"}}}
+{"ts":"2025-08-10T03:12:52.000Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.000Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.001Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.026Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" instructions"}}}
+{"ts":"2025-08-10T03:12:52.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.027Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.064Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":","}}}
+{"ts":"2025-08-10T03:12:52.065Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.065Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.066Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.076Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.077Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.091Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" not"}}}
+{"ts":"2025-08-10T03:12:52.091Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.091Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.092Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.117Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:12:52.117Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.117Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.118Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.144Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" change"}}}
+{"ts":"2025-08-10T03:12:52.144Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.144Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.145Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.170Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" code"}}}
+{"ts":"2025-08-10T03:12:52.170Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.170Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.171Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.181Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.182Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.196Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:12:52.196Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.196Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.198Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.222Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" They"}}}
+{"ts":"2025-08-10T03:12:52.222Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.222Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.223Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.248Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" probably"}}}
+{"ts":"2025-08-10T03:12:52.248Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.248Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.250Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.275Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" just"}}}
+{"ts":"2025-08-10T03:12:52.275Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.275Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.276Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.286Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.287Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.301Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" want"}}}
+{"ts":"2025-08-10T03:12:52.301Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.301Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.302Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.327Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:12:52.327Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.327Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.328Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.353Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" response"}}}
+{"ts":"2025-08-10T03:12:52.353Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.353Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.354Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.379Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:12:52.379Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.379Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.380Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.387Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.388Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.406Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" I'll"}}}
+{"ts":"2025-08-10T03:12:52.406Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.406Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.407Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.432Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" just"}}}
+{"ts":"2025-08-10T03:12:52.432Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.432Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.433Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.458Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" reply"}}}
+{"ts":"2025-08-10T03:12:52.458Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.458Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.460Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.484Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":" politely"}}}
+{"ts":"2025-08-10T03:12:52.484Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.484Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.486Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.492Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.493Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.510Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:12:52.510Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.511Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.512Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.597Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.598Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.694Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_message_delta","delta":"Hello"}}}
+{"ts":"2025-08-10T03:12:52.694Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.694Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.696Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.702Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.703Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.720Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_message_delta","delta":"!"}}}
+{"ts":"2025-08-10T03:12:52.720Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.720Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.721Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.747Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_message_delta","delta":" How"}}}
+{"ts":"2025-08-10T03:12:52.747Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.747Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.748Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.773Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_message_delta","delta":" can"}}}
+{"ts":"2025-08-10T03:12:52.773Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.773Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.774Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.799Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_message_delta","delta":" I"}}}
+{"ts":"2025-08-10T03:12:52.800Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.800Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.801Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.805Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.806Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.826Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_message_delta","delta":" help"}}}
+{"ts":"2025-08-10T03:12:52.826Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.826Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.827Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.852Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_message_delta","delta":" you"}}}
+{"ts":"2025-08-10T03:12:52.852Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.852Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.853Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.878Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_message_delta","delta":" today"}}}
+{"ts":"2025-08-10T03:12:52.878Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.878Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.879Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.904Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_message_delta","delta":"?"}}}
+{"ts":"2025-08-10T03:12:52.904Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.904Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.906Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.906Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.908Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:52.931Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"agent_message","message":"Hello! How can I help you today?"}}}
+{"ts":"2025-08-10T03:12:52.931Z","dir":"to_tui","kind":"codex_event","payload":{"id":"1","msg":{"type":"task_complete","last_agent_message":"Hello! How can I help you today?"}}}
+{"ts":"2025-08-10T03:12:52.931Z","dir":"to_tui","kind":"insert_history","lines":3}
+{"ts":"2025-08-10T03:12:52.931Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.931Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.931Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:52.932Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:12:53.011Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:12:53.013Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:54.286Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('h'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:54.286Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:54.288Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:54.368Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('h'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:54.430Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('e'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:54.430Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:54.432Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:54.510Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('e'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:54.523Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('l'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:54.523Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:54.524Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:54.579Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('l'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:54.663Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('l'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:54.663Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:54.664Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:54.721Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('l'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:54.813Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('o'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:54.813Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:54.814Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:54.889Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char(' '), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:54.889Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:54.890Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:54.931Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('o'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:54.971Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char(' '), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:55.043Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('a'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:55.043Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:55.044Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:55.114Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('a'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:55.128Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('g'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:55.128Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:55.130Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:55.194Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('g'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:55.247Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('a'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:55.247Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:55.248Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:55.300Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('i'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:55.300Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:55.302Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:55.342Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('a'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:55.367Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('i'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:55.461Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('n'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:55.461Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:55.462Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:55.525Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('n'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:55.618Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Enter, modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:21:55.618Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:55.618Z","dir":"to_tui","kind":"insert_history","lines":3}
+{"ts":"2025-08-10T03:21:55.619Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:55.619Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"task_started"}}}
+{"ts":"2025-08-10T03:21:55.619Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:55.619Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:55.619Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:55.620Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:55.719Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:55.721Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:55.820Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:55.821Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:55.924Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:55.925Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:56.027Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:56.028Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:56.128Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:56.129Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:56.228Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:56.229Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:56.330Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:56.332Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:56.431Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:56.432Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:56.533Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:56.535Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:56.635Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:56.636Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:56.736Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:56.737Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:56.836Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:56.837Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:56.940Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:56.941Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:57.040Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:57.042Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:57.145Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:57.147Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:57.249Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:57.251Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:57.351Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:57.352Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:57.451Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:57.452Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:57.552Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:57.553Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:57.656Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:57.658Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:57.761Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:57.762Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:57.864Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:57.865Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:57.967Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:57.968Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:58.068Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:58.069Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:58.173Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:58.174Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:58.278Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:58.279Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:58.382Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:58.383Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:58.487Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:58.488Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:58.590Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:58.591Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:58.695Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:58.696Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:58.797Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:58.798Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:58.900Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:58.901Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:59.000Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:59.002Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:59.105Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:59.107Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:59.210Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:59.212Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:59.313Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:59.314Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:59.417Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:59.418Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:59.522Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:59.523Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:59.627Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:59.628Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:59.732Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:59.733Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:59.834Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:59.835Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:21:59.934Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:21:59.935Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:00.036Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:00.039Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:00.137Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:00.139Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:00.242Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:00.244Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:00.347Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:00.349Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:00.452Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:00.454Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:00.554Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:00.556Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:00.660Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:00.661Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:00.761Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:00.762Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:00.866Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:00.867Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:00.972Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:00.973Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:01.077Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:01.078Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:01.182Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:01.183Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:01.287Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:01.288Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:01.392Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:01.393Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:01.396Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('w'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:22:01.396Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:01.397Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:01.464Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('w'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:22:01.496Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:01.498Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:01.594Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('r'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:22:01.594Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:01.595Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:01.601Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:01.602Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:01.667Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('r'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:22:01.706Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:01.708Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:01.714Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('i'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:22:01.714Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:01.716Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:01.811Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:01.813Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:01.818Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('i'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:22:01.834Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('t'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:22:01.834Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:01.836Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:01.902Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('t'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:22:01.916Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:01.918Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:02.021Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:02.023Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:02.026Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('e'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:22:02.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:02.027Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:02.074Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char(' '), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:22:02.074Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:02.075Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:02.113Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('e'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:22:02.126Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:02.128Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:02.150Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char(' '), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:22:02.229Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:02.231Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:02.334Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:02.336Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:02.440Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:02.441Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:02.545Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:02.546Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:02.648Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:02.649Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:02.752Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:02.754Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:02.857Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:02.858Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:02.962Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:02.964Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:03.063Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:03.064Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:03.167Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:03.168Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:03.272Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:03.273Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:03.377Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:03.378Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:03.480Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:03.481Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:03.585Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:03.587Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:03.690Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:03.691Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:03.795Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:03.796Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:03.900Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:03.901Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:04.002Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:04.004Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:04.108Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:04.110Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:04.213Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:04.214Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:04.318Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:04.319Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:04.419Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:04.421Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:04.526Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:04.527Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:04.627Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:04.629Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:04.728Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:04.729Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:04.833Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:04.834Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:04.936Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:04.937Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:05.041Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:05.042Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:05.144Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:05.146Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:05.249Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:05.251Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:05.354Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:05.355Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:05.454Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:05.455Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:05.556Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:05.557Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:05.661Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:05.662Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:05.761Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:05.762Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:05.866Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:05.867Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:05.969Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:05.971Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:06.070Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:06.071Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:06.172Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:06.173Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:06.277Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:06.278Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:06.382Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:06.522Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:06.626Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:06.627Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:06.731Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:06.732Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:06.836Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:06.837Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:06.941Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:06.942Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:07.046Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:07.047Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:07.151Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:07.152Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:07.256Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:07.258Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:07.362Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:07.363Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:07.463Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:07.464Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:07.568Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:07.569Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:07.673Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:07.674Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:07.773Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:07.775Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:07.879Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:07.880Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:07.984Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:07.985Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:08.089Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:08.090Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:08.194Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:08.195Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:08.299Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:08.300Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:08.404Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:08.405Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:08.509Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:08.510Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:08.614Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:08.616Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:08.719Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:08.721Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:08.824Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:08.826Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:08.929Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:08.931Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:09.035Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:09.036Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:09.138Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:09.139Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:09.240Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:09.241Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:09.345Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:09.346Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:09.447Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:09.449Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:09.552Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:09.554Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:09.654Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:09.655Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:09.759Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:09.760Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:09.864Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:09.865Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:09.967Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:09.969Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:10.073Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:10.074Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:10.178Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:10.179Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:10.280Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:10.281Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:10.385Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:10.386Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:10.490Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:10.492Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:10.594Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:10.596Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:10.696Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:10.697Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:10.800Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:10.802Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:10.902Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:10.904Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:11.008Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:11.009Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:11.113Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:11.114Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:11.218Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:11.219Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:11.323Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:11.324Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:11.423Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:11.425Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:11.529Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:11.530Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:11.632Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:11.633Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:11.734Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:11.735Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:11.836Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:11.837Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:11.941Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:11.942Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:12.046Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:12.047Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:12.151Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:12.152Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:12.256Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:12.257Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:12.361Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:12.363Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:12.466Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:12.468Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:12.571Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:12.573Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:12.676Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:12.678Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:12.782Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:12.783Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:12.887Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:12.888Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:12.992Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:12.993Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:13.097Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:13.098Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:13.202Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:13.204Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:13.306Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:13.307Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:13.407Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:13.408Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:13.512Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:13.513Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:13.617Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:13.618Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:13.722Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:13.724Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:13.827Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:13.829Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:13.932Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:13.934Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:14.037Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:14.039Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:14.138Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:14.140Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:14.240Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:14.241Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:14.345Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:14.347Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:14.450Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:14.452Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:14.556Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:14.557Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:14.661Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:14.662Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:14.763Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:14.764Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:14.868Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:14.870Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:14.973Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:14.975Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:15.079Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:15.080Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:15.184Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:15.185Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:15.289Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:15.290Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:15.394Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:15.395Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:15.499Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:15.500Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:15.600Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:15.602Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:15.706Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:15.707Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:15.811Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:15.812Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:15.916Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:15.917Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.021Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.022Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.126Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.127Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.231Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.232Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.334Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.335Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.434Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.436Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.510Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":"We"}}}
+{"ts":"2025-08-10T03:22:16.510Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.510Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:22:16.510Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.510Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.511Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.535Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.535Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":" need"}}}
+{"ts":"2025-08-10T03:22:16.561Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:22:16.587Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":" respond"}}}
+{"ts":"2025-08-10T03:22:16.595Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.595Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.595Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.595Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.595Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.595Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.596Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.613Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:22:16.613Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.613Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.614Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.638Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":" The"}}}
+{"ts":"2025-08-10T03:22:16.639Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.639Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.640Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.640Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.641Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.665Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":" user"}}}
+{"ts":"2025-08-10T03:22:16.665Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.665Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.666Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.691Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":" said"}}}
+{"ts":"2025-08-10T03:22:16.691Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.691Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.692Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.717Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":" \""}}}
+{"ts":"2025-08-10T03:22:16.717Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.717Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.718Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.743Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":"hello"}}}
+{"ts":"2025-08-10T03:22:16.743Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.743Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.743Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.744Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.769Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":" again"}}}
+{"ts":"2025-08-10T03:22:16.769Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.769Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.771Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.796Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":"\"."}}}
+{"ts":"2025-08-10T03:22:16.796Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.796Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.797Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.822Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":" No"}}}
+{"ts":"2025-08-10T03:22:16.822Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.822Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.824Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.848Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.848Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":" specific"}}}
+{"ts":"2025-08-10T03:22:16.848Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.848Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.849Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.874Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":" task"}}}
+{"ts":"2025-08-10T03:22:16.874Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.874Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.876Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.900Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:22:16.900Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.900Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.902Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.926Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":" Probably"}}}
+{"ts":"2025-08-10T03:22:16.926Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.927Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.928Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.948Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.950Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.953Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":" just"}}}
+{"ts":"2025-08-10T03:22:16.953Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.953Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.954Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:16.979Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":" greeting"}}}
+{"ts":"2025-08-10T03:22:16.979Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.979Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:16.980Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.005Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:22:17.005Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.006Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.007Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.053Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.055Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.157Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.158Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.198Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":"Hi"}}}
+{"ts":"2025-08-10T03:22:17.198Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.199Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.200Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.225Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":"!"}}}
+{"ts":"2025-08-10T03:22:17.226Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.226Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.227Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.253Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" If"}}}
+{"ts":"2025-08-10T03:22:17.253Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.253Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.254Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.259Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.260Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.280Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" you"}}}
+{"ts":"2025-08-10T03:22:17.280Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.280Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.281Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.307Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" have"}}}
+{"ts":"2025-08-10T03:22:17.307Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.308Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.309Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.335Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:22:17.335Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.335Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.336Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.362Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.362Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" task"}}}
+{"ts":"2025-08-10T03:22:17.362Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.362Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.363Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.389Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" or"}}}
+{"ts":"2025-08-10T03:22:17.390Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.390Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.391Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.417Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" question"}}}
+{"ts":"2025-08-10T03:22:17.417Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.417Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.419Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.445Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" about"}}}
+{"ts":"2025-08-10T03:22:17.445Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.445Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.446Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.467Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.468Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.473Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:22:17.473Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.473Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.475Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.501Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" repository"}}}
+{"ts":"2025-08-10T03:22:17.501Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.501Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.503Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.530Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:22:17.530Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.530Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.535Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.559Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" feel"}}}
+{"ts":"2025-08-10T03:22:17.559Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.560Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.561Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.572Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.573Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.588Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" free"}}}
+{"ts":"2025-08-10T03:22:17.588Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.588Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.589Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.615Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:22:17.615Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.615Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.617Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.643Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" let"}}}
+{"ts":"2025-08-10T03:22:17.643Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.643Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.645Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.670Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" me"}}}
+{"ts":"2025-08-10T03:22:17.671Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.671Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.672Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.677Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.678Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.697Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":" know"}}}
+{"ts":"2025-08-10T03:22:17.697Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.697Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.699Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.723Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message_delta","delta":"!"}}}
+{"ts":"2025-08-10T03:22:17.723Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.724Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.725Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.750Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"agent_message","message":"Hi! If you have a task or question about the repository, feel free to let me know!"}}}
+{"ts":"2025-08-10T03:22:17.750Z","dir":"to_tui","kind":"codex_event","payload":{"id":"3","msg":{"type":"task_complete","last_agent_message":"Hi! If you have a task or question about the repository, feel free to let me know!"}}}
+{"ts":"2025-08-10T03:22:17.750Z","dir":"to_tui","kind":"insert_history","lines":3}
+{"ts":"2025-08-10T03:22:17.750Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.750Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.750Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.751Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:22:17.782Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:22:17.807Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:02.908Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:02.909Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:02.935Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:02.937Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:02.961Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:02.965Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:04.584Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:04.585Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:04.617Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:04.621Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:04.648Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:04.650Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:04.730Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:04.732Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:04.764Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:04.765Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:04.792Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:04.794Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:04.823Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:04.827Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:04.849Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:04.850Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:18.326Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('w'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:18.327Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:18.329Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:18.427Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('w'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:18.664Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('r'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:18.664Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:18.666Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:18.739Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('r'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:18.793Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('i'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:18.794Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:18.797Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:18.868Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('t'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:18.868Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:18.870Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:18.884Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('i'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:18.933Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('t'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.033Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('e'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.033Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:19.035Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:19.073Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char(' '), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.074Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:19.076Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:19.113Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('e'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.137Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char(' '), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.214Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('m'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.214Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:19.216Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:19.280Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('e'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.280Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:19.281Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:19.288Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('m'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.350Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('e'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.367Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char(' '), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.369Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:19.372Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:19.435Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char(' '), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.488Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('a'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.488Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:19.490Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:19.550Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char(' '), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.551Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:19.553Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:19.568Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('a'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.617Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char(' '), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.749Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('l'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.750Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:19.751Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:19.810Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('l'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.846Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('l'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:19.847Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:19.849Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:19.908Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('l'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:20.152Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('o'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:20.152Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:20.155Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:20.204Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('o'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:20.501Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('n'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:20.502Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:20.503Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:20.571Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('n'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:20.773Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Backspace, modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:20.773Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:20.775Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:20.901Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Backspace, modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:20.902Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:20.905Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:21.073Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Backspace, modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:21.075Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:21.076Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:21.205Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('o'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:21.206Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:21.207Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:21.263Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('o'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:21.401Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('n'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:21.402Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:21.408Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:21.505Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('g'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:21.507Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:21.509Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('n'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:21.509Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:21.579Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('g'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:21.599Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char(' '), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:21.600Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:21.601Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:21.683Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char(' '), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:21.771Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('s'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:21.771Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:21.773Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:21.835Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('s'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:21.954Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('t'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:21.955Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:21.958Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:22.005Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('t'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:22.026Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('o'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:22.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.028Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:22.096Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('o'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:22.114Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('r'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:22.114Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.116Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:22.198Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('r'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:22.213Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('y'), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:22.214Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.216Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:22.277Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char(' '), modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:22.281Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.283Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:22.285Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('y'), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:22.331Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char(' '), modifiers: KeyModifiers(0x0), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:22.432Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Backspace, modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:22.432Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.435Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:22.525Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Enter, modifiers: KeyModifiers(0x0), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:23:22.525Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.525Z","dir":"to_tui","kind":"insert_history","lines":3}
+{"ts":"2025-08-10T03:23:22.525Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.526Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"task_started"}}}
+{"ts":"2025-08-10T03:23:22.526Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.526Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.526Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.527Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:22.628Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.629Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:22.733Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.734Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:22.835Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.837Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:22.940Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.942Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:22.993Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":"User"}}}
+{"ts":"2025-08-10T03:23:22.993Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.993Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:22.993Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.993Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:22.994Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.021Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":":"}}}
+{"ts":"2025-08-10T03:23:23.031Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.031Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.032Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.045Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.047Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.048Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" \""}}}
+{"ts":"2025-08-10T03:23:23.048Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.048Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.049Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.075Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":"write"}}}
+{"ts":"2025-08-10T03:23:23.075Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.075Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.076Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.102Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" me"}}}
+{"ts":"2025-08-10T03:23:23.102Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.102Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.103Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.129Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:23.130Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.130Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.131Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.151Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.152Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.157Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" long"}}}
+{"ts":"2025-08-10T03:23:23.157Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.157Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.158Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.184Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" story"}}}
+{"ts":"2025-08-10T03:23:23.184Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.184Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.185Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.211Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":"\"."}}}
+{"ts":"2025-08-10T03:23:23.211Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.211Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.213Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.239Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" They"}}}
+{"ts":"2025-08-10T03:23:23.239Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.239Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.240Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.252Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.254Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.266Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" didn't"}}}
+{"ts":"2025-08-10T03:23:23.266Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.266Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.267Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.293Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" specify"}}}
+{"ts":"2025-08-10T03:23:23.293Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.293Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.295Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.321Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" details"}}}
+{"ts":"2025-08-10T03:23:23.321Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.321Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.322Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.348Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:23.348Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.349Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.350Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.357Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.358Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.376Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" I"}}}
+{"ts":"2025-08-10T03:23:23.376Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.376Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.377Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.403Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" guess"}}}
+{"ts":"2025-08-10T03:23:23.403Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.403Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.405Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.431Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" we"}}}
+{"ts":"2025-08-10T03:23:23.431Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.431Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.432Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.459Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" just"}}}
+{"ts":"2025-08-10T03:23:23.459Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.459Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.460Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.460Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.462Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.487Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" create"}}}
+{"ts":"2025-08-10T03:23:23.487Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.487Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.488Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.514Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:23.514Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.514Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.516Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.542Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" story"}}}
+{"ts":"2025-08-10T03:23:23.542Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.542Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.543Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.561Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.563Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.569Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:23.569Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.569Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.570Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.596Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" Need"}}}
+{"ts":"2025-08-10T03:23:23.596Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.596Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.598Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.624Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" no"}}}
+{"ts":"2025-08-10T03:23:23.624Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.624Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.625Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.652Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" code"}}}
+{"ts":"2025-08-10T03:23:23.652Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.652Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.653Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.666Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.668Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.679Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" changes"}}}
+{"ts":"2025-08-10T03:23:23.679Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.679Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.680Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.707Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:23.707Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.707Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.708Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.734Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" Could"}}}
+{"ts":"2025-08-10T03:23:23.734Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.734Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.735Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.764Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" output"}}}
+{"ts":"2025-08-10T03:23:23.764Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.764Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.766Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.770Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.771Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.792Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:23.792Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.792Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.793Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.819Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" story"}}}
+{"ts":"2025-08-10T03:23:23.819Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.819Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.820Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.846Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:23.846Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.846Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.848Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.874Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" Should"}}}
+{"ts":"2025-08-10T03:23:23.874Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.874Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.875Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.875Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.901Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" we"}}}
+{"ts":"2025-08-10T03:23:23.901Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.901Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.903Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.929Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" produce"}}}
+{"ts":"2025-08-10T03:23:23.929Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.929Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.930Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.956Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:23.956Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.956Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.957Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.978Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.979Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:23.983Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" story"}}}
+{"ts":"2025-08-10T03:23:23.983Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.983Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:23.985Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.010Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":"?"}}}
+{"ts":"2025-08-10T03:23:24.010Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.010Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.012Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.038Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" Yes"}}}
+{"ts":"2025-08-10T03:23:24.038Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.038Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.039Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.065Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:24.065Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.065Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.066Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.083Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.084Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.092Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" Probably"}}}
+{"ts":"2025-08-10T03:23:24.093Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.093Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.094Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.120Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:24.120Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.120Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.121Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.147Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" random"}}}
+{"ts":"2025-08-10T03:23:24.147Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.148Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.149Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.175Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" long"}}}
+{"ts":"2025-08-10T03:23:24.175Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.175Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.176Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.188Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.190Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.202Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" story"}}}
+{"ts":"2025-08-10T03:23:24.202Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.202Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.204Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.230Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:24.230Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.230Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.231Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.257Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" Let's"}}}
+{"ts":"2025-08-10T03:23:24.257Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.257Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.258Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.284Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":" produce"}}}
+{"ts":"2025-08-10T03:23:24.284Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.284Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.285Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.293Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.295Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.310Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_reasoning_raw_content_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:24.310Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.310Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.311Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.398Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.400Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.495Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"**"}}}
+{"ts":"2025-08-10T03:23:24.495Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.495Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.496Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.503Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.505Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.521Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"The"}}}
+{"ts":"2025-08-10T03:23:24.521Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.521Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.523Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.548Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Last"}}}
+{"ts":"2025-08-10T03:23:24.548Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.548Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.549Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.574Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ember"}}}
+{"ts":"2025-08-10T03:23:24.575Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.575Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.576Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.601Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:24.601Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.601Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.602Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.609Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.610Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.627Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ever"}}}
+{"ts":"2025-08-10T03:23:24.627Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.627Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.628Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.653Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"night"}}}
+{"ts":"2025-08-10T03:23:24.653Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.653Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.655Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.679Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"**\n\n"}}}
+{"ts":"2025-08-10T03:23:24.680Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.680Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:24.680Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.681Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.706Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"In"}}}
+{"ts":"2025-08-10T03:23:24.706Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.706Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.707Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.714Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.715Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.732Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:24.732Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.732Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.733Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.735Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:24.735Z","dir":"to_tui","kind":"insert_history","lines":2}
+{"ts":"2025-08-10T03:23:24.735Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:24.735Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.736Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.758Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" valley"}}}
+{"ts":"2025-08-10T03:23:24.758Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.759Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.760Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.785Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:24.785Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.785Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.786Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.790Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:24.790Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:24.812Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ever"}}}
+{"ts":"2025-08-10T03:23:24.812Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.812Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.813Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.819Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.820Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.838Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"g"}}}
+{"ts":"2025-08-10T03:23:24.838Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.838Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.839Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.865Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"len"}}}
+{"ts":"2025-08-10T03:23:24.865Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.865Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.867Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.892Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:24.892Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.892Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.893Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.919Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" where"}}}
+{"ts":"2025-08-10T03:23:24.919Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.919Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.920Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.924Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.925Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.945Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:24.945Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.945Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.947Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.972Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" mist"}}}
+{"ts":"2025-08-10T03:23:24.972Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.972Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.973Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:24.999Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" cl"}}}
+{"ts":"2025-08-10T03:23:24.999Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:24.999Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.001Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.026Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ung"}}}
+{"ts":"2025-08-10T03:23:25.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.027Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.028Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.029Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.052Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:25.052Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.052Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.053Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.078Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:25.078Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.079Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.080Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.105Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" emerald"}}}
+{"ts":"2025-08-10T03:23:25.105Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.105Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.106Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.131Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.131Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" slopes"}}}
+{"ts":"2025-08-10T03:23:25.131Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.131Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.132Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.157Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" like"}}}
+{"ts":"2025-08-10T03:23:25.157Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.157Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.159Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.184Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:25.184Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.184Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.185Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.210Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" sil"}}}
+{"ts":"2025-08-10T03:23:25.210Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.210Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.212Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.236Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.237Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ken"}}}
+{"ts":"2025-08-10T03:23:25.237Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.237Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.237Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.263Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" shaw"}}}
+{"ts":"2025-08-10T03:23:25.263Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.263Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.264Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.289Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"l"}}}
+{"ts":"2025-08-10T03:23:25.289Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.289Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.290Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.315Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:25.315Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.315Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.317Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.341Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.342Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:25.342Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.342Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.342Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.369Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" night"}}}
+{"ts":"2025-08-10T03:23:25.369Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.369Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.370Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.395Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" never"}}}
+{"ts":"2025-08-10T03:23:25.395Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.395Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.397Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.422Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" truly"}}}
+{"ts":"2025-08-10T03:23:25.422Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.422Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.424Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.446Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.447Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.449Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" surrendered"}}}
+{"ts":"2025-08-10T03:23:25.449Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.449Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.450Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.476Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:25.476Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.476Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.477Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.503Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Though"}}}
+{"ts":"2025-08-10T03:23:25.503Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.503Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.504Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.530Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:25.530Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.530Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.531Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.551Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.552Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.557Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" moon"}}}
+{"ts":"2025-08-10T03:23:25.557Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.557Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.558Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.583Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" rose"}}}
+{"ts":"2025-08-10T03:23:25.583Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.583Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.585Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.610Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" each"}}}
+{"ts":"2025-08-10T03:23:25.610Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.610Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.612Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.637Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" evening"}}}
+{"ts":"2025-08-10T03:23:25.637Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.637Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.638Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.656Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.658Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.663Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:25.663Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.663Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.665Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.689Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" its"}}}
+{"ts":"2025-08-10T03:23:25.689Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.690Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.691Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.716Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" pall"}}}
+{"ts":"2025-08-10T03:23:25.716Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.716Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.717Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.743Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"id"}}}
+{"ts":"2025-08-10T03:23:25.743Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.743Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.744Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.761Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.763Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.769Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" glow"}}}
+{"ts":"2025-08-10T03:23:25.769Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.769Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.770Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.796Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" was"}}}
+{"ts":"2025-08-10T03:23:25.796Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.796Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.797Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.823Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" always"}}}
+{"ts":"2025-08-10T03:23:25.823Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.823Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.824Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.850Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" pierced"}}}
+{"ts":"2025-08-10T03:23:25.850Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.850Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.851Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.866Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.868Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.877Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" by"}}}
+{"ts":"2025-08-10T03:23:25.877Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.877Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.878Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.903Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" sparks"}}}
+{"ts":"2025-08-10T03:23:25.903Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.904Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.905Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.930Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:25.930Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.930Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.932Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.957Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" danced"}}}
+{"ts":"2025-08-10T03:23:25.957Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.957Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.958Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.968Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.969Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:25.984Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" from"}}}
+{"ts":"2025-08-10T03:23:25.984Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.984Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:25.985Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.010Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:26.010Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.010Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.012Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.037Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ancient"}}}
+{"ts":"2025-08-10T03:23:26.037Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.037Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.039Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.066Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ember"}}}
+{"ts":"2025-08-10T03:23:26.066Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.066Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.067Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.073Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.075Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.092Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"stone"}}}
+{"ts":"2025-08-10T03:23:26.092Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.092Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.093Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.118Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:26.118Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.118Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.120Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.145Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:26.145Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.145Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.146Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.172Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" relic"}}}
+{"ts":"2025-08-10T03:23:26.172Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.172Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.173Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.178Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.180Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.198Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" said"}}}
+{"ts":"2025-08-10T03:23:26.198Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.198Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.200Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.225Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:26.225Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.225Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.226Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.252Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" house"}}}
+{"ts":"2025-08-10T03:23:26.252Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.252Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.253Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.278Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:26.278Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.278Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.279Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.283Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.285Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.305Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" living"}}}
+{"ts":"2025-08-10T03:23:26.305Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.305Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.306Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.331Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" fire"}}}
+{"ts":"2025-08-10T03:23:26.331Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.331Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.332Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.358Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:26.358Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.358Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.359Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.384Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.385Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" The"}}}
+{"ts":"2025-08-10T03:23:26.385Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.385Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.386Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.412Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" stone"}}}
+{"ts":"2025-08-10T03:23:26.412Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.412Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.413Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.438Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" rested"}}}
+{"ts":"2025-08-10T03:23:26.438Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.438Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.440Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.465Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" in"}}}
+{"ts":"2025-08-10T03:23:26.465Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.465Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.466Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.485Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.486Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.492Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:26.492Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.492Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.494Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.521Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" cavern"}}}
+{"ts":"2025-08-10T03:23:26.521Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.521Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.522Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.547Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" beneath"}}}
+{"ts":"2025-08-10T03:23:26.547Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.548Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.549Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.574Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:26.574Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.574Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.575Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.590Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.591Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.600Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" old"}}}
+{"ts":"2025-08-10T03:23:26.600Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.600Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.601Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.627Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Keep"}}}
+{"ts":"2025-08-10T03:23:26.627Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.627Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.628Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.653Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:26.653Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.653Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.654Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.679Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" L"}}}
+{"ts":"2025-08-10T03:23:26.679Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.679Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.681Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.695Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.696Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.705Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"iora"}}}
+{"ts":"2025-08-10T03:23:26.705Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.705Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.707Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.732Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:26.732Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.732Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.733Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.758Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" guarded"}}}
+{"ts":"2025-08-10T03:23:26.758Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.758Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.759Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.784Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" by"}}}
+{"ts":"2025-08-10T03:23:26.784Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.784Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.785Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.795Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.796Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.810Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:26.810Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.810Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.812Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.836Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Order"}}}
+{"ts":"2025-08-10T03:23:26.836Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.836Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.837Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.863Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:26.863Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.863Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.864Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.890Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Light"}}}
+{"ts":"2025-08-10T03:23:26.890Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.890Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.891Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.900Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.901Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.916Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:26.917Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.917Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.918Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.943Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" who"}}}
+{"ts":"2025-08-10T03:23:26.943Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.943Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.944Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.972Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" sw"}}}
+{"ts":"2025-08-10T03:23:26.972Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.972Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:26.974Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:26.999Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ore"}}}
+{"ts":"2025-08-10T03:23:27.000Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.000Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.001Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.005Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.006Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.026Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:27.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.027Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.053Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" keep"}}}
+{"ts":"2025-08-10T03:23:27.053Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.053Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.054Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.080Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" it"}}}
+{"ts":"2025-08-10T03:23:27.080Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.080Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.081Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.106Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.107Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" unt"}}}
+{"ts":"2025-08-10T03:23:27.107Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.107Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.108Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.133Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"arn"}}}
+{"ts":"2025-08-10T03:23:27.134Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.134Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.135Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.160Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ished"}}}
+{"ts":"2025-08-10T03:23:27.160Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.160Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.162Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.187Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" from"}}}
+{"ts":"2025-08-10T03:23:27.187Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.187Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.188Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.212Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.213Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.214Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" any"}}}
+{"ts":"2025-08-10T03:23:27.214Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.214Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.215Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.241Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" mortal"}}}
+{"ts":"2025-08-10T03:23:27.241Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.241Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.242Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.267Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" touch"}}}
+{"ts":"2025-08-10T03:23:27.267Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.267Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.268Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.293Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":".\n\n"}}}
+{"ts":"2025-08-10T03:23:27.293Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.293Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:27.293Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.294Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.317Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.318Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.319Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"Among"}}}
+{"ts":"2025-08-10T03:23:27.319Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.319Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.320Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.345Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:27.345Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:27.345Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.345Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:27.346Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.346Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.346Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.372Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" village"}}}
+{"ts":"2025-08-10T03:23:27.372Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.372Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.373Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.398Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" was"}}}
+{"ts":"2025-08-10T03:23:27.398Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.398Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.399Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.400Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:27.400Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:27.400Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:27.400Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.402Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.422Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.424Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:27.450Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" boy"}}}
+{"ts":"2025-08-10T03:23:27.452Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:27.470Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.470Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.470Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.470Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.470Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:27.472Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.476Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" named"}}}
+{"ts":"2025-08-10T03:23:27.476Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.476Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.477Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.507Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ca"}}}
+{"ts":"2025-08-10T03:23:27.508Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.508Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.509Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.527Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.528Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.535Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"elan"}}}
+{"ts":"2025-08-10T03:23:27.535Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.535Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.536Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.561Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:27.561Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.561Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.563Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.588Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" He"}}}
+{"ts":"2025-08-10T03:23:27.588Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.588Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.589Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.615Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" had"}}}
+{"ts":"2025-08-10T03:23:27.615Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.615Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.616Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.631Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.632Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.642Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" grown"}}}
+{"ts":"2025-08-10T03:23:27.642Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.642Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.643Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.669Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" up"}}}
+{"ts":"2025-08-10T03:23:27.669Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.669Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.670Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.696Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" hearing"}}}
+{"ts":"2025-08-10T03:23:27.696Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.696Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.697Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.722Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:27.722Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.722Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.724Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.736Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.737Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.749Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" legends"}}}
+{"ts":"2025-08-10T03:23:27.749Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.749Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.750Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.775Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" –"}}}
+{"ts":"2025-08-10T03:23:27.775Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.775Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.777Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.802Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:27.802Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.802Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.803Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.829Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" tale"}}}
+{"ts":"2025-08-10T03:23:27.829Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.829Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.830Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.841Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.842Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.856Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:27.856Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.856Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.857Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.882Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:27.882Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.882Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.884Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.909Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ember"}}}
+{"ts":"2025-08-10T03:23:27.909Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.909Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.910Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.936Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"stone"}}}
+{"ts":"2025-08-10T03:23:27.936Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.936Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.938Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.946Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.947Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.963Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:27.963Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.963Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.964Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:27.990Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" kept"}}}
+{"ts":"2025-08-10T03:23:27.990Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.990Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:27.992Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.017Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:28.017Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.017Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.019Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.045Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" valley"}}}
+{"ts":"2025-08-10T03:23:28.045Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.045Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.046Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.046Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.072Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" alive"}}}
+{"ts":"2025-08-10T03:23:28.072Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.072Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.073Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.099Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:28.099Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.099Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.100Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.125Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:28.125Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.125Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.127Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.148Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.149Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.152Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" those"}}}
+{"ts":"2025-08-10T03:23:28.152Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.152Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.154Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.179Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" who"}}}
+{"ts":"2025-08-10T03:23:28.179Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.179Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.180Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.206Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" dared"}}}
+{"ts":"2025-08-10T03:23:28.206Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.206Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.207Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.233Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:28.233Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.233Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.234Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.253Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.254Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.260Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" steal"}}}
+{"ts":"2025-08-10T03:23:28.260Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.260Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.261Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.287Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" its"}}}
+{"ts":"2025-08-10T03:23:28.287Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.287Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.288Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.314Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" heart"}}}
+{"ts":"2025-08-10T03:23:28.314Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.314Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.315Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.342Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:28.342Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.342Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.343Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.358Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.359Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.369Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:28.369Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.369Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.370Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.396Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:28.397Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.397Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.398Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.427Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:28.427Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.427Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.429Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.456Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" cursed"}}}
+{"ts":"2025-08-10T03:23:28.456Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.457Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.458Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.458Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.460Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.485Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ones"}}}
+{"ts":"2025-08-10T03:23:28.485Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.485Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.486Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.513Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" who"}}}
+{"ts":"2025-08-10T03:23:28.513Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.513Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.514Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.544Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" turned"}}}
+{"ts":"2025-08-10T03:23:28.544Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.544Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.546Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.563Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.565Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.571Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" from"}}}
+{"ts":"2025-08-10T03:23:28.571Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.571Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.573Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.598Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:28.598Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.598Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.600Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.625Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" light"}}}
+{"ts":"2025-08-10T03:23:28.625Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.625Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.626Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.652Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:28.652Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.652Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.653Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.664Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.665Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.678Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ca"}}}
+{"ts":"2025-08-10T03:23:28.678Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.678Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.680Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.705Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"elan"}}}
+{"ts":"2025-08-10T03:23:28.705Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.705Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.707Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.732Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"'s"}}}
+{"ts":"2025-08-10T03:23:28.732Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.732Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.734Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.759Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" mother"}}}
+{"ts":"2025-08-10T03:23:28.759Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.759Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.761Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.768Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.770Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.786Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:28.786Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.786Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.787Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.813Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:28.813Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.813Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.814Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.840Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" healer"}}}
+{"ts":"2025-08-10T03:23:28.840Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.840Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.841Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.867Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" known"}}}
+{"ts":"2025-08-10T03:23:28.867Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.867Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.868Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.870Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.871Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.894Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" as"}}}
+{"ts":"2025-08-10T03:23:28.894Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.894Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.895Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.920Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Mae"}}}
+{"ts":"2025-08-10T03:23:28.920Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.920Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.922Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.947Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ve"}}}
+{"ts":"2025-08-10T03:23:28.947Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.947Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.948Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:28.973Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.974Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:28.974Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.974Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:28.975Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.000Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" warned"}}}
+{"ts":"2025-08-10T03:23:29.000Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.000Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.001Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.027Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" him"}}}
+{"ts":"2025-08-10T03:23:29.027Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.027Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.029Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.054Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" never"}}}
+{"ts":"2025-08-10T03:23:29.054Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.054Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.055Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.078Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.079Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.086Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:29.086Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.086Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.087Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.112Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" venture"}}}
+{"ts":"2025-08-10T03:23:29.112Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.112Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.114Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.139Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" beyond"}}}
+{"ts":"2025-08-10T03:23:29.139Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.140Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.141Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.167Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:29.167Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.167Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.168Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.183Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.184Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.193Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" river"}}}
+{"ts":"2025-08-10T03:23:29.193Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.193Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.194Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.220Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:29.220Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.220Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.221Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.247Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Yet"}}}
+{"ts":"2025-08-10T03:23:29.247Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.247Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.248Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.274Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" his"}}}
+{"ts":"2025-08-10T03:23:29.274Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.274Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.275Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.288Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.289Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.300Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" eyes"}}}
+{"ts":"2025-08-10T03:23:29.300Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.300Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.302Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.327Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" were"}}}
+{"ts":"2025-08-10T03:23:29.327Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.327Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.328Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.354Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" always"}}}
+{"ts":"2025-08-10T03:23:29.354Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.354Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.356Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.381Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" drawn"}}}
+{"ts":"2025-08-10T03:23:29.381Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.381Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.382Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.393Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.395Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.408Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" toward"}}}
+{"ts":"2025-08-10T03:23:29.408Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.408Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.409Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.434Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:29.434Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.434Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.436Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.461Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" gl"}}}
+{"ts":"2025-08-10T03:23:29.461Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.461Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.462Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.488Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"immer"}}}
+{"ts":"2025-08-10T03:23:29.488Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.488Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.489Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.497Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.499Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.514Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ing"}}}
+{"ts":"2025-08-10T03:23:29.514Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.514Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.516Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.541Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" blue"}}}
+{"ts":"2025-08-10T03:23:29.541Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.541Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.542Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.569Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:29.569Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.569Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.571Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.595Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" peek"}}}
+{"ts":"2025-08-10T03:23:29.595Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.595Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.596Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.599Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.600Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.621Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ed"}}}
+{"ts":"2025-08-10T03:23:29.621Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.621Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.623Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.649Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" from"}}}
+{"ts":"2025-08-10T03:23:29.649Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.649Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.650Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.675Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:29.675Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.675Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.677Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.702Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.702Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" depths"}}}
+{"ts":"2025-08-10T03:23:29.702Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.702Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.703Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.729Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:29.729Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.729Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.730Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.755Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:29.756Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.756Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.757Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.782Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" keep"}}}
+{"ts":"2025-08-10T03:23:29.782Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.782Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.784Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.807Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.808Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.809Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":".\n\n"}}}
+{"ts":"2025-08-10T03:23:29.809Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.810Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:29.810Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.811Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.836Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"One"}}}
+{"ts":"2025-08-10T03:23:29.836Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.836Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.838Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.863Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" crisp"}}}
+{"ts":"2025-08-10T03:23:29.863Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.863Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.865Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.865Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:29.865Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:29.865Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.866Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.890Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" autumn"}}}
+{"ts":"2025-08-10T03:23:29.890Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.890Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.891Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.912Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.913Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.917Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" night"}}}
+{"ts":"2025-08-10T03:23:29.917Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.917Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.918Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.920Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:29.920Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:29.920Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:29.920Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.921Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.944Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:29.971Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:29.975Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:29.991Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.991Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.991Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.991Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.991Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:29.992Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:29.998Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" strange"}}}
+{"ts":"2025-08-10T03:23:29.998Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.998Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:29.999Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.017Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.018Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.025Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" light"}}}
+{"ts":"2025-08-10T03:23:30.025Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.025Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.026Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.052Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" flutter"}}}
+{"ts":"2025-08-10T03:23:30.052Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.052Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.053Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.079Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ed"}}}
+{"ts":"2025-08-10T03:23:30.079Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.079Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.080Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.114Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" across"}}}
+{"ts":"2025-08-10T03:23:30.115Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.115Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.116Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.122Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.123Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.142Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:30.142Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.142Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.143Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.169Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" sky"}}}
+{"ts":"2025-08-10T03:23:30.169Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.169Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.170Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.196Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:30.196Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.196Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.197Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.223Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:30.223Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.223Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.223Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.225Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.250Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" comet"}}}
+{"ts":"2025-08-10T03:23:30.253Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.253Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.255Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.277Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" streak"}}}
+{"ts":"2025-08-10T03:23:30.277Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.277Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.278Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.304Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:30.304Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.304Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.305Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.328Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.330Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.331Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" hung"}}}
+{"ts":"2025-08-10T03:23:30.331Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.331Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.332Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.358Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" longer"}}}
+{"ts":"2025-08-10T03:23:30.358Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.358Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.359Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.385Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" than"}}}
+{"ts":"2025-08-10T03:23:30.385Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.385Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.386Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.412Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" it"}}}
+{"ts":"2025-08-10T03:23:30.412Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.412Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.413Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.433Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.435Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.438Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" should"}}}
+{"ts":"2025-08-10T03:23:30.439Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.439Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.440Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.465Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:30.465Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.465Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.467Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.492Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ca"}}}
+{"ts":"2025-08-10T03:23:30.492Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.492Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.493Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.519Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"elan"}}}
+{"ts":"2025-08-10T03:23:30.519Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.519Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.520Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.538Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.540Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.546Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" slipped"}}}
+{"ts":"2025-08-10T03:23:30.546Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.546Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.548Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.573Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" away"}}}
+{"ts":"2025-08-10T03:23:30.573Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.573Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.575Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.600Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:30.600Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.600Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.601Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.627Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" his"}}}
+{"ts":"2025-08-10T03:23:30.627Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.627Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.628Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.644Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.645Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.654Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" cloak"}}}
+{"ts":"2025-08-10T03:23:30.654Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.654Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.655Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.681Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:30.681Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.681Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.682Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.708Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" blur"}}}
+{"ts":"2025-08-10T03:23:30.708Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.708Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.710Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.735Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" against"}}}
+{"ts":"2025-08-10T03:23:30.735Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.735Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.737Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.749Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.750Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.762Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:30.762Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.762Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.763Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.789Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" silver"}}}
+{"ts":"2025-08-10T03:23:30.789Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.789Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.790Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.816Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ed"}}}
+{"ts":"2025-08-10T03:23:30.816Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.816Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.817Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.843Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" river"}}}
+{"ts":"2025-08-10T03:23:30.843Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.843Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.844Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.854Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.855Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.870Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"banks"}}}
+{"ts":"2025-08-10T03:23:30.870Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.870Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.871Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.897Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:30.897Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.897Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.898Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.924Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" He"}}}
+{"ts":"2025-08-10T03:23:30.924Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.924Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.925Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.951Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ran"}}}
+{"ts":"2025-08-10T03:23:30.951Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.951Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.952Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.959Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.960Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:30.978Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" into"}}}
+{"ts":"2025-08-10T03:23:30.978Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.978Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:30.979Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.005Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:31.005Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.005Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.006Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.032Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" forest"}}}
+{"ts":"2025-08-10T03:23:31.032Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.032Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.034Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.059Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:31.059Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.059Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.059Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.061Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.086Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" guided"}}}
+{"ts":"2025-08-10T03:23:31.086Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.086Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.087Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.113Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" by"}}}
+{"ts":"2025-08-10T03:23:31.113Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.113Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.114Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.149Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:31.149Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.149Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.150Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.164Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.165Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.177Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" comet"}}}
+{"ts":"2025-08-10T03:23:31.177Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.177Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.178Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.204Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"’s"}}}
+{"ts":"2025-08-10T03:23:31.204Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.204Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.205Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.231Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" tail"}}}
+{"ts":"2025-08-10T03:23:31.231Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.231Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.232Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.258Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:31.258Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.258Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.260Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.268Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.270Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.285Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" until"}}}
+{"ts":"2025-08-10T03:23:31.285Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.285Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.286Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.312Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" he"}}}
+{"ts":"2025-08-10T03:23:31.312Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.312Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.313Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.339Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" found"}}}
+{"ts":"2025-08-10T03:23:31.339Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.339Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.340Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.366Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" himself"}}}
+{"ts":"2025-08-10T03:23:31.366Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.366Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.367Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.373Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.375Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.393Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" at"}}}
+{"ts":"2025-08-10T03:23:31.393Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.393Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.394Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.419Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:31.419Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.419Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.421Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.446Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" base"}}}
+{"ts":"2025-08-10T03:23:31.447Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.447Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.448Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.473Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:31.473Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.473Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.473Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.475Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.500Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:31.500Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.500Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.502Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.527Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Keep"}}}
+{"ts":"2025-08-10T03:23:31.527Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.527Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.529Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.554Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:31.554Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.554Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.555Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.578Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.580Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.581Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" L"}}}
+{"ts":"2025-08-10T03:23:31.581Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.581Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.583Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.608Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"iora"}}}
+{"ts":"2025-08-10T03:23:31.609Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.609Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.610Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.635Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:31.635Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.635Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.637Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.663Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" The"}}}
+{"ts":"2025-08-10T03:23:31.663Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.663Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.664Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.683Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.685Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.694Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" stone"}}}
+{"ts":"2025-08-10T03:23:31.694Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.694Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.696Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.722Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" walls"}}}
+{"ts":"2025-08-10T03:23:31.722Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.722Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.723Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.749Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" gle"}}}
+{"ts":"2025-08-10T03:23:31.749Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.749Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.750Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.776Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"amed"}}}
+{"ts":"2025-08-10T03:23:31.776Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.776Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.777Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.789Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.790Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.803Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:31.803Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.803Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.804Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.830Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:31.830Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.830Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.832Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.857Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" an"}}}
+{"ts":"2025-08-10T03:23:31.857Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.857Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.858Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.884Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ancient"}}}
+{"ts":"2025-08-10T03:23:31.884Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.884Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.886Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.894Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.895Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.911Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" oak"}}}
+{"ts":"2025-08-10T03:23:31.911Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.911Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.912Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.938Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"'s"}}}
+{"ts":"2025-08-10T03:23:31.938Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.938Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.940Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.965Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" roots"}}}
+{"ts":"2025-08-10T03:23:31.965Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.965Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.967Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.992Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" tw"}}}
+{"ts":"2025-08-10T03:23:31.992Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.992Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:31.994Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:31.999Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.000Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.019Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ined"}}}
+{"ts":"2025-08-10T03:23:32.020Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.020Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.021Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.047Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" like"}}}
+{"ts":"2025-08-10T03:23:32.047Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.047Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.048Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.074Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" silver"}}}
+{"ts":"2025-08-10T03:23:32.074Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.074Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.075Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.101Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" cords"}}}
+{"ts":"2025-08-10T03:23:32.101Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.101Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.102Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.102Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.104Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.128Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" across"}}}
+{"ts":"2025-08-10T03:23:32.128Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.128Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.129Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.155Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:32.155Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.155Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.156Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.182Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" stone"}}}
+{"ts":"2025-08-10T03:23:32.182Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.182Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.183Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.207Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.209Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.209Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":".\n\n"}}}
+{"ts":"2025-08-10T03:23:32.209Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.209Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:32.209Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.211Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.236Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"Inside"}}}
+{"ts":"2025-08-10T03:23:32.236Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.236Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.237Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.263Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:32.263Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:32.263Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.263Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:32.263Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.263Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.264Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.290Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" keep"}}}
+{"ts":"2025-08-10T03:23:32.310Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.310Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.311Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.312Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.314Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.314Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:32.314Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:32.314Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:32.314Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.315Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.317Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:32.344Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:32.364Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:32.371Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" corridors"}}}
+{"ts":"2025-08-10T03:23:32.399Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" were"}}}
+{"ts":"2025-08-10T03:23:32.411Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.411Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.411Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.411Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.411Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:32.411Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.411Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.411Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.411Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.413Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.413Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.426Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" maze"}}}
+{"ts":"2025-08-10T03:23:32.426Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.426Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.427Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.453Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"-like"}}}
+{"ts":"2025-08-10T03:23:32.453Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.453Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.454Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.480Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:32.480Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.480Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.481Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.507Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:32.507Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.507Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.508Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.518Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.519Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.534Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" air"}}}
+{"ts":"2025-08-10T03:23:32.534Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.534Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.535Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.561Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" heavy"}}}
+{"ts":"2025-08-10T03:23:32.561Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.561Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.563Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.588Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" with"}}}
+{"ts":"2025-08-10T03:23:32.588Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.588Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.590Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.615Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:32.615Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.615Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.617Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.618Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.620Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.643Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" scent"}}}
+{"ts":"2025-08-10T03:23:32.643Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.643Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.644Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.670Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:32.670Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.670Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.671Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.697Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" stone"}}}
+{"ts":"2025-08-10T03:23:32.697Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.697Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.698Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.723Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.725Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.726Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:32.726Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.726Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.728Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.754Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" lingering"}}}
+{"ts":"2025-08-10T03:23:32.754Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.754Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.756Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.781Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" incense"}}}
+{"ts":"2025-08-10T03:23:32.781Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.781Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.783Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.808Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:32.808Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.808Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.810Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.828Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.830Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.835Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" At"}}}
+{"ts":"2025-08-10T03:23:32.835Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.835Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.837Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.863Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:32.863Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.863Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.864Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.890Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" heart"}}}
+{"ts":"2025-08-10T03:23:32.890Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.890Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.891Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.917Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:32.917Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.917Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.918Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.933Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.935Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.944Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:32.944Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.944Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.945Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.971Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" labyrinth"}}}
+{"ts":"2025-08-10T03:23:32.971Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.971Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.972Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:32.998Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" lay"}}}
+{"ts":"2025-08-10T03:23:32.998Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.998Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:32.999Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.025Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:33.025Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.025Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.026Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.039Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.040Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.052Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Chamber"}}}
+{"ts":"2025-08-10T03:23:33.052Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.052Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.053Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.080Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:33.080Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.080Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.081Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.107Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ember"}}}
+{"ts":"2025-08-10T03:23:33.107Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.107Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.108Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.134Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:33.134Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.134Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.135Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.144Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.145Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.161Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:33.161Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.161Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.162Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.188Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" vast"}}}
+{"ts":"2025-08-10T03:23:33.188Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.188Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.189Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.215Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" vault"}}}
+{"ts":"2025-08-10T03:23:33.215Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.215Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.217Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.242Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" carved"}}}
+{"ts":"2025-08-10T03:23:33.242Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.242Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.244Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.244Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.245Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.269Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" out"}}}
+{"ts":"2025-08-10T03:23:33.270Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.270Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.271Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.297Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:33.297Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.297Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.298Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.324Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" obs"}}}
+{"ts":"2025-08-10T03:23:33.324Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.324Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.325Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.345Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.346Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.351Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"idian"}}}
+{"ts":"2025-08-10T03:23:33.351Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.351Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.352Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.378Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:33.378Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.378Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.379Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.405Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" its"}}}
+{"ts":"2025-08-10T03:23:33.405Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.405Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.406Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.432Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" walls"}}}
+{"ts":"2025-08-10T03:23:33.432Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.432Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.433Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.450Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.451Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.459Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" pul"}}}
+{"ts":"2025-08-10T03:23:33.459Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.459Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.460Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.486Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"sing"}}}
+{"ts":"2025-08-10T03:23:33.486Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.486Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.488Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.514Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" faint"}}}
+{"ts":"2025-08-10T03:23:33.514Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.514Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.515Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.541Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ly"}}}
+{"ts":"2025-08-10T03:23:33.541Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.541Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.542Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.552Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.553Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.568Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:33.568Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.568Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.569Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.595Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" The"}}}
+{"ts":"2025-08-10T03:23:33.595Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.595Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.596Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.622Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ember"}}}
+{"ts":"2025-08-10T03:23:33.622Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.622Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.623Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.649Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"stone"}}}
+{"ts":"2025-08-10T03:23:33.649Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.649Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.650Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.652Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.653Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.676Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" lay"}}}
+{"ts":"2025-08-10T03:23:33.676Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.676Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.677Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.707Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" atop"}}}
+{"ts":"2025-08-10T03:23:33.707Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.707Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.708Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.735Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:33.735Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.735Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.736Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.757Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.758Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.762Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" dais"}}}
+{"ts":"2025-08-10T03:23:33.762Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.762Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.763Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.789Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:33.789Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.789Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.790Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.815Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" surrounded"}}}
+{"ts":"2025-08-10T03:23:33.816Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.816Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.817Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.842Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" by"}}}
+{"ts":"2025-08-10T03:23:33.842Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.842Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.844Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.862Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.863Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.869Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" glyph"}}}
+{"ts":"2025-08-10T03:23:33.869Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.869Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.871Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.897Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"s"}}}
+{"ts":"2025-08-10T03:23:33.897Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.897Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.898Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.924Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:33.924Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.924Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.925Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.951Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" forgotten"}}}
+{"ts":"2025-08-10T03:23:33.951Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.951Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.952Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.965Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.966Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:33.978Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" run"}}}
+{"ts":"2025-08-10T03:23:33.978Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.978Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:33.979Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.005Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"es"}}}
+{"ts":"2025-08-10T03:23:34.005Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.005Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.007Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.032Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:34.032Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.032Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.033Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.060Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" flick"}}}
+{"ts":"2025-08-10T03:23:34.060Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.060Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.061Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.067Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.068Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.087Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ered"}}}
+{"ts":"2025-08-10T03:23:34.087Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.087Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.088Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.114Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" like"}}}
+{"ts":"2025-08-10T03:23:34.114Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.114Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.115Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.141Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" nervous"}}}
+{"ts":"2025-08-10T03:23:34.141Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.141Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.142Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.168Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.168Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" fire"}}}
+{"ts":"2025-08-10T03:23:34.168Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.168Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.170Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.196Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"flies"}}}
+{"ts":"2025-08-10T03:23:34.196Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.196Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.197Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.226Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":".\n\n"}}}
+{"ts":"2025-08-10T03:23:34.226Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.226Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:34.226Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.228Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.253Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"Ca"}}}
+{"ts":"2025-08-10T03:23:34.253Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.254Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.255Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.273Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.275Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.281Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"elan"}}}
+{"ts":"2025-08-10T03:23:34.281Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.281Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.282Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:34.282Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:34.282Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.282Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.308Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"'s"}}}
+{"ts":"2025-08-10T03:23:34.329Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.329Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.330Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.335Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:34.335Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:34.335Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:34.335Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.335Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" heart"}}}
+{"ts":"2025-08-10T03:23:34.335Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.335Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.336Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.362Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" hammered"}}}
+{"ts":"2025-08-10T03:23:34.378Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.386Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:34.389Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" as"}}}
+{"ts":"2025-08-10T03:23:34.417Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" he"}}}
+{"ts":"2025-08-10T03:23:34.430Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.430Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.430Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:34.430Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.430Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.430Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.430Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.432Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.444Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" approached"}}}
+{"ts":"2025-08-10T03:23:34.444Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.444Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.445Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.471Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:34.471Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.471Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.472Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.483Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.485Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.498Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" He"}}}
+{"ts":"2025-08-10T03:23:34.498Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.498Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.500Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.526Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" remembered"}}}
+{"ts":"2025-08-10T03:23:34.526Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.526Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.527Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.553Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Mae"}}}
+{"ts":"2025-08-10T03:23:34.553Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.553Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.554Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.580Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ve"}}}
+{"ts":"2025-08-10T03:23:34.580Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.580Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.581Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.589Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.590Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.607Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"'s"}}}
+{"ts":"2025-08-10T03:23:34.607Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.607Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.609Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.634Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" words"}}}
+{"ts":"2025-08-10T03:23:34.634Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.635Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.636Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.662Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":":"}}}
+{"ts":"2025-08-10T03:23:34.663Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.663Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.665Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.689Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" \""}}}
+{"ts":"2025-08-10T03:23:34.689Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.689Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.690Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.694Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.695Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.716Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"The"}}}
+{"ts":"2025-08-10T03:23:34.716Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.716Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.717Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.745Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" fire"}}}
+{"ts":"2025-08-10T03:23:34.745Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.745Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.746Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.772Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:34.772Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.772Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.773Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.799Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.799Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ever"}}}
+{"ts":"2025-08-10T03:23:34.799Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.799Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.800Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.826Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"night"}}}
+{"ts":"2025-08-10T03:23:34.826Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.826Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.827Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.853Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" is"}}}
+{"ts":"2025-08-10T03:23:34.853Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.853Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.854Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.880Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" not"}}}
+{"ts":"2025-08-10T03:23:34.880Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.880Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.881Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.904Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.905Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.907Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:34.907Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.907Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.908Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.934Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" tool"}}}
+{"ts":"2025-08-10T03:23:34.934Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.934Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.935Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.961Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:34.961Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.961Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.962Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:34.988Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" be"}}}
+{"ts":"2025-08-10T03:23:34.988Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.988Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:34.990Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.009Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.010Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.016Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" wield"}}}
+{"ts":"2025-08-10T03:23:35.016Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.016Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.017Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.042Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ed"}}}
+{"ts":"2025-08-10T03:23:35.042Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.042Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.044Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.069Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:35.069Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.069Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.070Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.096Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" but"}}}
+{"ts":"2025-08-10T03:23:35.096Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.096Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.097Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.114Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.115Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.123Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:35.123Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.123Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.124Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.150Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" covenant"}}}
+{"ts":"2025-08-10T03:23:35.150Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.150Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.151Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.177Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":".\""}}}
+{"ts":"2025-08-10T03:23:35.177Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.177Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.179Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.205Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Yet"}}}
+{"ts":"2025-08-10T03:23:35.205Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.205Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.206Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.219Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.220Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.232Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:35.232Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.232Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.233Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.262Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ache"}}}
+{"ts":"2025-08-10T03:23:35.262Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.262Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.263Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.289Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:35.289Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.289Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.290Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.316Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" longing"}}}
+{"ts":"2025-08-10T03:23:35.316Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.316Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.317Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.320Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.321Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.343Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" burned"}}}
+{"ts":"2025-08-10T03:23:35.343Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.343Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.344Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.370Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" stronger"}}}
+{"ts":"2025-08-10T03:23:35.370Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.370Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.371Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.398Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"—"}}}
+{"ts":"2025-08-10T03:23:35.398Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.398Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.399Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.421Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.422Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.425Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"he"}}}
+{"ts":"2025-08-10T03:23:35.425Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.425Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.426Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.452Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" wanted"}}}
+{"ts":"2025-08-10T03:23:35.452Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.452Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.454Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.479Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:35.479Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.479Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.481Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.507Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" light"}}}
+{"ts":"2025-08-10T03:23:35.507Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.507Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.508Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.526Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.527Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.534Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:35.534Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.534Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.535Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.561Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" pier"}}}
+{"ts":"2025-08-10T03:23:35.561Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.561Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.562Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.588Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ce"}}}
+{"ts":"2025-08-10T03:23:35.589Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.589Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.590Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.616Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" his"}}}
+{"ts":"2025-08-10T03:23:35.616Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.616Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.617Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.631Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.632Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.643Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" village"}}}
+{"ts":"2025-08-10T03:23:35.643Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.643Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.644Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.670Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"'s"}}}
+{"ts":"2025-08-10T03:23:35.670Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.670Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.671Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.697Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" nights"}}}
+{"ts":"2025-08-10T03:23:35.697Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.697Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.699Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.725Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:35.725Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.725Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.726Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.735Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.736Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.752Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:35.752Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.752Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.753Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.780Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" cure"}}}
+{"ts":"2025-08-10T03:23:35.780Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.780Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.781Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.807Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:35.807Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.807Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.808Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.834Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:35.834Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.834Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.835Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.837Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.838Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.861Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"iling"}}}
+{"ts":"2025-08-10T03:23:35.861Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.861Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.862Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.888Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" crops"}}}
+{"ts":"2025-08-10T03:23:35.888Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.888Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.890Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.916Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:35.916Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.916Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.917Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.942Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.943Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.943Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:35.945Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.945Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.946Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.970Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ease"}}}
+{"ts":"2025-08-10T03:23:35.970Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.970Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.971Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:35.998Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" his"}}}
+{"ts":"2025-08-10T03:23:35.998Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.998Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:35.999Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.025Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" mother's"}}}
+{"ts":"2025-08-10T03:23:36.025Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.025Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.027Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.045Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.046Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.052Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" grief"}}}
+{"ts":"2025-08-10T03:23:36.052Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.052Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.053Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.080Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:36.080Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.080Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.081Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.107Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" In"}}}
+{"ts":"2025-08-10T03:23:36.107Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.107Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.108Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.134Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:36.134Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.134Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.135Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.147Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.148Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.161Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" moment"}}}
+{"ts":"2025-08-10T03:23:36.161Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.161Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.163Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.188Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:36.189Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.189Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.190Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.216Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" felt"}}}
+{"ts":"2025-08-10T03:23:36.216Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.216Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.217Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.243Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" like"}}}
+{"ts":"2025-08-10T03:23:36.243Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.243Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.244Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.248Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.249Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.270Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:36.270Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.270Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.272Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.297Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" choice"}}}
+{"ts":"2025-08-10T03:23:36.297Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.297Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.299Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.324Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" between"}}}
+{"ts":"2025-08-10T03:23:36.324Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.324Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.326Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.351Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.352Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" life"}}}
+{"ts":"2025-08-10T03:23:36.352Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.352Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.353Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.379Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:36.379Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.379Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.380Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.406Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" death"}}}
+{"ts":"2025-08-10T03:23:36.406Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.406Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.407Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.434Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" he"}}}
+{"ts":"2025-08-10T03:23:36.434Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.434Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.435Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.452Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.453Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.461Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" placed"}}}
+{"ts":"2025-08-10T03:23:36.461Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.461Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.462Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.488Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" his"}}}
+{"ts":"2025-08-10T03:23:36.488Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.488Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.489Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.515Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" palm"}}}
+{"ts":"2025-08-10T03:23:36.515Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.516Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.517Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.543Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" upon"}}}
+{"ts":"2025-08-10T03:23:36.543Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.543Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.544Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.557Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.558Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.570Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:36.570Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.570Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.571Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.597Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" cool"}}}
+{"ts":"2025-08-10T03:23:36.597Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.597Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.599Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.625Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" stone"}}}
+{"ts":"2025-08-10T03:23:36.625Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.625Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.626Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.652Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":".\n\n"}}}
+{"ts":"2025-08-10T03:23:36.652Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.653Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:36.653Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.654Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.662Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.663Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.679Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"Sud"}}}
+{"ts":"2025-08-10T03:23:36.679Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.679Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.681Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.707Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"denly"}}}
+{"ts":"2025-08-10T03:23:36.707Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.707Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.707Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:36.707Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:36.707Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.708Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.734Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:36.761Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:36.761Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:36.767Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.788Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" voice"}}}
+{"ts":"2025-08-10T03:23:36.816Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:36.816Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" reson"}}}
+{"ts":"2025-08-10T03:23:36.843Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ated"}}}
+{"ts":"2025-08-10T03:23:36.852Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.852Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.852Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:36.852Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:36.852Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.852Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.852Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.852Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.852Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:36.852Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.852Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.852Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.852Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.852Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.853Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.868Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:36.868Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.870Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" through"}}}
+{"ts":"2025-08-10T03:23:36.898Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:36.925Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" chamber"}}}
+{"ts":"2025-08-10T03:23:36.953Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:36.953Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:36.953Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.953Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.953Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.953Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.953Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.953Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.953Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.953Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.954Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.973Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.975Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:36.980Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" not"}}}
+{"ts":"2025-08-10T03:23:36.980Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.980Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:36.981Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.007Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" from"}}}
+{"ts":"2025-08-10T03:23:37.007Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.007Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.009Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.035Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" any"}}}
+{"ts":"2025-08-10T03:23:37.035Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.035Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.036Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.062Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" mortal"}}}
+{"ts":"2025-08-10T03:23:37.062Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.062Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.063Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.078Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.080Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.089Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ear"}}}
+{"ts":"2025-08-10T03:23:37.089Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.089Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.091Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.117Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:37.117Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.117Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.118Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.144Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" but"}}}
+{"ts":"2025-08-10T03:23:37.144Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.144Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.146Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.172Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" from"}}}
+{"ts":"2025-08-10T03:23:37.172Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.172Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.173Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.179Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.181Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.199Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:37.199Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.199Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.200Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.226Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" very"}}}
+{"ts":"2025-08-10T03:23:37.226Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.226Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.228Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.254Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" fire"}}}
+{"ts":"2025-08-10T03:23:37.254Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.254Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.255Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.281Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:37.281Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.281Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.282Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.283Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.284Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.308Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" had"}}}
+{"ts":"2025-08-10T03:23:37.308Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.308Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.310Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.337Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" kept"}}}
+{"ts":"2025-08-10T03:23:37.337Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.337Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.338Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.362Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:37.362Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.362Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.364Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.388Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.389Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" valley"}}}
+{"ts":"2025-08-10T03:23:37.389Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.389Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.389Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.416Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" alive"}}}
+{"ts":"2025-08-10T03:23:37.416Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.416Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.417Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.443Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":":"}}}
+{"ts":"2025-08-10T03:23:37.443Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.443Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.444Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.470Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" \""}}}
+{"ts":"2025-08-10T03:23:37.470Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.470Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.472Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.493Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.494Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.497Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"Child"}}}
+{"ts":"2025-08-10T03:23:37.497Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.497Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.499Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.525Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:37.525Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.525Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.526Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.552Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ember"}}}
+{"ts":"2025-08-10T03:23:37.552Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.552Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.553Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.579Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:37.579Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.579Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.580Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.598Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.599Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.607Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" you"}}}
+{"ts":"2025-08-10T03:23:37.607Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.607Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.608Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.634Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" seek"}}}
+{"ts":"2025-08-10T03:23:37.634Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.634Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.635Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.661Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" light"}}}
+{"ts":"2025-08-10T03:23:37.661Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.661Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.663Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.689Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:37.689Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.689Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.690Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.703Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.704Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.716Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" cannot"}}}
+{"ts":"2025-08-10T03:23:37.716Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.716Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.718Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.744Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" be"}}}
+{"ts":"2025-08-10T03:23:37.744Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.744Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.745Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.771Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" taken"}}}
+{"ts":"2025-08-10T03:23:37.771Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.771Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.772Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.798Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:37.798Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.798Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.800Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.808Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.809Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.826Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Do"}}}
+{"ts":"2025-08-10T03:23:37.826Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.826Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.827Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.853Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" you"}}}
+{"ts":"2025-08-10T03:23:37.853Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.853Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.855Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.881Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" dare"}}}
+{"ts":"2025-08-10T03:23:37.881Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.881Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.882Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.908Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" become"}}}
+{"ts":"2025-08-10T03:23:37.908Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.908Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.909Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.913Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.914Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.935Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:37.935Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.935Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.936Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.962Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" flame"}}}
+{"ts":"2025-08-10T03:23:37.962Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.962Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.964Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:37.990Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"?\"\n\n"}}}
+{"ts":"2025-08-10T03:23:37.990Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.990Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:37.990Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:37.991Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.017Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.017Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"From"}}}
+{"ts":"2025-08-10T03:23:38.017Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.017Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.018Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.044Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:38.044Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:38.044Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.045Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" behind"}}}
+{"ts":"2025-08-10T03:23:38.045Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.045Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.046Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.072Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" him"}}}
+{"ts":"2025-08-10T03:23:38.072Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.072Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.073Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.099Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:38.099Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:38.099Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:38.099Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.100Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" stepped"}}}
+{"ts":"2025-08-10T03:23:38.100Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.100Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.100Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.122Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.127Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:38.154Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:38.154Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" figure"}}}
+{"ts":"2025-08-10T03:23:38.164Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.164Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.165Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:38.165Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.165Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.166Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.181Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"—"}}}
+{"ts":"2025-08-10T03:23:38.181Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.181Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.183Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.209Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"t"}}}
+{"ts":"2025-08-10T03:23:38.209Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.209Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.210Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.227Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.228Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.236Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"all"}}}
+{"ts":"2025-08-10T03:23:38.236Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.236Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.238Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.264Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:38.264Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.264Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.265Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.291Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" clo"}}}
+{"ts":"2025-08-10T03:23:38.291Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.291Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.293Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.319Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"aked"}}}
+{"ts":"2025-08-10T03:23:38.319Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.319Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.320Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.332Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.333Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.346Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" in"}}}
+{"ts":"2025-08-10T03:23:38.346Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.346Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.347Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.374Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:38.374Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.374Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.375Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.403Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" mantle"}}}
+{"ts":"2025-08-10T03:23:38.403Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.403Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.405Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.431Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:38.431Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.431Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.433Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.433Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.459Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" darkness"}}}
+{"ts":"2025-08-10T03:23:38.459Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.459Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.460Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.486Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:38.486Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.486Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.487Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.514Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" seemed"}}}
+{"ts":"2025-08-10T03:23:38.514Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.514Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.515Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.538Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.539Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.541Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:38.541Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.541Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.542Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.568Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" dev"}}}
+{"ts":"2025-08-10T03:23:38.568Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.568Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.569Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.595Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"our"}}}
+{"ts":"2025-08-10T03:23:38.595Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.595Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.596Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.623Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" surrounding"}}}
+{"ts":"2025-08-10T03:23:38.623Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.623Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.624Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.643Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.644Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.650Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" light"}}}
+{"ts":"2025-08-10T03:23:38.650Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.650Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.652Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.678Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:38.678Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.678Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.679Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.705Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" The"}}}
+{"ts":"2025-08-10T03:23:38.705Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.705Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.706Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.733Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" figure"}}}
+{"ts":"2025-08-10T03:23:38.733Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.733Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.734Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.747Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.748Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.760Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" revealed"}}}
+{"ts":"2025-08-10T03:23:38.760Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.760Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.762Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.788Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" himself"}}}
+{"ts":"2025-08-10T03:23:38.788Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.788Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.789Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.815Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" as"}}}
+{"ts":"2025-08-10T03:23:38.815Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.815Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.817Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.843Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Az"}}}
+{"ts":"2025-08-10T03:23:38.843Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.843Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.844Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.847Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.848Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.870Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"r"}}}
+{"ts":"2025-08-10T03:23:38.870Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.870Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.871Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.898Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ion"}}}
+{"ts":"2025-08-10T03:23:38.898Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.898Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.899Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.925Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:38.925Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.925Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.927Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.952Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.953Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Keeper"}}}
+{"ts":"2025-08-10T03:23:38.953Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.953Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.953Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:38.980Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:38.980Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.980Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:38.982Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.008Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:39.008Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.008Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.009Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.035Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" guardian"}}}
+{"ts":"2025-08-10T03:23:39.035Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.035Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.036Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.057Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.058Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.062Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" who"}}}
+{"ts":"2025-08-10T03:23:39.062Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.062Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.064Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.090Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" had"}}}
+{"ts":"2025-08-10T03:23:39.090Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.090Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.091Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.117Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" sworn"}}}
+{"ts":"2025-08-10T03:23:39.117Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.117Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.119Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.145Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" his"}}}
+{"ts":"2025-08-10T03:23:39.145Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.145Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.146Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.162Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.163Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.172Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" oath"}}}
+{"ts":"2025-08-10T03:23:39.172Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.172Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.173Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.200Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:39.200Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.200Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.201Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.227Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:39.227Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.227Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.228Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.255Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" stone"}}}
+{"ts":"2025-08-10T03:23:39.255Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.255Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.256Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.267Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.268Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.282Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" for"}}}
+{"ts":"2025-08-10T03:23:39.282Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.282Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.283Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.310Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" centuries"}}}
+{"ts":"2025-08-10T03:23:39.310Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.310Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.311Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.337Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:39.337Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.337Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.338Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.365Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" His"}}}
+{"ts":"2025-08-10T03:23:39.365Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.365Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.366Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.368Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.370Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.392Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" eyes"}}}
+{"ts":"2025-08-10T03:23:39.392Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.392Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.394Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.420Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" contained"}}}
+{"ts":"2025-08-10T03:23:39.420Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.420Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.421Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.450Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" centuries"}}}
+{"ts":"2025-08-10T03:23:39.450Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.450Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.452Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.470Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.471Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.478Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:39.478Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.478Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.480Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.506Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" sorrow"}}}
+{"ts":"2025-08-10T03:23:39.506Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.506Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.507Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.533Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:39.533Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.533Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.535Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.561Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" \""}}}
+{"ts":"2025-08-10T03:23:39.561Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.561Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.562Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.575Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.576Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.589Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"I"}}}
+{"ts":"2025-08-10T03:23:39.589Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.589Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.590Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.616Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" see"}}}
+{"ts":"2025-08-10T03:23:39.616Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.616Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.617Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.644Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" your"}}}
+{"ts":"2025-08-10T03:23:39.644Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.644Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.645Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.671Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" heart"}}}
+{"ts":"2025-08-10T03:23:39.671Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.671Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.672Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.675Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.677Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.699Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" is"}}}
+{"ts":"2025-08-10T03:23:39.699Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.699Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.700Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.726Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" pure"}}}
+{"ts":"2025-08-10T03:23:39.726Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.726Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.727Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.753Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":",\""}}}
+{"ts":"2025-08-10T03:23:39.753Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.754Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.755Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.778Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.779Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.781Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" he"}}}
+{"ts":"2025-08-10T03:23:39.781Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.781Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.782Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.809Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" int"}}}
+{"ts":"2025-08-10T03:23:39.809Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.809Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.810Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.836Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"oned"}}}
+{"ts":"2025-08-10T03:23:39.836Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.836Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.837Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.864Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:39.864Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.864Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.865Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.879Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.880Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.891Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" \""}}}
+{"ts":"2025-08-10T03:23:39.891Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.891Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.892Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.919Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"But"}}}
+{"ts":"2025-08-10T03:23:39.919Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.919Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.920Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.946Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" we"}}}
+{"ts":"2025-08-10T03:23:39.946Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.946Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.948Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.974Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" are"}}}
+{"ts":"2025-08-10T03:23:39.974Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.974Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.976Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:39.981Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:39.982Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.001Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" bound"}}}
+{"ts":"2025-08-10T03:23:40.001Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.001Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.003Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.029Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:40.029Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.029Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.030Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.056Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:40.056Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.056Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.057Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.083Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.083Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" cycle"}}}
+{"ts":"2025-08-10T03:23:40.083Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.083Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.085Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.111Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":".\"\n\n"}}}
+{"ts":"2025-08-10T03:23:40.111Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.111Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:40.111Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.113Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.138Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"Ca"}}}
+{"ts":"2025-08-10T03:23:40.138Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.138Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.139Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.161Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:40.161Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:40.161Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.163Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.165Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"elan"}}}
+{"ts":"2025-08-10T03:23:40.182Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.182Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.183Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.188Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.190Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.192Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" listened"}}}
+{"ts":"2025-08-10T03:23:40.192Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.193Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.194Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.216Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:40.216Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:40.216Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:40.216Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.218Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.220Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:40.247Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" heart"}}}
+{"ts":"2025-08-10T03:23:40.268Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:40.274Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" pounding"}}}
+{"ts":"2025-08-10T03:23:40.283Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.283Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.283Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.283Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.283Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:40.283Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.283Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.285Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.293Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.295Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.302Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:40.302Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.302Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.303Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.329Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" \""}}}
+{"ts":"2025-08-10T03:23:40.329Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.329Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.330Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.357Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"I"}}}
+{"ts":"2025-08-10T03:23:40.357Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.357Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.358Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.384Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" will"}}}
+{"ts":"2025-08-10T03:23:40.384Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.384Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.386Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.398Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.400Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.412Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" spare"}}}
+{"ts":"2025-08-10T03:23:40.412Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.412Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.413Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.439Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:40.439Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.439Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.441Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.467Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" village"}}}
+{"ts":"2025-08-10T03:23:40.467Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.467Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.468Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.495Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":",\""}}}
+{"ts":"2025-08-10T03:23:40.495Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.495Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.496Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.499Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.500Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.529Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" he"}}}
+{"ts":"2025-08-10T03:23:40.529Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.529Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.530Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.557Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" said"}}}
+{"ts":"2025-08-10T03:23:40.557Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.557Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.558Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.585Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:40.585Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.585Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.586Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.603Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.604Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.612Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" voice"}}}
+{"ts":"2025-08-10T03:23:40.612Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.612Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.613Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.640Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" trembling"}}}
+{"ts":"2025-08-10T03:23:40.640Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.640Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.641Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.667Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:40.667Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.667Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.668Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.695Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" \""}}}
+{"ts":"2025-08-10T03:23:40.695Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.695Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.696Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.708Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.709Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.721Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"But"}}}
+{"ts":"2025-08-10T03:23:40.722Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.722Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.723Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.748Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" my"}}}
+{"ts":"2025-08-10T03:23:40.748Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.748Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.750Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.775Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" mother"}}}
+{"ts":"2025-08-10T03:23:40.775Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.775Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.776Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.802Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" suffers"}}}
+{"ts":"2025-08-10T03:23:40.802Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.802Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.803Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.811Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.813Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.829Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" from"}}}
+{"ts":"2025-08-10T03:23:40.829Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.829Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.830Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.856Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" illness"}}}
+{"ts":"2025-08-10T03:23:40.856Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.856Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.857Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.883Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:40.883Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.883Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.884Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.910Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Will"}}}
+{"ts":"2025-08-10T03:23:40.910Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.910Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.911Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.916Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.918Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.938Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" you"}}}
+{"ts":"2025-08-10T03:23:40.938Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.938Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.939Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.965Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" grant"}}}
+{"ts":"2025-08-10T03:23:40.965Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.965Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.966Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:40.993Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" me"}}}
+{"ts":"2025-08-10T03:23:40.993Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.993Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:40.994Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.020Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:41.020Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.020Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.021Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.022Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.048Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" sl"}}}
+{"ts":"2025-08-10T03:23:41.048Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.048Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.050Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.076Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"iver"}}}
+{"ts":"2025-08-10T03:23:41.076Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.076Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.077Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.103Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:41.103Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.103Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.104Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.126Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.128Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.131Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" fire"}}}
+{"ts":"2025-08-10T03:23:41.131Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.131Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.132Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.158Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"?\"\n\n"}}}
+{"ts":"2025-08-10T03:23:41.158Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.159Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:41.159Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.160Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.186Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"Az"}}}
+{"ts":"2025-08-10T03:23:41.186Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.186Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.187Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.213Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:41.213Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:41.213Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.214Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"r"}}}
+{"ts":"2025-08-10T03:23:41.214Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.214Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.215Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.232Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.241Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ion"}}}
+{"ts":"2025-08-10T03:23:41.268Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:41.269Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" sighed"}}}
+{"ts":"2025-08-10T03:23:41.293Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.293Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.293Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:41.293Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:41.293Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.293Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.293Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.295Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.296Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:41.323Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:41.324Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" The"}}}
+{"ts":"2025-08-10T03:23:41.337Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.351Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ember"}}}
+{"ts":"2025-08-10T03:23:41.379Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"stone"}}}
+{"ts":"2025-08-10T03:23:41.394Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.394Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.394Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:41.394Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.394Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.394Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.394Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.394Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.394Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.396Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.406Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:41.406Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.406Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.407Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.434Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" however"}}}
+{"ts":"2025-08-10T03:23:41.434Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.434Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.435Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.442Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.443Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.461Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:41.461Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.461Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.463Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.489Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" had"}}}
+{"ts":"2025-08-10T03:23:41.489Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.489Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.490Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.517Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:41.517Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.517Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.518Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.544Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" memory"}}}
+{"ts":"2025-08-10T03:23:41.544Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.544Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.545Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.547Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.548Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.571Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:41.571Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.571Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.573Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.605Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" It"}}}
+{"ts":"2025-08-10T03:23:41.605Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.605Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.607Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.634Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" remembered"}}}
+{"ts":"2025-08-10T03:23:41.634Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.634Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.635Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.652Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.653Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.661Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" all"}}}
+{"ts":"2025-08-10T03:23:41.661Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.661Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.662Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.689Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:41.689Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.689Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.690Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.717Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" had"}}}
+{"ts":"2025-08-10T03:23:41.717Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.717Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.718Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.744Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" come"}}}
+{"ts":"2025-08-10T03:23:41.744Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.744Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.746Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.753Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.754Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.772Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:41.772Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.772Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.773Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.800Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" its"}}}
+{"ts":"2025-08-10T03:23:41.800Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.800Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.801Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.827Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" fore"}}}
+{"ts":"2025-08-10T03:23:41.827Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.827Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.828Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.855Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:41.855Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.855Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.856Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.858Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.859Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.882Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" The"}}}
+{"ts":"2025-08-10T03:23:41.882Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.882Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.884Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.910Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ancient"}}}
+{"ts":"2025-08-10T03:23:41.910Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.910Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.911Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.938Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" run"}}}
+{"ts":"2025-08-10T03:23:41.938Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.938Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.939Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.963Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.965Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.965Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"es"}}}
+{"ts":"2025-08-10T03:23:41.965Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.965Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.967Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:41.993Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" whispered"}}}
+{"ts":"2025-08-10T03:23:41.993Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.993Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:41.994Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.020Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:42.021Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.021Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.022Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.048Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" verdict"}}}
+{"ts":"2025-08-10T03:23:42.048Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.048Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.049Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.068Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.070Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.076Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":":"}}}
+{"ts":"2025-08-10T03:23:42.076Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.076Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.077Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.104Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:42.104Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.104Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.105Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.131Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ember"}}}
+{"ts":"2025-08-10T03:23:42.131Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.131Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.133Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.161Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"stone"}}}
+{"ts":"2025-08-10T03:23:42.161Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.161Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.162Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.168Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.170Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.188Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" can"}}}
+{"ts":"2025-08-10T03:23:42.188Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.188Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.189Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.216Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" grant"}}}
+{"ts":"2025-08-10T03:23:42.216Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.216Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.217Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.244Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:42.244Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.244Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.245Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.272Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.272Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" single"}}}
+{"ts":"2025-08-10T03:23:42.272Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.272Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.273Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.299Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" boon"}}}
+{"ts":"2025-08-10T03:23:42.299Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.299Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.300Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.327Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:42.327Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.327Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.328Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.355Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:42.355Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.355Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.356Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.377Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.378Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.383Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" pure"}}}
+{"ts":"2025-08-10T03:23:42.383Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.383Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.384Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.410Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" heart"}}}
+{"ts":"2025-08-10T03:23:42.410Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.410Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.412Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.438Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" for"}}}
+{"ts":"2025-08-10T03:23:42.438Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.438Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.439Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.466Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:42.466Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.466Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.467Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.482Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.483Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.493Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" single"}}}
+{"ts":"2025-08-10T03:23:42.493Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.493Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.495Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.521Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" sacrifice"}}}
+{"ts":"2025-08-10T03:23:42.521Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.521Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.522Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.549Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:42.549Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.549Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.550Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.576Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:42.576Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.577Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.578Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.587Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.588Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.604Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" after"}}}
+{"ts":"2025-08-10T03:23:42.604Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.604Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.605Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.632Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:42.632Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.632Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.633Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.664Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" act"}}}
+{"ts":"2025-08-10T03:23:42.664Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.664Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.666Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.692Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.693Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:42.693Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.693Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.693Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.720Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:42.720Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.720Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.721Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.748Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" light"}}}
+{"ts":"2025-08-10T03:23:42.748Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.748Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.749Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.776Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" would"}}}
+{"ts":"2025-08-10T03:23:42.776Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.776Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.777Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.797Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.798Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.803Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" be"}}}
+{"ts":"2025-08-10T03:23:42.803Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.803Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.804Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.831Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" forever"}}}
+{"ts":"2025-08-10T03:23:42.831Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.831Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.832Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.859Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" extingu"}}}
+{"ts":"2025-08-10T03:23:42.859Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.859Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.860Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.886Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ished"}}}
+{"ts":"2025-08-10T03:23:42.886Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.886Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.887Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.902Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.903Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.914Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":".\n\n"}}}
+{"ts":"2025-08-10T03:23:42.914Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.914Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:42.915Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.916Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.941Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"Ca"}}}
+{"ts":"2025-08-10T03:23:42.941Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.941Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.942Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.968Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:42.968Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:42.968Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.969Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"elan"}}}
+{"ts":"2025-08-10T03:23:42.969Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.969Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:42.970Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:42.997Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" realized"}}}
+{"ts":"2025-08-10T03:23:43.007Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.010Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.010Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.011Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.019Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:43.019Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:43.019Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:43.019Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.020Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.025Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:43.052Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" magnitude"}}}
+{"ts":"2025-08-10T03:23:43.074Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:43.080Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:43.107Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.108Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" his"}}}
+{"ts":"2025-08-10T03:23:43.111Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.111Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.111Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.111Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.111Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:43.111Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.111Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.111Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.111Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.113Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.135Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" decision"}}}
+{"ts":"2025-08-10T03:23:43.135Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.135Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.136Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.163Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:43.163Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.163Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.164Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.191Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" If"}}}
+{"ts":"2025-08-10T03:23:43.191Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.191Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.192Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.212Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.213Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.218Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" he"}}}
+{"ts":"2025-08-10T03:23:43.218Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.218Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.220Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.246Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" used"}}}
+{"ts":"2025-08-10T03:23:43.246Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.246Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.247Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.274Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:43.274Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.274Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.275Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.302Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" fire"}}}
+{"ts":"2025-08-10T03:23:43.302Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.302Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.303Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.317Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.318Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.329Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:43.329Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.329Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.331Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.357Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:43.357Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.357Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.358Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.385Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" valley"}}}
+{"ts":"2025-08-10T03:23:43.385Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.385Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.386Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.412Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" would"}}}
+{"ts":"2025-08-10T03:23:43.412Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.413Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.414Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.418Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.420Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.440Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" be"}}}
+{"ts":"2025-08-10T03:23:43.440Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.440Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.442Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.468Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" plunged"}}}
+{"ts":"2025-08-10T03:23:43.468Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.468Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.469Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.496Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" into"}}}
+{"ts":"2025-08-10T03:23:43.496Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.496Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.497Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.520Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.521Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.524Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" darkness"}}}
+{"ts":"2025-08-10T03:23:43.524Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.524Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.525Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.551Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" forever"}}}
+{"ts":"2025-08-10T03:23:43.551Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.551Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.553Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.579Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:43.579Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.579Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.580Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.607Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" but"}}}
+{"ts":"2025-08-10T03:23:43.607Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.607Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.608Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.625Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.626Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.634Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" perhaps"}}}
+{"ts":"2025-08-10T03:23:43.634Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.634Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.635Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.662Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" this"}}}
+{"ts":"2025-08-10T03:23:43.662Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.662Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.663Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.690Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" one"}}}
+{"ts":"2025-08-10T03:23:43.690Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.690Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.691Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.725Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.726Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.727Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" act"}}}
+{"ts":"2025-08-10T03:23:43.727Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.727Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.728Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.755Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" would"}}}
+{"ts":"2025-08-10T03:23:43.755Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.755Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.757Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.782Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" save"}}}
+{"ts":"2025-08-10T03:23:43.783Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.783Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.784Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.810Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:43.810Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.810Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.811Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.828Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.829Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.838Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" life"}}}
+{"ts":"2025-08-10T03:23:43.838Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.838Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.839Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.865Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:43.865Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.866Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.867Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.893Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" He"}}}
+{"ts":"2025-08-10T03:23:43.893Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.893Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.895Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.921Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" closed"}}}
+{"ts":"2025-08-10T03:23:43.921Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.921Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.922Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.933Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.935Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.949Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" his"}}}
+{"ts":"2025-08-10T03:23:43.949Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.949Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.950Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:43.976Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" eyes"}}}
+{"ts":"2025-08-10T03:23:43.976Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.976Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:43.978Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.004Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:44.004Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.004Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.005Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.032Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" taking"}}}
+{"ts":"2025-08-10T03:23:44.032Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.032Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.033Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.038Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.040Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.060Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:44.060Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.060Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.061Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.088Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" deep"}}}
+{"ts":"2025-08-10T03:23:44.088Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.088Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.089Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.115Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" breath"}}}
+{"ts":"2025-08-10T03:23:44.115Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.115Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.117Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.143Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.143Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:44.143Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.143Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.144Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.171Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:44.171Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.171Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.172Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.199Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" placed"}}}
+{"ts":"2025-08-10T03:23:44.199Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.199Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.200Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.226Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:44.226Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.226Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.228Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.245Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.246Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.254Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" stone"}}}
+{"ts":"2025-08-10T03:23:44.254Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.254Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.255Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.291Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" under"}}}
+{"ts":"2025-08-10T03:23:44.291Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.291Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.292Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.320Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:44.320Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.320Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.321Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.348Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.348Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" palm"}}}
+{"ts":"2025-08-10T03:23:44.348Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.348Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.349Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.375Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:44.375Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.375Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.376Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.403Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" his"}}}
+{"ts":"2025-08-10T03:23:44.403Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.403Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.404Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.431Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" own"}}}
+{"ts":"2025-08-10T03:23:44.431Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.431Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.432Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.453Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.454Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.459Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:44.459Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.459Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.460Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.486Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" The"}}}
+{"ts":"2025-08-10T03:23:44.486Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.486Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.488Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.514Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ember"}}}
+{"ts":"2025-08-10T03:23:44.514Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.514Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.515Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.542Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" sparked"}}}
+{"ts":"2025-08-10T03:23:44.542Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.542Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.543Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.556Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.557Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.570Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:44.570Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.570Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.571Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.597Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:44.597Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.597Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.599Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.625Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" golden"}}}
+{"ts":"2025-08-10T03:23:44.625Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.625Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.626Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.652Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" breath"}}}
+{"ts":"2025-08-10T03:23:44.652Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.652Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.654Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.661Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.662Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.680Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:44.680Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.680Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.681Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.708Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" curled"}}}
+{"ts":"2025-08-10T03:23:44.708Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.708Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.709Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.736Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" into"}}}
+{"ts":"2025-08-10T03:23:44.736Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.736Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.737Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.763Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.764Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" his"}}}
+{"ts":"2025-08-10T03:23:44.764Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.764Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.765Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.791Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" fingers"}}}
+{"ts":"2025-08-10T03:23:44.791Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.791Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.793Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.819Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:44.820Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.820Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.821Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.847Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Inst"}}}
+{"ts":"2025-08-10T03:23:44.847Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.847Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.848Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.869Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.870Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.875Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"inct"}}}
+{"ts":"2025-08-10T03:23:44.875Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.875Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.876Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.902Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ively"}}}
+{"ts":"2025-08-10T03:23:44.905Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.905Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.907Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.932Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:44.932Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.932Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.933Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.961Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" he"}}}
+{"ts":"2025-08-10T03:23:44.961Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.961Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.962Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.974Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.975Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:44.989Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" carried"}}}
+{"ts":"2025-08-10T03:23:44.989Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.990Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:44.991Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.018Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:45.018Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.018Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.019Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.046Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" vial"}}}
+{"ts":"2025-08-10T03:23:45.046Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.046Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.048Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.075Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:45.075Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.075Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.076Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.079Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.080Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.103Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" fire"}}}
+{"ts":"2025-08-10T03:23:45.103Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.103Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.104Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.132Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":".\n\n"}}}
+{"ts":"2025-08-10T03:23:45.132Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.133Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:45.133Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.134Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.160Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"He"}}}
+{"ts":"2025-08-10T03:23:45.160Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.160Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.162Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.184Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.185Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.186Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:45.186Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:45.187Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.188Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.189Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" returned"}}}
+{"ts":"2025-08-10T03:23:45.217Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:45.230Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.230Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.230Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.230Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.232Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.242Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:45.242Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:45.242Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:45.242Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.243Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.246Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:45.274Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" village"}}}
+{"ts":"2025-08-10T03:23:45.288Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.297Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:45.303Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" as"}}}
+{"ts":"2025-08-10T03:23:45.332Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.332Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.332Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.332Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.332Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:45.332Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.332Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.332Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:45.332Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.332Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.333Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.361Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" night"}}}
+{"ts":"2025-08-10T03:23:45.361Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.361Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.362Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.389Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.390Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.393Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" fell"}}}
+{"ts":"2025-08-10T03:23:45.393Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.393Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.394Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.421Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:45.421Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.421Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.423Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.450Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" The"}}}
+{"ts":"2025-08-10T03:23:45.450Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.450Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.451Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.478Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" flames"}}}
+{"ts":"2025-08-10T03:23:45.479Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.479Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.480Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.494Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.496Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.507Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" were"}}}
+{"ts":"2025-08-10T03:23:45.507Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.507Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.509Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.536Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" small"}}}
+{"ts":"2025-08-10T03:23:45.536Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.536Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.537Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.566Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:45.566Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.566Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.567Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.594Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.594Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" trembling"}}}
+{"ts":"2025-08-10T03:23:45.594Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.594Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.596Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.623Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:45.623Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.623Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.624Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.652Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" yet"}}}
+{"ts":"2025-08-10T03:23:45.652Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.652Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.653Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.681Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" they"}}}
+{"ts":"2025-08-10T03:23:45.681Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.681Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.682Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.699Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.701Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.710Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" lit"}}}
+{"ts":"2025-08-10T03:23:45.710Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.710Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.711Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.738Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:45.738Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.738Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.739Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.766Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" wounds"}}}
+{"ts":"2025-08-10T03:23:45.766Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.766Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.767Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.794Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:45.794Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.794Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.795Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.804Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.806Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.822Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" his"}}}
+{"ts":"2025-08-10T03:23:45.822Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.822Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.823Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.850Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" mother's"}}}
+{"ts":"2025-08-10T03:23:45.850Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.850Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.851Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.878Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" fever"}}}
+{"ts":"2025-08-10T03:23:45.878Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.878Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.879Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.906Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:45.906Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.906Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.907Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.908Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.909Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.934Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Her"}}}
+{"ts":"2025-08-10T03:23:45.934Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.934Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.936Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.961Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" eyes"}}}
+{"ts":"2025-08-10T03:23:45.961Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.961Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.963Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:45.989Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" widened"}}}
+{"ts":"2025-08-10T03:23:45.989Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.989Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:45.991Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.013Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.014Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.018Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" as"}}}
+{"ts":"2025-08-10T03:23:46.018Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.018Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.019Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.045Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" warmth"}}}
+{"ts":"2025-08-10T03:23:46.045Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.045Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.047Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.073Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" flooded"}}}
+{"ts":"2025-08-10T03:23:46.073Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.073Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.074Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.101Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" through"}}}
+{"ts":"2025-08-10T03:23:46.101Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.101Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.102Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.118Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.119Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.129Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" her"}}}
+{"ts":"2025-08-10T03:23:46.129Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.129Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.130Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.157Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" bones"}}}
+{"ts":"2025-08-10T03:23:46.157Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.157Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.158Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.185Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:46.185Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.185Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.186Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.213Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" She"}}}
+{"ts":"2025-08-10T03:23:46.213Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.213Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.214Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.223Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.224Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.241Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" smiled"}}}
+{"ts":"2025-08-10T03:23:46.241Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.241Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.242Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.269Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:46.269Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.269Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.270Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.296Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:46.296Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.296Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.298Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.324Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" small"}}}
+{"ts":"2025-08-10T03:23:46.324Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.324Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.325Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.328Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.329Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.352Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" but"}}}
+{"ts":"2025-08-10T03:23:46.352Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.352Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.353Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.380Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" sincere"}}}
+{"ts":"2025-08-10T03:23:46.380Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.380Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.381Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.408Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" expression"}}}
+{"ts":"2025-08-10T03:23:46.408Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.408Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.409Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.428Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.430Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.436Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:46.436Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.436Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.437Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.464Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" gratitude"}}}
+{"ts":"2025-08-10T03:23:46.464Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.464Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.465Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.494Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:46.494Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.494Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.496Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.523Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" \""}}}
+{"ts":"2025-08-10T03:23:46.523Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.523Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.524Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.530Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.532Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.551Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"My"}}}
+{"ts":"2025-08-10T03:23:46.551Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.551Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.552Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.579Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" love"}}}
+{"ts":"2025-08-10T03:23:46.579Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.579Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.580Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.607Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":",\""}}}
+{"ts":"2025-08-10T03:23:46.607Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.607Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.608Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.631Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.632Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.635Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" she"}}}
+{"ts":"2025-08-10T03:23:46.635Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.635Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.636Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.663Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" whispered"}}}
+{"ts":"2025-08-10T03:23:46.663Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.663Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.664Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.691Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:46.691Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.691Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.692Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.719Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" \""}}}
+{"ts":"2025-08-10T03:23:46.719Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.719Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.720Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.735Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.736Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.746Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"you"}}}
+{"ts":"2025-08-10T03:23:46.746Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.747Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.748Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.774Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" have"}}}
+{"ts":"2025-08-10T03:23:46.774Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.774Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.776Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.802Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" saved"}}}
+{"ts":"2025-08-10T03:23:46.802Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.802Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.804Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.830Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" me"}}}
+{"ts":"2025-08-10T03:23:46.830Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.830Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.832Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.835Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.837Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.858Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:46.858Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.858Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.860Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.886Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" I"}}}
+{"ts":"2025-08-10T03:23:46.886Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.886Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.888Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.914Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" cannot"}}}
+{"ts":"2025-08-10T03:23:46.914Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.914Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.916Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.936Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.938Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.943Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" say"}}}
+{"ts":"2025-08-10T03:23:46.943Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.943Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.944Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.971Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" I"}}}
+{"ts":"2025-08-10T03:23:46.971Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.971Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.972Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:46.999Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" understand"}}}
+{"ts":"2025-08-10T03:23:46.999Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:46.999Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.000Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.026Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" how"}}}
+{"ts":"2025-08-10T03:23:47.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.028Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.040Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.042Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.054Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" you'd"}}}
+{"ts":"2025-08-10T03:23:47.054Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.054Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.056Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.082Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" choose"}}}
+{"ts":"2025-08-10T03:23:47.082Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.082Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.084Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.110Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" our"}}}
+{"ts":"2025-08-10T03:23:47.110Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.110Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.111Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.138Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" safety"}}}
+{"ts":"2025-08-10T03:23:47.138Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.138Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.139Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.145Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.147Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.166Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" for"}}}
+{"ts":"2025-08-10T03:23:47.166Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.166Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.167Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.194Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:47.194Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.194Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.195Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.222Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" single"}}}
+{"ts":"2025-08-10T03:23:47.222Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.222Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.223Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.248Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.249Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.250Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" flame"}}}
+{"ts":"2025-08-10T03:23:47.250Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.250Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.251Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.278Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"...\"\n\n"}}}
+{"ts":"2025-08-10T03:23:47.278Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.279Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:47.279Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.280Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.306Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"After"}}}
+{"ts":"2025-08-10T03:23:47.306Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.306Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.307Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.331Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:47.331Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:47.331Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.332Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.334Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:47.350Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.350Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.351Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.352Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.353Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.362Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" night"}}}
+{"ts":"2025-08-10T03:23:47.362Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.362Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.363Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.386Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:47.386Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:47.386Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:47.386Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.387Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.390Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:47.418Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ca"}}}
+{"ts":"2025-08-10T03:23:47.441Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:47.446Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"elan"}}}
+{"ts":"2025-08-10T03:23:47.451Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.451Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.451Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.451Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.451Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:47.451Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.451Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.453Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.457Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.458Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.473Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" sealed"}}}
+{"ts":"2025-08-10T03:23:47.473Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.473Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.474Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.505Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:47.505Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.505Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.506Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.533Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ember"}}}
+{"ts":"2025-08-10T03:23:47.533Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.533Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.534Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.561Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"stone"}}}
+{"ts":"2025-08-10T03:23:47.561Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.561Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.562Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.563Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.589Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" back"}}}
+{"ts":"2025-08-10T03:23:47.589Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.589Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.591Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.617Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" in"}}}
+{"ts":"2025-08-10T03:23:47.617Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.617Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.619Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.645Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" its"}}}
+{"ts":"2025-08-10T03:23:47.645Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.645Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.647Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.664Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.666Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.673Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" sanctuary"}}}
+{"ts":"2025-08-10T03:23:47.673Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.673Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.675Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.701Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:47.701Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.701Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.703Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.730Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" took"}}}
+{"ts":"2025-08-10T03:23:47.730Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.730Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.731Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.758Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:47.758Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.758Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.759Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.769Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.771Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.786Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" responsibility"}}}
+{"ts":"2025-08-10T03:23:47.786Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.786Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.787Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.814Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:47.814Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.814Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.815Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.842Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" keeping"}}}
+{"ts":"2025-08-10T03:23:47.842Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.842Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.843Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.870Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:47.870Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.870Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.871Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.871Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.873Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.898Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" light"}}}
+{"ts":"2025-08-10T03:23:47.898Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.898Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.899Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.926Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:47.926Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.926Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.927Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.954Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:47.954Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.954Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.955Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.976Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.978Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:47.982Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" keep"}}}
+{"ts":"2025-08-10T03:23:47.982Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.982Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:47.984Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.010Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:48.010Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.010Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.012Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.040Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Though"}}}
+{"ts":"2025-08-10T03:23:48.040Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.040Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.041Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.068Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:48.068Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.068Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.069Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.081Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.083Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.096Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" valley"}}}
+{"ts":"2025-08-10T03:23:48.096Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.096Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.097Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.124Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" was"}}}
+{"ts":"2025-08-10T03:23:48.124Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.124Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.125Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.152Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" robbed"}}}
+{"ts":"2025-08-10T03:23:48.152Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.152Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.153Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.180Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:48.180Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.180Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.181Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.182Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.208Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" its"}}}
+{"ts":"2025-08-10T03:23:48.208Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.208Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.210Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.236Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" eternal"}}}
+{"ts":"2025-08-10T03:23:48.236Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.236Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.237Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.264Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ember"}}}
+{"ts":"2025-08-10T03:23:48.264Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.264Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.266Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.285Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.287Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.292Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:48.292Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.292Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.294Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.320Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:48.321Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.321Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.322Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.349Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" memory"}}}
+{"ts":"2025-08-10T03:23:48.349Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.349Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.350Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.377Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" lasted"}}}
+{"ts":"2025-08-10T03:23:48.377Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.377Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.378Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.389Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.391Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.405Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:48.405Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.405Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.406Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.433Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" His"}}}
+{"ts":"2025-08-10T03:23:48.433Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.433Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.434Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.461Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" mother"}}}
+{"ts":"2025-08-10T03:23:48.461Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.461Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.462Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.489Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:48.489Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.489Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.490Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.490Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.521Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" healed"}}}
+{"ts":"2025-08-10T03:23:48.521Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.521Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.522Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.550Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:48.550Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.550Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.551Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.577Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" lived"}}}
+{"ts":"2025-08-10T03:23:48.577Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.577Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.579Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.591Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.593Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.605Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" many"}}}
+{"ts":"2025-08-10T03:23:48.605Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.605Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.607Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.634Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" more"}}}
+{"ts":"2025-08-10T03:23:48.634Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.634Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.635Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.661Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" years"}}}
+{"ts":"2025-08-10T03:23:48.661Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.661Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.663Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.689Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:48.689Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.689Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.690Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.692Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.693Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.717Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" The"}}}
+{"ts":"2025-08-10T03:23:48.717Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.717Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.718Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.745Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" village"}}}
+{"ts":"2025-08-10T03:23:48.745Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.745Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.746Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.773Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" adapted"}}}
+{"ts":"2025-08-10T03:23:48.773Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.773Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.774Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.793Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.794Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.801Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:48.801Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.801Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.803Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.829Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" learning"}}}
+{"ts":"2025-08-10T03:23:48.829Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.829Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.831Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.857Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:48.857Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.857Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.859Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.885Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" find"}}}
+{"ts":"2025-08-10T03:23:48.885Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.885Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.887Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.898Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.899Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.914Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" joy"}}}
+{"ts":"2025-08-10T03:23:48.914Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.914Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.915Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.942Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" in"}}}
+{"ts":"2025-08-10T03:23:48.942Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.942Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.943Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.970Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:48.970Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.970Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.971Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:48.998Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.998Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" flick"}}}
+{"ts":"2025-08-10T03:23:48.998Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.998Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:48.999Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.026Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"er"}}}
+{"ts":"2025-08-10T03:23:49.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.027Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.057Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:49.057Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.057Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.059Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.086Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:49.086Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.086Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.087Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.100Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.102Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.114Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" single"}}}
+{"ts":"2025-08-10T03:23:49.114Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.114Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.116Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.143Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" candle"}}}
+{"ts":"2025-08-10T03:23:49.143Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.143Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.144Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.171Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" each"}}}
+{"ts":"2025-08-10T03:23:49.171Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.171Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.172Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.199Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" night"}}}
+{"ts":"2025-08-10T03:23:49.199Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.199Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.200Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.201Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.202Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.227Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":".\n\n"}}}
+{"ts":"2025-08-10T03:23:49.227Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.228Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:49.228Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.229Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.255Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"Years"}}}
+{"ts":"2025-08-10T03:23:49.255Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.255Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.257Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.283Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:49.283Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:49.283Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.284Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" turned"}}}
+{"ts":"2025-08-10T03:23:49.284Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.284Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.284Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.302Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.312Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" into"}}}
+{"ts":"2025-08-10T03:23:49.338Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:49.340Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" decades"}}}
+{"ts":"2025-08-10T03:23:49.368Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:49.369Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.369Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.369Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:49.369Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:49.369Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.370Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.370Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.370Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.370Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.371Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.393Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:49.396Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:49.407Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.424Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" then"}}}
+{"ts":"2025-08-10T03:23:49.452Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" centuries"}}}
+{"ts":"2025-08-10T03:23:49.471Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:49.471Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.471Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.471Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.471Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.471Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.471Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.472Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.480Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:49.481Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.481Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.482Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.509Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.509Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" until"}}}
+{"ts":"2025-08-10T03:23:49.509Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.509Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.510Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.537Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:49.537Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.537Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.538Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.565Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Great"}}}
+{"ts":"2025-08-10T03:23:49.565Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.565Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.566Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.593Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Storm"}}}
+{"ts":"2025-08-10T03:23:49.593Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.593Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.594Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.614Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.615Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.629Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" swept"}}}
+{"ts":"2025-08-10T03:23:49.629Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.629Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.630Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.658Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" across"}}}
+{"ts":"2025-08-10T03:23:49.658Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.658Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.659Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.686Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ever"}}}
+{"ts":"2025-08-10T03:23:49.686Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.686Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.687Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.714Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"g"}}}
+{"ts":"2025-08-10T03:23:49.714Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.714Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.715Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.719Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.720Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.742Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"len"}}}
+{"ts":"2025-08-10T03:23:49.742Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.742Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.743Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.770Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:49.770Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.770Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.771Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.798Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" breaking"}}}
+{"ts":"2025-08-10T03:23:49.798Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.798Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.799Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.824Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.825Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.826Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:49.826Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.826Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.827Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.854Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" veil"}}}
+{"ts":"2025-08-10T03:23:49.854Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.854Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.855Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.882Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:49.882Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.882Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.883Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.910Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:49.910Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.910Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.911Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.929Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.930Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.938Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" once"}}}
+{"ts":"2025-08-10T03:23:49.938Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.938Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.940Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.966Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" un"}}}
+{"ts":"2025-08-10T03:23:49.966Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.966Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.968Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:49.994Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"break"}}}
+{"ts":"2025-08-10T03:23:49.994Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.995Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:49.996Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.023Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"able"}}}
+{"ts":"2025-08-10T03:23:50.023Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.023Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.024Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.034Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.035Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.051Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" stone"}}}
+{"ts":"2025-08-10T03:23:50.051Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.051Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.052Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.079Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" walls"}}}
+{"ts":"2025-08-10T03:23:50.079Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.079Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.080Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.107Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:50.107Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.107Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.109Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.135Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" The"}}}
+{"ts":"2025-08-10T03:23:50.135Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.135Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.136Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.139Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.140Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.164Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" storm"}}}
+{"ts":"2025-08-10T03:23:50.164Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.164Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.166Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.192Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" tore"}}}
+{"ts":"2025-08-10T03:23:50.192Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.192Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.193Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.220Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:50.220Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.220Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.221Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.244Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.245Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.248Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Keep"}}}
+{"ts":"2025-08-10T03:23:50.248Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.248Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.250Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.277Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:50.277Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.277Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.278Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.305Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" L"}}}
+{"ts":"2025-08-10T03:23:50.305Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.305Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.306Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.333Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"iora"}}}
+{"ts":"2025-08-10T03:23:50.333Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.333Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.334Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.347Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.348Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.361Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" into"}}}
+{"ts":"2025-08-10T03:23:50.361Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.361Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.363Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.390Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ruins"}}}
+{"ts":"2025-08-10T03:23:50.390Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.390Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.391Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.418Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:50.418Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.418Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.419Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.446Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" leaving"}}}
+{"ts":"2025-08-10T03:23:50.446Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.446Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.447Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.448Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.449Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.474Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:50.474Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.474Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.475Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.502Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ember"}}}
+{"ts":"2025-08-10T03:23:50.502Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.502Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.503Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.530Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"stone"}}}
+{"ts":"2025-08-10T03:23:50.530Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.530Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.531Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.552Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.553Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.558Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" un"}}}
+{"ts":"2025-08-10T03:23:50.558Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.558Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.560Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.587Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"protected"}}}
+{"ts":"2025-08-10T03:23:50.587Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.587Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.588Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.615Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:50.615Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.615Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.616Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.643Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" In"}}}
+{"ts":"2025-08-10T03:23:50.643Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.643Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.644Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.657Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.658Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.671Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:50.671Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.671Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.672Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.699Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ruins"}}}
+{"ts":"2025-08-10T03:23:50.699Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.699Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.700Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.736Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:50.736Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.736Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.737Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.762Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.764Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.767Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" whispers"}}}
+{"ts":"2025-08-10T03:23:50.767Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.768Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.769Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.796Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" spread"}}}
+{"ts":"2025-08-10T03:23:50.796Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.796Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.797Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.824Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:50.824Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.824Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.825Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.853Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" someone"}}}
+{"ts":"2025-08-10T03:23:50.854Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.854Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.856Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.863Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.865Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.881Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" from"}}}
+{"ts":"2025-08-10T03:23:50.881Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.881Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.882Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.909Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:50.909Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.909Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.910Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.937Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" past"}}}
+{"ts":"2025-08-10T03:23:50.937Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.937Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.938Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.964Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.965Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" had"}}}
+{"ts":"2025-08-10T03:23:50.965Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.965Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.966Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:50.993Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" stolen"}}}
+{"ts":"2025-08-10T03:23:50.993Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.993Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:50.994Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.021Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:51.021Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.021Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.022Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.049Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ember"}}}
+{"ts":"2025-08-10T03:23:51.049Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.049Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.050Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.069Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.071Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.077Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:51.077Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.077Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.078Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.105Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" or"}}}
+{"ts":"2025-08-10T03:23:51.105Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.105Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.107Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.133Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:51.133Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.133Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.135Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.162Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" it"}}}
+{"ts":"2025-08-10T03:23:51.162Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.162Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.163Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.171Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.172Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.190Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" had"}}}
+{"ts":"2025-08-10T03:23:51.190Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.190Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.191Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.218Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" been"}}}
+{"ts":"2025-08-10T03:23:51.218Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.218Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.219Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.246Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" left"}}}
+{"ts":"2025-08-10T03:23:51.246Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.246Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.248Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.274Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.275Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" behind"}}}
+{"ts":"2025-08-10T03:23:51.275Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.275Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.276Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.303Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":".\n\n"}}}
+{"ts":"2025-08-10T03:23:51.303Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.304Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:51.304Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.305Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.330Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"It"}}}
+{"ts":"2025-08-10T03:23:51.330Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.330Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.332Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.359Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" was"}}}
+{"ts":"2025-08-10T03:23:51.359Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.359Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.359Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:51.359Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:51.359Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.360Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.379Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.387Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" then"}}}
+{"ts":"2025-08-10T03:23:51.389Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.389Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.390Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.414Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:51.414Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:51.414Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:51.414Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.415Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.415Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:51.443Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:51.469Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:51.472Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" new"}}}
+{"ts":"2025-08-10T03:23:51.484Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.490Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.490Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.490Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.490Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.490Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:51.490Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.490Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.492Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.500Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" chapter"}}}
+{"ts":"2025-08-10T03:23:51.500Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.500Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.501Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.528Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" began"}}}
+{"ts":"2025-08-10T03:23:51.528Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.528Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.530Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.556Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:51.556Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.556Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.558Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.584Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" A"}}}
+{"ts":"2025-08-10T03:23:51.584Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.584Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.585Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.586Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.587Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.612Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" young"}}}
+{"ts":"2025-08-10T03:23:51.612Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.612Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.614Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.641Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" woman"}}}
+{"ts":"2025-08-10T03:23:51.641Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.641Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.642Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.669Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" named"}}}
+{"ts":"2025-08-10T03:23:51.669Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.669Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.670Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.691Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.692Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.697Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ar"}}}
+{"ts":"2025-08-10T03:23:51.697Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.697Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.698Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.725Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ia"}}}
+{"ts":"2025-08-10T03:23:51.725Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.725Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.727Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.754Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:51.754Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.754Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.755Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.782Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" descendant"}}}
+{"ts":"2025-08-10T03:23:51.782Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.782Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.783Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.796Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.797Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.810Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:51.810Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.810Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.811Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.843Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ca"}}}
+{"ts":"2025-08-10T03:23:51.843Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.843Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.844Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.872Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"elan"}}}
+{"ts":"2025-08-10T03:23:51.872Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.872Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.873Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.900Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.900Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"'s"}}}
+{"ts":"2025-08-10T03:23:51.900Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.900Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.901Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.929Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" line"}}}
+{"ts":"2025-08-10T03:23:51.929Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.929Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.930Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.957Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:51.957Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.957Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.958Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:51.985Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" with"}}}
+{"ts":"2025-08-10T03:23:51.985Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.985Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:51.987Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.002Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.003Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.014Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:52.014Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.014Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.015Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.042Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" keen"}}}
+{"ts":"2025-08-10T03:23:52.042Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.042Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.043Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.070Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" curiosity"}}}
+{"ts":"2025-08-10T03:23:52.070Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.070Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.071Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.098Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:52.098Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.098Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.099Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.107Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.108Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.127Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" an"}}}
+{"ts":"2025-08-10T03:23:52.127Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.127Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.128Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.155Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" un"}}}
+{"ts":"2025-08-10T03:23:52.155Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.155Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.156Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.183Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"fl"}}}
+{"ts":"2025-08-10T03:23:52.183Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.183Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.184Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.211Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.212Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"in"}}}
+{"ts":"2025-08-10T03:23:52.212Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.212Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.212Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.239Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ching"}}}
+{"ts":"2025-08-10T03:23:52.240Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.240Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.241Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.268Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" resolve"}}}
+{"ts":"2025-08-10T03:23:52.268Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.268Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.269Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.296Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:52.296Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.296Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.297Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.316Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.318Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.324Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" would"}}}
+{"ts":"2025-08-10T03:23:52.325Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.325Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.326Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.353Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" find"}}}
+{"ts":"2025-08-10T03:23:52.353Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.353Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.354Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.381Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" her"}}}
+{"ts":"2025-08-10T03:23:52.381Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.381Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.384Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.411Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" way"}}}
+{"ts":"2025-08-10T03:23:52.411Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.411Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.412Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.420Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.421Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.439Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:52.439Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.439Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.440Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.467Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" She"}}}
+{"ts":"2025-08-10T03:23:52.467Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.467Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.468Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.495Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" would"}}}
+{"ts":"2025-08-10T03:23:52.495Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.495Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.496Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.524Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" hear"}}}
+{"ts":"2025-08-10T03:23:52.524Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.524Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.525Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.525Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.552Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:52.552Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.552Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.553Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.580Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:52.580Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.580Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.582Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.609Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" old"}}}
+{"ts":"2025-08-10T03:23:52.609Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.609Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.610Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.630Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.631Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.637Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" stories"}}}
+{"ts":"2025-08-10T03:23:52.637Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.637Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.638Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.665Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:52.665Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.665Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.667Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.694Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:52.694Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.694Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.695Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.722Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" stone"}}}
+{"ts":"2025-08-10T03:23:52.722Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.722Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.723Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.735Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.736Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.750Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"'s"}}}
+{"ts":"2025-08-10T03:23:52.750Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.750Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.751Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.778Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ember"}}}
+{"ts":"2025-08-10T03:23:52.778Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.778Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.780Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.807Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:52.807Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.807Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.808Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.835Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:52.835Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.835Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.835Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.836Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.863Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" memory"}}}
+{"ts":"2025-08-10T03:23:52.863Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.863Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.864Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.892Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:52.892Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.892Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.893Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.920Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" carried"}}}
+{"ts":"2025-08-10T03:23:52.920Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.920Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.921Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.940Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.942Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.952Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:52.952Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.952Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.953Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:52.981Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" weight"}}}
+{"ts":"2025-08-10T03:23:52.981Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.981Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:52.982Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.009Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:53.009Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.009Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.011Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.038Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" choice"}}}
+{"ts":"2025-08-10T03:23:53.038Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.038Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.039Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.045Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.047Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.066Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":".\n\n"}}}
+{"ts":"2025-08-10T03:23:53.066Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.067Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:53.067Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.069Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.094Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"Ar"}}}
+{"ts":"2025-08-10T03:23:53.094Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.094Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.095Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.119Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:53.119Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:53.119Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.120Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.122Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ia"}}}
+{"ts":"2025-08-10T03:23:53.148Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.150Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" walked"}}}
+{"ts":"2025-08-10T03:23:53.169Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:53.179Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" along"}}}
+{"ts":"2025-08-10T03:23:53.206Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.206Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.206Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.206Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.206Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:53.206Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:53.206Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.206Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.206Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.207Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:53.207Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.207Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.208Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.224Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:53.236Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" river"}}}
+{"ts":"2025-08-10T03:23:53.252Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.264Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:53.292Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" found"}}}
+{"ts":"2025-08-10T03:23:53.307Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:53.307Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.307Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.307Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.307Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.307Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.307Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.308Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.321Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" herself"}}}
+{"ts":"2025-08-10T03:23:53.321Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.321Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.322Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.349Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" at"}}}
+{"ts":"2025-08-10T03:23:53.349Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.349Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.350Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.357Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.358Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.377Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:53.377Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.377Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.379Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.406Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ruins"}}}
+{"ts":"2025-08-10T03:23:53.406Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.406Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.407Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.434Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:53.434Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.434Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.436Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.462Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.462Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" She"}}}
+{"ts":"2025-08-10T03:23:53.462Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.462Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.463Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.491Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" felt"}}}
+{"ts":"2025-08-10T03:23:53.491Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.491Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.492Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.519Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:53.519Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.519Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.520Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.547Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" pull"}}}
+{"ts":"2025-08-10T03:23:53.547Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.547Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.548Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.564Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.565Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.575Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" in"}}}
+{"ts":"2025-08-10T03:23:53.575Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.575Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.576Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.604Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" her"}}}
+{"ts":"2025-08-10T03:23:53.604Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.604Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.605Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.632Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" heart"}}}
+{"ts":"2025-08-10T03:23:53.632Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.632Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.633Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.660Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:53.660Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.660Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.661Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.669Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.670Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.688Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" felt"}}}
+{"ts":"2025-08-10T03:23:53.688Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.688Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.689Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.716Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:53.716Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.716Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.717Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.743Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" stirring"}}}
+{"ts":"2025-08-10T03:23:53.743Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.743Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.745Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.771Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.771Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:53.771Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.771Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.772Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.799Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" destiny"}}}
+{"ts":"2025-08-10T03:23:53.799Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.799Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.800Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.827Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:53.827Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.827Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.828Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.855Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" She"}}}
+{"ts":"2025-08-10T03:23:53.855Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.856Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.857Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.876Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.877Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.884Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" discovered"}}}
+{"ts":"2025-08-10T03:23:53.884Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.884Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.885Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.912Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:53.912Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.912Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.913Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.941Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" in"}}}
+{"ts":"2025-08-10T03:23:53.941Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.941Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.942Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.969Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:53.969Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.969Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.971Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.981Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.982Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:53.998Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" middle"}}}
+{"ts":"2025-08-10T03:23:53.998Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.998Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:53.999Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.035Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:54.035Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.035Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.036Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.065Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:54.065Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.065Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.066Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.085Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.087Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.093Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ruins"}}}
+{"ts":"2025-08-10T03:23:54.093Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.093Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.094Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.121Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:54.121Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.122Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.123Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.150Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:54.150Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.150Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.151Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.178Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" cavity"}}}
+{"ts":"2025-08-10T03:23:54.178Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.178Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.180Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.185Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.187Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.207Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:54.207Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.207Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.208Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.235Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" gl"}}}
+{"ts":"2025-08-10T03:23:54.235Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.235Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.236Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.264Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"owed"}}}
+{"ts":"2025-08-10T03:23:54.264Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.264Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.265Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.290Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.292Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.292Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" faint"}}}
+{"ts":"2025-08-10T03:23:54.292Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.292Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.293Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.320Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ly"}}}
+{"ts":"2025-08-10T03:23:54.320Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.320Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.322Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.349Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" in"}}}
+{"ts":"2025-08-10T03:23:54.349Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.349Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.350Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.377Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:54.377Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.377Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.378Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.395Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.397Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.405Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" moon"}}}
+{"ts":"2025-08-10T03:23:54.405Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.405Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.407Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.434Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"light"}}}
+{"ts":"2025-08-10T03:23:54.434Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.434Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.435Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.463Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":":"}}}
+{"ts":"2025-08-10T03:23:54.463Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.463Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.464Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.491Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:54.491Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.491Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.492Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.499Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.500Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.520Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ember"}}}
+{"ts":"2025-08-10T03:23:54.520Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.520Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.521Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.548Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"stone"}}}
+{"ts":"2025-08-10T03:23:54.548Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.548Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.549Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.576Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:54.576Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.576Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.577Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.604Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.605Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.614Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" broken"}}}
+{"ts":"2025-08-10T03:23:54.614Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.614Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.615Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.643Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:54.643Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.643Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.644Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.672Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" yet"}}}
+{"ts":"2025-08-10T03:23:54.672Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.672Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.673Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.700Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" still"}}}
+{"ts":"2025-08-10T03:23:54.700Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.700Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.701Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.709Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.710Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.728Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" lit"}}}
+{"ts":"2025-08-10T03:23:54.728Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.728Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.730Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.757Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:54.757Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.757Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.758Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.785Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:54.785Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.785Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.787Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.814Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.814Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" same"}}}
+{"ts":"2025-08-10T03:23:54.814Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.814Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.815Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.842Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ember"}}}
+{"ts":"2025-08-10T03:23:54.842Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.842Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.844Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.871Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:54.871Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.871Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.872Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.899Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" had"}}}
+{"ts":"2025-08-10T03:23:54.899Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.899Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.901Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.919Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.920Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.928Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" lived"}}}
+{"ts":"2025-08-10T03:23:54.928Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.928Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.929Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.956Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" on"}}}
+{"ts":"2025-08-10T03:23:54.956Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.956Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.958Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:54.985Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ca"}}}
+{"ts":"2025-08-10T03:23:54.985Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.985Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:54.986Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.013Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"elan"}}}
+{"ts":"2025-08-10T03:23:55.014Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.014Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.015Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.024Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.025Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.042Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"'s"}}}
+{"ts":"2025-08-10T03:23:55.042Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.042Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.043Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.070Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" finger"}}}
+{"ts":"2025-08-10T03:23:55.070Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.070Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.072Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.099Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":".\n\n"}}}
+{"ts":"2025-08-10T03:23:55.099Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.100Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:55.100Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.101Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.127Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.127Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"With"}}}
+{"ts":"2025-08-10T03:23:55.127Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.127Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.128Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.152Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:55.152Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:55.152Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.153Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.156Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" careful"}}}
+{"ts":"2025-08-10T03:23:55.184Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" hands"}}}
+{"ts":"2025-08-10T03:23:55.207Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:55.213Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:55.223Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.223Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.223Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.223Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.223Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:55.223Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:55.223Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.223Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.223Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.225Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.232Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.241Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" she"}}}
+{"ts":"2025-08-10T03:23:55.262Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:55.270Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" reached"}}}
+{"ts":"2025-08-10T03:23:55.298Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" for"}}}
+{"ts":"2025-08-10T03:23:55.324Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.324Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.324Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:55.324Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.325Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.325Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.325Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.326Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.327Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" it"}}}
+{"ts":"2025-08-10T03:23:55.327Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.327Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.328Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.336Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.337Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.355Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:55.355Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.355Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.356Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.383Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" It"}}}
+{"ts":"2025-08-10T03:23:55.383Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.383Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.385Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.412Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" was"}}}
+{"ts":"2025-08-10T03:23:55.412Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.412Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.413Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.441Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" warm"}}}
+{"ts":"2025-08-10T03:23:55.441Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.441Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.441Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.442Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.469Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:55.469Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.469Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.470Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.498Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:55.498Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.498Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.499Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.526Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" when"}}}
+{"ts":"2025-08-10T03:23:55.526Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.526Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.527Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.546Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.547Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.554Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" she"}}}
+{"ts":"2025-08-10T03:23:55.554Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.554Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.555Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.583Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" embraced"}}}
+{"ts":"2025-08-10T03:23:55.583Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.583Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.584Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.611Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" it"}}}
+{"ts":"2025-08-10T03:23:55.611Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.611Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.612Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.640Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:55.640Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.640Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.641Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.651Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.652Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.668Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" she"}}}
+{"ts":"2025-08-10T03:23:55.668Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.668Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.670Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.703Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" felt"}}}
+{"ts":"2025-08-10T03:23:55.703Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.703Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.705Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.733Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:55.733Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.733Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.734Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.756Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.757Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.761Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" vision"}}}
+{"ts":"2025-08-10T03:23:55.761Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.761Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.762Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.790Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":":"}}}
+{"ts":"2025-08-10T03:23:55.790Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.790Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.791Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.818Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:55.818Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.818Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.819Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.847Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" valley"}}}
+{"ts":"2025-08-10T03:23:55.847Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.847Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.848Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.861Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.862Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.875Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" under"}}}
+{"ts":"2025-08-10T03:23:55.875Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.875Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.876Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.904Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:55.904Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.904Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.905Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.932Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" storm"}}}
+{"ts":"2025-08-10T03:23:55.932Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.932Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.934Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.961Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:55.961Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.961Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.961Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.962Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:55.989Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:55.989Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.989Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:55.990Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.017Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" light"}}}
+{"ts":"2025-08-10T03:23:56.017Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.017Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.018Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.045Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:56.045Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.045Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.046Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.066Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.067Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.073Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:56.073Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.073Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.075Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.102Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ember"}}}
+{"ts":"2025-08-10T03:23:56.102Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.102Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.103Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.130Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:56.130Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.130Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.131Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.158Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ca"}}}
+{"ts":"2025-08-10T03:23:56.158Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.158Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.159Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.169Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.170Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.186Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"elan"}}}
+{"ts":"2025-08-10T03:23:56.186Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.186Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.187Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.215Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"'s"}}}
+{"ts":"2025-08-10T03:23:56.215Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.215Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.216Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.243Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" smile"}}}
+{"ts":"2025-08-10T03:23:56.243Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.243Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.245Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.271Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:56.271Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.271Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.273Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.274Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.275Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.299Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:56.300Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.300Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.301Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.328Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" hope"}}}
+{"ts":"2025-08-10T03:23:56.328Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.328Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.329Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.356Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" he"}}}
+{"ts":"2025-08-10T03:23:56.356Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.356Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.358Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.379Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.380Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.385Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" brought"}}}
+{"ts":"2025-08-10T03:23:56.385Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.385Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.386Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.413Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:56.413Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.413Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.415Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.442Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" his"}}}
+{"ts":"2025-08-10T03:23:56.442Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.442Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.443Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.471Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" mother"}}}
+{"ts":"2025-08-10T03:23:56.471Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.471Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.472Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.484Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.485Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.499Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:56.499Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.499Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.500Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.528Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" She"}}}
+{"ts":"2025-08-10T03:23:56.528Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.528Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.529Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.556Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" understood"}}}
+{"ts":"2025-08-10T03:23:56.556Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.556Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.557Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.585Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.585Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" then"}}}
+{"ts":"2025-08-10T03:23:56.585Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.585Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.586Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.613Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:56.613Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.613Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.615Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.642Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" weight"}}}
+{"ts":"2025-08-10T03:23:56.642Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.642Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.643Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.671Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:56.671Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.671Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.672Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.690Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.691Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.699Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" decisions"}}}
+{"ts":"2025-08-10T03:23:56.699Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.699Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.700Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.727Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:56.727Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.727Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.728Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.756Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:56.756Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.756Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.757Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.788Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" price"}}}
+{"ts":"2025-08-10T03:23:56.788Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.788Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.790Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.790Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.791Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.818Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" paid"}}}
+{"ts":"2025-08-10T03:23:56.818Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.818Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.819Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.846Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":".\n\n"}}}
+{"ts":"2025-08-10T03:23:56.846Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.847Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:56.847Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.849Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.875Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"Ar"}}}
+{"ts":"2025-08-10T03:23:56.875Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.875Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.876Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.895Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.896Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.902Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:56.902Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:56.902Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.903Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ia"}}}
+{"ts":"2025-08-10T03:23:56.903Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.903Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.904Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.931Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" understood"}}}
+{"ts":"2025-08-10T03:23:56.939Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.939Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.940Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.957Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:56.957Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:56.957Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:56.957Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:56.958Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:56.960Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:56.988Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" she"}}}
+{"ts":"2025-08-10T03:23:57.000Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.012Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:57.016Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" must"}}}
+{"ts":"2025-08-10T03:23:57.040Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.040Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.040Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.040Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.040Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:57.040Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.040Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.041Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.044Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" protect"}}}
+{"ts":"2025-08-10T03:23:57.044Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.044Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.046Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.073Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:57.073Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.073Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.074Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.101Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ember"}}}
+{"ts":"2025-08-10T03:23:57.101Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.101Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.102Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.102Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.104Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.129Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:57.129Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.129Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.130Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.157Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" as"}}}
+{"ts":"2025-08-10T03:23:57.157Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.157Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.159Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.186Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:57.186Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.186Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.187Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.207Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.209Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.214Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Order"}}}
+{"ts":"2025-08-10T03:23:57.214Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.214Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.215Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.242Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" had"}}}
+{"ts":"2025-08-10T03:23:57.242Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.242Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.244Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.271Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" done"}}}
+{"ts":"2025-08-10T03:23:57.271Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.271Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.272Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.299Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" for"}}}
+{"ts":"2025-08-10T03:23:57.299Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.299Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.301Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.312Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.314Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.328Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" centuries"}}}
+{"ts":"2025-08-10T03:23:57.328Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.328Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.330Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.357Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:57.357Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.357Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.358Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.385Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" She"}}}
+{"ts":"2025-08-10T03:23:57.385Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.385Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.387Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.414Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.414Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" pledged"}}}
+{"ts":"2025-08-10T03:23:57.414Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.414Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.415Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.443Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:57.443Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.443Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.444Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.471Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" keep"}}}
+{"ts":"2025-08-10T03:23:57.471Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.471Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.472Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.500Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" it"}}}
+{"ts":"2025-08-10T03:23:57.500Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.500Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.501Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.519Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.520Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.528Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" safe"}}}
+{"ts":"2025-08-10T03:23:57.528Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.528Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.529Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.556Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" again"}}}
+{"ts":"2025-08-10T03:23:57.556Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.556Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.557Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.584Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:57.585Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.585Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.586Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.613Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" so"}}}
+{"ts":"2025-08-10T03:23:57.613Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.613Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.614Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.624Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.625Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.641Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:57.641Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.641Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.642Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.669Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" valley"}}}
+{"ts":"2025-08-10T03:23:57.669Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.670Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.671Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.698Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" might"}}}
+{"ts":"2025-08-10T03:23:57.698Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.698Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.699Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.726Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" thrive"}}}
+{"ts":"2025-08-10T03:23:57.726Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.726Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.727Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.729Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.730Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.754Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:57.754Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.754Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.756Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.783Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:57.783Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.783Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.784Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.811Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:57.811Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.811Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.812Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.834Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.835Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.839Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" history"}}}
+{"ts":"2025-08-10T03:23:57.839Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.839Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.840Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.877Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:57.877Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.877Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.878Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.906Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" compassion"}}}
+{"ts":"2025-08-10T03:23:57.906Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.906Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.907Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.934Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.935Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:57.935Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.935Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.936Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.963Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" had"}}}
+{"ts":"2025-08-10T03:23:57.963Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.963Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.964Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:57.991Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" guided"}}}
+{"ts":"2025-08-10T03:23:57.991Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.991Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:57.992Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.019Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" generations"}}}
+{"ts":"2025-08-10T03:23:58.019Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.019Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.021Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.039Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.041Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.048Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" might"}}}
+{"ts":"2025-08-10T03:23:58.048Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.048Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.049Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.076Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" continue"}}}
+{"ts":"2025-08-10T03:23:58.076Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.076Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.077Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.105Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":".\n\n"}}}
+{"ts":"2025-08-10T03:23:58.105Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.106Z","dir":"to_tui","kind":"app_event","variant":"StartCommitAnimation"}
+{"ts":"2025-08-10T03:23:58.106Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.108Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.134Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"So"}}}
+{"ts":"2025-08-10T03:23:58.134Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.134Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.135Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.145Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.146Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.161Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:58.161Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:58.161Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.162Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:58.162Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.162Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.163Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.191Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ember"}}}
+{"ts":"2025-08-10T03:23:58.214Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:58.219Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" returned"}}}
+{"ts":"2025-08-10T03:23:58.248Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:58.250Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.251Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.251Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.251Z","dir":"to_tui","kind":"insert_history","lines":1}
+{"ts":"2025-08-10T03:23:58.251Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:58.251Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.251Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.251Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.251Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.251Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.252Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.269Z","dir":"to_tui","kind":"app_event","variant":"CommitTick"}
+{"ts":"2025-08-10T03:23:58.276Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" its"}}}
+{"ts":"2025-08-10T03:23:58.305Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" keep"}}}
+{"ts":"2025-08-10T03:23:58.334Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:58.352Z","dir":"to_tui","kind":"app_event","variant":"StopCommitAnimation"}
+{"ts":"2025-08-10T03:23:58.352Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.352Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.352Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.352Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.352Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.352Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.353Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.355Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.356Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.362Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" It"}}}
+{"ts":"2025-08-10T03:23:58.362Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.362Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.363Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.391Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" was"}}}
+{"ts":"2025-08-10T03:23:58.391Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.391Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.392Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.419Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:58.419Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.419Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.421Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.449Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" small"}}}
+{"ts":"2025-08-10T03:23:58.449Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.449Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.451Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.460Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.461Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.478Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:58.478Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.478Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.479Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.507Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" steady"}}}
+{"ts":"2025-08-10T03:23:58.507Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.507Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.508Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.535Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" flame"}}}
+{"ts":"2025-08-10T03:23:58.535Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.535Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.537Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.564Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" amid"}}}
+{"ts":"2025-08-10T03:23:58.564Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.564Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.565Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.565Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.593Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" darkness"}}}
+{"ts":"2025-08-10T03:23:58.593Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.593Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.594Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.622Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:58.622Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.622Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.623Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.650Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" its"}}}
+{"ts":"2025-08-10T03:23:58.650Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.650Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.652Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.670Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.671Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.679Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" light"}}}
+{"ts":"2025-08-10T03:23:58.679Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.679Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.680Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.708Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:58.708Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.708Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.709Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.736Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" reminder"}}}
+{"ts":"2025-08-10T03:23:58.736Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.736Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.738Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.765Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:58.765Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.765Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.766Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.775Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.776Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.793Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" even"}}}
+{"ts":"2025-08-10T03:23:58.793Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.793Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.794Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.821Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" in"}}}
+{"ts":"2025-08-10T03:23:58.821Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.821Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.822Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.849Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" times"}}}
+{"ts":"2025-08-10T03:23:58.849Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.849Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.850Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.877Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.878Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:58.878Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.878Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.879Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.906Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" great"}}}
+{"ts":"2025-08-10T03:23:58.906Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.906Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.907Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.935Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" loss"}}}
+{"ts":"2025-08-10T03:23:58.935Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.935Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.937Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.969Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:58.969Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.969Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.970Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.982Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.984Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:58.998Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" there"}}}
+{"ts":"2025-08-10T03:23:58.998Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.998Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:58.999Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.026Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" is"}}}
+{"ts":"2025-08-10T03:23:59.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.026Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.028Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.054Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" always"}}}
+{"ts":"2025-08-10T03:23:59.055Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.055Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.056Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.083Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:23:59.083Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.083Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.085Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.085Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.086Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.112Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" spark"}}}
+{"ts":"2025-08-10T03:23:59.112Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.112Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.113Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.141Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:23:59.141Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.141Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.142Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.169Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" persists"}}}
+{"ts":"2025-08-10T03:23:59.169Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.169Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.171Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.187Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.188Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.198Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:23:59.198Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.198Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.199Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.227Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" The"}}}
+{"ts":"2025-08-10T03:23:59.227Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.227Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.228Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.255Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" people"}}}
+{"ts":"2025-08-10T03:23:59.255Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.255Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.257Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.284Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:59.284Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.284Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.286Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.292Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.293Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.312Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ever"}}}
+{"ts":"2025-08-10T03:23:59.312Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.313Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.314Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.341Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"g"}}}
+{"ts":"2025-08-10T03:23:59.341Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.341Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.342Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.369Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"len"}}}
+{"ts":"2025-08-10T03:23:59.369Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.369Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.371Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.397Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.398Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.398Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" learned"}}}
+{"ts":"2025-08-10T03:23:59.398Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.398Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.400Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.427Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:59.427Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.427Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.428Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.456Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" cherish"}}}
+{"ts":"2025-08-10T03:23:59.456Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.456Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.457Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.485Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:59.485Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.485Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.486Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.502Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.503Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.514Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ember"}}}
+{"ts":"2025-08-10T03:23:59.514Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.514Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.515Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.542Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:59.542Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.542Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.544Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.571Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:59.571Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.571Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.572Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.600Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" pass"}}}
+{"ts":"2025-08-10T03:23:59.600Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.600Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.601Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.602Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.604Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.629Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" down"}}}
+{"ts":"2025-08-10T03:23:59.629Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.629Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.630Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.657Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:23:59.657Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.657Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.659Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.686Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" stories"}}}
+{"ts":"2025-08-10T03:23:59.686Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.686Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.687Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.707Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.709Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.715Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:23:59.715Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.715Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.716Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.744Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ca"}}}
+{"ts":"2025-08-10T03:23:59.744Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.744Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.745Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.772Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"elan"}}}
+{"ts":"2025-08-10T03:23:59.772Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.772Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.774Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.801Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"'s"}}}
+{"ts":"2025-08-10T03:23:59.801Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.801Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.802Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.813Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.814Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.830Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" sacrifice"}}}
+{"ts":"2025-08-10T03:23:59.830Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.830Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.831Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.859Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:23:59.859Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.859Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.860Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.887Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:23:59.887Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.887Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.889Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.916Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:23:59.916Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.916Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.918Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.918Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.945Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" respect"}}}
+{"ts":"2025-08-10T03:23:59.945Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.945Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.946Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:23:59.974Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" its"}}}
+{"ts":"2025-08-10T03:23:59.974Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.974Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:23:59.975Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.002Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" significance"}}}
+{"ts":"2025-08-10T03:24:00.003Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.003Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.004Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.019Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.020Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.031Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:24:00.031Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.031Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.032Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.064Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" The"}}}
+{"ts":"2025-08-10T03:24:00.064Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.064Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.066Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.094Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" final"}}}
+{"ts":"2025-08-10T03:24:00.094Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.094Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.095Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.122Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.123Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ember"}}}
+{"ts":"2025-08-10T03:24:00.123Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.123Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.124Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.151Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" did"}}}
+{"ts":"2025-08-10T03:24:00.151Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.151Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.153Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.180Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" not"}}}
+{"ts":"2025-08-10T03:24:00.180Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.180Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.181Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.209Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" extingu"}}}
+{"ts":"2025-08-10T03:24:00.209Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.209Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.210Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.227Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.229Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.238Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"ish"}}}
+{"ts":"2025-08-10T03:24:00.238Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.238Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.239Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.267Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:24:00.267Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.267Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.268Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.295Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" entire"}}}
+{"ts":"2025-08-10T03:24:00.295Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.295Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.297Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.324Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" valley"}}}
+{"ts":"2025-08-10T03:24:00.324Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.324Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.325Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.332Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.334Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.353Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:24:00.353Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.353Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.354Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.382Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" it"}}}
+{"ts":"2025-08-10T03:24:00.382Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.382Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.383Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.410Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" taught"}}}
+{"ts":"2025-08-10T03:24:00.410Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.410Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.412Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.437Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.438Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.439Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" them"}}}
+{"ts":"2025-08-10T03:24:00.439Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.439Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.440Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.468Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" something"}}}
+{"ts":"2025-08-10T03:24:00.468Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.468Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.469Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.496Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" more"}}}
+{"ts":"2025-08-10T03:24:00.496Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.496Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.498Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.525Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" profound"}}}
+{"ts":"2025-08-10T03:24:00.525Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.525Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.526Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.542Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.543Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.554Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":":"}}}
+{"ts":"2025-08-10T03:24:00.554Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.554Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.555Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.583Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:24:00.583Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.583Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.584Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.612Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:24:00.612Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.612Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.613Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.640Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" light"}}}
+{"ts":"2025-08-10T03:24:00.640Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.640Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.641Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.647Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.648Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.669Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" is"}}}
+{"ts":"2025-08-10T03:24:00.669Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.669Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.670Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.697Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" both"}}}
+{"ts":"2025-08-10T03:24:00.698Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.698Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.699Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.726Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:24:00.726Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.726Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.728Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.752Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.753Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.755Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" blessing"}}}
+{"ts":"2025-08-10T03:24:00.755Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.755Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.756Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.783Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:24:00.784Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.784Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.785Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.812Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:24:00.812Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.812Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.814Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.841Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" burden"}}}
+{"ts":"2025-08-10T03:24:00.841Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.841Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.842Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.853Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.854Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.870Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:24:00.870Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.870Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.871Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.898Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" In"}}}
+{"ts":"2025-08-10T03:24:00.898Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.898Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.900Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.927Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" Ever"}}}
+{"ts":"2025-08-10T03:24:00.927Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.927Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.929Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.953Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.955Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.956Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"g"}}}
+{"ts":"2025-08-10T03:24:00.956Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.956Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.957Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:00.984Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"len"}}}
+{"ts":"2025-08-10T03:24:00.984Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.984Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:00.986Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.012Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:24:01.012Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.012Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.014Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.041Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:24:01.041Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.041Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.042Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.058Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.060Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.069Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" fire"}}}
+{"ts":"2025-08-10T03:24:01.069Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.069Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.071Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.097Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" was"}}}
+{"ts":"2025-08-10T03:24:01.097Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.097Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.099Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.126Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" never"}}}
+{"ts":"2025-08-10T03:24:01.126Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.126Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.127Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.154Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" just"}}}
+{"ts":"2025-08-10T03:24:01.154Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.154Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.156Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.161Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.162Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.188Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:24:01.188Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.188Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.189Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.217Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" physical"}}}
+{"ts":"2025-08-10T03:24:01.217Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.217Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.218Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.246Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" flame"}}}
+{"ts":"2025-08-10T03:24:01.246Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.246Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.247Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.264Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.266Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.274Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":";"}}}
+{"ts":"2025-08-10T03:24:01.274Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.274Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.275Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.302Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" it"}}}
+{"ts":"2025-08-10T03:24:01.302Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.302Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.304Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.331Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" became"}}}
+{"ts":"2025-08-10T03:24:01.331Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.331Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.332Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.359Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" a"}}}
+{"ts":"2025-08-10T03:24:01.361Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.361Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.363Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.369Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.370Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.388Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" guiding"}}}
+{"ts":"2025-08-10T03:24:01.388Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.388Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.389Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.416Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" star"}}}
+{"ts":"2025-08-10T03:24:01.416Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.416Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.418Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.446Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"—a"}}}
+{"ts":"2025-08-10T03:24:01.446Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.446Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.447Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.469Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.471Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.475Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" symbol"}}}
+{"ts":"2025-08-10T03:24:01.475Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.475Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.477Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.505Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" of"}}}
+{"ts":"2025-08-10T03:24:01.505Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.505Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.506Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.533Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" humanity"}}}
+{"ts":"2025-08-10T03:24:01.533Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.533Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.534Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.562Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"’s"}}}
+{"ts":"2025-08-10T03:24:01.562Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.562Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.563Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.570Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.571Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.590Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ability"}}}
+{"ts":"2025-08-10T03:24:01.590Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.590Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.591Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.618Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" to"}}}
+{"ts":"2025-08-10T03:24:01.618Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.618Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.619Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.646Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" make"}}}
+{"ts":"2025-08-10T03:24:01.646Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.646Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.647Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.671Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.673Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.674Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" difficult"}}}
+{"ts":"2025-08-10T03:24:01.674Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.674Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.676Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.702Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" choices"}}}
+{"ts":"2025-08-10T03:24:01.702Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.702Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.704Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.731Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":","}}}
+{"ts":"2025-08-10T03:24:01.731Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.731Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.733Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.759Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" and"}}}
+{"ts":"2025-08-10T03:24:01.759Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.759Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.760Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.773Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.774Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.787Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" the"}}}
+{"ts":"2025-08-10T03:24:01.787Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.787Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.789Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.815Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" unwavering"}}}
+{"ts":"2025-08-10T03:24:01.815Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.815Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.817Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.844Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" hope"}}}
+{"ts":"2025-08-10T03:24:01.844Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.844Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.845Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.872Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" that"}}}
+{"ts":"2025-08-10T03:24:01.872Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.872Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.873Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.878Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.879Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.900Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" even"}}}
+{"ts":"2025-08-10T03:24:01.900Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.900Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.901Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.929Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" one"}}}
+{"ts":"2025-08-10T03:24:01.929Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.929Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.930Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.957Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" ember"}}}
+{"ts":"2025-08-10T03:24:01.957Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.957Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.959Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.983Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.984Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:01.985Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" can"}}}
+{"ts":"2025-08-10T03:24:01.985Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.985Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:01.987Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:02.014Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" endure"}}}
+{"ts":"2025-08-10T03:24:02.014Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:02.014Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:02.015Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:02.042Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":" forever"}}}
+{"ts":"2025-08-10T03:24:02.042Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:02.042Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:02.043Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:02.070Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message_delta","delta":"."}}}
+{"ts":"2025-08-10T03:24:02.071Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:02.071Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:02.072Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:02.084Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:02.086Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:02.099Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"agent_message","message":"**The Last Ember of Evernight**\n\nIn the valley of Everglen, where the mist clung to the emerald slopes like a silken shawl, the night never truly surrendered. Though the moon rose each evening, its pallid glow was always pierced by sparks that danced from the ancient Emberstone, a relic said to house a living fire. The stone rested in a cavern beneath the old Keep of Liora, guarded by the Order of Light, who swore to keep it untarnished from any mortal touch.\n\nAmong the village was a boy named Caelan. He had grown up hearing the legends – the tale of the Emberstone that kept the valley alive, of those who dared to steal its heart, and of the cursed ones who turned from the light. Caelan's mother, a healer known as Maeve, warned him never to venture beyond the river. Yet his eyes were always drawn toward the glimmering blue that peeked from the depths of the keep.\n\nOne crisp autumn night, a strange light fluttered across the sky, a comet streak that hung longer than it should. Caelan slipped away, his cloak a blur against the silvered riverbanks. He ran into the forest, guided by the comet’s tail, until he found himself at the base of the Keep of Liora. The stone walls gleamed, and an ancient oak's roots twined like silver cords across the stone.\n\nInside the keep, the corridors were maze-like, the air heavy with the scent of stone and lingering incense. At the heart of the labyrinth lay the Chamber of Ember, a vast vault carved out of obsidian, its walls pulsing faintly. The Emberstone lay atop a dais, surrounded by glyphs of forgotten runes that flickered like nervous fireflies.\n\nCaelan's heart hammered as he approached. He remembered Maeve's words: \"The fire of Evernight is not a tool to be wielded, but a covenant.\" Yet the ache of longing burned stronger—he wanted the light to pierce his village's nights, to cure the ailing crops, to ease his mother's grief. In a moment that felt like a choice between life and death he placed his palm upon the cool stone.\n\nSuddenly, a voice resonated through the chamber, not from any mortal ear, but from the very fire that had kept the valley alive: \"Child of ember, you seek light that cannot be taken. Do you dare become the flame?\"\n\nFrom behind him stepped a figure—tall and cloaked in a mantle of darkness that seemed to devour surrounding light. The figure revealed himself as Azrion the Keeper, the guardian who had sworn his oath to the stone for centuries. His eyes contained centuries of sorrow. \"I see your heart is pure,\" he intoned. \"But we are bound to the cycle.\"\n\nCaelan listened, heart pounding. \"I will spare the village,\" he said, voice trembling. \"But my mother suffers from illness. Will you grant me a sliver of fire?\"\n\nAzrion sighed. The Emberstone, however, had a memory. It remembered all that had come to its fore. The ancient runes whispered a verdict: the Emberstone can grant a single boon to a pure heart for a single sacrifice and that after the act, the light would be forever extinguished.\n\nCaelan realized the magnitude of his decision. If he used the fire, the valley would be plunged into darkness forever, but perhaps this one act would save a life. He closed his eyes, taking a deep breath, and placed the stone under a palm of his own. The ember sparked, a golden breath that curled into his fingers. Instinctively, he carried a vial of fire.\n\nHe returned to the village as the night fell. The flames were small and trembling, yet they lit the wounds of his mother's fever. Her eyes widened as warmth flooded through her bones. She smiled, a small but sincere expression of gratitude. \"My love,\" she whispered, \"you have saved me. I cannot say I understand how you'd choose our safety for a single flame...\"\n\nAfter that night, Caelan sealed the Emberstone back in its sanctuary and took the responsibility of keeping the light to the keep. Though the valley was robbed of its eternal ember, the memory lasted. His mother, healed, lived many more years. The village adapted, learning to find joy in the flicker of a single candle each night.\n\nYears turned into decades, and then centuries, until the Great Storm swept across Everglen, breaking the veil of the once unbreakable stone walls. The storm tore the Keep of Liora into ruins, leaving the Emberstone unprotected. In the ruins, whispers spread that someone from the past had stolen the ember, or that it had been left behind.\n\nIt was then that a new chapter began. A young woman named Aria, descendant of Caelan's line, with a keen curiosity and an unflinching resolve, would find her way. She would hear of the old stories of the stone's ember, the memory that carried the weight of choice.\n\nAria walked along the river and found herself at the ruins. She felt a pull in her heart and felt a stirring of destiny. She discovered, in the middle of the ruins, a cavity that glowed faintly in the moonlight: the Emberstone, broken, yet still lit, the same ember that had lived on Caelan's finger.\n\nWith careful hands, she reached for it. It was warm, and when she embraced it, she felt a vision: the valley under a storm, the light of the ember, Caelan's smile, the hope he brought to his mother. She understood then the weight of decisions, the price paid.\n\nAria understood that she must protect the ember, as the Order had done for centuries. She pledged to keep it safe again, so the valley might thrive, and the history of compassion that had guided generations might continue.\n\nSo the ember returned to its keep. It was a small, steady flame amid darkness, its light a reminder that even in times of great loss, there is always a spark that persists. The people of Everglen learned to cherish the ember, to pass down the stories of Caelan's sacrifice, and to respect its significance. The final ember did not extinguish the entire valley, it taught them something more profound: that the light is both a blessing and a burden. In Everglen, the fire was never just a physical flame; it became a guiding star—a symbol of humanity’s ability to make difficult choices, and the unwavering hope that even one ember can endure forever."}}}
+{"ts":"2025-08-10T03:24:02.099Z","dir":"to_tui","kind":"codex_event","payload":{"id":"5","msg":{"type":"task_complete","last_agent_message":"**The Last Ember of Evernight**\n\nIn the valley of Everglen, where the mist clung to the emerald slopes like a silken shawl, the night never truly surrendered. Though the moon rose each evening, its pallid glow was always pierced by sparks that danced from the ancient Emberstone, a relic said to house a living fire. The stone rested in a cavern beneath the old Keep of Liora, guarded by the Order of Light, who swore to keep it untarnished from any mortal touch.\n\nAmong the village was a boy named Caelan. He had grown up hearing the legends – the tale of the Emberstone that kept the valley alive, of those who dared to steal its heart, and of the cursed ones who turned from the light. Caelan's mother, a healer known as Maeve, warned him never to venture beyond the river. Yet his eyes were always drawn toward the glimmering blue that peeked from the depths of the keep.\n\nOne crisp autumn night, a strange light fluttered across the sky, a comet streak that hung longer than it should. Caelan slipped away, his cloak a blur against the silvered riverbanks. He ran into the forest, guided by the comet’s tail, until he found himself at the base of the Keep of Liora. The stone walls gleamed, and an ancient oak's roots twined like silver cords across the stone.\n\nInside the keep, the corridors were maze-like, the air heavy with the scent of stone and lingering incense. At the heart of the labyrinth lay the Chamber of Ember, a vast vault carved out of obsidian, its walls pulsing faintly. The Emberstone lay atop a dais, surrounded by glyphs of forgotten runes that flickered like nervous fireflies.\n\nCaelan's heart hammered as he approached. He remembered Maeve's words: \"The fire of Evernight is not a tool to be wielded, but a covenant.\" Yet the ache of longing burned stronger—he wanted the light to pierce his village's nights, to cure the ailing crops, to ease his mother's grief. In a moment that felt like a choice between life and death he placed his palm upon the cool stone.\n\nSuddenly, a voice resonated through the chamber, not from any mortal ear, but from the very fire that had kept the valley alive: \"Child of ember, you seek light that cannot be taken. Do you dare become the flame?\"\n\nFrom behind him stepped a figure—tall and cloaked in a mantle of darkness that seemed to devour surrounding light. The figure revealed himself as Azrion the Keeper, the guardian who had sworn his oath to the stone for centuries. His eyes contained centuries of sorrow. \"I see your heart is pure,\" he intoned. \"But we are bound to the cycle.\"\n\nCaelan listened, heart pounding. \"I will spare the village,\" he said, voice trembling. \"But my mother suffers from illness. Will you grant me a sliver of fire?\"\n\nAzrion sighed. The Emberstone, however, had a memory. It remembered all that had come to its fore. The ancient runes whispered a verdict: the Emberstone can grant a single boon to a pure heart for a single sacrifice and that after the act, the light would be forever extinguished.\n\nCaelan realized the magnitude of his decision. If he used the fire, the valley would be plunged into darkness forever, but perhaps this one act would save a life. He closed his eyes, taking a deep breath, and placed the stone under a palm of his own. The ember sparked, a golden breath that curled into his fingers. Instinctively, he carried a vial of fire.\n\nHe returned to the village as the night fell. The flames were small and trembling, yet they lit the wounds of his mother's fever. Her eyes widened as warmth flooded through her bones. She smiled, a small but sincere expression of gratitude. \"My love,\" she whispered, \"you have saved me. I cannot say I understand how you'd choose our safety for a single flame...\"\n\nAfter that night, Caelan sealed the Emberstone back in its sanctuary and took the responsibility of keeping the light to the keep. Though the valley was robbed of its eternal ember, the memory lasted. His mother, healed, lived many more years. The village adapted, learning to find joy in the flicker of a single candle each night.\n\nYears turned into decades, and then centuries, until the Great Storm swept across Everglen, breaking the veil of the once unbreakable stone walls. The storm tore the Keep of Liora into ruins, leaving the Emberstone unprotected. In the ruins, whispers spread that someone from the past had stolen the ember, or that it had been left behind.\n\nIt was then that a new chapter began. A young woman named Aria, descendant of Caelan's line, with a keen curiosity and an unflinching resolve, would find her way. She would hear of the old stories of the stone's ember, the memory that carried the weight of choice.\n\nAria walked along the river and found herself at the ruins. She felt a pull in her heart and felt a stirring of destiny. She discovered, in the middle of the ruins, a cavity that glowed faintly in the moonlight: the Emberstone, broken, yet still lit, the same ember that had lived on Caelan's finger.\n\nWith careful hands, she reached for it. It was warm, and when she embraced it, she felt a vision: the valley under a storm, the light of the ember, Caelan's smile, the hope he brought to his mother. She understood then the weight of decisions, the price paid.\n\nAria understood that she must protect the ember, as the Order had done for centuries. She pledged to keep it safe again, so the valley might thrive, and the history of compassion that had guided generations might continue.\n\nSo the ember returned to its keep. It was a small, steady flame amid darkness, its light a reminder that even in times of great loss, there is always a spark that persists. The people of Everglen learned to cherish the ember, to pass down the stories of Caelan's sacrifice, and to respect its significance. The final ember did not extinguish the entire valley, it taught them something more profound: that the light is both a blessing and a burden. In Everglen, the fire was never just a physical flame; it became a guiding star—a symbol of humanity’s ability to make difficult choices, and the unwavering hope that even one ember can endure forever."}}}
+{"ts":"2025-08-10T03:24:02.100Z","dir":"to_tui","kind":"insert_history","lines":3}
+{"ts":"2025-08-10T03:24:02.101Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:02.101Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:02.101Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:02.102Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:24:02.187Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:24:02.191Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:48:49.756Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('c'), modifiers: KeyModifiers(CONTROL), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:48:49.758Z","dir":"to_tui","kind":"app_event","variant":"RequestRedraw"}
+{"ts":"2025-08-10T03:48:49.759Z","dir":"to_tui","kind":"app_event","variant":"Redraw"}
+{"ts":"2025-08-10T03:48:49.822Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('c'), modifiers: KeyModifiers(CONTROL), kind: Release, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:48:49.925Z","dir":"to_tui","kind":"key_event","event":"KeyEvent { code: Char('c'), modifiers: KeyModifiers(CONTROL), kind: Press, state: KeyEventState(0x0) }"}
+{"ts":"2025-08-10T03:48:49.925Z","dir":"from_tui","kind":"op","payload":{"type":"shutdown"}}
+{"ts":"2025-08-10T03:48:49.926Z","dir":"to_tui","kind":"log_line","line":"[INFO codex_core::codex] Shutting down Codex instance"}
+{"ts":"2025-08-10T03:48:49.927Z","dir":"to_tui","kind":"log_line","line":"[INFO codex_core::codex] Aborting existing session"}
+{"ts":"2025-08-10T03:48:49.927Z","dir":"to_tui","kind":"codex_event","payload":{"id":"7","msg":{"type":"shutdown_complete"}}}
+{"ts":"2025-08-10T03:48:49.927Z","dir":"to_tui","kind":"app_event","variant":"ExitRequest"}
+{"ts":"2025-08-10T03:48:49.927Z","dir":"meta","kind":"session_end"}

--- a/codex-rs/tui2/tests/suite/mod.rs
+++ b/codex-rs/tui2/tests/suite/mod.rs
@@ -1,0 +1,4 @@
+// Aggregates all former standalone integration tests as modules.
+mod status_indicator;
+mod vt100_history;
+mod vt100_live_commit;

--- a/codex-rs/tui2/tests/suite/status_indicator.rs
+++ b/codex-rs/tui2/tests/suite/status_indicator.rs
@@ -1,0 +1,24 @@
+//! Regression test: ensure that `StatusIndicatorWidget` sanitises ANSI escape
+//! sequences so that no raw `\x1b` bytes are written into the backing
+//! buffer.  Rendering logic is tricky to unit‑test end‑to‑end, therefore we
+//! verify the *public* contract of `ansi_escape_line()` which the widget now
+//! relies on.
+
+use codex_ansi_escape::ansi_escape_line;
+
+#[test]
+fn ansi_escape_line_strips_escape_sequences() {
+    let text_in_ansi_red = "\x1b[31mRED\x1b[0m";
+
+    // The returned line must contain three printable glyphs and **no** raw
+    // escape bytes.
+    let line = ansi_escape_line(text_in_ansi_red);
+
+    let combined: String = line
+        .spans
+        .iter()
+        .map(|span| span.content.to_string())
+        .collect();
+
+    assert_eq!(combined, "RED");
+}

--- a/codex-rs/tui2/tests/suite/vt100_history.rs
+++ b/codex-rs/tui2/tests/suite/vt100_history.rs
@@ -1,0 +1,153 @@
+#![cfg(feature = "vt100-tests")]
+#![expect(clippy::expect_used)]
+
+use crate::test_backend::VT100Backend;
+use ratatui::layout::Rect;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+
+// Small helper macro to assert a collection contains an item with a clearer
+// failure message.
+macro_rules! assert_contains {
+    ($collection:expr, $item:expr $(,)?) => {
+        assert!(
+            $collection.contains(&$item),
+            "Expected {:?} to contain {:?}",
+            $collection,
+            $item
+        );
+    };
+    ($collection:expr, $item:expr, $($arg:tt)+) => {
+        assert!($collection.contains(&$item), $($arg)+);
+    };
+}
+
+struct TestScenario {
+    term: codex_tui::custom_terminal::Terminal<VT100Backend>,
+}
+
+impl TestScenario {
+    fn new(width: u16, height: u16, viewport: Rect) -> Self {
+        let backend = VT100Backend::new(width, height);
+        let mut term = codex_tui::custom_terminal::Terminal::with_options(backend)
+            .expect("failed to construct terminal");
+        term.set_viewport_area(viewport);
+        Self { term }
+    }
+
+    fn run_insert(&mut self, lines: Vec<Line<'static>>) {
+        codex_tui::insert_history::insert_history_lines(&mut self.term, lines)
+            .expect("Failed to insert history lines in test");
+    }
+}
+
+#[test]
+fn basic_insertion_no_wrap() {
+    // Screen of 20x6; viewport is the last row (height=1 at y=5)
+    let area = Rect::new(0, 5, 20, 1);
+    let mut scenario = TestScenario::new(20, 6, area);
+
+    let lines = vec!["first".into(), "second".into()];
+    scenario.run_insert(lines);
+    let rows = scenario.term.backend().vt100().screen().contents();
+    assert_contains!(rows, String::from("first"));
+    assert_contains!(rows, String::from("second"));
+}
+
+#[test]
+fn long_token_wraps() {
+    let area = Rect::new(0, 5, 20, 1);
+    let mut scenario = TestScenario::new(20, 6, area);
+
+    let long = "A".repeat(45); // > 2 lines at width 20
+    let lines = vec![long.clone().into()];
+    scenario.run_insert(lines);
+    let screen = scenario.term.backend().vt100().screen();
+
+    // Count total A's on the screen
+    let mut count_a = 0usize;
+    for row in 0..6 {
+        for col in 0..20 {
+            if let Some(cell) = screen.cell(row, col)
+                && let Some(ch) = cell.contents().chars().next()
+                && ch == 'A'
+            {
+                count_a += 1;
+            }
+        }
+    }
+
+    assert_eq!(
+        count_a,
+        long.len(),
+        "wrapped content did not preserve all characters"
+    );
+}
+
+#[test]
+fn emoji_and_cjk() {
+    let area = Rect::new(0, 5, 20, 1);
+    let mut scenario = TestScenario::new(20, 6, area);
+
+    let text = String::from("😀😀😀😀😀 你好世界");
+    let lines = vec![text.clone().into()];
+    scenario.run_insert(lines);
+    let rows = scenario.term.backend().vt100().screen().contents();
+    for ch in text.chars().filter(|c| !c.is_whitespace()) {
+        assert!(
+            rows.contains(ch),
+            "missing character {ch:?} in reconstructed screen"
+        );
+    }
+}
+
+#[test]
+fn mixed_ansi_spans() {
+    let area = Rect::new(0, 5, 20, 1);
+    let mut scenario = TestScenario::new(20, 6, area);
+
+    let line = vec!["red".red(), "+plain".into()].into();
+    scenario.run_insert(vec![line]);
+    let rows = scenario.term.backend().vt100().screen().contents();
+    assert_contains!(rows, String::from("red+plain"));
+}
+
+#[test]
+fn cursor_restoration() {
+    let area = Rect::new(0, 5, 20, 1);
+    let mut scenario = TestScenario::new(20, 6, area);
+
+    let lines = vec!["x".into()];
+    scenario.run_insert(lines);
+    assert_eq!(scenario.term.last_known_cursor_pos, (0, 0).into());
+}
+
+#[test]
+fn word_wrap_no_mid_word_split() {
+    // Screen of 40x10; viewport is the last row
+    let area = Rect::new(0, 9, 40, 1);
+    let mut scenario = TestScenario::new(40, 10, area);
+
+    let sample = "Years passed, and Willowmere thrived in peace and friendship. Mira’s herb garden flourished with both ordinary and enchanted plants, and travelers spoke of the kindness of the woman who tended them.";
+    scenario.run_insert(vec![sample.into()]);
+    let joined = scenario.term.backend().vt100().screen().contents();
+    assert!(
+        !joined.contains("bo\nth"),
+        "word 'both' should not be split across lines:\n{joined}"
+    );
+}
+
+#[test]
+fn em_dash_and_space_word_wrap() {
+    // Repro from report: ensure we break before "inside", not mid-word.
+    let area = Rect::new(0, 9, 40, 1);
+    let mut scenario = TestScenario::new(40, 10, area);
+
+    let sample = "Mara found an old key on the shore. Curious, she opened a tarnished box half-buried in sand—and inside lay a single, glowing seed.";
+    scenario.run_insert(vec![sample.into()]);
+    let joined = scenario.term.backend().vt100().screen().contents();
+    assert!(
+        !joined.contains("insi\nde"),
+        "word 'inside' should not be split across lines:\n{joined}"
+    );
+}

--- a/codex-rs/tui2/tests/suite/vt100_live_commit.rs
+++ b/codex-rs/tui2/tests/suite/vt100_live_commit.rs
@@ -1,0 +1,45 @@
+#![cfg(feature = "vt100-tests")]
+
+use crate::test_backend::VT100Backend;
+use ratatui::layout::Rect;
+use ratatui::text::Line;
+
+#[test]
+fn live_001_commit_on_overflow() {
+    let backend = VT100Backend::new(20, 6);
+    let mut term = match codex_tui::custom_terminal::Terminal::with_options(backend) {
+        Ok(t) => t,
+        Err(e) => panic!("failed to construct terminal: {e}"),
+    };
+    let area = Rect::new(0, 5, 20, 1);
+    term.set_viewport_area(area);
+
+    // Build 5 explicit rows at width 20.
+    let mut rb = codex_tui::live_wrap::RowBuilder::new(20);
+    rb.push_fragment("one\n");
+    rb.push_fragment("two\n");
+    rb.push_fragment("three\n");
+    rb.push_fragment("four\n");
+    rb.push_fragment("five\n");
+
+    // Keep the last 3 in the live ring; commit the first 2.
+    let commit_rows = rb.drain_commit_ready(3);
+    let lines: Vec<Line<'static>> = commit_rows.into_iter().map(|r| r.text.into()).collect();
+
+    codex_tui::insert_history::insert_history_lines(&mut term, lines)
+        .expect("Failed to insert history lines in test");
+
+    let screen = term.backend().vt100().screen();
+
+    // The words "one" and "two" should appear above the viewport.
+    let joined = screen.contents();
+    assert!(
+        joined.contains("one"),
+        "expected committed 'one' to be visible\n{joined}"
+    );
+    assert!(
+        joined.contains("two"),
+        "expected committed 'two' to be visible\n{joined}"
+    );
+    // The last three (three,four,five) remain in the live ring, not committed here.
+}

--- a/codex-rs/tui2/tests/test_backend.rs
+++ b/codex-rs/tui2/tests/test_backend.rs
@@ -1,0 +1,4 @@
+#[path = "../src/test_backend.rs"]
+mod inner;
+
+pub use inner::VT100Backend;


### PR DESCRIPTION
- Copy latest tui sources into tui2
- Restore notifications, tests, and styles
- Keep codex-tui interop conversions and snapshots

The expected changes that are necessary to make this work are still in place:

diff -ru codex-rs/tui codex-rs/tui2 --exclude='*.snap' --exclude='*.snap.new'

```diff
diff -ru --ex codex-rs/tui/Cargo.toml codex-rs/tui2/Cargo.toml
--- codex-rs/tui/Cargo.toml	2025-12-12 16:39:12
+++ codex-rs/tui2/Cargo.toml	2025-12-12 17:31:01
@@ -1,15 +1,15 @@
 [package]
-name = "codex-tui"
+name = "codex-tui2"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 
 [[bin]]
-name = "codex-tui"
+name = "codex-tui2"
 path = "src/main.rs"
 
 [lib]
-name = "codex_tui"
+name = "codex_tui2"
 path = "src/lib.rs"
 
 [features]
@@ -42,6 +42,7 @@
 codex-login = { workspace = true }
 codex-protocol = { workspace = true }
 codex-utils-absolute-path = { workspace = true }
+codex-tui = { workspace = true }
 color-eyre = { workspace = true }
 crossterm = { workspace = true, features = ["bracketed-paste", "event-stream"] }
 derive_more = { workspace = true, features = ["is_variant"] }
diff -ru --ex codex-rs/tui/src/app.rs codex-rs/tui2/src/app.rs
--- codex-rs/tui/src/app.rs	2025-12-12 16:39:05
+++ codex-rs/tui2/src/app.rs	2025-12-12 17:30:36
@@ -69,6 +69,16 @@
     pub update_action: Option<UpdateAction>,
 }
 
+impl From<AppExitInfo> for codex_tui::AppExitInfo {
+    fn from(info: AppExitInfo) -> Self {
+        codex_tui::AppExitInfo {
+            token_usage: info.token_usage,
+            conversation_id: info.conversation_id,
+            update_action: info.update_action.map(Into::into),
+        }
+    }
+}
+
 fn session_summary(
     token_usage: TokenUsage,
     conversation_id: Option<ConversationId>,
Only in codex-rs/tui/src/bin: md-events.rs
Only in codex-rs/tui2/src/bin: md-events2.rs
diff -ru --ex codex-rs/tui/src/cli.rs codex-rs/tui2/src/cli.rs
--- codex-rs/tui/src/cli.rs	2025-11-19 13:40:42
+++ codex-rs/tui2/src/cli.rs	2025-12-12 17:30:43
@@ -88,3 +88,28 @@
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,
 }
+
+impl From<codex_tui::Cli> for Cli {
+    fn from(cli: codex_tui::Cli) -> Self {
+        Self {
+            prompt: cli.prompt,
+            images: cli.images,
+            resume_picker: cli.resume_picker,
+            resume_last: cli.resume_last,
+            resume_session_id: cli.resume_session_id,
+            resume_show_all: cli.resume_show_all,
+            model: cli.model,
+            oss: cli.oss,
+            oss_provider: cli.oss_provider,
+            config_profile: cli.config_profile,
+            sandbox_mode: cli.sandbox_mode,
+            approval_policy: cli.approval_policy,
+            full_auto: cli.full_auto,
+            dangerously_bypass_approvals_and_sandbox: cli.dangerously_bypass_approvals_and_sandbox,
+            cwd: cli.cwd,
+            web_search: cli.web_search,
+            add_dir: cli.add_dir,
+            config_overrides: cli.config_overrides,
+        }
+    }
+}
diff -ru --ex codex-rs/tui/src/main.rs codex-rs/tui2/src/main.rs
--- codex-rs/tui/src/main.rs	2025-12-12 16:39:05
+++ codex-rs/tui2/src/main.rs	2025-12-12 16:39:06
@@ -1,8 +1,8 @@
 use clap::Parser;
 use codex_arg0::arg0_dispatch_or_else;
 use codex_common::CliConfigOverrides;
-use codex_tui::Cli;
-use codex_tui::run_main;
+use codex_tui2::Cli;
+use codex_tui2::run_main;
 
 #[derive(Parser, Debug)]
 struct TopCli {
diff -ru --ex codex-rs/tui/src/update_action.rs codex-rs/tui2/src/update_action.rs
--- codex-rs/tui/src/update_action.rs	2025-11-19 11:11:47
+++ codex-rs/tui2/src/update_action.rs	2025-12-12 17:30:48
@@ -9,6 +9,20 @@
     BrewUpgrade,
 }
 
+impl From<UpdateAction> for codex_tui::update_action::UpdateAction {
+    fn from(action: UpdateAction) -> Self {
+        match action {
+            UpdateAction::NpmGlobalLatest => {
+                codex_tui::update_action::UpdateAction::NpmGlobalLatest
+            }
+            UpdateAction::BunGlobalLatest => {
+                codex_tui::update_action::UpdateAction::BunGlobalLatest
+            }
+            UpdateAction::BrewUpgrade => codex_tui::update_action::UpdateAction::BrewUpgrade,
+        }
+    }
+}
+
 impl UpdateAction {
     /// Returns the list of command-line arguments for invoking the update.
     pub fn command_args(self) -> (&'static str, &'static [&'static str]) {
```