### PR TITLE
fix: windows can now paste non-ascii multiline text

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -2587,8 +2587,6 @@ mod tests {
 程序员 与 Unicode 同行",
             // Simulate pasting "你　好\nhi" with an ideographic space to trigger pastey heuristics.
             "你　好\nhi",
-            // singular ascii character then hello
-            "试\nhello",
         ];
 
         for test_case in test_cases {

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -698,22 +698,23 @@ impl ChatComposer {
                         return (InputResult::None, true);
                     }
                     CharDecision::BeginBuffer { retro_chars } => {
-                        // Grab recent chars
                         let cur = self.textarea.cursor();
                         let txt = self.textarea.text();
                         let safe_cur = Self::clamp_to_char_boundary(txt, cur);
                         let before = &txt[..safe_cur];
-                        let start_byte =
-                            super::paste_burst::retro_start_index(before, retro_chars as usize);
-                        // remove the recent chars we grabbed
-                        let grabbed = before[start_byte..].to_string();
-                        if !grabbed.is_empty() {
-                            self.textarea.replace_range(start_byte..safe_cur, "");
+                        if let Some(grab) =
+                            self.paste_burst
+                                .decide_begin_buffer(now, before, retro_chars as usize)
+                        {
+                            if !grab.grabbed.is_empty() {
+                                self.textarea.replace_range(grab.start_byte..safe_cur, "");
+                            }
+                            // seed the paste burst buffer with everything (grabbed + new)
+                            self.paste_burst.append_char_to_buffer(ch, now);
+                            return (InputResult::None, true);
                         }
-                        // seed the paste burst buffer with everything (grabbed + new)
-                        self.paste_burst.begin_with_retro_grabbed(grabbed, now);
-                        self.paste_burst.append_char_to_buffer(ch, now);
-                        return (InputResult::None, true);
+                        // If decide_begin_buffer opted not to start buffering,
+                        // fall through to normal insertion below.
                     }
                     _ => unreachable!("on_plain_char_no_hold returned unexpected variant"),
                 }
@@ -2588,11 +2589,11 @@ mod tests {
             false,
         );
 
-        // Simulate pasting "你好你\nhi" - non-ASCII chars first, then Enter, then ASCII.
+        // Simulate pasting "你　好\nhi" with an ideographic space to trigger pastey heuristics.
         // We require enough fast chars to enter burst buffering before suppressing Enter.
         let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('你'), KeyModifiers::NONE));
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('　'), KeyModifiers::NONE));
         let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('好'), KeyModifiers::NONE));
