### PR TITLE
Immutable CodexAuth

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -582,7 +582,7 @@ impl CodexMessageProcessor {
                     .await;
 
                 let payload = AuthStatusChangeNotification {
-                    auth_method: self.auth_manager.auth().map(|auth| auth.mode),
+                    auth_method: self.auth_manager.auth_cached().map(|auth| auth.mode),
                 };
                 self.outgoing
                     .send_server_notification(ServerNotification::AuthStatusChange(payload))
@@ -612,7 +612,7 @@ impl CodexMessageProcessor {
                     .await;
 
                 let payload_v2 = AccountUpdatedNotification {
-                    auth_mode: self.auth_manager.auth().map(|auth| auth.mode),
+                    auth_mode: self.auth_manager.auth_cached().map(|auth| auth.mode),
                 };
                 self.outgoing
                     .send_server_notification(ServerNotification::AccountUpdated(payload_v2))
@@ -704,7 +704,7 @@ impl CodexMessageProcessor {
                             auth_manager.reload();
 
                             // Notify clients with the actual current auth mode.
-                            let current_auth_method = auth_manager.auth().map(|a| a.mode);
+                            let current_auth_method = auth_manager.auth_cached().map(|a| a.mode);
                             let payload = AuthStatusChangeNotification {
                                 auth_method: current_auth_method,
                             };
@@ -794,7 +794,7 @@ impl CodexMessageProcessor {
                             auth_manager.reload();
 
                             // Notify clients with the actual current auth mode.
-                            let current_auth_method = auth_manager.auth().map(|a| a.mode);
+                            let current_auth_method = auth_manager.auth_cached().map(|a| a.mode);
                             let payload_v2 = AccountUpdatedNotification {
                                 auth_mode: current_auth_method,
                             };
@@ -906,7 +906,7 @@ impl CodexMessageProcessor {
         }
 
         // Reflect the current auth method after logout (likely None).
-        Ok(self.auth_manager.auth().map(|auth| auth.mode))
+        Ok(self.auth_manager.auth_cached().map(|auth| auth.mode))
     }
 
     async fn logout_v1(&mut self, request_id: RequestId) {
@@ -973,10 +973,10 @@ impl CodexMessageProcessor {
                 requires_openai_auth: Some(false),
             }
         } else {
-            match self.auth_manager.auth() {
+            match self.auth_manager.auth().await {
                 Some(auth) => {
                     let auth_mode = auth.mode;
-                    let (reported_auth_method, token_opt) = match auth.get_token().await {
+                    let (reported_auth_method, token_opt) = match auth.get_token() {
                         Ok(token) if !token.is_empty() => {
                             let tok = if include_token { Some(token) } else { None };
                             (Some(auth_mode), tok)
@@ -1021,7 +1021,7 @@ impl CodexMessageProcessor {
             return;
         }
 
-        let account = match self.auth_manager.auth() {
+        let account = match self.auth_manager.auth_cached() {
             Some(auth) => Some(match auth.mode {
                 AuthMode::ApiKey => Account::ApiKey {},
                 AuthMode::ChatGPT => {
@@ -1075,7 +1075,7 @@ impl CodexMessageProcessor {
     }
 
     async fn fetch_account_rate_limits(&self) -> Result<CoreRateLimitSnapshot, JSONRPCErrorError> {
-        let Some(auth) = self.auth_manager.auth() else {
+        let Some(auth) = self.auth_manager.auth().await else {
             return Err(JSONRPCErrorError {
                 code: INVALID_REQUEST_ERROR_CODE,
                 message: "codex account authentication required to read rate limits".to_string(),
@@ -1092,7 +1092,6 @@ impl CodexMessageProcessor {
         }
 
         let client = BackendClient::from_auth(self.config.chatgpt_base_url.clone(), &auth)
-            .await
             .map_err(|err| JSONRPCErrorError {
                 code: INTERNAL_ERROR_CODE,
                 message: format!("failed to construct backend client: {err}"),
@@ -1132,7 +1131,10 @@ impl CodexMessageProcessor {
 
     async fn get_user_info(&self, request_id: RequestId) {
         // Read alleged user email from cached auth (best-effort; not verified).
-        let alleged_user_email = self.auth_manager.auth().and_then(|a| a.get_account_email());
+        let alleged_user_email = self
+            .auth_manager
+            .auth_cached()
+            .and_then(|a| a.get_account_email());
 
         let response = UserInfoResponse { alleged_user_email };
         self.outgoing.send_response(request_id, response).await;

--- a/codex-rs/backend-client/src/client.rs
+++ b/codex-rs/backend-client/src/client.rs
@@ -73,8 +73,8 @@ impl Client {
         })
     }
 
-    pub async fn from_auth(base_url: impl Into<String>, auth: &CodexAuth) -> Result<Self> {
-        let token = auth.get_token().await.map_err(anyhow::Error::from)?;
+    pub fn from_auth(base_url: impl Into<String>, auth: &CodexAuth) -> Result<Self> {
+        let token = auth.get_token().map_err(anyhow::Error::from)?;
         let mut client = Self::new(base_url)?
             .with_user_agent(get_codex_user_agent())
             .with_bearer_token(token);

--- a/codex-rs/chatgpt/src/chatgpt_token.rs
+++ b/codex-rs/chatgpt/src/chatgpt_token.rs
@@ -1,4 +1,4 @@
-use codex_core::CodexAuth;
+use codex_core::AuthManager;
 use std::path::Path;
 use std::sync::LazyLock;
 use std::sync::RwLock;
@@ -23,9 +23,10 @@ pub async fn init_chatgpt_token_from_auth(
     codex_home: &Path,
     auth_credentials_store_mode: AuthCredentialsStoreMode,
 ) -> std::io::Result<()> {
-    let auth = CodexAuth::from_auth_storage(codex_home, auth_credentials_store_mode)?;
-    if let Some(auth) = auth {
-        let token_data = auth.get_token_data().await?;
+    let auth_manager =
+        AuthManager::new(codex_home.to_path_buf(), false, auth_credentials_store_mode);
+    if let Some(auth) = auth_manager.auth().await {
+        let token_data = auth.get_token_data()?;
         set_chatgpt_token_data(token_data);
     }
     Ok(())

--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -155,7 +155,7 @@ pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {
 
     match CodexAuth::from_auth_storage(&config.codex_home, config.cli_auth_credentials_store_mode) {
         Ok(Some(auth)) => match auth.mode {
-            AuthMode::ApiKey => match auth.get_token().await {
+            AuthMode::ApiKey => match auth.get_token() {
                 Ok(api_key) => {
                     eprintln!("Logged in using an API key - {}", safe_format_key(&api_key));
                     std::process::exit(0);

--- a/codex-rs/cloud-tasks/src/util.rs
+++ b/codex-rs/cloud-tasks/src/util.rs
@@ -85,8 +85,8 @@ pub async fn build_chatgpt_headers() -> HeaderMap {
         HeaderValue::from_str(&ua).unwrap_or(HeaderValue::from_static("codex-cli")),
     );
     if let Some(am) = load_auth_manager().await
-        && let Some(auth) = am.auth()
-        && let Ok(tok) = auth.get_token().await
+        && let Some(auth) = am.auth().await
+        && let Ok(tok) = auth.get_token()
         && !tok.is_empty()
     {
         let v = format!("Bearer {tok}");

--- a/codex-rs/core/src/api_bridge.rs
+++ b/codex-rs/core/src/api_bridge.rs
@@ -100,7 +100,7 @@ fn extract_request_id(headers: Option<&HeaderMap>) -> Option<String> {
     })
 }
 
-pub(crate) async fn auth_provider_from_auth(
+pub(crate) fn auth_provider_from_auth(
     auth: Option<CodexAuth>,
     provider: &ModelProviderInfo,
 ) -> crate::error::Result<CoreAuthProvider> {
@@ -119,7 +119,7 @@ pub(crate) async fn auth_provider_from_auth(
     }
 
     if let Some(auth) = auth {
-        let token = auth.get_token().await?;
+        let token = auth.get_token()?;
         Ok(CoreAuthProvider {
             token: Some(token),
             account_id: auth.get_account_id(),

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -155,11 +155,14 @@ impl ModelClient {
 
         let mut refreshed = false;
         loop {
-            let auth = auth_manager.as_ref().and_then(|m| m.auth());
+            let auth = match auth_manager.as_ref() {
+                Some(manager) => manager.auth().await,
+                None => None,
+            };
             let api_provider = self
                 .provider
                 .to_api_provider(auth.as_ref().map(|a| a.mode))?;
-            let api_auth = auth_provider_from_auth(auth.clone(), &self.provider).await?;
+            let api_auth = auth_provider_from_auth(auth.clone(), &self.provider)?;
             let transport = ReqwestTransport::new(build_reqwest_client());
             let (request_telemetry, sse_telemetry) = self.build_streaming_telemetry();
             let client = ApiChatClient::new(transport, api_provider, api_auth)
@@ -243,11 +246,14 @@ impl ModelClient {
 
         let mut refreshed = false;
         loop {
-            let auth = auth_manager.as_ref().and_then(|m| m.auth());
+            let auth = match auth_manager.as_ref() {
+                Some(manager) => manager.auth().await,
+                None => None,
+            };
             let api_provider = self
                 .provider
                 .to_api_provider(auth.as_ref().map(|a| a.mode))?;
-            let api_auth = auth_provider_from_auth(auth.clone(), &self.provider).await?;
+            let api_auth = auth_provider_from_auth(auth.clone(), &self.provider)?;
             let transport = ReqwestTransport::new(build_reqwest_client());
             let (request_telemetry, sse_telemetry) = self.build_streaming_telemetry();
             let client = ApiResponsesClient::new(transport, api_provider, api_auth)
@@ -327,11 +333,14 @@ impl ModelClient {
             return Ok(Vec::new());
         }
         let auth_manager = self.auth_manager.clone();
-        let auth = auth_manager.as_ref().and_then(|m| m.auth());
+        let auth = match auth_manager.as_ref() {
+            Some(manager) => manager.auth().await,
+            None => None,
+        };
         let api_provider = self
             .provider
             .to_api_provider(auth.as_ref().map(|a| a.mode))?;
-        let api_auth = auth_provider_from_auth(auth.clone(), &self.provider).await?;
+        let api_auth = auth_provider_from_auth(auth.clone(), &self.provider)?;
         let transport = ReqwestTransport::new(build_reqwest_client());
         let request_telemetry = self.build_request_telemetry();
         let client = ApiCompactClient::new(transport, api_provider, api_auth)

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -7,6 +7,7 @@ use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 
 use crate::AuthManager;
+use crate::CodexAuth;
 use crate::SandboxState;
 use crate::agent::AgentControl;
 use crate::agent::AgentStatus;
@@ -643,13 +644,15 @@ impl Session {
         }
         maybe_push_chat_wire_api_deprecation(&config, &mut post_session_configured_events);
 
+        let auth = auth_manager.auth().await;
+        let auth = auth.as_ref();
         let otel_manager = OtelManager::new(
             conversation_id,
             session_configuration.model.as_str(),
             session_configuration.model.as_str(),
-            auth_manager.auth().and_then(|a| a.get_account_id()),
-            auth_manager.auth().and_then(|a| a.get_account_email()),
-            auth_manager.auth().map(|a| a.mode),
+            auth.and_then(CodexAuth::get_account_id),
+            auth.and_then(CodexAuth::get_account_email),
+            auth.map(|a| a.mode),
             config.otel.log_user_prompt,
             terminal::user_agent(),
             session_configuration.session_source.clone(),

--- a/codex-rs/core/src/models_manager/manager.rs
+++ b/codex-rs/core/src/models_manager/manager.rs
@@ -98,9 +98,9 @@ impl ModelsManager {
         if !remote_models_feature || self.auth_manager.get_auth_mode() == Some(AuthMode::ApiKey) {
             return Ok(());
         }
-        let auth = self.auth_manager.auth();
+        let auth = self.auth_manager.auth().await;
         let api_provider = self.provider.to_api_provider(Some(AuthMode::ChatGPT))?;
-        let api_auth = auth_provider_from_auth(auth.clone(), &self.provider).await?;
+        let api_auth = auth_provider_from_auth(auth.clone(), &self.provider)?;
         let transport = ReqwestTransport::new(build_reqwest_client());
         let client = ModelsClient::new(transport, api_provider, api_auth);
 

--- a/codex-rs/core/tests/suite/auth_refresh.rs
+++ b/codex-rs/core/tests/suite/auth_refresh.rs
@@ -3,7 +3,7 @@ use anyhow::Result;
 use base64::Engine;
 use chrono::Duration;
 use chrono::Utc;
-use codex_core::CodexAuth;
+use codex_core::AuthManager;
 use codex_core::auth::AuthCredentialsStoreMode;
 use codex_core::auth::AuthDotJson;
 use codex_core::auth::REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR;
@@ -45,32 +45,99 @@ async fn refresh_token_succeeds_updates_storage() -> Result<()> {
         .await;
 
     let ctx = RefreshTokenTestContext::new(&server)?;
-    let auth = ctx.auth.clone();
+    let initial_last_refresh = Utc::now() - Duration::days(1);
+    let initial_tokens = build_tokens(INITIAL_ACCESS_TOKEN, INITIAL_REFRESH_TOKEN);
+    let initial_auth = AuthDotJson {
+        openai_api_key: None,
+        tokens: Some(initial_tokens.clone()),
+        last_refresh: Some(initial_last_refresh),
+    };
+    ctx.write_auth(&initial_auth)?;
 
-    let access = auth
+    let access = ctx
+        .auth_manager
         .refresh_token()
         .await
         .context("refresh should succeed")?;
-    assert_eq!(access, "new-access-token");
+    assert_eq!(access, Some("new-access-token".to_string()));
 
+    let refreshed_tokens = TokenData {
+        access_token: "new-access-token".to_string(),
+        refresh_token: "new-refresh-token".to_string(),
+        ..initial_tokens.clone()
+    };
     let stored = ctx.load_auth()?;
     let tokens = stored.tokens.as_ref().context("tokens should exist")?;
-    assert_eq!(tokens.access_token, "new-access-token");
-    assert_eq!(tokens.refresh_token, "new-refresh-token");
+    assert_eq!(tokens, &refreshed_tokens);
     let refreshed_at = stored
         .last_refresh
         .as_ref()
         .context("last_refresh should be recorded")?;
     assert!(
-        *refreshed_at >= ctx.initial_last_refresh,
+        *refreshed_at >= initial_last_refresh,
         "last_refresh should advance"
     );
 
-    let cached = auth
+    let cached_auth = ctx.auth_manager.auth().context("auth should be cached")?;
+    let cached = cached_auth
         .get_token_data()
         .await
         .context("token data should be cached")?;
-    assert_eq!(cached.access_token, "new-access-token");
+    assert_eq!(cached, refreshed_tokens);
+
+    server.verify().await;
+    Ok(())
+}
+
+#[serial_test::serial(auth_refresh)]
+#[tokio::test]
+async fn refreshes_token_when_last_refresh_is_stale() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/token"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "access_token": "new-access-token",
+            "refresh_token": "new-refresh-token"
+        })))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let ctx = RefreshTokenTestContext::new(&server)?;
+    let stale_refresh = Utc::now() - Duration::days(9);
+    let initial_tokens = build_tokens(INITIAL_ACCESS_TOKEN, INITIAL_REFRESH_TOKEN);
+    let initial_auth = AuthDotJson {
+        openai_api_key: None,
+        tokens: Some(initial_tokens.clone()),
+        last_refresh: Some(stale_refresh),
+    };
+    ctx.write_auth(&initial_auth)?;
+
+    let cached_auth = ctx.auth_manager.auth().context("auth should be cached")?;
+    let refreshed_tokens = TokenData {
+        access_token: "new-access-token".to_string(),
+        refresh_token: "new-refresh-token".to_string(),
+        ..initial_tokens.clone()
+    };
+    let cached = cached_auth
+        .get_token_data()
+        .await
+        .context("token data should refresh")?;
+    assert_eq!(cached, refreshed_tokens);
+
+    let stored = ctx.load_auth()?;
+    let tokens = stored.tokens.as_ref().context("tokens should exist")?;
+    assert_eq!(tokens, &refreshed_tokens);
+    let refreshed_at = stored
+        .last_refresh
+        .as_ref()
+        .context("last_refresh should be recorded")?;
+    assert!(
+        *refreshed_at >= stale_refresh,
+        "last_refresh should advance"
+    );
 
     server.verify().await;
     Ok(())
@@ -94,9 +161,17 @@ async fn refresh_token_returns_permanent_error_for_expired_refresh_token() -> Re
         .await;
 
     let ctx = RefreshTokenTestContext::new(&server)?;
-    let auth = ctx.auth.clone();
+    let initial_last_refresh = Utc::now() - Duration::days(1);
+    let initial_tokens = build_tokens(INITIAL_ACCESS_TOKEN, INITIAL_REFRESH_TOKEN);
+    let initial_auth = AuthDotJson {
+        openai_api_key: None,
+        tokens: Some(initial_tokens.clone()),
+        last_refresh: Some(initial_last_refresh),
+    };
+    ctx.write_auth(&initial_auth)?;
 
-    let err = auth
+    let err = ctx
+        .auth_manager
         .refresh_token()
         .await
         .err()
@@ -104,16 +179,16 @@ async fn refresh_token_returns_permanent_error_for_expired_refresh_token() -> Re
     assert_eq!(err.failed_reason(), Some(RefreshTokenFailedReason::Expired));
 
     let stored = ctx.load_auth()?;
-    let tokens = stored.tokens.as_ref().context("tokens should remain")?;
-    assert_eq!(tokens.access_token, INITIAL_ACCESS_TOKEN);
-    assert_eq!(tokens.refresh_token, INITIAL_REFRESH_TOKEN);
-    assert_eq!(
-        *stored
-            .last_refresh
-            .as_ref()
-            .context("last_refresh should remain unchanged")?,
-        ctx.initial_last_refresh,
-    );
+    assert_eq!(stored, initial_auth);
+    let cached_auth = ctx
+        .auth_manager
+        .auth()
+        .context("auth should remain cached")?;
+    let cached = cached_auth
+        .get_token_data()
+        .await
+        .context("token data should remain cached")?;
+    assert_eq!(cached, initial_tokens);
 
     server.verify().await;
     Ok(())
@@ -135,9 +210,17 @@ async fn refresh_token_returns_transient_error_on_server_failure() -> Result<()>
         .await;
 
     let ctx = RefreshTokenTestContext::new(&server)?;
-    let auth = ctx.auth.clone();
+    let initial_last_refresh = Utc::now() - Duration::days(1);
+    let initial_tokens = build_tokens(INITIAL_ACCESS_TOKEN, INITIAL_REFRESH_TOKEN);
+    let initial_auth = AuthDotJson {
+        openai_api_key: None,
+        tokens: Some(initial_tokens.clone()),
+        last_refresh: Some(initial_last_refresh),
+    };
+    ctx.write_auth(&initial_auth)?;
 
-    let err = auth
+    let err = ctx
+        .auth_manager
         .refresh_token()
         .await
         .err()
@@ -146,16 +229,16 @@ async fn refresh_token_returns_transient_error_on_server_failure() -> Result<()>
     assert_eq!(err.failed_reason(), None);
 
     let stored = ctx.load_auth()?;
-    let tokens = stored.tokens.as_ref().context("tokens should remain")?;
-    assert_eq!(tokens.access_token, INITIAL_ACCESS_TOKEN);
-    assert_eq!(tokens.refresh_token, INITIAL_REFRESH_TOKEN);
-    assert_eq!(
-        *stored
-            .last_refresh
-            .as_ref()
-            .context("last_refresh should remain unchanged")?,
-        ctx.initial_last_refresh,
-    );
+    assert_eq!(stored, initial_auth);
+    let cached_auth = ctx
+        .auth_manager
+        .auth()
+        .context("auth should remain cached")?;
+    let cached = cached_auth
+        .get_token_data()
+        .await
+        .context("token data should remain cached")?;
+    assert_eq!(cached, initial_tokens);
 
     server.verify().await;
     Ok(())
@@ -163,44 +246,26 @@ async fn refresh_token_returns_transient_error_on_server_failure() -> Result<()>
 
 struct RefreshTokenTestContext {
     codex_home: TempDir,
-    auth: CodexAuth,
-    initial_last_refresh: chrono::DateTime<Utc>,
+    auth_manager: AuthManager,
     _env_guard: EnvGuard,
 }
 
 impl RefreshTokenTestContext {
     fn new(server: &MockServer) -> Result<Self> {
         let codex_home = TempDir::new()?;
-        let initial_last_refresh = Utc::now() - Duration::days(1);
-        let mut id_token = IdTokenInfo::default();
-        id_token.raw_jwt = minimal_jwt();
-        let tokens = TokenData {
-            id_token,
-            access_token: INITIAL_ACCESS_TOKEN.to_string(),
-            refresh_token: INITIAL_REFRESH_TOKEN.to_string(),
-            account_id: Some("account-id".to_string()),
-        };
-        let auth_dot_json = AuthDotJson {
-            openai_api_key: None,
-            tokens: Some(tokens),
-            last_refresh: Some(initial_last_refresh),
-        };
-        save_auth(
-            codex_home.path(),
-            &auth_dot_json,
-            AuthCredentialsStoreMode::File,
-        )?;
 
         let endpoint = format!("{}/oauth/token", server.uri());
         let env_guard = EnvGuard::set(REFRESH_TOKEN_URL_OVERRIDE_ENV_VAR, endpoint);
 
-        let auth = CodexAuth::from_auth_storage(codex_home.path(), AuthCredentialsStoreMode::File)?
-            .context("auth should load from storage")?;
+        let auth_manager = AuthManager::new(
+            codex_home.path().to_path_buf(),
+            false,
+            AuthCredentialsStoreMode::File,
+        );
 
         Ok(Self {
             codex_home,
-            auth,
-            initial_last_refresh,
+            auth_manager,
             _env_guard: env_guard,
         })
     }
@@ -209,6 +274,16 @@ impl RefreshTokenTestContext {
         load_auth_dot_json(self.codex_home.path(), AuthCredentialsStoreMode::File)
             .context("load auth.json")?
             .context("auth.json should exist")
+    }
+
+    fn write_auth(&self, auth_dot_json: &AuthDotJson) -> Result<()> {
+        save_auth(
+            self.codex_home.path(),
+            auth_dot_json,
+            AuthCredentialsStoreMode::File,
+        )?;
+        self.auth_manager.reload();
+        Ok(())
     }
 }
 
@@ -269,4 +344,15 @@ fn minimal_jwt() -> String {
     let payload_b64 = b64(&payload_bytes);
     let signature_b64 = b64(b"sig");
     format!("{header_b64}.{payload_b64}.{signature_b64}")
+}
+
+fn build_tokens(access_token: &str, refresh_token: &str) -> TokenData {
+    let mut id_token = IdTokenInfo::default();
+    id_token.raw_jwt = minimal_jwt();
+    TokenData {
+        id_token,
+        access_token: access_token.to_string(),
+        refresh_token: refresh_token.to_string(),
+        account_id: Some("account-id".to_string()),
+    }
 }

--- a/codex-rs/core/tests/suite/auth_refresh.rs
+++ b/codex-rs/core/tests/suite/auth_refresh.rs
@@ -78,10 +78,13 @@ async fn refresh_token_succeeds_updates_storage() -> Result<()> {
         "last_refresh should advance"
     );
 
-    let cached_auth = ctx.auth_manager.auth().context("auth should be cached")?;
+    let cached_auth = ctx
+        .auth_manager
+        .auth()
+        .await
+        .context("auth should be cached")?;
     let cached = cached_auth
         .get_token_data()
-        .await
         .context("token data should be cached")?;
     assert_eq!(cached, refreshed_tokens);
 
@@ -115,7 +118,11 @@ async fn refreshes_token_when_last_refresh_is_stale() -> Result<()> {
     };
     ctx.write_auth(&initial_auth)?;
 
-    let cached_auth = ctx.auth_manager.auth().context("auth should be cached")?;
+    let cached_auth = ctx
+        .auth_manager
+        .auth()
+        .await
+        .context("auth should be cached")?;
     let refreshed_tokens = TokenData {
         access_token: "new-access-token".to_string(),
         refresh_token: "new-refresh-token".to_string(),
@@ -123,7 +130,6 @@ async fn refreshes_token_when_last_refresh_is_stale() -> Result<()> {
     };
     let cached = cached_auth
         .get_token_data()
-        .await
         .context("token data should refresh")?;
     assert_eq!(cached, refreshed_tokens);
 
@@ -183,10 +189,10 @@ async fn refresh_token_returns_permanent_error_for_expired_refresh_token() -> Re
     let cached_auth = ctx
         .auth_manager
         .auth()
+        .await
         .context("auth should remain cached")?;
     let cached = cached_auth
         .get_token_data()
-        .await
         .context("token data should remain cached")?;
     assert_eq!(cached, initial_tokens);
 
@@ -233,10 +239,10 @@ async fn refresh_token_returns_transient_error_on_server_failure() -> Result<()>
     let cached_auth = ctx
         .auth_manager
         .auth()
+        .await
         .context("auth should remain cached")?;
     let cached = cached_auth
         .get_token_data()
-        .await
         .context("token data should remain cached")?;
     assert_eq!(cached, initial_tokens);
 

--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -218,7 +218,7 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
     let config =
         Config::load_with_cli_overrides_and_harness_overrides(cli_kv_overrides, overrides).await?;
 
-    if let Err(err) = enforce_login_restrictions(&config).await {
+    if let Err(err) = enforce_login_restrictions(&config) {
         eprintln!("{err}");
         std::process::exit(1);
     }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2321,12 +2321,11 @@ impl ChatWidget {
             let mut interval = tokio::time::interval(Duration::from_secs(60));
 
             loop {
-                if let Some(auth) = auth_manager.auth().await {
-                    if auth.mode == AuthMode::ChatGPT {
-                        if let Some(snapshot) = fetch_rate_limits(base_url.clone(), auth).await {
-                            app_event_tx.send(AppEvent::RateLimitSnapshotFetched(snapshot));
-                        }
-                    }
+                if let Some(auth) = auth_manager.auth().await
+                    && auth.mode == AuthMode::ChatGPT
+                    && let Some(snapshot) = fetch_rate_limits(base_url.clone(), auth).await
+                {
+                    app_event_tx.send(AppEvent::RateLimitSnapshotFetched(snapshot));
                 }
                 interval.tick().await;
             }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -235,7 +235,7 @@ pub async fn run_main(
     }
 
     #[allow(clippy::print_stderr)]
-    if let Err(err) = enforce_login_restrictions(&config).await {
+    if let Err(err) = enforce_login_restrictions(&config) {
         eprintln!("{err}");
         std::process::exit(1);
     }

--- a/codex-rs/tui/src/status/helpers.rs
+++ b/codex-rs/tui/src/status/helpers.rs
@@ -88,7 +88,7 @@ pub(crate) fn compose_account_display(
     auth_manager: &AuthManager,
     plan: Option<PlanType>,
 ) -> Option<StatusAccountDisplay> {
-    let auth = auth_manager.auth()?;
+    let auth = auth_manager.auth_cached()?;
 
     match auth.mode {
         AuthMode::ChatGPT => {

--- a/codex-rs/tui2/src/chatwidget.rs
+++ b/codex-rs/tui2/src/chatwidget.rs
@@ -2117,12 +2117,11 @@ impl ChatWidget {
             let mut interval = tokio::time::interval(Duration::from_secs(60));
 
             loop {
-                if let Some(auth) = auth_manager.auth().await {
-                    if auth.mode == AuthMode::ChatGPT {
-                        if let Some(snapshot) = fetch_rate_limits(base_url.clone(), auth).await {
-                            app_event_tx.send(AppEvent::RateLimitSnapshotFetched(snapshot));
-                        }
-                    }
+                if let Some(auth) = auth_manager.auth().await
+                    && auth.mode == AuthMode::ChatGPT
+                    && let Some(snapshot) = fetch_rate_limits(base_url.clone(), auth).await
+                {
+                    app_event_tx.send(AppEvent::RateLimitSnapshotFetched(snapshot));
                 }
                 interval.tick().await;
             }

--- a/codex-rs/tui2/src/chatwidget.rs
+++ b/codex-rs/tui2/src/chatwidget.rs
@@ -2105,22 +2105,24 @@ impl ChatWidget {
     fn prefetch_rate_limits(&mut self) {
         self.stop_rate_limit_poller();
 
-        let Some(auth) = self.auth_manager.auth() else {
-            return;
-        };
-        if auth.mode != AuthMode::ChatGPT {
+        if self.auth_manager.auth_cached().map(|auth| auth.mode) != Some(AuthMode::ChatGPT) {
             return;
         }
 
         let base_url = self.config.chatgpt_base_url.clone();
         let app_event_tx = self.app_event_tx.clone();
+        let auth_manager = Arc::clone(&self.auth_manager);
 
         let handle = tokio::spawn(async move {
             let mut interval = tokio::time::interval(Duration::from_secs(60));
 
             loop {
-                if let Some(snapshot) = fetch_rate_limits(base_url.clone(), auth.clone()).await {
-                    app_event_tx.send(AppEvent::RateLimitSnapshotFetched(snapshot));
+                if let Some(auth) = auth_manager.auth().await {
+                    if auth.mode == AuthMode::ChatGPT {
+                        if let Some(snapshot) = fetch_rate_limits(base_url.clone(), auth).await {
+                            app_event_tx.send(AppEvent::RateLimitSnapshotFetched(snapshot));
+                        }
+                    }
                 }
                 interval.tick().await;
             }
@@ -3502,7 +3504,7 @@ fn extract_first_bold(s: &str) -> Option<String> {
 }
 
 async fn fetch_rate_limits(base_url: String, auth: CodexAuth) -> Option<RateLimitSnapshot> {
-    match BackendClient::from_auth(base_url, &auth).await {
+    match BackendClient::from_auth(base_url, &auth) {
         Ok(client) => match client.get_rate_limits().await {
             Ok(snapshot) => Some(snapshot),
             Err(err) => {

--- a/codex-rs/tui2/src/lib.rs
+++ b/codex-rs/tui2/src/lib.rs
@@ -250,7 +250,7 @@ pub async fn run_main(
     }
 
     #[allow(clippy::print_stderr)]
-    if let Err(err) = enforce_login_restrictions(&config).await {
+    if let Err(err) = enforce_login_restrictions(&config) {
         eprintln!("{err}");
         std::process::exit(1);
     }

--- a/codex-rs/tui2/src/status/helpers.rs
+++ b/codex-rs/tui2/src/status/helpers.rs
@@ -88,7 +88,7 @@ pub(crate) fn compose_account_display(
     auth_manager: &AuthManager,
     plan: Option<PlanType>,
 ) -> Option<StatusAccountDisplay> {
-    let auth = auth_manager.auth()?;
+    let auth = auth_manager.auth_cached()?;
 
     match auth.mode {
         AuthMode::ChatGPT => {


### PR DESCRIPTION
Historically we started with a CodexAuth that knew how to refresh it's own tokens and then added AuthManager that did a different kind of refresh (re-reading from disk).

I don't think it makes sense for both `CodexAuth` and `AuthManager` to be mutable and contain behaviors. 

Move all refresh logic into `AuthManager` and keep `CodexAuth` as a data object.