### PR TITLE
feat: honor /etc/codex/config.toml

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -227,6 +227,8 @@ pub enum ConfigLayerSource {
     #[serde(rename_all = "camelCase")]
     #[ts(rename_all = "camelCase")]
     System {
+        /// This is the path to the system config.toml file, though it is not
+        /// guaranteed to exist.
         file: AbsolutePathBuf,
     },
 

--- a/codex-rs/app-server/tests/suite/v2/config_rpc.rs
+++ b/codex-rs/app-server/tests/suite/v2/config_rpc.rs
@@ -18,6 +18,7 @@ use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::SandboxMode;
 use codex_app_server_protocol::ToolsV2;
 use codex_app_server_protocol::WriteStatus;
+use codex_core::config_loader::SYSTEM_CONFIG_TOML_FILE_UNIX;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -73,8 +74,7 @@ sandbox_mode = "workspace-write"
         }
     );
     let layers = layers.expect("layers present");
-    assert_eq!(layers.len(), 1);
-    assert_eq!(layers[0].name, ConfigLayerSource::User { file: user_file });
+    assert_layers_user_then_optional_system(&layers, user_file)?;
 
     Ok(())
 }
@@ -136,8 +136,7 @@ view_image = false
     );
 
     let layers = layers.expect("layers present");
-    assert_eq!(layers.len(), 1);
-    assert_eq!(layers[0].name, ConfigLayerSource::User { file: user_file });
+    assert_layers_user_then_optional_system(&layers, user_file)?;
 
     Ok(())
 }
@@ -257,12 +256,7 @@ writable_roots = [{}]
     );
 
     let layers = layers.expect("layers present");
-    assert_eq!(layers.len(), 2);
-    assert_eq!(
-        layers[0].name,
-        ConfigLayerSource::LegacyManagedConfigTomlFromFile { file: managed_file }
-    );
-    assert_eq!(layers[1].name, ConfigLayerSource::User { file: user_file });
+    assert_layers_managed_user_then_optional_system(&layers, managed_file, user_file)?;
 
     Ok(())
 }
@@ -431,5 +425,52 @@ async fn config_batch_write_applies_multiple_edits() -> Result<()> {
     assert_eq!(sandbox.writable_roots, vec![writable_root]);
     assert!(!sandbox.network_access);
 
+    Ok(())
+}
+
+fn assert_layers_user_then_optional_system(
+    layers: &[codex_app_server_protocol::ConfigLayer],
+    user_file: AbsolutePathBuf,
+) -> Result<()> {
+    if cfg!(unix) {
+        let system_file = AbsolutePathBuf::from_absolute_path(SYSTEM_CONFIG_TOML_FILE_UNIX)?;
+        assert_eq!(layers.len(), 2);
+        assert_eq!(layers[0].name, ConfigLayerSource::User { file: user_file });
+        assert_eq!(
+            layers[1].name,
+            ConfigLayerSource::System { file: system_file }
+        );
+    } else {
+        assert_eq!(layers.len(), 1);
+        assert_eq!(layers[0].name, ConfigLayerSource::User { file: user_file });
+    }
+    Ok(())
+}
+
+fn assert_layers_managed_user_then_optional_system(
+    layers: &[codex_app_server_protocol::ConfigLayer],
+    managed_file: AbsolutePathBuf,
+    user_file: AbsolutePathBuf,
+) -> Result<()> {
+    if cfg!(unix) {
+        let system_file = AbsolutePathBuf::from_absolute_path(SYSTEM_CONFIG_TOML_FILE_UNIX)?;
+        assert_eq!(layers.len(), 3);
+        assert_eq!(
+            layers[0].name,
+            ConfigLayerSource::LegacyManagedConfigTomlFromFile { file: managed_file }
+        );
+        assert_eq!(layers[1].name, ConfigLayerSource::User { file: user_file });
+        assert_eq!(
+            layers[2].name,
+            ConfigLayerSource::System { file: system_file }
+        );
+    } else {
+        assert_eq!(layers.len(), 2);
+        assert_eq!(
+            layers[0].name,
+            ConfigLayerSource::LegacyManagedConfigTomlFromFile { file: managed_file }
+        );
+        assert_eq!(layers[1].name, ConfigLayerSource::User { file: user_file });
+    }
     Ok(())
 }

--- a/codex-rs/core/src/config/service.rs
+++ b/codex-rs/core/src/config/service.rs
@@ -778,15 +778,41 @@ remote_compaction = true
             },
         );
         let layers = response.layers.expect("layers present");
-        assert_eq!(layers.len(), 2, "expected two layers");
-        assert_eq!(
-            layers.first().unwrap().name,
-            ConfigLayerSource::LegacyManagedConfigTomlFromFile { file: managed_file }
-        );
-        assert_eq!(
-            layers.get(1).unwrap().name,
-            ConfigLayerSource::User { file: user_file }
-        );
+        if cfg!(unix) {
+            let system_file = AbsolutePathBuf::from_absolute_path(
+                crate::config_loader::SYSTEM_CONFIG_TOML_FILE_UNIX,
+            )
+            .expect("system file");
+            assert_eq!(layers.len(), 3, "expected three layers on unix");
+            assert_eq!(
+                layers.first().unwrap().name,
+                ConfigLayerSource::LegacyManagedConfigTomlFromFile {
+                    file: managed_file.clone()
+                }
+            );
+            assert_eq!(
+                layers.get(1).unwrap().name,
+                ConfigLayerSource::User {
+                    file: user_file.clone()
+                }
+            );
+            assert_eq!(
+                layers.get(2).unwrap().name,
+                ConfigLayerSource::System { file: system_file }
+            );
+        } else {
+            assert_eq!(layers.len(), 2, "expected two layers");
+            assert_eq!(
+                layers.first().unwrap().name,
+                ConfigLayerSource::LegacyManagedConfigTomlFromFile {
+                    file: managed_file.clone()
+                }
+            );
+            assert_eq!(
+                layers.get(1).unwrap().name,
+                ConfigLayerSource::User { file: user_file }
+            );
+        }
     }
 
     #[tokio::test]

--- a/codex-rs/core/src/config_loader/state.rs
+++ b/codex-rs/core/src/config_loader/state.rs
@@ -55,7 +55,7 @@ impl ConfigLayerEntry {
     pub fn config_folder(&self) -> Option<AbsolutePathBuf> {
         match &self.name {
             ConfigLayerSource::Mdm { .. } => None,
-            ConfigLayerSource::System { .. } => None,
+            ConfigLayerSource::System { file } => file.parent(),
             ConfigLayerSource::User { file } => file.parent(),
             ConfigLayerSource::Project { dot_codex_folder } => Some(dot_codex_folder.clone()),
             ConfigLayerSource::SessionFlags => None,

--- a/codex-rs/core/src/config_loader/tests.rs
+++ b/codex-rs/core/src/config_loader/tests.rs
@@ -119,9 +119,10 @@ async fn returns_empty_when_all_layers_missing() {
         .iter()
         .filter(|layer| matches!(layer.name, super::ConfigLayerSource::System { .. }))
         .count();
+    let expected_system_layers = if cfg!(unix) { 1 } else { 0 };
     assert_eq!(
-        num_system_layers, 0,
-        "managed config layer should be absent when file missing"
+        num_system_layers, expected_system_layers,
+        "system layer should be present only on unix"
     );
 
     #[cfg(not(target_os = "macos"))]


### PR DESCRIPTION
This adds logic to load `/etc/codex/config.toml` and associate it with `ConfigLayerSource::System` on UNIX. I refactored the code so it shares logic with the creation of the `ConfigLayerSource::User` layer.