### PR TITLE
upgrade runners in rust-ci.yml to use the larger runners

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -106,14 +106,12 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-14
+          - runner: macos-15-xlarge
             target: aarch64-apple-darwin
             profile: dev
-            runs_on: macos-14-xlarge
-          - runner: macos-14
+          - runner: macos-15-xlarge
             target: x86_64-apple-darwin
             profile: dev
-            runs_on: macos-14-xlarge
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             profile: dev
@@ -149,10 +147,9 @@ jobs:
           # there could be release-only build errors we want to catch.
           # Hopefully this also pre-populates the build cache to speed up
           # releases.
-          - runner: macos-14
+          - runner: macos-15-xlarge
             target: aarch64-apple-darwin
             profile: release
-            runs_on: macos-14-xlarge
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             profile: release
@@ -371,10 +368,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: macos-14
+          - runner: macos-15-xlarge
             target: aarch64-apple-darwin
             profile: dev
-            runs_on: macos-14-xlarge
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             profile: dev

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -393,21 +393,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # We have been running out of space when running this job on Linux for
-      # x86_64-unknown-linux-gnu, so remove some unnecessary dependencies.
-      - name: Remove unnecessary dependencies to save space
-        if: ${{ startsWith(matrix.runner, 'ubuntu') }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          sudo rm -rf \
-            /usr/local/lib/android \
-            /usr/share/dotnet \
-            /usr/local/share/boost \
-            /usr/local/lib/node_modules \
-            /opt/ghc
-          sudo apt-get remove -y docker.io docker-compose podman buildah
-
       # Some integration tests rely on DotSlash being installed.
       # See https://github.com/openai/codex/pull/7617.
       - name: Install DotSlash

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -88,7 +88,7 @@ jobs:
   # --- CI to validate on different os/targets --------------------------------
   lint_build:
     name: Lint/Build — ${{ matrix.runner }} - ${{ matrix.target }}${{ matrix.profile == 'release' && ' (release)' || '' }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.runs-on || matrix.runner }}
     timeout-minutes: 30
     needs: changed
     # Keep job-level if to avoid spinning up runners when not needed
@@ -115,15 +115,27 @@ jobs:
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             profile: dev
+            runs-on:
+              group: codex-runners
+              labels: codex-linux-x64
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             profile: dev
+            runs-on:
+              group: codex-runners
+              labels: codex-linux-x64
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             profile: dev
+            runs-on:
+              group: codex-runners
+              labels: codex-linux-arm64
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             profile: dev
+            runs-on:
+              group: codex-runners
+              labels: codex-linux-arm64
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
             profile: dev
@@ -141,6 +153,9 @@ jobs:
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             profile: release
+            runs-on:
+              group: codex-runners
+              labels: codex-linux-x64
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
             profile: release
@@ -336,7 +351,7 @@ jobs:
 
   tests:
     name: Tests — ${{ matrix.runner }} - ${{ matrix.target }}
-    runs-on: ${{ matrix.runner }}
+    runs-on: ${{ matrix.runs-on || matrix.runner }}
     timeout-minutes: 30
     needs: changed
     if: ${{ needs.changed.outputs.codex == 'true' || needs.changed.outputs.workflows == 'true' || github.event_name == 'push' }}
@@ -359,9 +374,15 @@ jobs:
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             profile: dev
+            runs-on:
+              group: codex-runners
+              labels: codex-linux-x64
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             profile: dev
+            runs-on:
+              group: codex-runners
+              labels: codex-linux-arm64
           - runner: windows-latest
             target: x86_64-pc-windows-msvc
             profile: dev

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -88,7 +88,7 @@ jobs:
   # --- CI to validate on different os/targets --------------------------------
   lint_build:
     name: Lint/Build — ${{ matrix.runner }} - ${{ matrix.target }}${{ matrix.profile == 'release' && ' (release)' || '' }}
-    runs-on: ${{ matrix.runs-on || matrix.runner }}
+    runs-on: ${{ matrix.runs_on || matrix.runner }}
     timeout-minutes: 30
     needs: changed
     # Keep job-level if to avoid spinning up runners when not needed