-        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('你'), KeyModifiers::NONE));
 
         // The Enter should be treated as a newline, not a submit
         let (result, _) =

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -683,7 +683,46 @@ impl ChatComposer {
             if self.paste_burst.try_append_char_if_active(ch, now) {
                 return (InputResult::None, true);
             }
-            self.paste_burst.extend_window(now);
+            let mut flushed_pending = false;
+            // Non-ASCII input often comes from IMEs and can arrive in quick bursts.
+            // We do not want to hold the first char (flicker suppression) on this path, but we
+            // still want to detect paste-like bursts. Before applying any non-ASCII input, flush
+            // any existing burst buffer (including a pending first char from the ASCII path) so
+            // we don't carry that transient state forward.
+            if let Some(pasted) = self.paste_burst.flush_before_modified_input() {
+                self.handle_paste(pasted);
+                flushed_pending = true;
+            }
+            if let Some(decision) = self.paste_burst.on_plain_char_no_hold(now) {
+                match decision {
+                    CharDecision::BufferAppend => {
+                        self.paste_burst.append_char_to_buffer(ch, now);
+                        return (InputResult::None, true);
+                    }
+                    CharDecision::BeginBuffer { retro_chars } => {
+                        let cur = self.textarea.cursor();
+                        let txt = self.textarea.text();
+                        let safe_cur = Self::clamp_to_char_boundary(txt, cur);
+                        let before = &txt[..safe_cur];
+                        if let Some(grab) =
+                            self.paste_burst
+                                .decide_begin_buffer(now, before, retro_chars as usize)
+                        {
+                            if !grab.grabbed.is_empty() {
+                                self.textarea.replace_range(grab.start_byte..safe_cur, "");
+                            }
+                            self.paste_burst.append_char_to_buffer(ch, now);
+                            return (InputResult::None, true);
+                        }
+                    }
+                    _ => unreachable!("on_plain_char_no_hold returned unexpected variant"),
+                }
+            }
+            // Keep the Enter suppression window alive while a burst is in-flight. If we flushed a
+            // buffered burst above, handle_paste() clears the window and we should not re-extend it.
+            if !flushed_pending {
+                self.paste_burst.extend_window(now);
+            }
         }
         if let Some(pasted) = self.paste_burst.flush_before_modified_input() {
             self.handle_paste(pasted);
@@ -1347,9 +1386,8 @@ impl ChatComposer {
         {
             let has_ctrl_or_alt = has_ctrl_or_alt(modifiers);
             if !has_ctrl_or_alt {
-                // Non-ASCII characters (e.g., from IMEs) can arrive in quick bursts and be
-                // misclassified by paste heuristics. Flush any active burst buffer and insert
-                // non-ASCII characters directly.
+                // Non-ASCII characters (e.g., from IMEs) can arrive in quick bursts, so avoid
+                // holding the first char while still allowing burst detection for paste input.
                 if !ch.is_ascii() {
                     return self.handle_non_ascii_char(input);
                 }
@@ -1371,7 +1409,6 @@ impl ChatComposer {
                             if !grab.grabbed.is_empty() {
                                 self.textarea.replace_range(grab.start_byte..safe_cur, "");
                             }
-                            self.paste_burst.begin_with_retro_grabbed(grab.grabbed, now);
                             self.paste_burst.append_char_to_buffer(ch, now);
                             return (InputResult::None, true);
                         }
@@ -2543,12 +2580,50 @@ mod tests {
         let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE));
         let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
 
+        std::thread::sleep(ChatComposer::recommended_paste_flush_delay());
+        let _ = composer.flush_paste_burst_if_due();
+
         // The text should now contain newline
         let text = composer.textarea.text();
         assert!(
             text.contains('\n'),
             "Text should contain newline: got '{text}'"
         );
+    }
+
+    #[test]
+    fn burst_paste_fast_non_ascii_prefix_inserts_placeholder_on_flush() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(
+            true,
+            sender,
+            false,
+            "Ask Codex to do anything".to_string(),
+            false,
+        );
+
+        let prefix = "你好".repeat(12);
+        let suffix = "x".repeat(LARGE_PASTE_CHAR_THRESHOLD + 7);
+        let paste = format!("{prefix}{suffix}");
+        for ch in paste.chars() {
+            let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+        }
+
+        std::thread::sleep(ChatComposer::recommended_paste_flush_delay());
+        let flushed = composer.flush_paste_burst_if_due();
+        assert!(flushed, "expected flush after stopping fast input");
+
+        let char_count = paste.chars().count();
+        let expected_placeholder = format!("[Pasted Content {char_count} chars]");
+        assert_eq!(composer.textarea.text(), expected_placeholder);
+        assert_eq!(composer.pending_pastes.len(), 1);
+        assert_eq!(composer.pending_pastes[0].0, expected_placeholder);
+        assert_eq!(composer.pending_pastes[0].1, paste);
     }
 
     #[test]

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -2571,7 +2571,7 @@ mod tests {
 
     // test a variety of non-ascii char sequences to ensure we are handling them correctly
     #[test]
-    fn non_ascii_burst_treats_enter_as_newline() {
+    fn non_ascii_burst_handles_newline() {
         let test_cases = [
             // triggers on windows
             "天地玄黄 宇宙洪荒
@@ -2655,46 +2655,6 @@ mod tests {
 
         let _ = flush_after_paste_burst(&mut composer);
         assert_eq!(composer.textarea.text(), "hi\nthere");
-    }
-
-    // On windows, ensure we're handling pasting of unicode characters correctly
-    #[test]
-    fn non_ascii_appends_to_active_burst_buffer() {
-        use crossterm::event::KeyCode;
-        use crossterm::event::KeyEvent;
-        use crossterm::event::KeyModifiers;
-
-        let (tx, _rx) = unbounded_channel::<AppEvent>();
-        let sender = AppEventSender::new(tx);
-        let mut composer = ChatComposer::new(
-            true,
-            sender,
-            false,
-            "Ask Codex to do anything".to_string(),
-            false,
-        );
-
-        // This string used to trigger early submission when pasted into the composer in powershell
-        // on Windows
-        let paste = r#"天地玄黄 宇宙洪荒
-日月盈昃 辰宿列张
-寒来暑往 秋收冬藏
-
-你好世界 编码测试
-汉字处理 UTF-8
-终端显示 正确无误
-
-风吹竹林 月照大江
-白云千载 青山依旧
-程序员 与 Unicode 同行"#;
-
-        for c in paste.chars() {
-            let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
-        }
-
-        assert!(composer.textarea.text().is_empty());
-        let _ = flush_after_paste_burst(&mut composer);
-        assert_eq!(composer.textarea.text(), paste);
     }
 
     #[test]

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -704,16 +704,15 @@ impl ChatComposer {
                         let txt = self.textarea.text();
                         let safe_cur = Self::clamp_to_char_boundary(txt, cur);
                         let before = &txt[..safe_cur];
-                        if let Some(grab) =
-                            self.paste_burst
-                                .decide_begin_buffer(now, before, retro_chars as usize)
-                        {
-                            if !grab.grabbed.is_empty() {
-                                self.textarea.replace_range(grab.start_byte..safe_cur, "");
-                            }
-                            self.paste_burst.append_char_to_buffer(ch, now);
-                            return (InputResult::None, true);
+                        let start_byte =
+                            super::paste_burst::retro_start_index(before, retro_chars as usize);
+                        let grabbed = before[start_byte..].to_string();
+                        if !grabbed.is_empty() {
+                            self.textarea.replace_range(start_byte..safe_cur, "");
                         }
+                        self.paste_burst.begin_with_retro_grabbed(grabbed, now);
+                        self.paste_burst.append_char_to_buffer(ch, now);
+                        return (InputResult::None, true);
                     }
                     _ => unreachable!("on_plain_char_no_hold returned unexpected variant"),
                 }
@@ -2309,8 +2308,7 @@ mod tests {
             composer.handle_key_event(KeyEvent::new(KeyCode::Char('?'), KeyModifiers::NONE));
         assert_eq!(result, InputResult::None);
         assert!(needs_redraw, "typing should still mark the view dirty");
-        std::thread::sleep(ChatComposer::recommended_paste_flush_delay());
-        let _ = composer.flush_paste_burst_if_due();
+        let _ = flush_after_paste_burst(&mut composer);
         assert_eq!(composer.textarea.text(), "h?");
         assert_eq!(composer.footer_mode, FooterMode::ShortcutSummary);
         assert_eq!(composer.footer_mode(), FooterMode::ContextOnly);
@@ -2580,8 +2578,7 @@ mod tests {
         let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE));
         let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
 
-        std::thread::sleep(ChatComposer::recommended_paste_flush_delay());
-        let _ = composer.flush_paste_burst_if_due();
+        let _ = flush_after_paste_burst(&mut composer);
 
         // The text should now contain newline
         let text = composer.textarea.text();
@@ -2614,8 +2611,7 @@ mod tests {
             let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
         }
 
-        std::thread::sleep(ChatComposer::recommended_paste_flush_delay());
-        let flushed = composer.flush_paste_burst_if_due();
+        let flushed = flush_after_paste_burst(&mut composer);
         assert!(flushed, "expected flush after stopping fast input");
 
         let char_count = paste.chars().count();
@@ -2914,6 +2910,11 @@ mod tests {
             },
             _ => panic!("slash popup not active after typing '/res'"),
         }
+    }
+
+    fn flush_after_paste_burst(composer: &mut ChatComposer) -> bool {
+        std::thread::sleep(PasteBurst::recommended_active_flush_delay());
+        composer.flush_paste_burst_if_due()
     }
 
     // Test helper: simulate human typing with a brief delay and flush the paste-burst buffer
@@ -4137,8 +4138,7 @@ mod tests {
             composer.textarea.text().is_empty(),
             "text should remain empty until flush"
         );
-        std::thread::sleep(ChatComposer::recommended_paste_flush_delay());
-        let flushed = composer.flush_paste_burst_if_due();
+        let flushed = flush_after_paste_burst(&mut composer);
         assert!(flushed, "expected buffered text to flush after stop");
         assert_eq!(composer.textarea.text(), "a".repeat(count));
         assert!(
@@ -4171,8 +4171,7 @@ mod tests {
 
         // Nothing should appear until we stop and flush
         assert!(composer.textarea.text().is_empty());
-        std::thread::sleep(ChatComposer::recommended_paste_flush_delay());
-        let flushed = composer.flush_paste_burst_if_due();
+        let flushed = flush_after_paste_burst(&mut composer);
         assert!(flushed, "expected flush after stopping fast input");
 
         let expected_placeholder = format!("[Pasted Content {count} chars]");

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -2728,18 +2728,27 @@ mod tests {
             false,
         );
 
-        // Force an active burst so the non-ASCII char takes the fast-path
-        // (try_append_char_if_active) into the burst buffer.
-        composer
-            .paste_burst
-            .begin_with_retro_grabbed(String::new(), Instant::now());
+        // This string used to trigger early submission when pasted into the composer in powershell
+        // on Windows
+        let paste = r#"天地玄黄 宇宙洪荒
+日月盈昃 辰宿列张
+寒来暑往 秋收冬藏
 
-        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('1'), KeyModifiers::NONE));
-        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('あ'), KeyModifiers::NONE));
+你好世界 编码测试
+汉字处理 UTF-8
+终端显示 正确无误
+
+风吹竹林 月照大江
+白云千载 青山依旧
+程序员 与 Unicode 同行"#;
+
+        for c in paste.chars() {
+            let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE));
+        }
 
         assert!(composer.textarea.text().is_empty());
         let _ = flush_after_paste_burst(&mut composer);
