### PR TITLE
test(tui2): re-enable ANSI for VT100 tests

### DIFF
--- a/codex-rs/tui2/src/test_backend.rs
+++ b/codex-rs/tui2/src/test_backend.rs
@@ -25,6 +25,7 @@ pub struct VT100Backend {
 impl VT100Backend {
     /// Creates a new `TestBackend` with the specified width and height.
     pub fn new(width: u16, height: u16) -> Self {
+        crossterm::style::Colored::set_ansi_color_disabled(false);
         Self {
             crossterm_backend: CrosstermBackend::new(vt100::Parser::new(height, width, 0)),
         }


### PR DESCRIPTION
Codex Unified Exec injects NO_COLOR=1 (and TERM=dumb) into shell tool commands to keep output stable. Crossterm respects NO_COLOR and suppresses ANSI escapes, which breaks our VT100-backed tests that assert on parsed ANSI color output (they see vt100::Color::Default everywhere).

Force ANSI color output back on in the VT100 test backend by overriding crossterm's memoized NO_COLOR setting in VT100Backend::new. This keeps Unified Exec behavior unchanged while making the VT100 tests meaningful and deterministic under Codex.

> [!WARNING]  
> it's possible that this might be a race condition problem for this and need to be solved a different way. Feel free to revert if it causes the opposite problem for other tests that assume NOCOLOR is set. If it does then we need to probably add some extra AGENTS.md lines for how to run tests when using unified exec.

(this same change was made in tui, so it's probably safe).