### PR TITLE
fix: add tui.alternate_screen config and --no-alt-screen CLI flag for Zellij scrollback

### DIFF
--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -95,7 +95,6 @@ function detectPackageManager() {
     return "bun";
   }
 
-
   if (
     __dirname.includes(".bun/install/global") ||
     __dirname.includes(".bun\\install\\global")

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1632,6 +1632,7 @@ persistence = "none"
                 scroll_wheel_tick_detect_max_ms: None,
                 scroll_wheel_like_max_duration_ms: None,
                 scroll_invert: false,
+                alternate_screen: AltScreenMode::Auto,
             }
         );
     }

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -32,6 +32,7 @@ use crate::protocol::AskForApproval;
 use crate::protocol::SandboxPolicy;
 use codex_app_server_protocol::Tools;
 use codex_app_server_protocol::UserSavedConfig;
+use codex_protocol::config_types::AltScreenMode;
 use codex_protocol::config_types::ForcedLoginMethod;
 use codex_protocol::config_types::ReasoningSummary;
 use codex_protocol::config_types::SandboxMode;
@@ -235,6 +236,14 @@ pub struct Config {
     /// This is the same `tui.scroll_invert` value from `config.toml` (see [`Tui`]) and is applied
     /// consistently to both mouse wheels and trackpads.
     pub tui_scroll_invert: bool,
+
+    /// Controls whether the TUI uses the terminal's alternate screen buffer.
+    ///
+    /// This is the same `tui.alternate_screen` value from `config.toml` (see [`Tui`]).
+    /// - `auto` (default): Disable alternate screen in Zellij, enable elsewhere.
+    /// - `always`: Always use alternate screen (original behavior).
+    /// - `never`: Never use alternate screen (inline mode, preserves scrollback).
+    pub tui_alternate_screen: AltScreenMode,
 
     /// The directory that should be treated as the current working directory
     /// for the session. All relative paths inside the business-logic layer are
@@ -1431,6 +1440,11 @@ impl Config {
                 .as_ref()
                 .and_then(|t| t.scroll_wheel_like_max_duration_ms),
             tui_scroll_invert: cfg.tui.as_ref().map(|t| t.scroll_invert).unwrap_or(false),
+            tui_alternate_screen: cfg
+                .tui
+                .as_ref()
+                .map(|t| t.alternate_screen)
+                .unwrap_or_default(),
             otel: {
                 let t: OtelConfigToml = cfg.otel.unwrap_or_default();
                 let log_user_prompt = t.log_user_prompt.unwrap_or(false);
@@ -3233,6 +3247,7 @@ model_verbosity = "high"
                 tui_scroll_wheel_tick_detect_max_ms: None,
                 tui_scroll_wheel_like_max_duration_ms: None,
                 tui_scroll_invert: false,
+                tui_alternate_screen: AltScreenMode::Auto,
                 otel: OtelConfig::default(),
             },
             o3_profile_config
@@ -3317,6 +3332,7 @@ model_verbosity = "high"
             tui_scroll_wheel_tick_detect_max_ms: None,
             tui_scroll_wheel_like_max_duration_ms: None,
             tui_scroll_invert: false,
+            tui_alternate_screen: AltScreenMode::Auto,
             otel: OtelConfig::default(),
         };
 
@@ -3416,6 +3432,7 @@ model_verbosity = "high"
             tui_scroll_wheel_tick_detect_max_ms: None,
             tui_scroll_wheel_like_max_duration_ms: None,
             tui_scroll_invert: false,
+            tui_alternate_screen: AltScreenMode::Auto,
             otel: OtelConfig::default(),
         };
 
@@ -3501,6 +3518,7 @@ model_verbosity = "high"
             tui_scroll_wheel_tick_detect_max_ms: None,
             tui_scroll_wheel_like_max_duration_ms: None,
             tui_scroll_invert: false,
+            tui_alternate_screen: AltScreenMode::Auto,
             otel: OtelConfig::default(),
         };
 

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -3,6 +3,7 @@
 // Note this file should generally be restricted to simple struct/enum
 // definitions that do not contain business logic.
 
