### PR TITLE
Add plan tool feature flag

### DIFF
--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -32,6 +32,8 @@ pub enum Feature {
     GhostCommit,
     /// Include the view_image tool.
     ViewImageTool,
+    /// Include the plan tool.
+    PlanTool,
     /// Send warnings to the model to correct it on the tool usage.
     ModelWarnings,
     /// Enable the default shell tool.
@@ -277,6 +279,12 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::ViewImageTool,
         key: "view_image_tool",
+        stage: Stage::Stable,
+        default_enabled: true,
+    },
+    FeatureSpec {
+        id: Feature::PlanTool,
+        key: "plan_tool",
         stage: Stage::Stable,
         default_enabled: true,
     },

--- a/docs/config.md
+++ b/docs/config.md
@@ -45,6 +45,7 @@ Supported features:
 | `rmcp_client`                         |  false  | Experimental | Enable oauth support for streamable HTTP MCP servers  |
 | `apply_patch_freeform`                |  false  | Beta         | Include the freeform `apply_patch` tool               |
 | `view_image_tool`                     |  true   | Stable       | Include the `view_image` tool                         |
+| `plan_tool`                           |  true   | Stable       | Include the `update_plan` tool                        |
 | `web_search_request`                  |  false  | Stable       | Allow the model to issue web searches                 |
 | `ghost_commit`                        |  false  | Experimental | Create a ghost commit each turn                       |
 | `enable_experimental_windows_sandbox` |  false  | Experimental | Use the Windows restricted-token sandbox              |

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -217,6 +217,7 @@ unified_exec = false
 rmcp_client = false
 apply_patch_freeform = false
 view_image_tool = true
+plan_tool = true
 web_search_request = false
 ghost_commit = false
 enable_experimental_windows_sandbox = false


### PR DESCRIPTION
## Summary
- add a plan tool feature flag (default on) to gate update_plan tool registration
- cover the disabled plan tool path in tool spec tests
- document the new plan_tool feature in config docs/examples

## Testing
- `just fmt`
- `just fix -p codex-core`
- `cargo test -p codex-core` *(fails: shell_snapshot::tests::linux_sh_snapshot_includes_sections requires bash; exec::tests::kill_child_process_group_kills_grandchildren_on_timeout reports a lingering grandchild process in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_693f8b9f74088322956b6606babe3229)