### PR TITLE
chore: upgrade rmcp crate from 0.10.0 to 0.12.0

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2207,6 +2207,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core 0.23.0",
+ "darling_macro 0.23.0",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2235,6 +2245,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2252,6 +2275,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
 dependencies = [
  "darling_core 0.21.3",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core 0.23.0",
  "quote",
  "syn 2.0.104",
 ]
@@ -5072,9 +5106,9 @@ dependencies = [
 
 [[package]]
 name = "process-wrap"
-version = "8.2.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ef4f2f0422f23a82ec9f628ea2acd12871c81a9362b02c43c1aa86acfc3ba1"
+checksum = "5e5fd83ab7fa55fd06f5e665e3fc52b8bca451c0486b8ea60ad649cd1c10a5da"
 dependencies = [
  "futures",
  "indexmap 2.12.0",
@@ -5484,9 +5518,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b18323edc657390a6ed4d7a9110b0dec2dc3ed128eb2a123edfbafabdbddc5"
+checksum = "528d42f8176e6e5e71ea69182b17d1d0a19a6b3b894b564678b74cd7cab13cfa"
 dependencies = [
  "async-trait",
  "base64",
@@ -5519,11 +5553,11 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "0.10.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c75d0a62676bf8c8003c4e3c348e2ceb6a7b3e48323681aaf177fdccdac2ce50"
+checksum = "e3f81daaa494eb8e985c9462f7d6ce1ab05e5299f48aafd76cdd3d8b060e6f59"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "proc-macro2",
  "quote",
  "serde_json",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -178,7 +178,7 @@ ratatui-macros = "0.6.0"
 regex = "1.12.2"
 regex-lite = "0.1.7"
 reqwest = "0.12"
-rmcp = { version = "0.10.0", default-features = false }
+rmcp = { version = "0.12.0", default-features = false }
 schemars = "0.8.22"
 seccompiler = "0.5.0"
 sentry = "0.46.0"

--- a/codex-rs/exec-server/src/posix/mcp.rs
+++ b/codex-rs/exec-server/src/posix/mcp.rs
@@ -183,10 +183,10 @@ impl ServerHandler for ExecTool {
 
     async fn on_custom_notification(
         &self,
-        notification: rmcp::model::CustomClientNotification,
+        notification: rmcp::model::CustomNotification,
         _context: rmcp::service::NotificationContext<rmcp::RoleServer>,
     ) {
-        let rmcp::model::CustomClientNotification { method, params, .. } = notification;
+        let rmcp::model::CustomNotification { method, params, .. } = notification;
         if method == MCP_SANDBOX_STATE_NOTIFICATION
             && let Some(params) = params
         {

--- a/codex-rs/exec-server/tests/common/lib.rs
+++ b/codex-rs/exec-server/tests/common/lib.rs
@@ -9,7 +9,7 @@ use rmcp::model::ClientCapabilities;
 use rmcp::model::ClientInfo;
 use rmcp::model::CreateElicitationRequestParam;
 use rmcp::model::CreateElicitationResult;
-use rmcp::model::CustomClientNotification;
+use rmcp::model::CustomNotification;
 use rmcp::model::ElicitationAction;
 use rmcp::service::RunningService;
 use rmcp::transport::ConfigureCommandExt;
@@ -129,7 +129,7 @@ async fn send_sandbox_notification<S>(
 where
     S: Service<RoleClient> + ClientHandler,
 {
-    let sandbox_state_notification = CustomClientNotification::new(
+    let sandbox_state_notification = CustomNotification::new(
         MCP_SANDBOX_STATE_NOTIFICATION,
         Some(serde_json::to_value(sandbox_state)?),
     );

--- a/codex-rs/rmcp-client/src/bin/rmcp_test_server.rs
+++ b/codex-rs/rmcp-client/src/bin/rmcp_test_server.rs
@@ -81,6 +81,7 @@ impl ServerHandler for TestToolServer {
             Ok(ListToolsResult {
                 tools: (*tools).clone(),
                 next_cursor: None,
+                meta: None,
             })
         }
     }

--- a/codex-rs/rmcp-client/src/bin/test_stdio_server.rs
+++ b/codex-rs/rmcp-client/src/bin/test_stdio_server.rs
@@ -95,6 +95,7 @@ impl TestToolServer {
             mime_type: Some("text/plain".to_string()),
             size: None,
             icons: None,
+            meta: None,
         };
         Resource::new(raw, None)
     }
@@ -146,6 +147,7 @@ impl ServerHandler for TestToolServer {
             Ok(ListToolsResult {
                 tools: (*tools).clone(),
                 next_cursor: None,
+                meta: None,
             })
         }
     }
@@ -160,6 +162,7 @@ impl ServerHandler for TestToolServer {
             Ok(ListResourcesResult {
                 resources: (*resources).clone(),
                 next_cursor: None,
+                meta: None,
             })
         }
     }
@@ -172,6 +175,7 @@ impl ServerHandler for TestToolServer {
         Ok(ListResourceTemplatesResult {
             resource_templates: (*self.resource_templates).clone(),
             next_cursor: None,
+            meta: None,
         })
     }
 

--- a/codex-rs/rmcp-client/src/bin/test_streamable_http_server.rs
+++ b/codex-rs/rmcp-client/src/bin/test_streamable_http_server.rs
@@ -92,6 +92,7 @@ impl TestToolServer {
             mime_type: Some("text/plain".to_string()),
             size: None,
             icons: None,
+            meta: None,
         };
         Resource::new(raw, None)
     }
@@ -143,6 +144,7 @@ impl ServerHandler for TestToolServer {
             Ok(ListToolsResult {
                 tools: (*tools).clone(),
                 next_cursor: None,
+                meta: None,
             })
         }
     }
@@ -157,6 +159,7 @@ impl ServerHandler for TestToolServer {
             Ok(ListResourcesResult {
                 resources: (*resources).clone(),
                 next_cursor: None,
+                meta: None,
             })
         }
     }
@@ -169,6 +172,7 @@ impl ServerHandler for TestToolServer {
         Ok(ListResourceTemplatesResult {
             resource_templates: (*self.resource_templates).clone(),
             next_cursor: None,
+            meta: None,
         })
     }
 

--- a/codex-rs/rmcp-client/src/rmcp_client.rs
+++ b/codex-rs/rmcp-client/src/rmcp_client.rs
@@ -28,7 +28,7 @@ use rmcp::model::CallToolRequestParam;
 use rmcp::model::ClientNotification;
 use rmcp::model::CreateElicitationRequestParam;
 use rmcp::model::CreateElicitationResult;
-use rmcp::model::CustomClientNotification;
+use rmcp::model::CustomNotification;
 use rmcp::model::Extensions;
 use rmcp::model::InitializeRequestParam;
 use rmcp::model::PaginatedRequestParam;
@@ -372,13 +372,11 @@ impl RmcpClient {
         let service: Arc<RunningService<RoleClient, LoggingClientHandler>> = self.service().await?;
         service.service();
         service
-            .send_notification(ClientNotification::CustomClientNotification(
-                CustomClientNotification {
-                    method: method.to_string(),
-                    params,
-                    extensions: Extensions::new(),
-                },
-            ))
+            .send_notification(ClientNotification::CustomNotification(CustomNotification {
+                method: method.to_string(),
+                params,
+                extensions: Extensions::new(),
+            }))
             .await?;
         Ok(())
     }


### PR DESCRIPTION
Version `0.12.0` includes https://github.com/modelcontextprotocol/rust-sdk/pull/590, which I will use in https://github.com/openai/codex/pull/8142.

Changes:

- `rmcp::model::CustomClientNotification` was renamed to `rmcp::model::CustomNotification`
- a bunch of types have a `meta` field now, but it is `Option`, so I added `meta: None` to a bunch of things