### PR TITLE
One-shot Terminal Titles

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -52,6 +52,14 @@ pub(crate) enum AppEvent {
     /// Result of computing a `/diff` command.
     DiffResult(String),
 
+    /// Generate a short terminal title from the initial user request.
+    GenerateTerminalTitle {
+        request: String,
+    },
+
+    /// Set the terminal title to the provided text.
+    SetTerminalTitle(String),
+
     InsertHistoryCell(Box<dyn HistoryCell>),
 
     StartCommitAnimation,

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -368,6 +368,7 @@ pub(crate) struct ChatWidget {
     // Current session rollout path (if known)
     current_rollout_path: Option<PathBuf>,
     external_editor_state: ExternalEditorState,
+    terminal_title_requested: bool,
 }
 
 struct UserMessage {
@@ -1478,6 +1479,7 @@ impl ChatWidget {
             feedback,
             current_rollout_path: None,
             external_editor_state: ExternalEditorState::Closed,
+            terminal_title_requested: false,
         };
 
         widget.prefetch_rate_limits();
@@ -1564,6 +1566,7 @@ impl ChatWidget {
             feedback,
             current_rollout_path: None,
             external_editor_state: ExternalEditorState::Closed,
+            terminal_title_requested: false,
         };
 
         widget.prefetch_rate_limits();
@@ -1942,6 +1945,13 @@ impl ChatWidget {
 
         for path in image_paths {
             items.push(UserInput::LocalImage { path });
+        }
+
+        if !self.terminal_title_requested && !text.is_empty() {
+            self.terminal_title_requested = true;
+            self.app_event_tx.send(AppEvent::GenerateTerminalTitle {
+                request: text.clone(),
+            });
         }
 
         if let Some(skills) = self.bottom_pane.skills() {

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -408,6 +408,7 @@ async fn make_chatwidget_manual(
         feedback: codex_feedback::CodexFeedback::new(),
         current_rollout_path: None,
         external_editor_state: ExternalEditorState::Closed,
+        terminal_title_requested: false,
     };
     (widget, rx, op_rx)
 }


### PR DESCRIPTION
### Motivation
- Provide a concise, helpful terminal/tab title derived from the first user request so the TUI session is easier to identify (similar to editors that set terminal titles).
- Avoid persistent background requests by using a one-shot sub-conversation to generate a short title.
- Keep the title generation unobtrusive and limited in scope (max 4 words).

### Description
- Add two new app events: `AppEvent::GenerateTerminalTitle { request: String }` and `AppEvent::SetTerminalTitle(String)` in `tui/src/app_event.rs` to request and apply titles.
- Trigger a one-shot generation after the first user message by setting `terminal_title_requested` in `chatwidget` and sending `GenerateTerminalTitle` from `codex-rs/tui/src/chatwidget.rs`.
- Implement `generate_terminal_title` in `codex-rs/tui/src/app.rs` to spawn a short-lived conversation with constrained instructions and extract a cleaned title (max 4 words) from the `TaskComplete` output.
- Add an OSC-based ANSI command `SetTerminalTitle` and a helper `Tui::set_terminal_title` in `codex-rs/tui/src/tui.rs` to set the terminal/tab title using `]0;TITLE`.
- Update test scaffolding in `codex-rs/tui/src/chatwidget/tests.rs` to initialize the new `terminal_title_requested` field.

### Testing
- Ran `just fmt` in `codex-rs` which completed but emitted warnings about `imports_granularity` requiring nightly; formatting otherwise ran.
- Ran `just fix -p codex-tui` to apply Clippy fixes and auto-corrections and it completed successfully.
- Ran `cargo test -p codex-tui` and the test suite passed; there were legacy snapshot format warnings that do not indicate failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_695e0ee1abc483218b75274b3b8d759e)