### PR TITLE
add tooltip hint for shell commands (!)

### DIFF
--- a/codex-rs/tui/src/bottom_pane/footer.rs
+++ b/codex-rs/tui/src/bottom_pane/footer.rs
@@ -159,6 +159,7 @@ fn esc_hint_line(esc_backtrack_hint: bool) -> Line<'static> {
 
 fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
     let mut commands = Line::from("");
+    let mut shell_commands = Line::from("");
     let mut newline = Line::from("");
     let mut file_paths = Line::from("");
     let mut paste_image = Line::from("");
@@ -171,6 +172,7 @@ fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
         if let Some(text) = descriptor.overlay_entry(state) {
             match descriptor.id {
                 ShortcutId::Commands => commands = text,
+                ShortcutId::ShellCommands => shell_commands = text,
                 ShortcutId::InsertNewline => newline = text,
                 ShortcutId::FilePaths => file_paths = text,
                 ShortcutId::PasteImage => paste_image = text,
@@ -184,6 +186,7 @@ fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
 
     let ordered = vec![
         commands,
+        shell_commands,
         newline,
         file_paths,
         paste_image,
@@ -261,6 +264,7 @@ fn context_window_line(percent: Option<i64>, used_tokens: Option<i64>) -> Line<'
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ShortcutId {
     Commands,
+    ShellCommands,
     InsertNewline,
     FilePaths,
     PasteImage,
@@ -343,6 +347,15 @@ const SHORTCUTS: &[ShortcutDescriptor] = &[
         }],
         prefix: "",
         label: " for commands",
+    },
+    ShortcutDescriptor {
+        id: ShortcutId::ShellCommands,
+        bindings: &[ShortcutBinding {
+            key: key_hint::plain(KeyCode::Char('!')),
+            condition: DisplayCondition::Always,
+        }],
+        prefix: "",
+        label: " for shell commands",
     },
     ShortcutDescriptor {
         id: ShortcutId::InsertNewline,

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/src/bottom_pane/chat_composer.rs
+assertion_line: 2151
 expression: terminal.backend()
 ---
 "                                                                                                    "
@@ -10,8 +11,8 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  / for commands                             shift + enter for newline                              "
-"  @ for file paths                           ctrl + v to paste images                               "
-"  ctrl + g to edit in external editor        esc again to edit previous message                     "
-"  ctrl + c to exit                                                                                  "
-"  ctrl + t to view transcript                                                                       "
+"  / for commands                            ! for shell commands                                    "
+"  shift + enter for newline                 @ for file paths                                        "
+"  ctrl + v to paste images                  ctrl + g to edit in external editor                     "
+"  esc again to edit previous message        ctrl + c to exit                                        "
+"                                            ctrl + t to view transcript                             "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
@@ -1,9 +1,10 @@
 ---
 source: tui/src/bottom_pane/footer.rs
+assertion_line: 455
 expression: terminal.backend()
 ---
-"  / for commands                             shift + enter for newline          "
-"  @ for file paths                           ctrl + v to paste images           "
-"  ctrl + g to edit in external editor        esc again to edit previous message "
-"  ctrl + c to exit                                                              "
-"  ctrl + t to view transcript                                                   "
+"  / for commands                            ! for shell commands                "
+"  shift + enter for newline                 @ for file paths                    "
+"  ctrl + v to paste images                  ctrl + g to edit in external editor "
+"  esc again to edit previous message        ctrl + c to exit                    "
+"                                            ctrl + t to view transcript         "

--- a/codex-rs/tui2/src/bottom_pane/footer.rs
+++ b/codex-rs/tui2/src/bottom_pane/footer.rs
@@ -203,6 +203,7 @@ fn esc_hint_line(esc_backtrack_hint: bool) -> Line<'static> {
 
 fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
     let mut commands = Line::from("");
+    let mut shell_commands = Line::from("");
     let mut newline = Line::from("");
     let mut file_paths = Line::from("");
     let mut paste_image = Line::from("");
@@ -214,6 +215,7 @@ fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
         if let Some(text) = descriptor.overlay_entry(state) {
             match descriptor.id {
                 ShortcutId::Commands => commands = text,
+                ShortcutId::ShellCommands => shell_commands = text,
                 ShortcutId::InsertNewline => newline = text,
                 ShortcutId::FilePaths => file_paths = text,
                 ShortcutId::PasteImage => paste_image = text,
@@ -226,6 +228,7 @@ fn shortcut_overlay_lines(state: ShortcutsState) -> Vec<Line<'static>> {
 
     let ordered = vec![
         commands,
+        shell_commands,
         newline,
         file_paths,
         paste_image,
@@ -302,6 +305,7 @@ fn context_window_line(percent: Option<i64>, used_tokens: Option<i64>) -> Line<'
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum ShortcutId {
     Commands,
+    ShellCommands,
     InsertNewline,
     FilePaths,
     PasteImage,
@@ -383,6 +387,15 @@ const SHORTCUTS: &[ShortcutDescriptor] = &[
         }],
         prefix: "",
         label: " for commands",
+    },
+    ShortcutDescriptor {
+        id: ShortcutId::ShellCommands,
+        bindings: &[ShortcutBinding {
+            key: key_hint::plain(KeyCode::Char('!')),
+            condition: DisplayCondition::Always,
+        }],
+        prefix: "",
+        label: " for shell commands",
     },
     ShortcutDescriptor {
         id: ShortcutId::InsertNewline,

--- a/codex-rs/tui2/src/bottom_pane/snapshots/codex_tui2__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
+++ b/codex-rs/tui2/src/bottom_pane/snapshots/codex_tui2__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
@@ -1,5 +1,6 @@
 ---
 source: tui2/src/bottom_pane/chat_composer.rs
+assertion_line: 2093
 expression: terminal.backend()
 ---
 "                                                                                                    "
@@ -10,7 +11,8 @@ expression: terminal.backend()
 "                                                                                                    "
 "                                                                                                    "
 "                                                                                                    "
-"  / for commands                            shift + enter for newline                               "
-"  @ for file paths                          ctrl + v to paste images                                "
-"  esc again to edit previous message        ctrl + c to exit                                        "
-"                                            ctrl + t to view transcript                             "
+"  / for commands                     ! for shell commands                                           "
+"  shift + enter for newline          @ for file paths                                               "
+"  ctrl + v to paste images           esc again to edit previous message                             "
+"  ctrl + c to exit                                                                                  "
+"  ctrl + t to view transcript                                                                       "

--- a/codex-rs/tui2/src/bottom_pane/snapshots/codex_tui2__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
+++ b/codex-rs/tui2/src/bottom_pane/snapshots/codex_tui2__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
@@ -1,8 +1,10 @@
 ---
 source: tui2/src/bottom_pane/footer.rs
+assertion_line: 486
 expression: terminal.backend()
 ---
-"  / for commands                            shift + enter for newline           "
-"  @ for file paths                          ctrl + v to paste images            "
-"  esc again to edit previous message        ctrl + c to exit                    "
-"                                            ctrl + t to view transcript         "
+"  / for commands                     ! for shell commands                       "
+"  shift + enter for newline          @ for file paths                           "
+"  ctrl + v to paste images           esc again to edit previous message         "
+"  ctrl + c to exit                                                              "
+"  ctrl + t to view transcript                                                   "


### PR DESCRIPTION
I didn't know this existed because its not listed in the hints.