### PR TITLE
fix: handle utf-8 in windows sandbox logs

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1936,6 +1936,7 @@ dependencies = [
  "chrono",
  "codex-protocol",
  "codex-utils-absolute-path",
+ "codex-utils-string",
  "dirs-next",
  "dunce",
  "pretty_assertions",

--- a/codex-rs/windows-sandbox-rs/Cargo.toml
+++ b/codex-rs/windows-sandbox-rs/Cargo.toml
@@ -25,6 +25,7 @@ chrono = { version = "0.4.42", default-features = false, features = [
     "std",
 ] }
 codex-utils-absolute-path = { workspace = true }
+codex-utils-string = { workspace = true }
 dunce = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION
Currently `apply_patch` will fail on Windows if the file contents happen to have a multi-byte character at the point where the `preview` function truncates.

I've used the existing `take_bytes_at_char_boundary` helper and added a regression test (that fails without the fix).

This is related to #4013 but doesn't fix it.