### PR TITLE
feat: Follow symlinked skills

### DIFF
--- a/docs/skills.md
+++ b/docs/skills.md
@@ -19,7 +19,7 @@ Skills are behind the experimental `skills` feature flag and are disabled by def
 
 ## Where skills live
 
-- Location (v1): `~/.codex/skills/**/SKILL.md` (recursive). Hidden entries and symlinks are skipped. Only files named exactly `SKILL.md` count.
+- Location (v1): `~/.codex/skills/**/SKILL.md` (recursive). Hidden entries are skipped; symlinks are followed. Only files named exactly `SKILL.md` count.
 - Sorting: rendered by name, then path for stability.
 
 ## File format


### PR DESCRIPTION
Closes #8369

Skills are an open standard and as such it should be easily possible to share skills across different agents. In my case, that involves setting up skills via symlinks.

This PR tracks symlinks in the skills traversal instead of skipping it. Note that symlinks can be recursive so we have to keep track of visited directories during the skills scan.

Disclaimer that the code is 100% written by GPT-5.2-Codex though :) But I did test it locally:

## Before

<img width="2496" height="518" alt="CleanShot 2025-12-20 at 23 46 02@2x" src="https://github.com/user-attachments/assets/e9916a2b-f05a-4ae1-b7e2-4353fae0b551" />

## After

<img width="930" height="560" alt="CleanShot 2025-12-20 at 23 50 44@2x" src="https://github.com/user-attachments/assets/a4be9d49-bd38-432c-9fd6-3b44564bb55a" />

I also ran one of the skills to ensure they work alright!