### PR TITLE
rust-release: avoid triggering on malformed tags

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -9,7 +9,9 @@ name: rust-release
 on:
   push:
     tags:
-      - "rust-v*.*.*"
+      # Require a digit immediately after `rust-v` to avoid accidentally
+      # triggering on malformed tags like `rust-vrust-v...`.
+      - "rust-v[0-9]*.*.*"
 
 concurrency:
   group: ${{ github.workflow }}


### PR DESCRIPTION
The rust-release workflow was triggered by a malformed tag (e.g. `rust-vrust-v0.78.0-alpha.6`) because the tag filter was too permissive (`rust-v*.*.*`).

This tightens the trigger to require a digit immediately after `rust-v` (`rust-v[0-9]*.*.*`), preventing accidental runs for tags with a duplicated prefix while keeping existing valid release tags working.
