### PR TITLE
feat: add /interrupt command to stop running tasks

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1583,6 +1583,16 @@ impl ChatWidget {
             SlashCommand::Undo => {
                 self.app_event_tx.send(AppEvent::CodexOp(Op::Undo));
             }
+            SlashCommand::Interrupt => {
+                if self.bottom_pane.is_task_running() {
+                    self.submit_op(Op::Interrupt);
+                } else {
+                    self.add_info_message(
+                        "No task is currently running to interrupt.".to_string(),
+                        None,
+                    );
+                }
+            }
             SlashCommand::Diff => {
                 self.add_diff_in_progress();
                 let tx = self.app_event_tx.clone();

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -21,6 +21,7 @@ pub enum SlashCommand {
     Init,
     Compact,
     Undo,
+    Interrupt,
     Diff,
     Mention,
     Status,
@@ -44,6 +45,7 @@ impl SlashCommand {
             SlashCommand::Review => "review my current changes and find issues",
             SlashCommand::Resume => "resume a saved chat",
             SlashCommand::Undo => "ask Codex to undo a turn",
+            SlashCommand::Interrupt => "interrupt the currently running task (alternative to Esc)",
             SlashCommand::Quit | SlashCommand::Exit => "exit Codex",
             SlashCommand::Diff => "show git diff (including untracked files)",
             SlashCommand::Mention => "mention a file",
@@ -82,6 +84,7 @@ impl SlashCommand {
             | SlashCommand::Status
             | SlashCommand::Mcp
             | SlashCommand::Feedback
+            | SlashCommand::Interrupt
             | SlashCommand::Quit
             | SlashCommand::Exit => true,
             SlashCommand::Rollout => true,

--- a/codex-rs/tui2/src/chatwidget.rs
+++ b/codex-rs/tui2/src/chatwidget.rs
@@ -1583,6 +1583,16 @@ impl ChatWidget {
             SlashCommand::Undo => {
                 self.app_event_tx.send(AppEvent::CodexOp(Op::Undo));
             }
+            SlashCommand::Interrupt => {
+                if self.bottom_pane.is_task_running() {
+                    self.submit_op(Op::Interrupt);
+                } else {
+                    self.add_info_message(
+                        "No task is currently running to interrupt.".to_string(),
+                        None,
+                    );
+                }
+            }
             SlashCommand::Diff => {
                 self.add_diff_in_progress();
                 let tx = self.app_event_tx.clone();

--- a/codex-rs/tui2/src/slash_command.rs
+++ b/codex-rs/tui2/src/slash_command.rs
@@ -21,6 +21,7 @@ pub enum SlashCommand {
     Init,
     Compact,
     Undo,
+    Interrupt,
     Diff,
     Mention,
     Status,
@@ -44,6 +45,7 @@ impl SlashCommand {
             SlashCommand::Review => "review my current changes and find issues",
             SlashCommand::Resume => "resume a saved chat",
             SlashCommand::Undo => "ask Codex to undo a turn",
+            SlashCommand::Interrupt => "interrupt the currently running task (alternative to Esc)",
             SlashCommand::Quit | SlashCommand::Exit => "exit Codex",
             SlashCommand::Diff => "show git diff (including untracked files)",
             SlashCommand::Mention => "mention a file",
@@ -82,6 +84,7 @@ impl SlashCommand {
             | SlashCommand::Status
             | SlashCommand::Mcp
             | SlashCommand::Feedback
+            | SlashCommand::Interrupt
             | SlashCommand::Quit
             | SlashCommand::Exit => true,
             SlashCommand::Rollout => true,

--- a/docs/slash_commands.md
+++ b/docs/slash_commands.md
@@ -20,6 +20,7 @@ Control Codex’s behavior during an interactive session with slash commands.
 | `/init`      | create an AGENTS.md file with instructions for Codex                       |
 | `/compact`   | summarize conversation to prevent hitting the context limit                |
 | `/undo`      | ask Codex to undo a turn                                                   |
+| `/interrupt` | interrupt the currently running task (alternative to pressing Esc)         |
 | `/diff`      | show git diff (including untracked files)                                  |
 | `/mention`   | mention a file                                                             |
 | `/status`    | show current session configuration and token usage                         |


### PR DESCRIPTION
**What**

- Add a `/interrupt` slash command to the TUI as an alternative way to cancel a running task when Esc is not available (e.g. some IDE or terminal integrations).
- Support the command in both the legacy TUI and TUI v2, and document it in the slash commands docs.

**Why**

- In some environments, Esc is intercepted by the host (IDE/terminal) and never reaches Codex, which makes it impossible to stop a long‑running task.
- Issue: [openai/codex#8072](https://github.com/openai/codex/issues/8072) requests a `/interrupt` command as an alternative.

**How**

- Extend the `SlashCommand` enum in `codex-rs/tui` and `codex-rs/tui2` with `Interrupt`, with a user-facing description and `available_during_task = true`.
- In `ChatWidget::dispatch_command` for both TUIs, handle `SlashCommand::Interrupt` by:
  - If a task is running: submit `Op::Interrupt` (same path as the existing Ctrl‑C handler and the status indicator’s `interrupt()` method).
  - If no task is running: emit an informational message so the user gets feedback.
- Update `docs/slash_commands.md` to list `/interrupt` and describe it as an alternative to pressing Esc.

**Tests**

- `cargo test -p codex-tui`
- `cargo test -p codex-tui2`

**Manual verification**

- Start Codex via:

 
  cd codex/codex-rs
  cargo run --bin codex --
  - Trigger a long-running task (e.g. “summarize this repo”) and verify:
  - Pressing `/interrupt` cancels the task (same behavior as Esc).
- With no task running, run `/interrupt` and verify an info message is shown indicating that there is no task to interrupt.