### PR TITLE
Respect gitignore for @ file completion

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1469,6 +1469,7 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/codex-rs/file-search/Cargo.toml
+++ b/codex-rs/file-search/Cargo.toml
@@ -23,3 +23,4 @@ tokio = { workspace = true, features = ["full"] }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+tempfile = { workspace = true }

--- a/codex-rs/file-search/src/lib.rs
+++ b/codex-rs/file-search/src/lib.rs
@@ -1,4 +1,5 @@
 use ignore::WalkBuilder;
+use ignore::overrides::Override;
 use ignore::overrides::OverrideBuilder;
 use nucleo_matcher::Matcher;
 use nucleo_matcher::Utf32Str;
@@ -10,17 +11,183 @@ use serde::Serialize;
 use std::cell::UnsafeCell;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::num::NonZero;
 use std::path::Path;
+use std::path::PathBuf;
+use std::process::Command;
 use std::sync::Arc;
+use std::sync::Mutex;
+use std::sync::OnceLock;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicUsize;
 use std::sync::atomic::Ordering;
-use tokio::process::Command;
+use std::time::Duration;
+use std::time::Instant;
+use tokio::process::Command as TokioCommand;
 
 mod cli;
 
 pub use cli::Cli;
+
+const GIT_FILE_LIST_TTL: Duration = Duration::from_secs(1);
+
+#[derive(Clone, Debug)]
+struct GitRepoInfo {
+    repo_root: PathBuf,
+    /// Search-directory path prefix from git's perspective. Always uses `/` separators and is either empty or ends with `/`.
+    prefix: String,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct GitFileListKey {
+    repo_root: PathBuf,
+    prefix: String,
+}
+
+#[derive(Clone)]
+struct GitFileListEntry {
+    created_at: Instant,
+    files: Arc<Vec<String>>,
+}
+
+static GIT_REPO_INFO_CACHE: OnceLock<Mutex<HashMap<PathBuf, Option<GitRepoInfo>>>> =
+    OnceLock::new();
+static GIT_FILE_LIST_CACHE: OnceLock<Mutex<HashMap<GitFileListKey, GitFileListEntry>>> =
+    OnceLock::new();
+
+fn canonicalize_for_cache(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn git_repo_info(search_directory: &Path) -> Option<GitRepoInfo> {
+    let key = canonicalize_for_cache(search_directory);
+    let cache = GIT_REPO_INFO_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+
+    {
+        let guard = cache.lock().unwrap_or_else(|err| err.into_inner());
+        if let Some(cached) = guard.get(&key) {
+            return cached.clone();
+        }
+    }
+
+    let output = Command::new("git")
+        .args(["rev-parse", "--show-toplevel", "--show-prefix"])
+        .current_dir(&key)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        let mut guard = cache.lock().unwrap_or_else(|err| err.into_inner());
+        guard.insert(key, None);
+        return None;
+    }
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let mut lines = stdout.lines();
+    let repo_root_raw = lines.next()?.trim();
+    let prefix = lines.next().unwrap_or("").trim().to_string();
+
+    let repo_info = GitRepoInfo {
+        repo_root: canonicalize_for_cache(Path::new(repo_root_raw)),
+        prefix,
+    };
+
+    let mut guard = cache.lock().unwrap_or_else(|err| err.into_inner());
+    guard.insert(key, Some(repo_info.clone()));
+
+    Some(repo_info)
+}
+
+fn normalize_git_path(path: &str) -> String {
+    #[cfg(windows)]
+    {
+        path.replace('/', "\\")
+    }
+
+    #[cfg(not(windows))]
+    {
+        path.to_string()
+    }
+}
+
+fn git_ls_files(repo_root: &Path, prefix: &str, extra_args: &[&str]) -> Option<Vec<String>> {
+    let mut cmd = Command::new("git");
+    cmd.current_dir(repo_root);
+    cmd.arg("ls-files").arg("-z");
+    cmd.args(extra_args);
+
+    let pathspec = prefix.trim_end_matches('/');
+    if !pathspec.is_empty() {
+        cmd.arg("--").arg(pathspec);
+    }
+
+    let output = cmd.output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let mut paths = Vec::new();
+    for entry in output.stdout.split(|b| *b == b'\0') {
+        if entry.is_empty() {
+            continue;
+        }
+        let Ok(path) = std::str::from_utf8(entry) else {
+            continue;
+        };
+
+        let rel = if prefix.is_empty() {
+            path
+        } else if let Some(stripped) = path.strip_prefix(prefix) {
+            stripped
+        } else {
+            continue;
+        };
+        paths.push(normalize_git_path(rel));
+    }
+    Some(paths)
+}
+
+fn git_files_for_search_directory(search_directory: &Path) -> Option<Arc<Vec<String>>> {
+    let repo_info = git_repo_info(search_directory)?;
+    let key = GitFileListKey {
+        repo_root: repo_info.repo_root.clone(),
+        prefix: repo_info.prefix.clone(),
+    };
+
+    let cache = GIT_FILE_LIST_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    {
+        let guard = cache.lock().unwrap_or_else(|err| err.into_inner());
+        if let Some(entry) = guard.get(&key)
+            && entry.created_at.elapsed() < GIT_FILE_LIST_TTL
+        {
+            return Some(entry.files.clone());
+        }
+    }
+
+    let mut tracked = git_ls_files(&repo_info.repo_root, &repo_info.prefix, &[])?;
+    let deleted = git_ls_files(&repo_info.repo_root, &repo_info.prefix, &["--deleted"])?;
+    let untracked = git_ls_files(
+        &repo_info.repo_root,
+        &repo_info.prefix,
+        &["--others", "--exclude-standard"],
+    )?;
+
+    let deleted_set: HashSet<String> = deleted.into_iter().collect();
+    tracked.retain(|p| !deleted_set.contains(p));
+    tracked.extend(untracked);
+
+    let files = Arc::new(tracked);
+    let entry = GitFileListEntry {
+        created_at: Instant::now(),
+        files: files.clone(),
+    };
+
+    let mut guard = cache.lock().unwrap_or_else(|err| err.into_inner());
+    guard.insert(key, entry);
+
+    Some(files)
+}
 
 /// A single match result returned from the search.
 ///
@@ -81,7 +248,7 @@ pub async fn run_main<T: Reporter>(
         None => {
             reporter.warn_no_search_pattern(&search_directory);
             #[cfg(unix)]
-            Command::new("ls")
+            TokioCommand::new("ls")
                 .arg("-al")
                 .current_dir(search_directory)
                 .stdout(std::process::Stdio::inherit())
@@ -90,7 +257,7 @@ pub async fn run_main<T: Reporter>(
                 .await?;
             #[cfg(windows)]
             {
-                Command::new("cmd")
+                TokioCommand::new("cmd")
                     .arg("/c")
                     .arg(search_directory)
                     .stdout(std::process::Stdio::inherit())
@@ -160,66 +327,87 @@ pub fn run(
         })
         .collect();
 
-    // Use the same tree-walker library that ripgrep uses. We use it directly so
-    // that we can leverage the parallelism it provides.
-    let mut walk_builder = WalkBuilder::new(search_directory);
-    walk_builder
-        .threads(num_walk_builder_threads)
-        // Allow hidden entries.
-        .hidden(false)
-        // Follow symlinks to search their contents.
-        .follow_links(true)
-        // Don't require git to be present to apply to apply git-related ignore rules.
-        .require_git(false);
-    if !respect_gitignore {
+    let exclude_matcher = if exclude.is_empty() {
+        None
+    } else {
+        let mut override_builder = OverrideBuilder::new(search_directory);
+        for exclude in &exclude {
+            // The `!` prefix is used to indicate an exclude pattern.
+            let exclude_pattern = format!("!{exclude}");
+            override_builder.add(&exclude_pattern)?;
+        }
+        Some(override_builder.build()?)
+    };
+
+    let git_best_lists = if respect_gitignore {
+        git_files_for_search_directory(search_directory).map(|files| {
+            build_best_lists_for_paths(
+                files,
+                limit.get(),
+                pattern.clone(),
+                cancel_flag.clone(),
+                exclude_matcher.clone(),
+                num_best_matches_lists,
+            )
+        })
+    } else {
+        None
+    };
+
+    if git_best_lists.is_none() {
+        // Fall back to a raw filesystem walk with *no* ignore filtering so completion still works
+        // when git isn't available or we aren't in a repository.
+        //
+        // We use the same tree-walker library that ripgrep uses so that we can leverage the
+        // parallelism it provides.
+        let mut walk_builder = WalkBuilder::new(search_directory);
         walk_builder
+            .threads(num_walk_builder_threads)
+            // Allow hidden entries.
+            .hidden(false)
+            // Follow symlinks to search their contents.
+            .follow_links(true)
+            // Do not apply ignore rules when git isn't being used.
             .git_ignore(false)
             .git_global(false)
             .git_exclude(false)
             .ignore(false)
             .parents(false);
-    }
 
-    if !exclude.is_empty() {
-        let mut override_builder = OverrideBuilder::new(search_directory);
-        for exclude in exclude {
-            // The `!` prefix is used to indicate an exclude pattern.
-            let exclude_pattern = format!("!{exclude}");
-            override_builder.add(&exclude_pattern)?;
+        if let Some(matcher) = &exclude_matcher {
+            walk_builder.overrides(matcher.clone());
         }
-        let override_matcher = override_builder.build()?;
-        walk_builder.overrides(override_matcher);
+
+        let walker = walk_builder.build_parallel();
+
+        // Each worker created by `WalkParallel::run()` will have its own `BestMatchesList` to update.
+        let index_counter = AtomicUsize::new(0);
+        walker.run(|| {
+            let index = index_counter.fetch_add(1, Ordering::Relaxed);
+            let best_list_ptr = best_matchers_per_worker[index].get();
+            let best_list = unsafe { &mut *best_list_ptr };
+
+            // Each worker keeps a local counter so we only read the atomic flag
+            // every N entries which is cheaper than checking on every file.
+            const CHECK_INTERVAL: usize = 1024;
+            let mut processed = 0;
+
+            let cancel = cancel_flag.clone();
+
+            Box::new(move |entry| {
+                if let Some(path) = get_file_path(&entry, search_directory) {
+                    best_list.insert(path);
+                }
+
+                processed += 1;
+                if processed % CHECK_INTERVAL == 0 && cancel.load(Ordering::Relaxed) {
+                    ignore::WalkState::Quit
+                } else {
+                    ignore::WalkState::Continue
+                }
+            })
+        });
     }
-    let walker = walk_builder.build_parallel();
-
-    // Each worker created by `WalkParallel::run()` will have its own
-    // `BestMatchesList` to update.
-    let index_counter = AtomicUsize::new(0);
-    walker.run(|| {
-        let index = index_counter.fetch_add(1, Ordering::Relaxed);
-        let best_list_ptr = best_matchers_per_worker[index].get();
-        let best_list = unsafe { &mut *best_list_ptr };
-
-        // Each worker keeps a local counter so we only read the atomic flag
-        // every N entries which is cheaper than checking on every file.
-        const CHECK_INTERVAL: usize = 1024;
-        let mut processed = 0;
-
-        let cancel = cancel_flag.clone();
-
-        Box::new(move |entry| {
-            if let Some(path) = get_file_path(&entry, search_directory) {
-                best_list.insert(path);
-            }
-
-            processed += 1;
-            if processed % CHECK_INTERVAL == 0 && cancel.load(Ordering::Relaxed) {
-                ignore::WalkState::Quit
-            } else {
-                ignore::WalkState::Continue
-            }
-        })
-    });
 
     fn get_file_path<'a>(
         entry_result: &'a Result<ignore::DirEntry, ignore::Error>,
@@ -250,17 +438,33 @@ pub fn run(
     // Merge results across best_matchers_per_worker.
     let mut global_heap: BinaryHeap<Reverse<(u32, String)>> = BinaryHeap::new();
     let mut total_match_count = 0;
-    for best_list_cell in best_matchers_per_worker.iter() {
-        let best_list = unsafe { &*best_list_cell.get() };
-        total_match_count += best_list.num_matches;
-        for &Reverse((score, ref line)) in best_list.binary_heap.iter() {
-            if global_heap.len() < limit.get() {
-                global_heap.push(Reverse((score, line.clone())));
-            } else if let Some(min_element) = global_heap.peek()
-                && score > min_element.0.0
-            {
-                global_heap.pop();
-                global_heap.push(Reverse((score, line.clone())));
+    if let Some(best_lists) = &git_best_lists {
+        for best_list in best_lists {
+            total_match_count += best_list.num_matches;
+            for &Reverse((score, ref line)) in best_list.binary_heap.iter() {
+                if global_heap.len() < limit.get() {
+                    global_heap.push(Reverse((score, line.clone())));
+                } else if let Some(min_element) = global_heap.peek()
+                    && score > min_element.0.0
+                {
+                    global_heap.pop();
+                    global_heap.push(Reverse((score, line.clone())));
+                }
+            }
+        }
+    } else {
+        for best_list_cell in best_matchers_per_worker.iter() {
+            let best_list = unsafe { &*best_list_cell.get() };
+            total_match_count += best_list.num_matches;
+            for &Reverse((score, ref line)) in best_list.binary_heap.iter() {
+                if global_heap.len() < limit.get() {
+                    global_heap.push(Reverse((score, line.clone())));
+                } else if let Some(min_element) = global_heap.peek()
+                    && score > min_element.0.0
+                {
+                    global_heap.pop();
+                    global_heap.push(Reverse((score, line.clone())));
+                }
             }
         }
     }
@@ -305,6 +509,101 @@ pub fn run(
         matches,
         total_match_count,
     })
+}
+
+fn build_best_lists_for_paths(
+    files: Arc<Vec<String>>,
+    max_count: usize,
+    pattern: Pattern,
+    cancel_flag: Arc<AtomicBool>,
+    exclude_matcher: Option<Override>,
+    worker_count: usize,
+) -> Vec<BestMatchesList> {
+    if files.is_empty() {
+        return Vec::new();
+    }
+
+    let worker_count = worker_count.clamp(1, files.len());
+    if worker_count == 1 {
+        let mut best_list = BestMatchesList::new(
+            max_count,
+            pattern,
+            Matcher::new(nucleo_matcher::Config::DEFAULT),
+        );
+
+        const CHECK_INTERVAL: usize = 1024;
+        let mut processed = 0usize;
+
+        for path in &*files {
+            if exclude_matcher
+                .as_ref()
+                .is_some_and(|m| m.matched(path.as_str(), false).is_ignore())
+            {
+                continue;
+            }
+            best_list.insert(path.as_str());
+
+            processed += 1;
+            if processed.is_multiple_of(CHECK_INTERVAL) && cancel_flag.load(Ordering::Relaxed) {
+                break;
+            }
+        }
+
+        return vec![best_list];
+    }
+
+    let chunk_size = files.len().div_ceil(worker_count).max(1);
+    let mut handles = Vec::with_capacity(worker_count);
+
+    for idx in 0..worker_count {
+        let start = idx * chunk_size;
+        if start >= files.len() {
+            break;
+        }
+        let end = ((idx + 1) * chunk_size).min(files.len());
+
+        let files = files.clone();
+        let pattern = pattern.clone();
+        let cancel_flag = cancel_flag.clone();
+        let exclude_matcher = exclude_matcher.clone();
+
+        handles.push(std::thread::spawn(move || {
+            let mut best_list = BestMatchesList::new(
+                max_count,
+                pattern,
+                Matcher::new(nucleo_matcher::Config::DEFAULT),
+            );
+
+            const CHECK_INTERVAL: usize = 1024;
+            let mut processed = 0usize;
+
+            for path in &files[start..end] {
+                if exclude_matcher
+                    .as_ref()
+                    .is_some_and(|m| m.matched(path.as_str(), false).is_ignore())
+                {
+                    continue;
+                }
+                best_list.insert(path.as_str());
+
+                processed += 1;
+                if processed.is_multiple_of(CHECK_INTERVAL) && cancel_flag.load(Ordering::Relaxed) {
+                    break;
+                }
+            }
+
+            best_list
+        }));
+    }
+
+    let mut best_lists = Vec::with_capacity(handles.len());
+    for handle in handles {
+        if let Ok(best_list) = handle.join() {
+            best_lists.push(best_list);
+        }
+    }
+
+    best_lists
 }
 
 /// Sort matches in-place by descending score, then ascending path.
@@ -412,6 +711,30 @@ fn create_pattern(pattern: &str) -> Pattern {
 mod tests {
     use super::*;
     use pretty_assertions::assert_eq;
+    use tempfile::TempDir;
+
+    fn run_git(repo: &Path, args: &[&str]) {
+        let output = Command::new("git")
+            .args(args)
+            .current_dir(repo)
+            .output()
+            .expect("git should run");
+        assert!(
+            output.status.success(),
+            "git {:?} failed.\nstdout:\n{}\nstderr:\n{}",
+            args,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr),
+        );
+    }
+
+    fn mk_repo() -> TempDir {
+        let dir = TempDir::new().expect("tempdir should create");
+        run_git(dir.path(), &["init"]);
+        run_git(dir.path(), &["config", "user.email", "codex@example.com"]);
+        run_git(dir.path(), &["config", "user.name", "Codex Tests"]);
+        dir
+    }
 
     #[test]
     fn verify_score_is_none_for_non_match() {
@@ -452,5 +775,66 @@ mod tests {
     #[test]
     fn file_name_from_path_falls_back_to_full_path() {
         assert_eq!(file_name_from_path(""), "");
+    }
+
+    #[test]
+    fn gitignore_filters_untracked_ignored_files_and_dirs() -> anyhow::Result<()> {
+        let repo = mk_repo();
+        std::fs::write(
+            repo.path().join(".gitignore"),
+            "ignored_dir/\nignored_file.txt\n",
+        )?;
+        std::fs::write(repo.path().join("ignored_file.txt"), "ignored")?;
+        std::fs::create_dir_all(repo.path().join("ignored_dir"))?;
+        std::fs::write(repo.path().join("ignored_dir").join("a.txt"), "ignored")?;
+        std::fs::write(repo.path().join("kept.txt"), "kept")?;
+
+        let results = run(
+            "txt",
+            NonZero::new(50).unwrap(),
+            repo.path(),
+            Vec::new(),
+            NonZero::new(2).unwrap(),
+            Arc::new(AtomicBool::new(false)),
+            false,
+            true,
+        )?;
+
+        let paths: Vec<&str> = results.matches.iter().map(|m| m.path.as_str()).collect();
+        let ignored_path = Path::new("ignored_dir")
+            .join("a.txt")
+            .to_string_lossy()
+            .to_string();
+        assert!(paths.contains(&"kept.txt"));
+        assert!(!paths.contains(&"ignored_file.txt"));
+        assert!(!paths.contains(&ignored_path.as_str()));
+        Ok(())
+    }
+
+    #[test]
+    fn gitignore_does_not_filter_tracked_files() -> anyhow::Result<()> {
+        let repo = mk_repo();
+        std::fs::write(repo.path().join("tracked.log"), "tracked")?;
+        run_git(repo.path(), &["add", "tracked.log"]);
+        run_git(repo.path(), &["commit", "-m", "track"]);
+
+        std::fs::write(repo.path().join(".gitignore"), "*.log\n")?;
+        std::fs::write(repo.path().join("ignored.log"), "ignored")?;
+
+        let results = run(
+            "log",
+            NonZero::new(50).unwrap(),
+            repo.path(),
+            Vec::new(),
+            NonZero::new(2).unwrap(),
+            Arc::new(AtomicBool::new(false)),
+            false,
+            true,
+        )?;
+
+        let paths: Vec<&str> = results.matches.iter().map(|m| m.path.as_str()).collect();
+        assert!(paths.contains(&"tracked.log"));
+        assert!(!paths.contains(&"ignored.log"));
+        Ok(())
     }
 }


### PR DESCRIPTION
## Summary
Fix `@` path completion to respect git ignore rules (including nested `.gitignore`, `.git/info/exclude`, and user global excludes) while keeping tracked files visible.

## Behavior
- In git repos with `git` available: completion candidates come from git (tracked + untracked-not-ignored).
- Outside git repos / without `git`: keep prior behavior (no filtering) so completion still works.

## Implementation
- Use `git ls-files` to build the corpus:
  - tracked: `git ls-files` (excluding `git ls-files --deleted`)
  - untracked-not-ignored: `git ls-files --others --exclude-standard`
- Cache repo info + file list for a short TTL (1s) to avoid spawning git on every keypress.

## Testing
- `cd codex-rs && cargo test -p codex-file-search`
