### PR TITLE
Work around crash in system-configuration library

### DIFF
--- a/codex-rs/rmcp-client/src/auth_status.rs
+++ b/codex-rs/rmcp-client/src/auth_status.rs
@@ -58,7 +58,10 @@ pub async fn supports_oauth_login(url: &str) -> Result<bool> {
 
 async fn supports_oauth_login_with_headers(url: &str, default_headers: &HeaderMap) -> Result<bool> {
     let base_url = Url::parse(url)?;
-    let builder = Client::builder().timeout(DISCOVERY_TIMEOUT);
+
+    // Use no_proxy to avoid a bug in the system-configuration crate that
+    // can result in a panic. See #8912.
+    let builder = Client::builder().timeout(DISCOVERY_TIMEOUT).no_proxy();
     let client = apply_default_headers(builder, default_headers).build()?;
 
     let mut last_error: Option<Error> = None;


### PR DESCRIPTION
This is a proposed fix for #8912

Information provided by Codex:

no_proxy means “don’t use any system proxy settings for this client,” even if macOS has proxies configured in System Settings or via environment. On macOS, reqwest’s proxy discovery can call into the system-configuration framework; that’s the code path that was panicking with “Attempted to create a NULL object.” By forcing a direct connection for the OAuth discovery request, we avoid that proxy-resolution path entirely, so the system-configuration crate never gets invoked and the panic disappears.

Effectively:

With proxies: reqwest asks the OS for proxy config → system-configuration gets touched → panic.
With no_proxy: reqwest skips proxy lookup → no system-configuration call → no panic.
So the fix doesn’t change any MCP protocol behavior; it just prevents the OAuth discovery probe from touching the macOS proxy APIs that are crashing in the reported environment.

This fix changes behavior for the OAuth discovery probe used in codex mcp list/auth status detection. With no_proxy, that probe won’t use system or env proxy settings, so:

If a server is only reachable via a proxy, the discovery call may fail and we’ll show auth as Unsupported/NotLoggedIn incorrectly.
If the server is reachable directly (common case), behavior is unchanged.



As an alternative, we could try to get a fix into the [system-configuration](https://github.com/mullvad/system-configuration-rs) library. It looks like this library is still under development but has slow release pace.