### PR TITLE
 [release] Add a dmg target for MacOS

### DIFF
--- a/.github/actions/macos-code-sign/action.yml
+++ b/.github/actions/macos-code-sign/action.yml
@@ -159,37 +159,7 @@ runs:
         }
         trap cleanup_notary EXIT
 
-        notarize_submission() {
-          local label="$1"
-          local path="$2"
-
-          if [[ ! -f "$path" ]]; then
-            echo "Notarization payload $path not found"
-            exit 1
-          fi
-
-          submission_json=$(xcrun notarytool submit "$path" \
-            --key "$notary_key_path" \
-            --key-id "$APPLE_NOTARIZATION_KEY_ID" \
-            --issuer "$APPLE_NOTARIZATION_ISSUER_ID" \
-            --output-format json \
-            --wait)
-
-          status=$(printf '%s\n' "$submission_json" | jq -r '.status // "Unknown"')
-          submission_id=$(printf '%s\n' "$submission_json" | jq -r '.id // ""')
-
-          if [[ -z "$submission_id" ]]; then
-            echo "Failed to retrieve submission ID for $label"
-            exit 1
-          fi
-
-          echo "::notice title=Notarization::$label submission ${submission_id} completed with status ${status}"
-
-          if [[ "$status" != "Accepted" ]]; then
-            echo "Notarization failed for ${label} (submission ${submission_id}, status ${status})"
-            exit 1
-          fi
-        }
+        source "$GITHUB_ACTION_PATH/notary_helpers.sh"
 
         notarize_binary() {
           local binary="$1"
@@ -204,7 +174,7 @@ runs:
           rm -f "$archive_path"
           ditto -c -k --keepParent "$source_path" "$archive_path"
 
-          notarize_submission "$binary" "$archive_path"
+          notarize_submission "$binary" "$archive_path" "$notary_key_path"
         }
 
         notarize_binary "codex"
@@ -234,37 +204,7 @@ runs:
         }
         trap cleanup_notary EXIT
 
-        notarize_submission() {
-          local label="$1"
-          local path="$2"
-
-          if [[ ! -f "$path" ]]; then
-            echo "Notarization payload $path not found"
-            exit 1
-          fi
-
-          submission_json=$(xcrun notarytool submit "$path" \
-            --key "$notary_key_path" \
-            --key-id "$APPLE_NOTARIZATION_KEY_ID" \
-            --issuer "$APPLE_NOTARIZATION_ISSUER_ID" \
-            --output-format json \
-            --wait)
-
-          status=$(printf '%s\n' "$submission_json" | jq -r '.status // "Unknown"')
-          submission_id=$(printf '%s\n' "$submission_json" | jq -r '.id // ""')
-
-          if [[ -z "$submission_id" ]]; then
-            echo "Failed to retrieve submission ID for $label"
-            exit 1
-          fi
-
-          echo "::notice title=Notarization::$label submission ${submission_id} completed with status ${status}"
-
-          if [[ "$status" != "Accepted" ]]; then
-            echo "Notarization failed for ${label} (submission ${submission_id}, status ${status})"
-            exit 1
-          fi
-        }
+        source "$GITHUB_ACTION_PATH/notary_helpers.sh"
 
         dmg_path="codex-rs/target/${{ inputs.target }}/release/codex-${{ inputs.target }}.dmg"
 
@@ -279,7 +219,7 @@ runs:
         fi
 
         codesign --force --timestamp --sign "$APPLE_CODESIGN_IDENTITY" "${keychain_args[@]}" "$dmg_path"
-        notarize_submission "codex-${{ inputs.target }}.dmg" "$dmg_path"
+        notarize_submission "codex-${{ inputs.target }}.dmg" "$dmg_path" "$notary_key_path"
         xcrun stapler staple "$dmg_path"
 
     - name: Remove signing keychain

--- a/.github/actions/macos-code-sign/action.yml
+++ b/.github/actions/macos-code-sign/action.yml
@@ -149,6 +149,38 @@ runs:
         }
         trap cleanup_notary EXIT
 
