### PR TITLE
better name for windows sandbox features

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1270,7 +1270,7 @@ impl CodexMessageProcessor {
         let mut cli_overrides = cli_overrides.unwrap_or_default();
         if cfg!(windows) && self.config.features.enabled(Feature::WindowsSandbox) {
             cli_overrides.insert(
-                "features.enable_experimental_windows_sandbox".to_string(),
+                "features.experimental_windows_sandbox".to_string(),
                 serde_json::json!(true),
             );
         }
@@ -2187,7 +2187,7 @@ impl CodexMessageProcessor {
                 let mut cli_overrides = cli_overrides.unwrap_or_default();
                 if cfg!(windows) && self.config.features.enabled(Feature::WindowsSandbox) {
                     cli_overrides.insert(
-                        "features.enable_experimental_windows_sandbox".to_string(),
+                        "features.experimental_windows_sandbox".to_string(),
                         serde_json::json!(true),
                     );
                 }

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -325,13 +325,13 @@ pub const FEATURES: &[FeatureSpec] = &[
     },
     FeatureSpec {
         id: Feature::WindowsSandbox,
-        key: "enable_experimental_windows_sandbox",
+        key: "experimental_windows_sandbox",
         stage: Stage::Experimental,
         default_enabled: false,
     },
     FeatureSpec {
         id: Feature::WindowsSandboxElevated,
-        key: "enable_elevated_windows_sandbox",
+        key: "elevated_windows_sandbox",
         stage: Stage::Experimental,
         default_enabled: false,
     },

--- a/codex-rs/core/src/features/legacy.rs
+++ b/codex-rs/core/src/features/legacy.rs
@@ -10,6 +10,10 @@ struct Alias {
 
 const ALIASES: &[Alias] = &[
     Alias {
+        legacy_key: "enable_experimental_windows_sandbox",
+        feature: Feature::WindowsSandbox,
+    },
+    Alias {
         legacy_key: "experimental_use_unified_exec_tool",
         feature: Feature::UnifiedExec,
     },

--- a/codex-rs/core/src/sandboxing/mod.rs
+++ b/codex-rs/core/src/sandboxing/mod.rs
@@ -81,7 +81,7 @@ impl SandboxManager {
             SandboxablePreference::Forbid => SandboxType::None,
             SandboxablePreference::Require => {
                 // Require a platform sandbox when available; on Windows this
-                // respects the enable_experimental_windows_sandbox feature.
+                // respects the experimental_windows_sandbox feature.
                 crate::safety::get_platform_sandbox().unwrap_or(SandboxType::None)
             }
             SandboxablePreference::Auto => match policy {


### PR DESCRIPTION
`--enable enable...` is a bad look