@@ -115,25 +115,25 @@ jobs:
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             profile: dev
-            runs-on:
+            runs_on:
               group: codex-runners
               labels: codex-linux-x64
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             profile: dev
-            runs-on:
+            runs_on:
               group: codex-runners
               labels: codex-linux-x64
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-musl
             profile: dev
-            runs-on:
+            runs_on:
               group: codex-runners
               labels: codex-linux-arm64
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             profile: dev
-            runs-on:
+            runs_on:
               group: codex-runners
               labels: codex-linux-arm64
           - runner: windows-latest
@@ -153,7 +153,7 @@ jobs:
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             profile: release
-            runs-on:
+            runs_on:
               group: codex-runners
               labels: codex-linux-x64
           - runner: windows-latest
@@ -351,7 +351,7 @@ jobs:
 
   tests:
     name: Tests — ${{ matrix.runner }} - ${{ matrix.target }}
-    runs-on: ${{ matrix.runs-on || matrix.runner }}
+    runs-on: ${{ matrix.runs_on || matrix.runner }}
     timeout-minutes: 30
     needs: changed
     if: ${{ needs.changed.outputs.codex == 'true' || needs.changed.outputs.workflows == 'true' || github.event_name == 'push' }}
@@ -374,13 +374,13 @@ jobs:
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             profile: dev
-            runs-on:
+            runs_on:
               group: codex-runners
               labels: codex-linux-x64
           - runner: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             profile: dev
-            runs-on:
+            runs_on:
               group: codex-runners
               labels: codex-linux-arm64
           - runner: windows-latest

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -136,12 +136,18 @@ jobs:
             runs_on:
               group: codex-runners
               labels: codex-linux-arm64
-          - runner: windows-latest
+          - runner: windows-x64
             target: x86_64-pc-windows-msvc
             profile: dev
-          - runner: windows-11-arm
+            runs_on:
+              group: codex-runners
+              labels: codex-windows-x64
+          - runner: windows-arm64
             target: aarch64-pc-windows-msvc
             profile: dev
+            runs_on:
+              group: codex-runners
+              labels: codex-windows-arm64
 
           # Also run representative release builds on Mac and Linux because
           # there could be release-only build errors we want to catch.
@@ -156,12 +162,18 @@ jobs:
             runs_on:
               group: codex-runners
               labels: codex-linux-x64
-          - runner: windows-latest
+          - runner: windows-x64
             target: x86_64-pc-windows-msvc
             profile: release
-          - runner: windows-11-arm
+            runs_on:
+              group: codex-runners
+              labels: codex-windows-x64
+          - runner: windows-arm64
             target: aarch64-pc-windows-msvc
             profile: release
+            runs_on:
+              group: codex-runners
+              labels: codex-windows-arm64
 
     steps:
       - uses: actions/checkout@v6
@@ -383,12 +395,18 @@ jobs:
             runs_on:
               group: codex-runners
               labels: codex-linux-arm64
-          - runner: windows-latest
+          - runner: windows-x64
             target: x86_64-pc-windows-msvc
             profile: dev
-          - runner: windows-11-arm
+            runs_on:
+              group: codex-runners
+              labels: codex-windows-x64
+          - runner: windows-arm64
             target: aarch64-pc-windows-msvc
             profile: dev
+            runs_on:
+              group: codex-runners
+              labels: codex-windows-arm64
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -109,9 +109,11 @@ jobs:
           - runner: macos-14
             target: aarch64-apple-darwin
             profile: dev
+            runs_on: macos-14-xlarge
           - runner: macos-14
             target: x86_64-apple-darwin
             profile: dev
+            runs_on: macos-14-xlarge
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             profile: dev
@@ -150,6 +152,7 @@ jobs:
           - runner: macos-14
             target: aarch64-apple-darwin
             profile: release
+            runs_on: macos-14-xlarge
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-musl
             profile: release
@@ -371,6 +374,7 @@ jobs:
           - runner: macos-14
             target: aarch64-apple-darwin
             profile: dev
+            runs_on: macos-14-xlarge
           - runner: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             profile: dev


### PR DESCRIPTION
Upgrades runners in rust-ci.yaml to larger runners

ubuntu-24.04 (x64 and arm64) -> custom 16 core ubuntu 24.04 runners
macos-14 -> mac0s-15-xlarge
windows (x64 and arm64) -> custom 16 core windows runners