+        notarize_submission() {
+          local label="$1"
+          local path="$2"
+
+          if [[ ! -f "$path" ]]; then
+            echo "Notarization payload $path not found"
+            exit 1
+          fi
+
+          submission_json=$(xcrun notarytool submit "$path" \
+            --key "$notary_key_path" \
+            --key-id "$APPLE_NOTARIZATION_KEY_ID" \
+            --issuer "$APPLE_NOTARIZATION_ISSUER_ID" \
+            --output-format json \
+            --wait)
+
+          status=$(printf '%s\n' "$submission_json" | jq -r '.status // "Unknown"')
+          submission_id=$(printf '%s\n' "$submission_json" | jq -r '.id // ""')
+
+          if [[ -z "$submission_id" ]]; then
+            echo "Failed to retrieve submission ID for $label"
+            exit 1
+          fi
+
+          echo "::notice title=Notarization::$label submission ${submission_id} completed with status ${status}"
+
+          if [[ "$status" != "Accepted" ]]; then
+            echo "Notarization failed for ${label} (submission ${submission_id}, status ${status})"
+            exit 1
+          fi
+        }
+
         notarize_binary() {
           local binary="$1"
           local source_path="codex-rs/target/${{ inputs.target }}/release/${binary}"
@@ -162,31 +194,69 @@ runs:
           rm -f "$archive_path"
           ditto -c -k --keepParent "$source_path" "$archive_path"
 
-          submission_json=$(xcrun notarytool submit "$archive_path" \
-            --key "$notary_key_path" \
-            --key-id "$APPLE_NOTARIZATION_KEY_ID" \
-            --issuer "$APPLE_NOTARIZATION_ISSUER_ID" \
-            --output-format json \
-            --wait)
+          notarize_submission "$binary" "$archive_path"
+        }
 
-          status=$(printf '%s\n' "$submission_json" | jq -r '.status // "Unknown"')
-          submission_id=$(printf '%s\n' "$submission_json" | jq -r '.id // ""')
+        build_dmg() {
+          local target="${{ inputs.target }}"
+          local release_dir="codex-rs/target/${target}/release"
+          local dmg_root="${RUNNER_TEMP}/codex-dmg-root"
+          local volname="Codex (${target})"
+          local dmg_path="${release_dir}/codex-${target}.dmg"
 
-          if [[ -z "$submission_id" ]]; then
-            echo "Failed to retrieve submission ID for $binary"
+          rm -rf "$dmg_root"
+          mkdir -p "$dmg_root"
+
+          for binary in codex codex-responses-api-proxy; do
+            local bin_path="${release_dir}/${binary}"
+            if [[ ! -f "$bin_path" ]]; then
+              echo "Binary $bin_path not found"
+              exit 1
+            fi
+            ditto "$bin_path" "${dmg_root}/${binary}"
+          done
+
+          rm -f "$dmg_path"
+          hdiutil create \
+            -volname "$volname" \
+            -srcfolder "$dmg_root" \
+            -format UDZO \
+            -ov \
+            "$dmg_path"
+
+          export CODEX_DMG_PATH="$dmg_path"
+          echo "CODEX_DMG_PATH=$dmg_path" >> "$GITHUB_ENV"
+        }
+
+        sign_dmg() {
+          local dmg_path="$1"
+
+          if [[ -z "${APPLE_CODESIGN_IDENTITY:-}" ]]; then
+            echo "APPLE_CODESIGN_IDENTITY is required for macOS signing"
             exit 1
           fi
 
-          echo "::notice title=Notarization::$binary submission ${submission_id} completed with status ${status}"
-
-          if [[ "$status" != "Accepted" ]]; then
-            echo "Notarization failed for ${binary} (submission ${submission_id}, status ${status})"
-            exit 1
+          keychain_args=()
+          if [[ -n "${APPLE_CODESIGN_KEYCHAIN:-}" && -f "${APPLE_CODESIGN_KEYCHAIN}" ]]; then
+            keychain_args+=(--keychain "${APPLE_CODESIGN_KEYCHAIN}")
           fi
+
+          codesign --force --timestamp --sign "$APPLE_CODESIGN_IDENTITY" "${keychain_args[@]}" "$dmg_path"
         }
 
         notarize_binary "codex"
         notarize_binary "codex-responses-api-proxy"
+
+        build_dmg
+
+        if [[ -z "${CODEX_DMG_PATH:-}" ]]; then
+          echo "CODEX_DMG_PATH not set after building DMG"
+          exit 1
+        fi
+
+        sign_dmg "$CODEX_DMG_PATH"
+        notarize_submission "codex-${{ inputs.target }}.dmg" "$CODEX_DMG_PATH"
+        xcrun stapler staple "$CODEX_DMG_PATH"
 
     - name: Remove signing keychain
       if: ${{ always() }}

