### PR TITLE
fix: brighten transcript copy affordance

### DIFF
--- a/codex-rs/tui2/src/transcript_copy_ui.rs
+++ b/codex-rs/tui2/src/transcript_copy_ui.rs
@@ -275,8 +275,8 @@ impl TranscriptCopyUi {
         };
 
         let pill_area = Rect::new(x, y, pill_width, 1);
-        let base_style = Style::new().bg(Color::DarkGray);
-        let icon_style = base_style.fg(Color::Cyan);
+        let base_style = Style::new().bg(Color::DarkGray).fg(Color::White);
+        let icon_style = base_style.add_modifier(Modifier::BOLD).fg(Color::LightCyan);
         let bold_style = base_style.add_modifier(Modifier::BOLD);
 
         let mut spans: Vec<Span<'static>> = vec![


### PR DESCRIPTION
- set the pill text to white so it stays legible on light themes
- render the icon in bold light cyan so it stands out
- reran `just fmt`, `just fix -p codex-tui2`, and `cargo test -p codex-tui2` after the tweak

https://github.com/user-attachments/assets/6c296b8d-84fb-45b9-bce7-57982e0d531b

