### PR TITLE
feat: Add directory selection to @ file search

### DIFF
--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -219,7 +219,11 @@ fn format_directory_tree(path: &std::path::Path, limit: usize) -> std::io::Resul
 
     for (i, entry) in entries.iter().take(display_count).enumerate() {
         let is_last = !truncated && i == display_count - 1;
-        let prefix = if is_last { "\u{2514}\u{2500}" } else { "\u{251C}\u{2500}" };
+        let prefix = if is_last {
+            "\u{2514}\u{2500}"
+        } else {
+            "\u{251C}\u{2500}"
+        };
         let suffix = if entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
             "/"
         } else {
@@ -234,7 +238,10 @@ fn format_directory_tree(path: &std::path::Path, limit: usize) -> std::io::Resul
     }
 
     if truncated {
-        result.push_str(&format!("...\n\u{2514}\u{2500} ({} more items)\n", total - display_count));
+        result.push_str(&format!(
+            "...\n\u{2514}\u{2500} ({} more items)\n",
+            total - display_count
+        ));
     }
 
     Ok(result)
@@ -368,18 +375,16 @@ impl From<Vec<UserInput>> for ResponseInputItem {
                         }
                     },
                     UserInput::Skill { .. } => None, // Skill bodies are injected later in core
-                    UserInput::LocalDirectory { path } => {
-                        match format_directory_tree(&path, 50) {
-                            Ok(listing) => Some(ContentItem::InputText { text: listing }),
-                            Err(err) => Some(ContentItem::InputText {
-                                text: format!(
-                                    "Codex could not read the directory at `{}`: {}",
-                                    path.display(),
-                                    err
-                                ),
-                            }),
-                        }
-                    }
+                    UserInput::LocalDirectory { path } => match format_directory_tree(&path, 50) {
+                        Ok(listing) => Some(ContentItem::InputText { text: listing }),
+                        Err(err) => Some(ContentItem::InputText {
+                            text: format!(
+                                "Codex could not read the directory at `{}`: {}",
+                                path.display(),
+                                err
+                            ),
+                        }),
+                    },
                 })
                 .collect::<Vec<ContentItem>>(),
         }
@@ -551,7 +556,6 @@ fn convert_content_blocks_to_items(
 ) -> Option<Vec<FunctionCallOutputContentItem>> {
     let mut saw_image = false;
     let mut items = Vec::with_capacity(blocks.len());
-    tracing::warn!("Blocks: {:?}", blocks);
     for block in blocks {
         match block {
             ContentBlock::TextContent(text) => {
@@ -933,7 +937,10 @@ mod tests {
                 assert_eq!(content.len(), 1);
                 match &content[0] {
                     ContentItem::InputText { text } => {
-                        assert!(text.contains("file1.txt"), "should contain file1.txt: {text}");
+                        assert!(
+                            text.contains("file1.txt"),
+                            "should contain file1.txt: {text}"
+                        );
                         assert!(text.contains("file2.rs"), "should contain file2.rs: {text}");
                         assert!(text.contains("subdir/"), "should contain subdir/: {text}");
                         assert!(
@@ -961,18 +968,19 @@ mod tests {
         }]);
 
         match item {
-            ResponseInputItem::Message { content, .. } => {
-                match &content[0] {
-                    ContentItem::InputText { text } => {
-                        assert!(text.contains("more items"), "should show truncation: {text}");
-                        assert!(
-                            !text.contains("file054.txt"),
-                            "should not show last items: {text}"
-                        );
-                    }
-                    other => panic!("expected text but found {other:?}"),
+            ResponseInputItem::Message { content, .. } => match &content[0] {
+                ContentItem::InputText { text } => {
+                    assert!(
+                        text.contains("more items"),
+                        "should show truncation: {text}"
+                    );
+                    assert!(
+                        !text.contains("file054.txt"),
+                        "should not show last items: {text}"
+                    );
                 }
-            }
+                other => panic!("expected text but found {other:?}"),
+            },
             other => panic!("expected message but got {other:?}"),
         }
         Ok(())
@@ -987,18 +995,16 @@ mod tests {
         }]);
 
         match item {
-            ResponseInputItem::Message { content, .. } => {
-                match &content[0] {
-                    ContentItem::InputText { text } => {
-                        assert!(text.contains("could not read"), "error text: {text}");
-                        assert!(
-                            text.contains(&missing.display().to_string()),
-                            "should contain path: {text}"
-                        );
-                    }
-                    other => panic!("expected text but found {other:?}"),
+            ResponseInputItem::Message { content, .. } => match &content[0] {
+                ContentItem::InputText { text } => {
+                    assert!(text.contains("could not read"), "error text: {text}");
+                    assert!(
+                        text.contains(&missing.display().to_string()),
+                        "should contain path: {text}"
+                    );
                 }
-            }
+                other => panic!("expected text but found {other:?}"),
+            },
             other => panic!("expected message but got {other:?}"),
         }
         Ok(())

--- a/codex-rs/protocol/src/user_input.rs
+++ b/codex-rs/protocol/src/user_input.rs
@@ -27,4 +27,10 @@ pub enum UserInput {
         name: String,
         path: std::path::PathBuf,
     },
+
+    /// Local directory path provided by the user. This will be converted to
+    /// a text listing during request serialization.
+    LocalDirectory {
+        path: std::path::PathBuf,
+    },
 }

--- a/codex-rs/tui2/src/bottom_pane/mod.rs
+++ b/codex-rs/tui2/src/bottom_pane/mod.rs
@@ -546,6 +546,10 @@ impl BottomPane {
         self.composer.take_recent_submission_images()
     }
 
+    pub(crate) fn take_recent_submission_directories(&mut self) -> Vec<PathBuf> {
+        self.composer.take_recent_submission_directories()
+    }
+
     fn as_renderable(&'_ self) -> RenderableItem<'_> {
         if let Some(view) = self.active_view() {
             RenderableItem::Borrowed(view)


### PR DESCRIPTION
###  What

  Adds directory support to the @ file search popup in TUI. Directories appear with a trailing / suffix and can be selected like files.

###  Why

  Closes Issue #8863 

  Referencing entire directories (modules, packages, libraries) is faster than selecting files one by one. The model can then list_dir or read as needed.

###  How

  - file-search/src/lib.rs: Add / suffix to directory entries
  - protocol/src/user_input.rs: Add LocalDirectory variant
  - protocol/src/models.rs: Convert directory to tree listing on submit
  - tui2/src/bottom_pane/chat_composer.rs: Detect and attach directories
  - tui2/src/chatwidget.rs: Include directories in UserMessage

  Includes 3 unit tests for tree formatting, truncation, and error handling.
  
###  Examples
  
<img width="1703" height="575" alt="image" src="https://github.com/user-attachments/assets/283748a8-c829-490a-84af-f6bb9397f00a" />

<img width="1703" height="575" alt="image" src="https://github.com/user-attachments/assets/b1167f16-893f-4d18-8f0a-e415c442e00a" />