--- a/.github/actions/macos-code-sign/action.yml
+++ b/.github/actions/macos-code-sign/action.yml
@@ -4,6 +4,17 @@ inputs:
   target:
     description: Rust compilation target triple (e.g. aarch64-apple-darwin).
     required: true
+  sign-binaries:
+    description: Whether to sign and notarize the macOS binaries.
+    required: false
+    default: "true"
+  sign-dmg:
+    description: Whether to sign and notarize the macOS DMG.
+    required: false
+    default: "true"
+  dmg-path:
+    description: Path to the DMG to sign and notarize (defaults to codex-rs/target/<target>/release/codex-<target>.dmg).
+    required: false
   apple-certificate:
     description: Base64-encoded Apple signing certificate (P12).
     required: true
@@ -107,6 +118,7 @@ runs:
         echo "::add-mask::$APPLE_CODESIGN_IDENTITY"
 
     - name: Sign macOS binaries
+      if: ${{ inputs.sign-binaries == 'true' }}
       shell: bash
       run: |
         set -euo pipefail
@@ -127,6 +139,7 @@ runs:
         done
 
     - name: Notarize macOS binaries
+      if: ${{ inputs.sign-binaries == 'true' }}
       shell: bash
       env:
         APPLE_NOTARIZATION_KEY_P8: ${{ inputs.apple-notarization-key-p8 }}
@@ -197,66 +210,88 @@ runs:
           notarize_submission "$binary" "$archive_path"
         }
 
-        build_dmg() {
-          local target="${{ inputs.target }}"
-          local release_dir="codex-rs/target/${target}/release"
-          local dmg_root="${RUNNER_TEMP}/codex-dmg-root"
-          local volname="Codex (${target})"
-          local dmg_path="${release_dir}/codex-${target}.dmg"
-
-          rm -rf "$dmg_root"
-          mkdir -p "$dmg_root"
-
-          for binary in codex codex-responses-api-proxy; do
-            local bin_path="${release_dir}/${binary}"
-            if [[ ! -f "$bin_path" ]]; then
-              echo "Binary $bin_path not found"
-              exit 1
-            fi
-            ditto "$bin_path" "${dmg_root}/${binary}"
-          done
-
-          rm -f "$dmg_path"
-          hdiutil create \
-            -volname "$volname" \
-            -srcfolder "$dmg_root" \
-            -format UDZO \
-            -ov \
-            "$dmg_path"
-
-          export CODEX_DMG_PATH="$dmg_path"
-          echo "CODEX_DMG_PATH=$dmg_path" >> "$GITHUB_ENV"
-        }
-
-        sign_dmg() {
-          local dmg_path="$1"
-
-          if [[ -z "${APPLE_CODESIGN_IDENTITY:-}" ]]; then
-            echo "APPLE_CODESIGN_IDENTITY is required for macOS signing"
-            exit 1
-          fi
-
-          keychain_args=()
-          if [[ -n "${APPLE_CODESIGN_KEYCHAIN:-}" && -f "${APPLE_CODESIGN_KEYCHAIN}" ]]; then
-            keychain_args+=(--keychain "${APPLE_CODESIGN_KEYCHAIN}")
-          fi
-
-          codesign --force --timestamp --sign "$APPLE_CODESIGN_IDENTITY" "${keychain_args[@]}" "$dmg_path"
-        }
-
         notarize_binary "codex"
         notarize_binary "codex-responses-api-proxy"
 
-        build_dmg
+    - name: Sign and notarize macOS DMG
+      if: ${{ inputs.sign-dmg == 'true' }}
+      shell: bash
+      env:
+        APPLE_NOTARIZATION_KEY_P8: ${{ inputs.apple-notarization-key-p8 }}
+        APPLE_NOTARIZATION_KEY_ID: ${{ inputs.apple-notarization-key-id }}
+        APPLE_NOTARIZATION_ISSUER_ID: ${{ inputs.apple-notarization-issuer-id }}
+      run: |
+        set -euo pipefail
 
-        if [[ -z "${CODEX_DMG_PATH:-}" ]]; then
-          echo "CODEX_DMG_PATH not set after building DMG"
+        if [[ -z "${APPLE_CODESIGN_IDENTITY:-}" ]]; then
+          echo "APPLE_CODESIGN_IDENTITY is required for macOS signing"
           exit 1
         fi
 
