### PR TITLE
feat: make ConstraintError an enum

### DIFF
--- a/codex-rs/core/src/config/constraint.rs
+++ b/codex-rs/core/src/config/constraint.rs
@@ -4,25 +4,25 @@ use std::sync::Arc;
 use thiserror::Error;
 
 #[derive(Debug, Error, PartialEq, Eq)]
-#[error("{message}")]
-pub struct ConstraintError {
-    pub message: String,
+pub enum ConstraintError {
+    #[error("value `{candidate}` is not in the allowed set {allowed}")]
+    InvalidValue { candidate: String, allowed: String },
+
+    #[error("field `{field_name}` cannot be empty")]
+    EmptyField { field_name: String },
 }
 
 impl ConstraintError {
     pub fn invalid_value(candidate: impl Into<String>, allowed: impl Into<String>) -> Self {
-        Self {
-            message: format!(
-                "value `{}` is not in the allowed set {}",
-                candidate.into(),
-                allowed.into()
-            ),
+        Self::InvalidValue {
+            candidate: candidate.into(),
+            allowed: allowed.into(),
         }
     }
 
     pub fn empty_field(field_name: impl Into<String>) -> Self {
-        Self {
-            message: format!("field `{}` cannot be empty", field_name.into()),
+        Self::EmptyField {
+            field_name: field_name.into(),
         }
     }
 }

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -2275,12 +2275,12 @@ async fn approvals_popup_shows_disabled_presets() {
     chat.config.approval_policy =
         Constrained::new(AskForApproval::OnRequest, |candidate| match candidate {
             AskForApproval::OnRequest => Ok(()),
-            _ => Err(ConstraintError {
-                message: "this message should be printed in the description".to_string(),
-            }),
+            _ => Err(ConstraintError::invalid_value(
+                candidate.to_string(),
+                "this message should be printed in the description",
+            )),
         })
         .expect("construct constrained approval policy");
-
     chat.open_approvals_popup();
 
     let width = 80;
@@ -2311,12 +2311,12 @@ async fn approvals_popup_navigation_skips_disabled() {
     chat.config.approval_policy =
         Constrained::new(AskForApproval::OnRequest, |candidate| match candidate {
             AskForApproval::OnRequest => Ok(()),
-            _ => Err(ConstraintError {
-                message: "disabled preset".to_string(),
-            }),
+            _ => Err(ConstraintError::invalid_value(
+                candidate.to_string(),
+                "[on-request]",
+            )),
         })
         .expect("construct constrained approval policy");
-
     chat.open_approvals_popup();
 
     // The approvals popup is the active bottom-pane view; drive navigation via chat handle_key_event.


### PR DESCRIPTION
This will make it easier to test for expected errors in unit tests since we can compare based on the field values rather than the message (which might change over time). See https://github.com/openai/codex/pull/8298 for an example.

It also ensures more consistency in the way a `ConstraintError` is constructed.