+pub use codex_protocol::config_types::AltScreenMode;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -514,6 +515,17 @@ pub struct Tui {
     /// wheel and trackpad input.
     #[serde(default)]
     pub scroll_invert: bool,
+
+    /// Controls whether the TUI uses the terminal's alternate screen buffer.
+    ///
+    /// - `auto` (default): Disable alternate screen in Zellij, enable elsewhere.
+    /// - `always`: Always use alternate screen (original behavior).
+    /// - `never`: Never use alternate screen (inline mode only, preserves scrollback).
+    ///
+    /// Using alternate screen provides a cleaner fullscreen experience but prevents
+    /// scrollback in terminal multiplexers like Zellij that follow the xterm spec.
+    #[serde(default)]
+    pub alternate_screen: AltScreenMode,
 }
 
 const fn default_true() -> bool {

--- a/codex-rs/protocol/src/config_types.rs
+++ b/codex-rs/protocol/src/config_types.rs
@@ -83,10 +83,27 @@ pub enum TrustLevel {
 
 /// Controls whether the TUI uses the terminal's alternate screen buffer.
 ///
-/// Using alternate screen provides a cleaner fullscreen experience but prevents
-/// scrollback in terminal multiplexers like Zellij that follow the xterm spec
-/// (which says alternate screen should not have scrollback).
-#[derive(Debug, Serialize, Deserialize, Default, Clone, Copy, PartialEq, Eq, Display, JsonSchema, TS)]
+/// **Background:** The alternate screen buffer provides a cleaner fullscreen experience
+/// without polluting the terminal's scrollback history. However, it conflicts with terminal
+/// multiplexers like Zellij that strictly follow the xterm specification, which defines
+/// that alternate screen buffers should not have scrollback.
+///
+/// **Zellij's behavior:** Zellij intentionally disables scrollback in alternate screen mode
+/// (see https://github.com/zellij-org/zellij/pull/1032) to comply with the xterm spec. This
+/// is by design and not configurable in Zellij—there is no option to enable scrollback in
+/// alternate screen mode.
+///
+/// **Solution:** This setting provides a pragmatic workaround:
+/// - `auto` (default): Automatically detect the terminal multiplexer. If running in Zellij,
+///   disable alternate screen to preserve scrollback. Enable it everywhere else.
+/// - `always`: Always use alternate screen mode (original behavior before this fix).
+/// - `never`: Never use alternate screen mode. Runs in inline mode, preserving scrollback
+///   in all multiplexers.
+///
+/// The CLI flag `--no-alt-screen` can override this setting at runtime.
+#[derive(
+    Debug, Serialize, Deserialize, Default, Clone, Copy, PartialEq, Eq, Display, JsonSchema, TS,
+)]
 #[serde(rename_all = "lowercase")]
 #[strum(serialize_all = "lowercase")]
 pub enum AltScreenMode {

--- a/codex-rs/protocol/src/config_types.rs
+++ b/codex-rs/protocol/src/config_types.rs
@@ -80,3 +80,21 @@ pub enum TrustLevel {
     Trusted,
     Untrusted,
 }
+
+/// Controls whether the TUI uses the terminal's alternate screen buffer.
+///
+/// Using alternate screen provides a cleaner fullscreen experience but prevents
+/// scrollback in terminal multiplexers like Zellij that follow the xterm spec
+/// (which says alternate screen should not have scrollback).
+#[derive(Debug, Serialize, Deserialize, Default, Clone, Copy, PartialEq, Eq, Display, JsonSchema, TS)]
+#[serde(rename_all = "lowercase")]
+#[strum(serialize_all = "lowercase")]
+pub enum AltScreenMode {
+    /// Auto-detect: disable alternate screen in Zellij, enable elsewhere.
+    #[default]
+    Auto,
+    /// Always use alternate screen (original behavior).
+    Always,
+    /// Never use alternate screen (inline mode only).
+    Never,
+}

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -85,8 +85,11 @@ pub struct Cli {
     #[arg(long = "add-dir", value_name = "DIR", value_hint = ValueHint::DirPath)]
     pub add_dir: Vec<PathBuf>,
 
-    /// Disable alternate screen mode for better scrollback in terminal multiplexers like Zellij.
-    /// This runs the TUI in inline mode, preserving terminal scrollback history.
+    /// Disable alternate screen mode
+    ///
+    /// Runs the TUI in inline mode, preserving terminal scrollback history. This is useful
+    /// in terminal multiplexers like Zellij that follow the xterm spec strictly and disable
+    /// scrollback in alternate screen buffers.
     #[arg(long = "no-alt-screen", default_value_t = false)]
     pub no_alt_screen: bool,
 

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -85,6 +85,11 @@ pub struct Cli {
     #[arg(long = "add-dir", value_name = "DIR", value_hint = ValueHint::DirPath)]
     pub add_dir: Vec<PathBuf>,
 
+    /// Disable alternate screen mode for better scrollback in terminal multiplexers like Zellij.
+    /// This runs the TUI in inline mode, preserving terminal scrollback history.
+    #[arg(long = "no-alt-screen", default_value_t = false)]
+    pub no_alt_screen: bool,
+
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,
 }

--- a/codex-rs/tui2/src/cli.rs
+++ b/codex-rs/tui2/src/cli.rs
@@ -85,6 +85,11 @@ pub struct Cli {
     #[arg(long = "add-dir", value_name = "DIR", value_hint = ValueHint::DirPath)]
     pub add_dir: Vec<PathBuf>,
 
+    /// Disable alternate screen mode for better scrollback in terminal multiplexers like Zellij.
+    /// This runs the TUI in inline mode, preserving terminal scrollback history.
+    #[arg(long = "no-alt-screen", default_value_t = false)]
+    pub no_alt_screen: bool,
+
     #[clap(skip)]
     pub config_overrides: CliConfigOverrides,
 }
@@ -109,6 +114,7 @@ impl From<codex_tui::Cli> for Cli {
             cwd: cli.cwd,
             web_search: cli.web_search,
             add_dir: cli.add_dir,
+            no_alt_screen: cli.no_alt_screen,
             config_overrides: cli.config_overrides,
         }
     }

--- a/codex-rs/tui2/src/lib.rs
+++ b/codex-rs/tui2/src/lib.rs
@@ -524,9 +524,15 @@ async fn run_ratatui_app(
         ..
     } = cli;
 
-    // Determine whether to use alternate screen based on CLI flag and config.
-    // Alternate screen provides a cleaner fullscreen experience but prevents
-    // scrollback in terminal multiplexers like Zellij that follow xterm spec.
+    // Run the main chat + transcript UI on the terminal's alternate screen so
+    // the entire viewport can be used without polluting normal scrollback. This
+    // mirrors the behavior of the legacy TUI but keeps inline mode available
+    // for smaller prompts like onboarding and model migration.
+    //
+    // However, alternate screen prevents scrollback in terminal multiplexers like
+    // Zellij that strictly follow the xterm spec (which disallows scrollback in
+    // alternate screen buffers). This auto-detects the terminal and disables
+    // alternate screen in Zellij while keeping it enabled elsewhere.
     let use_alt_screen = if no_alt_screen {
         // CLI flag explicitly disables alternate screen
         false

--- a/codex-rs/tui2/src/lib.rs
+++ b/codex-rs/tui2/src/lib.rs
@@ -542,9 +542,9 @@ async fn run_ratatui_app(
         }
     };
 
-    if use_alt_screen {
-        let _ = tui.enter_alt_screen();
-    }
+    // Set flag on Tui so all enter_alt_screen() calls respect the setting
+    tui.set_alt_screen_enabled(use_alt_screen);
+    let _ = tui.enter_alt_screen();
 
     let app_result = App::run(
         &mut tui,
@@ -559,9 +559,7 @@ async fn run_ratatui_app(
     )
     .await;
 
-    if use_alt_screen {
-        let _ = tui.leave_alt_screen();
-    }
+    let _ = tui.leave_alt_screen();
     restore();
     if let Ok(exit_info) = &app_result {
         let mut stdout = std::io::stdout();

--- a/docs/tui-alternate-screen.md
+++ b/docs/tui-alternate-screen.md
@@ -1,0 +1,121 @@
+# TUI Alternate Screen and Terminal Multiplexers
+
+## Overview
+
+This document explains the design decision behind Codex's alternate screen handling, particularly in terminal multiplexers like Zellij. This addresses a fundamental conflict between fullscreen TUI behavior and terminal scrollback history preservation.
+
+## The Problem
+
+### Fullscreen TUI Benefits
+
+Codex's TUI uses the terminal's **alternate screen buffer** to provide a clean fullscreen experience. This approach:
+- Uses the entire viewport without polluting the terminal's scrollback history
+- Provides a dedicated environment for the chat interface
+- Mirrors the behavior of other terminal applications (vim, tmux, etc.)
+
+### The Zellij Conflict
+
+Terminal multiplexers like **Zellij** strictly follow the xterm specification, which defines that alternate screen buffers should **not** have scrollback. This is intentional design, not a bug:
+
+- **Zellij PR:** https://github.com/zellij-org/zellij/pull/1032
+- **Rationale:** The xterm spec explicitly states that alternate screen mode disallows scrollback
+- **Configurability:** This is not configurable in Zellij—there is no option to enable scrollback in alternate screen mode
+
+When using Codex's TUI in Zellij, users cannot scroll back through the conversation history because:
+1. The TUI runs in alternate screen mode (fullscreen)
+2. Zellij disables scrollback in alternate screen buffers (per xterm spec)
+3. The entire conversation becomes inaccessible via normal terminal scrolling
+
+## The Solution
+
+Codex implements a **pragmatic workaround** with three modes, controlled by `tui.alternate_screen` in `config.toml`:
+
+### 1. `auto` (default)
+- **Behavior:** Automatically detect the terminal multiplexer
+- **In Zellij:** Disable alternate screen mode (inline mode, preserves scrollback)
+- **Elsewhere:** Enable alternate screen mode (fullscreen experience)
+- **Rationale:** Provides the best UX in each environment
+
+### 2. `always`
+- **Behavior:** Always use alternate screen mode (original behavior)
+- **Use case:** Users who prefer fullscreen and don't use Zellij, or who have found a workaround
+
+### 3. `never`
+- **Behavior:** Never use alternate screen mode (inline mode)
+- **Use case:** Users who always want scrollback history preserved
+- **Trade-off:** Pollutes the terminal scrollback with TUI output
+
+## Runtime Override
+
+The `--no-alt-screen` CLI flag can override the config setting at runtime:
+
+```bash
+codex --no-alt-screen
+```
+
+This runs the TUI in inline mode regardless of the configuration, useful for:
+- One-off sessions where scrollback is critical
+- Debugging terminal-related issues
+- Testing alternate screen behavior
+
+## Implementation Details
+
+### Auto-Detection
+
+The `auto` mode detects Zellij by checking the `ZELLIJ` environment variable:
+
+```rust
+let terminal_info = codex_core::terminal::terminal_info();
+!matches!(terminal_info.multiplexer, Some(Multiplexer::Zellij { .. }))
+```
+
+This detection happens in the helper function `determine_alt_screen_mode()` in `codex-rs/tui/src/lib.rs`.
+
+### Configuration Schema
+
+The `AltScreenMode` enum is defined in `codex-rs/protocol/src/config_types.rs` and serializes to lowercase TOML:
+
+```toml
+[tui]
+# Options: auto, always, never
+alternate_screen = "auto"
+```
+
+### Why Not Just Disable Alternate Screen in Zellij Permanently?
+
+We use `auto` detection instead of always disabling in Zellij because:
+1. Many Zellij users don't care about scrollback and prefer the fullscreen experience
+2. Some users may use tmux inside Zellij, creating a chain of multiplexers
+3. Provides user choice without requiring manual configuration
+
+## Related Issues and References
+
+- **Original Issue:** [GitHub #2558](https://github.com/openai/codex/issues/2558) - "No scrollback in Zellij"
+- **Implementation PR:** [GitHub #8555](https://github.com/openai/codex/pull/8555)
+- **Zellij PR:** https://github.com/zellij-org/zellij/pull/1032 (why scrollback is disabled)
+- **xterm Spec:** Alternate screen buffers should not have scrollback
+
+## Future Considerations
+
+### Alternative Approaches Considered
+
+1. **Implement custom scrollback in TUI:** Would require significant architectural changes to buffer and render all historical output
+2. **Request Zellij to add a config option:** Not viable—Zellij maintainers explicitly chose this behavior to follow the spec
+3. **Disable alternate screen unconditionally:** Would degrade UX for non-Zellij users
+
+### Transcript Pager
+
+Codex's transcript pager (opened with Ctrl+T) provides an alternative way to review conversation history, even in fullscreen mode. However, this is not as seamless as natural scrollback.
+
+## For Developers
+
+When modifying TUI code, remember:
+- The `determine_alt_screen_mode()` function encapsulates all the logic
+- Configuration is in `config.tui_alternate_screen`
+- CLI flag is in `cli.no_alt_screen`
+- The behavior is applied via `tui.set_alt_screen_enabled()`
+
+If you encounter issues with terminal state after running Codex, you can restore your terminal with:
+```bash
+reset
+```

--- a/docs/tui-alternate-screen.md
+++ b/docs/tui-alternate-screen.md
@@ -9,6 +9,7 @@ This document explains the design decision behind Codex's alternate screen handl
 ### Fullscreen TUI Benefits
 
 Codex's TUI uses the terminal's **alternate screen buffer** to provide a clean fullscreen experience. This approach:
+
 - Uses the entire viewport without polluting the terminal's scrollback history
 - Provides a dedicated environment for the chat interface
 - Mirrors the behavior of other terminal applications (vim, tmux, etc.)
@@ -22,6 +23,7 @@ Terminal multiplexers like **Zellij** strictly follow the xterm specification, w
 - **Configurability:** This is not configurable in Zellij—there is no option to enable scrollback in alternate screen mode
 
 When using Codex's TUI in Zellij, users cannot scroll back through the conversation history because:
+
 1. The TUI runs in alternate screen mode (fullscreen)
 2. Zellij disables scrollback in alternate screen buffers (per xterm spec)
 3. The entire conversation becomes inaccessible via normal terminal scrolling
@@ -31,16 +33,19 @@ When using Codex's TUI in Zellij, users cannot scroll back through the conversat
 Codex implements a **pragmatic workaround** with three modes, controlled by `tui.alternate_screen` in `config.toml`:
 
 ### 1. `auto` (default)
+
 - **Behavior:** Automatically detect the terminal multiplexer
 - **In Zellij:** Disable alternate screen mode (inline mode, preserves scrollback)
 - **Elsewhere:** Enable alternate screen mode (fullscreen experience)
 - **Rationale:** Provides the best UX in each environment
 
 ### 2. `always`
+
 - **Behavior:** Always use alternate screen mode (original behavior)
 - **Use case:** Users who prefer fullscreen and don't use Zellij, or who have found a workaround
 
 ### 3. `never`
+
 - **Behavior:** Never use alternate screen mode (inline mode)
 - **Use case:** Users who always want scrollback history preserved
 - **Trade-off:** Pollutes the terminal scrollback with TUI output
@@ -54,6 +59,7 @@ codex --no-alt-screen
 ```
 
 This runs the TUI in inline mode regardless of the configuration, useful for:
+
 - One-off sessions where scrollback is critical
 - Debugging terminal-related issues
 - Testing alternate screen behavior
@@ -84,6 +90,7 @@ alternate_screen = "auto"
 ### Why Not Just Disable Alternate Screen in Zellij Permanently?
 
 We use `auto` detection instead of always disabling in Zellij because:
+
 1. Many Zellij users don't care about scrollback and prefer the fullscreen experience
 2. Some users may use tmux inside Zellij, creating a chain of multiplexers
 3. Provides user choice without requiring manual configuration
@@ -110,12 +117,14 @@ Codex's transcript pager (opened with Ctrl+T) provides an alternative way to rev
 ## For Developers
 
 When modifying TUI code, remember:
+
 - The `determine_alt_screen_mode()` function encapsulates all the logic
 - Configuration is in `config.tui_alternate_screen`
 - CLI flag is in `cli.no_alt_screen`
 - The behavior is applied via `tui.set_alt_screen_enabled()`
 
 If you encounter issues with terminal state after running Codex, you can restore your terminal with:
+
 ```bash
 reset
 ```


### PR DESCRIPTION
Fixes #2558

Codex uses alternate screen mode (CSI 1049) which, per xterm spec, doesn't support scrollback. Zellij follows this strictly, so users can't scroll back through output.

**Changes:**
- Add `tui.alternate_screen` config: `auto` (default), `always`, `never`
- Add `--no-alt-screen` CLI flag
- Auto-detect Zellij and skip alt screen (uses existing `ZELLIJ` env var detection)

**Usage:**
```bash
# CLI flag
codex --no-alt-screen

# Or in config.toml
[tui]
alternate_screen = "never"
```

With default `auto` mode, Zellij users get working scrollback without any config changes.