### PR TITLE
feat: add justification arg to prefix_rule() in *.rules

### DIFF
--- a/codex-rs/cli/tests/execpolicy.rs
+++ b/codex-rs/cli/tests/execpolicy.rs
@@ -59,3 +59,61 @@ prefix_rule(
 
     Ok(())
 }
+
+#[test]
+fn execpolicy_check_includes_justification_when_present() -> Result<(), Box<dyn std::error::Error>>
+{
+    let codex_home = TempDir::new()?;
+    let policy_path = codex_home.path().join("rules").join("policy.rules");
+    fs::create_dir_all(
+        policy_path
+            .parent()
+            .expect("policy path should have a parent"),
+    )?;
+    fs::write(
+        &policy_path,
+        r#"
+prefix_rule(
+    pattern = ["git", "push"],
+    decision = "forbidden",
+    justification = "pushing is blocked in this repo",
+)
+"#,
+    )?;
+
+    let output = Command::new(codex_utils_cargo_bin::cargo_bin("codex")?)
+        .env("CODEX_HOME", codex_home.path())
+        .args([
+            "execpolicy",
+            "check",
+            "--rules",
+            policy_path
+                .to_str()
+                .expect("policy path should be valid UTF-8"),
+            "git",
+            "push",
+            "origin",
+            "main",
+        ])
+        .output()?;
+
+    assert!(output.status.success());
+    let result: serde_json::Value = serde_json::from_slice(&output.stdout)?;
+    assert_eq!(
+        result,
+        json!({
+            "decision": "forbidden",
+            "matchedRules": [
+                {
+                    "prefixRuleMatch": {
+                        "matchedPrefix": ["git", "push"],
+                        "decision": "forbidden",
+                        "justification": "pushing is blocked in this repo"
+                    }
+                }
+            ]
+        })
+    );
+
+    Ok(())
+}

--- a/codex-rs/core/tests/suite/exec_policy.rs
+++ b/codex-rs/core/tests/suite/exec_policy.rs
@@ -97,7 +97,7 @@ async fn execpolicy_blocks_shell_invocation() -> Result<()> {
 
     assert!(
         end.aggregated_output
-            .contains("execpolicy forbids this command"),
+            .contains("policy forbids commands starting with `echo`"),
         "unexpected output: {}",
         end.aggregated_output
     );

--- a/codex-rs/execpolicy/README.md
+++ b/codex-rs/execpolicy/README.md
@@ -1,52 +1,65 @@
 # codex-execpolicy
 
 ## Overview
-- Policy engine and CLI built around `prefix_rule(pattern=[...], decision?, match?, not_match?)`.
+
+- Policy engine and CLI built around `prefix_rule(pattern=[...], decision?, justification?, match?, not_match?)`.
 - This release covers the prefix-rule subset of the execpolicy language; a richer language will follow.
 - Tokens are matched in order; any `pattern` element may be a list to denote alternatives. `decision` defaults to `allow`; valid values: `allow`, `prompt`, `forbidden`.
+- `justification` is an optional human-readable rationale for why a rule exists. It can be provided for any `decision` and may be surfaced in different contexts (for example, in approval prompts or rejection messages). When `decision = "forbidden"` is used, include a recommended alternative in the `justification`, when appropriate (e.g., ``"Use `jj` instead of `git`."``).
 - `match` / `not_match` supply example invocations that are validated at load time (think of them as unit tests); examples can be token arrays or strings (strings are tokenized with `shlex`).
 - The CLI always prints the JSON serialization of the evaluation result.
 - The legacy rule matcher lives in `codex-execpolicy-legacy`.
 
 ## Policy shapes
+
 - Prefix rules use Starlark syntax:
+
 ```starlark
 prefix_rule(
     pattern = ["cmd", ["alt1", "alt2"]], # ordered tokens; list entries denote alternatives
     decision = "prompt",                 # allow | prompt | forbidden; defaults to allow
+    justification = "explain why this rule exists",
     match = [["cmd", "alt1"], "cmd alt2"],           # examples that must match this rule
     not_match = [["cmd", "oops"], "cmd alt3"],       # examples that must not match this rule
 )
 ```
 
 ## CLI
+
 - From the Codex CLI, run `codex execpolicy check` subcommand with one or more policy files (for example `src/default.rules`) to check a command:
+
 ```bash
 codex execpolicy check --rules path/to/policy.rules git status
 ```
+
 - Pass multiple `--rules` flags to merge rules, evaluated in the order provided, and use `--pretty` for formatted JSON.
 - You can also run the standalone dev binary directly during development:
+
 ```bash
 cargo run -p codex-execpolicy -- check --rules path/to/policy.rules git status
 ```
+
 - Example outcomes:
   - Match: `{"matchedRules":[{...}],"decision":"allow"}`
   - No match: `{"matchedRules":[]}`
 
 ## Response shape
+
 ```json
 {
   "matchedRules": [
     {
       "prefixRuleMatch": {
         "matchedPrefix": ["<token>", "..."],
-        "decision": "allow|prompt|forbidden"
+        "decision": "allow|prompt|forbidden",
+        "justification": "..."
       }
     }
   ],
   "decision": "allow|prompt|forbidden"
 }
 ```
+
 - When no rules match, `matchedRules` is an empty array and `decision` is omitted.
 - `matchedRules` lists every rule whose prefix matched the command; `matchedPrefix` is the exact prefix that matched.
 - The effective `decision` is the strictest severity across all matches (`forbidden` > `prompt` > `allow`).

--- a/codex-rs/execpolicy/examples/example.codexpolicy
+++ b/codex-rs/execpolicy/examples/example.codexpolicy
@@ -4,6 +4,7 @@
 prefix_rule(
     pattern = ["git", "reset", "--hard"],
     decision = "forbidden",
+    justification = "destructive operation",
     match = [
         ["git", "reset", "--hard"],
     ],

--- a/codex-rs/execpolicy/src/error.rs
+++ b/codex-rs/execpolicy/src/error.rs
@@ -11,6 +11,8 @@ pub enum Error {
     InvalidPattern(String),
     #[error("invalid example: {0}")]
     InvalidExample(String),
+    #[error("invalid rule: {0}")]
+    InvalidRule(String),
     #[error(
         "expected every example to match at least one rule. rules: {rules:?}; unmatched examples: \
          {examples:?}"

--- a/codex-rs/execpolicy/src/parser.rs
+++ b/codex-rs/execpolicy/src/parser.rs
@@ -212,11 +212,20 @@ fn policy_builtins(builder: &mut GlobalsBuilder) {
         decision: Option<&'v str>,
         r#match: Option<UnpackList<Value<'v>>>,
         not_match: Option<UnpackList<Value<'v>>>,
+        justification: Option<&'v str>,
         eval: &mut Evaluator<'v, '_, '_>,
     ) -> anyhow::Result<NoneType> {
         let decision = match decision {
             Some(raw) => Decision::parse(raw)?,
             None => Decision::Allow,
+        };
+
+        let justification = match justification {
+            Some(raw) if raw.trim().is_empty() => {
+                return Err(Error::InvalidRule("justification cannot be empty".to_string()).into());
+            }
+            Some(raw) => Some(raw.to_string()),
+            None => None,
         };
 
         let pattern_tokens = parse_pattern(pattern)?;
@@ -246,6 +255,7 @@ fn policy_builtins(builder: &mut GlobalsBuilder) {
                         rest: rest.clone(),
                     },
                     decision,
+                    justification: justification.clone(),
                 }) as RuleRef
             })
             .collect();

