### PR TITLE
Fix file search symlink escape (#8667)

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1463,11 +1463,13 @@ version = "0.0.0"
 dependencies = [
  "anyhow",
  "clap",
+ "dunce",
  "ignore",
  "nucleo-matcher",
  "pretty_assertions",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/codex-rs/file-search/Cargo.toml
+++ b/codex-rs/file-search/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/lib.rs"
 [dependencies]
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive"] }
+dunce = { workspace = true }
 ignore = { workspace = true }
 nucleo-matcher = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -23,3 +24,4 @@ tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+tempfile = { workspace = true }


### PR DESCRIPTION
Title: Fix file search symlink escape (#8667)

  ## What

  - Skip traversing symlinks that resolve outside the search root, preventing file search from escaping the workspace.
  - Add a regression test for symlink escapes.

  ## Why

  - The file search could follow symlinks out of the workspace, violating sandbox expectations on Windows and other platforms.

  ## How

  - Canonicalize the search root and compare each symlink’s resolved target to it; skip entries outside.
  - Add a unit test that creates a root + outside directory and asserts the outside file is not returned.

  ## Issue

  - https://github.com/openai/codex/issues/8667

  ## Tests

  - just fmt
  - cargo test -p codex-file-search
  - just fix -p codex-file-search
  
  I have read the CLA Document and I hereby sign the CLA