### PR TITLE
feat(cli): add --format to features list subcommand

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -751,6 +751,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
+
+[[package]]
 name = "bytemuck"
 version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1162,8 +1168,10 @@ dependencies = [
  "predicates",
  "pretty_assertions",
  "regex-lite",
+ "serde",
  "serde_json",
  "supports-color 3.0.2",
+ "tabled",
  "tempfile",
  "tokio",
  "toml 0.9.5",
@@ -4794,6 +4802,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "papergrid"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6978128c8b51d8f4080631ceb2302ab51e32cc6e8615f735ee2f83fd269ae3f1"
+dependencies = [
+ "bytecount",
+ "fnv",
+ "unicode-width 0.2.1",
+]
+
+[[package]]
 name = "parking"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5096,6 +5115,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
 dependencies = [
  "toml_edit",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -6642,6 +6683,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tabled"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e39a2ee1fbcd360805a771e1b300f78cc88fec7b8d3e2f71cd37bbf23e725c7d"
+dependencies = [
+ "papergrid",
+ "tabled_derive",
+ "testing_table",
+]
+
+[[package]]
+name = "tabled_derive"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
+dependencies = [
+ "heck",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6743,6 +6808,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.104",
+]
+
+[[package]]
+name = "testing_table"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
+dependencies = [
+ "unicode-width 0.2.1",
 ]
 
 [[package]]

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -42,8 +42,10 @@ ctor = { workspace = true }
 libc = { workspace = true }
 owo-colors = { workspace = true }
 regex-lite = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 supports-color = { workspace = true }
+tabled = "0.20.0"
 tokio = { workspace = true, features = [
     "io-std",
     "macros",

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -409,7 +409,7 @@ enum FeaturesSubcommand {
 
 #[derive(Debug, Args)]
 struct FeaturesListArgs {
-    /// Output format (plain, table, json, toml)
+    /// Output format (plain, table, markdown, json)
     #[arg(long, value_enum, default_value_t = FeaturesListFormat::Plain)]
     format: FeaturesListFormat,
 }
@@ -418,8 +418,8 @@ struct FeaturesListArgs {
 enum FeaturesListFormat {
     Plain,
     Table,
+    Markdown,
     Json,
-    Toml,
 }
 
 fn stage_str(stage: codex_core::features::Stage) -> &'static str {
@@ -454,7 +454,12 @@ fn write_features_list(rows: &[FeaturesListRow], format: FeaturesListFormat) -> 
         }
         FeaturesListFormat::Table => {
             let mut table = tabled::Table::new(rows.to_vec());
-            table.with(tabled::settings::Style::psql());
+            table.with(tabled::settings::Style::modern_rounded());
+            println!("{table}");
+        }
+        FeaturesListFormat::Markdown => {
+            let mut table = tabled::Table::new(rows.to_vec());
+            table.with(tabled::settings::Style::markdown());
             println!("{table}");
         }
         FeaturesListFormat::Json => {
@@ -463,13 +468,6 @@ fn write_features_list(rows: &[FeaturesListRow], format: FeaturesListFormat) -> 
             };
             let json = serde_json::to_string_pretty(&output)?;
             println!("{json}");
-        }
-        FeaturesListFormat::Toml => {
-            let output = FeaturesListOutput {
-                features: rows.to_vec(),
-            };
-            let toml = toml::to_string_pretty(&output)?;
-            println!("{toml}");
         }
     }
     Ok(())


### PR DESCRIPTION
## Summary
- Add a `--format` option to `codex features list` output.
- Document the available formats via `--help`.

## Key changes
- Add a `--format` flag to `codex features list`.
- Expose the allowed values in help text.

## Help (focused on --format)
```
List known features with their stage and effective state

Usage: codex features list [OPTIONS]

Options:
  ...
      --format <FORMAT>
          Output format (plain, table, markdown, json)
          
          [default: plain]
          [possible values: plain, table, markdown, json]
  ...
```

## Output examples
<details>
<summary>Output examples (trimmed)</summary>

table
```
╭──────────────────────────────┬──────────────┬─────────╮
│ name                         │ stage        │ enabled │
├──────────────────────────────┼──────────────┼─────────┤
│ undo                         │ stable       │ true    │
├──────────────────────────────┼──────────────┼─────────┤
│ parallel                     │ stable       │ true    │
├──────────────────────────────┼──────────────┼─────────┤
│ view_image_tool              │ stable       │ true    │
├──────────────────────────────┼──────────────┼─────────┤
│ ...                          │ ...          │ ...     │
├──────────────────────────────┼──────────────┼─────────┤
│ skills                       │ experimental │ true    │
├──────────────────────────────┼──────────────┼─────────┤
│ tui2                         │ experimental │ false   │
╰──────────────────────────────┴──────────────┴─────────╯
```

markdown
```
| name                         | stage        | enabled |
|------------------------------|--------------|---------|
| undo                         | stable       | true    |
| parallel                     | stable       | true    |
| view_image_tool              | stable       | true    |
| ...                          | ...          | ...     |
| skills                       | experimental | true    |
| tui2                         | experimental | false   |
```

plain
```
undo	stable	true
parallel	stable	true
view_image_tool	stable	true
...
skills	experimental	true
tui2	experimental	false
```

json
```json
{
  "features": [
    { "name": "undo", "stage": "stable", "enabled": true },
    { "name": "parallel", "stage": "stable", "enabled": true },
    { "name": "view_image_tool", "stage": "stable", "enabled": true },
    { "name": "...", "stage": "...", "enabled": "..." },
    { "name": "skills", "stage": "experimental", "enabled": true },
    { "name": "tui2", "stage": "experimental", "enabled": false }
  ]
}
```

</details>

## Discussion
- Should `table` become the default output format? It is more readable and maps fields to headers, but it could break existing expectations around plain output.
- Should the default output format be configurable via the config file?

## Testing
- just fix -p codex-cli
- cargo test -p codex-cli
