### PR TITLE
feat: inject session env vars for tool exec

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -763,6 +763,10 @@ impl Session {
         self.tx_event.clone()
     }
 
+    pub(crate) fn conversation_id(&self) -> ThreadId {
+        self.conversation_id
+    }
+
     /// Ensure all rollout writes are durably flushed.
     pub(crate) async fn flush_rollout(&self) {
         let recorder = {

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -16,6 +16,7 @@ use crate::exec::StdoutStream;
 use crate::exec::StreamOutput;
 use crate::exec::execute_exec_env;
 use crate::exec_env::create_env;
+use crate::exec_env::insert_session_env;
 use crate::parse_command::parse_command;
 use crate::protocol::EventMsg;
 use crate::protocol::ExecCommandBeginEvent;
@@ -99,10 +100,18 @@ impl SessionTask for UserShellCommandTask {
             )
             .await;
 
+        let mut env = create_env(&turn_context.shell_environment_policy);
+        insert_session_env(
+            &mut env,
+            session.conversation_id(),
+            &turn_context.sub_id,
+            &cwd,
+        );
+
         let exec_env = ExecEnv {
             command: command.clone(),
             cwd: cwd.clone(),
-            env: create_env(&turn_context.shell_environment_policy),
+            env,
             // TODO(zhao-oai): Now that we have ExecExpiration::Cancellation, we
             // should use that instead of an "arbitrarily large" timeout here.
             expiration: USER_SHELL_TIMEOUT_MS.into(),

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -14,6 +14,7 @@ use crate::bash::extract_bash_command;
 use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::exec_env::create_env;
+use crate::exec_env::insert_session_env;
 use crate::protocol::BackgroundEventEvent;
 use crate::protocol::EventMsg;
 use crate::protocol::ExecCommandSource;
@@ -497,7 +498,14 @@ impl UnifiedExecProcessManager {
         justification: Option<String>,
         context: &UnifiedExecContext,
     ) -> Result<UnifiedExecProcess, UnifiedExecError> {
-        let env = apply_unified_exec_env(create_env(&context.turn.shell_environment_policy));
+        let mut env = create_env(&context.turn.shell_environment_policy);
+        insert_session_env(
+            &mut env,
+            context.session.conversation_id(),
+            &context.turn.sub_id,
+            &cwd,
+        );
+        let env = apply_unified_exec_env(env);
         let features = context.session.features();
         let mut orchestrator = ToolOrchestrator::new();
         let mut runtime = UnifiedExecRuntime::new(self);

--- a/docs/config.md
+++ b/docs/config.md
@@ -17,3 +17,11 @@ Codex can connect to MCP servers configured in `~/.codex/config.toml`. See the c
 Codex can run a notification hook when the agent finishes a turn. See the configuration reference for the latest notification settings:
 
 - https://developers.openai.com/codex/config-reference
+
+## Tool environment variables
+
+When Codex runs shell-based tools (for example `shell`, `local_shell`, or `exec_command`), it injects:
+
+- `CODEX_CONVERSATION_ID` (the session/window id)
+- `CODEX_TURN_ID` (the current turn id)
+- `CODEX_CWD` (the resolved working directory for the command)


### PR DESCRIPTION
## What
- Inject session-scoped env vars into tool exec: `CODEX_CONVERSATION_ID`, `CODEX_TURN_ID`, `CODEX_CWD`.
- Wire the values through shell, user shell, and unified exec paths.
- Document the new tool env variables.

## Why
Users want access to session/cwd identifiers inside custom commands and shell tools (see #8750). This enables reliable per-session state tracking without parsing CLI output.

## How
- Add helpers in `exec_env` to populate session env vars.
- Pass conversation/turn/cwd into exec env construction.
- Update docs/config to describe injected variables.

## Issue
https://github.com/openai/codex/issues/8750

## Tests
- [x] just fmt
- [x] just fix -p codex-core
- [x] cargo test -p codex-core
- [x] cargo test --all-features
