### PR TITLE
feat(core): add elapsed-ms to notify payload

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use std::time::Instant;
 
 use crate::AuthManager;
 use crate::SandboxState;
@@ -2211,6 +2212,7 @@ pub(crate) async fn run_task(
     if input.is_empty() {
         return None;
     }
+    let turn_started_at = Instant::now();
 
     let auto_compact_limit = turn_context
         .client
@@ -2315,6 +2317,7 @@ pub(crate) async fn run_task(
                             thread_id: sess.conversation_id.to_string(),
                             turn_id: turn_context.sub_id.clone(),
                             cwd: turn_context.cwd.display().to_string(),
+                            elapsed_ms: turn_started_at.elapsed().as_millis() as u64,
                             input_messages: turn_input_messages,
                             last_assistant_message: last_agent_message.clone(),
                         });

--- a/codex-rs/core/src/user_notification.rs
+++ b/codex-rs/core/src/user_notification.rs
@@ -52,6 +52,7 @@ pub(crate) enum UserNotification {
         thread_id: String,
         turn_id: String,
         cwd: String,
+        elapsed_ms: u64,
 
         /// Messages that the user sent to the agent to initiate the turn.
         input_messages: Vec<String>,
@@ -72,6 +73,7 @@ mod tests {
             thread_id: "b5f6c1c2-1111-2222-3333-444455556666".to_string(),
             turn_id: "12345".to_string(),
             cwd: "/Users/example/project".to_string(),
+            elapsed_ms: 1234,
             input_messages: vec!["Rename `foo` to `bar` and update the callsites.".to_string()],
             last_assistant_message: Some(
                 "Rename complete and verified `cargo build` succeeds.".to_string(),
@@ -80,7 +82,7 @@ mod tests {
         let serialized = serde_json::to_string(&notification)?;
         assert_eq!(
             serialized,
-            r#"{"type":"agent-turn-complete","thread-id":"b5f6c1c2-1111-2222-3333-444455556666","turn-id":"12345","cwd":"/Users/example/project","input-messages":["Rename `foo` to `bar` and update the callsites."],"last-assistant-message":"Rename complete and verified `cargo build` succeeds."}"#
+            r#"{"type":"agent-turn-complete","thread-id":"b5f6c1c2-1111-2222-3333-444455556666","turn-id":"12345","cwd":"/Users/example/project","elapsed-ms":1234,"input-messages":["Rename `foo` to `bar` and update the callsites."],"last-assistant-message":"Rename complete and verified `cargo build` succeeds."}"#
         );
         Ok(())
     }

--- a/codex-rs/core/tests/suite/user_notification.rs
+++ b/codex-rs/core/tests/suite/user_notification.rs
@@ -73,6 +73,7 @@ echo -n "${@: -1}" > $(dirname "${0}")/notify.txt"#,
     assert_eq!(payload["type"], json!("agent-turn-complete"));
     assert_eq!(payload["input-messages"], json!(["hello world"]));
     assert_eq!(payload["last-assistant-message"], json!("Done"));
+    assert!(payload["elapsed-ms"].as_u64().is_some());
 
     Ok(())
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -671,6 +671,7 @@ Specify a program that will be executed to get notified about events generated b
   "thread-id": "b5f6c1c2-1111-2222-3333-444455556666",
   "turn-id": "12345",
   "cwd": "/Users/alice/projects/example",
+  "elapsed-ms": 1234,
   "input-messages": ["Rename `foo` to `bar` and update the callsites."],
   "last-assistant-message": "Rename complete and verified `cargo build` succeeds."
 }
@@ -681,6 +682,8 @@ The `"type"` property will always be set. Currently, `"agent-turn-complete"` is 
 `"thread-id"` contains a string that identifies the Codex session that produced the notification; you can use it to correlate multiple turns that belong to the same task.
 
 `"cwd"` reports the absolute working directory for the session so scripts can disambiguate which project triggered the notification.
+
+`"elapsed-ms"` reports the wall-clock time in milliseconds from the start of the turn until completion.
 
 As an example, here is a Python script that parses the JSON and decides whether to show a desktop push notification using [terminal-notifier](https://github.com/julienXX/terminal-notifier) on macOS:
 


### PR DESCRIPTION
## Summary
- add elapsed-ms to agent-turn-complete notify payload
- compute elapsed time per turn and serialize in notify JSON
- document notify payload update

## Testing
- just fix -p codex-core (user)
- tests from codex-rs/tests.txt (user)
  - FAIL: suite::send_message::test_send_message_raw_notifications_opt_in
  - FAIL: shell::tests::detects_bash
  - FAIL: seatbelt::tests::create_seatbelt_args_with_read_only_git_and_codex_subpaths