### PR TITLE
fix: update resource path resolution logic so it works with Bazel

### DIFF
--- a/codex-rs/exec-server/tests/common/lib.rs
+++ b/codex-rs/exec-server/tests/common/lib.rs
@@ -34,10 +34,11 @@ where
 {
     let mcp_executable = codex_utils_cargo_bin::cargo_bin("codex-exec-mcp-server")?;
     let execve_wrapper = codex_utils_cargo_bin::cargo_bin("codex-execve-wrapper")?;
-    // `bash` requires a special lookup when running under Buck because it is a
+
+    // `bash` requires a special lookup when running under Bazel because it is a
     // _resource_ rather than a binary target.
-    let bash = if let Some(root) = codex_utils_cargo_bin::buck_project_root()? {
-        root.join("codex-rs/exec-server/tests/suite/bash")
+    let bash = if let Some(bazel_runfiles_dir) = std::env::var_os("RUNFILES_DIR") {
+        PathBuf::from(bazel_runfiles_dir).join("_main/codex-rs/exec-server/tests/suite/bash")
     } else {
         Path::new(env!("CARGO_MANIFEST_DIR"))
             .join("..")


### PR DESCRIPTION
The Bazelification work in-flight over at https://github.com/openai/codex/pull/8832 needs this fix so that Bazel can find the path to the DotSlash file for `bash`.

With this change, the following almost works:

```
bazel test --test_output=errors //codex-rs/exec-server:exec-server-all-test
```

That is, now the `list_tools` test passes, but `accept_elicitation_for_prompt_rule` still fails because it runs Seatbelt itself, so it needs to be run outside Bazel's local sandboxing.