-        sign_dmg "$CODEX_DMG_PATH"
-        notarize_submission "codex-${{ inputs.target }}.dmg" "$CODEX_DMG_PATH"
-        xcrun stapler staple "$CODEX_DMG_PATH"
+        for var in APPLE_NOTARIZATION_KEY_P8 APPLE_NOTARIZATION_KEY_ID APPLE_NOTARIZATION_ISSUER_ID; do
+          if [[ -z "${!var:-}" ]]; then
+            echo "$var is required for notarization"
+            exit 1
+          fi
+        done
+
+        notary_key_path="${RUNNER_TEMP}/notarytool.key.p8"
+        echo "$APPLE_NOTARIZATION_KEY_P8" | base64 -d > "$notary_key_path"
+        cleanup_notary() {
+          rm -f "$notary_key_path"
+        }
+        trap cleanup_notary EXIT
+
+        notarize_submission() {
+          local label="$1"
+          local path="$2"
+
+          if [[ ! -f "$path" ]]; then
+            echo "Notarization payload $path not found"
+            exit 1
+          fi
+
+          submission_json=$(xcrun notarytool submit "$path" \
+            --key "$notary_key_path" \
+            --key-id "$APPLE_NOTARIZATION_KEY_ID" \
+            --issuer "$APPLE_NOTARIZATION_ISSUER_ID" \
+            --output-format json \
+            --wait)
+
+          status=$(printf '%s\n' "$submission_json" | jq -r '.status // "Unknown"')
+          submission_id=$(printf '%s\n' "$submission_json" | jq -r '.id // ""')
+
+          if [[ -z "$submission_id" ]]; then
+            echo "Failed to retrieve submission ID for $label"
+            exit 1
+          fi
+
+          echo "::notice title=Notarization::$label submission ${submission_id} completed with status ${status}"
+
+          if [[ "$status" != "Accepted" ]]; then
+            echo "Notarization failed for ${label} (submission ${submission_id}, status ${status})"
+            exit 1
+          fi
+        }
+
+        dmg_path="${{ inputs.dmg-path }}"
+        if [[ -z "$dmg_path" ]]; then
+          dmg_path="codex-rs/target/${{ inputs.target }}/release/codex-${{ inputs.target }}.dmg"
+        fi
+
+        if [[ ! -f "$dmg_path" ]]; then
+          echo "DMG $dmg_path not found"
+          exit 1
+        fi
+
+        keychain_args=()
+        if [[ -n "${APPLE_CODESIGN_KEYCHAIN:-}" && -f "${APPLE_CODESIGN_KEYCHAIN}" ]]; then
+          keychain_args+=(--keychain "${APPLE_CODESIGN_KEYCHAIN}")
+        fi
+
+        codesign --force --timestamp --sign "$APPLE_CODESIGN_IDENTITY" "${keychain_args[@]}" "$dmg_path"
+        notarize_submission "codex-${{ inputs.target }}.dmg" "$dmg_path"
+        xcrun stapler staple "$dmg_path"
 
     - name: Remove signing keychain
       if: ${{ always() }}

--- a/.github/actions/macos-code-sign/action.yml
+++ b/.github/actions/macos-code-sign/action.yml
@@ -9,12 +9,9 @@ inputs:
     required: false
     default: "true"
   sign-dmg:
-    description: Whether to sign and notarize the macOS DMG.
+    description: Whether to sign and notarize the macOS dmg.
     required: false
     default: "true"
-  dmg-path:
-    description: Path to the DMG to sign and notarize (defaults to codex-rs/target/<target>/release/codex-<target>.dmg).
-    required: false
   apple-certificate:
     description: Base64-encoded Apple signing certificate (P12).
     required: true
@@ -213,7 +210,7 @@ runs:
         notarize_binary "codex"
         notarize_binary "codex-responses-api-proxy"
 
-    - name: Sign and notarize macOS DMG
+    - name: Sign and notarize macOS dmg
       if: ${{ inputs.sign-dmg == 'true' }}
       shell: bash
       env:
@@ -223,14 +220,9 @@ runs:
       run: |
         set -euo pipefail
 
-        if [[ -z "${APPLE_CODESIGN_IDENTITY:-}" ]]; then
-          echo "APPLE_CODESIGN_IDENTITY is required for macOS signing"
-          exit 1
-        fi
-
-        for var in APPLE_NOTARIZATION_KEY_P8 APPLE_NOTARIZATION_KEY_ID APPLE_NOTARIZATION_ISSUER_ID; do
+        for var in APPLE_CODESIGN_IDENTITY APPLE_NOTARIZATION_KEY_P8 APPLE_NOTARIZATION_KEY_ID APPLE_NOTARIZATION_ISSUER_ID; do
           if [[ -z "${!var:-}" ]]; then
