### PR TITLE
fix(tui2): add missing TuiEvent::Mouse handler in update_prompt.rs

### DIFF
--- a/codex-rs/tui2/src/update_prompt.rs
+++ b/codex-rs/tui2/src/update_prompt.rs
@@ -56,6 +56,7 @@ pub(crate) async fn run_update_prompt_if_needed(
         if let Some(event) = events.next().await {
             match event {
                 TuiEvent::Key(key_event) => screen.handle_key(key_event),
+                TuiEvent::Mouse(_) => {}
                 TuiEvent::Paste(_) => {}
                 TuiEvent::Draw => {
                     tui.draw(u16::MAX, |frame| {


### PR DESCRIPTION
## Summary

Adds the missing `TuiEvent::Mouse(_)` match arm in `update_prompt.rs` to fix build failure.

## Problem

PR #7601 added the `TuiEvent::Mouse(crossterm::event::MouseEvent)` variant to the `TuiEvent` enum, but the match statement in `update_prompt.rs` was not updated to handle this new variant.

This causes a compilation error when building from source:

```
error[E0004]: non-exhaustive patterns: `TuiEvent::Mouse(_)` not covered
  --> tui2/src/update_prompt.rs:57
   |
57 |             match event {
   |                   ^^^^^ pattern `TuiEvent::Mouse(_)` not covered
```

## Solution

Added `TuiEvent::Mouse(_) => {}` to the match statement, consistent with how other similar files (`model_migration.rs`, `skill_error_prompt.rs`) handle this variant.

## Test plan

- [x] `cargo check --package codex-tui2` passes
- [x] Full build completes successfully

Fixes #8097