### PR TITLE
fix: include AGENTS.md as repo root marker for integration tests

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -108,3 +108,24 @@ jobs:
             --build_metadata=ROLE=CI \
             --build_metadata=VISIBILITY=PUBLIC \
             "--remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY"
+
+  cloud-build:
+    name: just bazel-remote-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Set up Bazel
+        uses: bazelbuild/setup-bazelisk@v3
+      - name: bazel test //... --config=remote
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          bazel test //... \
+            --build_metadata=REPO_URL=https://github.com/openai/codex.git \
+            --build_metadata=COMMIT_SHA=$(git rev-parse HEAD) \
+            --build_metadata=ROLE=CI \
+            --build_metadata=VISIBILITY=PUBLIC \
+            "--remote_header=x-buildbuddy-api-key=$BUILDBUDDY_API_KEY" \
+            --config=remote --platforms=//:rbe --keep_going

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -27,3 +27,5 @@ platform(
         "OSFamily": "Linux",
     },
 )
+
+exports_files(["AGENTS.md"])

--- a/codex-rs/core/BUILD.bazel
+++ b/codex-rs/core/BUILD.bazel
@@ -20,6 +20,15 @@ codex_rust_crate(
         "//codex-rs/apply-patch:apply_patch_tool_instructions.md",
         "prompt.md",
     ],
+    # This is a bit of a hack, but empirically, some of our integration tests
+    # are relying on the presence of this file as a repo root marker. When
+    # running tests locally, this "just works," but in remote execution,
+    # the working directory is different and so the file is not found unless it
+    # is explicitly added as test data.
+    #
+    # TODO(aibrahim): Update the tests so that `just bazel-remote-test` succeeds
+    # without this workaround.
+    test_data_extra = ["//:AGENTS.md"],
     integration_deps_extra = ["//codex-rs/core/tests/common:common"],
     test_tags = ["no-sandbox"],
     extra_binaries = [


### PR DESCRIPTION
As explained in `codex-rs/core/BUILD.bazel`, including the repo's own `AGENTS.md` is a hack to get some tests passing. We should fix this properly, but I wanted to put stake in the ground ASAP to get `just bazel-remote-test` working and then add a job to `bazel.yml` to ensure it keeps working.