### PR TITLE
Feat: appServer.requirementList for requirement.toml

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -197,9 +197,9 @@ client_request_definitions! {
         response: v2::ConfigWriteResponse,
     },
 
-    RequirementList => "requirements/list" {
+    ConfigRequirementsRead => "configRequirements/read" {
         params: #[ts(type = "undefined")] #[serde(skip_serializing_if = "Option::is_none")] Option<()>,
-        response: v2::RequirementListResponse,
+        response: v2::ConfigRequirementsReadResponse,
     },
 
     GetAccount => "account/read" {
@@ -709,6 +709,22 @@ mod tests {
         assert_eq!(
             json!({
                 "method": "account/rateLimits/read",
+                "id": 1,
+            }),
+            serde_json::to_value(&request)?,
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn serialize_config_requirements_read() -> Result<()> {
+        let request = ClientRequest::ConfigRequirementsRead {
+            request_id: RequestId::Integer(1),
+            params: None,
+        };
+        assert_eq!(
+            json!({
+                "method": "configRequirements/read",
                 "id": 1,
             }),
             serde_json::to_value(&request)?,

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -197,6 +197,11 @@ client_request_definitions! {
         response: v2::ConfigWriteResponse,
     },
 
+    RequirementList => "requirements/list" {
+        params: #[ts(type = "undefined")] #[serde(skip_serializing_if = "Option::is_none")] Option<()>,
+        response: v2::RequirementListResponse,
+    },
+
     GetAccount => "account/read" {
         params: v2::GetAccountParams,
         response: v2::GetAccountResponse,

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -453,6 +453,32 @@ pub struct ConfigReadResponse {
     pub layers: Option<Vec<ConfigLayer>>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "kebab-case")]
+#[ts(rename_all = "kebab-case", export_to = "v2/")]
+pub enum SandboxModeRequirement {
+    ReadOnly,
+    WorkspaceWrite,
+    DangerFullAccess,
+    ExternalSandbox,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct Requirements {
+    pub allowed_approval_policies: Option<Vec<AskForApproval>>,
+    pub allowed_sandbox_modes: Option<Vec<SandboxModeRequirement>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct RequirementListResponse {
+    /// Null if no requirements are configured (e.g. no requirements.toml/MDM entries).
+    pub requirements: Option<Requirements>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -456,7 +456,7 @@ pub struct ConfigReadResponse {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
-pub struct Requirements {
+pub struct ConfigRequirements {
     pub allowed_approval_policies: Option<Vec<AskForApproval>>,
     pub allowed_sandbox_modes: Option<Vec<SandboxMode>>,
 }
@@ -466,7 +466,7 @@ pub struct Requirements {
 #[ts(export_to = "v2/")]
 pub struct ConfigRequirementsReadResponse {
     /// Null if no requirements are configured (e.g. no requirements.toml/MDM entries).
-    pub requirements: Option<Requirements>,
+    pub requirements: Option<ConfigRequirements>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -453,22 +453,12 @@ pub struct ConfigReadResponse {
     pub layers: Option<Vec<ConfigLayer>>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, JsonSchema, TS)]
-#[serde(rename_all = "kebab-case")]
-#[ts(rename_all = "kebab-case", export_to = "v2/")]
-pub enum SandboxModeRequirement {
-    ReadOnly,
-    WorkspaceWrite,
-    DangerFullAccess,
-    ExternalSandbox,
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct Requirements {
     pub allowed_approval_policies: Option<Vec<AskForApproval>>,
-    pub allowed_sandbox_modes: Option<Vec<SandboxModeRequirement>>,
+    pub allowed_sandbox_modes: Option<Vec<SandboxMode>>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -464,7 +464,7 @@ pub struct Requirements {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
-pub struct RequirementListResponse {
+pub struct ConfigRequirementsReadResponse {
     /// Null if no requirements are configured (e.g. no requirements.toml/MDM entries).
     pub requirements: Option<Requirements>,
 }

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -88,6 +88,7 @@ Example (from OpenAI's official VSCode extension):
 - `config/read` — fetch the effective config on disk after resolving config layering.
 - `config/value/write` — write a single config key/value to the user's config.toml on disk.
 - `config/batchWrite` — apply multiple config edits atomically to the user's config.toml on disk.
+- `requirements/list` — fetch the loaded requirements allow-lists from `requirements.toml` and/or MDM (or `null` if none are configured).
 
 ### Example: Start or resume a thread
 

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -88,7 +88,7 @@ Example (from OpenAI's official VSCode extension):
 - `config/read` — fetch the effective config on disk after resolving config layering.
 - `config/value/write` — write a single config key/value to the user's config.toml on disk.
 - `config/batchWrite` — apply multiple config edits atomically to the user's config.toml on disk.
-- `requirements/list` — fetch the loaded requirements allow-lists from `requirements.toml` and/or MDM (or `null` if none are configured).
+- `configRequirements/read` — fetch the loaded requirements allow-lists from `requirements.toml` and/or MDM (or `null` if none are configured).
 
 ### Example: Start or resume a thread
 

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -510,6 +510,9 @@ impl CodexMessageProcessor {
             | ClientRequest::ConfigBatchWrite { .. } => {
                 warn!("Config request reached CodexMessageProcessor unexpectedly");
             }
+            ClientRequest::RequirementList { .. } => {
+                warn!("RequirementList request reached CodexMessageProcessor unexpectedly");
+            }
             ClientRequest::GetAccountRateLimits {
                 request_id,
                 params: _,

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -510,8 +510,8 @@ impl CodexMessageProcessor {
             | ClientRequest::ConfigBatchWrite { .. } => {
                 warn!("Config request reached CodexMessageProcessor unexpectedly");
             }
-            ClientRequest::RequirementList { .. } => {
-                warn!("RequirementList request reached CodexMessageProcessor unexpectedly");
+            ClientRequest::ConfigRequirementsRead { .. } => {
+                warn!("ConfigRequirementsRead request reached CodexMessageProcessor unexpectedly");
             }
             ClientRequest::GetAccountRateLimits {
                 request_id,

--- a/codex-rs/app-server/src/config_api.rs
+++ b/codex-rs/app-server/src/config_api.rs
@@ -7,9 +7,14 @@ use codex_app_server_protocol::ConfigValueWriteParams;
 use codex_app_server_protocol::ConfigWriteErrorCode;
 use codex_app_server_protocol::ConfigWriteResponse;
 use codex_app_server_protocol::JSONRPCErrorError;
+use codex_app_server_protocol::RequirementListResponse;
+use codex_app_server_protocol::Requirements;
+use codex_app_server_protocol::SandboxModeRequirement;
 use codex_core::config::ConfigService;
 use codex_core::config::ConfigServiceError;
+use codex_core::config_loader::ConfigRequirementsToml;
 use codex_core::config_loader::LoaderOverrides;
+use codex_core::config_loader::SandboxModeRequirement as CoreSandboxModeRequirement;
 use serde_json::json;
 use std::path::PathBuf;
 use toml::Value as TomlValue;
@@ -37,6 +42,19 @@ impl ConfigApi {
         self.service.read(params).await.map_err(map_error)
     }
 
+    pub(crate) async fn requirement_list(
+        &self,
+    ) -> Result<RequirementListResponse, JSONRPCErrorError> {
+        let requirements = self
+            .service
+            .read_requirements()
+            .await
+            .map_err(map_error)?
+            .map(map_requirements_toml_to_api);
+
+        Ok(RequirementListResponse { requirements })
+    }
+
     pub(crate) async fn write_value(
         &self,
         params: ConfigValueWriteParams,
@@ -49,6 +67,70 @@ impl ConfigApi {
         params: ConfigBatchWriteParams,
     ) -> Result<ConfigWriteResponse, JSONRPCErrorError> {
         self.service.batch_write(params).await.map_err(map_error)
+    }
+}
+
+fn map_requirements_toml_to_api(requirements: ConfigRequirementsToml) -> Requirements {
+    Requirements {
+        allowed_approval_policies: requirements.allowed_approval_policies.map(|policies| {
+            policies
+                .into_iter()
+                .map(codex_app_server_protocol::AskForApproval::from)
+                .collect()
+        }),
+        allowed_sandbox_modes: requirements.allowed_sandbox_modes.map(|modes| {
+            modes
+                .into_iter()
+                .map(map_sandbox_mode_requirement_to_api)
+                .collect()
+        }),
+    }
+}
+
+fn map_sandbox_mode_requirement_to_api(mode: CoreSandboxModeRequirement) -> SandboxModeRequirement {
+    match mode {
+        CoreSandboxModeRequirement::ReadOnly => SandboxModeRequirement::ReadOnly,
+        CoreSandboxModeRequirement::WorkspaceWrite => SandboxModeRequirement::WorkspaceWrite,
+        CoreSandboxModeRequirement::DangerFullAccess => SandboxModeRequirement::DangerFullAccess,
+        CoreSandboxModeRequirement::ExternalSandbox => SandboxModeRequirement::ExternalSandbox,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_protocol::protocol::AskForApproval as CoreAskForApproval;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn map_requirements_toml_to_api_converts_core_enums() {
+        let requirements = ConfigRequirementsToml {
+            allowed_approval_policies: Some(vec![
+                CoreAskForApproval::Never,
+                CoreAskForApproval::OnRequest,
+            ]),
+            allowed_sandbox_modes: Some(vec![
+                CoreSandboxModeRequirement::ReadOnly,
+                CoreSandboxModeRequirement::ExternalSandbox,
+            ]),
+        };
+
+        let mapped = map_requirements_toml_to_api(requirements);
+
+        assert_eq!(
+            mapped.allowed_approval_policies,
+            Some(vec![
+                codex_app_server_protocol::AskForApproval::Never,
+                codex_app_server_protocol::AskForApproval::OnRequest,
+            ])
+        );
+        assert_eq!(
+            mapped.allowed_sandbox_modes,
+            Some(vec![
+                SandboxModeRequirement::ReadOnly,
+                SandboxModeRequirement::ExternalSandbox,
+            ])
+        );
     }
 }
 

--- a/codex-rs/app-server/src/config_api.rs
+++ b/codex-rs/app-server/src/config_api.rs
@@ -3,11 +3,11 @@ use crate::error_code::INVALID_REQUEST_ERROR_CODE;
 use codex_app_server_protocol::ConfigBatchWriteParams;
 use codex_app_server_protocol::ConfigReadParams;
 use codex_app_server_protocol::ConfigReadResponse;
+use codex_app_server_protocol::ConfigRequirementsReadResponse;
 use codex_app_server_protocol::ConfigValueWriteParams;
 use codex_app_server_protocol::ConfigWriteErrorCode;
 use codex_app_server_protocol::ConfigWriteResponse;
 use codex_app_server_protocol::JSONRPCErrorError;
-use codex_app_server_protocol::RequirementListResponse;
 use codex_app_server_protocol::Requirements;
 use codex_app_server_protocol::SandboxMode;
 use codex_core::config::ConfigService;
@@ -42,9 +42,9 @@ impl ConfigApi {
         self.service.read(params).await.map_err(map_error)
     }
 
-    pub(crate) async fn requirement_list(
+    pub(crate) async fn config_requirements_read(
         &self,
-    ) -> Result<RequirementListResponse, JSONRPCErrorError> {
+    ) -> Result<ConfigRequirementsReadResponse, JSONRPCErrorError> {
         let requirements = self
             .service
             .read_requirements()
@@ -52,7 +52,7 @@ impl ConfigApi {
             .map_err(map_error)?
             .map(map_requirements_toml_to_api);
 
-        Ok(RequirementListResponse { requirements })
+        Ok(ConfigRequirementsReadResponse { requirements })
     }
 
     pub(crate) async fn write_value(

--- a/codex-rs/app-server/src/config_api.rs
+++ b/codex-rs/app-server/src/config_api.rs
@@ -3,12 +3,12 @@ use crate::error_code::INVALID_REQUEST_ERROR_CODE;
 use codex_app_server_protocol::ConfigBatchWriteParams;
 use codex_app_server_protocol::ConfigReadParams;
 use codex_app_server_protocol::ConfigReadResponse;
+use codex_app_server_protocol::ConfigRequirements;
 use codex_app_server_protocol::ConfigRequirementsReadResponse;
 use codex_app_server_protocol::ConfigValueWriteParams;
 use codex_app_server_protocol::ConfigWriteErrorCode;
 use codex_app_server_protocol::ConfigWriteResponse;
 use codex_app_server_protocol::JSONRPCErrorError;
-use codex_app_server_protocol::Requirements;
 use codex_app_server_protocol::SandboxMode;
 use codex_core::config::ConfigService;
 use codex_core::config::ConfigServiceError;
@@ -70,8 +70,8 @@ impl ConfigApi {
     }
 }
 
-fn map_requirements_toml_to_api(requirements: ConfigRequirementsToml) -> Requirements {
-    Requirements {
+fn map_requirements_toml_to_api(requirements: ConfigRequirementsToml) -> ConfigRequirements {
+    ConfigRequirements {
         allowed_approval_policies: requirements.allowed_approval_policies.map(|policies| {
             policies
                 .into_iter()

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -158,11 +158,11 @@ impl MessageProcessor {
             ClientRequest::ConfigBatchWrite { request_id, params } => {
                 self.handle_config_batch_write(request_id, params).await;
             }
-            ClientRequest::RequirementList {
+            ClientRequest::ConfigRequirementsRead {
                 request_id,
                 params: _,
             } => {
-                self.handle_requirement_list(request_id).await;
+                self.handle_config_requirements_read(request_id).await;
             }
             other => {
                 self.codex_message_processor.process_request(other).await;
@@ -217,8 +217,8 @@ impl MessageProcessor {
         }
     }
 
-    async fn handle_requirement_list(&self, request_id: RequestId) {
-        match self.config_api.requirement_list().await {
+    async fn handle_config_requirements_read(&self, request_id: RequestId) {
+        match self.config_api.config_requirements_read().await {
             Ok(response) => self.outgoing.send_response(request_id, response).await,
             Err(error) => self.outgoing.send_error(request_id, error).await,
         }

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -158,6 +158,12 @@ impl MessageProcessor {
             ClientRequest::ConfigBatchWrite { request_id, params } => {
                 self.handle_config_batch_write(request_id, params).await;
             }
+            ClientRequest::RequirementList {
+                request_id,
+                params: _,
+            } => {
+                self.handle_requirement_list(request_id).await;
+            }
             other => {
                 self.codex_message_processor.process_request(other).await;
             }
@@ -206,6 +212,13 @@ impl MessageProcessor {
         params: ConfigBatchWriteParams,
     ) {
         match self.config_api.batch_write(params).await {
+            Ok(response) => self.outgoing.send_response(request_id, response).await,
+            Err(error) => self.outgoing.send_error(request_id, error).await,
+        }
+    }
+
+    async fn handle_requirement_list(&self, request_id: RequestId) {
+        match self.config_api.requirement_list().await {
             Ok(response) => self.outgoing.send_response(request_id, response).await,
             Err(error) => self.outgoing.send_error(request_id, error).await,
         }

--- a/codex-rs/core/src/config/service.rs
+++ b/codex-rs/core/src/config/service.rs
@@ -4,6 +4,7 @@ use crate::config::edit::ConfigEdit;
 use crate::config::edit::ConfigEditsBuilder;
 use crate::config_loader::ConfigLayerEntry;
 use crate::config_loader::ConfigLayerStack;
+use crate::config_loader::ConfigRequirementsToml;
 use crate::config_loader::LoaderOverrides;
 use crate::config_loader::load_config_layers_state;
 use crate::config_loader::merge_toml_values;
@@ -155,6 +156,24 @@ impl ConfigService {
                     .collect()
             }),
         })
+    }
+
+    pub async fn read_requirements(
+        &self,
+    ) -> Result<Option<ConfigRequirementsToml>, ConfigServiceError> {
+        let layers = self
+            .load_thread_agnostic_config()
+            .await
+            .map_err(|err| ConfigServiceError::io("failed to read configuration layers", err))?;
+
+        let requirements = layers.requirements_toml().clone();
+        if requirements.allowed_approval_policies.is_none()
+            && requirements.allowed_sandbox_modes.is_none()
+        {
+            Ok(None)
+        } else {
+            Ok(Some(requirements))
+        }
     }
 
     pub async fn write_value(

--- a/codex-rs/core/src/config/service.rs
+++ b/codex-rs/core/src/config/service.rs
@@ -167,9 +167,7 @@ impl ConfigService {
             .map_err(|err| ConfigServiceError::io("failed to read configuration layers", err))?;
 
         let requirements = layers.requirements_toml().clone();
-        if requirements.allowed_approval_policies.is_none()
-            && requirements.allowed_sandbox_modes.is_none()
-        {
+        if requirements.is_empty() {
             Ok(None)
         } else {
             Ok(Some(requirements))

--- a/codex-rs/core/src/config_loader/config_requirements.rs
+++ b/codex-rs/core/src/config_loader/config_requirements.rs
@@ -58,6 +58,10 @@ impl From<SandboxMode> for SandboxModeRequirement {
 }
 
 impl ConfigRequirementsToml {
+    pub fn is_empty(&self) -> bool {
+        self.allowed_approval_policies.is_none() && self.allowed_sandbox_modes.is_none()
+    }
+
     /// For every field in `other` that is `Some`, if the corresponding field in
     /// `self` is `None`, copy the value from `other` into `self`.
     pub fn merge_unset_fields(&mut self, mut other: ConfigRequirementsToml) {

--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -12,7 +12,6 @@ mod tests;
 
 use crate::config::CONFIG_TOML_FILE;
 use crate::config::ConfigToml;
-use crate::config_loader::config_requirements::ConfigRequirementsToml;
 use crate::config_loader::layer_io::LoadedConfigLayers;
 use codex_app_server_protocol::ConfigLayerSource;
 use codex_protocol::config_types::SandboxMode;
@@ -25,6 +24,8 @@ use std::path::Path;
 use toml::Value as TomlValue;
 
 pub use config_requirements::ConfigRequirements;
+pub use config_requirements::ConfigRequirementsToml;
+pub use config_requirements::SandboxModeRequirement;
 pub use merge::merge_toml_values;
 pub use state::ConfigLayerEntry;
 pub use state::ConfigLayerStack;
@@ -201,7 +202,9 @@ pub async fn load_config_layers_state(
         ));
     }
 
-    ConfigLayerStack::new(layers, config_requirements_toml.try_into()?)
+    let requirements_toml = config_requirements_toml.clone();
+    let requirements = config_requirements_toml.try_into()?;
+    ConfigLayerStack::new(layers, requirements, requirements_toml)
 }
 
 /// Attempts to load a config.toml file from `config_toml`.

--- a/codex-rs/core/src/config_loader/state.rs
+++ b/codex-rs/core/src/config_loader/state.rs
@@ -1,4 +1,5 @@
 use crate::config_loader::ConfigRequirements;
+use crate::config_loader::ConfigRequirementsToml;
 
 use super::fingerprint::record_origins;
 use super::fingerprint::version_for_toml;
@@ -86,18 +87,25 @@ pub struct ConfigLayerStack {
     /// Constraints that must be enforced when deriving a [Config] from the
     /// layers.
     requirements: ConfigRequirements,
+
+    /// Raw requirements data as loaded from requirements.toml/MDM/legacy
+    /// sources. This preserves the original allow-lists so they can be
+    /// surfaced via APIs.
+    requirements_toml: ConfigRequirementsToml,
 }
 
 impl ConfigLayerStack {
     pub fn new(
         layers: Vec<ConfigLayerEntry>,
         requirements: ConfigRequirements,
+        requirements_toml: ConfigRequirementsToml,
     ) -> std::io::Result<Self> {
         let user_layer_index = verify_layer_ordering(&layers)?;
         Ok(Self {
             layers,
             user_layer_index,
             requirements,
+            requirements_toml,
         })
     }
 
@@ -109,6 +117,10 @@ impl ConfigLayerStack {
 
     pub fn requirements(&self) -> &ConfigRequirements {
         &self.requirements
+    }
+
+    pub fn requirements_toml(&self) -> &ConfigRequirementsToml {
+        &self.requirements_toml
     }
 
     /// Creates a new [ConfigLayerStack] using the specified values to inject a
@@ -131,6 +143,7 @@ impl ConfigLayerStack {
                     layers,
                     user_layer_index: self.user_layer_index,
                     requirements: self.requirements.clone(),
+                    requirements_toml: self.requirements_toml.clone(),
                 }
             }
             None => {
@@ -151,6 +164,7 @@ impl ConfigLayerStack {
                     layers,
                     user_layer_index: Some(user_layer_index),
                     requirements: self.requirements.clone(),
+                    requirements_toml: self.requirements_toml.clone(),
                 }
             }
         }

--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -421,6 +421,7 @@ mod tests {
     use crate::config_loader::ConfigLayerEntry;
     use crate::config_loader::ConfigLayerStack;
     use crate::config_loader::ConfigRequirements;
+    use crate::config_loader::ConfigRequirementsToml;
     use crate::features::Feature;
     use crate::features::Features;
     use codex_app_server_protocol::ConfigLayerSource;
@@ -441,7 +442,12 @@ mod tests {
             ConfigLayerSource::Project { dot_codex_folder },
             TomlValue::Table(Default::default()),
         );
-        ConfigLayerStack::new(vec![layer], ConfigRequirements::default()).expect("ConfigLayerStack")
+        ConfigLayerStack::new(
+            vec![layer],
+            ConfigRequirements::default(),
+            ConfigRequirementsToml::default(),
+        )
+        .expect("ConfigLayerStack")
     }
 
     #[tokio::test]
@@ -573,7 +579,11 @@ mod tests {
                 TomlValue::Table(Default::default()),
             ),
         ];
-        let config_stack = ConfigLayerStack::new(layers, ConfigRequirements::default())?;
+        let config_stack = ConfigLayerStack::new(
+            layers,
+            ConfigRequirements::default(),
+            ConfigRequirementsToml::default(),
+        )?;
 
         let policy = load_exec_policy(&config_stack).await?;
 

--- a/codex-rs/core/src/skills/loader.rs
+++ b/codex-rs/core/src/skills/loader.rs
@@ -316,6 +316,7 @@ mod tests {
     use crate::config_loader::ConfigLayerEntry;
     use crate::config_loader::ConfigLayerStack;
     use crate::config_loader::ConfigRequirements;
+    use crate::config_loader::ConfigRequirementsToml;
     use codex_protocol::protocol::SkillScope;
     use codex_utils_absolute_path::AbsolutePathBuf;
     use pretty_assertions::assert_eq;
@@ -377,7 +378,11 @@ mod tests {
                 TomlValue::Table(toml::map::Map::new()),
             ),
         ];
-        let stack = ConfigLayerStack::new(layers, ConfigRequirements::default())?;
+        let stack = ConfigLayerStack::new(
+            layers,
+            ConfigRequirements::default(),
+            ConfigRequirementsToml::default(),
+        )?;
 
         let got = skill_roots_from_layer_stack(&stack)
             .into_iter()


### PR DESCRIPTION
### Summary
We are exposing requirements via `requirement/list` method from app-server so that we can conditionally disable the agent mode dropdown selection in VSCE and correctly setting the default value.

### Sample output
#### `etc/codex/requirements.toml`
<img width="497" height="49" alt="Screenshot 2026-01-06 at 11 32 06 PM" src="https://github.com/user-attachments/assets/fbd9402e-515f-4b9e-a158-2abb23e866a0" />

#### App server response
<img width="1107" height="79" alt="Screenshot 2026-01-06 at 11 30 18 PM" src="https://github.com/user-attachments/assets/c0d669cd-54ef-4789-a26c-adb2c41950af" />
