### PR TITLE
fix: make the find_resource! macro responsible for the absolutize() call

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1881,6 +1881,7 @@ name = "codex-utils-cargo-bin"
 version = "0.0.0"
 dependencies = [
  "assert_cmd",
+ "path-absolutize",
  "thiserror 2.0.17",
 ]
 
@@ -2845,7 +2846,6 @@ dependencies = [
  "anyhow",
  "codex-core",
  "codex-utils-cargo-bin",
- "path-absolutize",
  "rmcp",
  "serde_json",
  "tokio",

--- a/codex-rs/exec-server/tests/common/Cargo.toml
+++ b/codex-rs/exec-server/tests/common/Cargo.toml
@@ -11,7 +11,6 @@ path = "lib.rs"
 anyhow = { workspace = true }
 codex-core = { workspace = true }
 codex-utils-cargo-bin = { workspace = true }
-path-absolutize = { workspace = true }
 rmcp = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/codex-rs/exec-server/tests/common/lib.rs
+++ b/codex-rs/exec-server/tests/common/lib.rs
@@ -2,7 +2,6 @@ use codex_core::MCP_SANDBOX_STATE_METHOD;
 use codex_core::SandboxState;
 use codex_core::protocol::SandboxPolicy;
 use codex_utils_cargo_bin::find_resource;
-use path_absolutize::Absolutize;
 use rmcp::ClientHandler;
 use rmcp::ErrorData as McpError;
 use rmcp::RoleClient;
@@ -38,14 +37,8 @@ where
     let execve_wrapper = codex_utils_cargo_bin::cargo_bin("codex-execve-wrapper")?;
 
     // `bash` is a test resource rather than a binary target, so we must use
-    // `find_resource!` to locate it instead of `cargo_bin`.
-    //
-    // Note we also have to normalize (but not canonicalize!) the path for
-    // _Bazel_ because the original value ends with
-    // `codex-rs/exec-server/tests/common/../suite/bash`, but the `tests/common`
-    // folder will not exist at runtime under Bazel. As such, we have to
-    // normalize it before passing it to `dotslash fetch`.
-    let bash = find_resource!("../suite/bash")?.absolutize()?.to_path_buf();
+    // `find_resource!` to locate it instead of `cargo_bin()`.
+    let bash = find_resource!("../suite/bash")?;
 
     // Need to ensure the artifact associated with the bash DotSlash file is
     // available before it is run in a read-only sandbox.

--- a/codex-rs/utils/cargo-bin/Cargo.toml
+++ b/codex-rs/utils/cargo-bin/Cargo.toml
@@ -9,4 +9,5 @@ workspace = true
 
 [dependencies]
 assert_cmd = { workspace = true }
+path-absolutize = { workspace = true }
 thiserror = { workspace = true }


### PR DESCRIPTION
https://github.com/openai/codex/pull/8879 introduced the `find_resource!` macro, but now that I am about to use it in more places, I realize that it should take care of this normalization case for callers.

Note the `use $crate::path_absolutize::Absolutize;` line is there so that users of `find_resource!` do not have to explicitly include `path-absolutize` to their own `Cargo.toml`.