### PR TITLE
Terminal Detection Metadata for Per-Terminal Scroll Scaling

### DIFF
--- a/.codespellignore
+++ b/.codespellignore
@@ -1,2 +1,3 @@
 iTerm
+iTerm2
 psuedo

--- a/.codespellrc
+++ b/.codespellrc
@@ -3,4 +3,4 @@
 skip = .git*,vendor,*-lock.yaml,*.lock,.codespellrc,*test.ts,*.jsonl,frame*.txt
 check-hidden = true
 ignore-regex = ^\s*"image/\S+": ".*|\b(afterAll)\b
-ignore-words-list = ratatui,ser
+ignore-words-list = ratatui,ser,iTerm,iterm2,iterm

--- a/codex-rs/core/src/terminal.rs
+++ b/codex-rs/core/src/terminal.rs
@@ -1,6 +1,167 @@
 use std::sync::OnceLock;
 
-static TERMINAL: OnceLock<String> = OnceLock::new();
+/// Structured terminal identification data.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TerminalInfo {
+    /// The detected terminal name category.
+    pub name: TerminalName,
+    /// The `TERM_PROGRAM` value when provided by the terminal.
+    pub term_program: Option<String>,
+    /// The terminal version string when available.
+    pub version: Option<String>,
+    /// The `TERM` value when falling back to capability strings.
+    pub term: Option<String>,
+    /// Multiplexer metadata when a terminal multiplexer is active.
+    pub multiplexer: Option<Multiplexer>,
+}
+
+/// Known terminal name categories derived from environment variables.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum TerminalName {
+    /// Apple Terminal (Terminal.app).
+    AppleTerminal,
+    /// Ghostty terminal emulator.
+    Ghostty,
+    /// iTerm2 terminal emulator.
+    Iterm2,
+    /// Warp terminal emulator.
+    WarpTerminal,
+    /// Visual Studio Code integrated terminal.
+    VsCode,
+    /// WezTerm terminal emulator.
+    WezTerm,
+    /// kitty terminal emulator.
+    Kitty,
+    /// Alacritty terminal emulator.
+    Alacritty,
+    /// KDE Konsole terminal emulator.
+    Konsole,
+    /// GNOME Terminal emulator.
+    GnomeTerminal,
+    /// VTE backend terminal.
+    Vte,
+    /// Windows Terminal emulator.
+    WindowsTerminal,
+    /// Unknown or missing terminal identification.
+    Unknown,
+}
+
+/// Detected terminal multiplexer metadata.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum Multiplexer {
+    /// tmux terminal multiplexer.
+    Tmux {
+        /// Client term type from `tmux display-message -p "#{client_termtype}"`.
+        ///
+        /// This is the closest equivalent to `TERM_PROGRAM` for tmux clients.
+        client_termtype: Option<String>,
+        /// Client term name from `tmux display-message -p "#{client_termname}"`.
+        ///
+        /// This is closest to a raw `TERM` capability string.
+        client_termname: Option<String>,
+    },
+    /// zellij terminal multiplexer.
+    Zellij {},
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct TmuxClientInfo {
+    termtype: Option<String>,
+    termname: Option<String>,
+}
+
+impl Default for TmuxClientInfo {
+    fn default() -> Self {
+        Self {
+            termtype: None,
+            termname: None,
+        }
+    }
+}
+
+impl TerminalInfo {
+    /// Creates terminal metadata from detected fields.
+    fn new(
+        name: TerminalName,
+        term_program: Option<String>,
+        version: Option<String>,
+        term: Option<String>,
+        multiplexer: Option<Multiplexer>,
+    ) -> Self {
+        Self {
+            name,
+            term_program,
+            version,
+            term,
+            multiplexer,
+        }
+    }
+
+    /// Creates terminal metadata from a `TERM_PROGRAM` match.
+    fn from_term_program(
+        name: TerminalName,
+        term_program: String,
+        version: Option<String>,
+        multiplexer: Option<Multiplexer>,
+    ) -> Self {
+        Self::new(name, Some(term_program), version, None, multiplexer)
+    }
+
+    /// Creates terminal metadata from a known terminal name and optional version.
+    fn from_name(
+        name: TerminalName,
+        version: Option<String>,
+        multiplexer: Option<Multiplexer>,
+    ) -> Self {
+        Self::new(name, None, version, None, multiplexer)
+    }
+
+    /// Creates terminal metadata from a `TERM` capability value.
+    fn from_term(term: String, multiplexer: Option<Multiplexer>) -> Self {
+        Self::new(TerminalName::Unknown, None, None, Some(term), multiplexer)
+    }
+
+    /// Creates terminal metadata for unknown terminals.
+    fn unknown(multiplexer: Option<Multiplexer>) -> Self {
+        Self::new(TerminalName::Unknown, None, None, None, multiplexer)
+    }
+
+    /// Formats the terminal info as a User-Agent token.
+    fn user_agent_token(&self) -> String {
+        let raw = if let Some(program) = self.term_program.as_ref() {
+            match self.version.as_ref().filter(|v| !v.is_empty()) {
+                Some(version) => format!("{program}/{version}"),
+                None => program.clone(),
+            }
+        } else if let Some(term) = self.term.as_ref().filter(|value| !value.is_empty()) {
+            term.clone()
+        } else {
+            match self.name {
+                TerminalName::AppleTerminal => {
+                    format_terminal_version("Apple_Terminal", &self.version)
+                }
+                TerminalName::Ghostty => format_terminal_version("Ghostty", &self.version),
+                TerminalName::Iterm2 => format_terminal_version("iTerm.app", &self.version),
+                TerminalName::WarpTerminal => {
+                    format_terminal_version("WarpTerminal", &self.version)
+                }
+                TerminalName::VsCode => format_terminal_version("vscode", &self.version),
+                TerminalName::WezTerm => format_terminal_version("WezTerm", &self.version),
+                TerminalName::Kitty => "kitty".to_string(),
+                TerminalName::Alacritty => "Alacritty".to_string(),
+                TerminalName::Konsole => format_terminal_version("Konsole", &self.version),
+                TerminalName::GnomeTerminal => "gnome-terminal".to_string(),
+                TerminalName::Vte => format_terminal_version("VTE", &self.version),
+                TerminalName::WindowsTerminal => "WindowsTerminal".to_string(),
+                TerminalName::Unknown => "unknown".to_string(),
+            }
+        };
+
+        sanitize_header_value(raw)
+    }
+}
+
+static TERMINAL_INFO: OnceLock<TerminalInfo> = OnceLock::new();
 
 /// Environment variable access used by terminal detection.
 ///