-        assert_eq!(composer.textarea.text(), "1あ");
+        assert_eq!(composer.textarea.text(), paste);
     }
 
     #[test]

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -683,6 +683,7 @@ impl ChatComposer {
             if self.paste_burst.try_append_char_if_active(ch, now) {
                 return (InputResult::None, true);
             }
+            self.paste_burst.extend_window(now);
         }
         if let Some(pasted) = self.paste_burst.flush_before_modified_input() {
             self.handle_paste(pasted);
@@ -2508,6 +2509,46 @@ mod tests {
             InputResult::Submitted(text) => assert_eq!(text, "1あ"),
             _ => panic!("expected Submitted"),
         }
+    }
+
+    #[test]
+    fn non_ascii_start_extends_burst_window_for_enter() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(
+            true,
+            sender,
+            false,
+            "Ask Codex to do anything".to_string(),
+            false,
+        );
+
+        // Simulate pasting "你好\nhi" - non-ASCII chars first, then Enter, then ASCII
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('你'), KeyModifiers::NONE));
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('好'), KeyModifiers::NONE));
+
+        // The Enter should be treated as a newline, not a submit
+        let (result, _) =
+            composer.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(
+            matches!(result, InputResult::None),
+            "Enter after non-ASCII should insert newline, not submit"
+        );
+
+        // Continue with more chars
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE));
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+
+        // The text should now contain newline
+        let text = composer.textarea.text();
+        assert!(
+            text.contains('\n'),
+            "Text should contain newline: got '{text}'"
+        );
     }
 
     #[test]

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -698,16 +698,19 @@ impl ChatComposer {
                         return (InputResult::None, true);
                     }
                     CharDecision::BeginBuffer { retro_chars } => {
+                        // Grab recent chars
                         let cur = self.textarea.cursor();
                         let txt = self.textarea.text();
                         let safe_cur = Self::clamp_to_char_boundary(txt, cur);
                         let before = &txt[..safe_cur];
                         let start_byte =
                             super::paste_burst::retro_start_index(before, retro_chars as usize);
+                        // remove the recent chars we grabbed
                         let grabbed = before[start_byte..].to_string();
                         if !grabbed.is_empty() {
                             self.textarea.replace_range(start_byte..safe_cur, "");
                         }
+                        // seed the paste burst buffer with everything (grabbed + new)
                         self.paste_burst.begin_with_retro_grabbed(grabbed, now);
                         self.paste_burst.append_char_to_buffer(ch, now);
                         return (InputResult::None, true);

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -702,6 +702,8 @@ impl ChatComposer {
                         let txt = self.textarea.text();
                         let safe_cur = Self::clamp_to_char_boundary(txt, cur);
                         let before = &txt[..safe_cur];
+                        // If decision is to buffer, seed the paste burst buffer with the grabbed chars + new.
+                        // Otherwise, fall through to normal insertion below.
                         if let Some(grab) =
                             self.paste_burst
                                 .decide_begin_buffer(now, before, retro_chars as usize)
@@ -713,8 +715,6 @@ impl ChatComposer {
                             self.paste_burst.append_char_to_buffer(ch, now);
                             return (InputResult::None, true);
                         }
-                        // If decide_begin_buffer opted not to start buffering,
-                        // fall through to normal insertion below.
                     }
                     _ => unreachable!("on_plain_char_no_hold returned unexpected variant"),
                 }

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -683,7 +683,6 @@ impl ChatComposer {
             if self.paste_burst.try_append_char_if_active(ch, now) {
                 return (InputResult::None, true);
             }
-            let mut flushed_pending = false;
             // Non-ASCII input often comes from IMEs and can arrive in quick bursts.
             // We do not want to hold the first char (flicker suppression) on this path, but we
             // still want to detect paste-like bursts. Before applying any non-ASCII input, flush
@@ -691,7 +690,6 @@ impl ChatComposer {
             // we don't carry that transient state forward.
             if let Some(pasted) = self.paste_burst.flush_before_modified_input() {
                 self.handle_paste(pasted);
-                flushed_pending = true;
             }
             if let Some(decision) = self.paste_burst.on_plain_char_no_hold(now) {
                 match decision {
@@ -716,11 +714,6 @@ impl ChatComposer {
                     }
                     _ => unreachable!("on_plain_char_no_hold returned unexpected variant"),
                 }
-            }
-            // Keep the Enter suppression window alive while a burst is in-flight. If we flushed a
-            // buffered burst above, handle_paste() clears the window and we should not re-extend it.
-            if !flushed_pending {
-                self.paste_burst.extend_window(now);
             }
         }
         if let Some(pasted) = self.paste_burst.flush_before_modified_input() {
@@ -2330,14 +2323,18 @@ mod tests {
             false,
         );
 
+        // Force an active paste burst so this test doesn't depend on tight timing.
+        composer
+            .paste_burst
+            .begin_with_retro_grabbed(String::new(), Instant::now());
+
         for ch in ['h', 'i', '?', 't', 'h', 'e', 'r', 'e'] {
             let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
         }
         assert!(composer.is_in_paste_burst());
         assert_eq!(composer.textarea.text(), "");
 
-        std::thread::sleep(ChatComposer::recommended_paste_flush_delay());
-        let _ = composer.flush_paste_burst_if_due();
+        let _ = flush_after_paste_burst(&mut composer);
 
         assert_eq!(composer.textarea.text(), "hi?there");
         assert_ne!(composer.footer_mode, FooterMode::ShortcutOverlay);
@@ -2547,7 +2544,7 @@ mod tests {
     }
 
     #[test]
-    fn non_ascii_start_extends_burst_window_for_enter() {
+    fn enter_submits_after_single_non_ascii_char() {
         use crossterm::event::KeyCode;
         use crossterm::event::KeyEvent;
         use crossterm::event::KeyModifiers;
@@ -2562,9 +2559,37 @@ mod tests {
             false,
         );
 
-        // Simulate pasting "你好\nhi" - non-ASCII chars first, then Enter, then ASCII
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('あ'), KeyModifiers::NONE));
+
+        let (result, _) =
+            composer.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        match result {
+            InputResult::Submitted(text) => assert_eq!(text, "あ"),
+            _ => panic!("expected Submitted"),
+        }
+    }
+
+    #[test]
+    fn non_ascii_burst_treats_enter_as_newline() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(
+            true,
+            sender,
+            false,
+            "Ask Codex to do anything".to_string(),
+            false,
+        );
+
+        // Simulate pasting "你好你\nhi" - non-ASCII chars first, then Enter, then ASCII.
+        // We require enough fast chars to enter burst buffering before suppressing Enter.
         let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('你'), KeyModifiers::NONE));
         let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('好'), KeyModifiers::NONE));
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('你'), KeyModifiers::NONE));
 
         // The Enter should be treated as a newline, not a submit
         let (result, _) =

