### PR TITLE
tui: optional bell on turn completion

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -167,6 +167,9 @@ pub struct Config {
     /// and turn completions when not focused.
     pub tui_notifications: Notifications,
 
+    /// Emit an audible terminal bell (`BEL`, `\x07`) when a turn completes.
+    pub tui_turn_complete_bell: bool,
+
     /// Enable ASCII animations and shimmer effects in the TUI.
     pub animations: bool,
 
@@ -1232,6 +1235,11 @@ impl Config {
                 .as_ref()
                 .map(|t| t.notifications.clone())
                 .unwrap_or_default(),
+            tui_turn_complete_bell: cfg
+                .tui
+                .as_ref()
+                .map(|t| t.turn_complete_bell)
+                .unwrap_or(false),
             animations: cfg.tui.as_ref().map(|t| t.animations).unwrap_or(true),
             show_tooltips: cfg.tui.as_ref().map(|t| t.show_tooltips).unwrap_or(true),
             otel: {
@@ -1408,6 +1416,7 @@ persistence = "none"
 
         assert_eq!(tui.notifications, Notifications::Enabled(true));
         assert!(tui.show_tooltips);
+        assert!(!tui.turn_complete_bell);
     }
 
     #[test]
@@ -2990,6 +2999,7 @@ model_verbosity = "high"
                 check_for_update_on_startup: true,
                 disable_paste_burst: false,
                 tui_notifications: Default::default(),
+                tui_turn_complete_bell: false,
                 animations: true,
                 show_tooltips: true,
                 otel: OtelConfig::default(),
@@ -3065,6 +3075,7 @@ model_verbosity = "high"
             check_for_update_on_startup: true,
             disable_paste_burst: false,
             tui_notifications: Default::default(),
+            tui_turn_complete_bell: false,
             animations: true,
             show_tooltips: true,
             otel: OtelConfig::default(),
@@ -3155,6 +3166,7 @@ model_verbosity = "high"
             check_for_update_on_startup: true,
             disable_paste_burst: false,
             tui_notifications: Default::default(),
+            tui_turn_complete_bell: false,
             animations: true,
             show_tooltips: true,
             otel: OtelConfig::default(),
@@ -3231,6 +3243,7 @@ model_verbosity = "high"
             check_for_update_on_startup: true,
             disable_paste_burst: false,
             tui_notifications: Default::default(),
+            tui_turn_complete_bell: false,
             animations: true,
             show_tooltips: true,
             otel: OtelConfig::default(),
@@ -3559,7 +3572,10 @@ mod notifications_tests {
 
     #[derive(Deserialize, Debug, PartialEq)]
     struct TuiTomlTest {
+        #[serde(default)]
         notifications: Notifications,
+        #[serde(default)]
+        turn_complete_bell: bool,
     }
 
     #[derive(Deserialize, Debug, PartialEq)]
@@ -3589,5 +3605,16 @@ mod notifications_tests {
             parsed.tui.notifications,
             Notifications::Custom(ref v) if v == &vec!["foo".to_string()]
         );
+    }
+
+    #[test]
+    fn test_tui_turn_complete_bell_true() {
+        let toml = r#"
+            [tui]
+            turn_complete_bell = true
+        "#;
+        let parsed: RootTomlTest =
+            toml::from_str(toml).expect("deserialize turn_complete_bell=true");
+        assert!(parsed.tui.turn_complete_bell);
     }
 }

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -371,6 +371,15 @@ pub struct Tui {
     #[serde(default)]
     pub notifications: Notifications,
 
+    /// Emit an audible terminal bell (`BEL`, `\x07`) when an agent turn completes.
+    ///
+    /// This is a cross-platform option that relies on the user's terminal settings to decide
+    /// whether the bell is audible, visual, or ignored.
+    ///
+    /// Defaults to `false`.
+    #[serde(default)]
+    pub turn_complete_bell: bool,
+
     /// Enable animations (welcome screen, shimmer effects, spinners).
     /// Defaults to `true`.
     #[serde(default = "default_true")]

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1997,6 +1997,11 @@ impl ChatWidget {
 
     pub(crate) fn maybe_post_pending_notification(&mut self, tui: &mut crate::tui::Tui) {
         if let Some(notif) = self.pending_notification.take() {
+            if matches!(&notif, Notification::AgentTurnComplete { .. })
+                && self.config.tui_turn_complete_bell
+            {
+                tui.ring_bell();
+            }
             tui.notify(notif.display());
         }
     }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -73,6 +73,7 @@ mod status;
 mod status_indicator_widget;
 mod streaming;
 mod style;
+mod terminal_bell;
 mod terminal_palette;
 mod text_formatting;
 mod tooltips;

--- a/codex-rs/tui/src/terminal_bell.rs
+++ b/codex-rs/tui/src/terminal_bell.rs
@@ -1,0 +1,43 @@
+use std::fmt;
+use std::io;
+use std::io::stdout;
+
+use crossterm::Command;
+use ratatui::crossterm::execute;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TerminalBell;
+
+impl TerminalBell {
+    pub fn ring(self) -> io::Result<()> {
+        execute!(stdout(), RingBell)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RingBell;
+
+impl Command for RingBell {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        write!(f, "\x07")
+    }
+
+    #[cfg(windows)]
+    fn is_ansi_code_supported(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RingBell;
+    use crossterm::Command;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn ring_bell_emits_bel() {
+        let mut out = String::new();
+        RingBell.write_ansi(&mut out).expect("write_ansi");
+        assert_eq!(out, "\u{0007}");
+    }
+}

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -40,6 +40,7 @@ use crate::custom_terminal::Terminal as CustomTerminal;
 use crate::notifications::DesktopNotificationBackend;
 use crate::notifications::NotificationBackendKind;
 use crate::notifications::detect_backend;
+use crate::terminal_bell::TerminalBell;
 use crate::tui::event_stream::EventBroker;
 use crate::tui::event_stream::TuiEventStream;
 #[cfg(unix)]
@@ -272,6 +273,15 @@ impl Tui {
                 }
             },
         }
+    }
+
+    /// Emit an audible terminal bell (`BEL`, `\x07`) if stdout is a TTY.
+    pub fn ring_bell(&mut self) -> bool {
+        if !stdout().is_terminal() {
+            return false;
+        }
+
+        TerminalBell.ring().is_ok()
     }
 
     pub fn event_stream(&self) -> Pin<Box<dyn Stream<Item = TuiEvent> + Send + 'static>> {

--- a/codex-rs/tui2/src/chatwidget.rs
+++ b/codex-rs/tui2/src/chatwidget.rs
@@ -1997,6 +1997,11 @@ impl ChatWidget {
 
     pub(crate) fn maybe_post_pending_notification(&mut self, tui: &mut crate::tui::Tui) {
         if let Some(notif) = self.pending_notification.take() {
+            if matches!(&notif, Notification::AgentTurnComplete { .. })
+                && self.config.tui_turn_complete_bell
+            {
+                tui.ring_bell();
+            }
             tui.notify(notif.display());
         }
     }

--- a/codex-rs/tui2/src/lib.rs
+++ b/codex-rs/tui2/src/lib.rs
@@ -74,6 +74,7 @@ mod status;
 mod status_indicator_widget;
 mod streaming;
 mod style;
+mod terminal_bell;
 mod terminal_palette;
 mod text_formatting;
 mod tooltips;

--- a/codex-rs/tui2/src/terminal_bell.rs
+++ b/codex-rs/tui2/src/terminal_bell.rs
@@ -1,0 +1,43 @@
+use std::fmt;
+use std::io;
+use std::io::stdout;
+
+use crossterm::Command;
+use ratatui::crossterm::execute;
+
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TerminalBell;
+
+impl TerminalBell {
+    pub fn ring(self) -> io::Result<()> {
+        execute!(stdout(), RingBell)
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+struct RingBell;
+
+impl Command for RingBell {
+    fn write_ansi(&self, f: &mut impl fmt::Write) -> fmt::Result {
+        write!(f, "\x07")
+    }
+
+    #[cfg(windows)]
+    fn is_ansi_code_supported(&self) -> bool {
+        true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RingBell;
+    use crossterm::Command;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn ring_bell_emits_bel() {
+        let mut out = String::new();
+        RingBell.write_ansi(&mut out).expect("write_ansi");
+        assert_eq!(out, "\u{0007}");
+    }
+}

--- a/codex-rs/tui2/src/tui.rs
+++ b/codex-rs/tui2/src/tui.rs
@@ -41,6 +41,7 @@ use crate::custom_terminal::Terminal as CustomTerminal;
 use crate::notifications::DesktopNotificationBackend;
 use crate::notifications::NotificationBackendKind;
 use crate::notifications::detect_backend;
+use crate::terminal_bell::TerminalBell;
 #[cfg(unix)]
 use crate::tui::job_control::SUSPEND_KEY;
 #[cfg(unix)]
@@ -222,6 +223,15 @@ impl Tui {
                 }
             },
         }
+    }
+
+    /// Emit an audible terminal bell (`BEL`, `\x07`) if stdout is a TTY.
+    pub fn ring_bell(&mut self) -> bool {
+        if !stdout().is_terminal() {
+            return false;
+        }
+
+        TerminalBell.ring().is_ok()
     }
 
     pub fn event_stream(&self) -> Pin<Box<dyn Stream<Item = TuiEvent> + Send + 'static>> {

--- a/docs/config.md
+++ b/docs/config.md
@@ -882,6 +882,10 @@ notifications = true
 # Available types are "agent-turn-complete" and "approval-requested".
 notifications = [ "agent-turn-complete", "approval-requested" ]
 
+# Emit an audible terminal bell (`BEL`, `\x07`) when an agent turn completes.
+# Defaults to false.
+turn_complete_bell = false
+
 # Disable terminal animations (welcome screen, status shimmer, spinner).
 # Defaults to true.
 animations = false
@@ -974,6 +978,7 @@ Valid values:
 | `file_opener`                                    | `vscode` \| `vscode-insiders` \| `windsurf` \| `cursor` \| `none` | URI scheme for clickable citations (default: `vscode`).                                                                         |
 | `tui`                                            | table                                                             | TUI‑specific options.                                                                                                           |
 | `tui.notifications`                              | boolean \| array<string>                                          | Enable desktop notifications in the tui (default: true).                                                                        |
+| `tui.turn_complete_bell`                         | boolean                                                           | Emit an audible terminal bell (`BEL`, `\x07`) when an agent turn completes (default: false).                                    |
 | `hide_agent_reasoning`                           | boolean                                                           | Hide model reasoning events.                                                                                                    |
 | `check_for_update_on_startup`                    | boolean                                                           | Check for Codex updates on startup (default: true). Set to `false` only if updates are centrally managed.                       |
 | `show_raw_agent_reasoning`                       | boolean                                                           | Show raw reasoning (when available).                                                                                            |


### PR DESCRIPTION
## Summary
Adds an optional terminal bell that plays when a turn completes in the TUI. The behavior is gated by configuration and remains disabled by default.

## Changes
- Add a configurable "turn complete bell" setting (default: disabled).
- Wire the bell behavior into both TUI variants.
- Add config parsing tests and update documentation.

## Testing
- `cargo test -p codex-tui`