@@ -8,6 +169,9 @@ static TERMINAL: OnceLock<String> = OnceLock::new();
 trait Environment {
     /// Returns an environment variable when set.
     fn var(&self, name: &str) -> Option<String>;
+
+    /// Returns tmux client details when available.
+    fn tmux_client_info(&self) -> TmuxClientInfo;
 }
 
 /// Reads environment variables from the running process.
@@ -24,18 +188,158 @@ impl Environment for ProcessEnvironment {
             }
         }
     }
+
+    fn tmux_client_info(&self) -> TmuxClientInfo {
+        tmux_client_info()
+    }
 }
 
 /// Returns a sanitized terminal identifier for User-Agent strings.
 pub fn user_agent() -> String {
-    TERMINAL.get_or_init(detect_terminal).to_string()
+    terminal_info().user_agent_token()
 }
 
-/// Sanitize a header value to be used in a User-Agent string.
+/// Returns structured terminal metadata for the current process.
+pub fn terminal_info() -> TerminalInfo {
+    TERMINAL_INFO
+        .get_or_init(|| detect_terminal_info_from_env(&ProcessEnvironment))
+        .clone()
+}
+
+/// Detects structured terminal metadata from an injectable environment.
 ///
-/// This function replaces any characters that are not allowed in a User-Agent string with an underscore.
-fn is_valid_header_value_char(c: char) -> bool {
-    c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '/'
+/// When `TERM_PROGRAM` matches a known terminal, the terminal name is set accordingly. When
+/// only `TERM` is available, the terminal name remains `Unknown` while the capability string
+/// is preserved for the user-agent token.
+fn detect_terminal_info_from_env(env: &dyn Environment) -> TerminalInfo {
+    let multiplexer = detect_multiplexer(env);
+
+    if let Some(term_program) = env.var("TERM_PROGRAM")
+        && !term_program.trim().is_empty()
+    {
+        let version = env.var("TERM_PROGRAM_VERSION").and_then(none_if_whitespace);
+        let name = terminal_name_from_term_program(&term_program).unwrap_or(TerminalName::Unknown);
+        return TerminalInfo::from_term_program(name, term_program, version, multiplexer.clone());
+    }
+
+    if let Some(version) = env.var("WEZTERM_VERSION") {
+        return TerminalInfo::from_name(
+            TerminalName::WezTerm,
+            none_if_whitespace(version),
+            multiplexer.clone(),
+        );
+    }
+
+    if env.var("ITERM_SESSION_ID").is_some()
+        || env.var("ITERM_PROFILE").is_some()
+        || env.var("ITERM_PROFILE_NAME").is_some()
+    {
+        return TerminalInfo::from_name(TerminalName::Iterm2, None, multiplexer.clone());
+    }
+
+    if env.var("TERM_SESSION_ID").is_some() {
+        return TerminalInfo::from_name(TerminalName::AppleTerminal, None, multiplexer.clone());
+    }
+
+    if env.var("KITTY_WINDOW_ID").is_some()
+        || env
+            .var("TERM")
+            .map(|term| term.contains("kitty"))
+            .unwrap_or(false)
+    {
+        return TerminalInfo::from_name(TerminalName::Kitty, None, multiplexer.clone());
+    }
+
+    if env.var("ALACRITTY_SOCKET").is_some()
+        || env
+            .var("TERM")
+            .map(|term| term == "alacritty")
+            .unwrap_or(false)
+    {
+        return TerminalInfo::from_name(TerminalName::Alacritty, None, multiplexer.clone());
+    }
+
+    if let Some(version) = env.var("KONSOLE_VERSION") {
+        return TerminalInfo::from_name(
+            TerminalName::Konsole,
+            none_if_whitespace(version),
+            multiplexer.clone(),
+        );
+    }
+
+    if env.var("GNOME_TERMINAL_SCREEN").is_some() {
+        return TerminalInfo::from_name(TerminalName::GnomeTerminal, None, multiplexer.clone());
+    }
+
+    if let Some(version) = env.var("VTE_VERSION") {
+        return TerminalInfo::from_name(
+            TerminalName::Vte,
+            none_if_whitespace(version),
+            multiplexer.clone(),
+        );
+    }
+
+    if env.var("WT_SESSION").is_some() {
+        return TerminalInfo::from_name(TerminalName::WindowsTerminal, None, multiplexer.clone());
+    }
+
+    if multiplexer.is_none() {
+        let tmux_client_info = env.tmux_client_info();
+        if let Some(termtype) = tmux_client_info.termtype {
+            let name = terminal_name_from_term_program(&termtype).unwrap_or(TerminalName::Unknown);
+            return TerminalInfo::from_term_program(name, termtype, None, multiplexer.clone());
+        }
+
+        if let Some(termname) = tmux_client_info.termname {
+            return TerminalInfo::from_term(termname, multiplexer.clone());
+        }
+    }
+
+    if let Some(term) = env.var("TERM").and_then(none_if_whitespace) {
+        return TerminalInfo::from_term(term, multiplexer.clone());
+    }
+
+    TerminalInfo::unknown(multiplexer)
+}
+
+fn detect_multiplexer(env: &dyn Environment) -> Option<Multiplexer> {
+    if env.var("TMUX").is_some() || env.var("TMUX_PANE").is_some() {
+        let client_info = env.tmux_client_info();
+        return Some(Multiplexer::Tmux {
+            client_termtype: client_info.termtype,
+            client_termname: client_info.termname,
+        });
+    }
+
+    if env.var("ZELLIJ").is_some()
+        || env.var("ZELLIJ_SESSION_NAME").is_some()
+        || env.var("ZELLIJ_VERSION").is_some()
+    {
+        return Some(Multiplexer::Zellij {});
+    }
+
+    None
+}
+
+fn tmux_client_info() -> TmuxClientInfo {
+    let termtype = tmux_display_message("#{client_termtype}");
+    let termname = tmux_display_message("#{client_termname}");
+
+    TmuxClientInfo { termtype, termname }
+}
+
+fn tmux_display_message(format: &str) -> Option<String> {
+    let output = std::process::Command::new("tmux")
+        .args(["display-message", "-p", format])
+        .output()
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let value = String::from_utf8(output.stdout).ok()?;
+    none_if_whitespace(value.trim().to_string())
 }
 
 /// Sanitizes a terminal token for use in User-Agent headers.
@@ -45,62 +349,45 @@ fn sanitize_header_value(value: String) -> String {
     value.replace(|c| !is_valid_header_value_char(c), "_")
 }
 
-/// Detects the current terminal from the process environment.
-fn detect_terminal() -> String {
-    detect_terminal_from_env(&ProcessEnvironment)
+/// Returns whether a character is allowed in User-Agent header values.
+fn is_valid_header_value_char(c: char) -> bool {
+    c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '/'
 }
 
-/// Detects a terminal identifier from an injectable environment.
-///
-/// The logic mirrors the existing detection order, preferring explicit
-/// identifiers like `TERM_PROGRAM` before falling back to capability strings.
-fn detect_terminal_from_env(env: &dyn Environment) -> String {
-    sanitize_header_value(
-        if let Some(tp) = env.var("TERM_PROGRAM")
-            && !tp.trim().is_empty()
-        {
-            let ver = env.var("TERM_PROGRAM_VERSION");
-            match ver {
-                Some(v) if !v.trim().is_empty() => format!("{tp}/{v}"),
-                _ => tp,
-            }
-        } else if let Some(v) = env.var("WEZTERM_VERSION") {
-            if !v.trim().is_empty() {
-                format!("WezTerm/{v}")
-            } else {
-                "WezTerm".to_string()
-            }
-        } else if env.var("KITTY_WINDOW_ID").is_some()
-            || env
-                .var("TERM")
-                .map(|t| t.contains("kitty"))
-                .unwrap_or(false)
-        {
-            "kitty".to_string()
-        } else if env.var("ALACRITTY_SOCKET").is_some()
-            || env.var("TERM").map(|t| t == "alacritty").unwrap_or(false)
-        {
-            "Alacritty".to_string()
-        } else if let Some(v) = env.var("KONSOLE_VERSION") {
-            if !v.trim().is_empty() {
-                format!("Konsole/{v}")
-            } else {
-                "Konsole".to_string()
-            }
-        } else if env.var("GNOME_TERMINAL_SCREEN").is_some() {
-            return "gnome-terminal".to_string();
-        } else if let Some(v) = env.var("VTE_VERSION") {
-            if !v.trim().is_empty() {
-                format!("VTE/{v}")
-            } else {
-                "VTE".to_string()
-            }
-        } else if env.var("WT_SESSION").is_some() {
-            return "WindowsTerminal".to_string();
-        } else {
-            env.var("TERM").unwrap_or_else(|| "unknown".to_string())
-        },
-    )
+fn terminal_name_from_term_program(value: &str) -> Option<TerminalName> {
+    let normalized: String = value
+        .trim()
+        .chars()
+        .filter(|c| !matches!(c, ' ' | '-' | '_' | '.'))
+        .map(|c| c.to_ascii_lowercase())
+        .collect();
+
+    match normalized.as_str() {
+        "appleterminal" => Some(TerminalName::AppleTerminal),
+        "ghostty" => Some(TerminalName::Ghostty),
+        "iterm" | "iterm2" | "itermapp" => Some(TerminalName::Iterm2),
+        "warp" | "warpterminal" => Some(TerminalName::WarpTerminal),
+        "vscode" => Some(TerminalName::VsCode),
+        "wezterm" => Some(TerminalName::WezTerm),
+        "kitty" => Some(TerminalName::Kitty),
+        "alacritty" => Some(TerminalName::Alacritty),
+        "konsole" => Some(TerminalName::Konsole),
+        "gnometerminal" => Some(TerminalName::GnomeTerminal),
+        "vte" => Some(TerminalName::Vte),
+        "windowsterminal" => Some(TerminalName::WindowsTerminal),
+        _ => None,
+    }
+}
+
+fn format_terminal_version(name: &str, version: &Option<String>) -> String {
+    match version.as_ref().filter(|value| !value.is_empty()) {
+        Some(version) => format!("{name}/{version}"),
+        None => name.to_string(),
+    }
+}
+
+fn none_if_whitespace(value: String) -> Option<String> {
+    (!value.trim().is_empty()).then_some(value)
 }
 
 #[cfg(test)]
@@ -111,12 +398,14 @@ mod tests {
 
     struct FakeEnvironment {
         vars: HashMap<String, String>,
+        tmux_client_info: TmuxClientInfo,
     }
 
     impl FakeEnvironment {
         fn new() -> Self {
             Self {
                 vars: HashMap::new(),
+                tmux_client_info: TmuxClientInfo::default(),
             }
         }
 
@@ -124,11 +413,39 @@ mod tests {
             self.vars.insert(key.to_string(), value.to_string());
             self
         }
+
+        fn with_tmux_client_info(mut self, termtype: Option<&str>, termname: Option<&str>) -> Self {
+            self.tmux_client_info = TmuxClientInfo {
+                termtype: termtype.map(ToString::to_string),
+                termname: termname.map(ToString::to_string),
+            };
+            self
+        }
     }
 
     impl Environment for FakeEnvironment {
         fn var(&self, name: &str) -> Option<String> {
             self.vars.get(name).cloned()
+        }
+
+        fn tmux_client_info(&self) -> TmuxClientInfo {
+            self.tmux_client_info.clone()
+        }
+    }
+
+    fn terminal_info(
+        name: TerminalName,
+        term_program: Option<&str>,
+        version: Option<&str>,
+        term: Option<&str>,
+        multiplexer: Option<Multiplexer>,
+    ) -> TerminalInfo {
+        TerminalInfo {
+            name,
+            term_program: term_program.map(ToString::to_string),
+            version: version.map(ToString::to_string),
+            term: term.map(ToString::to_string),
+            multiplexer,
         }
     }
 
@@ -138,128 +455,591 @@ mod tests {
             .with_var("TERM_PROGRAM", "iTerm.app")
             .with_var("TERM_PROGRAM_VERSION", "3.5.0")
             .with_var("WEZTERM_VERSION", "2024.2");
+        let terminal = detect_terminal_info_from_env(&env);
         assert_eq!(
-            detect_terminal_from_env(&env),
+            terminal,
+            terminal_info(
+                TerminalName::Iterm2,
+                Some("iTerm.app"),
+                Some("3.5.0"),
+                None,
+                None,
+            ),
+            "term_program_with_version_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
             "iTerm.app/3.5.0",
-            "term_program_with_version"
+            "term_program_with_version_user_agent"
         );
 
         let env = FakeEnvironment::new()
             .with_var("TERM_PROGRAM", "iTerm.app")
             .with_var("TERM_PROGRAM_VERSION", "");
+        let terminal = detect_terminal_info_from_env(&env);
         assert_eq!(
-            detect_terminal_from_env(&env),
+            terminal,
+            terminal_info(TerminalName::Iterm2, Some("iTerm.app"), None, None, None),
+            "term_program_without_version_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
             "iTerm.app",
-            "term_program_without_version"
+            "term_program_without_version_user_agent"
         );
 
         let env = FakeEnvironment::new()
             .with_var("TERM_PROGRAM", "iTerm.app")
             .with_var("WEZTERM_VERSION", "2024.2");
+        let terminal = detect_terminal_info_from_env(&env);
         assert_eq!(
-            detect_terminal_from_env(&env),
+            terminal,
+            terminal_info(TerminalName::Iterm2, Some("iTerm.app"), None, None, None),
+            "term_program_overrides_wezterm_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
             "iTerm.app",
-            "term_program_overrides_wezterm"
+            "term_program_overrides_wezterm_user_agent"
+        );
+    }
+
+    #[test]
+    fn detects_iterm2() {
+        let env = FakeEnvironment::new().with_var("ITERM_SESSION_ID", "w0t1p0");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(TerminalName::Iterm2, None, None, None, None),
+            "iterm_session_id_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "iTerm.app",
+            "iterm_session_id_user_agent"
+        );
+    }
+
+    #[test]
+    fn detects_apple_terminal() {
+        let env = FakeEnvironment::new().with_var("TERM_PROGRAM", "Apple_Terminal");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(
+                TerminalName::AppleTerminal,
+                Some("Apple_Terminal"),
+                None,
+                None,
+                None,
+            ),
+            "apple_term_program_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "Apple_Terminal",
+            "apple_term_program_user_agent"
+        );
+
+        let env = FakeEnvironment::new().with_var("TERM_SESSION_ID", "A1B2C3");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(TerminalName::AppleTerminal, None, None, None, None),
+            "apple_term_session_id_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "Apple_Terminal",
+            "apple_term_session_id_user_agent"
+        );
+    }
+
+    #[test]
+    fn detects_ghostty() {
+        let env = FakeEnvironment::new().with_var("TERM_PROGRAM", "Ghostty");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(TerminalName::Ghostty, Some("Ghostty"), None, None, None),
+            "ghostty_term_program_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "Ghostty",
+            "ghostty_term_program_user_agent"
+        );
+    }
+
+    #[test]
+    fn detects_vscode() {
+        let env = FakeEnvironment::new()
+            .with_var("TERM_PROGRAM", "vscode")
+            .with_var("TERM_PROGRAM_VERSION", "1.86.0");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(
+                TerminalName::VsCode,
+                Some("vscode"),
+                Some("1.86.0"),
+                None,
+                None
+            ),
+            "vscode_term_program_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "vscode/1.86.0",
+            "vscode_term_program_user_agent"
+        );
+    }
+
+    #[test]
+    fn detects_warp_terminal() {
+        let env = FakeEnvironment::new()
+            .with_var("TERM_PROGRAM", "WarpTerminal")
+            .with_var("TERM_PROGRAM_VERSION", "v0.2025.12.10.08.12.stable_03");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(
+                TerminalName::WarpTerminal,
+                Some("WarpTerminal"),
+                Some("v0.2025.12.10.08.12.stable_03"),
+                None,
+                None,
+            ),
+            "warp_term_program_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "WarpTerminal/v0.2025.12.10.08.12.stable_03",
+            "warp_term_program_user_agent"
+        );
+    }
+
+    #[test]
+    fn detects_tmux_multiplexer() {
+        let env = FakeEnvironment::new()
+            .with_var("TMUX", "/tmp/tmux-1000/default,123,0")
+            .with_tmux_client_info(Some("xterm-256color"), Some("screen-256color"));
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            TerminalInfo {
+                name: TerminalName::Unknown,
+                term_program: None,
+                version: None,
+                term: None,
+                multiplexer: Some(Multiplexer::Tmux {
+                    client_termtype: Some("xterm-256color".to_string()),
+                    client_termname: Some("screen-256color".to_string()),
+                }),
+            },
+            "tmux_multiplexer"
+        );
+    }
+
+    #[test]
+    fn detects_zellij_multiplexer() {
+        let env = FakeEnvironment::new().with_var("ZELLIJ", "1");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            TerminalInfo {
+                name: TerminalName::Unknown,
+                term_program: None,
+                version: None,
+                term: None,
+                multiplexer: Some(Multiplexer::Zellij {}),
+            },
+            "zellij_multiplexer"
+        );
+    }
+
+    #[test]
+    fn detects_tmux_client_termtype_without_multiplexer() {
+        let env = FakeEnvironment::new().with_tmux_client_info(Some("WezTerm"), None);
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(TerminalName::WezTerm, Some("WezTerm"), None, None, None),
+            "tmux_client_termtype_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "WezTerm",
+            "tmux_client_termtype_user_agent"
+        );
+    }
+
+    #[test]
+    fn detects_tmux_client_termname_without_multiplexer() {
+        let env = FakeEnvironment::new().with_tmux_client_info(None, Some("xterm-256color"));
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(
+                TerminalName::Unknown,
+                None,
+                None,
+                Some("xterm-256color"),
+                None
+            ),
+            "tmux_client_termname_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "xterm-256color",
+            "tmux_client_termname_user_agent"
         );
     }
 
     #[test]
     fn detects_wezterm() {
         let env = FakeEnvironment::new().with_var("WEZTERM_VERSION", "2024.2");
+        let terminal = detect_terminal_info_from_env(&env);
         assert_eq!(
-            detect_terminal_from_env(&env),
+            terminal,
+            terminal_info(TerminalName::WezTerm, None, Some("2024.2"), None, None),
+            "wezterm_version_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
             "WezTerm/2024.2",
-            "wezterm_version"
+            "wezterm_version_user_agent"
+        );
+
+        let env = FakeEnvironment::new()
+            .with_var("TERM_PROGRAM", "WezTerm")
+            .with_var("TERM_PROGRAM_VERSION", "2024.2");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(
+                TerminalName::WezTerm,
+                Some("WezTerm"),
+                Some("2024.2"),
+                None,
+                None
+            ),
+            "wezterm_term_program_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "WezTerm/2024.2",
+            "wezterm_term_program_user_agent"
         );
 
         let env = FakeEnvironment::new().with_var("WEZTERM_VERSION", "");