--- a/codex-rs/tui/src/bottom_pane/paste_burst.rs
+++ b/codex-rs/tui/src/bottom_pane/paste_burst.rs
@@ -6,6 +6,11 @@ use std::time::Instant;
 const PASTE_BURST_MIN_CHARS: u16 = 3;
 const PASTE_BURST_CHAR_INTERVAL: Duration = Duration::from_millis(8);
 const PASTE_ENTER_SUPPRESS_WINDOW: Duration = Duration::from_millis(120);
+// Slower paste burts have been observed in windows environments, but ideally
+// we want to keep this low
+#[cfg(not(windows))]
+const PASTE_BURST_ACTIVE_IDLE_TIMEOUT: Duration = Duration::from_millis(8);
+#[cfg(windows)]
 const PASTE_BURST_ACTIVE_IDLE_TIMEOUT: Duration = Duration::from_millis(60);
 
 #[derive(Default)]

--- a/codex-rs/tui2/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui2/src/bottom_pane/chat_composer.rs
@@ -1556,7 +1556,8 @@ impl ChatComposer {
 
         let toggles = matches!(key_event.code, KeyCode::Char('?'))
             && !has_ctrl_or_alt(key_event.modifiers)
-            && self.is_empty();
+            && self.is_empty()
+            && !self.is_in_paste_burst();
 
         if !toggles {
             return false;
@@ -2253,6 +2254,40 @@ mod tests {
     }
 
     #[test]
+    fn question_mark_does_not_toggle_during_paste_burst() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(
+            true,
+            sender,
+            false,
+            "Ask Codex to do anything".to_string(),
+            false,
+        );
+
+        // Force an active paste burst so this test doesn't depend on tight timing.
+        composer
+            .paste_burst
+            .begin_with_retro_grabbed(String::new(), Instant::now());
+
+        for ch in ['h', 'i', '?', 't', 'h', 'e', 'r', 'e'] {
+            let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+        }
+        assert!(composer.is_in_paste_burst());
+        assert_eq!(composer.textarea.text(), "");
+
+        let flushed = flush_after_paste_burst(&mut composer);
+        assert!(flushed, "expected buffered text to flush after stop");
+
+        assert_eq!(composer.textarea.text(), "hi?there");
+        assert_ne!(composer.footer_mode, FooterMode::ShortcutOverlay);
+    }
+
+    #[test]
     fn shortcut_overlay_persists_while_task_running() {
         use crossterm::event::KeyCode;
         use crossterm::event::KeyEvent;
@@ -2456,6 +2491,28 @@ mod tests {
     }
 
     #[test]
+    fn non_ascii_char_inserts_immediately_without_burst_state() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(
+            true,
+            sender,
+            false,
+            "Ask Codex to do anything".to_string(),
+            false,
+        );
+
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('あ'), KeyModifiers::NONE));
+
+        assert_eq!(composer.textarea.text(), "あ");
+        assert!(!composer.is_in_paste_burst());
+    }
+
+    #[test]
     fn enter_submits_after_single_non_ascii_char() {
         use crossterm::event::KeyCode;
         use crossterm::event::KeyEvent;
@@ -2523,6 +2580,75 @@ mod tests {
             text.contains('\n'),
             "Text should contain newline: got '{text}'"
         );
+    }
+
+    #[test]
+    fn ascii_burst_treats_enter_as_newline() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(
+            true,
+            sender,
+            false,
+            "Ask Codex to do anything".to_string(),
+            false,
+        );
+
+        // Force an active burst so this test doesn't depend on tight timing.
+        composer
+            .paste_burst
+            .begin_with_retro_grabbed(String::new(), Instant::now());
+
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE));
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('i'), KeyModifiers::NONE));
+
+        let (result, _) =
+            composer.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert!(
+            matches!(result, InputResult::None),
+            "Enter during a burst should insert newline, not submit"
+        );
+
+        for ch in ['t', 'h', 'e', 'r', 'e'] {
+            let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+        }
+
+        let _ = flush_after_paste_burst(&mut composer);
+        assert_eq!(composer.textarea.text(), "hi\nthere");
+    }
+
+    #[test]
+    fn non_ascii_appends_to_active_burst_buffer() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(
+            true,
+            sender,
+            false,
+            "Ask Codex to do anything".to_string(),
+            false,
+        );
+
+        // Force an active burst so the non-ASCII char takes the fast-path
+        // (try_append_char_if_active) into the burst buffer.
+        composer
+            .paste_burst
+            .begin_with_retro_grabbed(String::new(), Instant::now());
+
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('1'), KeyModifiers::NONE));
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('あ'), KeyModifiers::NONE));
+
+        assert!(composer.textarea.text().is_empty());
+        let _ = flush_after_paste_burst(&mut composer);
+        assert_eq!(composer.textarea.text(), "1あ");
     }
 
     #[test]
