### PR TITLE
chore: prefer AsRef<Path> to &Path

### DIFF
--- a/codex-rs/core/src/config/service.rs
+++ b/codex-rs/core/src/config/service.rs
@@ -470,15 +470,15 @@ fn validate_config(value: &TomlValue) -> Result<(), toml::de::Error> {
     Ok(())
 }
 
-fn paths_match(expected: &Path, provided: &Path) -> bool {
+fn paths_match(expected: impl AsRef<Path>, provided: impl AsRef<Path>) -> bool {
     if let (Ok(expanded_expected), Ok(expanded_provided)) = (
-        path_utils::normalize_for_path_comparison(expected),
-        path_utils::normalize_for_path_comparison(provided),
+        path_utils::normalize_for_path_comparison(&expected),
+        path_utils::normalize_for_path_comparison(&provided),
     ) {
-        return expanded_expected == expanded_provided;
+        expanded_expected == expanded_provided
+    } else {
+        expected.as_ref() == provided.as_ref()
     }
-
-    expected == provided
 }
 
 fn value_at_path<'a>(root: &'a TomlValue, segments: &[String]) -> Option<&'a TomlValue> {

--- a/codex-rs/core/src/config_loader/layer_io.rs
+++ b/codex-rs/core/src/config_loader/layer_io.rs
@@ -56,27 +56,27 @@ pub(super) async fn load_config_layers_internal(
 }
 
 pub(super) async fn read_config_from_path(
-    path: &Path,
+    path: impl AsRef<Path>,
     log_missing_as_info: bool,
 ) -> io::Result<Option<TomlValue>> {
-    match fs::read_to_string(path).await {
+    match fs::read_to_string(path.as_ref()).await {
         Ok(contents) => match toml::from_str::<TomlValue>(&contents) {
             Ok(value) => Ok(Some(value)),
             Err(err) => {
-                tracing::error!("Failed to parse {}: {err}", path.display());
+                tracing::error!("Failed to parse {}: {err}", path.as_ref().display());
                 Err(io::Error::new(io::ErrorKind::InvalidData, err))
             }
         },
         Err(err) if err.kind() == io::ErrorKind::NotFound => {
             if log_missing_as_info {
-                tracing::info!("{} not found, using defaults", path.display());
+                tracing::info!("{} not found, using defaults", path.as_ref().display());
             } else {
-                tracing::debug!("{} not found", path.display());
+                tracing::debug!("{} not found", path.as_ref().display());
             }
             Ok(None)
         }
         Err(err) => {
-            tracing::error!("Failed to read {}: {err}", path.display());
+            tracing::error!("Failed to read {}: {err}", path.as_ref().display());
             Err(err)
         }
     }

--- a/codex-rs/core/src/path_utils.rs
+++ b/codex-rs/core/src/path_utils.rs
@@ -3,8 +3,8 @@ use std::path::PathBuf;
 
 use crate::env;
 
-pub fn normalize_for_path_comparison(path: &Path) -> std::io::Result<PathBuf> {
-    let canonical = path.canonicalize()?;
+pub fn normalize_for_path_comparison(path: impl AsRef<Path>) -> std::io::Result<PathBuf> {
+    let canonical = path.as_ref().canonicalize()?;
     Ok(normalize_for_wsl(canonical))
 }
 


### PR DESCRIPTION
This is some minor API cleanup that will make it easier to use `AbsolutePathBuf` in more places in a subsequent PR.




