### PR TITLE
feat: expose external_sandbox policy to codex exec

### DIFF
--- a/codex-rs/exec/src/cli.rs
+++ b/codex-rs/exec/src/cli.rs
@@ -30,7 +30,12 @@ pub struct Cli {
     /// Select the sandbox policy to use when executing model-generated shell
     /// commands.
     #[arg(long = "sandbox", short = 's', value_enum)]
-    pub sandbox_mode: Option<codex_common::SandboxModeCliArg>,
+    pub sandbox_mode: Option<SandboxCliArg>,
+
+    /// When using `--sandbox external-sandbox`, declare whether outbound
+    /// network access is available to the external sandbox.
+    #[arg(long = "network-access", value_enum)]
+    pub external_sandbox_network_access: Option<NetworkAccessCliArg>,
 
     /// Configuration profile from config.toml to specify default options.
     #[arg(long = "profile", short = 'p')]
@@ -154,4 +159,31 @@ pub enum Color {
     Never,
     #[default]
     Auto,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum SandboxCliArg {
+    ReadOnly,
+    WorkspaceWrite,
+    DangerFullAccess,
+
+    /// Indicates the process is already in an external sandbox.
+    ExternalSandbox,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum NetworkAccessCliArg {
+    Restricted,
+    Enabled,
+}
+
+impl NetworkAccessCliArg {
+    pub fn to_network_access(self) -> codex_core::protocol::NetworkAccess {
+        match self {
+            Self::Restricted => codex_core::protocol::NetworkAccess::Restricted,
+            Self::Enabled => codex_core::protocol::NetworkAccess::Enabled,
+        }
+    }
 }

--- a/codex-rs/exec/tests/suite/mod.rs
+++ b/codex-rs/exec/tests/suite/mod.rs
@@ -6,4 +6,5 @@ mod originator;
 mod output_schema;
 mod resume;
 mod sandbox;
+mod sandbox_mode;
 mod server_error_exit;

--- a/codex-rs/exec/tests/suite/sandbox_mode.rs
+++ b/codex-rs/exec/tests/suite/sandbox_mode.rs
@@ -1,0 +1,163 @@
+#![cfg(not(target_os = "windows"))]
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use core_test_support::responses;
+use core_test_support::test_codex_exec::test_codex_exec;
+use pretty_assertions::assert_eq;
+
+async fn run_exec_with_server(args: &[&str], prompt: &str) -> anyhow::Result<String> {
+    let test = test_codex_exec();
+
+    let server = responses::start_mock_server().await;
+    let body = responses::sse(vec![
+        responses::ev_response_created("response_1"),
+        responses::ev_assistant_message("response_1", "Task completed"),
+        responses::ev_completed("response_1"),
+    ]);
+    responses::mount_sse_once(&server, body).await;
+
+    let output = {
+        let mut cmd = test.cmd_with_server(&server);
+        cmd.arg("--skip-git-repo-check");
+        for arg in args {
+            cmd.arg(arg);
+        }
+        cmd.arg(prompt).output()?
+    };
+
+    assert!(output.status.success(), "run failed: {output:?}");
+    Ok(String::from_utf8(output.stderr)?)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn accepts_read_only_sandbox_flag() -> anyhow::Result<()> {
+    let stderr =
+        run_exec_with_server(&["--sandbox", "read-only"], "test read-only sandbox").await?;
+    assert!(stderr.contains("sandbox: read-only"), "{stderr}");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn accepts_workspace_write_sandbox_flag() -> anyhow::Result<()> {
+    let stderr = run_exec_with_server(
+        &["--sandbox", "workspace-write"],
+        "test workspace-write sandbox",
+    )
+    .await?;
+    assert!(stderr.contains("sandbox: workspace-write"), "{stderr}");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn accepts_danger_full_access_sandbox_flag() -> anyhow::Result<()> {
+    let stderr = run_exec_with_server(
+        &["--sandbox", "danger-full-access"],
+        "test danger-full-access sandbox",
+    )
+    .await?;
+    assert!(stderr.contains("sandbox: danger-full-access"), "{stderr}");
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn accepts_external_sandbox_flag_defaults_to_restricted_network() -> anyhow::Result<()> {
+    let stderr =
+        run_exec_with_server(&["--sandbox", "external-sandbox"], "test external sandbox").await?;
+    assert!(stderr.contains("sandbox: external-sandbox"), "{stderr}");
+    assert!(
+        !stderr.contains("network access enabled"),
+        "stderr unexpectedly claims network access enabled: {stderr}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn accepts_external_sandbox_with_enabled_network_access() -> anyhow::Result<()> {
+    let stderr = run_exec_with_server(
+        &[
+            "--sandbox",
+            "external-sandbox",
+            "--network-access",
+            "enabled",
+        ],
+        "test external sandbox network enabled",
+    )
+    .await?;
+    assert!(
+        stderr.contains("sandbox: external-sandbox (network access enabled)"),
+        "{stderr}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rejects_network_access_without_external_sandbox() -> anyhow::Result<()> {
+    let test = test_codex_exec();
+
+    let output = test
+        .cmd()
+        .arg("--skip-git-repo-check")
+        .arg("--network-access")
+        .arg("enabled")
+        .arg("test")
+        .output()?;
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        stderr.contains("--network-access can only be used with --sandbox external-sandbox"),
+        "{stderr}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rejects_external_sandbox_with_full_auto() -> anyhow::Result<()> {
+    let test = test_codex_exec();
+
+    let output = test
+        .cmd()
+        .arg("--skip-git-repo-check")
+        .arg("--full-auto")
+        .arg("--sandbox")
+        .arg("external-sandbox")
+        .arg("test")
+        .output()?;
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        stderr.contains("--sandbox external-sandbox cannot be used with --full-auto"),
+        "{stderr}"
+    );
+
+    Ok(())
+}
+
+#[test]
+fn rejects_external_sandbox_with_dangerously_bypass_approvals_and_sandbox() -> anyhow::Result<()> {
+    let test = test_codex_exec();
+
+    let output = test
+        .cmd()
+        .arg("--skip-git-repo-check")
+        .arg("--sandbox")
+        .arg("external-sandbox")
+        .arg("--dangerously-bypass-approvals-and-sandbox")
+        .arg("test")
+        .output()?;
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8(output.stderr)?;
+    assert!(
+        stderr.contains(
+            "--sandbox external-sandbox cannot be used with --dangerously-bypass-approvals-and-sandbox"
+        ),
+        "{stderr}"
+    );
+
+    Ok(())
+}


### PR DESCRIPTION
### Motivation
- Allow `codex exec` to be used in environments that already enforce an external sandbox while still communicating network restrictions to the agent.
- Reduce failed attempts/retries caused by the agent assuming network access when it is actually blocked by the surrounding sandbox.

### Description
- Extend `codex exec --sandbox` to accept `external-sandbox` and add `--network-access restricted|enabled` to declare outbound network availability.
- When `external-sandbox` is selected, override the effective config to use `SandboxPolicy::ExternalSandbox { network_access }` without adding config-wide support.
- Add validation for incompatible flag combinations and integration tests covering all `--sandbox` options plus the key error cases.

### Testing
- `cargo test -p codex-exec` (pass)