@@ -3976,6 +4102,33 @@ mod tests {
 
         let expected = "First: one two\nSecond: one two".to_string();
         assert_eq!(InputResult::Submitted(expected), result);
+    }
+
+    #[test]
+    fn pending_first_ascii_char_flushes_as_typed() {
+        use crossterm::event::KeyCode;
+        use crossterm::event::KeyEvent;
+        use crossterm::event::KeyModifiers;
+
+        let (tx, _rx) = unbounded_channel::<AppEvent>();
+        let sender = AppEventSender::new(tx);
+        let mut composer = ChatComposer::new(
+            true,
+            sender,
+            false,
+            "Ask Codex to do anything".to_string(),
+            false,
+        );
+
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Char('h'), KeyModifiers::NONE));
+        assert!(composer.is_in_paste_burst());
+        assert!(composer.textarea.text().is_empty());
+
+        std::thread::sleep(ChatComposer::recommended_paste_flush_delay());
+        let flushed = composer.flush_paste_burst_if_due();
+        assert!(flushed, "expected pending first char to flush");
+        assert_eq!(composer.textarea.text(), "h");
+        assert!(!composer.is_in_paste_burst());
     }
 
     #[test]

--- a/codex-rs/tui2/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui2/src/bottom_pane/chat_composer.rs
@@ -2492,7 +2492,7 @@ mod tests {
     }
 
     #[test]
