### PR TITLE
chore: include User layer in ConfigLayerStack even if config.toml is empty

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -237,6 +237,8 @@ pub enum ConfigLayerSource {
     #[serde(rename_all = "camelCase")]
     #[ts(rename_all = "camelCase")]
     User {
+        /// This is the path to the user's config.toml file, though it is not
+        /// guaranteed to exist.
         file: AbsolutePathBuf,
     },
 

--- a/codex-rs/core/src/config_loader/tests.rs
+++ b/codex-rs/core/src/config_loader/tests.rs
@@ -88,9 +88,24 @@ async fn returns_empty_when_all_layers_missing() {
     )
     .await
     .expect("load layers");
-    assert!(
-        layers.get_user_layer().is_none(),
-        "no user layer when CODEX_HOME/config.toml does not exist"
+    let user_layer = layers
+        .get_user_layer()
+        .expect("expected a user layer even when CODEX_HOME/config.toml does not exist");
+    assert_eq!(
+        &ConfigLayerEntry {
+            name: super::ConfigLayerSource::User {
+                file: AbsolutePathBuf::resolve_path_against_base(CONFIG_TOML_FILE, tmp.path())
+                    .expect("resolve user config.toml path")
+            },
+            config: TomlValue::Table(toml::map::Map::new()),
+            version: version_for_toml(&TomlValue::Table(toml::map::Map::new())),
+        },
+        user_layer,
+    );
+    assert_eq!(
+        user_layer.config,
+        TomlValue::Table(toml::map::Map::new()),
+        "expected empty config for user layer when config.toml does not exist"
     );
 
     let binding = layers.effective_config();


### PR DESCRIPTION
This is necessary so that `$CODEX_HOME/skills` and `$CODEX_HOME/rules` still get loaded even if `$CODEX_HOME/config.toml` does not exist. See #8453.

For now, it is possible to omit this layer when creating a dummy `ConfigLayerStack` in a test. We can revisit that later, if it turns out to be the right thing to do.