### PR TITLE
chore: silent just fmt

### DIFF
--- a/justfile
+++ b/justfile
@@ -25,7 +25,7 @@ app-server-test-client *args:
 
 # format code
 fmt:
-    cargo fmt -- --config imports_granularity=Item
+    cargo fmt -- --config imports_granularity=Item 2>/dev/null
 
 fix *args:
     cargo clippy --fix --all-features --tests --allow-dirty "$@"


### PR DESCRIPTION
Done to avoid spammy warnings to end up in the model context without having to switch to nightly
```
Warning: can't set `imports_granularity = Item`, unstable features are only available in nightly channel.
```