### PR TITLE
fix: treat null MCP resource args as empty

### DIFF
--- a/codex-rs/core/src/tools/handlers/mcp_resource.rs
+++ b/codex-rs/core/src/tools/handlers/mcp_resource.rs
@@ -640,9 +640,14 @@ fn parse_arguments(raw_args: &str) -> Result<Option<Value>, FunctionCallError> {
     if raw_args.trim().is_empty() {
         Ok(None)
     } else {
-        serde_json::from_str(raw_args).map(Some).map_err(|err| {
+        let value: Value = serde_json::from_str(raw_args).map_err(|err| {
             FunctionCallError::RespondToModel(format!("failed to parse function arguments: {err}"))
-        })
+        })?;
+        if value.is_null() {
+            Ok(None)
+        } else {
+            Ok(Some(value))
+        }
     }
 }
 
@@ -767,6 +772,11 @@ mod tests {
         assert!(
             parse_arguments(" \n\t").unwrap().is_none(),
             "expected None for empty arguments"
+        );
+
+        assert!(
+            parse_arguments("null").unwrap().is_none(),
+            "expected None for null arguments"
         );
 
         let value = parse_arguments(r#"{"server":"figma"}"#)


### PR DESCRIPTION
Handle null tool arguments in the MCP resource handler so optional resource tools accept null without failing, preserving normal JSON parsing for non-null payloads and improving robustness when models emit null; this avoids spurious argument parse errors for list/read MCP resource calls.