### PR TITLE
Do not panic when session contains a tool call without an output

### DIFF
--- a/codex-rs/core/src/context_manager/history_tests.rs
+++ b/codex-rs/core/src/context_manager/history_tests.rs
@@ -699,11 +699,8 @@ fn normalize_mixed_inserts_and_removals() {
     );
 }
 
-// In debug builds we panic on normalization errors instead of silently fixing them.
-#[cfg(debug_assertions)]
 #[test]
-#[should_panic]
-fn normalize_adds_missing_output_for_function_call_panics_in_debug() {
+fn normalize_adds_missing_output_for_function_call_inserts_output() {
     let items = vec![ResponseItem::FunctionCall {
         id: None,
         name: "do_it".to_string(),
@@ -712,6 +709,24 @@ fn normalize_adds_missing_output_for_function_call_panics_in_debug() {
     }];
     let mut h = create_history_with_items(items);
     h.normalize_history();
+    assert_eq!(
+        h.contents(),
+        vec![
+            ResponseItem::FunctionCall {
+                id: None,
+                name: "do_it".to_string(),
+                arguments: "{}".to_string(),
+                call_id: "call-x".to_string(),
+            },
+            ResponseItem::FunctionCallOutput {
+                call_id: "call-x".to_string(),
+                output: FunctionCallOutputPayload {
+                    content: "aborted".to_string(),
+                    ..Default::default()
+                },
+            },
+        ]
+    );
 }
 
 #[cfg(debug_assertions)]

--- a/codex-rs/core/src/context_manager/normalize.rs
+++ b/codex-rs/core/src/context_manager/normalize.rs
@@ -4,6 +4,7 @@ use codex_protocol::models::FunctionCallOutputPayload;
 use codex_protocol::models::ResponseItem;
 
 use crate::util::error_or_panic;
+use tracing::info;
 
 pub(crate) fn ensure_call_outputs_present(items: &mut Vec<ResponseItem>) {
     // Collect synthetic outputs to insert immediately after their calls.
@@ -22,9 +23,7 @@ pub(crate) fn ensure_call_outputs_present(items: &mut Vec<ResponseItem>) {
                 });
 
                 if !has_output {
-                    error_or_panic(format!(
-                        "Function call output is missing for call id: {call_id}"
-                    ));
+                    info!("Function call output is missing for call id: {call_id}");
                     missing_outputs_to_insert.push((
                         idx,
                         ResponseItem::FunctionCallOutput {


### PR DESCRIPTION
Normally, all tool calls within a saved session should have a response, but there are legitimate reasons for the response to be missing. This can occur if the user canceled the call or there was an error of some sort during the rollout. We shouldn't panic in this case.

This is a partial fix for #7990
