### PR TITLE
feat: load ExecPolicyManager from ConfigLayerStack

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -240,7 +240,7 @@ impl Codex {
         )
         .await;
 
-        let exec_policy = ExecPolicyManager::load(&config.features, &config.codex_home)
+        let exec_policy = ExecPolicyManager::load(&config.features, &config.config_layer_stack)
             .await
             .map_err(|err| CodexErr::Fatal(format!("failed to load execpolicy: {err}")))?;
 

--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -28,6 +28,7 @@ pub use config_requirements::ConfigRequirements;
 pub use merge::merge_toml_values;
 pub use state::ConfigLayerEntry;
 pub use state::ConfigLayerStack;
+pub use state::ConfigLayerStackOrdering;
 pub use state::LoaderOverrides;
 
 /// On Unix systems, load requirements from this file path, if present.

--- a/codex-rs/exec-server/src/posix.rs
+++ b/codex-rs/exec-server/src/posix.rs
@@ -230,7 +230,21 @@ fn format_program_name(path: &Path, preserve_program_paths: bool) -> Option<Stri
 
 async fn load_exec_policy() -> anyhow::Result<Policy> {
     let codex_home = find_codex_home().context("failed to resolve codex_home for execpolicy")?;
-    codex_core::load_exec_policy(&codex_home)
+
+    // TODO(mbolin): At a minimum, `cwd` should be configurable via
+    // `codex/sandbox-state/update` or some other custom MCP call.
+    let cwd = None;
+    let cli_overrides = Vec::new();
+    let overrides = codex_core::config_loader::LoaderOverrides::default();
+    let config_layer_stack = codex_core::config_loader::load_config_layers_state(
+        &codex_home,
+        cwd,
+        &cli_overrides,
+        overrides,
+    )
+    .await?;
+
+    codex_core::load_exec_policy(&config_layer_stack)
         .await
         .map_err(anyhow::Error::from)
 }

--- a/codex-rs/utils/absolute-path/src/lib.rs
+++ b/codex-rs/utils/absolute-path/src/lib.rs
@@ -43,6 +43,13 @@ impl AbsolutePathBuf {
         Self::resolve_path_against_base(path, &self.0)
     }
 
+    pub fn parent(&self) -> Option<Self> {
+        self.0.parent().map(|p| {
+            #[expect(clippy::expect_used)]
+            Self::from_absolute_path(p).expect("parent of AbsolutePathBuf must be absolute")
+        })
+    }
+
     pub fn as_path(&self) -> &Path {
         &self.0
     }


### PR DESCRIPTION
https://github.com/openai/codex/pull/8354 added support for in-repo `.config/` files, so this PR updates the logic for loading `*.rules` files to load `*.rules` files from all relevant layers. The main change to the business logic is `load_exec_policy()` in `codex-rs/core/src/exec_policy.rs`.

Note this adds a `config_folder()` method to `ConfigLayerSource` that returns `Option<AbsolutePathBuf>` so that it is straightforward to iterate over the sources and get the associated config folder, if any.