-            echo "$var is required for notarization"
+            echo "$var is required"
             exit 1
           fi
         done
@@ -274,13 +266,10 @@ runs:
           fi
         }
 
-        dmg_path="${{ inputs.dmg-path }}"
-        if [[ -z "$dmg_path" ]]; then
-          dmg_path="codex-rs/target/${{ inputs.target }}/release/codex-${{ inputs.target }}.dmg"
-        fi
+        dmg_path="codex-rs/target/${{ inputs.target }}/release/codex-${{ inputs.target }}.dmg"
 
         if [[ ! -f "$dmg_path" ]]; then
-          echo "DMG $dmg_path not found"
+          echo "dmg $dmg_path not found"
           exit 1
         fi
 

--- a/.github/actions/macos-code-sign/notary_helpers.sh
+++ b/.github/actions/macos-code-sign/notary_helpers.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+notarize_submission() {
+  local label="$1"
+  local path="$2"
+  local notary_key_path="$3"
+
+  if [[ -z "${APPLE_NOTARIZATION_KEY_ID:-}" || -z "${APPLE_NOTARIZATION_ISSUER_ID:-}" ]]; then
+    echo "APPLE_NOTARIZATION_KEY_ID and APPLE_NOTARIZATION_ISSUER_ID are required for notarization"
+    exit 1
+  fi
+
+  if [[ -z "$notary_key_path" || ! -f "$notary_key_path" ]]; then
+    echo "Notary key file $notary_key_path not found"
+    exit 1
+  fi
+
+  if [[ ! -f "$path" ]]; then
+    echo "Notarization payload $path not found"
+    exit 1
+  fi
+
+  local submission_json
+  submission_json=$(xcrun notarytool submit "$path" \
+    --key "$notary_key_path" \
+    --key-id "$APPLE_NOTARIZATION_KEY_ID" \
+    --issuer "$APPLE_NOTARIZATION_ISSUER_ID" \
+    --output-format json \
+    --wait)
+
+  local status submission_id
+  status=$(printf '%s\n' "$submission_json" | jq -r '.status // "Unknown"')
+  submission_id=$(printf '%s\n' "$submission_json" | jq -r '.id // ""')
+
+  if [[ -z "$submission_id" ]]; then
+    echo "Failed to retrieve submission ID for $label"
+    exit 1
+  fi
+
+  echo "::notice title=Notarization::$label submission ${submission_id} completed with status ${status}"
+
+  if [[ "$status" != "Accepted" ]]; then
+    echo "Notarization failed for ${label} (submission ${submission_id}, status ${status})"
+    exit 1
+  fi
+}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -128,7 +128,7 @@ jobs:
           account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
           certificate-profile-name: ${{ secrets.AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME }}
 
-      - if: ${{ matrix.runner == 'macos-15-xlarge' }}
+      - if: ${{ runner.os == 'macOS' }}
         name: MacOS code signing (binaries)
         uses: ./.github/actions/macos-code-sign
         with:
@@ -141,8 +141,8 @@ jobs:
           apple-notarization-key-id: ${{ secrets.APPLE_NOTARIZATION_KEY_ID }}
           apple-notarization-issuer-id: ${{ secrets.APPLE_NOTARIZATION_ISSUER_ID }}
 
-      - if: ${{ matrix.runner == 'macos-15-xlarge' }}
-        name: Build macOS DMG
+      - if: ${{ runner.os == 'macOS' }}
+        name: Build macOS dmg
         shell: bash
         run: |
           set -euo pipefail
@@ -155,7 +155,7 @@ jobs:
 
           # The previous "MacOS code signing (binaries)" step signs + notarizes the
           # built artifacts in `${release_dir}`. This step packages *those same*
-          # signed binaries into a DMG.
+          # signed binaries into a dmg.
           codex_binary_path="${release_dir}/codex"
           proxy_binary_path="${release_dir}/codex-responses-api-proxy"
 
@@ -183,11 +183,11 @@ jobs:
             "$dmg_path"
 
           if [[ ! -f "$dmg_path" ]]; then
-            echo "DMG $dmg_path not found after build"
+            echo "dmg $dmg_path not found after build"
             exit 1
           fi
 
