### PR TITLE
Override truncation policy at model info level

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -544,10 +544,7 @@ impl Session {
             final_output_json_schema: None,
             codex_linux_sandbox_exe: per_turn_config.codex_linux_sandbox_exe.clone(),
             tool_call_gate: Arc::new(ReadinessFlag::new()),
-            truncation_policy: TruncationPolicy::new(
-                per_turn_config.as_ref(),
-                model_info.truncation_policy.into(),
-            ),
+            truncation_policy: model_info.truncation_policy.into(),
         }
     }
 
@@ -2244,10 +2241,7 @@ async fn spawn_review_thread(
         final_output_json_schema: None,
         codex_linux_sandbox_exe: parent_turn_context.codex_linux_sandbox_exe.clone(),
         tool_call_gate: Arc::new(ReadinessFlag::new()),
-        truncation_policy: TruncationPolicy::new(
-            &per_turn_config,
-            model_info.truncation_policy.into(),
-        ),
+        truncation_policy: model_info.truncation_policy.into(),
     };
 
     // Seed the child task with the review prompt as the initial user message.

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -268,7 +268,6 @@ pub struct Config {
     /// Additional filenames to try when looking for project-level docs.
     pub project_doc_fallback_filenames: Vec<String>,
 
-    // todo(aibrahim): this should be used in the override model info
     /// Token budget applied when storing tool/function outputs in the context manager.
     pub tool_output_token_limit: Option<usize>,
 

--- a/codex-rs/core/src/truncate.rs
+++ b/codex-rs/core/src/truncate.rs
@@ -2,7 +2,6 @@
 //! and suffix on UTF-8 boundaries, and helpers for line/token‑based truncation
 //! used across the core crate.
 
-use crate::config::Config;
 use codex_protocol::models::FunctionCallOutputContentItem;
 use codex_protocol::openai_models::TruncationMode;
 use codex_protocol::openai_models::TruncationPolicyConfig;
@@ -43,27 +42,6 @@ impl TruncationPolicy {
             }
             TruncationPolicy::Tokens(tokens) => {
                 TruncationPolicy::Tokens((tokens as f64 * multiplier).ceil() as usize)
-            }
-        }
-    }
-
-    pub fn new(config: &Config, truncation_policy: TruncationPolicy) -> Self {
-        let config_token_limit = config.tool_output_token_limit;
-
-        match truncation_policy {
-            TruncationPolicy::Bytes(family_bytes) => {
-                if let Some(token_limit) = config_token_limit {
-                    Self::Bytes(approx_bytes_for_tokens(token_limit))
-                } else {
-                    Self::Bytes(family_bytes)
-                }
-            }
-            TruncationPolicy::Tokens(family_tokens) => {
-                if let Some(token_limit) = config_token_limit {
-                    Self::Tokens(token_limit)
-                } else {
-                    Self::Tokens(family_tokens)
-                }
             }
         }
     }
@@ -313,7 +291,7 @@ pub(crate) fn approx_token_count(text: &str) -> usize {
     len.saturating_add(APPROX_BYTES_PER_TOKEN.saturating_sub(1)) / APPROX_BYTES_PER_TOKEN
 }
 
-fn approx_bytes_for_tokens(tokens: usize) -> usize {
+pub(crate) fn approx_bytes_for_tokens(tokens: usize) -> usize {
     tokens.saturating_mul(APPROX_BYTES_PER_TOKEN)
 }
 

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -35,6 +35,7 @@ mod json_result;
 mod list_dir;
 mod list_models;
 mod live_cli;
+mod model_info_overrides;
 mod model_overrides;
 mod model_tools;
 mod models_etag_responses;

--- a/codex-rs/core/tests/suite/model_info_overrides.rs
+++ b/codex-rs/core/tests/suite/model_info_overrides.rs
@@ -1,0 +1,32 @@
+use codex_core::models_manager::manager::ModelsManager;
+use codex_protocol::openai_models::TruncationPolicyConfig;
+use core_test_support::load_default_config_for_test;
+use pretty_assertions::assert_eq;
+use tempfile::TempDir;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn offline_model_info_without_tool_output_override() {
+    let codex_home = TempDir::new().expect("create temp dir");
+    let config = load_default_config_for_test(&codex_home).await;
+
+    let model_info = ModelsManager::construct_model_info_offline("gpt-5.1", &config);
+
+    assert_eq!(
+        model_info.truncation_policy,
+        TruncationPolicyConfig::bytes(10_000)
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn offline_model_info_with_tool_output_override() {
+    let codex_home = TempDir::new().expect("create temp dir");
+    let mut config = load_default_config_for_test(&codex_home).await;
+    config.tool_output_token_limit = Some(123);
+
+    let model_info = ModelsManager::construct_model_info_offline("gpt-5.1-codex", &config);
+
+    assert_eq!(
+        model_info.truncation_policy,
+        TruncationPolicyConfig::tokens(123)
+    );
+}


### PR DESCRIPTION
We used to override truncation policy by comparing model info vs config value in context manager. A better way to do it is to construct model info using the config value