### PR TITLE
Fix: Skip Option<()> schema generation to avoid invalid Windows filenames (#7479)

### DIFF
--- a/codex-rs/app-server-protocol/src/export.rs
+++ b/codex-rs/app-server-protocol/src/export.rs
@@ -31,6 +31,7 @@ use std::process::Command;
 use ts_rs::TS;
 
 const HEADER: &str = "// GENERATED CODE! DO NOT MODIFY BY HAND!\n\n";
+const IGNORED_DEFINITIONS: &[&str] = &["Option<()>"];
 
 #[derive(Clone)]
 pub struct GeneratedSchema {
@@ -184,7 +185,6 @@ fn build_schema_bundle(schemas: Vec<GeneratedSchema>) -> Result<Value> {
         "ServerNotification",
         "ServerRequest",
     ];
-    const IGNORED_DEFINITIONS: &[&str] = &["Option<()>"];
 
     let namespaced_types = collect_namespaced_types(&schemas);
     let mut definitions = Map::new();
@@ -304,8 +304,11 @@ where
         out_dir.join(format!("{file_stem}.json"))
     };
 
-    write_pretty_json(out_path, &schema_value)
-        .with_context(|| format!("Failed to write JSON schema for {file_stem}"))?;
+    if !IGNORED_DEFINITIONS.contains(&logical_name) {
+        write_pretty_json(out_path, &schema_value)
+            .with_context(|| format!("Failed to write JSON schema for {file_stem}"))?;
+    }
+
     let namespace = match raw_namespace {
         Some("v1") | None => None,
         Some(ns) => Some(ns.to_string()),


### PR DESCRIPTION
## Problem

When generating JSON schemas on Windows, the `codex app-server generate-json-schema` command fails with a filename error:
```text
Error: Failed to write JSON schema for Option<()>
Caused by:
    0: Failed to write .\Option<()>.json
    1: The filename, directory name, or volume label syntax is incorrect. (os error 123)
```
This occurs because Windows doesn't allow certain characters in filenames, specifically the angle brackets **<>** used in the **Option<()>** type name.

## Root Cause

The schema generation process attempts to create individual JSON files for each schema definition, including `Option<()>`. However, the characters `<` and `>` are invalid in Windows filenames, causing the file creation to fail.

## Solution

The fix extends the existing `IGNORED_DEFINITIONS` constant (which was already being used in the **bundle generation**) to also skip `Option<()>` when generating individual JSON schema files. This maintains consistency with the existing behavior where `Option<()>` is excluded from the bundled schema.

---

close #7479