-      - if: ${{ matrix.runner == 'macos-15-xlarge' }}
+      - if: ${{ runner.os == 'macOS' }}
         name: MacOS code signing (dmg)
         uses: ./.github/actions/macos-code-sign
         with:

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -129,10 +129,71 @@ jobs:
           certificate-profile-name: ${{ secrets.AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME }}
 
       - if: ${{ matrix.runner == 'macos-15-xlarge' }}
-        name: MacOS code signing
+        name: MacOS code signing (binaries)
         uses: ./.github/actions/macos-code-sign
         with:
           target: ${{ matrix.target }}
+          sign-binaries: "true"
+          sign-dmg: "false"
+          apple-certificate: ${{ secrets.APPLE_CERTIFICATE_P12 }}
+          apple-certificate-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          apple-notarization-key-p8: ${{ secrets.APPLE_NOTARIZATION_KEY_P8 }}
+          apple-notarization-key-id: ${{ secrets.APPLE_NOTARIZATION_KEY_ID }}
+          apple-notarization-issuer-id: ${{ secrets.APPLE_NOTARIZATION_ISSUER_ID }}
+
+      - if: ${{ matrix.runner == 'macos-15-xlarge' }}
+        name: Build macOS DMG
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          target="${{ matrix.target }}"
+          release_dir="target/${target}/release"
+          dmg_root="${RUNNER_TEMP}/codex-dmg-root"
+          volname="Codex (${target})"
+          dmg_path="${release_dir}/codex-${target}.dmg"
+
+          # The previous "MacOS code signing (binaries)" step signs + notarizes the
+          # built artifacts in `${release_dir}`. This step packages *those same*
+          # signed binaries into a DMG.
+          codex_binary_path="${release_dir}/codex"
+          proxy_binary_path="${release_dir}/codex-responses-api-proxy"
+
+          rm -rf "$dmg_root"
+          mkdir -p "$dmg_root"
+
+          if [[ ! -f "$codex_binary_path" ]]; then
+            echo "Binary $codex_binary_path not found"
+            exit 1
+          fi
+          if [[ ! -f "$proxy_binary_path" ]]; then
+            echo "Binary $proxy_binary_path not found"
+            exit 1
+          fi
+
+          ditto "$codex_binary_path" "${dmg_root}/codex"
+          ditto "$proxy_binary_path" "${dmg_root}/codex-responses-api-proxy"
+
+          rm -f "$dmg_path"
+          hdiutil create \
+            -volname "$volname" \
+            -srcfolder "$dmg_root" \
+            -format UDZO \
+            -ov \
+            "$dmg_path"
+
+          if [[ ! -f "$dmg_path" ]]; then
+            echo "DMG $dmg_path not found after build"
+            exit 1
+          fi
+
+      - if: ${{ matrix.runner == 'macos-15-xlarge' }}
+        name: MacOS code signing (dmg)
+        uses: ./.github/actions/macos-code-sign
+        with:
+          target: ${{ matrix.target }}
+          sign-binaries: "false"
+          sign-dmg: "true"
           apple-certificate: ${{ secrets.APPLE_CERTIFICATE_P12 }}
           apple-certificate-password: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
           apple-notarization-key-p8: ${{ secrets.APPLE_NOTARIZATION_KEY_P8 }}

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -160,6 +160,10 @@ jobs:
             cp target/${{ matrix.target }}/release/codex-responses-api-proxy.sigstore "$dest/codex-responses-api-proxy-${{ matrix.target }}.sigstore"
           fi
 
+          if [[ "${{ matrix.target }}" == *apple-darwin ]]; then
+            cp target/${{ matrix.target }}/release/codex-${{ matrix.target }}.dmg "$dest/codex-${{ matrix.target }}.dmg"
+          fi
+
       - if: ${{ matrix.runner == 'windows-11-arm' }}
         name: Install zstd
         shell: powershell
@@ -194,7 +198,7 @@ jobs:
             base="$(basename "$f")"
             # Skip files that are already archives (shouldn't happen, but be
             # safe).
-            if [[ "$base" == *.tar.gz || "$base" == *.zip ]]; then
+            if [[ "$base" == *.tar.gz || "$base" == *.zip || "$base" == *.dmg ]]; then
               continue
             fi
 


### PR DESCRIPTION
Add a dmg target that bundles the codex and codex responses api proxy binaries for MacOS. this target is signed and notarized.

Verified by triggering a build here: https://github.com/openai/codex/actions/runs/20318136302/job/58367155205. Downloaded the artifact and verified that the dmg is signed and notarized, and the codex binary contained works as expected.