### PR TITLE
add experimental path to skill installer

### DIFF
--- a/codex-rs/core/src/skills/assets/samples/skill-installer/SKILL.md
+++ b/codex-rs/core/src/skills/assets/samples/skill-installer/SKILL.md
@@ -13,6 +13,7 @@ Use the helper scripts based on the task:
 - List curated skills when the user asks what is available, or if the user uses this skill without specifying what to do.
 - Install from the curated list when the user provides a skill name.
 - Install from another repo when the user provides a GitHub repo/path (including private repos).
+- List experimental skills when the user asks (use the experimental path).
 
 Install skills with the helper scripts.
 
@@ -34,6 +35,7 @@ After installing a skill, tell the user: "Restart Codex to pick up new skills."
 All of these scripts use network, so when running in the sandbox, request escalation when running them.
 
 - `scripts/list-curated-skills.py` (prints curated list with installed annotations)
+- `scripts/list-curated-skills.py --path skills/.experimental`
 - `scripts/list-curated-skills.py --format json`
 - `scripts/install-skill-from-github.py --repo <owner>/<repo> --path <path/to/skill> [<path/to/skill> ...]`
 - `scripts/install-skill-from-github.py --url https://github.com/<owner>/<repo>/tree/<ref>/<path>`
@@ -45,11 +47,13 @@ All of these scripts use network, so when running in the sandbox, request escala
 - Aborts if the destination skill directory already exists.
 - Installs into `$CODEX_HOME/skills/<skill-name>` (defaults to `~/.codex/skills`).
 - Multiple `--path` values install multiple skills in one run, each named from the path basename unless `--name` is supplied.
+- When the user asks to list skills for a channel directory (like `skills/.experimental`), call `list-curated-skills.py --path <path>` and present the numbered list.
 - Options: `--ref <ref>` (default `main`), `--dest <path>`, `--method auto|download|git`.
 
 ## Notes
 
 - Curated listing is fetched from `https://github.com/openai/skills/tree/main/skills/.curated` via the GitHub API. If it is unavailable, explain the error and exit.
+- Experimental listing uses `https://github.com/openai/skills/tree/main/skills/.experimental`.
 - Private GitHub repos can be accessed via existing git credentials or optional `GITHUB_TOKEN`/`GH_TOKEN` for download.
 - Git fallback tries HTTPS first, then SSH.
 - The skills at https://github.com/openai/skills/tree/main/skills/.system are preinstalled, so no need to help users install those. If they ask, just explain this. If they insist, you can download and overwrite.


### PR DESCRIPTION
# Update skill-installer guidance to cover experimental skills listing

This PR updates `codex-rs/core/src/skills/assets/samples/skill-installer/SKILL.md` to document how to list skills from `skills/.experimental` using `list-curated-skills.py --path skills/.experimental` or `list-curated-skills.py experimental` (output documented below).

This addresses the issue where the plan skill moved to `.experimental` in 0.77 and is no longer discoverable via the skill-installer workflow.

Issue: [Link](https://github.com/openai/codex/issues/8439)

## Validation output (local rebuild)

```
$ skill-installer experimental

[approved] You approved codex to run /Users/justin.smethers/.codex/skills/.system/skill-installer/scripts/list-cur... this time

- Ran /Users/justin.smethers/.codex/skills/.system/skill-installer/scripts/list-curated-skills.py --path
  | skills/.experimental
  ` zsh:1: permission denied: /Users/justin.smethers/.codex/skills/.system/skill-installer/scripts/list-curated-skills.py

[approved] You approved codex to run python3 /Users/justin.smethers/.codex/skills/.system/skill-installer/scripts/list-curated-skills.py --path skills/.experimental this time

- Ran python3 /Users/justin.smethers/.codex/skills/.system/skill-installer/scripts/list-curated-skills.py --path
  | skills/.experimental
  ` 1. create-plan
    2. linear

--- Worked for 14s ---

- Skills from https://github.com/openai/skills/tree/main/skills/.experimental:

  1. create-plan
  2. linear

  Which ones would you like installed?

$ skill-installer --path=skills/.experimental

- You provided the experimental channel path but not which skill(s) to install. Which of these should I install: create-plan or linear?

$ skill-installer create-plan

[approved] You approved codex to run python3 /Users/justin.smethers/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py this time

- Ran python3 /Users/justin.smethers/.codex/skills/.system/skill-installer/scripts/install-skill-from-github.py
  | --repo openai/skills --path skills/.experimental/create-plan
  ` Installed create-plan to /Users/justin.smethers/.codex/skills/create-plan

--- Worked for 7s ---

- Installed create-plan to /Users/justin.smethers/.codex/skills/create-plan. Restart Codex to pick up new skills.

$ skill-installer

[approved] You approved codex to run python3 /Users/justin.smethers/.codex/skills/.system/skill-installer/scripts/list-curated-skills.py this time

- Ran python3 /Users/justin.smethers/.codex/skills/.system/skill-installer/scripts/list-curated-skills.py
  ` 1. gh-address-comments
    2. gh-fix-ci
    ... +2 lines
    5. notion-research-documentation
    6. notion-spec-to-implementation

--- Worked for 7s ---

- Skills from https://github.com/openai/skills/tree/main/skills/.curated:

  1. gh-address-comments
  2. gh-fix-ci
  3. notion-knowledge-capture
  4. notion-meeting-intelligence
  5. notion-research-documentation
  6. notion-spec-to-implementation

  Which ones would you like installed?
```