### PR TITLE
Terminate process group on interruption to avoid dangling processes

### DIFF
--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -199,11 +199,19 @@ impl Session {
     async fn handle_task_abort(self: &Arc<Self>, task: RunningTask, reason: TurnAbortReason) {
         let sub_id = task.turn_context.sub_id.clone();
         if task.cancellation_token.is_cancelled() {
+            self.services
+                .unified_exec_manager
+                .terminate_sessions_for_turn(&sub_id)
+                .await;
             return;
         }
 
         trace!(task_kind = ?task.kind, sub_id, "aborting running task");
         task.cancellation_token.cancel();
+        self.services
+            .unified_exec_manager
+            .terminate_sessions_for_turn(&sub_id)
+            .await;
         let session_task = task.task;
 
         select! {

--- a/codex-rs/core/src/unified_exec/session_manager.rs
+++ b/codex-rs/core/src/unified_exec/session_manager.rs
@@ -643,6 +643,25 @@ impl UnifiedExecSessionManager {
             entry.session.terminate();
         }
     }
+
+    pub(crate) async fn terminate_sessions_for_turn(&self, sub_id: &str) {
+        let entries: Vec<SessionEntry> = {
+            let mut sessions = self.session_store.lock().await;
+            let ids: Vec<String> = sessions
+                .sessions
+                .iter()
+                .filter(|(_, entry)| entry.turn_ref.sub_id == sub_id)
+                .map(|(id, _)| id.clone())
+                .collect();
+            ids.into_iter()
+                .filter_map(|id| sessions.remove(&id))
+                .collect()
+        };
+
+        for entry in entries {
+            entry.session.terminate();
+        }
+    }
 }
 
 enum SessionStatus {

--- a/codex-rs/core/src/unified_exec/session_manager.rs
+++ b/codex-rs/core/src/unified_exec/session_manager.rs
@@ -647,14 +647,10 @@ impl UnifiedExecSessionManager {
     pub(crate) async fn terminate_sessions_for_turn(&self, sub_id: &str) {
         let entries: Vec<SessionEntry> = {
             let mut sessions = self.session_store.lock().await;
-            let ids: Vec<String> = sessions
+            sessions
                 .sessions
-                .iter()
-                .filter(|(_, entry)| entry.turn_ref.sub_id == sub_id)
-                .map(|(id, _)| id.clone())
-                .collect();
-            ids.into_iter()
-                .filter_map(|id| sessions.remove(&id))
+                .extract_if(|_, entry| entry.turn_ref.sub_id == sub_id)
+                .map(|(_, entry)| entry)
                 .collect()
         };
 


### PR DESCRIPTION
This PR tracks an executed process for tool execution and forcibly terminates the process group if the user cancels the turn. Previously, the process was allowed to keep executing.

This addresses #7985