### PR TITLE
Extend OTLP loopback test window

### DIFF
--- a/codex-rs/otel/tests/suite/otlp_http_loopback.rs
+++ b/codex-rs/otel/tests/suite/otlp_http_loopback.rs
@@ -137,7 +137,7 @@ fn otlp_http_exporter_sends_metrics_to_collector() -> Result<()> {
     let (tx, rx) = mpsc::channel::<Vec<CapturedRequest>>();
     let server = thread::spawn(move || {
         let mut captured = Vec::new();
-        let deadline = Instant::now() + Duration::from_secs(3);
+        let deadline = Instant::now() + Duration::from_secs(12);
 
         while Instant::now() < deadline {
             match listener.accept() {
@@ -150,6 +150,9 @@ fn otlp_http_exporter_sends_metrics_to_collector() -> Result<()> {
                             content_type: headers.get("content-type").cloned(),
                             body,
                         });
+                        if !captured.is_empty() {
+                            break;
+                        }
                     }
                 }
                 Err(err) if err.kind() == std::io::ErrorKind::WouldBlock => {


### PR DESCRIPTION
- extend the OTLP loopback server window and exit after the first request