### PR TITLE
fix tui2 compile error

### DIFF
--- a/codex-rs/tui2/src/update_prompt.rs
+++ b/codex-rs/tui2/src/update_prompt.rs
@@ -62,6 +62,7 @@ pub(crate) async fn run_update_prompt_if_needed(
                         frame.render_widget_ref(&screen, frame.area());
                     })?;
                 }
+                TuiEvent::Mouse(_) => {}
             }
         } else {
             break;


### PR DESCRIPTION
I'm not sure if this fix is ​​correct for the intended change in #7601, but at least the compilation error is fixed.

regression: #7601

```
error[E0004]: non-exhaustive patterns: `TuiEvent::Mouse(_)` not covered
   --> tui2/src/update_prompt.rs:57:19
    |
 57 |             match event {
    |                   ^^^^^ pattern `TuiEvent::Mouse(_)` not covered
    |
note: `TuiEvent` defined here
   --> tui2/src/tui.rs:122:10
    |
122 | pub enum TuiEvent {
    |          ^^^^^^^^
...
126 |     Mouse(crossterm::event::MouseEvent),
    |     ----- not covered
    = note: the matched value is of type `TuiEvent`
help: ensure that all possible cases are being handled by adding a match arm with a wildcard pattern or an explicit pattern as shown
    |
 64 ~                 },
 65 +                 TuiEvent::Mouse(_) => todo!()
    |
```