### PR TITLE
 tui: show active model and reasoning effort in footer

### DIFF
--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -381,6 +381,17 @@ impl BottomPane {
         self.request_redraw();
     }
 
+    /// Update the model and reasoning effort displayed in the footer.
+    pub(crate) fn set_footer_model_reasoning(
+        &mut self,
+        model: Option<String>,
+        reasoning_effort: Option<codex_protocol::openai_models::ReasoningEffort>,
+    ) {
+        self.composer
+            .set_footer_model_reasoning(model, reasoning_effort);
+        self.request_redraw();
+    }
+
     /// Show a generic list selection view with the provided items.
     pub(crate) fn show_selection_view(&mut self, params: list_selection_view::SelectionViewParams) {
         let view = list_selection_view::ListSelectionView::new(params, self.app_event_tx.clone());

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_context_only_with_model.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_context_only_with_model.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/bottom_pane/footer.rs
+expression: terminal.backend()
+---
+"  claude-opus-4 · high reasoning · 80% context left                             "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_model_no_reasoning.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_model_no_reasoning.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/bottom_pane/footer.rs
+expression: terminal.backend()
+---
+"  o3-mini · 50% context left · ? for shortcuts                                  "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_model_with_reasoning.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_model_with_reasoning.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/bottom_pane/footer.rs
+expression: terminal.backend()
+---
+"  gpt-5.1-codex-max · medium reasoning · 72% context left · ? for shortcuts     "

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -444,6 +444,8 @@ fn make_chatwidget_manual(
         last_rendered_width: std::cell::Cell::new(None),
         feedback: codex_feedback::CodexFeedback::new(),
         current_rollout_path: None,
+        footer_model: None,
+        footer_reasoning_effort: None,
     };
     (widget, rx, op_rx)
 }


### PR DESCRIPTION
  ### What
  Show the currently selected model and reasoning effort in the TUI footer.

  Format:
  `<model> · <effort> reasoning · <context> · ? for shortcuts`

  Example:
  `gpt-5.2 · high reasoning · 72% context left · ? for shortcuts`

  ### Why
  Developers increasingly switch models and reasoning effort depending on the task (e.g. higher effort for planning -> lower effort for routine implementation -> higher effort for review). With multiple concurrent sessions/projects, it's easy to lose track of the active model/effort for each session; the footer makes this visible at a glance.

  ### How
  - Extend footer props to include model + reasoning effort.
  - Plumb updates from ChatWidget → BottomPane → ChatComposer → Footer renderer.
  - Display the model's effective effort (explicit selection if set, otherwise the model default), and never show the word "default".

  ### Screenshots

1. Full screen: 
<img width="1739" height="128" alt="Screenshot 2025-12-15 at 10 58 12 AM" src="https://github.com/user-attachments/assets/681bad55-3d1f-414b-9b86-7b783de083c2" />

2. Zoomed in: 
<img width="533" height="128" alt="Screenshot 2025-12-15 at 10 57 48 AM" src="https://github.com/user-attachments/assets/2e6addae-a340-4367-8bb2-5ad4baa3d56b" />


### Tests
  - [x] `just fmt` (codex-rs)
  - [x] `just fix -p codex-tui` (codex-rs)
  - [x] `cargo test -p codex-tui` (codex-rs)
  - [x] Manual: footer updates immediately when changing model/reasoning via `/model`


  ### Issue
  Addresses #8035 

  ### Context
  Saw the team's post inviting contributions: https://x.com/thsottiaux/status/1999980696534909144

  P.S. I'm exploring employment/contracting opportunities with the Codex team and would love to help more if there's a fit.
