### PR TITLE
Fix unresponsive UI during reasoning: show progress instead of blank screen

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -506,6 +506,12 @@ impl ChatWidget {
     fn on_reasoning_section_break(&mut self) {
         let reasoning_summary_format = self.get_model_family().reasoning_summary_format;
         if !self.reasoning_buffer.trim().is_empty() {
+            // Extract header from the section we're about to flush so the status
+            // doesn't fall back to "Working" while waiting for the next section.
+            if let Some(header) = extract_first_bold(&self.reasoning_buffer) {
+                self.set_status_header(header);
+            }
+
             let cell = history_cell::new_reasoning_summary_block(
                 std::mem::take(&mut self.reasoning_buffer),
                 reasoning_summary_format,

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -493,25 +493,28 @@ impl ChatWidget {
 
     fn on_agent_reasoning_final(&mut self) {
         let reasoning_summary_format = self.get_model_family().reasoning_summary_format;
-        // At the end of a reasoning block, record transcript-only content.
-        self.full_reasoning_buffer.push_str(&self.reasoning_buffer);
-        if !self.full_reasoning_buffer.is_empty() {
+        if !self.reasoning_buffer.trim().is_empty() {
             let cell = history_cell::new_reasoning_summary_block(
-                self.full_reasoning_buffer.clone(),
+                std::mem::take(&mut self.reasoning_buffer),
                 reasoning_summary_format,
             );
             self.add_boxed_history(cell);
         }
-        self.reasoning_buffer.clear();
-        self.full_reasoning_buffer.clear();
         self.request_redraw();
     }
 
     fn on_reasoning_section_break(&mut self) {
-        // Start a new reasoning block for header extraction and accumulate transcript.
-        self.full_reasoning_buffer.push_str(&self.reasoning_buffer);
-        self.full_reasoning_buffer.push_str("\n\n");
-        self.reasoning_buffer.clear();
+        let reasoning_summary_format = self.get_model_family().reasoning_summary_format;
+        if !self.reasoning_buffer.trim().is_empty() {
+            let cell = history_cell::new_reasoning_summary_block(
+                std::mem::take(&mut self.reasoning_buffer),
+                reasoning_summary_format,
+            );
+            self.add_boxed_history(cell);
+            self.request_redraw();
+        } else {
+            self.reasoning_buffer.clear();
+        }
     }
 
     // Raw reasoning uses the same flow as summarized reasoning

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1449,10 +1449,11 @@ pub(crate) fn new_reasoning_summary_block(
             }
         }
     }
+    // Show reasoning summaries in the main view, not just transcript
     Box::new(ReasoningSummaryCell::new(
         "".to_string(),
         full_reasoning_buffer,
-        true,
+        false,
     ))
 }
 

--- a/codex-rs/tui2/src/chatwidget.rs
+++ b/codex-rs/tui2/src/chatwidget.rs
@@ -506,6 +506,12 @@ impl ChatWidget {
     fn on_reasoning_section_break(&mut self) {
         let reasoning_summary_format = self.get_model_family().reasoning_summary_format;
         if !self.reasoning_buffer.trim().is_empty() {
+            // Extract header from the section we're about to flush so the status
+            // doesn't fall back to "Working" while waiting for the next section.
+            if let Some(header) = extract_first_bold(&self.reasoning_buffer) {
+                self.set_status_header(header);
+            }
+
             let cell = history_cell::new_reasoning_summary_block(
                 std::mem::take(&mut self.reasoning_buffer),
                 reasoning_summary_format,

--- a/codex-rs/tui2/src/chatwidget.rs
+++ b/codex-rs/tui2/src/chatwidget.rs
@@ -493,25 +493,28 @@ impl ChatWidget {
 
     fn on_agent_reasoning_final(&mut self) {
         let reasoning_summary_format = self.get_model_family().reasoning_summary_format;
-        // At the end of a reasoning block, record transcript-only content.
-        self.full_reasoning_buffer.push_str(&self.reasoning_buffer);
-        if !self.full_reasoning_buffer.is_empty() {
+        if !self.reasoning_buffer.trim().is_empty() {
             let cell = history_cell::new_reasoning_summary_block(
-                self.full_reasoning_buffer.clone(),
+                std::mem::take(&mut self.reasoning_buffer),
                 reasoning_summary_format,
             );
             self.add_boxed_history(cell);
         }
-        self.reasoning_buffer.clear();
-        self.full_reasoning_buffer.clear();
         self.request_redraw();
     }
 
     fn on_reasoning_section_break(&mut self) {
-        // Start a new reasoning block for header extraction and accumulate transcript.
-        self.full_reasoning_buffer.push_str(&self.reasoning_buffer);
-        self.full_reasoning_buffer.push_str("\n\n");
-        self.reasoning_buffer.clear();
+        let reasoning_summary_format = self.get_model_family().reasoning_summary_format;
+        if !self.reasoning_buffer.trim().is_empty() {
+            let cell = history_cell::new_reasoning_summary_block(
+                std::mem::take(&mut self.reasoning_buffer),
+                reasoning_summary_format,
+            );
+            self.add_boxed_history(cell);
+            self.request_redraw();
+        } else {
+            self.reasoning_buffer.clear();
+        }
     }
 
     // Raw reasoning uses the same flow as summarized reasoning

--- a/codex-rs/tui2/src/history_cell.rs
+++ b/codex-rs/tui2/src/history_cell.rs
@@ -1449,10 +1449,11 @@ pub(crate) fn new_reasoning_summary_block(
             }
         }
     }
+    // Show reasoning summaries in the main view, not just transcript
     Box::new(ReasoningSummaryCell::new(
         "".to_string(),
         full_reasoning_buffer,
-        true,
+        false,
     ))
 }
 


### PR DESCRIPTION
## Problem

**Codex appears frozen/unresponsive during reasoning** - users see nothing happening for extended periods (30+ seconds) while the model thinks, leading to poor perceived latency. This has driven complaints on Twitter that "Claude Code feels faster" regardless of actual response times.

The root cause: reasoning content is accumulated silently in a buffer and only displayed *after* reasoning completes. Users stare at a static screen with no feedback.

## Solution

Flush reasoning summary blocks to the UI **immediately as they arrive** rather than batching them until the end. This provides continuous visual feedback during long thinking periods.

### Same prompt, same time elapsed, default settings

tui:

<img width="1800" height="1064" alt="image" src="https://github.com/user-attachments/assets/2cceef67-ebb1-4951-8c77-69a67b58c221" />

tui2:

<img width="1800" height="1083" alt="image" src="https://github.com/user-attachments/assets/717a83f6-9079-4f4d-b768-b1531590cae8" />

Prompt:

```
Can you think about this problem? Don't look up the solution.

Let πe(G) denote the set of orders of elements of a group G, and h(Γ) the
number of non-isomorphic finite groups G with πe(G) = Γ. Do there exist two finite
groups G1, G2 such that πe(G1) = πe(G2), h(πe(G1)) < ∞, and neither of the two
groups G1, G2 is isomorphic to a subgroup or a quotient of a normal subgroup of the
other?
```

## Changes

1. **Incremental display**: Flush reasoning sections to history on section breaks instead of accumulating in `full_reasoning_buffer`
2. **Status header fix**: Extract bold header before flushing so status doesn't flash to "Working" between sections
3. **Default visibility**: Show reasoning summaries in main chat view by default (was hidden unless format was Experimental)

## Test plan

- [ ] Verify reasoning blocks appear incrementally during model responses
- [ ] Confirm status header doesn't regress to "Working" between sections
- [ ] Check reasoning summaries visible in main view without Ctrl+T

---

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: gpt-5.2 <noreply@openai.com>