### PR TITLE
feat: add support for project-specific custom prompts

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1636,7 +1636,7 @@ mod handlers {
     use crate::tasks::RegularTask;
     use crate::tasks::UndoTask;
     use crate::tasks::UserShellCommandTask;
-    use codex_protocol::custom_prompts::CustomPrompt;
+    
     use codex_protocol::protocol::CodexErrorInfo;
     use codex_protocol::protocol::ErrorEvent;
     use codex_protocol::protocol::Event;
@@ -1866,12 +1866,12 @@ mod handlers {
     }
 
     pub async fn list_custom_prompts(sess: &Session, sub_id: String) {
-        let custom_prompts: Vec<CustomPrompt> =
-            if let Some(dir) = crate::custom_prompts::default_prompts_dir() {
-                crate::custom_prompts::discover_prompts_in(&dir).await
-            } else {
-                Vec::new()
-            };
+        let cwd = {
+            let state = sess.state.lock().await;
+            state.session_configuration.cwd.clone()
+        };
+
+        let custom_prompts = crate::custom_prompts::collect_prompts(&cwd).await;
 
         let event = Event {
             id: sub_id,

--- a/docs/prompts.md
+++ b/docs/prompts.md
@@ -5,6 +5,7 @@ Custom prompts turn your repeatable instructions into reusable slash commands, s
 ### Where prompts live
 
 - Location: store prompts in `$CODEX_HOME/prompts/` (defaults to `~/.codex/prompts/`). Set `CODEX_HOME` if you want to use a different folder.
+- Project-specific prompts: if your current working directory contains `.codex/prompts/`, Codex loads prompts from there first, then falls back to the global folder. Project prompts override global prompts with the same name.
 - File type: Codex only loads `.md` files. Non-Markdown files are ignored. Both regular files and symlinks to Markdown files are supported.
 - Naming: The filename (without `.md`) becomes the prompt name. A file called `review.md` registers the prompt `review`.
 - Refresh: Prompts are loaded when a session starts. Restart Codex (or start a new session) after adding or editing files.


### PR DESCRIPTION
Allow projects to include custom prompts under ,
taking precedence over global prompts with the same name.

- Add collect_prompts() that merges project and global prompts
- Add project_prompts_dir() helper to locate project prompt directory
- Update list_custom_prompts handler to use current working directory
- Document project-specific prompts in user docs
