### PR TITLE
fix: use tokio for I/O in an async function

### DIFF
--- a/codex-rs/chatgpt/tests/suite/apply_command_e2e.rs
+++ b/codex-rs/chatgpt/tests/suite/apply_command_e2e.rs
@@ -69,7 +69,7 @@ async fn create_temp_git_repo() -> anyhow::Result<TempDir> {
 
 async fn mock_get_task_with_fixture() -> anyhow::Result<GetTaskResponse> {
     let fixture_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/task_turn_fixture.json");
-    let fixture_content = std::fs::read_to_string(fixture_path)?;
+    let fixture_content = tokio::fs::read_to_string(fixture_path).await?;
     let response: GetTaskResponse = serde_json::from_str(&fixture_content)?;
     Ok(response)
 }


### PR DESCRIPTION
I thought this might solve a bug I'm working on, but it turned out to be a red herring. Nevertheless, this seems like the right thing to do here.