-        assert_eq!(detect_terminal_from_env(&env), "WezTerm", "wezterm_empty");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(TerminalName::WezTerm, None, None, None, None),
+            "wezterm_empty_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "WezTerm",
+            "wezterm_empty_user_agent"
+        );
     }
 
     #[test]
     fn detects_kitty() {
         let env = FakeEnvironment::new().with_var("KITTY_WINDOW_ID", "1");
-        assert_eq!(detect_terminal_from_env(&env), "kitty", "kitty_window_id");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(TerminalName::Kitty, None, None, None, None),
+            "kitty_window_id_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "kitty",
+            "kitty_window_id_user_agent"
+        );
+
+        let env = FakeEnvironment::new()
+            .with_var("TERM_PROGRAM", "kitty")
+            .with_var("TERM_PROGRAM_VERSION", "0.30.1");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(
+                TerminalName::Kitty,
+                Some("kitty"),
+                Some("0.30.1"),
+                None,
+                None
+            ),
+            "kitty_term_program_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "kitty/0.30.1",
+            "kitty_term_program_user_agent"
+        );
 
         let env = FakeEnvironment::new()
             .with_var("TERM", "xterm-kitty")
             .with_var("ALACRITTY_SOCKET", "/tmp/alacritty");
+        let terminal = detect_terminal_info_from_env(&env);
         assert_eq!(
-            detect_terminal_from_env(&env),
+            terminal,
+            terminal_info(TerminalName::Kitty, None, None, None, None),
+            "kitty_term_over_alacritty_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
             "kitty",
-            "kitty_term_over_alacritty"
+            "kitty_term_over_alacritty_user_agent"
         );
     }
 
     #[test]
     fn detects_alacritty() {
         let env = FakeEnvironment::new().with_var("ALACRITTY_SOCKET", "/tmp/alacritty");
+        let terminal = detect_terminal_info_from_env(&env);
         assert_eq!(
-            detect_terminal_from_env(&env),
+            terminal,
+            terminal_info(TerminalName::Alacritty, None, None, None, None),
+            "alacritty_socket_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
             "Alacritty",
-            "alacritty_socket"
+            "alacritty_socket_user_agent"
+        );
+
+        let env = FakeEnvironment::new()
+            .with_var("TERM_PROGRAM", "Alacritty")
+            .with_var("TERM_PROGRAM_VERSION", "0.13.2");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(
+                TerminalName::Alacritty,
+                Some("Alacritty"),
+                Some("0.13.2"),
+                None,
+                None,
+            ),
+            "alacritty_term_program_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "Alacritty/0.13.2",
+            "alacritty_term_program_user_agent"
         );
 
         let env = FakeEnvironment::new().with_var("TERM", "alacritty");
