### PR TITLE
fix:unexpected status 403 forbedden

### DIFF
--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -54,7 +54,7 @@ os_info = { workspace = true }
 rand = { workspace = true }
 regex = { workspace = true }
 regex-lite = { workspace = true }
-reqwest = { workspace = true, features = ["json", "stream"] }
+reqwest = { workspace = true, features = ["json", "stream", "cookies", "brotli"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }

--- a/codex-rs/core/src/default_client.rs
+++ b/codex-rs/core/src/default_client.rs
@@ -135,14 +135,21 @@ pub fn create_client() -> CodexHttpClient {
 
 pub fn build_reqwest_client() -> reqwest::Client {
     use reqwest::header::HeaderMap;
+    use reqwest::header::HeaderValue;
 
     let mut headers = HeaderMap::new();
     headers.insert("originator", originator().header_value.clone());
+    // Add browser-like headers to help avoid Cloudflare bot detection
+    headers.insert("Accept", HeaderValue::from_static("application/json, text/plain, */*"));
+    headers.insert("Accept-Language", HeaderValue::from_static("en-US,en;q=0.9"));
+    headers.insert("Accept-Encoding", HeaderValue::from_static("gzip, deflate, br"));
     let ua = get_codex_user_agent();
 
     let mut builder = reqwest::Client::builder()
         // Set UA via dedicated helper to avoid header validation pitfalls
         .user_agent(ua)
+        // Enable cookie store to handle session cookies from Cloudflare/auth endpoints
+        .cookie_store(true)
         .default_headers(headers);
     if is_sandboxed() {
         builder = builder.no_proxy();


### PR DESCRIPTION
# Problem
Codex CLI is receiving a 403 Forbidden response from Cloudflare when making requests to [https://chatgpt.com/backend-api/codex/responses](https://chatgpt.com/backend-api/codex/responses). The response is a Cloudflare challenge page ("Just a moment... Enable JavaScript and cookies to continue"), indicating Cloudflare is blocking the request before it reaches the backend API(#8516 ).
# Solution
1. Improved Cloudflare Challenge Detection
File: `codex-rs/core/src/error.rs`
Enhanced `UnexpectedResponseError::friendly_message()` to detect Cloudflare challenge pages by identifying common markers and providing clearer, actionable error messages, with tests added to validate challenge detection.
File: `codex-rs/core/src/api_bridge.rs`
Added specific handling for 403 Forbidden responses by detecting Cloudflare challenge pages, converting them into retryable Stream errors with a suggested 2-second retry delay, while preserving the request ID for debugging.
2. Cookie Store Support
File: `codex-rs/core/src/default_client.rs`
Enabled `.cookie_store(true)` on the reqwest client builder to persist and automatically send cookies, improving compatibility with Cloudflare session handling and authentication flows.
3. Browser-Like Headers
File: `codex-rs/core/src/default_client.rs`
Added browser-like request headers (`Accept`, `Accept-Language`, and `Accept-Encoding`) to make requests appear more human and reduce bot detection.
