### PR TITLE
ci: prevent workflows from running on forks

### DIFF
--- a/.github/workflows/close-stale-contributor-prs.yml
+++ b/.github/workflows/close-stale-contributor-prs.yml
@@ -12,6 +12,8 @@ permissions:
 
 jobs:
   close-stale-contributor-prs:
+    # Prevent scheduled runs on forks
+    if: github.repository == 'openai/codex'
     runs-on: ubuntu-latest
     steps:
       - name: Close inactive PRs from contributors

--- a/.github/workflows/issue-deduplicator.yml
+++ b/.github/workflows/issue-deduplicator.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   gather-duplicates:
     name: Identify potential duplicates
-    if: ${{ github.event.action == 'opened' || (github.event.action == 'labeled' && github.event.label.name == 'codex-deduplicate') }}
+    # Prevent runs on forks (requires OpenAI API key, wastes Actions minutes)
+    if: github.repository == 'openai/codex' && (github.event.action == 'opened' || (github.event.action == 'labeled' && github.event.label.name == 'codex-deduplicate'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -9,7 +9,8 @@ on:
 jobs:
   gather-labels:
     name: Generate label suggestions
-    if: ${{ github.event.action == 'opened' || (github.event.action == 'labeled' && github.event.label.name == 'codex-label') }}
+    # Prevent runs on forks (requires OpenAI API key, wastes Actions minutes)
+    if: github.repository == 'openai/codex' && (github.event.action == 'opened' || (github.event.action == 'labeled' && github.event.label.name == 'codex-label'))
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/rust-release-prepare.yml
+++ b/.github/workflows/rust-release-prepare.yml
@@ -14,6 +14,8 @@ permissions:
 
 jobs:
   prepare:
+    # Prevent scheduled runs on forks (no secrets, wastes Actions minutes)
+    if: github.repository == 'openai/codex'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Forked repositories inherit GitHub Actions workflows including scheduled ones. This causes:

1. **Wasted Actions minutes** - Scheduled workflows run on forks even though they will fail
2. **Failed runs** - Workflows requiring `CODEX_OPENAI_API_KEY` fail immediately on forks
3. **Noise** - Fork owners see failed workflow runs they didn't trigger

This PR adds `if: github.repository == 'openai/codex'` guards to workflows that should only run on the upstream repository.

### Affected workflows

| Workflow | Trigger | Issue |
|----------|---------|-------|
| `rust-release-prepare` | `schedule: */4 hours` | Runs 6x/day on every fork |
| `close-stale-contributor-prs` | `schedule: daily` | Runs daily on every fork |
| `issue-deduplicator` | `issues: opened` | Requires `CODEX_OPENAI_API_KEY` |
| `issue-labeler` | `issues: opened` | Requires `CODEX_OPENAI_API_KEY` |

### Note

`cla.yml` already has this guard (`github.repository_owner == 'openai'`), so it was not modified.

## Test plan

- [ ] Verify workflows still run correctly on `openai/codex`
- [ ] Verify workflows are skipped on forks (can check via Actions tab on any fork)