-    fn non_ascii_burst_treats_enter_as_newline() {
+    fn non_ascii_burst_handles_newline() {
         let test_cases = [
             // triggers on windows
             "天地玄黄 宇宙洪荒

--- a/codex-rs/tui2/src/bottom_pane/paste_burst.rs
+++ b/codex-rs/tui2/src/bottom_pane/paste_burst.rs
@@ -6,6 +6,7 @@ use std::time::Instant;
 const PASTE_BURST_MIN_CHARS: u16 = 3;
 const PASTE_BURST_CHAR_INTERVAL: Duration = Duration::from_millis(8);
 const PASTE_ENTER_SUPPRESS_WINDOW: Duration = Duration::from_millis(120);
+const PASTE_BURST_ACTIVE_IDLE_TIMEOUT: Duration = Duration::from_millis(60);
 
 #[derive(Default)]
 pub(crate) struct PasteBurst {
@@ -52,16 +53,14 @@ impl PasteBurst {
         PASTE_BURST_CHAR_INTERVAL + Duration::from_millis(1)
     }
 
+    #[cfg(test)]
+    pub(crate) fn recommended_active_flush_delay() -> Duration {
+        PASTE_BURST_ACTIVE_IDLE_TIMEOUT + Duration::from_millis(1)
+    }
+
     /// Entry point: decide how to treat a plain char with current timing.
     pub fn on_plain_char(&mut self, ch: char, now: Instant) -> CharDecision {
-        match self.last_plain_char_time {
-            Some(prev) if now.duration_since(prev) <= PASTE_BURST_CHAR_INTERVAL => {
-                self.consecutive_plain_char_burst =
-                    self.consecutive_plain_char_burst.saturating_add(1)
-            }
-            _ => self.consecutive_plain_char_burst = 1,
-        }
-        self.last_plain_char_time = Some(now);
+        self.note_plain_char(now);
 
         if self.active {
             self.burst_window_until = Some(now + PASTE_ENTER_SUPPRESS_WINDOW);
@@ -92,6 +91,40 @@ impl PasteBurst {
         CharDecision::RetainFirstChar
     }
 
+    /// Like on_plain_char(), but never holds the first char.
+    ///
+    /// Used for non-ASCII input paths (e.g., IMEs) where holding a character can
+    /// feel like dropped input, while still allowing burst-based paste detection.
+    ///
+    /// Note: This method will only ever return BufferAppend or BeginBuffer.
+    pub fn on_plain_char_no_hold(&mut self, now: Instant) -> Option<CharDecision> {
+        self.note_plain_char(now);
+
+        if self.active {
+            self.burst_window_until = Some(now + PASTE_ENTER_SUPPRESS_WINDOW);
+            return Some(CharDecision::BufferAppend);
+        }
+
+        if self.consecutive_plain_char_burst >= PASTE_BURST_MIN_CHARS {
+            return Some(CharDecision::BeginBuffer {
+                retro_chars: self.consecutive_plain_char_burst.saturating_sub(1),
+            });
+        }
+
+        None
+    }
+
+    fn note_plain_char(&mut self, now: Instant) {
+        match self.last_plain_char_time {
+            Some(prev) if now.duration_since(prev) <= PASTE_BURST_CHAR_INTERVAL => {
+                self.consecutive_plain_char_burst =
+                    self.consecutive_plain_char_burst.saturating_add(1)
+            }
+            _ => self.consecutive_plain_char_burst = 1,
+        }
+        self.last_plain_char_time = Some(now);
+    }
+
     /// Flush the buffered burst if the inter-key timeout has elapsed.
     ///
     /// Returns Some(String) when either:
@@ -102,9 +135,14 @@ impl PasteBurst {
     ///
     /// Returns None if the timeout has not elapsed or there is nothing to flush.
     pub fn flush_if_due(&mut self, now: Instant) -> FlushResult {
+        let timeout = if self.is_active_internal() {
+            PASTE_BURST_ACTIVE_IDLE_TIMEOUT
+        } else {
+            PASTE_BURST_CHAR_INTERVAL
+        };
         let timed_out = self
             .last_plain_char_time
-            .is_some_and(|t| now.duration_since(t) > PASTE_BURST_CHAR_INTERVAL);
+            .is_some_and(|t| now.duration_since(t) > timeout);
         if timed_out && self.is_active_internal() {
             self.active = false;
             let out = std::mem::take(&mut self.buffer);

--- a/codex-rs/tui2/src/bottom_pane/paste_burst.rs
+++ b/codex-rs/tui2/src/bottom_pane/paste_burst.rs
@@ -6,6 +6,11 @@ use std::time::Instant;
 const PASTE_BURST_MIN_CHARS: u16 = 3;
 const PASTE_BURST_CHAR_INTERVAL: Duration = Duration::from_millis(8);
 const PASTE_ENTER_SUPPRESS_WINDOW: Duration = Duration::from_millis(120);
+// Slower paste burts have been observed in windows environments, but ideally
+// we want to keep this low
+#[cfg(not(windows))]
+const PASTE_BURST_ACTIVE_IDLE_TIMEOUT: Duration = Duration::from_millis(8);
+#[cfg(windows)]
 const PASTE_BURST_ACTIVE_IDLE_TIMEOUT: Duration = Duration::from_millis(60);
 
 #[derive(Default)]


### PR DESCRIPTION
## Summary
This PR builds _heavily_ on the work from @occurrent in #8021 - I've only added a small fix, added additional tests, and propagated the changes to tui2.

From the original PR:

> On Windows, Codex relies on PasteBurst for paste detection because bracketed paste is not reliably available via crossterm.
> 
> When pasted content starts with non-ASCII characters, input is routed through handle_non_ascii_char, which bypasses the normal paste burst logic. This change extends the paste burst window for that path, which should ensure that Enter is correctly grouped as part of the paste.


## Testing
- [x] tested locally cross-platform
- [x] added regression tests