### PR TITLE
Feat: Service Tier for API

### DIFF
--- a/codex-rs/codex-api/src/common.rs
+++ b/codex-rs/codex-api/src/common.rs
@@ -131,6 +131,9 @@ pub struct ResponsesApiRequest<'a> {
     pub include: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub prompt_cache_key: Option<String>,
+    /// Optional service tier to request from the provider (for OpenAI Responses/Completions).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub service_tier: Option<&'a str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub text: Option<TextControls>,
 }

--- a/codex-rs/codex-api/src/endpoint/chat.rs
+++ b/codex-rs/codex-api/src/endpoint/chat.rs
@@ -55,11 +55,13 @@ impl<T: HttpTransport, A: AuthProvider> ChatClient<T, A> {
         prompt: &ApiPrompt,
         conversation_id: Option<String>,
         session_source: Option<SessionSource>,
+        service_tier: Option<String>,
     ) -> Result<ResponseStream, ApiError> {
         use crate::requests::ChatRequestBuilder;
 
         let request =
             ChatRequestBuilder::new(model, &prompt.instructions, &prompt.input, &prompt.tools)
+                .service_tier(service_tier)
                 .conversation_id(conversation_id)
                 .session_source(session_source)
                 .build(self.streaming.provider())?;

--- a/codex-rs/codex-api/src/endpoint/responses.rs
+++ b/codex-rs/codex-api/src/endpoint/responses.rs
@@ -29,6 +29,8 @@ pub struct ResponsesOptions {
     pub include: Vec<String>,
     pub prompt_cache_key: Option<String>,
     pub text: Option<TextControls>,
+    /// Optional default service_tier for Responses/Completions requests (e.g. "priority", "flex").
+    pub service_tier: Option<String>,
     pub store_override: Option<bool>,
     pub conversation_id: Option<String>,
     pub session_source: Option<SessionSource>,
@@ -71,6 +73,7 @@ impl<T: HttpTransport, A: AuthProvider> ResponsesClient<T, A> {
             include,
             prompt_cache_key,
             text,
+            service_tier,
             store_override,
             conversation_id,
             session_source,
@@ -81,6 +84,7 @@ impl<T: HttpTransport, A: AuthProvider> ResponsesClient<T, A> {
             .tools(&prompt.tools)
             .parallel_tool_calls(prompt.parallel_tool_calls)
             .reasoning(reasoning)
+            .service_tier(service_tier.clone())
             .include(include)
             .prompt_cache_key(prompt_cache_key)
             .text(text)

--- a/codex-rs/codex-api/src/requests/responses.rs
+++ b/codex-rs/codex-api/src/requests/responses.rs
@@ -28,6 +28,7 @@ pub struct ResponsesRequestBuilder<'a> {
     include: Vec<String>,
     prompt_cache_key: Option<String>,
     text: Option<TextControls>,
+    pub service_tier: Option<String>,
     conversation_id: Option<String>,
     session_source: Option<SessionSource>,
     store_override: Option<bool>,
@@ -71,6 +72,11 @@ impl<'a> ResponsesRequestBuilder<'a> {
 
     pub fn text(mut self, text: Option<TextControls>) -> Self {
         self.text = text;
+        self
+    }
+
+    pub fn service_tier(mut self, tier: Option<String>) -> Self {
+        self.service_tier = tier;
         self
     }
 
@@ -118,6 +124,9 @@ impl<'a> ResponsesRequestBuilder<'a> {
             tool_choice: "auto",
             parallel_tool_calls: self.parallel_tool_calls,
             reasoning: self.reasoning,
+            // service_tier is an optional top-level parameter for Responses
+            // and Completions requests; include it when present.
+            service_tier: self.service_tier.as_deref(),
             store,
             stream: true,
             include: self.include,

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -171,6 +171,7 @@ impl ModelClient {
                     &api_prompt,
                     Some(conversation_id.clone()),
                     Some(session_source.clone()),
+                    self.config.model_service_tier.clone(),
                 )
                 .await;
 

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -259,6 +259,8 @@ impl ModelClient {
                 include: include.clone(),
                 prompt_cache_key: Some(conversation_id.clone()),
                 text: text.clone(),
+                // Propagate configured model_service_tier (e.g. "priority" or "flex")
+                service_tier: self.config.model_service_tier.clone(),
                 store_override: None,
                 conversation_id: Some(conversation_id.clone()),
                 session_source: Some(session_source.clone()),

--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -345,6 +345,7 @@ mod tests {
             stream: true,
             include: vec![],
             prompt_cache_key: None,
+            service_tier: None,
             text: Some(TextControls {
                 verbosity: Some(OpenAiVerbosity::Low),
                 format: None,
@@ -386,6 +387,7 @@ mod tests {
             stream: true,
             include: vec![],
             prompt_cache_key: None,
+            service_tier: None,
             text: Some(text_controls),
         };
 
@@ -422,6 +424,7 @@ mod tests {
             stream: true,
             include: vec![],
             prompt_cache_key: None,
+            service_tier: None,
             text: None,
         };
 

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -304,7 +304,7 @@ pub struct Config {
 
     /// Optional verbosity control for GPT-5 models (Responses API `text.verbosity`).
     pub model_verbosity: Option<Verbosity>,
-    /// Optional service_tier to request for Responses/Completions (e.g. "priority", "flex").
+    /// Optional service_tier to request for Responses/Completions and Chat Completions (e.g. "priority", "flex").
     pub model_service_tier: Option<String>,
 
     /// Base URL for requests to ChatGPT (as opposed to the OpenAI API).
@@ -780,7 +780,7 @@ pub struct ConfigToml {
     pub model_reasoning_summary: Option<ReasoningSummary>,
     /// Optional verbosity control for GPT-5 models (Responses API `text.verbosity`).
     pub model_verbosity: Option<Verbosity>,
-    /// Optional service_tier to request for Responses/Completions (e.g. "priority", "flex").
+    /// Optional service_tier to request for Responses/Completions and Chat Completions (e.g. "priority", "flex").
     pub model_service_tier: Option<String>,
 
     /// Override to force-enable reasoning summaries for the configured model.

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -304,6 +304,8 @@ pub struct Config {
 
     /// Optional verbosity control for GPT-5 models (Responses API `text.verbosity`).
     pub model_verbosity: Option<Verbosity>,
+    /// Optional service_tier to request for Responses/Completions (e.g. "priority", "flex").
+    pub model_service_tier: Option<String>,
 
     /// Base URL for requests to ChatGPT (as opposed to the OpenAI API).
     pub chatgpt_base_url: String,
@@ -778,6 +780,8 @@ pub struct ConfigToml {
     pub model_reasoning_summary: Option<ReasoningSummary>,
     /// Optional verbosity control for GPT-5 models (Responses API `text.verbosity`).
     pub model_verbosity: Option<Verbosity>,
+    /// Optional service_tier to request for Responses/Completions (e.g. "priority", "flex").
+    pub model_service_tier: Option<String>,
 
     /// Override to force-enable reasoning summaries for the configured model.
     pub model_supports_reasoning_summaries: Option<bool>,
@@ -1373,6 +1377,7 @@ impl Config {
                 .unwrap_or_default(),
             model_supports_reasoning_summaries: cfg.model_supports_reasoning_summaries,
             model_verbosity: config_profile.model_verbosity.or(cfg.model_verbosity),
+            model_service_tier: config_profile.model_service_tier.or(cfg.model_service_tier),
             chatgpt_base_url: config_profile
                 .chatgpt_base_url
                 .or(cfg.chatgpt_base_url)
@@ -3182,6 +3187,7 @@ model_verbosity = "high"
                 model_reasoning_summary: ReasoningSummary::Detailed,
                 model_supports_reasoning_summaries: None,
                 model_verbosity: None,
+                model_service_tier: None,
                 chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
                 base_instructions: None,
                 developer_instructions: None,
@@ -3265,6 +3271,7 @@ model_verbosity = "high"
             model_reasoning_summary: ReasoningSummary::default(),
             model_supports_reasoning_summaries: None,
             model_verbosity: None,
+            model_service_tier: None,
             chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
             base_instructions: None,
             developer_instructions: None,
@@ -3363,6 +3370,7 @@ model_verbosity = "high"
             model_reasoning_summary: ReasoningSummary::default(),
             model_supports_reasoning_summaries: None,
             model_verbosity: None,
+            model_service_tier: None,
             chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
             base_instructions: None,
             developer_instructions: None,
@@ -3447,6 +3455,7 @@ model_verbosity = "high"
             model_reasoning_summary: ReasoningSummary::Detailed,
             model_supports_reasoning_summaries: None,
             model_verbosity: Some(Verbosity::High),
+            model_service_tier: None,
             chatgpt_base_url: "https://chatgpt.com/backend-api/".to_string(),
             base_instructions: None,
             developer_instructions: None,

--- a/codex-rs/core/src/config/profile.rs
+++ b/codex-rs/core/src/config/profile.rs
@@ -21,6 +21,8 @@ pub struct ConfigProfile {
     pub model_reasoning_effort: Option<ReasoningEffort>,
     pub model_reasoning_summary: Option<ReasoningSummary>,
     pub model_verbosity: Option<Verbosity>,
+    /// Optional service_tier to request for Responses/Completions (e.g. "priority", "flex").
+    pub model_service_tier: Option<String>,
     pub chatgpt_base_url: Option<String>,
     pub experimental_instructions_file: Option<AbsolutePathBuf>,
     pub experimental_compact_prompt_file: Option<AbsolutePathBuf>,

--- a/codex-rs/core/src/config/profile.rs
+++ b/codex-rs/core/src/config/profile.rs
@@ -21,7 +21,7 @@ pub struct ConfigProfile {
     pub model_reasoning_effort: Option<ReasoningEffort>,
     pub model_reasoning_summary: Option<ReasoningSummary>,
     pub model_verbosity: Option<Verbosity>,
-    /// Optional service_tier to request for Responses/Completions (e.g. "priority", "flex").
+    /// Optional service_tier to request for Responses/Completions and Chat Completions (e.g. "priority", "flex").
     pub model_service_tier: Option<String>,
     pub chatgpt_base_url: Option<String>,
     pub experimental_instructions_file: Option<AbsolutePathBuf>,

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -64,6 +64,7 @@ struct StatusHistoryCell {
     agents_summary: String,
     account: Option<StatusAccountDisplay>,
     session_id: Option<String>,
+    service_tier: Option<String>,
     token_usage: StatusTokenUsageData,
     rate_limits: StatusRateLimitData,
 }
@@ -134,6 +135,7 @@ impl StatusHistoryCell {
         let agents_summary = compose_agents_summary(config);
         let account = compose_account_display(auth_manager, plan_type);
         let session_id = session_id.as_ref().map(std::string::ToString::to_string);
+        let service_tier = config.model_service_tier.clone();
         let context_window = model_family.context_window.and_then(|window| {
             context_usage.map(|usage| StatusContextWindowData {
                 percent_remaining: usage.percent_of_context_window_remaining(window),
@@ -159,6 +161,7 @@ impl StatusHistoryCell {
             agents_summary,
             account,
             session_id,
+            service_tier,
             token_usage,
             rate_limits,
         }
@@ -383,6 +386,9 @@ impl HistoryCell for StatusHistoryCell {
         lines.push(formatter.line("Directory", vec![Span::from(directory_value)]));
         lines.push(formatter.line("Approval", vec![Span::from(self.approval.clone())]));
         lines.push(formatter.line("Sandbox", vec![Span::from(self.sandbox.clone())]));
+        if let Some(tier) = self.service_tier.as_ref() {
+            lines.push(formatter.line("Service tier", vec![Span::from(tier.clone())]));
+        }
         lines.push(formatter.line("Agents.md", vec![Span::from(self.agents_summary.clone())]));
 
         if let Some(account_value) = account_value {

--- a/docs/config.md
+++ b/docs/config.md
@@ -244,8 +244,8 @@ model_supports_reasoning_summaries = true
 Optional default service tier to request for Responses/Completions (examples: "priority", "flex"). When set, Codex includes this value as a top-level `service_tier` parameter in outgoing Responses/Completions requests. Providers that do not support `service_tier` will ignore the parameter.
 
 ```toml
-# Request the "priority" tier by default for responses/completions
-model_service_tier = "priority"
+# Request the "flex" tier by default for responses/completions
+model_service_tier = "flex"
 ```
 ```
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -241,10 +241,10 @@ model_supports_reasoning_summaries = true
 
 ### model_service_tier
 
-Optional default service tier to request for Responses/Completions (examples: "priority", "flex"). When set, Codex includes this value as a top-level `service_tier` parameter in outgoing Responses/Completions requests. Providers that do not support `service_tier` will ignore the parameter.
+Optional default service tier to request for Responses/Completions and Chat Completions (examples: "priority", "flex"). When set, Codex includes this value as a top-level `service_tier` parameter in outgoing requests. Providers that do not support `service_tier` will ignore the parameter.
 
 ```toml
-# Request the "flex" tier by default for responses/completions
+# Request the "flex" tier by default for responses/chat completions
 model_service_tier = "flex"
 ```
 ```

--- a/docs/config.md
+++ b/docs/config.md
@@ -238,6 +238,15 @@ By default, `reasoning` is only set on requests to OpenAI models that are known 
 
 ```toml
 model_supports_reasoning_summaries = true
+
+### model_service_tier
+
+Optional default service tier to request for Responses/Completions (examples: "priority", "flex"). When set, Codex includes this value as a top-level `service_tier` parameter in outgoing Responses/Completions requests. Providers that do not support `service_tier` will ignore the parameter.
+
+```toml
+# Request the "priority" tier by default for responses/completions
+model_service_tier = "priority"
+```
 ```
 
 ### model_context_window

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -24,9 +24,9 @@ model = "gpt-5.1-codex-max"
 # Model used by the /review feature (code reviews). Default: "gpt-5.1-codex-max".
 review_model = "gpt-5.1-codex-max"
 
-# Optional default service tier to request from the model provider (e.g. "priority" or "flex").
+# Optional default service tier to request from the model provider (e.g. "flex").
 # See docs/service-tiers.md for details.
-# model_service_tier = "priority"
+# model_service_tier = "flex"
 
 # Provider id selected from [model_providers]. Default: "openai".
 model_provider = "openai"

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -24,6 +24,10 @@ model = "gpt-5.1-codex-max"
 # Model used by the /review feature (code reviews). Default: "gpt-5.1-codex-max".
 review_model = "gpt-5.1-codex-max"
 
+# Optional default service tier to request from the model provider (e.g. "priority" or "flex").
+# See docs/service-tiers.md for details.
+# model_service_tier = "priority"
+
 # Provider id selected from [model_providers]. Default: "openai".
 model_provider = "openai"
 

--- a/docs/service-tiers.md
+++ b/docs/service-tiers.md
@@ -1,0 +1,42 @@
+# Service Tiers
+
+Codex supports requesting an optional "service tier" from model providers that expose this feature (for example, some OpenAI endpoints).
+
+A service tier is an opaque string sent as a top-level `service_tier` parameter in Responses/Completions requests. Examples used in this codebase include:
+
+- `priority` — higher priority routing for lower-latency or higher-throughput access
+- `flex` — lower-cost or best-effort routing
+
+Note: exact semantics and available tier names depend on the provider. If the provider does not support `service_tier`, the parameter is ignored.
+
+Where to configure
+
+- Per-installation default: set `model_service_tier` in your `$CODEX_HOME/config.toml` (see `docs/example-config.md`). This value is propagated to outgoing requests where no per-request tier is set.
+- Per-request override: callers that build Responses/Completions requests can set `service_tier` on the request object; this overrides the configured default for that request.
+
+Behavior in Codex
+
+- The `model_service_tier` configuration key is optional. When set, Codex includes the value as the `service_tier` top-level parameter on Responses/Completions requests for providers that use the Responses API.
+- The TUI displays the active service tier in the status card when it is configured.
+
+Security and privacy
+
+- Service tier values are treated as non-secret metadata and are not redacted. Do not use secrets or tokens as tier values.
+
+Examples
+
+1. Configuring a default in `~/.codex/config.toml`:
+
+```toml
+# Request the "priority" tier by default for responses/completions
+model_service_tier = "priority"
+```
+
+2. Overriding per-request (high-level example):
+
+```rust
+let req = ResponsesRequest::new(...).service_tier(Some("flex".to_string()));
+```
+
+When in doubt, consult your model provider's documentation for supported service tier names and semantics.
+

--- a/docs/service-tiers.md
+++ b/docs/service-tiers.md
@@ -2,7 +2,7 @@
 
 Codex supports requesting an optional "service tier" from model providers that expose this feature (for example, some OpenAI endpoints).
 
-A service tier is an opaque string sent as a top-level `service_tier` parameter in Responses/Completions requests. Examples used in this codebase include:
+A service tier is an opaque string sent as a top-level `service_tier` parameter in Responses/Completions and Chat Completions requests. Examples used in this codebase include:
 
 - `flex` — lower-cost or best-effort routing
 - `priority` — higher priority routing for lower-latency or higher-throughput access
@@ -17,6 +17,7 @@ Where to configure
 Behavior in Codex
 
 - The `model_service_tier` configuration key is optional. When set, Codex includes the value as the `service_tier` top-level parameter on Responses/Completions requests for providers that use the Responses API.
+- When using a provider configured with `wire_api = "chat"`, Codex also includes `service_tier` on Chat Completions requests.
 - The TUI displays the active service tier in the status card when it is configured.
 
 Security and privacy
@@ -28,7 +29,7 @@ Examples
 1. Configuring a default in `~/.codex/config.toml`:
 
 ```toml
-# Request the "flex" tier by default for responses/completions
+# Request the "flex" tier by default for responses/chat completions
 model_service_tier = "flex"
 ```
 

--- a/docs/service-tiers.md
+++ b/docs/service-tiers.md
@@ -4,8 +4,8 @@ Codex supports requesting an optional "service tier" from model providers that e
 
 A service tier is an opaque string sent as a top-level `service_tier` parameter in Responses/Completions requests. Examples used in this codebase include:
 
-- `priority` — higher priority routing for lower-latency or higher-throughput access
 - `flex` — lower-cost or best-effort routing
+- `priority` — higher priority routing for lower-latency or higher-throughput access
 
 Note: exact semantics and available tier names depend on the provider. If the provider does not support `service_tier`, the parameter is ignored.
 
@@ -28,8 +28,8 @@ Examples
 1. Configuring a default in `~/.codex/config.toml`:
 
 ```toml
-# Request the "priority" tier by default for responses/completions
-model_service_tier = "priority"
+# Request the "flex" tier by default for responses/completions
+model_service_tier = "flex"
 ```
 
 2. Overriding per-request (high-level example):
@@ -39,4 +39,3 @@ let req = ResponsesRequest::new(...).service_tier(Some("flex".to_string()));
 ```
 
 When in doubt, consult your model provider's documentation for supported service tier names and semantics.
-


### PR DESCRIPTION
Hello Codex Team!

I know your not currently accepting feature requests, but I do want to bring this up with the team. Please take as long as you need to review the PR. It's not an urgent request, but I think the API users would benefit from this.

# What
This PR adds support for requesting a Service Tier on OpenAI API (Responses/Completions) requests. It wires an optional tier string through configuration, request-building, and UI so users can request specific routing such as priority or flex. This resolves issue #2916.

# Why
The Open AI API supports an optional service_tier parameter that influences routing, latency, and cost characteristics. Exposing this option lets users choose a default routing preference for Codex while still allowing individual requests to override that default. It makes Codex API usage behaviour more explicit and gives users an easy, documented lever for changing model routing.

# How
The feature is implemented end-to-end, so a value configured at install-time can be overridden per request and is visible in the UI:
### Configuration
Added a new optional config key model_service_tier (string) that, when set, becomes the default service tier for outgoing API Responses/Completions requests.
### Request plumbing
Requests now include an optional service_tier field and builders expose a .service_tier(...) setter for per-request overrides. When building a request, if a per-request tier is present it takes precedence; otherwise the configured model_service_tier is propagated.
### API / endpoint layer
The Responses/Completions endpoint code includes the service_tier top-level parameter where supported by the wire API.
### Client behaviour
The client propagates the configured model_service_tier into request construction when no per-request override is provided.
### TUI
The status card displays the active service tier when configured so users can quickly see what tier is being requested.
### Tests and verification
Unit tests added/updated to assert the top-level service_tier is sent when configured or when set on a request.
### Documentation
Added docs/service-tiers.md explaining what service tiers are, how to configure the model_service_tier key, and how to override per-request.

---
Test suite status matches main (same failures observed); this PR introduces no additional failures. I ran "just fix" as stated in the Contributing guide and ensured correct formatting. I compiled and built release binaries on my own machine and verified service tiers working correctly.

# Screenshots
<img width="643" height="475" alt="image" src="https://github.com/user-attachments/assets/687a9757-8d53-42cd-81a9-5420875efec3" />
<img width="368" height="230" alt="image" src="https://github.com/user-attachments/assets/94b29cf0-5284-4169-925d-d467953e4c3a" />

---
Thanks again to the Codex Team for creating Codex and taking the time to read this PR.
