### PR TITLE
Handle image paste from empty paste events

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -517,7 +517,7 @@ impl App {
                     // [tui-textarea]: https://github.com/rhysd/tui-textarea/blob/4d18622eeac13b309e0ff6a55a46ac6706da68cf/src/textarea.rs#L782-L783
                     // [iTerm2]: https://github.com/gnachman/iTerm2/blob/5d0c0d9f68523cbd0494dad5422998964a2ecd8d/sources/iTermPasteHelper.m#L206-L216
                     let pasted = pasted.replace("\r", "\n");
-                    self.chat_widget.handle_paste(pasted);
+                    self.chat_widget.handle_paste_event(pasted);
                 }
                 TuiEvent::Draw => {
                     self.chat_widget.maybe_post_pending_notification(tui);

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__footer_mode_shortcut_overlay.snap
@@ -1,6 +1,5 @@
 ---
 source: tui/src/bottom_pane/chat_composer.rs
-assertion_line: 2151
 expression: terminal.backend()
 ---
 "                                                                                                    "

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_shortcuts_shift_and_esc.snap
@@ -1,6 +1,5 @@
 ---
 source: tui/src/bottom_pane/footer.rs
-assertion_line: 455
 expression: terminal.backend()
 ---
 "  / for commands                            ! for shell commands                "


### PR DESCRIPTION
Handle image paste on empty paste events.

- Intent: make image paste work in terminals that emit empty paste events.
- Approach: route paste events through an image-aware handler and read the clipboard when text is empty.
- That's best effort to detect it. Some terminals don't send the empty signal.