### PR TITLE
chore(event_mapping) handle new ide context format

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1379,6 +1379,9 @@ pub enum TurnStatus {
 pub struct TurnStartParams {
     pub thread_id: String,
     pub input: Vec<UserInput>,
+    /// Helpful information about the user's IDE state. Use judiciously to provide the model with
+    /// useful context.
+    pub user_ide_context: Option<String>,
     /// Override the working directory for this turn and subsequent turns.
     pub cwd: Option<PathBuf>,
     /// Override the approval policy for this turn and subsequent turns.

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -8,10 +8,16 @@ use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::ENVIRONMENT_CONTEXT_CLOSE_TAG;
 use codex_protocol::protocol::ENVIRONMENT_CONTEXT_OPEN_TAG;
+use codex_protocol::protocol::USER_IDE_CONTEXT_CLOSE_TAG;
+use codex_protocol::protocol::USER_IDE_CONTEXT_OPEN_TAG;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use serde::Deserialize;
 use serde::Serialize;
 use std::path::PathBuf;
+
+pub(crate) fn is_user_ide_context(text: &str) -> bool {
+    text.starts_with(USER_IDE_CONTEXT_OPEN_TAG) && text.ends_with(USER_IDE_CONTEXT_CLOSE_TAG)
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(rename = "environment_context", rename_all = "snake_case")]

--- a/codex-rs/core/src/event_mapping.rs
+++ b/codex-rs/core/src/event_mapping.rs
@@ -140,7 +140,7 @@ mod tests {
     use super::parse_turn_item;
     use codex_protocol::items::AgentMessageContent;
     use codex_protocol::items::TurnItem;
-    use codex_protocol::items::UserMessageItem;
+    
     use codex_protocol::models::ContentItem;
     use codex_protocol::models::ReasoningItemContent;
     use codex_protocol::models::ReasoningItemReasoningSummary;

--- a/codex-rs/core/src/event_mapping.rs
+++ b/codex-rs/core/src/event_mapping.rs
@@ -39,7 +39,8 @@ fn parse_user_message(message: &[ContentItem]) -> Option<UserMessageItem> {
                 if is_session_prefix(text) || is_user_shell_command_text(text) {
                     return None;
                 }
-                // user_ide_context is bundled with the user's prompt in its own content item
+                // user_ide_context is bundled with the user's prompt in its own content item.
+                // skip over it, but there might be subsequent content items to include
                 if is_user_ide_context(text) {
                     continue;
                 }
@@ -140,7 +141,7 @@ mod tests {
     use super::parse_turn_item;
     use codex_protocol::items::AgentMessageContent;
     use codex_protocol::items::TurnItem;
-    
+
     use codex_protocol::models::ContentItem;
     use codex_protocol::models::ReasoningItemContent;
     use codex_protocol::models::ReasoningItemReasoningSummary;

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -111,6 +111,8 @@ pub mod util;
 pub use apply_patch::CODEX_APPLY_PATCH_ARG1;
 pub use command_safety::is_dangerous_command;
 pub use command_safety::is_safe_command;
+pub use environment_context::normalize_user_ide_context;
+pub use environment_context::prepend_user_ide_context;
 pub use exec_policy::ExecPolicyError;
 pub use exec_policy::load_exec_policy;
 pub use safety::get_platform_sandbox;

--- a/codex-rs/core/src/rollout/truncation.rs
+++ b/codex-rs/core/src/rollout/truncation.rs
@@ -77,7 +77,7 @@ mod tests {
         ResponseItem::Message {
             id: None,
             role: "user".to_string(),
-            content: vec![ContentItem::OutputText {
+            content: vec![ContentItem::InputText {
                 text: text.to_string(),
             }],
         }

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -310,7 +310,7 @@ mod tests {
         ResponseItem::Message {
             id: None,
             role: "user".to_string(),
-            content: vec![ContentItem::OutputText {
+            content: vec![ContentItem::InputText {
                 text: text.to_string(),
             }],
         }

--- a/codex-rs/protocol/src/items.rs
+++ b/codex-rs/protocol/src/items.rs
@@ -10,7 +10,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use ts_rs::TS;
 
-#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema, PartialEq)]
 #[serde(tag = "type")]
 #[ts(tag = "type")]
 pub enum TurnItem {
@@ -20,26 +20,26 @@ pub enum TurnItem {
     WebSearch(WebSearchItem),
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema, PartialEq)]
 pub struct UserMessageItem {
     pub id: String,
     pub content: Vec<UserInput>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema, PartialEq)]
 #[serde(tag = "type")]
 #[ts(tag = "type")]
 pub enum AgentMessageContent {
     Text { text: String },
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema, PartialEq)]
 pub struct AgentMessageItem {
     pub id: String,
     pub content: Vec<AgentMessageContent>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema, PartialEq)]
 pub struct ReasoningItem {
     pub id: String,
     pub summary_text: Vec<String>,
@@ -47,7 +47,7 @@ pub struct ReasoningItem {
     pub raw_content: Vec<String>,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema)]
+#[derive(Debug, Clone, Deserialize, Serialize, TS, JsonSchema, PartialEq)]
 pub struct WebSearchItem {
     pub id: String,
     pub query: String,

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -49,6 +49,8 @@ pub const USER_INSTRUCTIONS_OPEN_TAG: &str = "<user_instructions>";
 pub const USER_INSTRUCTIONS_CLOSE_TAG: &str = "</user_instructions>";
 pub const ENVIRONMENT_CONTEXT_OPEN_TAG: &str = "<environment_context>";
 pub const ENVIRONMENT_CONTEXT_CLOSE_TAG: &str = "</environment_context>";
+pub const USER_IDE_CONTEXT_OPEN_TAG: &str = "<user_ide_context>";
+pub const USER_IDE_CONTEXT_CLOSE_TAG: &str = "</user_ide_context>";
 pub const USER_MESSAGE_BEGIN: &str = "## My request for Codex:";
 
 /// Submission Queue Entry - requests from user


### PR DESCRIPTION
## Summary
We're migrating the VSCE IDE context to more clearly separate this content in a way that more closely aligns with environment_context and skills. We want to preserve existing split behavior for old threads, at least for now. We might migrate old conversations in the future, but new threads from the VSCE will soon start appearing with a <user_ide_context> tag:

```
UserMessage {
  content: [
    ContentItem::Text { text: "<user_ide_context> ... context ... </user_ide_context>" },
    ContentItem::Text { text: "i am the user and I would like codex to do something" }
  ]
}
```

## Testing
- [x] Added unit tests
- [x] Ran locally both with 