### PR TITLE
feat(tui): persist approval policy selection (Fixes #8193)

### DIFF
--- a/codex-rs/core/src/config/edit.rs
+++ b/codex-rs/core/src/config/edit.rs
@@ -643,6 +643,14 @@ impl ConfigEditsBuilder {
         self
     }
 
+    pub fn set_approval_policy(mut self, policy: crate::protocol::AskForApproval) -> Self {
+        self.edits.push(ConfigEdit::SetPath {
+            segments: vec!["approval_policy".to_string()],
+            value: value(policy.to_string()),
+        });
+        self
+    }
+
     pub fn set_project_trust_level<P: Into<PathBuf>>(
         mut self,
         project_path: P,

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -118,6 +118,9 @@ pub(crate) enum AppEvent {
     /// Update the current sandbox policy in the running app and widget.
     UpdateSandboxPolicy(SandboxPolicy),
 
+    /// Persist the selected approval policy to the config.
+    PersistAskForApprovalPolicy(AskForApproval),
+
     /// Update feature flags and persist them to the top-level config.
     UpdateFeatureFlags {
         updates: Vec<(Feature, bool)>,

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2838,6 +2838,7 @@ impl ChatWidget {
                 summary: None,
             }));
             tx.send(AppEvent::UpdateAskForApprovalPolicy(approval));
+            tx.send(AppEvent::PersistAskForApprovalPolicy(approval));
             tx.send(AppEvent::UpdateSandboxPolicy(sandbox_clone));
         })]
     }


### PR DESCRIPTION
This PR fixes Issue #8193 by enforcing persistence of the approval policy when it is changed via the TUI (e.g., through the Approval Preset menu). Previously, these changes were session-ephemeral. This implementation utilizes `ConfigEditsBuilder` to update the `config.toml` file.