### PR TITLE
tui: require Esc twice to interrupt

### DIFF
--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -173,6 +173,16 @@ impl BottomPane {
 
     /// Forward a key event to the active view or the composer.
     pub fn handle_key_event(&mut self, key_event: KeyEvent) -> InputResult {
+        let esc_interrupt_candidate = matches!(key_event.code, KeyCode::Esc)
+            && self.is_task_running
+            && self.status.is_some()
+            && !self.composer.popup_active()
+            && self.view_stack.is_empty();
+
+        if !esc_interrupt_candidate && let Some(status) = self.status.as_mut() {
+            status.clear_esc_interrupt_prime();
+        }
+
         // If a modal/view is active, handle it here; otherwise forward to composer.
         if let Some(view) = self.view_stack.last_mut() {
             if key_event.code == KeyCode::Esc
@@ -191,14 +201,12 @@ impl BottomPane {
             self.request_redraw();
             InputResult::None
         } else {
-            // If a task is running and a status line is visible, allow Esc to
-            // send an interrupt even while the composer has focus.
-            if matches!(key_event.code, crossterm::event::KeyCode::Esc)
-                && self.is_task_running
-                && let Some(status) = &self.status
-            {
-                // Send Op::Interrupt
-                status.interrupt();
+            // If a task is running and a status line is visible, allow Esc-Esc to
+            // interrupt even while the composer has focus.
+            if esc_interrupt_candidate && let Some(status) = self.status.as_mut() {
+                if status.handle_esc_interrupt() {
+                    status.interrupt();
+                }
                 self.request_redraw();
                 return InputResult::None;
             }
@@ -859,5 +867,36 @@ mod tests {
             "status_and_queued_messages_snapshot",
             render_snapshot(&pane, area)
         );
+    }
+
+    #[test]
+    fn esc_twice_interrupts_task() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        let (tx_raw, mut rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let mut pane = BottomPane::new(BottomPaneParams {
+            app_event_tx: tx,
+            frame_requester: FrameRequester::test_dummy(),
+            has_input_focus: true,
+            enhanced_keys_supported: false,
+            placeholder_text: "Ask Codex to do anything".to_string(),
+            disable_paste_burst: false,
+            animations_enabled: true,
+            skills: Some(Vec::new()),
+        });
+
+        pane.set_task_running(true);
+
+        pane.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        assert!(rx.try_recv().is_err(), "expected no interrupt on first Esc");
+
+        pane.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+        match rx.try_recv() {
+            Ok(AppEvent::CodexOp(codex_core::protocol::Op::Interrupt)) => {}
+            other => panic!("expected Op::Interrupt, got {other:?}"),
+        }
     }
 }

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__tests__status_and_composer_fill_height_without_bottom_padding.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__tests__status_and_composer_fill_height_without_bottom_padding.snap
@@ -2,7 +2,7 @@
 source: tui/src/bottom_pane/mod.rs
 expression: "render_snapshot(&pane, area)"
 ---
-• Working (0s • esc to interru
+• Working (0s • esc esc to int
                               
                               
 › Ask Codex to do anything    

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__tests__status_and_queued_messages_snapshot.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__tests__status_and_queued_messages_snapshot.snap
@@ -2,7 +2,7 @@
 source: tui/src/bottom_pane/mod.rs
 expression: "render_snapshot(&pane, area)"
 ---
-• Working (0s • esc to interrupt)               
+• Working (0s • esc esc to interrupt)           
   ↳ Queued follow-up question                   
     ⌥ + ↑ edit                                  
                                                 

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__chatwidget_exec_and_status_layout_vt100_snapshot.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__chatwidget_exec_and_status_layout_vt100_snapshot.snap
@@ -2,6 +2,33 @@
 source: tui/src/chatwidget/tests.rs
 expression: term.backend().vt100().screen().contents()
 ---
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 • I’m going to search the repo for where “Change Approved” is rendered to update
   that view.
 
@@ -9,7 +36,7 @@ expression: term.backend().vt100().screen().contents()
   └ Search Change Approved
     Read diff_render.rs
 
-• Investigating rendering code (0s • esc to interrupt)
+• Investigating rendering code (0s • esc esc to interrupt)
 
 
 › Summarize recent commits

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__chatwidget_tall.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__chatwidget_tall.snap
@@ -2,7 +2,8 @@
 source: tui/src/chatwidget/tests.rs
 expression: term.backend().vt100().screen().contents()
 ---
-• Working (0s • esc to interrupt)
+
+• Working (0s • esc esc to interrupt)
   ↳ Hello, world! 0
   ↳ Hello, world! 1
   ↳ Hello, world! 2

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__mcp_startup_header_booting.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__mcp_startup_header_booting.snap
@@ -3,7 +3,7 @@ source: tui/src/chatwidget/tests.rs
 expression: terminal.backend()
 ---
 "                                                                                "
-"• Booting MCP server: alpha (0s • esc to interrupt)                             "
+"• Booting MCP server: alpha (0s • esc esc to interrupt)                         "
 "                                                                                "
 "                                                                                "
 "› Ask Codex to do anything                                                      "

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_widget_active.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__status_widget_active.snap
@@ -1,10 +1,9 @@
 ---
 source: tui/src/chatwidget/tests.rs
-assertion_line: 1577
 expression: terminal.backend()
 ---
 "                                                                                "
-"• Analyzing (0s • esc to interrupt)                                             "
+"• Analyzing (0s • esc esc to interrupt)                                         "
 "                                                                                "
 "                                                                                "
 "› Ask Codex to do anything                                                      "

--- a/codex-rs/tui/src/snapshots/codex_tui__status_indicator_widget__tests__renders_with_working_header.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__status_indicator_widget__tests__renders_with_working_header.snap
@@ -2,5 +2,5 @@
 source: tui/src/status_indicator_widget.rs
 expression: terminal.backend()
 ---
-"• Working (0s • esc to interrupt)                                               "
+"• Working (0s • esc esc to interrupt)                                           "
 "                                                                                "

--- a/codex-rs/tui2/src/bottom_pane/snapshots/codex_tui2__bottom_pane__tests__status_and_composer_fill_height_without_bottom_padding.snap
+++ b/codex-rs/tui2/src/bottom_pane/snapshots/codex_tui2__bottom_pane__tests__status_and_composer_fill_height_without_bottom_padding.snap
@@ -2,7 +2,7 @@
 source: tui2/src/bottom_pane/mod.rs
 expression: "render_snapshot(&pane, area)"
 ---
-• Working (0s • esc to interru
+• Working (0s • esc esc to int
                               
                               
 › Ask Codex to do anything    

--- a/codex-rs/tui2/src/bottom_pane/snapshots/codex_tui2__bottom_pane__tests__status_and_queued_messages_snapshot.snap
+++ b/codex-rs/tui2/src/bottom_pane/snapshots/codex_tui2__bottom_pane__tests__status_and_queued_messages_snapshot.snap
@@ -2,7 +2,7 @@
 source: tui2/src/bottom_pane/mod.rs
 expression: "render_snapshot(&pane, area)"
 ---
-• Working (0s • esc to interrupt)               
+• Working (0s • esc esc to interrupt)           
   ↳ Queued follow-up question                   
     ⌥ + ↑ edit                                  
                                                 

--- a/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__chatwidget_exec_and_status_layout_vt100_snapshot.snap
+++ b/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__chatwidget_exec_and_status_layout_vt100_snapshot.snap
@@ -2,6 +2,33 @@
 source: tui2/src/chatwidget/tests.rs
 expression: term.backend().vt100().screen().contents()
 ---
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 • I’m going to search the repo for where “Change Approved” is rendered to update
   that view.
 
@@ -9,7 +36,7 @@ expression: term.backend().vt100().screen().contents()
   └ Search Change Approved
     Read diff_render.rs
 
-• Investigating rendering code (0s • esc to interrupt)
+• Investigating rendering code (0s • esc esc to interrupt)
 
 
 › Summarize recent commits

--- a/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__chatwidget_tall.snap
+++ b/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__chatwidget_tall.snap
@@ -2,7 +2,8 @@
 source: tui2/src/chatwidget/tests.rs
 expression: term.backend().vt100().screen().contents()
 ---
-• Working (0s • esc to interrupt)
+
+• Working (0s • esc esc to interrupt)
   ↳ Hello, world! 0
   ↳ Hello, world! 1
   ↳ Hello, world! 2

--- a/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__mcp_startup_header_booting.snap
+++ b/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__mcp_startup_header_booting.snap
@@ -3,7 +3,7 @@ source: tui2/src/chatwidget/tests.rs
 expression: terminal.backend()
 ---
 "                                                                                "
-"• Booting MCP server: alpha (0s • esc to interrupt)                             "
+"• Booting MCP server: alpha (0s • esc esc to interrupt)                         "
 "                                                                                "
 "                                                                                "
 "› Ask Codex to do anything                                                      "

--- a/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__status_widget_active.snap
+++ b/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__status_widget_active.snap
@@ -3,7 +3,7 @@ source: tui2/src/chatwidget/tests.rs
 expression: terminal.backend()
 ---
 "                                                                                "
-"• Analyzing (0s • esc to interrupt)                                             "
+"• Analyzing (0s • esc esc to interrupt)                                         "
 "                                                                                "
 "                                                                                "
 "› Ask Codex to do anything                                                      "

--- a/codex-rs/tui2/src/snapshots/codex_tui2__status_indicator_widget__tests__renders_with_working_header.snap
+++ b/codex-rs/tui2/src/snapshots/codex_tui2__status_indicator_widget__tests__renders_with_working_header.snap
@@ -2,5 +2,5 @@
 source: tui2/src/status_indicator_widget.rs
 expression: terminal.backend()
 ---
-"• Working (0s • esc to interrupt)                                               "
+"• Working (0s • esc esc to interrupt)                                           "
 "                                                                                "


### PR DESCRIPTION
### Summary
- Require `Esc` twice to interrupt a running turn (TUI + TUI2).
- Status line hint updates to `esc esc` (and shows `esc again` after the first press).

### Rationale
Single `Esc` interrupts are easy to hit accidentally; this adds a lightweight confirmation without adding a modal.

### Notes
- Second `Esc` must be pressed within ~2 seconds; any other key clears the pending interrupt.
- Backtracking / other `Esc` behaviors are unchanged.

### Testing
- `cargo test -p codex-tui`
- `cargo test -p codex-tui2`
