### PR TITLE
Revert "chore: review in read-only (#7593)"

### DIFF
--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -16,7 +16,6 @@ use tokio_util::sync::CancellationToken;
 use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::codex_delegate::run_codex_conversation_one_shot;
-use crate::protocol::SandboxPolicy;
 use crate::review_format::format_review_findings_block;
 use crate::review_format::render_review_output_text;
 use crate::state::TaskKind;
@@ -78,7 +77,6 @@ async fn start_review_conversation(
 ) -> Option<async_channel::Receiver<Event>> {
     let config = ctx.client.config();
     let mut sub_agent_config = config.as_ref().clone();
-    sub_agent_config.sandbox_policy = SandboxPolicy::new_read_only_policy();
     // Run with only reviewer rubric — drop outer user_instructions
     sub_agent_config.user_instructions = None;
     // Avoid loading project docs; reviewer only needs findings

--- a/codex-rs/core/tests/suite/review.rs
+++ b/codex-rs/core/tests/suite/review.rs
@@ -580,10 +580,6 @@ async fn review_input_isolated_from_parent_history() {
         review_prompt,
         "user message should only contain the raw review prompt"
     );
-    assert!(
-        env_text.contains("<sandbox_mode>read-only</sandbox_mode>"),
-        "review environment context must run with read-only sandbox"
-    );
 
     // Ensure the REVIEW_PROMPT rubric is sent via instructions.
     let instructions = body["instructions"].as_str().expect("instructions string");


### PR DESCRIPTION
This reverts commit 291b54a762db8f76402d4a854ad342679cc22806.

This commit was intended to prevent the model from making code changes during `/review`, which is sometimes does. Unfortunately, it has other unintended side effects that cause `/review` to fail in a variety of ways. See #8115 and #7815. We've therefore decided to revert this change.