### PR TITLE
Add lighthearted joke to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,4 +56,6 @@ You can also use Codex with an API key, but this requires [additional setup](htt
 - [**Installing & building**](./docs/install.md)
 - [**Open source fund**](./docs/open-source-fund.md)
 
+Joke: Why do programmers prefer dark mode? Because light attracts bugs.
+
 This repository is licensed under the [Apache-2.0 License](LICENSE).


### PR DESCRIPTION
### Motivation
- Make the project README slightly more approachable by adding a small, lighthearted line.  
- This is a documentation-only tweak intended to add a bit of personality to the top-level docs.  
- No functional or API changes were intended by this edit.

### Description
- Inserted a single-line joke immediately above the license line in `README.md`: "Joke: Why do programmers prefer dark mode? Because light attracts bugs.".  
- No source code, configuration, or test files were modified.  
- The change is a one-line textual addition to the repository documentation.

### Testing
- This is a documentation-only change so no automated tests were run.  
- No `cargo`, `just`, or linters were invoked because no Rust code was changed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_695c6c7c72908320b1a739a0a4038587)