### PR TITLE
chore: simplify loading of Mac-specific logic in config_loader

### DIFF
--- a/codex-rs/core/src/config_loader/layer_io.rs
+++ b/codex-rs/core/src/config_loader/layer_io.rs
@@ -1,4 +1,5 @@
 use super::LoaderOverrides;
+#[cfg(target_os = "macos")]
 use super::macos::load_managed_admin_config_layer;
 use super::overrides::default_empty_table;
 use crate::config::CONFIG_TOML_FILE;
@@ -45,7 +46,7 @@ pub(super) async fn load_config_layers_internal(
         load_managed_admin_config_layer(managed_preferences_base64.as_deref()).await?;
 
     #[cfg(not(target_os = "macos"))]
-    let managed_preferences = load_managed_admin_config_layer(None).await?;
+    let managed_preferences = None;
 
     Ok(LoadedConfigLayers {
         base: user_config.unwrap_or_else(default_empty_table),

--- a/codex-rs/core/src/config_loader/macos.rs
+++ b/codex-rs/core/src/config_loader/macos.rs
@@ -1,118 +1,100 @@
+use base64::Engine;
+use base64::prelude::BASE64_STANDARD;
+use core_foundation::base::TCFType;
+use core_foundation::string::CFString;
+use core_foundation::string::CFStringRef;
+use std::ffi::c_void;
 use std::io;
+use tokio::task;
 use toml::Value as TomlValue;
 
-#[cfg(target_os = "macos")]
-mod native {
-    use super::*;
-    use base64::Engine;
-    use base64::prelude::BASE64_STANDARD;
-    use core_foundation::base::TCFType;
-    use core_foundation::string::CFString;
-    use core_foundation::string::CFStringRef;
-    use std::ffi::c_void;
-    use tokio::task;
+const MANAGED_PREFERENCES_APPLICATION_ID: &str = "com.openai.codex";
+const MANAGED_PREFERENCES_CONFIG_KEY: &str = "config_toml_base64";
 
-    pub(crate) async fn load_managed_admin_config_layer(
-        override_base64: Option<&str>,
-    ) -> io::Result<Option<TomlValue>> {
-        if let Some(encoded) = override_base64 {
-            let trimmed = encoded.trim();
-            return if trimmed.is_empty() {
-                Ok(None)
-            } else {
-                parse_managed_preferences_base64(trimmed).map(Some)
-            };
-        }
-
-        const LOAD_ERROR: &str = "Failed to load managed preferences configuration";
-
-        match task::spawn_blocking(load_managed_admin_config).await {
-            Ok(result) => result,
-            Err(join_err) => {
-                if join_err.is_cancelled() {
-                    tracing::error!("Managed preferences load task was cancelled");
-                } else {
-                    tracing::error!("Managed preferences load task failed: {join_err}");
-                }
-                Err(io::Error::other(LOAD_ERROR))
-            }
-        }
-    }
-
-    pub(super) fn load_managed_admin_config() -> io::Result<Option<TomlValue>> {
-        #[link(name = "CoreFoundation", kind = "framework")]
-        unsafe extern "C" {
-            fn CFPreferencesCopyAppValue(
-                key: CFStringRef,
-                application_id: CFStringRef,
-            ) -> *mut c_void;
-        }
-
-        const MANAGED_PREFERENCES_APPLICATION_ID: &str = "com.openai.codex";
-        const MANAGED_PREFERENCES_CONFIG_KEY: &str = "config_toml_base64";
-
-        let application_id = CFString::new(MANAGED_PREFERENCES_APPLICATION_ID);
-        let key = CFString::new(MANAGED_PREFERENCES_CONFIG_KEY);
-
-        let value_ref = unsafe {
-            CFPreferencesCopyAppValue(
-                key.as_concrete_TypeRef(),
-                application_id.as_concrete_TypeRef(),
-            )
+pub(crate) async fn load_managed_admin_config_layer(
+    override_base64: Option<&str>,
+) -> io::Result<Option<TomlValue>> {
+    if let Some(encoded) = override_base64 {
+        let trimmed = encoded.trim();
+        return if trimmed.is_empty() {
+            Ok(None)
+        } else {
+            parse_managed_preferences_base64(trimmed).map(Some)
         };
-
-        if value_ref.is_null() {
-            tracing::debug!(
-                "Managed preferences for {} key {} not found",
-                MANAGED_PREFERENCES_APPLICATION_ID,
-                MANAGED_PREFERENCES_CONFIG_KEY
-            );
-            return Ok(None);
-        }
-
-        let value = unsafe { CFString::wrap_under_create_rule(value_ref as _) };
-        let contents = value.to_string();
-        let trimmed = contents.trim();
-
-        parse_managed_preferences_base64(trimmed).map(Some)
     }
 
-    pub(super) fn parse_managed_preferences_base64(encoded: &str) -> io::Result<TomlValue> {
-        let decoded = BASE64_STANDARD.decode(encoded.as_bytes()).map_err(|err| {
-            tracing::error!("Failed to decode managed preferences as base64: {err}");
-            io::Error::new(io::ErrorKind::InvalidData, err)
-        })?;
+    const LOAD_ERROR: &str = "Failed to load managed preferences configuration";
 
-        let decoded_str = String::from_utf8(decoded).map_err(|err| {
-            tracing::error!("Managed preferences base64 contents were not valid UTF-8: {err}");
-            io::Error::new(io::ErrorKind::InvalidData, err)
-        })?;
-
-        match toml::from_str::<TomlValue>(&decoded_str) {
-            Ok(TomlValue::Table(parsed)) => Ok(TomlValue::Table(parsed)),
-            Ok(other) => {
-                tracing::error!(
-                    "Managed preferences TOML must have a table at the root, found {other:?}",
-                );
-                Err(io::Error::new(
-                    io::ErrorKind::InvalidData,
-                    "managed preferences root must be a table",
-                ))
+    match task::spawn_blocking(load_managed_admin_config).await {
+        Ok(result) => result,
+        Err(join_err) => {
+            if join_err.is_cancelled() {
+                tracing::error!("Managed preferences load task was cancelled");
+            } else {
+                tracing::error!("Managed preferences load task failed: {join_err}");
             }
-            Err(err) => {
-                tracing::error!("Failed to parse managed preferences TOML: {err}");
-                Err(io::Error::new(io::ErrorKind::InvalidData, err))
-            }
+            Err(io::Error::other(LOAD_ERROR))
         }
     }
 }
 
-#[cfg(target_os = "macos")]
-pub(crate) use native::load_managed_admin_config_layer;
+fn load_managed_admin_config() -> io::Result<Option<TomlValue>> {
+    #[link(name = "CoreFoundation", kind = "framework")]
+    unsafe extern "C" {
+        fn CFPreferencesCopyAppValue(key: CFStringRef, application_id: CFStringRef) -> *mut c_void;
+    }
 
-#[cfg(not(target_os = "macos"))]
-pub(crate) async fn load_managed_admin_config_layer(
-    _override_base64: Option<&str>,
-) -> io::Result<Option<TomlValue>> {
-    Ok(None)
+    let application_id = CFString::new(MANAGED_PREFERENCES_APPLICATION_ID);
+    let key = CFString::new(MANAGED_PREFERENCES_CONFIG_KEY);
+
+    let value_ref = unsafe {
+        CFPreferencesCopyAppValue(
+            key.as_concrete_TypeRef(),
+            application_id.as_concrete_TypeRef(),
+        )
+    };
+
+    if value_ref.is_null() {
+        tracing::debug!(
+            "Managed preferences for {} key {} not found",
+            MANAGED_PREFERENCES_APPLICATION_ID,
+            MANAGED_PREFERENCES_CONFIG_KEY
+        );
+        return Ok(None);
+    }
+
+    let value = unsafe { CFString::wrap_under_create_rule(value_ref as _) };
+    let contents = value.to_string();
+    let trimmed = contents.trim();
+
+    parse_managed_preferences_base64(trimmed).map(Some)
+}
+
+fn parse_managed_preferences_base64(encoded: &str) -> io::Result<TomlValue> {
+    let decoded = BASE64_STANDARD.decode(encoded.as_bytes()).map_err(|err| {
+        tracing::error!("Failed to decode managed preferences as base64: {err}");
+        io::Error::new(io::ErrorKind::InvalidData, err)
+    })?;
+
+    let decoded_str = String::from_utf8(decoded).map_err(|err| {
+        tracing::error!("Managed preferences base64 contents were not valid UTF-8: {err}");
+        io::Error::new(io::ErrorKind::InvalidData, err)
+    })?;
+
+    match toml::from_str::<TomlValue>(&decoded_str) {
+        Ok(TomlValue::Table(parsed)) => Ok(TomlValue::Table(parsed)),
+        Ok(other) => {
+            tracing::error!(
+                "Managed preferences TOML must have a table at the root, found {other:?}",
+            );
+            Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "managed preferences root must be a table",
+            ))
+        }
+        Err(err) => {
+            tracing::error!("Failed to parse managed preferences TOML: {err}");
+            Err(io::Error::new(io::ErrorKind::InvalidData, err))
+        }
+    }
 }

--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -1,5 +1,6 @@
 mod fingerprint;
 mod layer_io;
+#[cfg(target_os = "macos")]
 mod macos;
 mod merge;
 mod overrides;


### PR DESCRIPTION
Over in `config_loader/macos.rs`, we were doing this complicated `mod` thing to expose one version of `load_managed_admin_config_layer()` for Mac:

https://github.com/openai/codex/blob/580c59aa9af61cb4bffb5b204bd16a5dcc4bc911/codex-rs/core/src/config_loader/macos.rs#L4-L5

While exposing a trivial implementation for non-Mac:

https://github.com/openai/codex/blob/580c59aa9af61cb4bffb5b204bd16a5dcc4bc911/codex-rs/core/src/config_loader/macos.rs#L110-L117

That was being used like this:

https://github.com/openai/codex/blob/580c59aa9af61cb4bffb5b204bd16a5dcc4bc911/codex-rs/core/src/config_loader/layer_io.rs#L47-L48

This PR simplifies that callsite in `layer_io.rs` to just be:

```rust
    #[cfg(not(target_os = "macos"))]
    let managed_preferences = None;
```

And updates `config_loader/mod.rs` so we only pull in `macos.rs` on Mac:

```rust
#[cfg(target_os = "macos")]
mod macos;
```

This simplifies `macos.rs` considerably, though it looks like a big change because everything gets unindented and reformatted because we can drop the whole `mod native` thing now.




---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/openai/codex/pull/8248).
* #8251
* #8249
* __->__ #8248