### PR TITLE
feat(cli): add --no-tips flag and fix clippy lints

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -760,6 +760,9 @@ fn merge_resume_cli_flags(interactive: &mut TuiCli, resume_cli: TuiCli) {
     if let Some(prompt) = resume_cli.prompt {
         interactive.prompt = Some(prompt);
     }
+    if resume_cli.no_tips {
+        interactive.no_tips = true;
+    }
 
     interactive
         .config_overrides

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -199,6 +199,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
         include_apply_patch_tool: None,
         show_raw_agent_reasoning: oss.then_some(true),
         tools_web_search_request: None,
+        show_tooltips: None,
         additional_writable_roots: add_dir,
     };
 

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -85,6 +85,10 @@ pub struct Cli {
     #[arg(long = "add-dir", value_name = "DIR", value_hint = ValueHint::DirPath)]
     pub add_dir: Vec<PathBuf>,
 
+    /// Disable startup tips in the TUI welcome screen.
+    #[arg(long = "no-tips", default_value_t = false)]
+    pub no_tips: bool,
+
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,
 }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -204,15 +204,21 @@ pub async fn run_main(
 
     let overrides = ConfigOverrides {
         model,
+        review_model: None,
         approval_policy,
         sandbox_mode,
         cwd,
         model_provider: model_provider_override.clone(),
         config_profile: cli.config_profile.clone(),
         codex_linux_sandbox_exe,
+        base_instructions: None,
+        developer_instructions: None,
+        compact_prompt: None,
+        include_apply_patch_tool: None,
         show_raw_agent_reasoning: cli.oss.then_some(true),
+        tools_web_search_request: None,
+        show_tooltips: if cli.no_tips { Some(false) } else { None },
         additional_writable_roots: additional_dirs,
-        ..Default::default()
     };
 
     let config = load_config_or_exit(cli_kv_overrides.clone(), overrides.clone()).await;

--- a/codex-rs/tui2/src/cli.rs
+++ b/codex-rs/tui2/src/cli.rs
@@ -85,6 +85,10 @@ pub struct Cli {
     #[arg(long = "add-dir", value_name = "DIR", value_hint = ValueHint::DirPath)]
     pub add_dir: Vec<PathBuf>,
 
+    /// Disable startup tips in the TUI welcome screen.
+    #[arg(long = "no-tips", default_value_t = false)]
+    pub no_tips: bool,
+
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,
 }
@@ -109,6 +113,7 @@ impl From<codex_tui::Cli> for Cli {
             cwd: cli.cwd,
             web_search: cli.web_search,
             add_dir: cli.add_dir,
+            no_tips: cli.no_tips,
             config_overrides: cli.config_overrides,
         }
     }

--- a/codex-rs/tui2/src/lib.rs
+++ b/codex-rs/tui2/src/lib.rs
@@ -219,6 +219,7 @@ pub async fn run_main(
         show_raw_agent_reasoning: cli.oss.then_some(true),
         tools_web_search_request: None,
         additional_writable_roots: additional_dirs,
+        show_tooltips: if cli.no_tips { Some(false) } else { None },
     };
 
     let config = load_config_or_exit(cli_kv_overrides.clone(), overrides.clone()).await;


### PR DESCRIPTION
## Description
This PR implements the `--no-tips` CLI flag to disable tooltips, adhering to the requested feature. It also addresses various Clippy lints found in the codebase.

## Changes
- Added `--no-tips` flag to CLI arguments.
- Implemented logic to suppress tooltips when the flag is set.
- Fixed CLippy warnings in related files.

## Testing
- Verified manually that `--no-tips` suppresses tooltips.
- `cargo check` and `cargo clippy` pass.