### PR TITLE
grant read ACL to exe directory first so we can call the command runner

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
@@ -195,6 +195,11 @@ fn canonical_existing(paths: &[PathBuf]) -> Vec<PathBuf> {
 
 pub(crate) fn gather_read_roots(command_cwd: &Path, policy: &SandboxPolicy) -> Vec<PathBuf> {
     let mut roots: Vec<PathBuf> = Vec::new();
+    if let Ok(exe) = std::env::current_exe() {
+        if let Some(dir) = exe.parent() {
+            roots.push(dir.to_path_buf());
+        }
+    }
     for p in [
         PathBuf::from(r"C:\Windows"),
         PathBuf::from(r"C:\Program Files"),


### PR DESCRIPTION
when granting read access to the sandbox user, grant the codex/command-runner exe directory first so commands can run before the entire read ACL process is finished.