### PR TITLE
feat(sdk): add xhigh reasoning effort support to TypeScript SDK

### DIFF
--- a/sdk/typescript/src/threadOptions.ts
+++ b/sdk/typescript/src/threadOptions.ts
@@ -2,7 +2,7 @@ export type ApprovalMode = "never" | "on-request" | "on-failure" | "untrusted";
 
 export type SandboxMode = "read-only" | "workspace-write" | "danger-full-access";
 
-export type ModelReasoningEffort = "minimal" | "low" | "medium" | "high";
+export type ModelReasoningEffort = "minimal" | "low" | "medium" | "high" | "xhigh";
 
 export type ThreadOptions = {
   model?: string;


### PR DESCRIPTION
Add "xhigh" to the ModelReasoningEffort type to match the Rust backend which already supports this reasoning level for models like gpt-5.1-codex-max.
