### PR TITLE
Configurable default login shell for shell tools

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -84,6 +84,7 @@ use crate::config::Config;
 use crate::config::Constrained;
 use crate::config::ConstraintResult;
 use crate::config::GhostSnapshotConfig;
+use crate::config::types::ShellConfig;
 use crate::config::types::ShellEnvironmentPolicy;
 use crate::context_manager::ContextManager;
 use crate::environment_context::EnvironmentContext;
@@ -382,6 +383,7 @@ pub(crate) struct TurnContext {
     pub(crate) approval_policy: AskForApproval,
     pub(crate) sandbox_policy: SandboxPolicy,
     pub(crate) shell_environment_policy: ShellEnvironmentPolicy,
+    pub(crate) shell: ShellConfig,
     pub(crate) tools_config: ToolsConfig,
     pub(crate) ghost_snapshot: GhostSnapshotConfig,
     pub(crate) final_output_json_schema: Option<Value>,
@@ -540,6 +542,7 @@ impl Session {
             approval_policy: session_configuration.approval_policy.value(),
             sandbox_policy: session_configuration.sandbox_policy.get().clone(),
             shell_environment_policy: per_turn_config.shell_environment_policy.clone(),
+            shell: per_turn_config.shell.clone(),
             tools_config,
             ghost_snapshot: per_turn_config.ghost_snapshot.clone(),
             final_output_json_schema: None,
@@ -2266,6 +2269,7 @@ async fn spawn_review_thread(
         approval_policy: parent_turn_context.approval_policy,
         sandbox_policy: parent_turn_context.sandbox_policy.clone(),
         shell_environment_policy: parent_turn_context.shell_environment_policy.clone(),
+        shell: parent_turn_context.shell.clone(),
         cwd: parent_turn_context.cwd.clone(),
         final_output_json_schema: None,
         codex_linux_sandbox_exe: parent_turn_context.codex_linux_sandbox_exe.clone(),

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -555,6 +555,24 @@ impl Notice {
     pub(crate) const TABLE_KEY: &'static str = "notice";
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+pub struct ShellConfig {
+    #[serde(default = "default_login_shell")]
+    pub default_login: bool,
+}
+
+const fn default_login_shell() -> bool {
+    true
+}
+
+impl Default for ShellConfig {
+    fn default() -> Self {
+        Self {
+            default_login: true,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct SandboxWorkspaceWrite {
     #[serde(default)]

--- a/codex-rs/core/src/tools/handlers/unified_exec.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec.rs
@@ -285,8 +285,10 @@ fn format_response(response: &UnifiedExecResponse) -> String {
 mod tests {
     use super::*;
     use crate::shell::default_user_shell;
+    #[cfg(not(windows))]
     use crate::shell_snapshot::ShellSnapshot;
     use std::sync::Arc;
+    #[cfg(not(windows))]
     use tempfile::TempDir;
 
     #[test]


### PR DESCRIPTION
  Summary
  Adds [shell].default_login to control the default login‑shell behavior for shell, local_shell, and shell_command when a tool call does not
  specify login. Explicit login=true|false in the tool call always overrides the config.

  Motivation
  In curated environments, PATH and other env vars are intentionally inherited. The current default login shell can reinitialize PATH and
  override the inherited environment. A config‑level default lets users preserve the inherited environment when needed while keeping existing
  behavior unchanged if the option is absent.

  Behavior

  - Backwards‑compatible default: If [shell].default_login is not set, the default remains true (login shells).
  - Explicit tool calls win: login=true|false in tool arguments always overrides config.
  - Applies to: shell, local_shell, and shell_command.
  - Unified exec: snapshot behavior is unchanged; when a snapshot exists and login is omitted, it still defaults to non‑login. Otherwise it
    uses default_login.

  Docs (external)
  In‑repo docs are link‑only (per #8662). Please update external docs:

  Config reference (https://developers.openai.com/codex/config-reference)

  [shell]
  default_login = true

  default_login (boolean, default true): When true, shell commands run with login semantics (e.g., bash -lc). When false, Codex avoids login
  shells by default. Explicit login values on a tool call still override this default.

  Config sample (https://developers.openai.com/codex/config-sample)

  [shell]
  # Default when tool calls omit `login`. Default: true
  default_login = true

  Tests

  - just fmt
  - just fix -p codex-core
  - cargo test -p codex-core

  Issue

  - https://github.com/openai/codex/issues/8922