--- a/codex-rs/execpolicy/src/policy.rs
+++ b/codex-rs/execpolicy/src/policy.rs
@@ -46,6 +46,7 @@ impl Policy {
                     .into(),
             },
             decision,
+            justification: None,
         });
 
         self.rules_by_program.insert(first_token.clone(), rule);

--- a/codex-rs/execpolicy/src/rule.rs
+++ b/codex-rs/execpolicy/src/rule.rs
@@ -63,6 +63,12 @@ pub enum RuleMatch {
         #[serde(rename = "matchedPrefix")]
         matched_prefix: Vec<String>,
         decision: Decision,
+        /// Optional rationale for why this rule exists.
+        ///
+        /// This can be supplied for any decision and may be surfaced in different contexts
+        /// (e.g., prompt reasons or rejection messages).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        justification: Option<String>,
     },
     HeuristicsRuleMatch {
         command: Vec<String>,
@@ -83,6 +89,7 @@ impl RuleMatch {
 pub struct PrefixRule {
     pub pattern: PrefixPattern,
     pub decision: Decision,
+    pub justification: Option<String>,
 }
 
 pub trait Rule: Any + Debug + Send + Sync {
@@ -104,6 +111,7 @@ impl Rule for PrefixRule {
             .map(|matched_prefix| RuleMatch::PrefixRuleMatch {
                 matched_prefix,
                 decision: self.decision,
+                justification: self.justification.clone(),
             })
     }
 }


### PR DESCRIPTION
Adds an optional `justification` parameter to the `prefix_rule()` execpolicy DSL so policy authors can attach human-readable rationale to a rule. That justification is propagated through parsing/matching and can be surfaced to the model (or approval UI) when a command is blocked or requires approval.

When a command is rejected (or gated behind approval) due to policy, a generic message makes it hard for the model/user to understand what went wrong and what to do instead. Allowing policy authors to supply a short justification improves debuggability and helps guide the model toward compliant alternatives.

Example:

```python
prefix_rule(
    pattern = ["git", "push"],
    decision = "forbidden",
    justification = "pushing is blocked in this repo",
)
```

If Codex tried to run `git push origin main`, now the failure would include:

```
`git push origin main` rejected: pushing is blocked in this repo
```

whereas previously, all it was told was:

```
execpolicy forbids this command
```