+        let terminal = detect_terminal_info_from_env(&env);
         assert_eq!(
-            detect_terminal_from_env(&env),
+            terminal,
+            terminal_info(TerminalName::Alacritty, None, None, None, None),
+            "alacritty_term_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
             "Alacritty",
-            "alacritty_term"
+            "alacritty_term_user_agent"
         );
     }
 
     #[test]
     fn detects_konsole() {
         let env = FakeEnvironment::new().with_var("KONSOLE_VERSION", "230800");
+        let terminal = detect_terminal_info_from_env(&env);
         assert_eq!(
-            detect_terminal_from_env(&env),
+            terminal,
+            terminal_info(TerminalName::Konsole, None, Some("230800"), None, None),
+            "konsole_version_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
             "Konsole/230800",
-            "konsole_version"
+            "konsole_version_user_agent"
+        );
+
+        let env = FakeEnvironment::new()
+            .with_var("TERM_PROGRAM", "Konsole")
+            .with_var("TERM_PROGRAM_VERSION", "230800");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(
+                TerminalName::Konsole,
+                Some("Konsole"),
+                Some("230800"),
+                None,
+                None
+            ),
+            "konsole_term_program_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "Konsole/230800",
+            "konsole_term_program_user_agent"
         );
 
         let env = FakeEnvironment::new().with_var("KONSOLE_VERSION", "");
