### PR TITLE
Fix: send commandExecution before approval request

### DIFF
--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -225,6 +225,26 @@ pub(crate) async fn apply_bespoke_event_handling(
                 let proposed_execpolicy_amendment_v2 =
                     proposed_execpolicy_amendment.map(V2ExecPolicyAmendment::from);
 
+                let item = ThreadItem::CommandExecution {
+                    id: item_id.clone(),
+                    command: command_string.clone(),
+                    cwd: cwd.clone(),
+                    process_id: None,
+                    status: CommandExecutionStatus::InProgress,
+                    command_actions: command_actions.clone(),
+                    aggregated_output: None,
+                    exit_code: None,
+                    duration_ms: None,
+                };
+                let notification = ItemStartedNotification {
+                    thread_id: conversation_id.to_string(),
+                    turn_id: event_turn_id.clone(),
+                    item,
+                };
+                outgoing
+                    .send_server_notification(ServerNotification::ItemStarted(notification))
+                    .await;
+
                 let params = CommandExecutionRequestApprovalParams {
                     thread_id: conversation_id.to_string(),
                     turn_id: turn_id.clone(),


### PR DESCRIPTION
### Issue
We noticed that exec command approval request is no longer rendered correctly after CLI version bump from `0.78.0` to `0.79.0`. In this case we are stuck on the turn without able to move forward. 

<img width="800" height="1861" alt="Screenshot 2026-01-10 at 11 30 05 AM" src="https://github.com/user-attachments/assets/335996cf-aa10-4c9a-90d2-5691bd40e88c" />

### Fix
We send a `ThreadItem::CommandExecution` notification so that request can be properly match on VSCE side. 
Please ignore the message on the approval and we will still need to improve that. 

<img width="863" height="1553" alt="Screenshot 2026-01-10 at 11 33 40 AM" src="https://github.com/user-attachments/assets/969e0f83-a54b-4381-b18f-5c9fff5a1c0b" />
