### PR TITLE
Allow disabling keyring loading in debug

### DIFF
--- a/codex-rs/rmcp-client/src/oauth.rs
+++ b/codex-rs/rmcp-client/src/oauth.rs
@@ -50,7 +50,7 @@ use tokio::sync::Mutex;
 use crate::find_codex_home::find_codex_home;
 
 const KEYRING_SERVICE: &str = "Codex MCP Credentials";
-const MCP_OAUTH_KEYRING_DEBUG_ALLOW_ENV_VAR: &str = "CODEX_MCP_OAUTH_KEYRING_DEBUG_ALLOW";
+const MCP_OAUTH_KEYRING_DEBUG_DISABLE_ENV_VAR: &str = "CODEX_MCP_OAUTH_KEYRING_DEBUG_DISABLE";
 const REFRESH_SKEW_MILLIS: u64 = 30_000;
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -97,12 +97,9 @@ pub(crate) fn load_oauth_tokens(
     store_mode: OAuthCredentialsStoreMode,
 ) -> Result<Option<StoredOAuthTokens>> {
     if keyring_load_disabled_in_debug() {
-        if store_mode == OAuthCredentialsStoreMode::Keyring {
-            return Err(anyhow::anyhow!(
-                "MCP OAuth keyring access is disabled in debug builds on macOS; set {MCP_OAUTH_KEYRING_DEBUG_ALLOW_ENV_VAR}=1 to enable."
-            ));
-        }
-        return load_oauth_tokens_from_file(server_name, url);
+        return Err(anyhow::anyhow!(
+            "MCP OAuth keyring access is disabled in debug because {MCP_OAUTH_KEYRING_DEBUG_DISABLE_ENV_VAR} is set."
+        ));
     }
 
     let keyring_store = DefaultKeyringStore;
@@ -129,7 +126,7 @@ pub(crate) fn has_oauth_tokens(
 fn keyring_load_disabled_in_debug() -> bool {
     cfg!(debug_assertions)
         && cfg!(target_os = "macos")
-        && std::env::var_os(MCP_OAUTH_KEYRING_DEBUG_ALLOW_ENV_VAR).is_none()
+        && std::env::var_os(MCP_OAUTH_KEYRING_DEBUG_DISABLE_ENV_VAR).is_some_and(|v| v == "1")
 }
 
 fn refresh_expires_in_from_timestamp(tokens: &mut StoredOAuthTokens) {

--- a/docs/config.md
+++ b/docs/config.md
@@ -12,6 +12,8 @@ Codex can connect to MCP servers configured in `~/.codex/config.toml`. See the c
 
 - https://developers.openai.com/codex/config-reference
 
+On macOS debug builds, Codex skips reading MCP OAuth tokens from the system keychain to avoid repeated access prompts. Set `CODEX_MCP_OAUTH_KEYRING_DEBUG_ALLOW=1` to allow keychain reads when debugging.
+
 ## Notify
 
 Codex can run a notification hook when the agent finishes a turn. See the configuration reference for the latest notification settings:


### PR DESCRIPTION
Today the MacOS opens a password dialog for every MCP server in config that we attempt to load OAuth keys for. Makes debugging codex pretty hard.