-        assert_eq!(detect_terminal_from_env(&env), "Konsole", "konsole_empty");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(TerminalName::Konsole, None, None, None, None),
+            "konsole_empty_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "Konsole",
+            "konsole_empty_user_agent"
+        );
     }
 
     #[test]
     fn detects_gnome_terminal() {
         let env = FakeEnvironment::new().with_var("GNOME_TERMINAL_SCREEN", "1");
+        let terminal = detect_terminal_info_from_env(&env);
         assert_eq!(
-            detect_terminal_from_env(&env),
+            terminal,
+            terminal_info(TerminalName::GnomeTerminal, None, None, None, None),
+            "gnome_terminal_screen_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
             "gnome-terminal",
-            "gnome_terminal_screen"
+            "gnome_terminal_screen_user_agent"
+        );
+
+        let env = FakeEnvironment::new()
+            .with_var("TERM_PROGRAM", "gnome-terminal")
+            .with_var("TERM_PROGRAM_VERSION", "3.50");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(
+                TerminalName::GnomeTerminal,
+                Some("gnome-terminal"),
+                Some("3.50"),
+                None,
+                None,
+            ),
+            "gnome_terminal_term_program_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "gnome-terminal/3.50",
+            "gnome_terminal_term_program_user_agent"
         );
     }
 
     #[test]
     fn detects_vte() {
         let env = FakeEnvironment::new().with_var("VTE_VERSION", "7000");
-        assert_eq!(detect_terminal_from_env(&env), "VTE/7000", "vte_version");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(TerminalName::Vte, None, Some("7000"), None, None),
+            "vte_version_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "VTE/7000",
+            "vte_version_user_agent"
+        );
+
+        let env = FakeEnvironment::new()
+            .with_var("TERM_PROGRAM", "VTE")
+            .with_var("TERM_PROGRAM_VERSION", "7000");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(TerminalName::Vte, Some("VTE"), Some("7000"), None, None),
+            "vte_term_program_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "VTE/7000",
+            "vte_term_program_user_agent"
+        );
 
         let env = FakeEnvironment::new().with_var("VTE_VERSION", "");
