### PR TITLE
fix: restrict windows-sys to Windows target

### DIFF
--- a/codex-rs/windows-sandbox-rs/Cargo.toml
+++ b/codex-rs/windows-sandbox-rs/Cargo.toml
@@ -47,7 +47,7 @@ version = "0.8"
 [dependencies.dirs-next]
 version = "2.0"
 
-[dependencies.windows-sys]
+[target.'cfg(windows)'.dependencies.windows-sys]
 features = [
     "Win32_Foundation",
     "Win32_System_Diagnostics_Debug",


### PR DESCRIPTION
I attempted to build codex on LoongArch Linux and encountered compilation errors.
After investigation, the errors were traced to certain `windows-sys` features
which rely on platform-specific cfgs that only support x86 and aarch64.

With this change applied, the project now builds and runs successfully on my
platform:
- OS: AOSC OS (loongarch64)
- Kernel: Linux 6.17
- CPU: Loongson-3A6000

Please let me know if this approach is reasonable, or if there is a better way
to support additional platforms.