### PR TITLE
cli: emit JSONL run trace when CODEX_TRACE_PATH is set

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1081,6 +1081,7 @@ dependencies = [
  "codex-ollama",
  "codex-protocol",
  "serde",
+ "serde_json",
  "toml 0.9.5",
 ]
 

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -24,7 +24,7 @@ codex-app-server-protocol = { workspace = true }
 codex-arg0 = { workspace = true }
 codex-chatgpt = { workspace = true }
 codex-cloud-tasks = { path = "../cloud-tasks" }
-codex-common = { workspace = true, features = ["cli"] }
+codex-common = { workspace = true, features = ["cli", "trace"] }
 codex-core = { workspace = true }
 codex-exec = { workspace = true }
 codex-execpolicy = { workspace = true }

--- a/codex-rs/common/Cargo.toml
+++ b/codex-rs/common/Cargo.toml
@@ -8,15 +8,17 @@ license.workspace = true
 workspace = true
 
 [dependencies]
+serde_json = { workspace = true, optional = true }
 clap = { workspace = true, features = ["derive", "wrap_help"], optional = true }
 codex-core = { workspace = true }
 codex-lmstudio = { workspace = true }
 codex-ollama = { workspace = true }
 codex-protocol = { workspace = true }
-serde = { workspace = true, optional = true }
+serde = { workspace = true, features = ["derive"], optional = true }
 toml = { workspace = true, optional = true }
 
 [features]
+trace = ["serde", "serde_json"]
 # Separate feature so that `clap` is not a mandatory dependency.
 cli = ["clap", "serde", "toml"]
 elapsed = []

--- a/codex-rs/common/src/lib.rs
+++ b/codex-rs/common/src/lib.rs
@@ -37,3 +37,5 @@ pub mod fuzzy_match;
 pub mod approval_presets;
 // Shared OSS provider utilities used by TUI and exec
 pub mod oss;
+#[cfg(feature = "trace")]
+pub mod trace_jsonl;

--- a/codex-rs/common/src/trace_jsonl.rs
+++ b/codex-rs/common/src/trace_jsonl.rs
@@ -1,0 +1,158 @@
+use serde::Deserialize;
+use serde::Serialize;
+use std::fs::File;
+use std::fs::OpenOptions;
+use std::io::BufWriter;
+use std::io::Write;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::SystemTime;
+use std::time::UNIX_EPOCH;
+
+#[derive(Debug, Clone)]
+pub struct TraceConfig {
+    pub path: Option<PathBuf>,
+    pub redact: bool,
+}
+
+impl TraceConfig {
+    // Enable by setting CODEX_TRACE_PATH=/path/to/trace.jsonl
+    pub fn from_env() -> Self {
+        let path = std::env::var_os("CODEX_TRACE_PATH").map(PathBuf::from);
+        let redact = std::env::var("CODEX_TRACE_REDACT")
+            .ok()
+            .map(|v| matches!(v.as_str(), "1" | "true" | "TRUE" | "yes" | "YES"))
+            .unwrap_or(true);
+
+        Self { path, redact }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        self.path.is_some()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TraceEvent {
+    RunStarted(RunStarted),
+    RunFinished(RunFinished),
+    ToolCallStarted(ToolCallStarted),
+    ToolCallFinished(ToolCallFinished),
+    ModelRequestStarted(ModelRequestStarted),
+    ModelRequestFinished(ModelRequestFinished),
+    MessageEmitted(MessageEmitted),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunStarted {
+    pub ts_ms: u64,
+    pub run_id: String,
+    pub mode: String, // "tui" | "exec" | "cli"
+    pub cwd: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RunFinished {
+    pub ts_ms: u64,
+    pub run_id: String,
+    pub ok: bool,
+    pub exit_code: Option<i32>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCallStarted {
+    pub ts_ms: u64,
+    pub run_id: String,
+    pub tool: String,
+    pub call_id: String,
+    pub args_redacted: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ToolCallFinished {
+    pub ts_ms: u64,
+    pub run_id: String,
+    pub tool: String,
+    pub call_id: String,
+    pub ok: bool,
+    pub result_redacted: Option<serde_json::Value>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelRequestStarted {
+    pub ts_ms: u64,
+    pub run_id: String,
+    pub request_id: String,
+    pub model: Option<String>,
+    pub input_redacted: Option<serde_json::Value>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModelRequestFinished {
+    pub ts_ms: u64,
+    pub run_id: String,
+    pub request_id: String,
+    pub ok: bool,
+    pub output_redacted: Option<serde_json::Value>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MessageEmitted {
+    pub ts_ms: u64,
+    pub run_id: String,
+    pub role: String, // "user" | "assistant" | "system"
+    pub content_redacted: Option<String>,
+}
+
+pub struct TraceWriter {
+    run_id: String,
+    redact: bool,
+    out: BufWriter<File>,
+}
+
+impl TraceWriter {
+    pub fn open<P: AsRef<Path>>(path: P, run_id: String, redact: bool) -> std::io::Result<Self> {
+        let file = OpenOptions::new().create(true).append(true).open(path)?;
+        Ok(Self {
+            run_id,
+            redact,
+            out: BufWriter::new(file),
+        })
+    }
+
+    pub fn run_id(&self) -> &str {
+        &self.run_id
+    }
+
+    pub fn redact(&self) -> bool {
+        self.redact
+    }
+
+    pub fn write_event(&mut self, event: TraceEvent) -> std::io::Result<()> {
+        let line = serde_json::to_string(&event)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+        self.out.write_all(line.as_bytes())?;
+        self.out.write_all(b"\n")?;
+        self.out.flush()?;
+        Ok(())
+    }
+}
+
+pub fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+pub fn redact_string(s: &str, enabled: bool) -> String {
+    if enabled {
+        "[REDACTED]".to_string()
+    } else {
+        s.to_string()
+    }
+}


### PR DESCRIPTION
This adds a small, best-effort JSONL trace for codex-cli when CODEX_TRACE_PATH is set.

• Feature-gated in codex-common (trace feature)
• CLI wrapper writes run_started and run_finished events
• Includes cwd and run_id; never fails the CLI if trace IO fails

Manual test:

export CODEX_TRACE_PATH=/tmp/codex-trace.jsonl
rm -f /tmp/codex-trace.jsonl
just codex   # then type: quit
tail -n 5 /tmp/codex-trace.jsonl

Additional note:

- Writes a best-effort JSONL trace only when CODEX_TRACE_PATH is set (no behavior change by default); 
- Trace support is feature-gated behind codex-common's "trace" feature.
- Output is JSONL (one JSON object per line), which makes it easy to stream, grep, or ingest in other tooling.