### PR TITLE
Fix: Detect Bun global install via path check

### DIFF
--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -95,6 +95,14 @@ function detectPackageManager() {
     return "bun";
   }
 
+
+  if (
+    __dirname.includes(".bun/install/global") ||
+    __dirname.includes(".bun\\install\\global")
+  ) {
+    return "bun";
+  }
+
   return userAgent ? "npm" : null;
 }
 


### PR DESCRIPTION
## Summary
Restores ability to detect when Codex is installed globally via **Bun**, which was broken by c3e4f920b4e965085164d6ee0249a873ef96da77. Fixes #8003.

Instead of relying on `npm_config_user_agent` (which is only set when running via `bunx` or `bun run`), this adds a path-based check to see if the CLI wrapper is located in Bun's global installation directory.

## Regression Context
Commit `c3e4f920b4e965085164d6ee0249a873ef96da77` removed the `BUN_INSTALL` environment variable checks to prevent false positives. However, this caused false negatives for genuine Bun global installs because `detectPackageManager()` defaults to NPM when no signal is found.

## Changes
- Updated `codex-cli/bin/codex.js` to check if `__dirname` contains `.bun/install/global` (handles both POSIX and Windows paths).

## Verification
Verified by performing a global install of the patched CLI (v0.69.0 to trigger the update prompt):

1. Packed the CLI using `npm pack` in `codex-cli/` to create a release tarball.
2. Installed globally via Bun: `bun install -g $(pwd)/openai-codex-0.0.0-dev.tgz`.
3. Ran `codex`, confirmed it detected Bun (banner showed `bun install -g @openai/codex`), selected "Update now", and verified it correctly spawned `bun install -g` instead of `npm`.
4. Confirmed the upgrade completed successfully using Bun.
<img width="1038" height="813" alt="verifying installation via bun" src="https://github.com/user-attachments/assets/00c9301a-18f1-4440-aa95-82ccffba896c" />
5. Verified installations via npm are unaffected.
<img width="2090" height="842" alt="verifying installation via npm" src="https://github.com/user-attachments/assets/ccb3e031-b85c-4bbe-bac7-23b087c5b844" />
