### PR TITLE
Add timestamp to exec JSON stream events

### DIFF
--- a/codex-rs/exec/src/exec_events.rs
+++ b/codex-rs/exec/src/exec_events.rs
@@ -39,6 +39,9 @@ pub enum ThreadEvent {
 pub struct ThreadStartedEvent {
     /// The identified of the new thread. Can be used to resume the thread later.
     pub thread_id: String,
+    /// RFC3339 timestamp (UTC) when the session was created.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, TS, Default)]

--- a/codex-rs/exec/tests/event_processor_with_json_output.rs
+++ b/codex-rs/exec/tests/event_processor_with_json_output.rs
@@ -72,10 +72,12 @@ fn session_configured_produces_thread_started_event() {
         codex_protocol::ConversationId::from_string("67e55044-10b1-426f-9247-bb680e5fe0c8")
             .unwrap();
     let rollout_path = PathBuf::from("/tmp/rollout.json");
+    let timestamp = Some("2025-09-05T16:53:11.850Z".to_string());
     let ev = event(
         "e1",
         EventMsg::SessionConfigured(SessionConfiguredEvent {
             session_id,
+            timestamp: timestamp.clone(),
             model: "codex-mini-latest".to_string(),
             model_provider_id: "test-provider".to_string(),
             approval_policy: AskForApproval::Never,
@@ -93,6 +95,7 @@ fn session_configured_produces_thread_started_event() {
         out,
         vec![ThreadEvent::ThreadStarted(ThreadStartedEvent {
             thread_id: "67e55044-10b1-426f-9247-bb680e5fe0c8".to_string(),
+            timestamp,
         })]
     );
 }

--- a/codex-rs/mcp-server/src/outgoing_message.rs
+++ b/codex-rs/mcp-server/src/outgoing_message.rs
@@ -257,6 +257,7 @@ mod tests {
             id: "1".to_string(),
             msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
                 session_id: conversation_id,
+                timestamp: None,
                 model: "gpt-4o".to_string(),
                 model_provider_id: "test-provider".to_string(),
                 approval_policy: AskForApproval::Never,
@@ -296,6 +297,7 @@ mod tests {
         let rollout_file = NamedTempFile::new()?;
         let session_configured_event = SessionConfiguredEvent {
             session_id: conversation_id,
+            timestamp: None,
             model: "gpt-4o".to_string(),
             model_provider_id: "test-provider".to_string(),
             approval_policy: AskForApproval::Never,

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -1774,6 +1774,9 @@ pub struct SkillsListEntry {
 pub struct SessionConfiguredEvent {
     /// Name left as session_id instead of conversation_id for backwards compatibility.
     pub session_id: ConversationId,
+    /// RFC3339 timestamp (UTC) when the session was created.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
 
     /// Tell the client what model is being queried.
     pub model: String,
@@ -1938,6 +1941,7 @@ mod tests {
             id: "1234".to_string(),
             msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
                 session_id: conversation_id,
+                timestamp: None,
                 model: "codex-mini-latest".to_string(),
                 model_provider_id: "openai".to_string(),
                 approval_policy: AskForApproval::Never,

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1555,6 +1555,7 @@ mod tests {
         let make_header = |is_first| {
             let event = SessionConfiguredEvent {
                 session_id: ConversationId::new(),
+                timestamp: None,
                 model: "gpt-test".to_string(),
                 model_provider_id: "test-provider".to_string(),
                 approval_policy: AskForApproval::Never,
@@ -1610,6 +1611,7 @@ mod tests {
         let conversation_id = ConversationId::new();
         let event = SessionConfiguredEvent {
             session_id: conversation_id,
+            timestamp: None,
             model: "gpt-test".to_string(),
             model_provider_id: "test-provider".to_string(),
             approval_policy: AskForApproval::Never,

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -105,6 +105,7 @@ async fn resumed_initial_messages_render_history() {
     let rollout_file = NamedTempFile::new().unwrap();
     let configured = codex_core::protocol::SessionConfiguredEvent {
         session_id: conversation_id,
+        timestamp: None,
         model: "test-model".to_string(),
         model_provider_id: "test-provider".to_string(),
         approval_policy: AskForApproval::Never,

--- a/codex-rs/tui2/src/app.rs
+++ b/codex-rs/tui2/src/app.rs
@@ -2309,6 +2309,7 @@ mod tests {
         let make_header = |is_first| {
             let event = SessionConfiguredEvent {
                 session_id: ConversationId::new(),
+                timestamp: None,
                 model: "gpt-test".to_string(),
                 model_provider_id: "test-provider".to_string(),
                 approval_policy: AskForApproval::Never,
@@ -2604,6 +2605,7 @@ mod tests {
         let conversation_id = ConversationId::new();
         let event = SessionConfiguredEvent {
             session_id: conversation_id,
+            timestamp: None,
             model: "gpt-test".to_string(),
             model_provider_id: "test-provider".to_string(),
             approval_policy: AskForApproval::Never,

--- a/codex-rs/tui2/src/chatwidget/tests.rs
+++ b/codex-rs/tui2/src/chatwidget/tests.rs
@@ -103,6 +103,7 @@ async fn resumed_initial_messages_render_history() {
     let rollout_file = NamedTempFile::new().unwrap();
     let configured = codex_core::protocol::SessionConfiguredEvent {
         session_id: conversation_id,
+        timestamp: None,
         model: "test-model".to_string(),
         model_provider_id: "test-provider".to_string(),
         approval_policy: AskForApproval::Never,

--- a/docs/exec.md
+++ b/docs/exec.md
@@ -20,9 +20,9 @@ To write the output of `codex exec` to a file, in addition to using a shell redi
 
 `codex exec` supports a `--json` mode that streams events to stdout as JSON Lines (JSONL) while the agent runs.
 
-Supported event types:
+Supported event types (all events include a `timestamp` field with the session creation time, RFC3339 UTC):
 
-- `thread.started` - when a thread is started or resumed.
+- `thread.started` - when a thread is started or resumed. Includes `thread_id`.
 - `turn.started` - when a turn starts. A turn encompasses all events between the user message and the assistant response.
 - `turn.completed` - when a turn completes; includes token usage.
 - `turn.failed` - when a turn fails; includes error details.
@@ -44,14 +44,14 @@ Typically, an `agent_message` is added at the end of the turn.
 Sample output:
 
 ```jsonl
-{"type":"thread.started","thread_id":"0199a213-81c0-7800-8aa1-bbab2a035a53"}
-{"type":"turn.started"}
-{"type":"item.completed","item":{"id":"item_0","type":"reasoning","text":"**Searching for README files**"}}
-{"type":"item.started","item":{"id":"item_1","type":"command_execution","command":"bash -lc ls","aggregated_output":"","status":"in_progress"}}
-{"type":"item.completed","item":{"id":"item_1","type":"command_execution","command":"bash -lc ls","aggregated_output":"2025-09-11\nAGENTS.md\nCHANGELOG.md\ncliff.toml\ncodex-cli\ncodex-rs\ndocs\nexamples\nflake.lock\nflake.nix\nLICENSE\nnode_modules\nNOTICE\npackage.json\npnpm-lock.yaml\npnpm-workspace.yaml\nPNPM.md\nREADME.md\nscripts\nsdk\ntmp\n","exit_code":0,"status":"completed"}}
-{"type":"item.completed","item":{"id":"item_2","type":"reasoning","text":"**Checking repository root for README**"}}
-{"type":"item.completed","item":{"id":"item_3","type":"agent_message","text":"Yep — there’s a `README.md` in the repository root."}}
-{"type":"turn.completed","usage":{"input_tokens":24763,"cached_input_tokens":24448,"output_tokens":122}}
+{"type":"thread.started","thread_id":"0199a213-81c0-7800-8aa1-bbab2a035a53","timestamp":"2025-09-11T15:20:05Z"}
+{"type":"turn.started","timestamp":"2025-09-11T15:20:05Z"}
+{"type":"item.completed","timestamp":"2025-09-11T15:20:05Z","item":{"id":"item_0","type":"reasoning","text":"**Searching for README files**"}}
+{"type":"item.started","timestamp":"2025-09-11T15:20:05Z","item":{"id":"item_1","type":"command_execution","command":"bash -lc ls","aggregated_output":"","status":"in_progress"}}
+{"type":"item.completed","timestamp":"2025-09-11T15:20:05Z","item":{"id":"item_1","type":"command_execution","command":"bash -lc ls","aggregated_output":"2025-09-11\nAGENTS.md\nCHANGELOG.md\ncliff.toml\ncodex-cli\ncodex-rs\ndocs\nexamples\nflake.lock\nflake.nix\nLICENSE\nnode_modules\nNOTICE\npackage.json\npnpm-lock.yaml\npnpm-workspace.yaml\nPNPM.md\nREADME.md\nscripts\nsdk\ntmp\n","exit_code":0,"status":"completed"}}
+{"type":"item.completed","timestamp":"2025-09-11T15:20:05Z","item":{"id":"item_2","type":"reasoning","text":"**Checking repository root for README**"}}
+{"type":"item.completed","timestamp":"2025-09-11T15:20:05Z","item":{"id":"item_3","type":"agent_message","text":"Yep — there’s a `README.md` in the repository root."}}
+{"type":"turn.completed","timestamp":"2025-09-11T15:20:05Z","usage":{"input_tokens":24763,"cached_input_tokens":24448,"output_tokens":122}}
 ```
 
 ### Structured output


### PR DESCRIPTION
## What
- Add a `timestamp` field to every exec JSONL event line (session creation time).
- Document the timestamp in `codex exec --json` output.

## Why
- Needed to synchronize sessions later by querying JSONL updates since a recorded timestamp.

## How
- Capture the session timestamp from `SessionConfigured` and inject it into each JSONL event line.
- Update exec JSON docs with the new field.

Refs openai/codex#8620