### PR TITLE
[device-auth] Update login instruction for headless environments.

### DIFF
--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -279,6 +279,12 @@ impl AuthModeWidget {
             lines.push("".into());
             lines.push(Line::from(state.auth_url.as_str().cyan().underlined()));
             lines.push("".into());
+            lines.push(Line::from(vec![
+                "  On a remote or headless machine? Use ".into(),
+                "codex login --device-auth".cyan(),
+                " instead".into(),
+            ]));
+            lines.push("".into());
         }
 
         lines.push("  Press Esc to cancel".dim().into());

--- a/codex-rs/tui2/src/onboarding/auth.rs
+++ b/codex-rs/tui2/src/onboarding/auth.rs
@@ -279,6 +279,12 @@ impl AuthModeWidget {
             lines.push("".into());
             lines.push(Line::from(state.auth_url.as_str().cyan().underlined()));
             lines.push("".into());
+            lines.push(Line::from(vec![
+                "  On a remote or headless machine? Use ".into(),
+                "codex login --device-auth".cyan(),
+                " instead".into(),
+            ]));
+            lines.push("".into());
         }
 
         lines.push("  Press Esc to cancel".dim().into());


### PR DESCRIPTION
We've seen reports that people who try to login on a remote/headless machine will open the login link on their own machine and got errors. Update the instructions to ask those users to use `codex login --device-auth` instead.

<img width="1434" height="938" alt="CleanShot 2026-01-05 at 11 35 02@2x" src="https://github.com/user-attachments/assets/2b209953-6a42-4eb0-8b55-bb0733f2e373" />

