### PR TITLE
Fix tui2 code block wrapping and copy

### DIFF
--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -3574,7 +3574,8 @@ printf 'fenced within fenced\n'
 {
   // comment allowed in jsonc
   "path": "C:\\Program Files\\App",
-  "regex": "^foo.*(bar)?$"
+  "regex": "^foo.*(bar)?$",
+  "long": "this code line is intentionally very very long so that it wraps inside the viewport without being truncated on the right side"
 }
 ```
 "#;

--- a/codex-rs/tui2/docs/streaming_wrapping_design.md
+++ b/codex-rs/tui2/docs/streaming_wrapping_design.md
@@ -1,85 +1,169 @@
-# Streaming Markdown Wrapping & Animation – TUI2 Notes
+# Streaming Wrapping Reflow (tui2)
 
-This document mirrors the original `tui/streaming_wrapping_design.md` and
-captures how the same concerns apply to the new `tui2` crate. It exists so that
-future viewport and streaming work in TUI2 can rely on the same context without
-having to cross‑reference the legacy TUI implementation.
+This document describes a correctness bug in `codex-rs/tui2` and the chosen fix:
+while streaming assistant markdown, soft-wrap decisions were effectively persisted as hard line
+breaks, so resizing the viewport could not reflow prose.
 
-At a high level, the design constraints are the same:
+## Goal
 
-- Streaming agent responses are rendered incrementally, with an animation loop
-  that reveals content over time.
-- Non‑streaming history cells are rendered width‑agnostically and wrapped only
-  at display time, so they reflow correctly when the terminal is resized.
-- Streaming content should eventually follow the same “wrap on display” model so
-  the transcript reflows consistently across width changes, without regressing
-  animation or markdown semantics.
+- Resizing the viewport reflows transcript prose (including streaming assistant output).
+- Width-derived breaks are always treated as *soft wraps* (not logical newlines).
+- Copy/paste continues to treat soft wraps as joinable (via joiners), and hard breaks as newlines.
 
-## 1. Where streaming is implemented in TUI2
+Non-goals:
 
-TUI2 keeps the streaming pipeline conceptually aligned with the legacy TUI but
-in a separate crate:
+- Reflowing terminal scrollback that has already been printed.
+- Reflowing content that is intentionally treated as preformatted (e.g., code blocks, raw stdout).
 
-- `tui2/src/markdown_stream.rs` implements the markdown streaming collector and
-  animation controller for agent deltas.
-- `tui2/src/chatwidget.rs` integrates streamed content into the transcript via
-  `HistoryCell` implementations.
-- `tui2/src/history_cell.rs` provides the concrete history cell types used by
-  the inline transcript and overlays.
-- `tui2/src/wrapping.rs` contains the shared text wrapping utilities used by
-  both streaming and non‑streaming render paths:
-  - `RtOptions` describes viewport‑aware wrapping (width, indents, algorithm).
-  - `word_wrap_line`, `word_wrap_lines`, and `word_wrap_lines_borrowed` provide
-    span‑aware wrapping that preserves markdown styling and emoji width.
+## Background: where reflow happens in tui2
 
-As in the original TUI, the key tension is between:
+TUI2 renders the transcript as a list of `HistoryCell`s:
 
-- **Pre‑wrapping streamed content at commit time** (simpler animation, but
-  baked‑in splits that don’t reflow), and
-- **Deferring wrapping to render time** (better reflow, but requires a more
-  sophisticated streaming cell model or recomputation on each frame).
+1. A cell stores width-agnostic content (string, diff, logical lines, etc.).
+2. At draw time (and on resize), `transcript_render` asks each cell for lines at the *current*
+   width (ideally via `HistoryCell::transcript_lines_with_joiners(width)`).
+3. `TranscriptViewCache` caches the wrapped visual lines keyed by width; a width change triggers a
+   rebuild.
 
-## 2. Current behavior and limitations
+This only works if cells do *not* persist width-derived wrapping inside their stored state.
 
-TUI2 is intentionally conservative for now:
+## The bug: soft wraps became hard breaks during streaming
 
-- Streaming responses use the same markdown streaming and wrapping utilities as
-  the legacy TUI, with width decisions made near the streaming collector.
-- The transcript viewport (`App::render_transcript_cells` in
-  `tui2/src/app.rs`) always uses `word_wrap_lines_borrowed` against the
-  current `Rect` width, so:
-  - Non‑streaming cells reflow naturally on resize.
-  - Streamed cells respect whatever wrapping was applied when their lines were
-    constructed, and may not fully “un‑wrap” if that work happened at a fixed
-    width earlier in the pipeline.
+Ratatui represents multi-line content as `Vec<Line>`. If we split a paragraph into multiple `Line`s
+because the viewport is narrow, that split is indistinguishable from an explicit newline unless we
+also carry metadata describing which breaks were “soft”.
 
-This means TUI2 shares the same fundamental limitation documented in the
-original design note: streamed paragraphs can retain historical wrap decisions
-made at the time they were streamed, even if the viewport later grows wider.
+Streaming assistant output used to generate already-wrapped `Line`s and store them inside the
+history cell. Later, when the viewport became wider, the transcript renderer could not “un-split”
+those baked lines — they looked like hard breaks.
 
-## 3. Design directions (forward‑looking)
+## Chosen solution (A, F1): stream logical markdown lines; wrap in the cell at render-time
 
-The options outlined in the legacy document apply here as well:
+User choice recap:
 
-1. **Keep the current behavior but clarify tests and documentation.**
-   - Ensure tests in `tui2/src/markdown_stream.rs`, `tui2/src/markdown_render.rs`,
-     `tui2/src/history_cell.rs`, and `tui2/src/wrapping.rs` encode the current
-     expectations around streaming, wrapping, and emoji / markdown styling.
-2. **Move towards width‑agnostic streaming cells.**
-   - Introduce a dedicated streaming history cell that stores the raw markdown
-     buffer and lets `HistoryCell::display_lines(width)` perform both markdown
-     rendering and wrapping based on the current viewport width.
-   - Keep the commit animation logic expressed in terms of “logical” positions
-     (e.g., number of tokens or lines committed) rather than pre‑wrapped visual
-     lines at a fixed width.
-3. **Hybrid “visual line count” model.**
-   - Track committed visual lines as a scalar and re‑render the streamed prefix
-     at the current width, revealing only the first `N` visual lines on each
-     animation tick.
+- **A**: Keep append-only streaming (new history cell per commit tick), but make the streamed data
+  width-agnostic.
+- **F1**: Make the agent message cell responsible for wrapping-to-width so transcript-level wrapping
+  can be a no-op for it.
 
-TUI2 does not yet implement these refactors; it intentionally stays close to
-the legacy behavior while the viewport work (scrolling, selection, exit
-transcripts) is being ported. This document exists to make that trade‑off
-explicit for TUI2 and to provide a natural home for any TUI2‑specific streaming
-wrapping notes as the design evolves.
+### Key idea: separate markdown parsing from wrapping
 
+We introduce a width-agnostic “logical markdown line” representation that preserves the metadata
+needed to wrap correctly later:
+
+- `codex-rs/tui2/src/markdown_render.rs`
+  - `MarkdownLogicalLine { content, initial_indent, subsequent_indent, line_style, is_preformatted }`
+  - `render_markdown_logical_lines(input: &str) -> Vec<MarkdownLogicalLine>`
+
+This keeps:
+
+- hard breaks (paragraph/list boundaries, explicit newlines),
+- markdown indentation rules for wraps (list markers, nested lists, blockquotes),
+- preformatted runs (code blocks) stable.
+
+### Updated streaming pipeline
+
+- `codex-rs/tui2/src/markdown_stream.rs`
+  - `MarkdownStreamCollector` is newline-gated (no change), but now commits
+    `Vec<MarkdownLogicalLine>` instead of already-wrapped `Vec<Line>`.
+  - Width is removed from the collector; wrapping is not performed during streaming.
+
+- `codex-rs/tui2/src/streaming/controller.rs`
+  - Emits `AgentMessageCell::new_logical(...)` containing logical lines.
+
+- `codex-rs/tui2/src/history_cell.rs`
+  - `AgentMessageCell` stores `Vec<MarkdownLogicalLine>`.
+  - `HistoryCell::transcript_lines_with_joiners(width)` wraps each logical line at the current
+    width using `word_wrap_line_with_joiners` and composes indents as:
+    - transcript gutter prefix (`• ` / `  `), plus
+    - markdown-provided initial/subsequent indents.
+  - Preformatted logical lines are rendered without wrapping.
+
+Result: on resize, the transcript cache rebuilds against the new width and the agent output reflows
+correctly because the stored content contains no baked soft wraps.
+
+## Overlay deferral fix (D): defer cells, not rendered lines
+
+When an overlay (transcript/static) is active, TUI2 is in alt screen and the normal terminal buffer
+is not visible. Historically, `tui2` attempted to queue “history to print” for the normal buffer by
+deferring *rendered lines*, which baked the then-current width.
+
+User choice recap:
+
+- **D**: Store deferred *cells* and render them at overlay close time.
+
+Implementation:
+
+- `codex-rs/tui2/src/app.rs`
+  - `deferred_history_cells: Vec<Arc<dyn HistoryCell>>` (replaces `deferred_history_lines`).
+  - `AppEvent::InsertHistoryCell` pushes cells into the deferral list when `overlay.is_some()`.
+
+- `codex-rs/tui2/src/app_backtrack.rs`
+  - `close_transcript_overlay` renders deferred cells at the *current* width when closing the
+    overlay, then queues the resulting lines for the normal terminal buffer.
+
+Note: as of today, `Tui::insert_history_lines` queues lines but `Tui::draw` does not flush them into
+the terminal (see `codex-rs/tui2/src/tui.rs`). This section is therefore best read as “behavior we
+want when/if scrollback printing is re-enabled”, not a guarantee that content is printed during the
+main TUI loop. For the current intended behavior around printing, see
+`codex-rs/tui2/docs/tui_viewport_and_history.md`.
+
+## Tests (G2)
+
+User choice recap:
+
+- **G2**: Add resize reflow tests + snapshot coverage.
+
+Added coverage:
+
+- `codex-rs/tui2/src/history_cell.rs`
+  - `agent_message_cell_reflows_streamed_prose_on_resize`
+  - `agent_message_cell_reflows_streamed_prose_vt100_snapshot`
+
+These assert that a streamed agent cell produces fewer visual lines at wider widths and provide
+snapshots showing reflow for list items and blockquotes.
+
+## Audit: other `HistoryCell`s and width-baked paths
+
+This section answers “what else might behave like this?” up front.
+
+### History cells
+
+- `AgentMessageCell` (`codex-rs/tui2/src/history_cell.rs`): **was affected**; now stores logical
+  markdown lines and wraps at render time.
+- `UserHistoryCell` (`codex-rs/tui2/src/history_cell.rs`): wraps at render time from stored `String`
+  using `word_wrap_lines_with_joiners` (reflowable).
+- `ReasoningSummaryCell` (`codex-rs/tui2/src/history_cell.rs`): renders from stored `String` on each
+  call; it does call `append_markdown(..., Some(width))`, but that wrapping is recomputed per width
+  (reflowable).
+- `PrefixedWrappedHistoryCell` (`codex-rs/tui2/src/history_cell.rs`): wraps at render time and
+  returns joiners (reflowable).
+- `PlainHistoryCell` (`codex-rs/tui2/src/history_cell.rs`): stores `Vec<Line>` and returns it
+  unchanged (not reflowable by design; used for already-structured/preformatted output).
+
+Rule of thumb: any cell that stores already-wrapped `Vec<Line>` for prose is a candidate for the
+same bug; cells that store source text or logical lines and compute wrapping inside
+`display_lines(width)` are safe.
+
+### Width-baked output outside the transcript model
+
+Even with the streaming fix, some paths are inherently width-baked:
+
+- Printed transcript after exit (`codex-rs/tui2/src/app.rs`): `AppExitInfo.session_lines` is rendered
+  once using the final width and then printed; it cannot reflow afterward.
+- Optional scrollback insertion helper (`codex-rs/tui2/src/insert_history.rs`): once ANSI is written
+  to the terminal, that output cannot be reflowed later. This helper is currently used for
+  deterministic ANSI emission (`write_spans`) and tests; it is not wired into the main TUI draw
+  loop.
+- Static overlays (`codex-rs/tui2/src/pager_overlay.rs`): reflow depends on whether callers provided
+  width-agnostic input; pre-split `Vec<Line>` cannot be “un-split” within the overlay.
+
+## Deferred / follow-ups
+
+The fix above is sufficient to unblock correct reflow on resize. Remaining choices can be deferred:
+
+- Streaming granularity: one logical line can wrap into multiple visual lines, so “commit tick”
+  updates can appear in larger chunks than before. If this becomes a UX issue, we can add a render-
+  time “progressive reveal” layer without reintroducing width baking.
+- Expand logical-line rendering to other markdown-ish cells if needed (e.g., unify `append_markdown`
+  usage), but only if we find a concrete reflow bug beyond `AgentMessageCell`.

--- a/codex-rs/tui2/src/chatwidget.rs
+++ b/codex-rs/tui2/src/chatwidget.rs
@@ -1023,9 +1023,9 @@ impl ChatWidget {
                 self.needs_final_message_separator = false;
                 needs_redraw = true;
             }
-            self.stream_controller = Some(StreamController::new(
-                self.last_rendered_width.get().map(|w| w.saturating_sub(2)),
-            ));
+            // Streaming must not capture the current viewport width: width-derived wraps are
+            // applied later, at render time, so the transcript can reflow on resize.
+            self.stream_controller = Some(StreamController::new());
         }
         if let Some(controller) = self.stream_controller.as_mut()
             && controller.push(&delta)

--- a/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__chatwidget_markdown_code_blocks_vt100_snapshot.snap
+++ b/codex-rs/tui2/src/chatwidget/snapshots/codex_tui2__chatwidget__tests__chatwidget_markdown_code_blocks_vt100_snapshot.snap
@@ -1,7 +1,41 @@
 ---
 source: tui2/src/chatwidget/tests.rs
+assertion_line: 3280
 expression: term.backend().vt100().screen().contents()
 ---
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 •     -- Indented code block (4 spaces)
       SELECT *
       FROM "users"
@@ -14,5 +48,7 @@ expression: term.backend().vt100().screen().contents()
   {
     // comment allowed in jsonc
     "path": "C:\\Program Files\\App",
-    "regex": "^foo.*(bar)?$"
+    "regex": "^foo.*(bar)?$",
+    "long": "this code line is intentionally very very long so that it wraps
+  inside the viewport without being truncated on the right side"
   }

--- a/codex-rs/tui2/src/chatwidget/tests.rs
+++ b/codex-rs/tui2/src/chatwidget/tests.rs
@@ -3226,7 +3226,8 @@ printf 'fenced within fenced\n'
 {
   // comment allowed in jsonc
   "path": "C:\\Program Files\\App",
-  "regex": "^foo.*(bar)?$"
+  "regex": "^foo.*(bar)?$",
+  "long": "this code line is intentionally very very long so that it wraps inside the viewport without being truncated on the right side"
 }
 ```
 "#;

