### PR TITLE
Change "Team" to "Buisness" and add Education

### DIFF
--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -217,7 +217,7 @@ impl AuthModeWidget {
         };
 
         let chatgpt_description = if self.is_chatgpt_login_allowed() {
-            "Usage included with Plus, Pro, Buisness, and Enterprise plans"
+            "Usage included with Plus, Pro, Buisness, Education, and Enterprise plans"
         } else {
             "ChatGPT login is disabled"
         };

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -217,7 +217,7 @@ impl AuthModeWidget {
         };
 
         let chatgpt_description = if self.is_chatgpt_login_allowed() {
-            "Usage included with Plus, Pro, Buisness, Education, and Enterprise plans"
+            "Usage included with Plus, Pro, Business, Education, and Enterprise plans"
         } else {
             "ChatGPT login is disabled"
         };

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -217,7 +217,7 @@ impl AuthModeWidget {
         };
 
         let chatgpt_description = if self.is_chatgpt_login_allowed() {
-            "Usage included with Plus, Pro, Team, and Enterprise plans"
+            "Usage included with Plus, Pro, Buisness, and Enterprise plans"
         } else {
             "ChatGPT login is disabled"
         };

--- a/codex-rs/tui2/src/onboarding/auth.rs
+++ b/codex-rs/tui2/src/onboarding/auth.rs
@@ -217,7 +217,7 @@ impl AuthModeWidget {
         };
 
         let chatgpt_description = if self.is_chatgpt_login_allowed() {
-            "Usage included with Plus, Pro, Buisness, and Enterprise plans"
+            "Usage included with Plus, Pro, Buisness, Education, and Enterprise plans"
         } else {
             "ChatGPT login is disabled"
         };

--- a/codex-rs/tui2/src/onboarding/auth.rs
+++ b/codex-rs/tui2/src/onboarding/auth.rs
@@ -217,7 +217,7 @@ impl AuthModeWidget {
         };
 
         let chatgpt_description = if self.is_chatgpt_login_allowed() {
-            "Usage included with Plus, Pro, Buisness, Education, and Enterprise plans"
+            "Usage included with Plus, Pro, Business, Education, and Enterprise plans"
         } else {
             "ChatGPT login is disabled"
         };

--- a/codex-rs/tui2/src/onboarding/auth.rs
+++ b/codex-rs/tui2/src/onboarding/auth.rs
@@ -217,7 +217,7 @@ impl AuthModeWidget {
         };
 
         let chatgpt_description = if self.is_chatgpt_login_allowed() {
-            "Usage included with Plus, Pro, Team, and Enterprise plans"
+            "Usage included with Plus, Pro, Buisness, and Enterprise plans"
         } else {
             "ChatGPT login is disabled"
         };


### PR DESCRIPTION
This pull request updates the ChatGPT login description in the onboarding authentication widgets to clarify which plans include usage. The description now lists "Business" rather than "Team" and adds "Education" plans in addition to the previously mentioned plans.

I have read the CLA Document and I hereby sign the CLAs.