### PR TITLE
fix: fix test that was writing temp file to cwd instead of TMPDIR

### DIFF
--- a/codex-rs/tui/src/diff_render.rs
+++ b/codex-rs/tui/src/diff_render.rs
@@ -557,23 +557,15 @@ mod tests {
 
     #[test]
     fn ui_snapshot_apply_delete_block() {
-        // Write a temporary file so the delete renderer can read original content
-        let tmp_path = PathBuf::from("tmp_delete_example.txt");
-        std::fs::write(&tmp_path, "first\nsecond\nthird\n").expect("write tmp file");
-
         let mut changes: HashMap<PathBuf, FileChange> = HashMap::new();
         changes.insert(
-            tmp_path.clone(),
+            PathBuf::from("tmp_delete_example.txt"),
             FileChange::Delete {
                 content: "first\nsecond\nthird\n".to_string(),
             },
         );
 
         let lines = diff_summary_for_tests(&changes);
-
-        // Cleanup best-effort; rendering has already read the file
-        let _ = std::fs::remove_file(&tmp_path);
-
         snapshot_lines("apply_delete_block", lines, 80, 12);
     }
 

--- a/codex-rs/tui2/src/diff_render.rs
+++ b/codex-rs/tui2/src/diff_render.rs
@@ -568,23 +568,15 @@ mod tests {
 
     #[test]
     fn ui_snapshot_apply_delete_block() {
-        // Write a temporary file so the delete renderer can read original content
-        let tmp_path = PathBuf::from("tmp_delete_example.txt");
-        std::fs::write(&tmp_path, "first\nsecond\nthird\n").expect("write tmp file");
-
         let mut changes: HashMap<PathBuf, FileChange> = HashMap::new();
         changes.insert(
-            tmp_path.clone(),
+            PathBuf::from("tmp_delete_example.txt"),
             FileChange::Delete {
                 content: "first\nsecond\nthird\n".to_string(),
             },
         );
 
         let lines = diff_summary_for_tests(&changes);
-
-        // Cleanup best-effort; rendering has already read the file
-        let _ = std::fs::remove_file(&tmp_path);
-
         snapshot_lines("apply_delete_block", lines, 80, 12);
     }
 


### PR DESCRIPTION
I am trying to support building with [Buck2](https://buck2.build), which reports which files have changed between invocations of `buck2 test` and `tmp_delete_example.txt` came up. This turned out to be the reason.