-        assert_eq!(detect_terminal_from_env(&env), "VTE", "vte_empty");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(TerminalName::Vte, None, None, None, None),
+            "vte_empty_info"
+        );
+        assert_eq!(terminal.user_agent_token(), "VTE", "vte_empty_user_agent");
     }
 
     #[test]
     fn detects_windows_terminal() {
         let env = FakeEnvironment::new().with_var("WT_SESSION", "1");
+        let terminal = detect_terminal_info_from_env(&env);
         assert_eq!(
-            detect_terminal_from_env(&env),
+            terminal,
+            terminal_info(TerminalName::WindowsTerminal, None, None, None, None),
+            "wt_session_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
             "WindowsTerminal",
-            "wt_session"
+            "wt_session_user_agent"
+        );
+
+        let env = FakeEnvironment::new()
+            .with_var("TERM_PROGRAM", "WindowsTerminal")
+            .with_var("TERM_PROGRAM_VERSION", "1.21");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(
+                TerminalName::WindowsTerminal,
+                Some("WindowsTerminal"),
+                Some("1.21"),
+                None,
+                None,
+            ),
+            "windows_terminal_term_program_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
+            "WindowsTerminal/1.21",
+            "windows_terminal_term_program_user_agent"
         );
     }
 
     #[test]
     fn detects_term_fallbacks() {
         let env = FakeEnvironment::new().with_var("TERM", "xterm-256color");
+        let terminal = detect_terminal_info_from_env(&env);
         assert_eq!(
-            detect_terminal_from_env(&env),
+            terminal,
+            terminal_info(
+                TerminalName::Unknown,
+                None,
+                None,
+                Some("xterm-256color"),
+                None,
+            ),
+            "term_fallback_info"
+        );
+        assert_eq!(
+            terminal.user_agent_token(),
             "xterm-256color",
-            "term_fallback"
+            "term_fallback_user_agent"
         );
 
         let env = FakeEnvironment::new();
-        assert_eq!(detect_terminal_from_env(&env), "unknown", "unknown");
+        let terminal = detect_terminal_info_from_env(&env);
+        assert_eq!(
+            terminal,
+            terminal_info(TerminalName::Unknown, None, None, None, None),
+            "unknown_info"
+        );
+        assert_eq!(terminal.user_agent_token(), "unknown", "unknown_user_agent");
     }
 }

--- a/codex-rs/core/src/terminal.rs
+++ b/codex-rs/core/src/terminal.rs
@@ -2,6 +2,31 @@ use std::sync::OnceLock;
 
 static TERMINAL: OnceLock<String> = OnceLock::new();
 
+/// Environment variable access used by terminal detection.
+///
+/// This trait exists to allow faking the environment in tests.
+trait Environment {
+    /// Returns an environment variable when set.
+    fn var(&self, name: &str) -> Option<String>;
+}
+
+/// Reads environment variables from the running process.
+struct ProcessEnvironment;
+
+impl Environment for ProcessEnvironment {
+    fn var(&self, name: &str) -> Option<String> {
+        match std::env::var(name) {
+            Ok(value) => Some(value),
+            Err(std::env::VarError::NotPresent) => None,
+            Err(std::env::VarError::NotUnicode(_)) => {
+                tracing::warn!("failed to read env var {name}: value not valid UTF-8");
+                None
+            }
+        }
+    }
+}
+
+/// Returns a sanitized terminal identifier for User-Agent strings.
 pub fn user_agent() -> String {
     TERMINAL.get_or_init(detect_terminal).to_string()
 }
