### PR TITLE
test(mcp-server): make Chat Completions WireMock emit [DONE]

### DIFF
--- a/codex-rs/mcp-server/tests/common/responses.rs
+++ b/codex-rs/mcp-server/tests/common/responses.rs
@@ -34,7 +34,7 @@ pub fn create_shell_command_sse_response(
     });
 
     let sse = format!(
-        "data: {}\n\ndata: DONE\n\n",
+        "data: {}\n\ndata: [DONE]\n\n",
         serde_json::to_string(&tool_call)?
     );
     Ok(sse)
@@ -53,7 +53,7 @@ pub fn create_final_assistant_message_sse_response(message: &str) -> anyhow::Res
     });
 
     let sse = format!(
-        "data: {}\n\ndata: DONE\n\n",
+        "data: {}\n\ndata: [DONE]\n\n",
         serde_json::to_string(&assistant_message)?
     );
     Ok(sse)
@@ -89,7 +89,7 @@ pub fn create_apply_patch_sse_response(
     });
 
     let sse = format!(
-        "data: {}\n\ndata: DONE\n\n",
+        "data: {}\n\ndata: [DONE]\n\n",
         serde_json::to_string(&tool_call)?
     );
     Ok(sse)


### PR DESCRIPTION
## Problem
Windows CI sometimes flakes in `codex-mcp-server` tests that stub `/v1/chat/completions` with WireMock.

The mock SSE payload ended with `data: DONE` (nonstandard) instead of the upstream terminal sentinel `data: [DONE]`. Depending on platform/timing, that can leave the client waiting for stream termination via connection close.

## Fix
Update the test fixture to emit `data: [DONE]` to match the server-side wire format. No changes to production protocol handling.

## Tests
- `cargo test -p codex-mcp-server`