### PR TITLE
Clear copy pill background and add snapshot test

### DIFF
--- a/codex-rs/tui2/src/snapshots/codex_tui2__transcript_copy_ui__tests__copy_pill_clears_background.snap
+++ b/codex-rs/tui2/src/snapshots/codex_tui2__transcript_copy_ui__tests__copy_pill_clears_background.snap
@@ -1,0 +1,7 @@
+---
+source: tui2/src/transcript_copy_ui.rs
+expression: rendered
+---
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+xxxxxxxxxx ⧉ copy ctrl + shift + c xxxxx


### PR DESCRIPTION
### Motivation
- Fix a visual bug where transcript text could bleed through the on-screen copy "pill" overlay. 
- Ensure the copy affordance fully covers the underlying buffer so the pill background is solid and consistent with styling. 
- Document the approach in-code to make the background-clearing rationale explicit. 

### Description
- Clear the pill area before drawing by iterating `Rect::positions()` and calling `cell.set_symbol(" ")` and `cell.set_style(base_style)` in `render_copy_pill` in `transcript_copy_ui.rs`. 
- Added an explanatory comment for why the pill background is explicitly cleared. 
- Added a unit test `copy_pill_clears_background` and committed the corresponding snapshot file to validate the rendering behavior. 

### Testing
- Ran `just fmt` (formatting completed; non-blocking environment warning may appear). 
- Ran `just fix -p codex-tui2` to apply lints/fixes (completed). 
- Ran `cargo test -p codex-tui2` and all tests passed (snapshot updated and tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_695c9b23e9b8832997d5a457c4d83410)