@@ -9,64 +34,232 @@ pub fn user_agent() -> String {
 /// Sanitize a header value to be used in a User-Agent string.
 ///
 /// This function replaces any characters that are not allowed in a User-Agent string with an underscore.
-///
-/// # Arguments
-///
-/// * `value` - The value to sanitize.
 fn is_valid_header_value_char(c: char) -> bool {
     c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.' || c == '/'
 }
 
+/// Sanitizes a terminal token for use in User-Agent headers.
+///
+/// Invalid header characters are replaced with underscores.
 fn sanitize_header_value(value: String) -> String {
     value.replace(|c| !is_valid_header_value_char(c), "_")
 }
 
+/// Detects the current terminal from the process environment.
 fn detect_terminal() -> String {
+    detect_terminal_from_env(&ProcessEnvironment)
+}
+
+/// Detects a terminal identifier from an injectable environment.
+///
+/// The logic mirrors the existing detection order, preferring explicit
+/// identifiers like `TERM_PROGRAM` before falling back to capability strings.
+fn detect_terminal_from_env(env: &dyn Environment) -> String {
     sanitize_header_value(
-        if let Ok(tp) = std::env::var("TERM_PROGRAM")
+        if let Some(tp) = env.var("TERM_PROGRAM")
             && !tp.trim().is_empty()
         {
-            let ver = std::env::var("TERM_PROGRAM_VERSION").ok();
+            let ver = env.var("TERM_PROGRAM_VERSION");
             match ver {
                 Some(v) if !v.trim().is_empty() => format!("{tp}/{v}"),
                 _ => tp,
             }
-        } else if let Ok(v) = std::env::var("WEZTERM_VERSION") {
+        } else if let Some(v) = env.var("WEZTERM_VERSION") {
             if !v.trim().is_empty() {
                 format!("WezTerm/{v}")
             } else {
                 "WezTerm".to_string()
             }
-        } else if std::env::var("KITTY_WINDOW_ID").is_ok()
-            || std::env::var("TERM")
+        } else if env.var("KITTY_WINDOW_ID").is_some()
+            || env
+                .var("TERM")
                 .map(|t| t.contains("kitty"))
                 .unwrap_or(false)
         {
             "kitty".to_string()
-        } else if std::env::var("ALACRITTY_SOCKET").is_ok()
-            || std::env::var("TERM")
-                .map(|t| t == "alacritty")
-                .unwrap_or(false)
+        } else if env.var("ALACRITTY_SOCKET").is_some()
+            || env.var("TERM").map(|t| t == "alacritty").unwrap_or(false)
         {
             "Alacritty".to_string()
-        } else if let Ok(v) = std::env::var("KONSOLE_VERSION") {
+        } else if let Some(v) = env.var("KONSOLE_VERSION") {
             if !v.trim().is_empty() {
                 format!("Konsole/{v}")
             } else {
                 "Konsole".to_string()
             }
-        } else if std::env::var("GNOME_TERMINAL_SCREEN").is_ok() {
+        } else if env.var("GNOME_TERMINAL_SCREEN").is_some() {
             return "gnome-terminal".to_string();
-        } else if let Ok(v) = std::env::var("VTE_VERSION") {
+        } else if let Some(v) = env.var("VTE_VERSION") {
             if !v.trim().is_empty() {
                 format!("VTE/{v}")
             } else {
                 "VTE".to_string()
             }
-        } else if std::env::var("WT_SESSION").is_ok() {
+        } else if env.var("WT_SESSION").is_some() {
             return "WindowsTerminal".to_string();
         } else {
-            std::env::var("TERM").unwrap_or_else(|_| "unknown".to_string())
+            env.var("TERM").unwrap_or_else(|| "unknown".to_string())
         },
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use std::collections::HashMap;
+
+    struct FakeEnvironment {
+        vars: HashMap<String, String>,
+    }
+
+    impl FakeEnvironment {
+        fn new() -> Self {
+            Self {
+                vars: HashMap::new(),
+            }
+        }
+
+        fn with_var(mut self, key: &str, value: &str) -> Self {
+            self.vars.insert(key.to_string(), value.to_string());
+            self
+        }
+    }
+
+    impl Environment for FakeEnvironment {
+        fn var(&self, name: &str) -> Option<String> {
+            self.vars.get(name).cloned()
+        }
+    }
+
+    #[test]
+    fn detects_term_program() {
+        let env = FakeEnvironment::new()
+            .with_var("TERM_PROGRAM", "iTerm.app")
+            .with_var("TERM_PROGRAM_VERSION", "3.5.0")
+            .with_var("WEZTERM_VERSION", "2024.2");
+        assert_eq!(
+            detect_terminal_from_env(&env),
+            "iTerm.app/3.5.0",
+            "term_program_with_version"
+        );
+
+        let env = FakeEnvironment::new()
+            .with_var("TERM_PROGRAM", "iTerm.app")
+            .with_var("TERM_PROGRAM_VERSION", "");
+        assert_eq!(
+            detect_terminal_from_env(&env),
+            "iTerm.app",
+            "term_program_without_version"
+        );
+
+        let env = FakeEnvironment::new()
+            .with_var("TERM_PROGRAM", "iTerm.app")
+            .with_var("WEZTERM_VERSION", "2024.2");
+        assert_eq!(
+            detect_terminal_from_env(&env),
+            "iTerm.app",
+            "term_program_overrides_wezterm"
+        );
+    }
+
+    #[test]
+    fn detects_wezterm() {
+        let env = FakeEnvironment::new().with_var("WEZTERM_VERSION", "2024.2");
+        assert_eq!(
+            detect_terminal_from_env(&env),
+            "WezTerm/2024.2",
+            "wezterm_version"
+        );
+
+        let env = FakeEnvironment::new().with_var("WEZTERM_VERSION", "");
+        assert_eq!(detect_terminal_from_env(&env), "WezTerm", "wezterm_empty");
+    }
+
+    #[test]
+    fn detects_kitty() {
+        let env = FakeEnvironment::new().with_var("KITTY_WINDOW_ID", "1");
+        assert_eq!(detect_terminal_from_env(&env), "kitty", "kitty_window_id");
+
+        let env = FakeEnvironment::new()
+            .with_var("TERM", "xterm-kitty")
+            .with_var("ALACRITTY_SOCKET", "/tmp/alacritty");
+        assert_eq!(
+            detect_terminal_from_env(&env),
+            "kitty",
+            "kitty_term_over_alacritty"
+        );
+    }
+
+    #[test]
+    fn detects_alacritty() {
+        let env = FakeEnvironment::new().with_var("ALACRITTY_SOCKET", "/tmp/alacritty");
+        assert_eq!(
+            detect_terminal_from_env(&env),
+            "Alacritty",
+            "alacritty_socket"
+        );
+
+        let env = FakeEnvironment::new().with_var("TERM", "alacritty");
+        assert_eq!(
+            detect_terminal_from_env(&env),
+            "Alacritty",
+            "alacritty_term"
+        );
+    }
+
+    #[test]
+    fn detects_konsole() {
+        let env = FakeEnvironment::new().with_var("KONSOLE_VERSION", "230800");
+        assert_eq!(
+            detect_terminal_from_env(&env),
+            "Konsole/230800",
+            "konsole_version"
+        );
+
+        let env = FakeEnvironment::new().with_var("KONSOLE_VERSION", "");
+        assert_eq!(detect_terminal_from_env(&env), "Konsole", "konsole_empty");
+    }
+
+    #[test]
+    fn detects_gnome_terminal() {
+        let env = FakeEnvironment::new().with_var("GNOME_TERMINAL_SCREEN", "1");
+        assert_eq!(
+            detect_terminal_from_env(&env),
+            "gnome-terminal",
+            "gnome_terminal_screen"
+        );
+    }
+
+    #[test]
+    fn detects_vte() {
+        let env = FakeEnvironment::new().with_var("VTE_VERSION", "7000");
+        assert_eq!(detect_terminal_from_env(&env), "VTE/7000", "vte_version");
+
+        let env = FakeEnvironment::new().with_var("VTE_VERSION", "");
+        assert_eq!(detect_terminal_from_env(&env), "VTE", "vte_empty");
+    }
+
+    #[test]
+    fn detects_windows_terminal() {
+        let env = FakeEnvironment::new().with_var("WT_SESSION", "1");
+        assert_eq!(
+            detect_terminal_from_env(&env),
+            "WindowsTerminal",
+            "wt_session"
+        );
+    }
+
+    #[test]
+    fn detects_term_fallbacks() {
+        let env = FakeEnvironment::new().with_var("TERM", "xterm-256color");
+        assert_eq!(
+            detect_terminal_from_env(&env),
+            "xterm-256color",
+            "term_fallback"
+        );
+
+        let env = FakeEnvironment::new();
+        assert_eq!(detect_terminal_from_env(&env), "unknown", "unknown");
+    }
 }

