### PR TITLE
add static mcp callback uri support

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -2358,6 +2358,7 @@ impl CodexMessageProcessor {
             env_http_headers,
             scopes.as_deref().unwrap_or_default(),
             timeout_secs,
+            config.mcp_oauth_callback_port,
         )
         .await
         {

--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -274,6 +274,7 @@ async fn run_add(config_overrides: &CliConfigOverrides, add_args: AddArgs) -> Re
                     http_headers.clone(),
                     env_http_headers.clone(),
                     &Vec::new(),
+                    config.mcp_oauth_callback_port,
                 )
                 .await?;
                 println!("Successfully logged in.");
@@ -352,6 +353,7 @@ async fn run_login(config_overrides: &CliConfigOverrides, login_args: LoginArgs)
         http_headers,
         env_http_headers,
         &scopes,
+        config.mcp_oauth_callback_port,
     )
     .await?;
     println!("Successfully logged in to MCP server '{name}'.");

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -259,6 +259,12 @@ pub struct Config {
     /// auto (default): keyring if available, otherwise file.
     pub mcp_oauth_credentials_store_mode: OAuthCredentialsStoreMode,
 
+    /// Optional fixed port to use for the local HTTP callback server used during MCP OAuth login.
+    ///
+    /// When unset, Codex will bind to an ephemeral port chosen by the OS. The environment
+    /// variable `CODEX_MCP_OAUTH_CALLBACK_PORT` takes precedence over this value if set.
+    pub mcp_oauth_callback_port: Option<u16>,
+
     /// Combined provider map (defaults merged with user-defined overrides).
     pub model_providers: HashMap<String, ModelProviderInfo>,
 
@@ -737,6 +743,11 @@ pub struct ConfigToml {
     /// auto (default): Use the OS-specific keyring service if available, otherwise use a file.
     #[serde(default)]
     pub mcp_oauth_credentials_store: Option<OAuthCredentialsStoreMode>,
+
+    /// Optional fixed port for the local HTTP callback server used during MCP OAuth login.
+    /// When unset, Codex will bind to an ephemeral port chosen by the OS. The environment
+    /// variable `CODEX_MCP_OAUTH_CALLBACK_PORT` takes precedence over this value if set.
+    pub mcp_oauth_callback_port: Option<u16>,
 
     /// User-defined provider entries that extend/override the built-in list.
     #[serde(default)]
@@ -1344,6 +1355,7 @@ impl Config {
             // The config.toml omits "_mode" because it's a config file. However, "_mode"
             // is important in code to differentiate the mode from the store implementation.
             mcp_oauth_credentials_store_mode: cfg.mcp_oauth_credentials_store.unwrap_or_default(),
+            mcp_oauth_callback_port: cfg.mcp_oauth_callback_port,
             model_providers,
             project_doc_max_bytes: cfg.project_doc_max_bytes.unwrap_or(PROJECT_DOC_MAX_BYTES),
             project_doc_fallback_filenames: cfg
@@ -3198,6 +3210,7 @@ model_verbosity = "high"
                 cli_auth_credentials_store_mode: Default::default(),
                 mcp_servers: HashMap::new(),
                 mcp_oauth_credentials_store_mode: Default::default(),
+                mcp_oauth_callback_port: None,
                 model_providers: fixture.model_provider_map.clone(),
                 project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
                 project_doc_fallback_filenames: Vec::new(),
@@ -3282,6 +3295,7 @@ model_verbosity = "high"
             cli_auth_credentials_store_mode: Default::default(),
             mcp_servers: HashMap::new(),
             mcp_oauth_credentials_store_mode: Default::default(),
+            mcp_oauth_callback_port: None,
             model_providers: fixture.model_provider_map.clone(),
             project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
             project_doc_fallback_filenames: Vec::new(),
@@ -3381,6 +3395,7 @@ model_verbosity = "high"
             cli_auth_credentials_store_mode: Default::default(),
             mcp_servers: HashMap::new(),
             mcp_oauth_credentials_store_mode: Default::default(),
+            mcp_oauth_callback_port: None,
             model_providers: fixture.model_provider_map.clone(),
             project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
             project_doc_fallback_filenames: Vec::new(),
@@ -3466,6 +3481,7 @@ model_verbosity = "high"
             cli_auth_credentials_store_mode: Default::default(),
             mcp_servers: HashMap::new(),
             mcp_oauth_credentials_store_mode: Default::default(),
+            mcp_oauth_callback_port: None,
             model_providers: fixture.model_provider_map.clone(),
             project_doc_max_bytes: PROJECT_DOC_MAX_BYTES,
             project_doc_fallback_filenames: Vec::new(),
@@ -3775,6 +3791,34 @@ trust_level = "untrusted"
             Some("test-profile".to_string()),
         );
         assert_eq!(result, Some("explicit-provider".to_string()));
+    }
+
+    #[test]
+    fn config_toml_deserializes_mcp_oauth_callback_port() {
+        let toml = r#"mcp_oauth_callback_port = 4321"#;
+        let cfg: ConfigToml =
+            toml::from_str(toml).expect("TOML deserialization should succeed for callback port");
+        assert_eq!(cfg.mcp_oauth_callback_port, Some(4321));
+    }
+
+    #[test]
+    fn config_loads_mcp_oauth_callback_port_from_toml() -> std::io::Result<()> {
+        let codex_home = TempDir::new()?;
+        let toml = r#"
+model = "gpt-5.1"
+mcp_oauth_callback_port = 5678
+"#;
+        let cfg: ConfigToml =
+            toml::from_str(toml).expect("TOML deserialization should succeed for callback port");
+
+        let config = Config::load_from_base_config_with_overrides(
+            cfg,
+            ConfigOverrides::default(),
+            codex_home.path().to_path_buf(),
+        )?;
+
+        assert_eq!(config.mcp_oauth_callback_port, Some(5678));
+        Ok(())
     }
 
     #[test]

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -261,8 +261,7 @@ pub struct Config {
 
     /// Optional fixed port to use for the local HTTP callback server used during MCP OAuth login.
     ///
-    /// When unset, Codex will bind to an ephemeral port chosen by the OS. The environment
-    /// variable `CODEX_MCP_OAUTH_CALLBACK_PORT` takes precedence over this value if set.
+    /// When unset, Codex will bind to an ephemeral port chosen by the OS.
     pub mcp_oauth_callback_port: Option<u16>,
 
     /// Combined provider map (defaults merged with user-defined overrides).
@@ -745,8 +744,7 @@ pub struct ConfigToml {
     pub mcp_oauth_credentials_store: Option<OAuthCredentialsStoreMode>,
 
     /// Optional fixed port for the local HTTP callback server used during MCP OAuth login.
-    /// When unset, Codex will bind to an ephemeral port chosen by the OS. The environment
-    /// variable `CODEX_MCP_OAUTH_CALLBACK_PORT` takes precedence over this value if set.
+    /// When unset, Codex will bind to an ephemeral port chosen by the OS.
     pub mcp_oauth_callback_port: Option<u16>,
 
     /// User-defined provider entries that extend/override the built-in list.

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -1,5 +1,4 @@
 use std::collections::HashMap;
-use std::env;
 use std::string::String;
 use std::sync::Arc;
 use std::time::Duration;
@@ -23,8 +22,6 @@ use crate::oauth::compute_expires_at_millis;
 use crate::save_oauth_tokens;
 use crate::utils::apply_default_headers;
 use crate::utils::build_default_headers;
-
-const CODEX_MCP_OAUTH_CALLBACK_PORT_ENV: &str = "CODEX_MCP_OAUTH_CALLBACK_PORT";
 
 struct OauthHeaders {
     http_headers: Option<HashMap<String, String>>,
@@ -197,30 +194,7 @@ struct OauthLoginFlow {
     timeout: Duration,
 }
 
-fn load_callback_port_from_env() -> Result<Option<u16>> {
-    let port = match env::var(CODEX_MCP_OAUTH_CALLBACK_PORT_ENV) {
-        Ok(value) => value,
-        Err(env::VarError::NotPresent) => return Ok(None),
-        Err(err) => bail!("invalid {CODEX_MCP_OAUTH_CALLBACK_PORT_ENV} value: {err}"),
-    };
-
-    let parsed: u16 = port
-        .parse()
-        .with_context(|| format!("invalid {CODEX_MCP_OAUTH_CALLBACK_PORT_ENV} `{port}`"))?;
-    if parsed == 0 {
-        bail!(
-            "invalid {CODEX_MCP_OAUTH_CALLBACK_PORT_ENV} `{port}`: port must be between 1 and 65535"
-        );
-    }
-
-    Ok(Some(parsed))
-}
-
 fn resolve_callback_port(callback_port: Option<u16>) -> Result<Option<u16>> {
-    if let Some(env_port) = load_callback_port_from_env()? {
-        return Ok(Some(env_port));
-    }
-
     if let Some(config_port) = callback_port {
         if config_port == 0 {
             bail!(


### PR DESCRIPTION
Currently the callback URI for MCP authentication is dynamically generated. More specifically, the callback URI is dynamic because the port part of it is randomly chosen by the OS. This is not ideal as callback URIs are recommended to be static and many authorization servers do not support dynamic callback URIs. 

This PR fixes that issue by exposing a new config option named `mcp_oauth_callback_port`. When it is set, the callback URI is constructed using this port rather than a random one chosen by the OS, thereby making callback URI static. 

Related issue: https://github.com/openai/codex/issues/8827