### PR TITLE
cli(login): add --no-browser flag for ChatGPT login

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -214,6 +214,10 @@ struct LoginCommand {
     #[arg(long = "device-auth")]
     use_device_code: bool,
 
+    /// Do not automatically open the browser; print the login URL instead.
+    #[arg(long = "no-browser", default_value_t = false)]
+    no_browser: bool,
+
     /// EXPERIMENTAL: Use custom OAuth issuer base URL (advanced)
     /// Override the OAuth issuer base URL (advanced)
     #[arg(long = "experimental_issuer", value_name = "URL", hide = true)]
@@ -535,7 +539,8 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
                         let api_key = read_api_key_from_stdin();
                         run_login_with_api_key(login_cli.config_overrides, api_key).await;
                     } else {
-                        run_login_with_chatgpt(login_cli.config_overrides).await;
+                        run_login_with_chatgpt(login_cli.config_overrides, !login_cli.no_browser)
+                            .await;
                     }
                 }
             }

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -66,3 +66,5 @@ ssh -L 1455:localhost:1455 <user>@<remote-host>
 ```
 
 Then, in that SSH session, run `codex` and select "Sign in with ChatGPT". When prompted, open the printed URL (it will be `http://localhost:1455/...`) in your local browser. The traffic will be tunneled to the remote server.
+
+If you do not want Codex to open your default browser automatically, add `--no-browser` when starting the login flow. The CLI will print the login URL so you can copy/paste it into any browser you have access to.


### PR DESCRIPTION
Fixes #8576

## Summary
This PR adds a `--no-browser` flag to the `codex login` command to suppress automatically opening the default browser during the ChatGPT OAuth login flow.

## Motivation
In headless / remote / SSH environments (or when embedding login into a controlled browser context), auto-opening a browser is not desirable and sometimes impossible. Users typically want the CLI to print the auth URL so they can open it in any browser they have access to.

## What changed
- **CLI:** Adds `--no-browser` to `codex login`.
- **Login flow:** Threads an `open_browser` boolean through the ChatGPT login path and applies it to the login server options.
- **UX:** Adjusts the login message depending on whether `open_browser` is enabled (auto-open vs manual open).
- **Docs:** Updates `docs/authentication.md` to mention `--no-browser` for headless setups.

## Testing
- `cargo fmt`
- `cargo clippy -p codex-cli --tests`
- `cargo clippy -p codex-login --tests`

## Notes
Default behavior is unchanged: without `--no-browser`, the CLI continues to auto-open the browser as before.