### PR TITLE
docs: document enabling experimental skills

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -49,6 +49,7 @@ Supported features:
 | `ghost_commit`                        |  false  | Experimental | Create a ghost commit each turn                       |
 | `enable_experimental_windows_sandbox` |  false  | Experimental | Use the Windows restricted-token sandbox              |
 | `tui2`                                |  false  | Experimental | Use the experimental TUI v2 (viewport) implementation |
+| `skills`                              |  false  | Experimental | Enable discovery and injection of skills              |
 
 Notes:
 

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -220,6 +220,7 @@ view_image_tool = true
 web_search_request = false
 ghost_commit = false
 enable_experimental_windows_sandbox = false
+skills = false
 
 ################################################################################
 # Experimental toggles (legacy; prefer [features])

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -4,6 +4,19 @@
 
 Codex can automatically discover reusable "skills" you keep on disk. A skill is a small bundle with a name, a short description (what it does and when to use it), and an optional body of instructions you can open when needed. Codex injects only the name, description, and file path into the runtime context; the body stays on disk.
 
+## Enable skills
+
+Skills are behind the experimental `skills` feature flag and are disabled by default.
+
+- Enable in config (preferred): add the following to `$CODEX_HOME/config.toml` (usually `~/.codex/config.toml`) and restart Codex:
+
+  ```toml
+  [features]
+  skills = true
+  ```
+
+- Enable for a single run: launch Codex with `codex --enable skills`
+
 ## Where skills live
 
 - Location (v1): `~/.codex/skills/**/SKILL.md` (recursive). Hidden entries and symlinks are skipped. Only files named exactly `SKILL.md` count.
@@ -22,6 +35,11 @@ Codex can automatically discover reusable "skills" you keep on disk. A skill is 
 - Loaded once at startup.
 - If valid skills exist, Codex appends a runtime-only `## Skills` section after `AGENTS.md`, one bullet per skill: `- <name>: <description> (file: /absolute/path/to/SKILL.md)`.
 - If no valid skills exist, the section is omitted. On-disk files are never modified.
+
+## Using skills
+
+- Mention a skill by name in a message using `$<skill-name>`.
+- In the TUI, you can also use `/skills` to browse and insert skills.
 
 ## Validation and errors
 

--- a/docs/slash_commands.md
+++ b/docs/slash_commands.md
@@ -24,6 +24,7 @@ Control Codex’s behavior during an interactive session with slash commands.
 | `/mention`   | mention a file                                              |
 | `/status`    | show current session configuration and token usage          |
 | `/mcp`       | list configured MCP tools                                   |
+| `/skills`    | browse and insert skills (experimental; see [docs/skills.md](./skills.md)) |
 | `/logout`    | log out of Codex                                            |
 | `/quit`      | exit Codex                                                  |
 | `/exit`      | exit Codex                                                  |

--- a/docs/slash_commands.md
+++ b/docs/slash_commands.md
@@ -10,24 +10,24 @@ Slash commands are special commands you can type that start with `/`.
 
 Control Codex’s behavior during an interactive session with slash commands.
 
-| Command      | Purpose                                                     |
-| ------------ | ----------------------------------------------------------- |
-| `/model`     | choose what model and reasoning effort to use               |
-| `/approvals` | choose what Codex can do without approval                   |
-| `/review`    | review my current changes and find issues                   |
-| `/new`       | start a new chat during a conversation                      |
-| `/resume`    | resume an old chat                                          |
-| `/init`      | create an AGENTS.md file with instructions for Codex        |
-| `/compact`   | summarize conversation to prevent hitting the context limit |
-| `/undo`      | ask Codex to undo a turn                                    |
-| `/diff`      | show git diff (including untracked files)                   |
-| `/mention`   | mention a file                                              |
-| `/status`    | show current session configuration and token usage          |
-| `/mcp`       | list configured MCP tools                                   |
+| Command      | Purpose                                                                    |
+| ------------ | -------------------------------------------------------------------------- |
+| `/model`     | choose what model and reasoning effort to use                              |
+| `/approvals` | choose what Codex can do without approval                                  |
+| `/review`    | review my current changes and find issues                                  |
+| `/new`       | start a new chat during a conversation                                     |
+| `/resume`    | resume an old chat                                                         |
+| `/init`      | create an AGENTS.md file with instructions for Codex                       |
+| `/compact`   | summarize conversation to prevent hitting the context limit                |
+| `/undo`      | ask Codex to undo a turn                                                   |
+| `/diff`      | show git diff (including untracked files)                                  |
+| `/mention`   | mention a file                                                             |
+| `/status`    | show current session configuration and token usage                         |
+| `/mcp`       | list configured MCP tools                                                  |
 | `/skills`    | browse and insert skills (experimental; see [docs/skills.md](./skills.md)) |
-| `/logout`    | log out of Codex                                            |
-| `/quit`      | exit Codex                                                  |
-| `/exit`      | exit Codex                                                  |
-| `/feedback`  | send logs to maintainers                                    |
+| `/logout`    | log out of Codex                                                           |
+| `/quit`      | exit Codex                                                                 |
+| `/exit`      | exit Codex                                                                 |
+| `/feedback`  | send logs to maintainers                                                   |
 
 ---


### PR DESCRIPTION
## Notes

Skills are behind the experimental `skills` feature flag (disabled by default), but the skills guide didn't explain how to turn them on.

- Add an explicit enable section to `docs/skills.md` (config + `--enable`)
- Add the skills flag to `docs/config.md` and `docs/example-config.md`
- Document the `/skills` slash command
