### PR TITLE
fix: add .git to .bazelignore

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,0 +1,3 @@
+# Without this, Bazel will consider BUILD.bazel files in
+# .git/sl/origbackups (which can be populated by Sapling SCM).
+.git


### PR DESCRIPTION
As noted in the comment, this was causing a problem for me locally because Sapling backed up some files under `.git/sl` named `BUILD.bazel` and so Bazel tried to parse them.

It's a bit surprising that Bazel does not ignore `.git` out of the box such that you have to opt-in to considering it rather than opting-out.