### PR TITLE
bug fixes and perf improvements for elevated sandbox setup

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/audit.rs
+++ b/codex-rs/windows-sandbox-rs/src/audit.rs
@@ -251,7 +251,7 @@ pub fn apply_capability_denies_for_world_writable(
     }
     std::fs::create_dir_all(codex_home)?;
     let cap_path = cap_sid_file(codex_home);
-    let caps = load_or_create_cap_sids(codex_home);
+    let caps = load_or_create_cap_sids(codex_home)?;
     std::fs::write(&cap_path, serde_json::to_string(&caps)?)?;
     let (active_sid, workspace_roots): (*mut c_void, Vec<PathBuf>) = match sandbox_policy {
         SandboxPolicy::WorkspaceWrite { writable_roots, .. } => {

--- a/codex-rs/windows-sandbox-rs/src/cap.rs
+++ b/codex-rs/windows-sandbox-rs/src/cap.rs
@@ -1,3 +1,5 @@
+use anyhow::Context;
+use anyhow::Result;
 use rand::rngs::SmallRng;
 use rand::RngCore;
 use rand::SeedableRng;
@@ -26,25 +28,39 @@ fn make_random_cap_sid_string() -> String {
     format!("S-1-5-21-{}-{}-{}-{}", a, b, c, d)
 }
 
-pub fn load_or_create_cap_sids(codex_home: &Path) -> CapSids {
+fn persist_caps(path: &Path, caps: &CapSids) -> Result<()> {
+    if let Some(dir) = path.parent() {
+        fs::create_dir_all(dir)
+            .with_context(|| format!("create cap sid dir {}", dir.display()))?;
+    }
+    let json = serde_json::to_string(caps)?;
+    fs::write(path, json).with_context(|| format!("write cap sid file {}", path.display()))?;
+    Ok(())
+}
+
+pub fn load_or_create_cap_sids(codex_home: &Path) -> Result<CapSids> {
     let path = cap_sid_file(codex_home);
     if path.exists() {
-        if let Ok(txt) = fs::read_to_string(&path) {
-            let t = txt.trim();
-            if t.starts_with('{') && t.ends_with('}') {
-                if let Ok(obj) = serde_json::from_str::<CapSids>(t) {
-                    return obj;
-                }
-            } else if !t.is_empty() {
-                return CapSids {
-                    workspace: t.to_string(),
-                    readonly: make_random_cap_sid_string(),
-                };
+        let txt = fs::read_to_string(&path)
+            .with_context(|| format!("read cap sid file {}", path.display()))?;
+        let t = txt.trim();
+        if t.starts_with('{') && t.ends_with('}') {
+            if let Ok(obj) = serde_json::from_str::<CapSids>(t) {
+                return Ok(obj);
             }
+        } else if !t.is_empty() {
+            let caps = CapSids {
+                workspace: t.to_string(),
+                readonly: make_random_cap_sid_string(),
+            };
+            persist_caps(&path, &caps)?;
+            return Ok(caps);
         }
     }
-    CapSids {
+    let caps = CapSids {
         workspace: make_random_cap_sid_string(),
         readonly: make_random_cap_sid_string(),
-    }
+    };
+    persist_caps(&path, &caps)?;
+    Ok(caps)
 }

--- a/codex-rs/windows-sandbox-rs/src/setup_main_win.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_main_win.rs
@@ -20,6 +20,7 @@ use rand::RngCore;
 use rand::SeedableRng;
 use serde::Deserialize;
 use serde::Serialize;
+use std::collections::HashSet;
 use std::ffi::c_void;
 use std::ffi::OsStr;
 use std::fs::File;
@@ -392,8 +393,8 @@ fn run_netsh_firewall(sid: &str, log: &mut File) -> Result<()> {
             log_line(
                 log,
                 &format!(
-                "firewall rule configured via COM with LocalUserAuthorizedList={local_user_spec}"
-            ),
+                    "firewall rule configured via COM with LocalUserAuthorizedList={local_user_spec}"
+                ),
             )?;
             Ok(())
         })()
@@ -647,7 +648,7 @@ fn run_setup(payload: &Payload, log: &mut File, sbx_dir: &Path) -> Result<()> {
             string_from_sid_bytes(&online_sid).map_err(anyhow::Error::msg)?
         ),
     )?;
-    let caps = load_or_create_cap_sids(&payload.codex_home);
+    let caps = load_or_create_cap_sids(&payload.codex_home)?;
     let cap_psid = unsafe {
         convert_string_sid_to_sid(&caps.workspace)
             .ok_or_else(|| anyhow::anyhow!("convert capability SID failed"))?
@@ -758,7 +759,19 @@ fn run_setup(payload: &Payload, log: &mut File, sbx_dir: &Path) -> Result<()> {
         }
     }
 
+    let cap_sid_str = caps.workspace.clone();
+    let online_sid_str = string_from_sid_bytes(&online_sid).map_err(anyhow::Error::msg)?;
+    let sid_strings = vec![offline_sid_str.clone(), online_sid_str, cap_sid_str];
+    let write_mask =
+        FILE_GENERIC_READ | FILE_GENERIC_WRITE | FILE_GENERIC_EXECUTE | DELETE | FILE_DELETE_CHILD;
+    let mut grant_tasks: Vec<PathBuf> = Vec::new();
+
+    let mut seen_write_roots: HashSet<PathBuf> = HashSet::new();
+
     for root in &payload.write_roots {
+        if !seen_write_roots.insert(root.clone()) {
+            continue;
+        }
         if !root.exists() {
             log_line(
                 log,
@@ -766,12 +779,10 @@ fn run_setup(payload: &Payload, log: &mut File, sbx_dir: &Path) -> Result<()> {
             )?;
             continue;
         }
-        let sids = vec![offline_psid, online_psid, cap_psid];
-        let write_mask = FILE_GENERIC_READ
-            | FILE_GENERIC_WRITE
-            | FILE_GENERIC_EXECUTE
-            | DELETE
-            | FILE_DELETE_CHILD;
+        let cap_present = match path_mask_allows(root, &[cap_psid], write_mask, true) {
+            Ok(h) => h,
+            Err(_) => false,
+        };
         let mut need_grant = false;
         for (label, psid) in [
             ("offline", offline_psid),
@@ -817,25 +828,7 @@ fn run_setup(payload: &Payload, log: &mut File, sbx_dir: &Path) -> Result<()> {
                     root.display()
                 ),
             )?;
-            match unsafe { ensure_allow_write_aces(root, &sids) } {
-                Ok(res) => {
-                    log_line(
-                        log,
-                        &format!(
-                            "write ACE {} on {}",
-                            if res { "added" } else { "already present" },
-                            root.display()
-                        ),
-                    )?;
-                }
-                Err(e) => {
-                    refresh_errors.push(format!("write ACE failed on {}: {}", root.display(), e));
-                    log_line(
-                        log,
-                        &format!("write ACE grant failed on {}: {}", root.display(), e),
-                    )?;
-                }
-            }
+            grant_tasks.push(root.clone());
         } else {
             log_line(
                 log,
@@ -846,6 +839,65 @@ fn run_setup(payload: &Payload, log: &mut File, sbx_dir: &Path) -> Result<()> {
             )?;
         }
     }
+
+    let (tx, rx) = mpsc::channel::<(PathBuf, Result<bool>)>();
+    std::thread::scope(|scope| {
+        for root in grant_tasks {
+            let sid_strings = sid_strings.clone();
+            let tx = tx.clone();
+            scope.spawn(move || {
+                // Convert SID strings to psids locally in this thread.
+                let mut psids: Vec<*mut c_void> = Vec::new();
+                for sid_str in &sid_strings {
+                    if let Some(psid) = unsafe { convert_string_sid_to_sid(sid_str) } {
+                        psids.push(psid);
+                    } else {
+                        let _ = tx.send((root.clone(), Err(anyhow::anyhow!("convert SID failed"))));
+                        return;
+                    }
+                }
+
+                let res = unsafe { ensure_allow_write_aces(&root, &psids) };
+
+                for psid in psids {
+                    unsafe {
+                        LocalFree(psid as HLOCAL);
+                    }
+                }
+                let _ = tx.send((root, res));
+            });
+        }
+        drop(tx);
+        for (root, res) in rx {
+            match res {
+                Ok(added) => {
+                    if log_line(
+                        log,
+                        &format!(
+                            "write ACE {} on {}",
+                            if added { "added" } else { "already present" },
+                            root.display()
+                        ),
+                    )
+                    .is_err()
+                    {
+                        // ignore log errors inside scoped thread
+                    }
+                }
+                Err(e) => {
+                    refresh_errors.push(format!("write ACE failed on {}: {}", root.display(), e));
+                    if log_line(
+                        log,
+                        &format!("write ACE grant failed on {}: {}", root.display(), e),
+                    )
+                    .is_err()
+                    {
+                        // ignore log errors inside scoped thread
+                    }
+                }
+            }
+        }
+    });
 
     if refresh_only {
         log_line(

--- a/codex-rs/windows-sandbox-rs/src/setup_main_win.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_main_win.rs
@@ -779,10 +779,6 @@ fn run_setup(payload: &Payload, log: &mut File, sbx_dir: &Path) -> Result<()> {
             )?;
             continue;
         }
-        let cap_present = match path_mask_allows(root, &[cap_psid], write_mask, true) {
-            Ok(h) => h,
-            Err(_) => false,
-        };
         let mut need_grant = false;
         for (label, psid) in [
             ("offline", offline_psid),

--- a/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
@@ -1,6 +1,7 @@
 use serde::Deserialize;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::collections::HashSet;
 use std::ffi::c_void;
 use std::os::windows::process::CommandExt;
 use std::path::Path;
@@ -54,13 +55,22 @@ pub fn run_setup_refresh(
     if matches!(policy, SandboxPolicy::DangerFullAccess) {
         return Ok(());
     }
+    let (read_roots, write_roots) = build_payload_roots(
+        policy,
+        policy_cwd,
+        command_cwd,
+        env_map,
+        codex_home,
+        None,
+        None,
+    );
     let payload = ElevationPayload {
         version: SETUP_VERSION,
         offline_username: OFFLINE_USERNAME.to_string(),
         online_username: ONLINE_USERNAME.to_string(),
         codex_home: codex_home.to_path_buf(),
-        read_roots: gather_read_roots(command_cwd, policy),
-        write_roots: gather_write_roots(policy, policy_cwd, command_cwd, env_map),
+        read_roots,
+        write_roots,
         real_user: std::env::var("USERNAME").unwrap_or_else(|_| "Administrators".to_string()),
         refresh_only: true,
     };
@@ -219,7 +229,14 @@ pub(crate) fn gather_write_roots(
     let AllowDenyPaths { allow, .. } =
         compute_allow_paths(policy, policy_cwd, command_cwd, env_map);
     roots.extend(allow);
-    canonical_existing(&roots)
+    let mut dedup: HashSet<PathBuf> = HashSet::new();
+    let mut out: Vec<PathBuf> = Vec::new();
+    for r in canonical_existing(&roots) {
+        if dedup.insert(r.clone()) {
+            out.push(r);
+        }
+    }
+    out
 }
 
 #[derive(Serialize)]
@@ -355,19 +372,15 @@ pub fn run_elevated_setup(
     // Ensure the shared sandbox directory exists before we send it to the elevated helper.
     let sbx_dir = sandbox_dir(codex_home);
     std::fs::create_dir_all(&sbx_dir)?;
-    let mut write_roots = if let Some(roots) = write_roots_override {
-        roots
-    } else {
-        gather_write_roots(policy, policy_cwd, command_cwd, env_map)
-    };
-    if !write_roots.contains(&sbx_dir) {
-        write_roots.push(sbx_dir.clone());
-    }
-    let read_roots = if let Some(roots) = read_roots_override {
-        roots
-    } else {
-        gather_read_roots(command_cwd, policy)
-    };
+    let (read_roots, write_roots) = build_payload_roots(
+        policy,
+        policy_cwd,
+        command_cwd,
+        env_map,
+        codex_home,
+        read_roots_override,
+        write_roots_override,
+    );
     let payload = ElevationPayload {
         version: SETUP_VERSION,
         offline_username: OFFLINE_USERNAME.to_string(),
@@ -380,4 +393,32 @@ pub fn run_elevated_setup(
     };
     let needs_elevation = !is_elevated()?;
     run_setup_exe(&payload, needs_elevation)
+}
+
+fn build_payload_roots(
+    policy: &SandboxPolicy,
+    policy_cwd: &Path,
+    command_cwd: &Path,
+    env_map: &HashMap<String, String>,
+    codex_home: &Path,
+    read_roots_override: Option<Vec<PathBuf>>,
+    write_roots_override: Option<Vec<PathBuf>>,
+) -> (Vec<PathBuf>, Vec<PathBuf>) {
+    let sbx_dir = sandbox_dir(codex_home);
+    let mut write_roots = if let Some(roots) = write_roots_override {
+        canonical_existing(&roots)
+    } else {
+        gather_write_roots(policy, policy_cwd, command_cwd, env_map)
+    };
+    if !write_roots.contains(&sbx_dir) {
+        write_roots.push(sbx_dir.clone());
+    }
+    let mut read_roots = if let Some(roots) = read_roots_override {
+        canonical_existing(&roots)
+    } else {
+        gather_read_roots(command_cwd, policy)
+    };
+    let write_root_set: HashSet<PathBuf> = write_roots.iter().cloned().collect();
+    read_roots.retain(|root| !write_root_set.contains(root));
+    (read_roots, write_roots)
 }


### PR DESCRIPTION
a few fixes based on testing feedback:
* ensure cap_sid file is always written by elevated setup.
* always log to same file whether using elevated sandbox or not
* process potentially slow ACE write operations in parallel
* dedupe write roots so we don't double process any
* don't try to create read/write ACEs on the same directories, due to race condition