### PR TITLE
Fix admin skills.

### DIFF
--- a/codex-rs/core/src/skills/loader.rs
+++ b/codex-rs/core/src/skills/loader.rs
@@ -148,22 +148,26 @@ pub(crate) fn repo_skills_root(cwd: &Path) -> Option<SkillRoot> {
     })
 }
 
-fn skill_roots(config: &Config) -> Vec<SkillRoot> {
+pub(crate) fn skill_roots_for_cwd(codex_home: &Path, cwd: &Path) -> Vec<SkillRoot> {
     let mut roots = Vec::new();
 
-    if let Some(repo_root) = repo_skills_root(&config.cwd) {
+    if let Some(repo_root) = repo_skills_root(cwd) {
         roots.push(repo_root);
     }
 
     // Load order matters: we dedupe by name, keeping the first occurrence.
     // Priority order: repo, user, system, then admin.
-    roots.push(user_skills_root(&config.codex_home));
-    roots.push(system_skills_root(&config.codex_home));
+    roots.push(user_skills_root(codex_home));
+    roots.push(system_skills_root(codex_home));
     if cfg!(unix) {
         roots.push(admin_skills_root());
     }
 
     roots
+}
+
+fn skill_roots(config: &Config) -> Vec<SkillRoot> {
+    skill_roots_for_cwd(&config.codex_home, &config.cwd)
 }
 
 fn discover_skills_under_root(root: &Path, scope: SkillScope, outcome: &mut SkillLoadOutcome) {

--- a/codex-rs/core/src/skills/manager.rs
+++ b/codex-rs/core/src/skills/manager.rs
@@ -5,9 +5,7 @@ use std::sync::RwLock;
 
 use crate::skills::SkillLoadOutcome;
 use crate::skills::loader::load_skills_from_roots;
-use crate::skills::loader::repo_skills_root;
-use crate::skills::loader::system_skills_root;
-use crate::skills::loader::user_skills_root;
+use crate::skills::loader::skill_roots_for_cwd;
 use crate::skills::system::install_system_skills;
 pub struct SkillsManager {
     codex_home: PathBuf,
@@ -39,12 +37,7 @@ impl SkillsManager {
             return outcome;
         }
 
-        let mut roots = Vec::new();
-        if let Some(repo_root) = repo_skills_root(cwd) {
-            roots.push(repo_root);
-        }
-        roots.push(user_skills_root(&self.codex_home));
-        roots.push(system_skills_root(&self.codex_home));
+        let roots = skill_roots_for_cwd(&self.codex_home, cwd);
         let outcome = load_skills_from_roots(roots);
         match self.cache_by_cwd.write() {
             Ok(mut cache) => {


### PR DESCRIPTION
We were assembling the skill roots in two different places, and the admin root was missing in one of them. This change centralizes root selection into a helper so both paths stay in sync.