### PR TITLE
chore: save more about turn context in rollout log file

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2514,6 +2514,11 @@ async fn try_run_turn(
         model: turn_context.client.get_model(),
         effort: turn_context.client.get_reasoning_effort(),
         summary: turn_context.client.get_reasoning_summary(),
+        base_instructions: turn_context.base_instructions.clone(),
+        user_instructions: turn_context.user_instructions.clone(),
+        developer_instructions: turn_context.developer_instructions.clone(),
+        final_output_json_schema: turn_context.final_output_json_schema.clone(),
+        truncation_policy: Some(turn_context.truncation_policy.into()),
     });
 
     sess.persist_rollout_items(&[rollout_item]).await;

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -86,6 +86,11 @@ async fn run_compact_task_inner(
         model: turn_context.client.get_model(),
         effort: turn_context.client.get_reasoning_effort(),
         summary: turn_context.client.get_reasoning_summary(),
+        base_instructions: turn_context.base_instructions.clone(),
+        user_instructions: turn_context.user_instructions.clone(),
+        developer_instructions: turn_context.developer_instructions.clone(),
+        final_output_json_schema: turn_context.final_output_json_schema.clone(),
+        truncation_policy: Some(turn_context.truncation_policy.into()),
     });
     sess.persist_rollout_items(&[rollout_item]).await;
 

--- a/codex-rs/core/src/truncate.rs
+++ b/codex-rs/core/src/truncate.rs
@@ -6,6 +6,7 @@ use crate::config::Config;
 use codex_protocol::models::FunctionCallOutputContentItem;
 use codex_protocol::openai_models::TruncationMode;
 use codex_protocol::openai_models::TruncationPolicyConfig;
+use codex_protocol::protocol::TruncationPolicy as ProtocolTruncationPolicy;
 
 const APPROX_BYTES_PER_TOKEN: usize = 4;
 
@@ -13,6 +14,15 @@ const APPROX_BYTES_PER_TOKEN: usize = 4;
 pub enum TruncationPolicy {
     Bytes(usize),
     Tokens(usize),
+}
+
+impl From<TruncationPolicy> for ProtocolTruncationPolicy {
+    fn from(value: TruncationPolicy) -> Self {
+        match value {
+            TruncationPolicy::Bytes(bytes) => Self::Bytes(bytes),
+            TruncationPolicy::Tokens(tokens) => Self::Tokens(tokens),
+        }
+    }
 }
 
 impl From<TruncationPolicyConfig> for TruncationPolicy {

--- a/codex-rs/core/tests/suite/resume_warning.rs
+++ b/codex-rs/core/tests/suite/resume_warning.rs
@@ -28,6 +28,11 @@ fn resume_history(
         model: previous_model.to_string(),
         effort: config.model_reasoning_effort,
         summary: config.model_reasoning_summary,
+        base_instructions: None,
+        user_instructions: None,
+        developer_instructions: None,
+        final_output_json_schema: None,
+        truncation_policy: None,
     };
 
     InitialHistory::Resumed(ResumedHistory {

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -1324,6 +1324,23 @@ pub struct TurnContextItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub effort: Option<ReasoningEffortConfig>,
     pub summary: ReasoningSummaryConfig,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_instructions: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub user_instructions: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub developer_instructions: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub final_output_json_schema: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncation_policy: Option<TruncationPolicy>,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+#[serde(tag = "mode", content = "limit", rename_all = "snake_case")]
+pub enum TruncationPolicy {
+    Bytes(usize),
+    Tokens(usize),
 }
 
 #[derive(Serialize, Deserialize, Clone, JsonSchema)]


### PR DESCRIPTION
### Motivation
- Persist richer per-turn configuration in rollouts so resumed/forked sessions and tooling can reason about the exact instruction inputs and output constraints used for a turn.

### Description
- Extend `TurnContextItem` to include optional `base_instructions`, `user_instructions`, and `developer_instructions`.
- Record the optional `final_output_json_schema` associated with a turn.
- Add an optional `truncation_policy` to `TurnContextItem` and populate it when writing turn-context rollout items.
- Introduce a protocol-level `TruncationPolicy` representation and convert from core truncation policy when recording.

### Testing
- `cargo test -p codex-protocol` (pass)
