### PR TITLE
feat: add stop hooks

### DIFF
--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -397,6 +397,22 @@ impl Default for ScrollInputMode {
     }
 }
 
+/// Controls how Stop hook activity is surfaced in the TUI.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum StopHookVisibility {
+    Off,
+    Status,
+    Summary,
+    Verbose,
+}
+
+impl Default for StopHookVisibility {
+    fn default() -> Self {
+        Self::Status
+    }
+}
+
 /// Collection of settings that are specific to the TUI.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct Tui {
@@ -414,6 +430,11 @@ pub struct Tui {
     /// Defaults to `true`.
     #[serde(default = "default_true")]
     pub show_tooltips: bool,
+
+    /// Control how Stop hook activity is displayed in the TUI.
+    /// Defaults to `status`.
+    #[serde(default)]
+    pub stop_hook_visibility: StopHookVisibility,
 
     /// Override the *wheel* event density used to normalize TUI2 scrolling.
     ///

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -85,6 +85,7 @@ pub mod shell;
 pub mod shell_snapshot;
 pub mod skills;
 pub mod spawn;
+pub mod stop_hooks;
 pub mod terminal;
 mod tools;
 pub mod turn_diff_tracker;

--- a/codex-rs/core/src/rollout/policy.rs
+++ b/codex-rs/core/src/rollout/policy.rs
@@ -70,6 +70,7 @@ pub(crate) fn should_persist_event_msg(ev: &EventMsg) -> bool {
         | EventMsg::ElicitationRequest(_)
         | EventMsg::ApplyPatchApprovalRequest(_)
         | EventMsg::BackgroundEvent(_)
+        | EventMsg::StopHookEvent(_)
         | EventMsg::StreamError(_)
         | EventMsg::PatchApplyBegin(_)
         | EventMsg::PatchApplyEnd(_)

--- a/codex-rs/core/src/stop_hooks.rs
+++ b/codex-rs/core/src/stop_hooks.rs
@@ -1,0 +1,854 @@
+use async_trait::async_trait;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use serde::Deserialize;
+use serde::Serialize;
+use std::collections::BTreeMap;
+use std::collections::HashSet;
+use std::path::Path;
+use std::path::PathBuf;
+use std::time::Duration;
+use std::time::Instant;
+use thiserror::Error;
+use tokio::io::AsyncWriteExt;
+use tokio::process::Command;
+use tokio::time;
+use tracing::warn;
+
+use crate::protocol::StopHookEvent;
+use crate::protocol::StopHookEventDecision;
+use crate::protocol::StopHookEventStage;
+use crate::protocol::StopHookEventStatus;
+
+const DOT_CODEX_DIR: &str = ".codex";
+const HOOKS_DIR: &str = "hooks";
+const HOOKS_FILE: &str = "hooks.json";
+const DEFAULT_HOOK_TIMEOUT_SECS: u64 = 30;
+
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
+pub struct StopHooksToml {
+    #[serde(default)]
+    pub include_project_hooks: Option<bool>,
+    #[serde(default)]
+    pub sources: BTreeMap<String, StopHookSourceToml>,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct StopHookSourceToml {
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub order: Option<i64>,
+    #[serde(default)]
+    pub command: Option<String>,
+    #[serde(default)]
+    pub args: Option<Vec<String>>,
+    #[serde(default)]
+    pub timeout: Option<u64>,
+    #[serde(default)]
+    pub timeout_ms: Option<u64>,
+    #[serde(default)]
+    pub file: Option<AbsolutePathBuf>,
+    #[serde(default, rename = "type")]
+    pub hook_type: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StopHooksConfig {
+    pub include_project_hooks: bool,
+    pub sources: Vec<StopHookSource>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StopHookSource {
+    Command(StopHookCommand),
+    HooksFile(PathBuf),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StopHookCommand {
+    pub command: String,
+    pub args: Vec<String>,
+    pub timeout: Option<u64>,
+    pub timeout_ms: Option<u64>,
+}
+
+impl StopHooksConfig {
+    pub fn from_toml(value: Option<StopHooksToml>) -> Self {
+        let mut config = StopHooksConfig {
+            include_project_hooks: true,
+            sources: Vec::new(),
+        };
+        let Some(value) = value else {
+            return config;
+        };
+
+        config.include_project_hooks = value.include_project_hooks.unwrap_or(true);
+
+        let mut sources = Vec::new();
+        for (name, source) in value.sources {
+            if source.enabled == Some(false) {
+                continue;
+            }
+
+            let order = source.order.unwrap_or(0);
+            if let Some(file) = source.file {
+                if source.command.is_some() {
+                    warn!("Stop hook source `{name}` specifies both file and command; skipping",);
+                    continue;
+                }
+                sources.push((order, name, StopHookSource::HooksFile(file.into())));
+                continue;
+            }
+
+            let Some(command) = source.command else {
+                warn!("Stop hook source `{name}` missing command or file; skipping");
+                continue;
+            };
+            if let Some(hook_type) = source.hook_type.as_deref()
+                && !hook_type.eq_ignore_ascii_case("command")
+            {
+                warn!("Stop hook source `{name}` has unsupported type `{hook_type}`; skipping",);
+                continue;
+            }
+            let args = source.args.unwrap_or_default();
+            let entry = StopHookCommand {
+                command,
+                args,
+                timeout: source.timeout,
+                timeout_ms: source.timeout_ms,
+            };
+            sources.push((order, name, StopHookSource::Command(entry)));
+        }
+
+        sources.sort_by(|(left_order, left_name, _), (right_order, right_name, _)| {
+            left_order
+                .cmp(right_order)
+                .then_with(|| left_name.cmp(right_name))
+        });
+
+        config.sources = sources.into_iter().map(|(_, _, source)| source).collect();
+        config
+    }
+}
+
+impl Default for StopHooksConfig {
+    fn default() -> Self {
+        Self {
+            include_project_hooks: true,
+            sources: Vec::new(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StopHookContext {
+    pub cwd: PathBuf,
+    pub conversation_id: String,
+    pub turn_id: String,
+    pub rollout_path: Option<PathBuf>,
+    pub input_messages: Vec<String>,
+    pub last_agent_message: Option<String>,
+    pub stop_hooks: StopHooksConfig,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StopHookDecision {
+    Allow,
+    Block {
+        reason: String,
+        system_message: Option<String>,
+    },
+}
+
+#[derive(Debug, Error)]
+pub enum StopHookError {
+    #[error("stop hook I/O error: {0}")]
+    Io(#[from] std::io::Error),
+    #[error("stop hook JSON error: {0}")]
+    Json(#[from] serde_json::Error),
+}
+
+#[async_trait]
+pub trait StopHookEventSink: Send + Sync {
+    async fn emit(&self, event: StopHookEvent);
+}
+
+#[derive(Debug, Clone)]
+struct StopHookRunOutcome {
+    status: StopHookEventStatus,
+    output: Option<HookOutput>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct HooksFile {
+    #[serde(default)]
+    hooks: Option<HookSection>,
+    #[serde(default, rename = "Stop")]
+    stop_upper: Option<Vec<StopHookItem>>,
+    #[serde(default, rename = "stop")]
+    stop_lower: Option<Vec<StopHookItem>>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct HookSection {
+    #[serde(default, rename = "Stop")]
+    stop_upper: Option<Vec<StopHookItem>>,
+    #[serde(default, rename = "stop")]
+    stop_lower: Option<Vec<StopHookItem>>,
+}
+
+#[derive(Debug, Clone)]
+enum StopHookItem {
+    Entry(HookEntry),
+    Group(HookGroup),
+}
+
+impl<'de> Deserialize<'de> for StopHookItem {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        if value.get("hooks").is_some() {
+            let group: HookGroup =
+                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+            Ok(StopHookItem::Group(group))
+        } else {
+            let entry: HookEntry =
+                serde_json::from_value(value).map_err(serde::de::Error::custom)?;
+            Ok(StopHookItem::Entry(entry))
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct HookGroup {
+    #[serde(default)]
+    hooks: Vec<HookEntry>,
+    #[serde(default, rename = "matcher")]
+    _matcher: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct HookEntry {
+    #[serde(default, rename = "type")]
+    hook_type: Option<String>,
+    command: Option<String>,
+    #[serde(default)]
+    args: Option<Vec<String>>,
+    #[serde(default)]
+    timeout: Option<u64>,
+    #[serde(default)]
+    timeout_ms: Option<u64>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct HookOutput {
+    decision: Option<String>,
+    reason: Option<String>,
+    #[serde(rename = "systemMessage")]
+    system_message: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct HookInput {
+    hook_event_name: &'static str,
+    cwd: String,
+    conversation_id: String,
+    turn_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    rollout_path: Option<String>,
+    input_messages: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    last_agent_message: Option<String>,
+}
+
+pub async fn evaluate_stop_hooks(
+    ctx: StopHookContext,
+    reporter: Option<&dyn StopHookEventSink>,
+) -> Result<StopHookDecision, StopHookError> {
+    let hook_entries = collect_hook_entries(&ctx).await;
+    if hook_entries.is_empty() {
+        return Ok(StopHookDecision::Allow);
+    }
+
+    let total = u32::try_from(hook_entries.len()).unwrap_or(u32::MAX);
+    emit_stop_hook_event(
+        reporter,
+        StopHookEvent {
+            stage: StopHookEventStage::Started,
+            hook_display: None,
+            index: None,
+            total: Some(total),
+            status: None,
+            decision: None,
+            reason: None,
+            system_message: None,
+            error: None,
+            duration_ms: None,
+        },
+    )
+    .await;
+
+    let input = HookInput {
+        hook_event_name: "stop",
+        cwd: ctx.cwd.display().to_string(),
+        conversation_id: ctx.conversation_id.clone(),
+        turn_id: ctx.turn_id.clone(),
+        rollout_path: ctx
+            .rollout_path
+            .as_ref()
+            .map(|path| path.display().to_string()),
+        input_messages: ctx.input_messages.clone(),
+        last_agent_message: ctx.last_agent_message.clone(),
+    };
+    let payload = serde_json::to_vec(&input)?;
+
+    let mut system_messages: Vec<String> = Vec::new();
+    for (idx, hook) in hook_entries.into_iter().enumerate() {
+        let index = u32::try_from(idx + 1).unwrap_or(u32::MAX);
+        let hook_display = hook.display();
+        emit_stop_hook_event(
+            reporter,
+            StopHookEvent {
+                stage: StopHookEventStage::HookStarted,
+                hook_display: Some(hook_display.clone()),
+                index: Some(index),
+                total: Some(total),
+                status: None,
+                decision: None,
+                reason: None,
+                system_message: None,
+                error: None,
+                duration_ms: None,
+            },
+        )
+        .await;
+
+        let started_at = Instant::now();
+        let outcome = match run_hook(&ctx, &hook, &payload).await {
+            Ok(outcome) => outcome,
+            Err(err) => {
+                warn!("Stop hook execution failed for {}: {err}", hook_display);
+                emit_stop_hook_event(
+                    reporter,
+                    StopHookEvent {
+                        stage: StopHookEventStage::HookFinished,
+                        hook_display: Some(hook_display),
+                        index: Some(index),
+                        total: Some(total),
+                        status: Some(StopHookEventStatus::Error),
+                        decision: None,
+                        reason: None,
+                        system_message: None,
+                        error: Some(err.to_string()),
+                        duration_ms: Some(elapsed_ms(started_at)),
+                    },
+                )
+                .await;
+                continue;
+            }
+        };
+
+        let mut status = outcome.status;
+        let mut decision = None;
+        let mut error = None;
+        let mut block_reason = None;
+        if let Some(result) = outcome.output {
+            if let Some(message) = result.system_message
+                && !message.trim().is_empty()
+            {
+                system_messages.push(message);
+            }
+            if let Some(decision_raw) = result.decision {
+                match decision_raw.to_ascii_lowercase().as_str() {
+                    "block" => {
+                        let reason = result.reason.unwrap_or_default();
+                        if reason.trim().is_empty() {
+                            warn!(
+                                "Stop hook returned block without reason; ignoring: {}",
+                                hook_display
+                            );
+                            status = StopHookEventStatus::InvalidOutput;
+                            error = Some("block without reason".to_string());
+                        } else {
+                            decision = Some(StopHookEventDecision::Block);
+                            block_reason = Some(reason);
+                        }
+                    }
+                    "approve" => {
+                        decision = Some(StopHookEventDecision::Allow);
+                    }
+                    _ => {
+                        warn!("Stop hook returned unknown decision: {decision_raw}");
+                        status = StopHookEventStatus::InvalidOutput;
+                        error = Some(format!("unknown decision: {decision_raw}"));
+                    }
+                }
+            }
+        }
+
+        emit_stop_hook_event(
+            reporter,
+            StopHookEvent {
+                stage: StopHookEventStage::HookFinished,
+                hook_display: Some(hook_display.clone()),
+                index: Some(index),
+                total: Some(total),
+                status: Some(status),
+                decision,
+                reason: block_reason.clone(),
+                system_message: None,
+                error,
+                duration_ms: Some(elapsed_ms(started_at)),
+            },
+        )
+        .await;
+
+        if let Some(reason) = block_reason {
+            let system_message = combine_system_messages(system_messages);
+            emit_stop_hook_event(
+                reporter,
+                StopHookEvent {
+                    stage: StopHookEventStage::Completed,
+                    hook_display: None,
+                    index: None,
+                    total: Some(total),
+                    status: None,
+                    decision: Some(StopHookEventDecision::Block),
+                    reason: Some(reason.clone()),
+                    system_message: system_message.clone(),
+                    error: None,
+                    duration_ms: None,
+                },
+            )
+            .await;
+            return Ok(StopHookDecision::Block {
+                reason,
+                system_message,
+            });
+        }
+    }
+
+    emit_stop_hook_event(
+        reporter,
+        StopHookEvent {
+            stage: StopHookEventStage::Completed,
+            hook_display: None,
+            index: None,
+            total: Some(total),
+            status: None,
+            decision: Some(StopHookEventDecision::Allow),
+            reason: None,
+            system_message: None,
+            error: None,
+            duration_ms: None,
+        },
+    )
+    .await;
+
+    Ok(StopHookDecision::Allow)
+}
+
+async fn emit_stop_hook_event(reporter: Option<&dyn StopHookEventSink>, event: StopHookEvent) {
+    if let Some(reporter) = reporter {
+        reporter.emit(event).await;
+    }
+}
+
+fn elapsed_ms(started_at: Instant) -> u64 {
+    u64::try_from(started_at.elapsed().as_millis()).unwrap_or(u64::MAX)
+}
+
+async fn collect_hook_entries(ctx: &StopHookContext) -> Vec<HookEntry> {
+    let mut entries = Vec::new();
+    let mut seen_files: HashSet<PathBuf> = HashSet::new();
+
+    for source in &ctx.stop_hooks.sources {
+        match source {
+            StopHookSource::Command(command) => {
+                entries.push(hook_entry_from_command(command));
+            }
+            StopHookSource::HooksFile(path) => {
+                if !seen_files.insert(path.clone()) {
+                    continue;
+                }
+                match load_hook_entries(path).await {
+                    Ok(mut file_entries) => entries.append(&mut file_entries),
+                    Err(err) => {
+                        warn!("Stop hook file {} failed to load: {err}", path.display());
+                    }
+                }
+            }
+        }
+    }
+
+    if ctx.stop_hooks.include_project_hooks
+        && let Some(path) = find_hooks_file(&ctx.cwd)
+        && seen_files.insert(path.clone())
+    {
+        match load_hook_entries(&path).await {
+            Ok(mut file_entries) => entries.append(&mut file_entries),
+            Err(err) => {
+                warn!("Stop hook file {} failed to load: {err}", path.display());
+            }
+        }
+    }
+
+    entries
+}
+
+async fn load_hook_entries(path: &Path) -> Result<Vec<HookEntry>, StopHookError> {
+    let contents = tokio::fs::read_to_string(path).await?;
+    let hooks_file: HooksFile = serde_json::from_str(&contents)?;
+    Ok(extract_stop_hooks(&hooks_file))
+}
+
+fn hook_entry_from_command(command: &StopHookCommand) -> HookEntry {
+    HookEntry {
+        hook_type: Some("command".to_string()),
+        command: Some(command.command.clone()),
+        args: if command.args.is_empty() {
+            None
+        } else {
+            Some(command.args.clone())
+        },
+        timeout: command.timeout,
+        timeout_ms: command.timeout_ms,
+    }
+}
+
+fn extract_stop_hooks(file: &HooksFile) -> Vec<HookEntry> {
+    let mut hooks = Vec::new();
+    if let Some(section) = &file.hooks {
+        if let Some(entries) = section.stop_upper.clone() {
+            hooks.extend(flatten_items(entries));
+        }
+        if let Some(entries) = section.stop_lower.clone() {
+            hooks.extend(flatten_items(entries));
+        }
+    }
+    if let Some(entries) = file.stop_upper.clone() {
+        hooks.extend(flatten_items(entries));
+    }
+    if let Some(entries) = file.stop_lower.clone() {
+        hooks.extend(flatten_items(entries));
+    }
+    hooks
+        .into_iter()
+        .filter(|hook| match hook.hook_type.as_deref() {
+            Some(t) => t.eq_ignore_ascii_case("command"),
+            None => true,
+        })
+        .filter(|hook| hook.command.is_some())
+        .collect()
+}
+
+fn flatten_items(items: Vec<StopHookItem>) -> Vec<HookEntry> {
+    let mut out = Vec::new();
+    for item in items {
+        match item {
+            StopHookItem::Entry(entry) => out.push(entry),
+            StopHookItem::Group(group) => out.extend(group.hooks),
+        }
+    }
+    out
+}
+
+fn find_hooks_file(cwd: &Path) -> Option<PathBuf> {
+    for ancestor in cwd.ancestors() {
+        let candidate = ancestor
+            .join(DOT_CODEX_DIR)
+            .join(HOOKS_DIR)
+            .join(HOOKS_FILE);
+        if candidate.exists() {
+            return Some(candidate);
+        }
+        let fallback = ancestor.join(DOT_CODEX_DIR).join(HOOKS_FILE);
+        if fallback.exists() {
+            return Some(fallback);
+        }
+    }
+    None
+}
+
+async fn run_hook(
+    ctx: &StopHookContext,
+    hook: &HookEntry,
+    payload: &[u8],
+) -> Result<StopHookRunOutcome, StopHookError> {
+    let Some(command) = hook.command.as_ref() else {
+        return Ok(StopHookRunOutcome {
+            status: StopHookEventStatus::InvalidOutput,
+            output: None,
+        });
+    };
+
+    let timeout = hook
+        .timeout_ms
+        .map(Duration::from_millis)
+        .or_else(|| hook.timeout.map(Duration::from_secs));
+    let timeout = timeout.unwrap_or_else(|| Duration::from_secs(DEFAULT_HOOK_TIMEOUT_SECS));
+
+    let mut cmd = Command::new(command);
+    if let Some(args) = hook.args.as_ref() {
+        cmd.args(args);
+    }
+    let mut env = BTreeMap::new();
+    env.insert("CODEX_HOOK_EVENT".to_string(), "stop".to_string());
+    env.insert("CODEX_CWD".to_string(), ctx.cwd.display().to_string());
+    env.insert(
+        "CODEX_CONVERSATION_ID".to_string(),
+        ctx.conversation_id.clone(),
+    );
+    env.insert("CODEX_TURN_ID".to_string(), ctx.turn_id.clone());
+    if let Some(path) = ctx.rollout_path.as_ref() {
+        env.insert("CODEX_ROLLOUT_PATH".to_string(), path.display().to_string());
+    }
+    cmd.envs(env);
+    cmd.current_dir(&ctx.cwd);
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn()?;
+    if let Some(mut stdin) = child.stdin.take() {
+        stdin.write_all(payload).await?;
+    }
+
+    let output = match time::timeout(timeout, child.wait_with_output()).await {
+        Ok(result) => result?,
+        Err(_) => {
+            warn!("Stop hook timed out: {}", hook.display());
+            return Ok(StopHookRunOutcome {
+                status: StopHookEventStatus::Timeout,
+                output: None,
+            });
+        }
+    };
+
+    if !output.status.success() {
+        warn!(
+            "Stop hook exited with status {:?}: {}",
+            output.status.code(),
+            hook.display()
+        );
+        return Ok(StopHookRunOutcome {
+            status: StopHookEventStatus::ExitFailure,
+            output: None,
+        });
+    }
+
+    if output.stdout.is_empty() {
+        return Ok(StopHookRunOutcome {
+            status: StopHookEventStatus::NoOutput,
+            output: None,
+        });
+    }
+
+    let parsed: HookOutput = match serde_json::from_slice(&output.stdout) {
+        Ok(parsed) => parsed,
+        Err(err) => {
+            warn!("Stop hook output invalid JSON: {err}");
+            return Ok(StopHookRunOutcome {
+                status: StopHookEventStatus::InvalidOutput,
+                output: None,
+            });
+        }
+    };
+    Ok(StopHookRunOutcome {
+        status: StopHookEventStatus::Ok,
+        output: Some(parsed),
+    })
+}
+
+fn combine_system_messages(messages: Vec<String>) -> Option<String> {
+    if messages.is_empty() {
+        None
+    } else {
+        Some(messages.join("\n"))
+    }
+}
+
+impl HookEntry {
+    fn display(&self) -> String {
+        match (&self.command, &self.args) {
+            (Some(cmd), Some(args)) if !args.is_empty() => {
+                format!("{cmd} {}", args.join(" "))
+            }
+            (Some(cmd), _) => cmd.clone(),
+            _ => "<unknown hook>".to_string(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+    use serde_json::json;
+    use std::collections::BTreeMap;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn parses_stop_hooks_from_groups_and_top_level() {
+        let payload = json!({
+            "hooks": {
+                "Stop": [
+                    { "type": "command", "command": "one" },
+                    { "hooks": [ { "command": "two" }, { "command": "three" } ] }
+                ]
+            },
+            "Stop": [
+                { "command": "four" }
+            ]
+        });
+        let hooks_file: HooksFile = serde_json::from_value(payload).expect("deserialize hooks");
+        let hooks = extract_stop_hooks(&hooks_file);
+        let commands: Vec<String> = hooks.into_iter().filter_map(|hook| hook.command).collect();
+        assert_eq!(commands, vec!["one", "two", "three", "four"]);
+    }
+
+    #[test]
+    fn stop_hooks_config_orders_and_filters_sources() -> anyhow::Result<()> {
+        let temp = TempDir::new()?;
+        let file_path = temp.path().join("hooks.json");
+        let file = AbsolutePathBuf::from_absolute_path(&file_path)?;
+
+        let mut sources = BTreeMap::new();
+        sources.insert(
+            "disabled".to_string(),
+            StopHookSourceToml {
+                enabled: Some(false),
+                order: Some(1),
+                command: Some("skip".to_string()),
+                args: None,
+                timeout: None,
+                timeout_ms: None,
+                file: None,
+                hook_type: None,
+            },
+        );
+        sources.insert(
+            "file".to_string(),
+            StopHookSourceToml {
+                enabled: None,
+                order: Some(0),
+                command: None,
+                args: None,
+                timeout: None,
+                timeout_ms: None,
+                file: Some(file.clone()),
+                hook_type: None,
+            },
+        );
+        sources.insert(
+            "later".to_string(),
+            StopHookSourceToml {
+                enabled: None,
+                order: Some(2),
+                command: Some("later".to_string()),
+                args: Some(vec!["--ok".to_string()]),
+                timeout: None,
+                timeout_ms: Some(500),
+                file: None,
+                hook_type: None,
+            },
+        );
+        sources.insert(
+            "early".to_string(),
+            StopHookSourceToml {
+                enabled: None,
+                order: Some(1),
+                command: Some("early".to_string()),
+                args: None,
+                timeout: Some(3),
+                timeout_ms: None,
+                file: None,
+                hook_type: Some("command".to_string()),
+            },
+        );
+
+        let toml = StopHooksToml {
+            include_project_hooks: Some(false),
+            sources,
+        };
+
+        let config = StopHooksConfig::from_toml(Some(toml));
+        assert_eq!(config.include_project_hooks, false);
+        assert_eq!(
+            config.sources,
+            vec![
+                StopHookSource::HooksFile(file.into()),
+                StopHookSource::Command(StopHookCommand {
+                    command: "early".to_string(),
+                    args: Vec::new(),
+                    timeout: Some(3),
+                    timeout_ms: None,
+                }),
+                StopHookSource::Command(StopHookCommand {
+                    command: "later".to_string(),
+                    args: vec!["--ok".to_string()],
+                    timeout: None,
+                    timeout_ms: Some(500),
+                }),
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn stop_hook_blocks_with_reason() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp = TempDir::new().expect("temp dir");
+        let cwd = temp.path();
+        let hooks_dir = cwd.join(DOT_CODEX_DIR).join(HOOKS_DIR);
+        fs::create_dir_all(&hooks_dir).expect("create hooks dir");
+
+        let script_path = cwd.join("stop_hook.sh");
+        fs::write(
+            &script_path,
+            r#"#!/bin/sh
+echo '{"decision":"block","reason":"repeat","systemMessage":"loop"}'
+"#,
+        )
+        .expect("write hook script");
+        let mut perms = fs::metadata(&script_path).expect("metadata").permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&script_path, perms).expect("chmod");
+
+        let hooks_json = json!({
+            "hooks": {
+                "Stop": [
+                    { "type": "command", "command": script_path.to_string_lossy() }
+                ]
+            }
+        });
+        let hooks_path = hooks_dir.join(HOOKS_FILE);
+        fs::write(&hooks_path, serde_json::to_string(&hooks_json).unwrap())
+            .expect("write hooks.json");
+
+        let ctx = StopHookContext {
+            cwd: cwd.to_path_buf(),
+            conversation_id: "conv".to_string(),
+            turn_id: "turn".to_string(),
+            rollout_path: None,
+            input_messages: vec!["hi".to_string()],
+            last_agent_message: Some("done".to_string()),
+            stop_hooks: StopHooksConfig::default(),
+        };
+
+        let decision = evaluate_stop_hooks(ctx, None).await.expect("hook run");
+        assert_eq!(
+            decision,
+            StopHookDecision::Block {
+                reason: "repeat".to_string(),
+                system_message: Some("loop".to_string()),
+            }
+        );
+    }
+}

--- a/codex-rs/core/tests/suite/stop_hooks.rs
+++ b/codex-rs/core/tests/suite/stop_hooks.rs
@@ -1,0 +1,147 @@
+#![cfg(not(target_os = "windows"))]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use codex_core::protocol::EventMsg;
+use codex_core::protocol::Op;
+use codex_protocol::user_input::UserInput;
+use core_test_support::responses;
+use core_test_support::skip_if_no_network;
+use core_test_support::test_codex::test_codex;
+use core_test_support::wait_for_event;
+use pretty_assertions::assert_eq;
+use serde_json::json;
+
+use responses::ev_assistant_message;
+use responses::ev_completed;
+use responses::ev_response_created;
+use responses::sse;
+use responses::start_mock_server;
+
+fn write_hook_script(path: &Path, contents: &str) -> anyhow::Result<()> {
+    std::fs::write(path, contents)?;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms)?;
+    Ok(())
+}
+
+fn write_hooks_json(path: &Path, script_path: &Path) -> anyhow::Result<()> {
+    let hooks_json = json!({
+        "hooks": {
+            "Stop": [
+                {
+                    "type": "command",
+                    "command": script_path.to_string_lossy()
+                }
+            ]
+        }
+    });
+    std::fs::write(path, serde_json::to_string(&hooks_json)?)?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stop_hook_block_reinjects_prompt() -> anyhow::Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let first = sse(vec![
+        ev_response_created("resp-1"),
+        ev_assistant_message("msg-1", "First response"),
+        ev_completed("resp-1"),
+    ]);
+    let second = sse(vec![
+        ev_response_created("resp-2"),
+        ev_assistant_message("msg-2", "Second response"),
+        ev_completed("resp-2"),
+    ]);
+    let response_mock = responses::mount_sse_sequence(&server, vec![first, second]).await;
+
+    let fixture = test_codex().with_model("gpt-5.1").build(&server).await?;
+
+    let hooks_dir = fixture.cwd_path().join(".codex").join("hooks");
+    std::fs::create_dir_all(&hooks_dir)?;
+
+    let script_path = fixture.cwd_path().join("stop-hook.sh");
+    write_hook_script(
+        &script_path,
+        r#"#!/bin/sh
+set -e
+FLAG=.codex/stop-hook.once
+if [ -f "$FLAG" ]; then
+  echo '{"decision":"approve"}'
+  exit 0
+fi
+mkdir -p .codex
+touch "$FLAG"
+echo '{"decision":"block","reason":"repeat","systemMessage":"loop"}'
+"#,
+    )?;
+
+    write_hooks_json(&hooks_dir.join("hooks.json"), &script_path)?;
+
+    fixture
+        .codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "hello".into(),
+            }],
+        })
+        .await?;
+
+    wait_for_event(&fixture.codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
+
+    let requests = response_mock.requests();
+    assert_eq!(requests.len(), 2);
+    let second_request = requests.last().expect("second request");
+    let user_texts = second_request.message_input_texts("user");
+    assert!(user_texts.iter().any(|text| text == "repeat"));
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn stop_hook_approve_allows_completion() -> anyhow::Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let first = sse(vec![
+        ev_response_created("resp-1"),
+        ev_assistant_message("msg-1", "Done"),
+        ev_completed("resp-1"),
+    ]);
+    let response_mock = responses::mount_sse_sequence(&server, vec![first]).await;
+
+    let fixture = test_codex().with_model("gpt-5.1").build(&server).await?;
+
+    let hooks_dir = fixture.cwd_path().join(".codex").join("hooks");
+    std::fs::create_dir_all(&hooks_dir)?;
+
+    let script_path = fixture.cwd_path().join("stop-hook-approve.sh");
+    write_hook_script(
+        &script_path,
+        r#"#!/bin/sh
+echo '{"decision":"approve"}'
+"#,
+    )?;
+
+    write_hooks_json(&hooks_dir.join("hooks.json"), &script_path)?;
+
+    fixture
+        .codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "hello".into(),
+            }],
+        })
+        .await?;
+
+    wait_for_event(&fixture.codex, |ev| matches!(ev, EventMsg::TaskComplete(_))).await;
+
+    let requests = response_mock.requests();
+    assert_eq!(requests.len(), 1);
+
+    Ok(())
+}

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -596,7 +596,8 @@ impl EventProcessor for EventProcessorWithHumanOutput {
             | EventMsg::SkillsUpdateAvailable
             | EventMsg::UndoCompleted(_)
             | EventMsg::UndoStarted(_)
-            | EventMsg::ThreadRolledBack(_) => {}
+            | EventMsg::ThreadRolledBack(_)
+            | EventMsg::StopHookEvent(_) => {}
         }
         CodexStatus::Running
     }

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -281,6 +281,7 @@ async fn run_codex_tool_session_inner(
                     | EventMsg::ExecCommandOutputDelta(_)
                     | EventMsg::ExecCommandEnd(_)
                     | EventMsg::BackgroundEvent(_)
+                    | EventMsg::StopHookEvent(_)
                     | EventMsg::StreamError(_)
                     | EventMsg::PatchApplyBegin(_)
                     | EventMsg::PatchApplyEnd(_)

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -626,6 +626,9 @@ pub enum EventMsg {
 
     BackgroundEvent(BackgroundEventEvent),
 
+    /// Stop hook activity updates.
+    StopHookEvent(StopHookEvent),
+
     UndoStarted(UndoStartedEvent),
 
     UndoCompleted(UndoCompletedEvent),
@@ -1607,6 +1610,56 @@ pub struct TerminalInteractionEvent {
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS)]
 pub struct BackgroundEventEvent {
     pub message: String,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum StopHookEventStage {
+    Started,
+    HookStarted,
+    HookFinished,
+    Completed,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum StopHookEventStatus {
+    Ok,
+    Timeout,
+    ExitFailure,
+    NoOutput,
+    InvalidOutput,
+    Error,
+}
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum StopHookEventDecision {
+    Allow,
+    Block,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS)]
+pub struct StopHookEvent {
+    pub stage: StopHookEventStage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hook_display: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub index: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<StopHookEventStatus>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decision: Option<StopHookEventDecision>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub system_message: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration_ms: Option<u64>,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS)]

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -396,6 +396,7 @@ async fn make_chatwidget_manual(
         full_reasoning_buffer: String::new(),
         current_status_header: String::from("Working"),
         retry_status_header: None,
+        stop_hook_previous_status_header: None,
         thread_id: None,
         frame_requester: FrameRequester::test_dummy(),
         show_welcome_banner: true,

--- a/codex-rs/tui2/src/chatwidget.rs
+++ b/codex-rs/tui2/src/chatwidget.rs
@@ -10,6 +10,7 @@ use codex_backend_client::Client as BackendClient;
 use codex_core::config::Config;
 use codex_core::config::ConstraintResult;
 use codex_core::config::types::Notifications;
+use codex_core::config::types::StopHookVisibility;
 use codex_core::git_info::current_branch_name;
 use codex_core::git_info::local_git_branches;
 use codex_core::models_manager::manager::ModelsManager;
@@ -46,6 +47,10 @@ use codex_core::protocol::RateLimitSnapshot;
 use codex_core::protocol::ReviewRequest;
 use codex_core::protocol::ReviewTarget;
 use codex_core::protocol::SkillsListEntry;
+use codex_core::protocol::StopHookEvent;
+use codex_core::protocol::StopHookEventDecision;
+use codex_core::protocol::StopHookEventStage;
+use codex_core::protocol::StopHookEventStatus;
 use codex_core::protocol::StreamErrorEvent;
 use codex_core::protocol::TaskCompleteEvent;
 use codex_core::protocol::TerminalInteractionEvent;
@@ -311,6 +316,8 @@ pub(crate) struct ChatWidget {
     current_status_header: String,
     // Previous status header to restore after a transient stream retry.
     retry_status_header: Option<String>,
+    // Previous status header to restore after stop hook updates finish.
+    stop_hook_previous_status_header: Option<String>,
     conversation_id: Option<ThreadId>,
     frame_requester: FrameRequester,
     // Whether to include the initial welcome banner on session configured
@@ -393,6 +400,21 @@ impl ChatWidget {
     fn restore_retry_status_header_if_present(&mut self) {
         if let Some(header) = self.retry_status_header.take() {
             self.set_status_header(header);
+        }
+    }
+
+    fn set_stop_hook_status(&mut self, details: Option<String>) {
+        if self.stop_hook_previous_status_header.is_none() {
+            self.stop_hook_previous_status_header = Some(self.current_status_header.clone());
+        }
+        self.bottom_pane.ensure_status_indicator();
+        self.bottom_pane.set_interrupt_hint_visible(true);
+        self.set_status(String::from("Stop hooks"), details);
+    }
+
+    fn restore_stop_hook_status(&mut self) {
+        if let Some(previous) = self.stop_hook_previous_status_header.take() {
+            self.set_status_header(previous);
         }
     }
 
@@ -527,6 +549,7 @@ impl ChatWidget {
         self.bottom_pane.clear_ctrl_c_quit_hint();
         self.bottom_pane.set_task_running(true);
         self.retry_status_header = None;
+        self.stop_hook_previous_status_header = None;
         self.bottom_pane.set_interrupt_hint_visible(true);
         self.set_status_header(String::from("Working"));
         self.full_reasoning_buffer.clear();
@@ -927,6 +950,113 @@ impl ChatWidget {
         self.set_status_header(message);
     }
 
+    fn on_stop_hook_event(&mut self, event: StopHookEvent) {
+        let visibility = self.config.tui_stop_hook_visibility;
+        if matches!(visibility, StopHookVisibility::Off) {
+            return;
+        }
+
+        let show_status = matches!(
+            visibility,
+            StopHookVisibility::Status | StopHookVisibility::Summary | StopHookVisibility::Verbose
+        );
+        let show_summary = matches!(
+            visibility,
+            StopHookVisibility::Summary | StopHookVisibility::Verbose
+        );
+        let show_verbose = matches!(visibility, StopHookVisibility::Verbose);
+
+        let index_label = stop_hook_index_label(&event);
+        let status_label = stop_hook_status_label(event.decision, event.status);
+
+        match event.stage {
+            StopHookEventStage::Started => {
+                if show_status {
+                    let details = event
+                        .total
+                        .map(|total| format!("{total} hook{}", if total == 1 { "" } else { "s" }));
+                    self.set_stop_hook_status(details);
+                }
+            }
+            StopHookEventStage::HookStarted => {
+                if show_status {
+                    let mut parts = Vec::new();
+                    if let Some(label) = &index_label {
+                        parts.push(label.clone());
+                    }
+                    if let Some(display) = event.hook_display.as_ref() {
+                        parts.push(display.clone());
+                    }
+                    let details = (!parts.is_empty()).then(|| parts.join(" · "));
+                    self.set_stop_hook_status(details);
+                }
+                if show_verbose {
+                    let message = stop_hook_verbose_message("started", index_label.as_deref());
+                    let hint = event.hook_display;
+                    self.add_to_history(history_cell::new_info_event(message, hint));
+                }
+            }
+            StopHookEventStage::HookFinished => {
+                if show_status {
+                    let mut parts = Vec::new();
+                    if let Some(label) = &index_label {
+                        parts.push(label.clone());
+                    }
+                    if let Some(label) = status_label {
+                        parts.push(label.to_string());
+                    }
+                    let details = (!parts.is_empty()).then(|| parts.join(" · "));
+                    self.set_stop_hook_status(details);
+                }
+                if show_verbose {
+                    let message = stop_hook_verbose_message("finished", index_label.as_deref());
+                    let mut hint_parts = Vec::new();
+                    if let Some(label) = status_label {
+                        hint_parts.push(label.to_string());
+                    }
+                    if let Some(duration_ms) = event.duration_ms {
+                        hint_parts.push(format!("{duration_ms}ms"));
+                    }
+                    if let Some(display) = event.hook_display.as_ref() {
+                        hint_parts.push(display.clone());
+                    }
+                    if let Some(error) = event.error.as_ref() {
+                        hint_parts.push(error.clone());
+                    }
+                    let hint = (!hint_parts.is_empty()).then(|| hint_parts.join(" · "));
+                    self.add_to_history(history_cell::new_info_event(message, hint));
+                }
+            }
+            StopHookEventStage::Completed => {
+                if show_summary {
+                    let mut hint_parts = Vec::new();
+                    if let Some(reason) = event
+                        .reason
+                        .as_deref()
+                        .and_then(|text| text.lines().find(|line| !line.trim().is_empty()))
+                    {
+                        hint_parts.push(format!("reason: {}", reason.trim()));
+                    }
+                    if let Some(total) = event.total {
+                        hint_parts
+                            .push(format!("{total} hook{}", if total == 1 { "" } else { "s" }));
+                    }
+                    let hint = (!hint_parts.is_empty()).then(|| hint_parts.join(" · "));
+                    let message = match event.decision {
+                        Some(StopHookEventDecision::Block) => "Stop hooks blocked".to_string(),
+                        Some(StopHookEventDecision::Allow) | None => {
+                            "Stop hooks allowed".to_string()
+                        }
+                    };
+                    self.add_to_history(history_cell::new_info_event(message, hint));
+                }
+                if show_status {
+                    self.restore_stop_hook_status();
+                }
+            }
+        }
+    }
+
     fn on_undo_started(&mut self, event: UndoStartedEvent) {
         self.bottom_pane.ensure_status_indicator();
         self.bottom_pane.set_interrupt_hint_visible(false);
@@ -1325,6 +1455,7 @@ impl ChatWidget {
             full_reasoning_buffer: String::new(),
             current_status_header: String::from("Working"),
             retry_status_header: None,
+            stop_hook_previous_status_header: None,
             conversation_id: None,
             queued_user_messages: VecDeque::new(),
             show_welcome_banner: is_first_run,
@@ -1409,6 +1540,7 @@ impl ChatWidget {
             full_reasoning_buffer: String::new(),
             current_status_header: String::from("Working"),
             retry_status_header: None,
+            stop_hook_previous_status_header: None,
             conversation_id: None,
             queued_user_messages: VecDeque::new(),
             show_welcome_banner: false,
@@ -1930,6 +2062,7 @@ impl ChatWidget {
             EventMsg::BackgroundEvent(BackgroundEventEvent { message }) => {
                 self.on_background_event(message)
             }
+            EventMsg::StopHookEvent(event) => self.on_stop_hook_event(event),
             EventMsg::UndoStarted(ev) => self.on_undo_started(ev),
             EventMsg::UndoCompleted(ev) => self.on_undo_completed(ev),
             EventMsg::StreamError(StreamErrorEvent {
@@ -3369,6 +3502,40 @@ impl ChatWidget {
             RenderableItem::Borrowed(&self.bottom_pane).inset(Insets::tlbr(1, 0, 0, 0)),
         );
         RenderableItem::Owned(Box::new(flex))
+    }
+}
+
+fn stop_hook_index_label(event: &StopHookEvent) -> Option<String> {
+    match (event.index, event.total) {
+        (Some(index), Some(total)) => Some(format!("{index}/{total}")),
+        (Some(index), None) => Some(format!("{index}")),
+        _ => None,
+    }
+}
+
+fn stop_hook_status_label(
+    decision: Option<StopHookEventDecision>,
+    status: Option<StopHookEventStatus>,
+) -> Option<&'static str> {
+    match decision {
+        Some(StopHookEventDecision::Block) => Some("blocked"),
+        Some(StopHookEventDecision::Allow) => Some("approved"),
+        None => match status {
+            Some(StopHookEventStatus::Ok) => Some("ok"),
+            Some(StopHookEventStatus::Timeout) => Some("timed out"),
+            Some(StopHookEventStatus::ExitFailure) => Some("failed"),
+            Some(StopHookEventStatus::NoOutput) => Some("no output"),
+            Some(StopHookEventStatus::InvalidOutput) => Some("invalid output"),
+            Some(StopHookEventStatus::Error) => Some("error"),
+            None => None,
+        },
+    }
+}
+
+fn stop_hook_verbose_message(stage: &str, index_label: Option<&str>) -> String {
+    match index_label {
+        Some(label) => format!("Stop hook {label} {stage}"),
+        None => format!("Stop hook {stage}"),
     }
 }
 

--- a/codex-rs/tui2/src/chatwidget/tests.rs
+++ b/codex-rs/tui2/src/chatwidget/tests.rs
@@ -392,6 +392,7 @@ async fn make_chatwidget_manual(
         full_reasoning_buffer: String::new(),
         current_status_header: String::from("Working"),
         retry_status_header: None,
+        stop_hook_previous_status_header: None,
         conversation_id: None,
         frame_requester: FrameRequester::test_dummy(),
         show_welcome_banner: true,

--- a/docs/config.md
+++ b/docs/config.md
@@ -17,3 +17,9 @@ Codex can connect to MCP servers configured in `~/.codex/config.toml`. See the c
 Codex can run a notification hook when the agent finishes a turn. See the configuration reference for the latest notification settings:
 
 - https://developers.openai.com/codex/config-reference
+
+## Stop Hooks
+
+Codex can run **Stop hooks** when the model is about to finish a turn. Hooks can approve or block completion and optionally inject a follow‑up prompt in the same session.
+
+See `docs/stop-hooks.md` for configuration and payload details (including `config.toml`).

--- a/docs/stop-hooks.md
+++ b/docs/stop-hooks.md
@@ -1,0 +1,128 @@
+# Stop Hooks
+
+Codex can run **Stop hooks** when the model is about to finish a turn. A Stop hook can approve the stop or block it and provide a follow‑up prompt that will be injected into the same session.
+
+This is a **generic plugin mechanism**: any external script can participate.
+
+## Hook Discovery
+
+Codex searches upward from the current working directory for:
+
+- `.codex/hooks/hooks.json` (preferred)
+- `.codex/hooks.json` (fallback)
+
+The first file found is used.
+
+## Hook File Format
+
+Use a Claude‑style hook configuration. Only `Stop` hooks are currently supported.
+
+```json
+{
+  "hooks": {
+    "Stop": [
+      {
+        "type": "command",
+        "command": "./scripts/stop-hook.sh",
+        "args": ["--verbose"],
+        "timeout": 30
+      }
+    ]
+  }
+}
+```
+
+Notes:
+- `timeout` is in seconds. You can also use `timeout_ms` for milliseconds.
+- If no timeout is set, Codex defaults to 30 seconds.
+- `type` is optional; if present it must be `command`.
+- You may also use a top‑level `Stop` array instead of `hooks.Stop`.
+
+## Config.toml (Global or Project)
+
+You can configure Stop hooks in `config.toml` (global `~/.codex/config.toml` or project
+`./.codex/config.toml`) under `[stop_hooks]`.
+
+```toml
+[stop_hooks]
+include_project_hooks = true
+
+[stop_hooks.sources.primary]
+command = "/abs/path/stop-hook.sh"
+timeout = 30
+order = 10
+
+[stop_hooks.sources.extra_checks]
+file = "/abs/path/hooks.json"
+order = 20
+enabled = true
+```
+
+Notes:
+- Each source is a named table under `stop_hooks.sources`.
+- `command` sources run a single command hook (same fields as hooks.json).
+- `file` sources load a `hooks.json` file and extract `Stop` hooks.
+- `order` sorts sources (ascending) before execution; ties sort by name.
+- `enabled = false` skips a source.
+- `include_project_hooks = true` keeps the `.codex/hooks/hooks.json` discovery behavior.
+
+## TUI Visibility
+
+Stop hook activity can be surfaced in the TUI via the `[tui]` config section:
+
+```toml
+[tui]
+stop_hook_visibility = "status"
+```
+
+Values:
+- `off`: no UI output
+- `status` (default): show a status-line update while hooks run
+- `summary`: status-line updates + a final summary line
+- `verbose`: status-line updates + per-hook history lines
+
+## Hook Input (stdin JSON)
+
+The Stop hook receives a JSON object on stdin:
+
+```json
+{
+  "hook_event_name": "stop",
+  "cwd": "/path/to/repo",
+  "conversation_id": "...",
+  "turn_id": "...",
+  "rollout_path": "/path/to/rollout.jsonl",
+  "input_messages": ["<user messages for this turn>"],
+  "last_agent_message": "<assistant final message>"
+}
+```
+
+Codex also sets environment variables for convenience:
+
+- `CODEX_HOOK_EVENT=stop`
+- `CODEX_CWD`
+- `CODEX_CONVERSATION_ID`
+- `CODEX_TURN_ID`
+- `CODEX_ROLLOUT_PATH` (if available)
+
+## Hook Output (stdout JSON)
+
+Return JSON on stdout. If missing or invalid, the hook is ignored.
+
+```json
+{
+  "decision": "block",
+  "reason": "Repeat the original prompt here",
+  "systemMessage": "Optional system message injected into context"
+}
+```
+
+- `decision`: `approve` or `block`
+- `reason`: required when `block` (used as the next user prompt)
+- `systemMessage`: optional system message inserted before re‑prompt
+
+If any Stop hook returns `block`, Codex injects `reason` and continues the same session.
+
+## Security
+
+Stop hooks run local commands with your user permissions. Only enable scripts you trust.


### PR DESCRIPTION
## What
- Add stop hook support that runs before a turn stops and can approve or block with a follow‑up prompt.
- Support Claude‑style hook config discovery from `.codex/hooks/hooks.json` (fallback `.codex/hooks.json`) plus `config.toml` sources with ordering.
- Wire hook payloads through core/protocol, add TUI visibility modes, and document usage.

## Why
This is a minimal, concrete subset of the “Event Hooks” request, enabling blocking + feedback hooks as discussed in #2109. It aligns with Claude Code’s hook schema and provides a safe, external‑script extension point without in‑process hooks.

## How
- Implement stop hook runner (stdin JSON payload, stdout JSON decision).
- Parse config sources + project discovery with ordering and enable/disable flags.
- Expose visibility levels in TUI/TUI2 (off/status/summary/verbose).
- Document configuration and payloads.

## Issue
https://github.com/openai/codex/issues/2109

## Tests
- [x] just fmt
- [x] just fix -p codex-core
- [x] just fix -p codex-protocol
- [x] just fix -p codex-exec
- [x] just fix -p codex-mcp-server
- [x] just fix -p codex-tui
- [x] just fix -p codex-tui2
- [x] cargo test -p codex-core
- [x] cargo test -p codex-protocol
- [x] cargo test -p codex-exec
- [x] cargo test -p codex-mcp-server
- [x] cargo test -p codex-tui
- [x] cargo test -p codex-tui2
- [x] cargo test --all-features
