### PR TITLE
use default shell in tool desc

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -964,6 +964,7 @@ impl Session {
             self.conversation_id,
             sub_id,
         );
+        turn_context.tools_config.default_shell_name = Some(self.user_shell().display_name());
         if let Some(final_schema) = final_output_json_schema {
             turn_context.final_output_json_schema = final_schema;
         }
@@ -2219,10 +2220,11 @@ async fn spawn_review_thread(
     review_features
         .disable(crate::features::Feature::WebSearchRequest)
         .disable(crate::features::Feature::WebSearchCached);
-    let tools_config = ToolsConfig::new(&ToolsConfigParams {
+    let mut tools_config = ToolsConfig::new(&ToolsConfigParams {
         model_info: &review_model_info,
         features: &review_features,
     });
+    tools_config.default_shell_name = Some(sess.user_shell().display_name());
 
     let base_instructions = REVIEW_PROMPT.to_string();
     let review_prompt = resolved.prompt.clone();

--- a/codex-rs/core/src/shell.rs
+++ b/codex-rs/core/src/shell.rs
@@ -33,6 +33,14 @@ impl Shell {
         }
     }
 
+    pub(crate) fn display_name(&self) -> String {
+        self.shell_path
+            .file_stem()
+            .and_then(|stem| stem.to_str())
+            .map(str::to_string)
+            .unwrap_or_else(|| self.name().to_string())
+    }
+
     /// Takes a string of shell and returns the full list of command args to
     /// use with `exec()` to run the shell command.
     pub fn derive_exec_args(&self, command: &str, use_login_shell: bool) -> Vec<String> {


### PR DESCRIPTION
Variant to #8997.

Inform the model of the actual default shell rather than saying `the user's default shell`.