### PR TITLE
docs: clarify codex resume --all (CWD column & filtering)

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,7 +21,8 @@ Key flags: `--model/-m`, `--ask-for-approval/-a`.
 - Run `codex resume` to display the session picker UI
 - Resume most recent: `codex resume --last`
 - Resume by id: `codex resume <SESSION_ID>` (You can get session ids from /status or `~/.codex/sessions/`)
-- The picker shows the session's original working directory and, when available, the Git branch it was recorded on
+- The picker shows the session's recorded Git branch when available.
+- To show the session's original working directory (CWD), run `codex resume --all` (this also disables cwd filtering and adds a `CWD` column).
 
 Examples:
 


### PR DESCRIPTION
This pull request makes a small update to the session picker documentation for `codex resume`. The main change clarifies how to view the original working directory (CWD) for sessions and when the Git branch is shown.

- The session picker now displays the recorded Git branch when available, and instructions are added for showing the original working directory by using the `--all` flag, which also disables CWD filtering and adds a `CWD` column.
