### PR TITLE
perf(tui): cap redraw scheduling to 60fps

### DIFF
--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -47,6 +47,7 @@ use crate::tui::event_stream::TuiEventStream;
 use crate::tui::job_control::SuspendContext;
 
 mod event_stream;
+mod frame_rate_limiter;
 mod frame_requester;
 #[cfg(unix)]
 mod job_control;

--- a/codex-rs/tui/src/tui/frame_rate_limiter.rs
+++ b/codex-rs/tui/src/tui/frame_rate_limiter.rs
@@ -1,0 +1,62 @@
+//! Limits how frequently frame draw notifications may be emitted.
+//!
+//! Widgets sometimes call `FrameRequester::schedule_frame()` more frequently than a user can
+//! perceive. This limiter clamps draw notifications to a maximum of 60 FPS to avoid wasted work.
+//!
+//! This is intentionally a small, pure helper so it can be unit-tested in isolation and used by
+//! the async frame scheduler without adding complexity to the app/event loop.
+
+use std::time::Duration;
+use std::time::Instant;
+
+/// A 60 FPS minimum frame interval (≈16.67ms).
+pub(super) const MIN_FRAME_INTERVAL: Duration = Duration::from_nanos(16_666_667);
+
+/// Remembers the most recent emitted draw, allowing deadlines to be clamped forward.
+#[derive(Debug, Default)]
+pub(super) struct FrameRateLimiter {
+    last_emitted_at: Option<Instant>,
+}
+
+impl FrameRateLimiter {
+    /// Returns `requested`, clamped forward if it would exceed the maximum frame rate.
+    pub(super) fn clamp_deadline(&self, requested: Instant) -> Instant {
+        let Some(last_emitted_at) = self.last_emitted_at else {
+            return requested;
+        };
+        let min_allowed = last_emitted_at
+            .checked_add(MIN_FRAME_INTERVAL)
+            .unwrap_or(last_emitted_at);
+        requested.max(min_allowed)
+    }
+
+    /// Records that a draw notification was emitted at `emitted_at`.
+    pub(super) fn mark_emitted(&mut self, emitted_at: Instant) {
+        self.last_emitted_at = Some(emitted_at);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn default_does_not_clamp() {
+        let t0 = Instant::now();
+        let limiter = FrameRateLimiter::default();
+        assert_eq!(limiter.clamp_deadline(t0), t0);
+    }
+
+    #[test]
+    fn clamps_to_min_interval_since_last_emit() {
+        let t0 = Instant::now();
+        let mut limiter = FrameRateLimiter::default();
+
+        assert_eq!(limiter.clamp_deadline(t0), t0);
+        limiter.mark_emitted(t0);
+
+        let too_soon = t0 + Duration::from_millis(1);
+        assert_eq!(limiter.clamp_deadline(too_soon), t0 + MIN_FRAME_INTERVAL);
+    }
+}

--- a/codex-rs/tui2/src/app.rs
+++ b/codex-rs/tui2/src/app.rs
@@ -1114,9 +1114,8 @@ impl App {
                 .scrolled_by(delta_lines, &line_meta, visible_lines);
 
         if schedule_frame {
-            // Delay redraws slightly so scroll bursts coalesce into a single frame.
-            tui.frame_requester()
-                .schedule_frame_in(Duration::from_millis(16));
+            // Request a redraw; the frame scheduler coalesces bursts and clamps to 60fps.
+            tui.frame_requester().schedule_frame();
         }
     }
 

--- a/codex-rs/tui2/src/pager_overlay.rs
+++ b/codex-rs/tui2/src/pager_overlay.rs
@@ -1,6 +1,5 @@
 use std::io::Result;
 use std::sync::Arc;
-use std::time::Duration;
 
 use crate::history_cell::HistoryCell;
 use crate::history_cell::UserHistoryCell;
@@ -280,8 +279,8 @@ impl PagerView {
                 return Ok(());
             }
         }
