### PR TITLE
Chore: remove rmcp feature and exp flag usages

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1992,16 +1992,6 @@ impl CodexMessageProcessor {
             }
         };
 
-        if !config.features.enabled(Feature::RmcpClient) {
-            let error = JSONRPCErrorError {
-                code: INVALID_REQUEST_ERROR_CODE,
-                message: "OAuth login is only supported when [features].rmcp_client is true in config.toml".to_string(),
-                data: None,
-            };
-            self.outgoing.send_error(request_id, error).await;
-            return;
-        }
-
         let McpServerOauthLoginParams {
             name,
             scopes,

--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -19,8 +19,6 @@ use codex_rmcp_client::delete_oauth_tokens;
 use codex_rmcp_client::perform_oauth_login;
 use codex_rmcp_client::supports_oauth_login;
 
-/// [experimental] Launch Codex as an MCP server or manage configured MCP servers.
-///
 /// Subcommands:
 /// - `serve`  — run the MCP server on stdio
 /// - `list`   — list configured servers (with `--json`)
@@ -38,22 +36,11 @@ pub struct McpCli {
 
 #[derive(Debug, clap::Subcommand)]
 pub enum McpSubcommand {
-    /// [experimental] List configured MCP servers.
     List(ListArgs),
-
-    /// [experimental] Show details for a configured MCP server.
     Get(GetArgs),
-
-    /// [experimental] Add a global MCP server entry.
     Add(AddArgs),
-
-    /// [experimental] Remove a global MCP server entry.
     Remove(RemoveArgs),
-
-    /// [experimental] Authenticate with a configured MCP server via OAuth.
     Login(LoginArgs),
-
-    /// [experimental] Remove stored OAuth credentials for a server.
     Logout(LogoutArgs),
 }
 

--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -13,7 +13,6 @@ use codex_core::config::find_codex_home;
 use codex_core::config::load_global_mcp_servers;
 use codex_core::config::types::McpServerConfig;
 use codex_core::config::types::McpServerTransportConfig;
-use codex_core::features::Feature;
 use codex_core::mcp::auth::compute_auth_statuses;
 use codex_core::protocol::McpAuthStatus;
 use codex_rmcp_client::delete_oauth_tokens;
@@ -52,11 +51,9 @@ pub enum McpSubcommand {
     Remove(RemoveArgs),
 
     /// [experimental] Authenticate with a configured MCP server via OAuth.
-    /// Requires features.rmcp_client = true in config.toml.
     Login(LoginArgs),
 
     /// [experimental] Remove stored OAuth credentials for a server.
-    /// Requires features.rmcp_client = true in config.toml.
     Logout(LogoutArgs),
 }
 
@@ -282,24 +279,17 @@ async fn run_add(config_overrides: &CliConfigOverrides, add_args: AddArgs) -> Re
     {
         match supports_oauth_login(&url).await {
             Ok(true) => {
-                if !config.features.enabled(Feature::RmcpClient) {
-                    println!(
-                        "MCP server supports login. Add `features.rmcp_client = true` \
-                         to your config.toml and run `codex mcp login {name}` to login."
-                    );
-                } else {
-                    println!("Detected OAuth support. Starting OAuth flow…");
-                    perform_oauth_login(
-                        &name,
-                        &url,
-                        config.mcp_oauth_credentials_store_mode,
-                        http_headers.clone(),
-                        env_http_headers.clone(),
-                        &Vec::new(),
-                    )
-                    .await?;
-                    println!("Successfully logged in.");
-                }
+                println!("Detected OAuth support. Starting OAuth flow…");
+                perform_oauth_login(
+                    &name,
+                    &url,
+                    config.mcp_oauth_credentials_store_mode,
+                    http_headers.clone(),
+                    env_http_headers.clone(),
+                    &Vec::new(),
+                )
+                .await?;
+                println!("Successfully logged in.");
             }
             Ok(false) => {}
             Err(_) => println!(
@@ -351,12 +341,6 @@ async fn run_login(config_overrides: &CliConfigOverrides, login_args: LoginArgs)
     let config = Config::load_with_cli_overrides(overrides)
         .await
         .context("failed to load configuration")?;
-
-    if !config.features.enabled(Feature::RmcpClient) {
-        bail!(
-            "OAuth login is only supported when [features].rmcp_client is true in config.toml. See https://github.com/openai/codex/blob/main/docs/config.md#feature-flags for details."
-        );
-    }
 
     let LoginArgs { name, scopes } = login_args;
 

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -269,10 +269,6 @@ pub struct Config {
     /// If set to `true`, used only the experimental unified exec tool.
     pub use_experimental_unified_exec_tool: bool,
 
-    /// If set to `true`, use the experimental official Rust MCP client.
-    /// https://github.com/modelcontextprotocol/rust-sdk
-    pub use_experimental_use_rmcp_client: bool,
-
     /// Settings for ghost snapshots (used for undo).
     pub ghost_snapshot: GhostSnapshotConfig,
 
@@ -774,7 +770,6 @@ pub struct ConfigToml {
     pub experimental_instructions_file: Option<AbsolutePathBuf>,
     pub experimental_compact_prompt_file: Option<AbsolutePathBuf>,
     pub experimental_use_unified_exec_tool: Option<bool>,
-    pub experimental_use_rmcp_client: Option<bool>,
     pub experimental_use_freeform_apply_patch: Option<bool>,
     /// Preferred OSS provider for local models, e.g. "lmstudio" or "ollama".
     pub oss_provider: Option<String>,
@@ -1190,7 +1185,6 @@ impl Config {
         let include_apply_patch_tool_flag = features.enabled(Feature::ApplyPatchFreeform);
         let tools_web_search_request = features.enabled(Feature::WebSearchRequest);
         let use_experimental_unified_exec_tool = features.enabled(Feature::UnifiedExec);
-        let use_experimental_use_rmcp_client = features.enabled(Feature::RmcpClient);
 
         let forced_chatgpt_workspace_id =
             cfg.forced_chatgpt_workspace_id.as_ref().and_then(|value| {
@@ -1330,7 +1324,6 @@ impl Config {
             include_apply_patch_tool: include_apply_patch_tool_flag,
             tools_web_search_request,
             use_experimental_unified_exec_tool,
-            use_experimental_use_rmcp_client,
             ghost_snapshot,
             features,
             active_profile: active_profile_name,
@@ -1908,7 +1901,6 @@ trust_level = "trusted"
         let codex_home = TempDir::new()?;
         let cfg = ConfigToml {
             experimental_use_unified_exec_tool: Some(true),
-            experimental_use_rmcp_client: Some(true),
             experimental_use_freeform_apply_patch: Some(true),
             ..Default::default()
         };
@@ -1921,12 +1913,10 @@ trust_level = "trusted"
 
         assert!(config.features.enabled(Feature::ApplyPatchFreeform));
         assert!(config.features.enabled(Feature::UnifiedExec));
-        assert!(config.features.enabled(Feature::RmcpClient));
 
         assert!(config.include_apply_patch_tool);
 
         assert!(config.use_experimental_unified_exec_tool);
-        assert!(config.use_experimental_use_rmcp_client);
 
         Ok(())
     }
@@ -3107,7 +3097,6 @@ model_verbosity = "high"
                 include_apply_patch_tool: false,
                 tools_web_search_request: false,
                 use_experimental_unified_exec_tool: false,
-                use_experimental_use_rmcp_client: false,
                 ghost_snapshot: GhostSnapshotConfig::default(),
                 features: Features::with_defaults(),
                 active_profile: Some("o3".to_string()),
@@ -3182,7 +3171,6 @@ model_verbosity = "high"
             include_apply_patch_tool: false,
             tools_web_search_request: false,
             use_experimental_unified_exec_tool: false,
-            use_experimental_use_rmcp_client: false,
             ghost_snapshot: GhostSnapshotConfig::default(),
             features: Features::with_defaults(),
             active_profile: Some("gpt3".to_string()),
@@ -3272,7 +3260,6 @@ model_verbosity = "high"
             include_apply_patch_tool: false,
             tools_web_search_request: false,
             use_experimental_unified_exec_tool: false,
-            use_experimental_use_rmcp_client: false,
             ghost_snapshot: GhostSnapshotConfig::default(),
             features: Features::with_defaults(),
             active_profile: Some("zdr".to_string()),
@@ -3348,7 +3335,6 @@ model_verbosity = "high"
             include_apply_patch_tool: false,
             tools_web_search_request: false,
             use_experimental_unified_exec_tool: false,
-            use_experimental_use_rmcp_client: false,
             ghost_snapshot: GhostSnapshotConfig::default(),
             features: Features::with_defaults(),
             active_profile: Some("gpt5".to_string()),

--- a/codex-rs/core/src/config/profile.rs
+++ b/codex-rs/core/src/config/profile.rs
@@ -25,7 +25,6 @@ pub struct ConfigProfile {
     pub experimental_compact_prompt_file: Option<AbsolutePathBuf>,
     pub include_apply_patch_tool: Option<bool>,
     pub experimental_use_unified_exec_tool: Option<bool>,
-    pub experimental_use_rmcp_client: Option<bool>,
     pub experimental_use_freeform_apply_patch: Option<bool>,
     pub tools_web_search: Option<bool>,
     pub tools_view_image: Option<bool>,

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -69,8 +69,6 @@ pub enum Feature {
     // Experimental
     /// Use the single unified PTY-backed exec tool.
     UnifiedExec,
-    /// Enable experimental RMCP features such as OAuth login.
-    RmcpClient,
     /// Include the freeform apply_patch tool.
     ApplyPatchFreeform,
     /// Allow the model to request web searches.
@@ -226,7 +224,6 @@ impl Features {
         let base_legacy = LegacyFeatureToggles {
             experimental_use_freeform_apply_patch: cfg.experimental_use_freeform_apply_patch,
             experimental_use_unified_exec_tool: cfg.experimental_use_unified_exec_tool,
-            experimental_use_rmcp_client: cfg.experimental_use_rmcp_client,
             tools_web_search: cfg.tools.as_ref().and_then(|t| t.web_search),
             tools_view_image: cfg.tools.as_ref().and_then(|t| t.view_image),
             ..Default::default()
@@ -243,7 +240,6 @@ impl Features {
                 .experimental_use_freeform_apply_patch,
 
             experimental_use_unified_exec_tool: config_profile.experimental_use_unified_exec_tool,
-            experimental_use_rmcp_client: config_profile.experimental_use_rmcp_client,
             tools_web_search: config_profile.tools_web_search,
             tools_view_image: config_profile.tools_view_image,
         };
@@ -346,13 +342,6 @@ pub const FEATURES: &[FeatureSpec] = &[
             menu_description: "Snapshot your shell environment to avoid re-running login scripts for every command.",
             announcement: "NEW! Try shell snapshotting to make your Codex faster. Enable in /experimental!",
         },
-        default_enabled: false,
-    },
-    // Unstable features.
-    FeatureSpec {
-        id: Feature::RmcpClient,
-        key: "rmcp_client",
-        stage: Stage::Experimental,
         default_enabled: false,
     },
     FeatureSpec {

--- a/codex-rs/core/src/features/legacy.rs
+++ b/codex-rs/core/src/features/legacy.rs
@@ -18,10 +18,6 @@ const ALIASES: &[Alias] = &[
         feature: Feature::UnifiedExec,
     },
     Alias {
-        legacy_key: "experimental_use_rmcp_client",
-        feature: Feature::RmcpClient,
-    },
-    Alias {
         legacy_key: "experimental_use_freeform_apply_patch",
         feature: Feature::ApplyPatchFreeform,
     },
@@ -50,7 +46,6 @@ pub struct LegacyFeatureToggles {
     pub include_apply_patch_tool: Option<bool>,
     pub experimental_use_freeform_apply_patch: Option<bool>,
     pub experimental_use_unified_exec_tool: Option<bool>,
-    pub experimental_use_rmcp_client: Option<bool>,
     pub tools_web_search: Option<bool>,
     pub tools_view_image: Option<bool>,
 }
@@ -74,12 +69,6 @@ impl LegacyFeatureToggles {
             Feature::UnifiedExec,
             self.experimental_use_unified_exec_tool,
             "experimental_use_unified_exec_tool",
-        );
-        set_if_some(
-            features,
-            Feature::RmcpClient,
-            self.experimental_use_rmcp_client,
-            "experimental_use_rmcp_client",
         );
         set_if_some(
             features,

--- a/codex-rs/core/tests/suite/rmcp_client.rs
+++ b/codex-rs/core/tests/suite/rmcp_client.rs
@@ -10,7 +10,6 @@ use std::time::UNIX_EPOCH;
 
 use codex_core::config::types::McpServerConfig;
 use codex_core::config::types::McpServerTransportConfig;
-use codex_core::features::Feature;
 
 use codex_core::protocol::AskForApproval;
 use codex_core::protocol::EventMsg;
@@ -79,7 +78,6 @@ async fn stdio_server_round_trip() -> anyhow::Result<()> {
 
     let fixture = test_codex()
         .with_config(move |config| {
-            config.features.enable(Feature::RmcpClient);
             config.mcp_servers.insert(
                 server_name.to_string(),
                 McpServerConfig {
@@ -217,7 +215,6 @@ async fn stdio_image_responses_round_trip() -> anyhow::Result<()> {
 
     let fixture = test_codex()
         .with_config(move |config| {
-            config.features.enable(Feature::RmcpClient);
             config.mcp_servers.insert(
                 server_name.to_string(),
                 McpServerConfig {
@@ -413,7 +410,6 @@ async fn stdio_image_completions_round_trip() -> anyhow::Result<()> {
     let fixture = test_codex()
         .with_config(move |config| {
             config.model_provider.wire_api = codex_core::WireApi::Chat;
-            config.features.enable(Feature::RmcpClient);
             config.mcp_servers.insert(
                 server_name.to_string(),
                 McpServerConfig {
@@ -560,7 +556,6 @@ async fn stdio_server_propagates_whitelisted_env_vars() -> anyhow::Result<()> {
 
     let fixture = test_codex()
         .with_config(move |config| {
-            config.features.enable(Feature::RmcpClient);
             config.mcp_servers.insert(
                 server_name.to_string(),
                 McpServerConfig {
@@ -710,7 +705,6 @@ async fn streamable_http_tool_call_round_trip() -> anyhow::Result<()> {
 
     let fixture = test_codex()
         .with_config(move |config| {
-            config.features.enable(Feature::RmcpClient);
             config.mcp_servers.insert(
                 server_name.to_string(),
                 McpServerConfig {
@@ -891,7 +885,6 @@ async fn streamable_http_with_oauth_round_trip() -> anyhow::Result<()> {
 
     let fixture = test_codex()
         .with_config(move |config| {
-            config.features.enable(Feature::RmcpClient);
             config.mcp_servers.insert(
                 server_name.to_string(),
                 McpServerConfig {

--- a/codex-rs/core/tests/suite/truncation.rs
+++ b/codex-rs/core/tests/suite/truncation.rs
@@ -5,7 +5,6 @@ use anyhow::Context;
 use anyhow::Result;
 use codex_core::config::types::McpServerConfig;
 use codex_core::config::types::McpServerTransportConfig;
-use codex_core::features::Feature;
 use codex_core::protocol::AskForApproval;
 use codex_core::protocol::EventMsg;
 use codex_core::protocol::Op;
@@ -421,7 +420,6 @@ async fn mcp_tool_call_output_exceeds_limit_truncated_for_model() -> Result<()> 
         .into_owned();
 
     let mut builder = test_codex().with_config(move |config| {
-        config.features.enable(Feature::RmcpClient);
         config.mcp_servers.insert(
             server_name.to_string(),
             codex_core::config::types::McpServerConfig {
@@ -511,7 +509,6 @@ async fn mcp_image_output_preserves_image_and_no_text_summary() -> Result<()> {
     let openai_png = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMB/ee9bQAAAABJRU5ErkJggg==";
 
     let mut builder = test_codex().with_config(move |config| {
-        config.features.enable(Feature::RmcpClient);
         config.mcp_servers.insert(
             server_name.to_string(),
             McpServerConfig {
@@ -774,7 +771,6 @@ async fn mcp_tool_call_output_not_truncated_with_custom_limit() -> Result<()> {
         .into_owned();
 
     let mut builder = test_codex().with_config(move |config| {
-        config.features.enable(Feature::RmcpClient);
         config.tool_output_token_limit = Some(50_000);
         config.mcp_servers.insert(
             server_name.to_string(),

--- a/docs/config.md
+++ b/docs/config.md
@@ -464,7 +464,7 @@ http_headers = { "HEADER_NAME" = "HEADER_VALUE" }
 env_http_headers = { "HEADER_NAME" = "ENV_VAR" }
 ```
 
-Streamable HTTP connections always use the experimental Rust MCP client under the hood, so expect occasional rough edges. When a server supports OAuth, run `codex mcp login <server-name>` to authenticate.
+Streamable HTTP connections always use the Rust MCP client under the hood. Run `codex mcp login <server-name>` to authenticate for servers supporting OAuth.
 
 #### Other configuration options
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -42,7 +42,6 @@ Supported features:
 | Key                                   | Default | Stage        | Description                                           |
 | ------------------------------------- | :-----: | ------------ | ----------------------------------------------------- |
 | `unified_exec`                        |  false  | Experimental | Use the unified PTY-backed exec tool                  |
-| `rmcp_client`                         |  false  | Experimental | Enable oauth support for streamable HTTP MCP servers  |
 | `apply_patch_freeform`                |  false  | Beta         | Include the freeform `apply_patch` tool               |
 | `view_image_tool`                     |  true   | Stable       | Include the `view_image` tool                         |
 | `web_search_request`                  |  false  | Stable       | Allow the model to issue web searches                 |
@@ -465,14 +464,7 @@ http_headers = { "HEADER_NAME" = "HEADER_VALUE" }
 env_http_headers = { "HEADER_NAME" = "ENV_VAR" }
 ```
 
-Streamable HTTP connections always use the experimental Rust MCP client under the hood, so expect occasional rough edges. OAuth login flows are gated on the `rmcp_client = true` flag:
-
-```toml
-[features]
-rmcp_client = true
-```
-
-After enabling it, run `codex mcp login <server-name>` when the server supports OAuth.
+Streamable HTTP connections always use the experimental Rust MCP client under the hood, so expect occasional rough edges. When a server supports OAuth, run `codex mcp login <server-name>` to authenticate.
 
 #### Other configuration options
 

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -214,7 +214,6 @@ view_image = true
 [features]
 # Leave this table empty to accept defaults. Set explicit booleans to opt in/out.
 unified_exec = false
-rmcp_client = false
 apply_patch_freeform = false
 view_image_tool = true
 web_search_request = false


### PR DESCRIPTION
### Summary
With codesigning on Mac, Windows and Linux, we should be able to safely remove `features.rmcp_client` and `use_experimental_use_rmcp_client` check from the codebase now. 