### PR TITLE
fix(tui2): avoid scroll stickiness at cell boundaries

### DIFF
--- a/codex-rs/tui2/src/app.rs
+++ b/codex-rs/tui2/src/app.rs
@@ -1135,7 +1135,8 @@ impl App {
         let max_start = total_lines.saturating_sub(max_visible);
         let top_offset = match self.transcript_scroll {
             TranscriptScroll::ToBottom => max_start,
-            TranscriptScroll::Scrolled { .. } => {
+            TranscriptScroll::Scrolled { .. }
+            | TranscriptScroll::ScrolledSpacerBeforeCell { .. } => {
                 // Already anchored; nothing to lock.
                 return;
             }


### PR DESCRIPTION
Mouse/trackpad scrolling in tui2 applies deltas in visual lines, but the transcript scroll state was anchored only to CellLine entries.

When a 1-line scroll landed on the synthetic inter-cell Spacer row (inserted between non-continuation cells), `TranscriptScroll::anchor_for` would skip that row and snap back to the adjacent cell line. That makes the resolved top offset unchanged for small/coalesced scroll deltas, so scrolling appears to get stuck right before certain cells (commonly user prompts and command output cells).

Fix this by making spacer rows a first-class scroll anchor:
- Add `TranscriptScroll::ScrolledSpacerBeforeCell` and resolve it back to the spacer row index when present.
- Update `anchor_for`/`scrolled_by` to preserve spacers instead of skipping them.
- Treat the new variant as "already anchored" in `lock_transcript_scroll_to_current_view`.

Tests:
- cargo test -p codex-tui2