--- a/codex-rs/tui2/src/lib.rs
+++ b/codex-rs/tui2/src/lib.rs
@@ -320,6 +320,9 @@ pub async fn run_main(
         .with(otel_logger_layer)
         .try_init();
 
+    let terminal_info = codex_core::terminal::terminal_info();
+    tracing::info!(terminal = ?terminal_info, "Detected terminal info");
+
     run_ratatui_app(
         cli,
         config,


### PR DESCRIPTION
# Terminal Detection Metadata for Per-Terminal Scroll Scaling

## Summary
Expand terminal detection into structured metadata (`TerminalInfo`) with multiplexer awareness, plus a testable environment shim and characterization tests.

## Context / Motivation
- TUI2 owns its viewport and scrolling model (see `codex-rs/tui2/docs/tui_viewport_and_history.md`), so scroll behavior must be consistent across terminals and independent of terminal scrollback quirks.
- Prior investigations show mouse wheel scroll deltas vary noticeably by terminal. To tune scroll scaling (line increments per wheel tick) we need reliable terminal identification, including when running inside tmux/zellij.
- tmux is especially tricky because it can mask the underlying terminal; we now consult `tmux display-message` client termtype/name to attribute sessions to the actual terminal rather than tmux itself.
- This remains backwards compatible with the existing OpenTelemetry user-agent token because `user_agent()` is still derived from the same environment signals (now via `TerminalInfo`).

## Changes
- Introduce `TerminalInfo`, `TerminalName`, and `Multiplexer` with `TERM_PROGRAM`/`TERM`/multiplexer detection and user-agent formatting in `codex-rs/core/src/terminal.rs`.
- Add an injectable `Environment` trait + `FakeEnvironment` for testing, and comprehensive characterization tests covering known terminals, tmux client termtype/name, and zellij.
- Document module usage and detection order; update `terminal_info()` to be the primary interface for callers.

## Testing
- `cargo test -p codex-core terminal::tests`
- manually checked ghostty, iTerm2, Terminal.app, vscode, tmux, zellij, Warp, alacritty, kitty.
```
2025-12-18T07:07:49.191421Z  INFO Detected terminal info terminal=TerminalInfo { name: Iterm2, term_program: Some("iTerm.app"), version: Some("3.6.6"), term: None, multiplexer: None }
2025-12-18T07:07:57.991776Z  INFO Detected terminal info terminal=TerminalInfo { name: AppleTerminal, term_program: Some("Apple_Terminal"), version: Some("455.1"), term: None, multiplexer: None }
2025-12-18T07:08:07.732095Z  INFO Detected terminal info terminal=TerminalInfo { name: WarpTerminal, term_program: Some("WarpTerminal"), version: Some("v0.2025.12.10.08.12.stable_03"), term: None, multiplexer: None }
2025-12-18T07:08:24.860316Z  INFO Detected terminal info terminal=TerminalInfo { name: Kitty, term_program: None, version: None, term: None, multiplexer: None }
2025-12-18T07:08:38.302761Z  INFO Detected terminal info terminal=TerminalInfo { name: Alacritty, term_program: None, version: None, term: None, multiplexer: None }
2025-12-18T07:08:50.887748Z  INFO Detected terminal info terminal=TerminalInfo { name: VsCode, term_program: Some("vscode"), version: Some("1.107.1"), term: None, multiplexer: None }
2025-12-18T07:10:01.309802Z  INFO Detected terminal info terminal=TerminalInfo { name: WezTerm, term_program: Some("WezTerm"), version: Some("20240203-110809-5046fc22"), term: None, multiplexer: None }
2025-12-18T08:05:17.009271Z  INFO Detected terminal info terminal=TerminalInfo { name: Ghostty, term_program: Some("ghostty"), version: Some("1.2.3"), term: None, multiplexer: None }
2025-12-18T08:05:23.819973Z  INFO Detected terminal info terminal=TerminalInfo { name: Ghostty, term_program: Some("ghostty"), version: Some("1.2.3"), term: Some("xterm-ghostty"), multiplexer: Some(Tmux { version: Some("3.6a") }) }
2025-12-18T08:05:35.572853Z  INFO Detected terminal info terminal=TerminalInfo { name: Ghostty, term_program: Some("ghostty"), version: Some("1.2.3"), term: None, multiplexer: Some(Zellij) }
```

## Notes / Follow-ups
- Next step is to wire `TerminalInfo` into TUI2’s scroll scaling configuration and add a per-terminal tuning table.
- The log output in TUI2 helps validate real-world detection before applying behavior changes.
