### PR TITLE
tui: expand image placeholders to full paths for models (keep basenames for users)

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -507,33 +507,12 @@ impl ChatComposer {
     }
 
     fn display_label_for_image_placeholder(path: &Path) -> String {
-        let Some(file_name) = path.file_name().and_then(|name| name.to_str()) else {
-            return "image".to_string();
-        };
-
-        // Avoid dumping very long absolute paths into the composer UI (common when attaching screenshots).
-        if !path.is_absolute() {
-            return path.display().to_string();
-        }
-
-        // Count normal path segments (including the file name).
-        let mut segments: Vec<String> = Vec::new();
-        for c in path.components() {
-            if let std::path::Component::Normal(seg) = c {
-                segments.push(seg.to_string_lossy().into_owned());
-            }
-        }
-
-        // Keep short absolute paths readable.
-        if segments.len() <= 2 {
-            return path.display().to_string();
-        }
-
-        let top = segments
-            .first()
-            .cloned()
-            .unwrap_or_else(|| "...".to_string());
-        format!("/{top}/.../{file_name}")
+        // Keep the UI placeholder compact: show only the basename (pre-existing behavior).
+        // The model can still receive the full path via model_placeholder expansion.
+        path.file_name()
+            .and_then(|name| name.to_str())
+            .map(str::to_string)
+            .unwrap_or_else(|| "image".to_string())
     }
 
     fn model_placeholder_from_display_placeholder(
@@ -3320,7 +3299,7 @@ mod tests {
         let (result, _) =
             composer.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         match result {
-            InputResult::Submitted(text) => assert_eq!(text, "[/tmp/image1.png 32x16] hi"),
+            InputResult::Submitted(text) => assert_eq!(text, "[image1.png 32x16] hi"),
             _ => panic!("expected Submitted"),
         }
         let imgs = composer.take_recent_submission_images();
@@ -3343,7 +3322,7 @@ mod tests {
         let (result, _) =
             composer.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         match result {
-            InputResult::Submitted(text) => assert_eq!(text, "[/tmp/image2.png 10x5]"),
+            InputResult::Submitted(text) => assert_eq!(text, "[image2.png 10x5]"),
             _ => panic!("expected Submitted"),
         }
         let imgs = composer.take_recent_submission_images();
@@ -3369,15 +3348,15 @@ mod tests {
         composer.attach_image(path, 10, 5, "PNG");
 
         let text = composer.textarea.text().to_string();
-        assert!(text.contains("[/tmp/image_dup.png 10x5]"));
-        assert!(text.contains("[/tmp/image_dup.png 10x5 #2]"));
+        assert!(text.contains("[image_dup.png 10x5]"));
+        assert!(text.contains("[image_dup.png 10x5 #2]"));
         assert_eq!(
             composer.attached_images[0].display_placeholder,
-            "[/tmp/image_dup.png 10x5]"
+            "[image_dup.png 10x5]"
         );
         assert_eq!(
             composer.attached_images[1].display_placeholder,
-            "[/tmp/image_dup.png 10x5 #2]"
+            "[image_dup.png 10x5 #2]"
         );
     }
 
@@ -3445,15 +3424,11 @@ mod tests {
         composer.handle_key_event(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
 
         assert_eq!(composer.attached_images.len(), 1);
-        let expected_placeholder_prefix = format!(
-            "[{} 10x5]",
-            PathBuf::from("/tmp/image_multibyte.png").display()
-        );
         assert!(
             composer
                 .textarea
                 .text()
-                .starts_with(&expected_placeholder_prefix)
+                .starts_with("[image_multibyte.png 10x5]")
         );
     }
 
@@ -3501,7 +3476,7 @@ mod tests {
         assert_eq!(
             vec![AttachedImage {
                 path: path2,
-                display_placeholder: "[/tmp/image_dup2.png 10x5]".to_string(),
+                display_placeholder: "[image_dup2.png 10x5]".to_string(),
                 model_placeholder: "[/tmp/image_dup2.png 10x5]".to_string()
             }],
             composer.attached_images,

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -549,6 +549,14 @@ impl BottomPane {
         self.composer.take_recent_submission_images()
     }
 
+    pub(crate) fn expand_attached_image_placeholders_for_model(
+        &self,
+        display_text: &str,
+    ) -> String {
+        self.composer
+            .expand_attached_image_placeholders_for_model(display_text)
+    }
+
     fn as_renderable(&'_ self) -> RenderableItem<'_> {
         if let Some(view) = self.active_view() {
             RenderableItem::Borrowed(view)

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -371,14 +371,16 @@ pub(crate) struct ChatWidget {
 }
 
 struct UserMessage {
-    text: String,
+    display_text: String,
+    model_text: String,
     image_paths: Vec<PathBuf>,
 }
 
 impl From<String> for UserMessage {
     fn from(text: String) -> Self {
         Self {
-            text,
+            display_text: text.clone(),
+            model_text: text,
             image_paths: Vec::new(),
         }
     }
@@ -387,7 +389,8 @@ impl From<String> for UserMessage {
 impl From<&str> for UserMessage {
     fn from(text: &str) -> Self {
         Self {
-            text: text.to_string(),
+            display_text: text.to_string(),
+            model_text: text.to_string(),
             image_paths: Vec::new(),
         }
     }
@@ -397,7 +400,11 @@ fn create_initial_user_message(text: String, image_paths: Vec<PathBuf>) -> Optio
     if text.is_empty() && image_paths.is_empty() {
         None
     } else {
-        Some(UserMessage { text, image_paths })
+        Some(UserMessage {
+            display_text: text.clone(),
+            model_text: text,
+            image_paths,
+        })
     }
 }
 
@@ -813,7 +820,7 @@ impl ChatWidget {
             let queued_text = self
                 .queued_user_messages
                 .iter()
-                .map(|m| m.text.clone())
+                .map(|m| m.display_text.clone())
                 .collect::<Vec<_>>()
                 .join("\n");
             let existing_text = self.bottom_pane.composer_text();
@@ -1621,7 +1628,8 @@ impl ChatWidget {
             } if !self.queued_user_messages.is_empty() => {
                 // Prefer the most recently queued item.
                 if let Some(user_message) = self.queued_user_messages.pop_back() {
-                    self.bottom_pane.set_composer_text(user_message.text);
+                    self.bottom_pane
+                        .set_composer_text(user_message.display_text);
                     self.refresh_queued_user_messages();
                     self.request_redraw();
                 }
@@ -1630,8 +1638,12 @@ impl ChatWidget {
                 match self.bottom_pane.handle_key_event(key_event) {
                     InputResult::Submitted(text) => {
                         // If a task is running, queue the user input to be sent after the turn completes.
+                        let model_text = self
+                            .bottom_pane
+                            .expand_attached_image_placeholders_for_model(&text);
                         let user_message = UserMessage {
-                            text,
+                            display_text: text,
+                            model_text,
                             image_paths: self.bottom_pane.take_recent_submission_images(),
                         };
                         self.queue_user_message(user_message);
@@ -1909,15 +1921,19 @@ impl ChatWidget {
     }
 
     fn submit_user_message(&mut self, user_message: UserMessage) {
-        let UserMessage { text, image_paths } = user_message;
-        if text.is_empty() && image_paths.is_empty() {
+        let UserMessage {
+            display_text,
+            model_text,
+            image_paths,
+        } = user_message;
+        if display_text.is_empty() && image_paths.is_empty() {
             return;
         }
 
         let mut items: Vec<UserInput> = Vec::new();
 
         // Special-case: "!cmd" executes a local shell command instead of sending to the model.
-        if let Some(stripped) = text.strip_prefix('!') {
+        if let Some(stripped) = display_text.strip_prefix('!') {
             let cmd = stripped.trim();
             if cmd.is_empty() {
                 self.app_event_tx.send(AppEvent::InsertHistoryCell(Box::new(
@@ -1934,8 +1950,8 @@ impl ChatWidget {
             return;
         }
 
-        if !text.is_empty() {
-            items.push(UserInput::Text { text: text.clone() });
+        if !model_text.is_empty() {
+            items.push(UserInput::Text { text: model_text });
         }
 
         for path in image_paths {
@@ -1943,7 +1959,7 @@ impl ChatWidget {
         }
 
         if let Some(skills) = self.bottom_pane.skills() {
-            let skill_mentions = find_skill_mentions(&text, skills);
+            let skill_mentions = find_skill_mentions(&display_text, skills);
             for skill in skill_mentions {
                 items.push(UserInput::Skill {
                     name: skill.name.clone(),
@@ -1959,17 +1975,19 @@ impl ChatWidget {
             });
 
         // Persist the text to cross-session message history.
-        if !text.is_empty() {
+        if !display_text.is_empty() {
             self.codex_op_tx
-                .send(Op::AddToHistory { text: text.clone() })
+                .send(Op::AddToHistory {
+                    text: display_text.clone(),
+                })
                 .unwrap_or_else(|e| {
                     tracing::error!("failed to send AddHistory op: {e}");
                 });
         }
 
         // Only show the text portion in conversation history.
-        if !text.is_empty() {
-            self.add_to_history(history_cell::new_user_prompt(text));
+        if !display_text.is_empty() {
+            self.add_to_history(history_cell::new_user_prompt(display_text));
         }
         self.needs_final_message_separator = false;
     }
@@ -2226,7 +2244,7 @@ impl ChatWidget {
         let messages: Vec<String> = self
             .queued_user_messages
             .iter()
-            .map(|m| m.text.clone())
+            .map(|m| m.display_text.clone())
             .collect();
         self.bottom_pane.set_queued_user_messages(messages);
     }

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1093,7 +1093,7 @@ async fn ctrl_c_cleared_prompt_is_recoverable_via_history() {
     chat.bottom_pane.insert_str("draft message ");
     chat.bottom_pane
         .attach_image(PathBuf::from("/tmp/preview.png"), 24, 42, "png");
-    let placeholder = "[/tmp/preview.png 24x42]";
+    let placeholder = "[preview.png 24x42]";
     assert!(
         chat.bottom_pane.composer_text().ends_with(placeholder),
         "expected placeholder {placeholder:?} in composer text"
@@ -1124,7 +1124,7 @@ async fn ctrl_c_cleared_prompt_is_recoverable_via_history() {
 async fn submitting_image_shows_short_path_but_sends_full_path_to_model() {
     let (mut chat, mut rx, mut op_rx) = make_chatwidget_manual(None).await;
 
-    // Use a long absolute path so the display placeholder is shortened.
+    // Use a long absolute path so we can verify display vs model text differ.
     let image_path = PathBuf::from("/var/tmp/some/dir/image.png");
 
     chat.bottom_pane.insert_str("see ");
@@ -1133,8 +1133,8 @@ async fn submitting_image_shows_short_path_but_sends_full_path_to_model() {
 
     let display_text = chat.bottom_pane.composer_text();
     assert!(
-        display_text.contains("[/var/.../image.png 24x42]"),
-        "expected shortened display placeholder, got {display_text:?}"
+        display_text.contains("[image.png 24x42]"),
+        "expected basename display placeholder, got {display_text:?}"
     );
 
     chat.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
@@ -1147,8 +1147,8 @@ async fn submitting_image_shows_short_path_but_sends_full_path_to_model() {
     );
     let rendered = lines_to_single_string(&cells[0]);
     assert!(
-        rendered.contains("/var/.../image.png"),
-        "expected transcript to contain shortened placeholder, got {rendered:?}"
+        rendered.contains("image.png 24x42"),
+        "expected transcript to contain basename placeholder, got {rendered:?}"
     );
     assert!(
         !rendered.contains("/var/tmp/some/dir/image.png"),
@@ -1176,8 +1176,8 @@ async fn submitting_image_shows_short_path_but_sends_full_path_to_model() {
         "expected model text to contain full path, got {model_text:?}"
     );
     assert!(
-        !model_text.contains("/var/.../image.png"),
-        "expected model text not to contain shortened placeholder, got {model_text:?}"
+        !model_text.contains("[image.png 24x42]"),
+        "expected model text not to contain display placeholder, got {model_text:?}"
     );
 }
 

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1093,7 +1093,7 @@ async fn ctrl_c_cleared_prompt_is_recoverable_via_history() {
     chat.bottom_pane.insert_str("draft message ");
     chat.bottom_pane
         .attach_image(PathBuf::from("/tmp/preview.png"), 24, 42, "png");
-    let placeholder = "[preview.png 24x42]";
+    let placeholder = "[/tmp/preview.png 24x42]";
     assert!(
         chat.bottom_pane.composer_text().ends_with(placeholder),
         "expected placeholder {placeholder:?} in composer text"

--- a/codex-rs/tui2/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui2/src/bottom_pane/chat_composer.rs
@@ -330,10 +330,8 @@ impl ChatComposer {
 
     /// Attempt to start a burst by retro-capturing recent chars before the cursor.
     pub fn attach_image(&mut self, path: PathBuf, width: u32, height: u32, _format_label: &str) {
-        let file_label = path
-            .file_name()
-            .map(|name| name.to_string_lossy().into_owned())
-            .unwrap_or_else(|| "image".to_string());
+        // Include the full path in the placeholder so the model can refer back to the local file.
+        let file_label = path.display().to_string();
         let placeholder = format!("[{file_label} {width}x{height}]");
         // Insert as an element to match large paste placeholder behavior:
         // styled distinctly and treated atomically for cursor/mutations.
@@ -3167,7 +3165,7 @@ mod tests {
         let (result, _) =
             composer.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         match result {
-            InputResult::Submitted(text) => assert_eq!(text, "[image1.png 32x16] hi"),
+            InputResult::Submitted(text) => assert_eq!(text, "[/tmp/image1.png 32x16] hi"),
             _ => panic!("expected Submitted"),
         }
         let imgs = composer.take_recent_submission_images();
@@ -3190,7 +3188,7 @@ mod tests {
         let (result, _) =
             composer.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
         match result {
-            InputResult::Submitted(text) => assert_eq!(text, "[image2.png 10x5]"),
+            InputResult::Submitted(text) => assert_eq!(text, "[/tmp/image2.png 10x5]"),
             _ => panic!("expected Submitted"),
         }
         let imgs = composer.take_recent_submission_images();
@@ -3263,11 +3261,15 @@ mod tests {
         composer.handle_key_event(KeyEvent::new(KeyCode::Backspace, KeyModifiers::NONE));
 
         assert_eq!(composer.attached_images.len(), 1);
+        let expected_placeholder_prefix = format!(
+            "[{} 10x5]",
+            PathBuf::from("/tmp/image_multibyte.png").display()
+        );
         assert!(
             composer
                 .textarea
                 .text()
-                .starts_with("[image_multibyte.png 10x5]")
+                .starts_with(&expected_placeholder_prefix)
         );
     }
 
@@ -3315,7 +3317,7 @@ mod tests {
         assert_eq!(
             vec![AttachedImage {
                 path: path2,
-                placeholder: "[image_dup2.png 10x5]".to_string()
+                placeholder: "[/tmp/image_dup2.png 10x5]".to_string()
             }],
             composer.attached_images,
             "one image mapping remains"
@@ -3342,12 +3344,8 @@ mod tests {
 
         let needs_redraw = composer.handle_paste(tmp_path.to_string_lossy().to_string());
         assert!(needs_redraw);
-        assert!(
-            composer
-                .textarea
-                .text()
-                .starts_with("[codex_tui_test_paste_image.png 3x2] ")
-        );
+        let expected_prefix = format!("[{} 3x2] ", tmp_path.display());
+        assert!(composer.textarea.text().starts_with(&expected_prefix));
 
         let imgs = composer.take_recent_submission_images();
         assert_eq!(imgs, vec![tmp_path]);

--- a/codex-rs/tui2/src/bottom_pane/mod.rs
+++ b/codex-rs/tui2/src/bottom_pane/mod.rs
@@ -536,6 +536,14 @@ impl BottomPane {
         self.composer.take_recent_submission_images()
     }
 
+    pub(crate) fn expand_attached_image_placeholders_for_model(
+        &self,
+        display_text: &str,
+    ) -> String {
+        self.composer
+            .expand_attached_image_placeholders_for_model(display_text)
+    }
+
     fn as_renderable(&'_ self) -> RenderableItem<'_> {
         if let Some(view) = self.active_view() {
             RenderableItem::Borrowed(view)

--- a/codex-rs/tui2/src/chatwidget.rs
+++ b/codex-rs/tui2/src/chatwidget.rs
@@ -1759,9 +1759,7 @@ impl ChatWidget {
         }
 
         if !model_text.is_empty() {
-            items.push(UserInput::Text {
-                text: model_text.clone(),
-            });
+            items.push(UserInput::Text { text: model_text });
         }
 
         for path in image_paths {

--- a/codex-rs/tui2/src/chatwidget/tests.rs
+++ b/codex-rs/tui2/src/chatwidget/tests.rs
@@ -1053,7 +1053,7 @@ async fn ctrl_c_cleared_prompt_is_recoverable_via_history() {
     chat.bottom_pane.insert_str("draft message ");
     chat.bottom_pane
         .attach_image(PathBuf::from("/tmp/preview.png"), 24, 42, "png");
-    let placeholder = "[preview.png 24x42]";
+    let placeholder = "[/tmp/preview.png 24x42]";
     assert!(
         chat.bottom_pane.composer_text().ends_with(placeholder),
         "expected placeholder {placeholder:?} in composer text"

--- a/codex-rs/tui2/src/chatwidget/tests.rs
+++ b/codex-rs/tui2/src/chatwidget/tests.rs
@@ -1085,11 +1085,11 @@ async fn submitting_image_shows_short_path_but_sends_full_path_to_model() {
     let (mut chat, mut rx, mut op_rx) = make_chatwidget_manual(None).await;
 
     // Use a long absolute path so we can verify display vs model text differ.
-    let image_path = PathBuf::from("/var/tmp/some/dir/image.png");
+    let image_path = "/var/tmp/some/dir/image.png";
 
     chat.bottom_pane.insert_str("see ");
     chat.bottom_pane
-        .attach_image(image_path.clone(), 24, 42, "png");
+        .attach_image(PathBuf::from(image_path), 24, 42, "png");
 
     let display_text = chat.bottom_pane.composer_text();
     assert!(
@@ -1111,14 +1111,14 @@ async fn submitting_image_shows_short_path_but_sends_full_path_to_model() {
         "expected transcript to contain basename placeholder, got {rendered:?}"
     );
     assert!(
-        !rendered.contains("/var/tmp/some/dir/image.png"),
+        !rendered.contains(image_path),
         "expected transcript not to contain full path, got {rendered:?}"
     );
 
     // The model-facing text should expand the placeholder to the full path.
     let mut model_text: Option<String> = None;
     while let Ok(op) = op_rx.try_recv() {
-        if let Op::UserInput { items } = op {
+        if let Op::UserInput { items, .. } = op {
             for item in items {
                 if let codex_protocol::user_input::UserInput::Text { text } = item {
                     model_text = Some(text);
@@ -1132,7 +1132,7 @@ async fn submitting_image_shows_short_path_but_sends_full_path_to_model() {
     }
     let model_text = model_text.expect("expected Op::UserInput with a Text item");
     assert!(
-        model_text.contains("/var/tmp/some/dir/image.png"),
+        model_text.contains(image_path),
         "expected model text to contain full path, got {model_text:?}"
     );
     assert!(

--- a/codex-rs/tui2/src/chatwidget/tests.rs
+++ b/codex-rs/tui2/src/chatwidget/tests.rs
@@ -1053,7 +1053,7 @@ async fn ctrl_c_cleared_prompt_is_recoverable_via_history() {
     chat.bottom_pane.insert_str("draft message ");
     chat.bottom_pane
         .attach_image(PathBuf::from("/tmp/preview.png"), 24, 42, "png");
-    let placeholder = "[/tmp/preview.png 24x42]";
+    let placeholder = "[preview.png 24x42]";
     assert!(
         chat.bottom_pane.composer_text().ends_with(placeholder),
         "expected placeholder {placeholder:?} in composer text"
@@ -1084,7 +1084,7 @@ async fn ctrl_c_cleared_prompt_is_recoverable_via_history() {
 async fn submitting_image_shows_short_path_but_sends_full_path_to_model() {
     let (mut chat, mut rx, mut op_rx) = make_chatwidget_manual(None).await;
 
-    // Use a long absolute path so the display placeholder is shortened.
+    // Use a long absolute path so we can verify display vs model text differ.
     let image_path = PathBuf::from("/var/tmp/some/dir/image.png");
 
     chat.bottom_pane.insert_str("see ");
@@ -1093,8 +1093,8 @@ async fn submitting_image_shows_short_path_but_sends_full_path_to_model() {
 
     let display_text = chat.bottom_pane.composer_text();
     assert!(
-        display_text.contains("[/var/.../image.png 24x42]"),
-        "expected shortened display placeholder, got {display_text:?}"
+        display_text.contains("[image.png 24x42]"),
+        "expected basename display placeholder, got {display_text:?}"
     );
 
     chat.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
@@ -1107,8 +1107,8 @@ async fn submitting_image_shows_short_path_but_sends_full_path_to_model() {
     );
     let rendered = lines_to_single_string(&cells[0]);
     assert!(
-        rendered.contains("/var/.../image.png"),
-        "expected transcript to contain shortened placeholder, got {rendered:?}"
+        rendered.contains("image.png 24x42"),
+        "expected transcript to contain basename placeholder, got {rendered:?}"
     );
     assert!(
         !rendered.contains("/var/tmp/some/dir/image.png"),
@@ -1136,8 +1136,8 @@ async fn submitting_image_shows_short_path_but_sends_full_path_to_model() {
         "expected model text to contain full path, got {model_text:?}"
     );
     assert!(
-        !model_text.contains("/var/.../image.png"),
-        "expected model text not to contain shortened placeholder, got {model_text:?}"
+        !model_text.contains("[image.png 24x42]"),
+        "expected model text not to contain display placeholder, got {model_text:?}"
     );
 }
 

--- a/codex-rs/tui2/src/chatwidget/tests.rs
+++ b/codex-rs/tui2/src/chatwidget/tests.rs
@@ -970,7 +970,7 @@ async fn alt_up_edits_most_recent_queued_message() {
     // And the queue should now contain only the remaining (older) item.
     assert_eq!(chat.queued_user_messages.len(), 1);
     assert_eq!(
-        chat.queued_user_messages.front().unwrap().text,
+        chat.queued_user_messages.front().unwrap().display_text,
         "first queued"
     );
 }
@@ -1000,7 +1000,7 @@ async fn enqueueing_history_prompt_multiple_times_is_stable() {
 
     assert_eq!(chat.queued_user_messages.len(), 3);
     for message in chat.queued_user_messages.iter() {
-        assert_eq!(message.text, "repeat me");
+        assert_eq!(message.display_text, "repeat me");
     }
 }
 
@@ -1021,7 +1021,7 @@ async fn streaming_final_answer_keeps_task_running_state() {
 
     assert_eq!(chat.queued_user_messages.len(), 1);
     assert_eq!(
-        chat.queued_user_messages.front().unwrap().text,
+        chat.queued_user_messages.front().unwrap().display_text,
         "queued submission"
     );
     assert_matches!(op_rx.try_recv(), Err(TryRecvError::Empty));
@@ -1077,6 +1077,67 @@ async fn ctrl_c_cleared_prompt_is_recoverable_via_history() {
     assert!(
         images.is_empty(),
         "attachments are not preserved in history recall"
+    );
+}
+
+#[tokio::test]
+async fn submitting_image_shows_short_path_but_sends_full_path_to_model() {
+    let (mut chat, mut rx, mut op_rx) = make_chatwidget_manual(None).await;
+
+    // Use a long absolute path so the display placeholder is shortened.
+    let image_path = PathBuf::from("/var/tmp/some/dir/image.png");
+
+    chat.bottom_pane.insert_str("see ");
+    chat.bottom_pane
+        .attach_image(image_path.clone(), 24, 42, "png");
+
+    let display_text = chat.bottom_pane.composer_text();
+    assert!(
+        display_text.contains("[/var/.../image.png 24x42]"),
+        "expected shortened display placeholder, got {display_text:?}"
+    );
+
+    chat.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    // The user-visible transcript should keep the short placeholder.
+    let cells = drain_insert_history(&mut rx);
+    assert!(
+        !cells.is_empty(),
+        "expected a user history cell to be inserted"
+    );
+    let rendered = lines_to_single_string(&cells[0]);
+    assert!(
+        rendered.contains("/var/.../image.png"),
+        "expected transcript to contain shortened placeholder, got {rendered:?}"
+    );
+    assert!(
+        !rendered.contains("/var/tmp/some/dir/image.png"),
+        "expected transcript not to contain full path, got {rendered:?}"
+    );
+
+    // The model-facing text should expand the placeholder to the full path.
+    let mut model_text: Option<String> = None;
+    while let Ok(op) = op_rx.try_recv() {
+        if let Op::UserInput { items } = op {
+            for item in items {
+                if let codex_protocol::user_input::UserInput::Text { text } = item {
+                    model_text = Some(text);
+                    break;
+                }
+            }
+        }
+        if model_text.is_some() {
+            break;
+        }
+    }
+    let model_text = model_text.expect("expected Op::UserInput with a Text item");
+    assert!(
+        model_text.contains("/var/tmp/some/dir/image.png"),
+        "expected model text to contain full path, got {model_text:?}"
+    );
+    assert!(
+        !model_text.contains("/var/.../image.png"),
+        "expected model text not to contain shortened placeholder, got {model_text:?}"
     );
 }
 


### PR DESCRIPTION
### What

- When a user pastes a local image file path (or pastes an image from the clipboard), the TUI inserts an attachment
    placeholder into the composed prompt. This placeholder now includes the full path (e.g. `/tmp/image.png` instead of only the basename (e.g. `image.png`).
- We separate the user-visible vs model-visible placeholder, to preserve the current aesthetics and avoid cluttering the input. So the user still sees `image.png` while the model sees `/tmp/image.png`.
- Updated both TUI implementations (codex-tui and codex-tui2) + tests.

### Why

  - Basename-only placeholders make it hard for the model to refer back to the actual local path (e.g. when the user wants
    the model to use the path in commands / docs / patches rather than “just see the image”).

### Testing done

1. Updated automated tests and ran:
```bash
cargo test -p codex-tui; cargo test -p codex-tui2
```
2. Built codex locally and confirmed it can now see the full path

<img width="1037" height="319" alt="Screenshot 2026-01-06 at 19 06 15" src="https://github.com/user-attachments/assets/65e2c1f7-3b69-462a-8d07-a391aa08b380" />