### PR TITLE
chore(ci): drop Homebrew origin/main workaround for macOS runners

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -385,28 +385,6 @@ jobs:
             /opt/ghc
           sudo apt-get remove -y docker.io docker-compose podman buildah
 
-      # Ensure brew includes this fix so that brew's shellenv.sh loads
-      # cleanly in the Codex sandbox (it is frequently eval'd via .zprofile
-      # for Brew users, including the macOS runners on GitHub):
-      #
-      # https://github.com/Homebrew/brew/pull/21157
-      #
-      # Once brew 5.0.5 is released and is the default on macOS runners, this
-      # step can be removed.
-      - name: Upgrade brew
-        if: ${{ startsWith(matrix.runner, 'macos') }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          brew --version
-          git -C "$(brew --repo)" fetch origin
-          git -C "$(brew --repo)" checkout main
-          git -C "$(brew --repo)" reset --hard origin/main
-          export HOMEBREW_UPDATE_TO_TAG=0
-          brew update
-          brew upgrade
-          brew --version
-
       # Some integration tests rely on DotSlash being installed.
       # See https://github.com/openai/codex/pull/7617.
       - name: Install DotSlash


### PR DESCRIPTION
## Notes

GitHub Actions macOS runners now ship a Homebrew version (5.0.5) that includes the fix that was needed in a change, so it's possible to remove the temporary CI step that forced using brew from origin/main (added in #7680).

Proof of macOS GitHub Actions coming packaged with 5.0.5 - latest commit on `main` (https://github.com/openai/codex/actions/runs/20245177832/job/58123247999)
- <img width="1286" height="136" alt="image" src="https://github.com/user-attachments/assets/8b25fd57-dad5-45c5-907c-4f4da6a36c3f" />

`actions/runner-images` upgraded the macOS 14 image from pre-release to release today (https://github.com/actions/runner-images/releases/tag/macos-14-arm64%2F20251210.0045)

- <img width="1076" height="793" alt="image" src="https://github.com/user-attachments/assets/357ea4bd-40b0-49c3-a6cd-e7d87ba6766d" />
