### PR TITLE
feat(core): allow disabling apply_patch tool + interception

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2336,6 +2336,7 @@ async fn run_turn(
         parallel_tool_calls: model_supports_parallel && sess.enabled(Feature::ParallelToolCalls),
         base_instructions_override: turn_context.base_instructions.clone(),
         output_schema: turn_context.final_output_json_schema.clone(),
+        apply_patch_enabled: turn_context.tools_config.apply_patch_enabled,
     };
 
     let mut retries = 0;

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -47,6 +47,7 @@ async fn run_remote_compact_task_inner_impl(
         parallel_tool_calls: false,
         base_instructions_override: turn_context.base_instructions.clone(),
         output_schema: None,
+        apply_patch_enabled: turn_context.tools_config.apply_patch_enabled,
     };
 
     let mut new_history = turn_context

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -36,6 +36,8 @@ pub enum Feature {
     ModelWarnings,
     /// Enable the default shell tool.
     ShellTool,
+    /// Enable the built-in apply_patch editing tool and apply_patch command interception.
+    ApplyPatchTool,
 
     // Experimental
     /// Use the single unified PTY-backed exec tool.
@@ -271,6 +273,12 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::ParallelToolCalls,
         key: "parallel",
+        stage: Stage::Stable,
+        default_enabled: true,
+    },
+    FeatureSpec {
+        id: Feature::ApplyPatchTool,
+        key: "apply_patch_tool",
         stage: Stage::Stable,
         default_enabled: true,
     },

--- a/codex-rs/core/src/tools/handlers/apply_patch.rs
+++ b/codex-rs/core/src/tools/handlers/apply_patch.rs
@@ -170,6 +170,10 @@ pub(crate) async fn intercept_apply_patch(
     call_id: &str,
     tool_name: &str,
 ) -> Result<Option<ToolOutput>, FunctionCallError> {
+    if !turn.tools_config.apply_patch_enabled {
+        return Ok(None);
+    }
+
     match codex_apply_patch::maybe_parse_apply_patch_verified(command, cwd) {
         codex_apply_patch::MaybeApplyPatchVerified::Body(changes) => {
             session

--- a/docs/config.md
+++ b/docs/config.md
@@ -44,6 +44,7 @@ Supported features:
 | `unified_exec`                        |  false  | Experimental | Use the unified PTY-backed exec tool                  |
 | `rmcp_client`                         |  false  | Experimental | Enable oauth support for streamable HTTP MCP servers  |
 | `apply_patch_freeform`                |  false  | Beta         | Include the freeform `apply_patch` tool               |
+| `apply_patch_tool`                    |  true   | Stable       | Enable the built-in `apply_patch` tool and command interception |
 | `view_image_tool`                     |  true   | Stable       | Include the `view_image` tool                         |
 | `web_search_request`                  |  false  | Stable       | Allow the model to issue web searches                 |
 | `ghost_commit`                        |  false  | Experimental | Create a ghost commit each turn                       |


### PR DESCRIPTION

## What

- Add a new stable feature flag: `[features].apply_patch_tool` (default: `true`).
- When disabled (`apply_patch_tool = false`), Codex:
  - does **not** expose the built-in `apply_patch` tool to the model
  - does **not** intercept `apply_patch`-shaped commands issued via `shell` / `unified_exec`
  - does **not** inject apply_patch-specific instructions for models that normally require them

## Why

Some users run custom MCP servers that provide their own editing tools (audit logging, policy enforcement, different patch formats, remote editing, etc.). In those setups, users need a reliable way to **prevent the model from using Codex’s built-in editing path**.

Today, `apply_patch` can be effectively “always on” in practice:

- tool exposure can be influenced by model-family defaults
- even when `apply_patch` isn’t exposed, Codex can still intercept `apply_patch`-shaped commands sent via other tools

This PR adds a user-respecting “master switch” that disables both the tool and the interception path.

## How

- Gate apply_patch tool exposure in `ToolsConfig` behind `Feature::ApplyPatchTool`.
- Gate apply_patch interception (`intercept_apply_patch`) behind the same flag.
- Suppress apply_patch instruction injection when apply_patch is intentionally disabled.
- Document the new flag in `docs/config.md`.

## Issue

Fixes #8161

Issue link: https://github.com/openai/codex/issues/8161

## Notes

- Default behavior remains unchanged: `apply_patch_tool` defaults to `true`.
- Existing `apply_patch_freeform` behavior remains unchanged when `apply_patch_tool = true`.