### PR TITLE
fix(core): batch record parallel tool outputs to prevent partial history state

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2477,16 +2477,19 @@ async fn drain_in_flight(
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
 ) -> CodexResult<()> {
+    let mut items = Vec::new();
     while let Some(res) = in_flight.next().await {
         match res {
             Ok(response_input) => {
-                sess.record_conversation_items(&turn_context, &[response_input.into()])
-                    .await;
+                items.push(response_input.into());
             }
             Err(err) => {
                 error_or_panic(format!("in-flight tool future failed during drain: {err}"));
             }
         }
+    }
+    if !items.is_empty() {
+        sess.record_conversation_items(&turn_context, &items).await;
     }
     Ok(())
 }


### PR DESCRIPTION
## Problem
When processing parallel tool calls, [drain_in_flight](cci:1://file:///Users/galaxy/Project/GalaxyAI/codex/codex-rs/core/src/codex.rs:2474:0-2494:1) was recording output items one by one as they completed. This created a race condition where the conversation history could be in an inconsistent state (containing a tool call without its corresponding output) if inspected by a background task (like auto-compact or seatbelt) during the draining process. This resulted in "tool_call_id missing response" errors (GitHub Issue #8479).
## Solution
Modified [drain_in_flight](cci:1://file:///Users/galaxy/Project/GalaxyAI/codex/codex-rs/core/src/codex.rs:2474:0-2494:1) in [core/src/codex.rs](cci:7://file:///Users/galaxy/Project/GalaxyAI/codex/codex-rs/core/src/codex.rs:0:0-0:0) to:
1. Collect all completed tool outputs from the current batch into a `Vec`.
2. Record them to the conversation history in a single atomic [record_conversation_items](cci:1://file:///Users/galaxy/Project/GalaxyAI/codex/codex-rs/core/src/codex.rs:1163:4-1173:5) call.
## Validation
- `cargo check -p codex-core` passed.
- `cargo clippy -p codex-core` passed.
- `cargo test -p codex-core` passed.