### PR TITLE
Support cmd+v image paste in TUIs

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1588,7 +1588,8 @@ impl ChatWidget {
                 modifiers,
                 kind: KeyEventKind::Press,
                 ..
-            } if modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+            } if modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)
                 && c.eq_ignore_ascii_case(&'v') =>
             {
                 match paste_image_to_temp_png() {

--- a/codex-rs/tui2/src/chatwidget.rs
+++ b/codex-rs/tui2/src/chatwidget.rs
@@ -1447,7 +1447,8 @@ impl ChatWidget {
                 modifiers,
                 kind: KeyEventKind::Press,
                 ..
-            } if modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+            } if modifiers
+                .intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)
                 && c.eq_ignore_ascii_case(&'v') =>
             {
                 match paste_image_to_temp_png() {


### PR DESCRIPTION
### Motivation
- Enable macOS users to paste images using Command+V in the TUI chat widgets by treating the Command key as `KeyModifiers::SUPER`.
- The previous logic only detected `Ctrl`/`Alt` combinations which prevented `cmd+v` from triggering image paste handlers.

### Description
- Include `KeyModifiers::SUPER` in the paste-detection predicate by changing `modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)` to `modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT | KeyModifiers::SUPER)` in `codex-rs/tui/src/chatwidget.rs` and `codex-rs/tui2/src/chatwidget.rs`.
- Adjusted the `if` expression formatting to a multi-line form to satisfy clippy/style conventions.
- Ran automatic formatting (`just fmt`) and linter fixes for the affected crates.

### Testing
- Ran `just fmt` which completed successfully.
- Ran `just fix -p codex-tui` and `just fix -p codex-tui2` which completed successfully to apply clippy fixes.
- Ran `cargo test -p codex-tui` which mostly passed but had 2 snapshot failures due to snapshot differences (legacy snapshot format / `OPENAI_BASE_URL` warning) and therefore failed.
- Ran `cargo test -p codex-tui2` which completed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_69614df4295883219188228e889ae290)