### PR TITLE
[fix] app server flaky thread/resume tests

### DIFF
--- a/codex-rs/app-server/tests/common/lib.rs
+++ b/codex-rs/app-server/tests/common/lib.rs
@@ -20,6 +20,7 @@ pub use core_test_support::test_tmp_path_buf;
 pub use mcp_process::McpProcess;
 pub use mock_model_server::create_mock_chat_completions_server;
 pub use mock_model_server::create_mock_chat_completions_server_unchecked;
+pub use mock_model_server::create_mock_responses_server_repeating_assistant;
 pub use models_cache::write_models_cache;
 pub use models_cache::write_models_cache_with_models;
 pub use responses::create_apply_patch_sse_response;

--- a/codex-rs/app-server/tests/suite/v2/thread_resume.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_resume.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use app_test_support::McpProcess;
 use app_test_support::create_fake_rollout;
-use app_test_support::create_mock_chat_completions_server;
+use app_test_support::create_mock_responses_server_repeating_assistant;
 use app_test_support::to_response;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::RequestId;
@@ -23,7 +23,7 @@ const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 
 #[tokio::test]
 async fn thread_resume_returns_original_thread() -> Result<()> {
-    let server = create_mock_chat_completions_server(vec![]).await;
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), &server.uri())?;
 
@@ -66,7 +66,7 @@ async fn thread_resume_returns_original_thread() -> Result<()> {
 
 #[tokio::test]
 async fn thread_resume_returns_rollout_history() -> Result<()> {
-    let server = create_mock_chat_completions_server(vec![]).await;
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), &server.uri())?;
 
@@ -130,7 +130,7 @@ async fn thread_resume_returns_rollout_history() -> Result<()> {
 
 #[tokio::test]
 async fn thread_resume_prefers_path_over_thread_id() -> Result<()> {
-    let server = create_mock_chat_completions_server(vec![]).await;
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), &server.uri())?;
 
@@ -174,7 +174,7 @@ async fn thread_resume_prefers_path_over_thread_id() -> Result<()> {
 
 #[tokio::test]
 async fn thread_resume_supports_history_and_overrides() -> Result<()> {
-    let server = create_mock_chat_completions_server(vec![]).await;
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
     let codex_home = TempDir::new()?;
     create_config_toml(codex_home.path(), &server.uri())?;
 
@@ -247,7 +247,7 @@ model_provider = "mock_provider"
 [model_providers.mock_provider]
 name = "Mock provider for test"
 base_url = "{server_uri}/v1"
-wire_api = "chat"
+wire_api = "responses"
 request_max_retries = 0
 stream_max_retries = 0
 "#


### PR DESCRIPTION
Fix flakiness of CI tests: https://github.com/openai/codex/actions/runs/20350530276/job/58473691443?pr=8282

This PR does two things:
1. test with responses API instead of chat completions API in thread_resume tests;
2. have a new responses API fixture that mocks out arbitrary numbers of responses API calls (including no calls) and have the same repeated response.

Tested by CI