### PR TITLE
fix: enable resume_warning that was missing from mod.rs

### DIFF
--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -43,6 +43,7 @@ mod quota_exceeded;
 mod read_file;
 mod remote_models;
 mod resume;
+mod resume_warning;
 mod review;
 mod rmcp_client;
 mod rollout_list_find;

--- a/codex-rs/core/tests/suite/resume_warning.rs
+++ b/codex-rs/core/tests/suite/resume_warning.rs
@@ -4,7 +4,6 @@ use codex_core::AuthManager;
 use codex_core::CodexAuth;
 use codex_core::ConversationManager;
 use codex_core::NewConversation;
-use codex_core::built_in_model_providers;
 use codex_core::protocol::EventMsg;
 use codex_core::protocol::InitialHistory;
 use codex_core::protocol::ResumedHistory;


### PR DESCRIPTION
This test was introduced in https://github.com/openai/codex/pull/6507, but was not included in `mod.rs`. It does not appear that it was getting compiled?