--- a/codex-rs/tui2/src/history_cell.rs
+++ b/codex-rs/tui2/src/history_cell.rs
@@ -119,6 +119,19 @@ pub(crate) trait HistoryCell: std::fmt::Debug + Send + Sync + Any {
     /// Most cells can use the default implementation (no joiners), but cells that apply wrapping
     /// should override this and return joiners derived from the same wrapping operation so
     /// clipboard reconstruction can distinguish hard breaks from soft wraps.
+    ///
+    /// `joiner_before[i]` describes the boundary *between* `lines[i - 1]` and `lines[i]`:
+    ///
+    /// - `None` means "hard break": copy inserts a newline between the two lines.
+    /// - `Some(joiner)` means "soft wrap continuation": copy inserts `joiner` and continues on the
+    ///   same logical line.
+    ///
+    /// Example (one logical line wrapped across two visual lines):
+    ///
+    /// - `lines = ["• Hello", "  world"]`
+    /// - `joiner_before = [None, Some(\" \")]`
+    ///
+    /// Copy should produce `"Hello world"` (no hard newline).
     fn transcript_lines_with_joiners(&self, width: u16) -> TranscriptLinesWithJoiners {
         let lines = self.transcript_lines(width);
         TranscriptLinesWithJoiners {
@@ -313,14 +326,64 @@ impl HistoryCell for ReasoningSummaryCell {
 
 #[derive(Debug)]
 pub(crate) struct AgentMessageCell {
-    lines: Vec<Line<'static>>,
+    /// Width-agnostic logical markdown lines for this chunk.
+    ///
+    /// These are produced either:
+    /// - by streaming (`markdown_stream` → `markdown_render::render_markdown_logical_lines`), or
+    /// - by legacy/non-streaming callers that pass pre-rendered `Vec<Line>` via [`Self::new`].
+    ///
+    /// Importantly, this stores *logical* lines, not already-wrapped visual lines, so the transcript
+    /// can reflow on resize.
+    logical_lines: Vec<crate::markdown_render::MarkdownLogicalLine>,
+    /// Whether this cell should render the leading transcript bullet (`• `).
+    ///
+    /// Streaming emits multiple immutable `AgentMessageCell`s per assistant message; only the first
+    /// chunk shows the bullet. Continuations use a two-space gutter.
     is_first_line: bool,
 }
 
 impl AgentMessageCell {
+    /// Construct an agent message cell from already-rendered `Line`s.
+    ///
+    /// This is primarily used by non-streaming paths. The lines are treated as already "logical"
+    /// lines (no additional markdown indentation metadata is available), and wrapping is still
+    /// performed at render time so the transcript can reflow on resize.
     pub(crate) fn new(lines: Vec<Line<'static>>, is_first_line: bool) -> Self {
         Self {
-            lines,
+            logical_lines: lines
+                .into_iter()
+                .map(|line| {
+                    let is_preformatted = line.style.fg == Some(ratatui::style::Color::Cyan);
+                    let line_style = line.style;
+                    let content = Line {
+                        style: Style::default(),
+                        alignment: line.alignment,
+                        spans: line.spans,
+                    };
+                    crate::markdown_render::MarkdownLogicalLine {
+                        content,
+                        initial_indent: Line::default(),
+                        subsequent_indent: Line::default(),
+                        line_style,
+                        is_preformatted,
+                    }
+                })
+                .collect(),
+            is_first_line,
+        }
+    }
+
+    /// Construct an agent message cell from markdown logical lines.
+    ///
+    /// This is the preferred streaming constructor: it preserves markdown indentation rules (list
+    /// markers, nested list continuation indent, blockquote prefix, etc.) so wrapping can be
+    /// performed correctly at render time for the current viewport width.
+    pub(crate) fn new_logical(
+        logical_lines: Vec<crate::markdown_render::MarkdownLogicalLine>,
+        is_first_line: bool,
+    ) -> Self {
+        Self {
+            logical_lines,
             is_first_line,
         }
     }
@@ -331,42 +394,97 @@ impl HistoryCell for AgentMessageCell {
         self.transcript_lines_with_joiners(width).lines
     }
 
+    /// Render wrapped transcript lines plus soft-wrap joiners.
+    ///
+    /// This is where width-dependent wrapping happens for streaming agent output. The cell composes
+    /// indentation as:
+    ///
+    /// - transcript gutter (`• ` or `  `), plus
+    /// - markdown-provided indent/prefix spans (`initial_indent` / `subsequent_indent`)
+    ///
+    /// The wrapping algorithm returns a `joiner_before` vector so copy/paste can treat soft wraps
+    /// as joinable (no hard newline) while preserving exact whitespace at wrap boundaries.
     fn transcript_lines_with_joiners(&self, width: u16) -> TranscriptLinesWithJoiners {
-        use ratatui::style::Color;
+        if width == 0 {
+            return TranscriptLinesWithJoiners {
+                lines: Vec::new(),
+                joiner_before: Vec::new(),
+            };
+        }
 
         let mut out_lines: Vec<Line<'static>> = Vec::new();
         let mut joiner_before: Vec<Option<String>> = Vec::new();
 
-        let mut is_first_output_line = true;
-        for line in &self.lines {
-            let is_code_block_line = line.style.fg == Some(Color::Cyan);
-            let initial_indent: Line<'static> = if is_first_output_line && self.is_first_line {
+        // `at_cell_start` tracks whether we're about to emit the first *visual* line of this cell.
+        // Only the first chunk of a streamed message gets the `• ` gutter; continuations use `  `.
+        let mut at_cell_start = true;
+        for logical in &self.logical_lines {
+            let gutter_first_visual_line: Line<'static> = if at_cell_start && self.is_first_line {
                 "• ".dim().into()
             } else {
                 "  ".into()
             };
-            let subsequent_indent: Line<'static> = "  ".into();
+            let gutter_continuation: Line<'static> = "  ".into();
 
-            if is_code_block_line {
-                let mut spans = initial_indent.spans;
-                spans.extend(line.spans.iter().cloned());
-                out_lines.push(Line::from(spans).style(line.style));
+            // Compose the transcript gutter with markdown-provided indentation:
+            //
+            // - `gutter_*` is the transcript-level prefix (`• ` / `  `).
+            // - `initial_indent` / `subsequent_indent` come from markdown structure (blockquote
+            //   prefix, list marker indentation, nested list continuation indentation, etc.).
+            //
+            // We apply these indents during wrapping so:
+            // - the UI renders with correct continuation indentation, and
+            // - soft-wrap joiners stay aligned with the exact whitespace the wrapper skipped.
+            let compose_indent =
+                |gutter: &Line<'static>, md_indent: &Line<'static>| -> Line<'static> {
+                    let mut spans = gutter.spans.clone();
+                    spans.extend(md_indent.spans.iter().cloned());
+                    Line::from(spans)
+                };
+
+            // Preformatted lines are rendered as a single visual line (no wrapping).
+            // This preserves code-block whitespace and keeps code copy behavior stable.
+            if logical.is_preformatted {
+                let mut spans = gutter_first_visual_line.spans.clone();
+                spans.extend(logical.initial_indent.spans.iter().cloned());
+                spans.extend(logical.content.spans.iter().cloned());
+                out_lines.push(Line::from(spans).style(logical.line_style));
                 joiner_before.push(None);
-                is_first_output_line = false;
+                at_cell_start = false;
                 continue;
             }
 
+            // Prose path: wrap to current width and capture joiners.
+            //
+            // `word_wrap_line_with_joiners` guarantees:
+            // - `wrapped.len() == wrapped_joiners.len()`
+            // - `wrapped_joiners[0] == None` (first visual segment of a logical line is a hard break)
+            // - subsequent entries are `Some(joiner)` (soft-wrap continuations).
             let opts = RtOptions::new(width as usize)
-                .initial_indent(initial_indent)
-                .subsequent_indent(subsequent_indent.clone());
+                .initial_indent(compose_indent(
+                    &gutter_first_visual_line,
+                    &logical.initial_indent,
+                ))
+                .subsequent_indent(compose_indent(
+                    &gutter_continuation,
+                    &logical.subsequent_indent,
+                ));
+
             let (wrapped, wrapped_joiners) =
-                crate::wrapping::word_wrap_line_with_joiners(line, opts);
-            for (l, j) in wrapped.into_iter().zip(wrapped_joiners) {
-                out_lines.push(line_to_static(&l));
-                joiner_before.push(j);
-                is_first_output_line = false;
+                crate::wrapping::word_wrap_line_with_joiners(&logical.content, opts);
+            for (visual, joiner) in wrapped.into_iter().zip(wrapped_joiners) {
+                out_lines.push(line_to_static(&visual).style(logical.line_style));
+                joiner_before.push(joiner);
+                at_cell_start = false;
             }
         }
+
+        debug_assert_eq!(out_lines.len(), joiner_before.len());
+        debug_assert!(
+            joiner_before
+                .first()
+                .is_none_or(std::option::Option::is_none)
+        );
 
         TranscriptLinesWithJoiners {
             lines: out_lines,
@@ -1672,6 +1790,131 @@ mod tests {
 
     fn render_transcript(cell: &dyn HistoryCell) -> Vec<String> {
         render_lines(&cell.transcript_lines(u16::MAX))
+    }
+
+    /// Remove a single leading markdown blockquote marker (`> `) from `line`.
+    ///
+    /// This is a test-only normalization helper.
+    ///
+    /// In the rendered transcript, blockquote indentation is represented as literal `> ` spans in
+    /// the line prefix. For wrapped blockquote prose, those prefix spans can appear on every visual
+    /// line (including soft-wrap continuations). When we want to compare the *logical* joined text
+    /// across different widths, we strip the repeated marker on continuation lines so the
+    /// comparison doesn't fail due to prefix duplication.
+    fn strip_leading_blockquote_marker(line: &str) -> String {
+        let mut out = String::with_capacity(line.len());
+        let mut seen_non_space = false;
+        let mut removed = false;
+        let mut chars = line.chars().peekable();
+        while let Some(ch) = chars.next() {
+            if !seen_non_space {
+                if ch == ' ' {
+                    out.push(ch);
+                    continue;
+                }
+                seen_non_space = true;
+                if ch == '>' && !removed {
+                    removed = true;
+                    if matches!(chars.peek(), Some(' ')) {
+                        chars.next();
+                    }
+                    continue;
+                }
+            }
+            out.push(ch);
+        }
+        out
+    }
+
+    /// Normalize rendered transcript output into a width-insensitive "logical text" string.
+    ///
+    /// This is used by resize/reflow tests:
+    ///
+    /// - Joiners tell us which visual line breaks are soft wraps (`Some(joiner)`) vs hard breaks
+    ///   (`None`).
+    /// - For soft-wrap continuation lines, we strip repeated blockquote markers so we can compare
+    ///   the underlying prose independent of prefix repetition.
+    /// - Finally, we collapse whitespace so wrapping differences (line breaks vs spaces) do not
+    ///   affect equality.
+    fn normalize_rendered_text_with_joiners(tr: &TranscriptLinesWithJoiners) -> String {
+        let mut rendered = render_lines(&tr.lines);
+        for (line, joiner) in rendered.iter_mut().zip(&tr.joiner_before) {
+            if joiner.is_some() {
+                *line = strip_leading_blockquote_marker(line);
+            }
+        }
+        rendered
+            .join("\n")
+            .split_whitespace()
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+
+    #[test]
+    fn agent_message_cell_reflows_streamed_prose_on_resize() {
+        let md = concat!(
+            "- This is a long list item that should reflow when the viewport width changes. ",
+            "The old streaming implementation used to bake soft wraps into hard line breaks.\n",
+            "> A blockquote line that is also long enough to wrap and should reflow cleanly.\n",
+        );
+        let logical_lines = crate::markdown_stream::simulate_stream_markdown_for_tests(&[md], true);
+        let cell = AgentMessageCell::new_logical(logical_lines, true);
+
+        let narrow = cell.transcript_lines_with_joiners(28);
+        let wide = cell.transcript_lines_with_joiners(80);
+
+        assert!(
+            narrow.lines.len() > wide.lines.len(),
+            "expected fewer visual lines at wider width; narrow={} wide={}",
+            narrow.lines.len(),
+            wide.lines.len()
+        );
+        assert_eq!(
+            normalize_rendered_text_with_joiners(&narrow),
+            normalize_rendered_text_with_joiners(&wide)
+        );
+
+        let snapshot = format!(
+            "narrow:\n{}\n\nwide:\n{}",
+            render_lines(&narrow.lines).join("\n"),
+            render_lines(&wide.lines).join("\n")
+        );
+        insta::assert_snapshot!("agent_message_cell_reflow_on_resize", snapshot);
+    }
+
+    #[test]
+    fn agent_message_cell_reflows_streamed_prose_vt100_snapshot() {
+        use crate::test_backend::VT100Backend;
+
+        let md = concat!(
+            "- This is a long list item that should reflow when the viewport width changes.\n",
+            "> A blockquote that also reflows across widths.\n",
+        );
+        let logical_lines = crate::markdown_stream::simulate_stream_markdown_for_tests(&[md], true);
+        let cell = AgentMessageCell::new_logical(logical_lines, true);
+
+        let render = |width, height| -> String {
+            let backend = VT100Backend::new(width, height);
+            let mut terminal = ratatui::Terminal::new(backend).expect("terminal");
+            terminal
+                .draw(|f| {
+                    let area = f.area();
+                    let lines = cell.display_lines(area.width);
+                    Paragraph::new(Text::from(lines))
+                        .wrap(Wrap { trim: false })
+                        .render(area, f.buffer_mut());
+                })
+                .expect("draw");
+            terminal.backend().vt100().screen().contents()
+        };
+
+        let narrow = render(30, 12);
+        let wide = render(70, 12);
+
+        insta::assert_snapshot!(
+            "agent_message_cell_reflow_on_resize_vt100",
+            format!("narrow:\n{narrow}\n\nwide:\n{wide}")
+        );
     }
 
     #[tokio::test]

--- a/codex-rs/tui2/src/insert_history.rs
+++ b/codex-rs/tui2/src/insert_history.rs
@@ -1,8 +1,12 @@
-//! Render `ratatui` transcript lines into terminal scrollback.
+//! Render `ratatui` transcript lines into terminal output (scrollback) and/or deterministic ANSI.
 //!
 //! `insert_history_lines` is responsible for inserting rendered transcript lines
 //! *above* the TUI viewport by emitting ANSI control sequences through the
 //! terminal backend writer.
+//!
+//! Note: the current `tui2` main draw loop does not call `insert_history_lines` (see
+//! `codex-rs/tui2/src/tui.rs`). This module is still used for deterministic ANSI emission via
+//! `write_spans` (e.g., "print after exit" flows) and for tests.
 //!
 //! ## Why we use crossterm style commands
 //!

--- a/codex-rs/tui2/src/snapshots/codex_tui2__history_cell__tests__agent_message_cell_reflow_on_resize.snap
+++ b/codex-rs/tui2/src/snapshots/codex_tui2__history_cell__tests__agent_message_cell_reflow_on_resize.snap
@@ -1,0 +1,25 @@
+---
+source: tui2/src/history_cell.rs
+expression: snapshot
+---
+narrow:
+• - This is a long list item
+    that should reflow when
+    the viewport width
+    changes. The old
+    streaming implementation
+    used to bake soft wraps
+    into hard line breaks.
+  
+  > A blockquote line that
+  > is also long enough to
+  > wrap and should reflow
+  > cleanly.
+
+wide:
+• - This is a long list item that should reflow when the viewport width changes.
+    The old streaming implementation used to bake soft wraps into hard line
+    breaks.
+  
+  > A blockquote line that is also long enough to wrap and should reflow
+  > cleanly.

--- a/codex-rs/tui2/src/snapshots/codex_tui2__history_cell__tests__agent_message_cell_reflow_on_resize_vt100.snap
+++ b/codex-rs/tui2/src/snapshots/codex_tui2__history_cell__tests__agent_message_cell_reflow_on_resize_vt100.snap
@@ -1,0 +1,20 @@
+---
+source: tui2/src/history_cell.rs
+expression: "format!(\"narrow:\\n{narrow}\\n\\nwide:\\n{wide}\")"
+---
+narrow:
+• - This is a long list item
+    that should reflow when
+    the viewport width
+    changes.
+
+
+  > A blockquote that also
+  > reflows across widths.
+
+wide:
+• - This is a long list item that should reflow when the viewport
+    width changes.
+
+
+  > A blockquote that also reflows across widths.

--- a/codex-rs/tui2/src/streaming/mod.rs
+++ b/codex-rs/tui2/src/streaming/mod.rs
@@ -1,39 +1,59 @@
+//! Streaming state for newline-gated assistant output.
+//!
+//! The streaming pipeline in `tui2` is split into:
+//!
+//! - [`crate::markdown_stream::MarkdownStreamCollector`]: accumulates raw deltas and commits
+//!   completed *logical* markdown lines (width-agnostic).
+//! - [`StreamState`]: a small queue that supports "commit tick" animation by releasing at most one
+//!   logical line per tick.
+//! - [`controller::StreamController`]: orchestration (header emission, finalize/drain semantics,
+//!   and converting queued logical lines into `HistoryCell`s).
+//!
+//! Keeping the queued units as logical lines (not wrapped visual lines) is essential for resize
+//! reflow: visual wrapping depends on the current viewport width and must be performed at render
+//! time inside the relevant history cell.
+
 use std::collections::VecDeque;
 
-use ratatui::text::Line;
-
+use crate::markdown_render::MarkdownLogicalLine;
 use crate::markdown_stream::MarkdownStreamCollector;
 pub(crate) mod controller;
 
 pub(crate) struct StreamState {
     pub(crate) collector: MarkdownStreamCollector,
-    queued_lines: VecDeque<Line<'static>>,
+    queued_lines: VecDeque<MarkdownLogicalLine>,
     pub(crate) has_seen_delta: bool,
 }
 
 impl StreamState {
-    pub(crate) fn new(width: Option<usize>) -> Self {
+    /// Create a fresh streaming state for one assistant message.
+    pub(crate) fn new() -> Self {
         Self {
-            collector: MarkdownStreamCollector::new(width),
+            collector: MarkdownStreamCollector::new(),
             queued_lines: VecDeque::new(),
             has_seen_delta: false,
         }
     }
+    /// Reset state for the next stream.
     pub(crate) fn clear(&mut self) {
         self.collector.clear();
         self.queued_lines.clear();
         self.has_seen_delta = false;
     }
-    pub(crate) fn step(&mut self) -> Vec<Line<'static>> {
+    /// Pop at most one queued logical line (for commit-tick animation).
+    pub(crate) fn step(&mut self) -> Vec<MarkdownLogicalLine> {
         self.queued_lines.pop_front().into_iter().collect()
     }
-    pub(crate) fn drain_all(&mut self) -> Vec<Line<'static>> {
+    /// Drain all queued logical lines (used on finalize).
+    pub(crate) fn drain_all(&mut self) -> Vec<MarkdownLogicalLine> {
         self.queued_lines.drain(..).collect()
     }
+    /// True when there is no queued output waiting to be emitted by commit ticks.
     pub(crate) fn is_idle(&self) -> bool {
         self.queued_lines.is_empty()
     }
-    pub(crate) fn enqueue(&mut self, lines: Vec<Line<'static>>) {
+    /// Enqueue newly committed logical lines.
+    pub(crate) fn enqueue(&mut self, lines: Vec<MarkdownLogicalLine>) {
         self.queued_lines.extend(lines);
     }
 }

--- a/codex-rs/tui2/src/transcript_render.rs
+++ b/codex-rs/tui2/src/transcript_render.rs
@@ -199,8 +199,8 @@ pub(crate) fn append_wrapped_transcript_cell(
                 line_in_cell: visual_line_in_cell,
             });
             visual_line_in_cell = visual_line_in_cell.saturating_add(1);
-            // Preformatted lines are treated as hard breaks; we keep the cell-provided joiner
-            // (which is typically `None`).
+            // Preformatted lines are treated as hard breaks; we keep the cell-provided joiner (which
+            // may describe an earlier soft wrap inside the cell).
             out.joiner_before.push(
                 rendered
                     .joiner_before

--- a/codex-rs/tui2/src/tui.rs
+++ b/codex-rs/tui2/src/tui.rs
@@ -95,7 +95,7 @@ pub fn restore() -> Result<()> {
     Ok(())
 }
 
-/// Initialize the terminal (inline viewport; history stays in normal scrollback)
+/// Initialize the terminal (inline viewport; no always-on scrollback printing).
 pub fn init() -> Result<Terminal> {
     if !stdin().is_terminal() {
         return Err(std::io::Error::other("stdin is not a terminal"));


### PR DESCRIPTION
- wrap preformatted markdown lines with joiners so code fences reflow instead of truncating
- preserve code block copy fidelity by joining soft-wrap segments and trimming repeated indent
- extend markdown/code snapshots with long fenced lines to cover wrapping