-        tui.frame_requester()
-            .schedule_frame_in(Duration::from_millis(16));
+        // Request a redraw; the frame scheduler coalesces bursts and clamps to 60fps.
+        tui.frame_requester().schedule_frame();
         Ok(())
     }
 
@@ -298,8 +297,8 @@ impl PagerView {
                 return Ok(());
             }
         }
-        tui.frame_requester()
-            .schedule_frame_in(Duration::from_millis(16));
+        // Request a redraw; the frame scheduler coalesces bursts and clamps to 60fps.
+        tui.frame_requester().schedule_frame();
         Ok(())
     }
 

--- a/codex-rs/tui2/src/tui.rs
+++ b/codex-rs/tui2/src/tui.rs
@@ -47,6 +47,7 @@ use crate::tui::job_control::SUSPEND_KEY;
 use crate::tui::job_control::SuspendContext;
 
 mod alt_screen_nesting;
+mod frame_rate_limiter;
 mod frame_requester;
 #[cfg(unix)]
 mod job_control;

--- a/codex-rs/tui2/src/tui/frame_rate_limiter.rs
+++ b/codex-rs/tui2/src/tui/frame_rate_limiter.rs
@@ -1,0 +1,62 @@
+//! Limits how frequently frame draw notifications may be emitted.
+//!
+//! Widgets sometimes call `FrameRequester::schedule_frame()` more frequently than a user can
+//! perceive. This limiter clamps draw notifications to a maximum of 60 FPS to avoid wasted work.
+//!
+//! This is intentionally a small, pure helper so it can be unit-tested in isolation and used by
+//! the async frame scheduler without adding complexity to the app/event loop.
+
+use std::time::Duration;
+use std::time::Instant;
+
+/// A 60 FPS minimum frame interval (≈16.67ms).
+pub(super) const MIN_FRAME_INTERVAL: Duration = Duration::from_nanos(16_666_667);
+
+/// Remembers the most recent emitted draw, allowing deadlines to be clamped forward.
+#[derive(Debug, Default)]
+pub(super) struct FrameRateLimiter {
+    last_emitted_at: Option<Instant>,
+}
+
+impl FrameRateLimiter {
+    /// Returns `requested`, clamped forward if it would exceed the maximum frame rate.
+    pub(super) fn clamp_deadline(&self, requested: Instant) -> Instant {
+        let Some(last_emitted_at) = self.last_emitted_at else {
+            return requested;
+        };
+        let min_allowed = last_emitted_at
+            .checked_add(MIN_FRAME_INTERVAL)
+            .unwrap_or(last_emitted_at);
+        requested.max(min_allowed)
+    }
+
+    /// Records that a draw notification was emitted at `emitted_at`.
+    pub(super) fn mark_emitted(&mut self, emitted_at: Instant) {
+        self.last_emitted_at = Some(emitted_at);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn default_does_not_clamp() {
+        let t0 = Instant::now();
+        let limiter = FrameRateLimiter::default();
+        assert_eq!(limiter.clamp_deadline(t0), t0);
+    }
+
+    #[test]
+    fn clamps_to_min_interval_since_last_emit() {
+        let t0 = Instant::now();
+        let mut limiter = FrameRateLimiter::default();
+
+        assert_eq!(limiter.clamp_deadline(t0), t0);
+        limiter.mark_emitted(t0);
+
+        let too_soon = t0 + Duration::from_millis(1);
+        assert_eq!(limiter.clamp_deadline(too_soon), t0 + MIN_FRAME_INTERVAL);
+    }
+}


### PR DESCRIPTION
Clamp frame draw notifications in the `FrameRequester` scheduler so we don't redraw more frequently than a user can perceive.

This applies to both `codex-tui` and `codex-tui2`, and keeps the draw/dispatch loops simple by centralizing the rate limiting in a small helper module.

- Add `FrameRateLimiter` (pure, unit-tested) to clamp draw deadlines
- Apply the limiter in the scheduler before emitting `TuiEvent::Draw`
- Use immediate redraw requests for scroll paths (scheduler now coalesces + clamps)
- Add scheduler tests covering immediate/delayed interactions
