### PR TITLE
Update is_dangerous_command.rs

### DIFF
--- a/codex-rs/core/src/command_safety/is_dangerous_command.rs
+++ b/codex-rs/core/src/command_safety/is_dangerous_command.rs
@@ -70,7 +70,7 @@ fn is_dangerous_to_call_with_exec(command: &[String]) -> bool {
             matches!(command.get(1).map(String::as_str), Some("reset" | "rm" | "--force" ))
         }
 
-        Some("rm") => matches!(command.get(1).map(String::as_str), Some("-f" | "-rf" | "-Rf" | "-fr" | "-fR" | "--force" | )),
+        Some("rm") => matches!(command.get(1).map(String::as_str), Some("-f" | "-rf" | "-Rf" | "-fr" | "-fR" | "--force" )),
 
         // for sudo <cmd> simply do the check for <cmd>
         Some("sudo") => is_dangerous_to_call_with_exec(&command[1..]),

--- a/codex-rs/core/src/command_safety/is_dangerous_command.rs
+++ b/codex-rs/core/src/command_safety/is_dangerous_command.rs
@@ -68,13 +68,13 @@ fn is_dangerous_to_call_with_exec(command: &[String]) -> bool {
     match cmd0 {
         Some(cmd) if cmd.ends_with("git") || cmd.ends_with("/git") => {
             matches!(
-                command.get(1).map(String::as_str), 
+                command.get(1).map(String::as_str),
                 Some("reset" | "rm" | "--force")
             )
         }
 
         Some("rm") => matches!(
-            command.get(1).map(String::as_str), 
+            command.get(1).map(String::as_str),
             Some("-f" | "-rf" | "-Rf" | "-fr" | "-fR" | "--force")
         ),
 

--- a/codex-rs/core/src/command_safety/is_dangerous_command.rs
+++ b/codex-rs/core/src/command_safety/is_dangerous_command.rs
@@ -67,10 +67,10 @@ fn is_dangerous_to_call_with_exec(command: &[String]) -> bool {
 
     match cmd0 {
         Some(cmd) if cmd.ends_with("git") || cmd.ends_with("/git") => {
-            matches!(command.get(1).map(String::as_str), Some("reset" | "rm"))
+            matches!(command.get(1).map(String::as_str), Some("reset" | "rm" | "--force" ))
         }
 
-        Some("rm") => matches!(command.get(1).map(String::as_str), Some("-f" | "-rf")),
+        Some("rm") => matches!(command.get(1).map(String::as_str), Some("-f" | "-rf" | "-Rf" | "-fr" | "-fR" | "--force" | )),
 
         // for sudo <cmd> simply do the check for <cmd>
         Some("sudo") => is_dangerous_to_call_with_exec(&command[1..]),

--- a/codex-rs/core/src/command_safety/is_dangerous_command.rs
+++ b/codex-rs/core/src/command_safety/is_dangerous_command.rs
@@ -69,13 +69,13 @@ fn is_dangerous_to_call_with_exec(command: &[String]) -> bool {
         Some(cmd) if cmd.ends_with("git") || cmd.ends_with("/git") => {
             matches!(
                 command.get(1).map(String::as_str), 
-                Some("reset" | "rm" | "--force" )
+                Some("reset" | "rm" | "--force")
             )
         }
 
         Some("rm") => matches!(
             command.get(1).map(String::as_str), 
-            Some("-f" | "-rf" | "-Rf" | "-fr" | "-fR" | "--force" )
+            Some("-f" | "-rf" | "-Rf" | "-fr" | "-fR" | "--force")
         ),
 
         // for sudo <cmd> simply do the check for <cmd>

--- a/codex-rs/core/src/command_safety/is_dangerous_command.rs
+++ b/codex-rs/core/src/command_safety/is_dangerous_command.rs
@@ -67,10 +67,16 @@ fn is_dangerous_to_call_with_exec(command: &[String]) -> bool {
 
     match cmd0 {
         Some(cmd) if cmd.ends_with("git") || cmd.ends_with("/git") => {
-            matches!(command.get(1).map(String::as_str), Some("reset" | "rm" | "--force" ))
+            matches!(
+                command.get(1).map(String::as_str), 
+                Some("reset" | "rm" | "--force" )
+            )
         }
 
-        Some("rm") => matches!(command.get(1).map(String::as_str), Some("-f" | "-rf" | "-Rf" | "-fr" | "-fR" | "--force" )),
+        Some("rm") => matches!(
+            command.get(1).map(String::as_str), 
+            Some("-f" | "-rf" | "-Rf" | "-fr" | "-fR" | "--force" )
+        ),
 
         // for sudo <cmd> simply do the check for <cmd>
         Some("sudo") => is_dangerous_to_call_with_exec(&command[1..]),


### PR DESCRIPTION
This pull request updates the logic in the `is_dangerous_to_call_with_exec` function to better detect dangerous command invocations, especially for `git` and `rm` commands. The main improvements are the inclusion of additional flags and options that are commonly associated with destructive operations.

**Dangerous command detection improvements:**

* Expanded detection of dangerous `git` commands to include the `--force` flag, in addition to `reset` and `rm` subcommands.
* Enhanced detection of dangerous `rm` commands by adding more flag variants (`-Rf`, `-fr`, `-fR`, `--force`) to the list of recognized destructive options.# External (non-OpenAI) Pull Request Requirements

Before opening this Pull Request, please read the dedicated "Contributing" markdown file or your PR may be closed:
https://github.com/openai/codex/blob/main/docs/contributing.md

If your PR conforms to our contribution guidelines, replace this text with a detailed and high quality description of your changes.

Include a link to a bug report or enhancement request.
