### PR TITLE
fix: add bazelisk and dotslash to Dockerfile for devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,6 +14,26 @@ RUN apt-get update && \
     pkg-config clang musl-tools libssl-dev just && \
     rm -rf /var/lib/apt/lists/*
 
+# Install Bazel via Bazelisk (mirrors bazelbuild/setup-bazelisk@v3).
+ARG BAZELISK_VERSION=latest
+RUN arch="$(uname -m)" && \
+    case "$arch" in \
+      x86_64) arch="amd64" ;; \
+      aarch64) arch="arm64" ;; \
+      *) echo "Unsupported architecture: $arch" >&2; exit 1 ;; \
+    esac && \
+    if [ "$BAZELISK_VERSION" = "latest" ]; then \
+      url="https://github.com/bazelbuild/bazelisk/releases/latest/download/bazelisk-linux-${arch}"; \
+    else \
+      url="https://github.com/bazelbuild/bazelisk/releases/download/v${BAZELISK_VERSION}/bazelisk-linux-${arch}"; \
+    fi && \
+    curl -fsSL "$url" -o /usr/local/bin/bazelisk && \
+    chmod +x /usr/local/bin/bazelisk && \
+    ln -s /usr/local/bin/bazelisk /usr/local/bin/bazel
+
+# Install dotslash.
+RUN curl -LSfs "https://github.com/facebook/dotslash/releases/download/v0.5.8/dotslash-ubuntu-22.04.$(uname -m).tar.gz" | tar fxz - -C /usr/local/bin
+
 # Ubuntu 24.04 ships with user 'ubuntu' already created with UID 1000.
 USER ubuntu
 


### PR DESCRIPTION
In working on the new `Dockerfile.bazel` in https://github.com/openai/codex/pull/8875, it occurred to me these would be good fixes to make for the devcontainer.