### PR TITLE
feat: add support for read-only bind mounts in the linux sandbox

### DIFF
--- a/codex-rs/core/README.md
+++ b/codex-rs/core/README.md
@@ -10,6 +10,10 @@ Note that `codex-core` makes some assumptions about certain helper utilities bei
 
 Expects `/usr/bin/sandbox-exec` to be present.
 
+When using the workspace-write sandbox policy, the Seatbelt profile allows
+writes under the configured writable roots while keeping `.git` (directory or
+pointer file), the resolved `gitdir:` target, and `.codex` read-only.
+
 ### Linux
 
 Expects the binary containing `codex-core` to run the equivalent of `codex sandbox linux` (legacy alias: `codex debug landlock`) when `arg0` is `codex-linux-sandbox`. See the `codex-arg0` crate for details.

--- a/codex-rs/core/src/seatbelt.rs
+++ b/codex-rs/core/src/seatbelt.rs
@@ -177,12 +177,13 @@ mod tests {
     #[test]
     fn create_seatbelt_args_with_read_only_git_and_codex_subpaths() {
         // Create a temporary workspace with two writable roots: one containing
-        // top-level .git and .codex directories and one without them.
+        // top-level .git hooks/config and .codex directories and one without them.
         let tmp = TempDir::new().expect("tempdir");
         let PopulatedTmp {
             vulnerable_root,
             vulnerable_root_canonical,
-            dot_git_canonical,
+            dot_git_config_canonical,
+            dot_git_hooks_canonical,
             dot_codex_canonical,
             empty_root,
             empty_root_canonical,
@@ -223,13 +224,13 @@ mod tests {
         // Note that the policy includes:
         // - the base policy,
         // - read-only access to the filesystem,
-        // - write access to WRITABLE_ROOT_0 (but not its .git or .codex), WRITABLE_ROOT_1, and cwd as WRITABLE_ROOT_2.
+        // - write access to WRITABLE_ROOT_0 (but not its .git/hooks, .git/config, or .codex), WRITABLE_ROOT_1, and cwd as WRITABLE_ROOT_2.
         let expected_policy = format!(
             r#"{MACOS_SEATBELT_BASE_POLICY}
 ; allow read-only file operations
 (allow file-read*)
 (allow file-write*
-(require-all (subpath (param "WRITABLE_ROOT_0")) (require-not (subpath (param "WRITABLE_ROOT_0_RO_0"))) (require-not (subpath (param "WRITABLE_ROOT_0_RO_1"))) ) (subpath (param "WRITABLE_ROOT_1")) (subpath (param "WRITABLE_ROOT_2"))
+(require-all (subpath (param "WRITABLE_ROOT_0")) (require-not (subpath (param "WRITABLE_ROOT_0_RO_0"))) (require-not (subpath (param "WRITABLE_ROOT_0_RO_1"))) (require-not (subpath (param "WRITABLE_ROOT_0_RO_2"))) ) (subpath (param "WRITABLE_ROOT_1")) (subpath (param "WRITABLE_ROOT_2"))
 )
 "#,
         );
@@ -243,10 +244,14 @@ mod tests {
             ),
             format!(
                 "-DWRITABLE_ROOT_0_RO_0={}",
-                dot_git_canonical.to_string_lossy()
+                dot_git_hooks_canonical.to_string_lossy()
             ),
             format!(
                 "-DWRITABLE_ROOT_0_RO_1={}",
+                dot_git_config_canonical.to_string_lossy()
+            ),
+            format!(
+                "-DWRITABLE_ROOT_0_RO_2={}",
                 dot_codex_canonical.to_string_lossy()
             ),
             format!(
@@ -296,8 +301,8 @@ mod tests {
         );
 
         // Create a similar Seatbelt command that tries to write to a file in
-        // the .git folder, which should also be blocked.
-        let pre_commit_hook = dot_git_canonical.join("hooks").join("pre-commit");
+        // the .git/hooks folder, which should also be blocked.
+        let pre_commit_hook = dot_git_hooks_canonical.join("pre-commit");
         let shell_command_git: Vec<String> = [
             "bash",
             "-c",
@@ -367,12 +372,13 @@ mod tests {
     #[test]
     fn create_seatbelt_args_for_cwd_as_git_repo() {
         // Create a temporary workspace with two writable roots: one containing
-        // top-level .git and .codex directories and one without them.
+        // top-level .git hooks/config and .codex directories and one without them.
         let tmp = TempDir::new().expect("tempdir");
         let PopulatedTmp {
             vulnerable_root,
             vulnerable_root_canonical,
-            dot_git_canonical,
+            dot_git_config_canonical,
+            dot_git_hooks_canonical,
             dot_codex_canonical,
             ..
         } = populate_tmpdir(tmp.path());
@@ -419,13 +425,13 @@ mod tests {
         // Note that the policy includes:
         // - the base policy,
         // - read-only access to the filesystem,
-        // - write access to WRITABLE_ROOT_0 (but not its .git or .codex), WRITABLE_ROOT_1, and cwd as WRITABLE_ROOT_2.
+        // - write access to WRITABLE_ROOT_0 (but not its .git/hooks, .git/config, or .codex), WRITABLE_ROOT_1, and cwd as WRITABLE_ROOT_2.
         let expected_policy = format!(
             r#"{MACOS_SEATBELT_BASE_POLICY}
 ; allow read-only file operations
 (allow file-read*)
 (allow file-write*
-(require-all (subpath (param "WRITABLE_ROOT_0")) (require-not (subpath (param "WRITABLE_ROOT_0_RO_0"))) (require-not (subpath (param "WRITABLE_ROOT_0_RO_1"))) ) (subpath (param "WRITABLE_ROOT_1")){tempdir_policy_entry}
+(require-all (subpath (param "WRITABLE_ROOT_0")) (require-not (subpath (param "WRITABLE_ROOT_0_RO_0"))) (require-not (subpath (param "WRITABLE_ROOT_0_RO_1"))) (require-not (subpath (param "WRITABLE_ROOT_0_RO_2"))) ) (subpath (param "WRITABLE_ROOT_1")){tempdir_policy_entry}
 )
 "#,
         );
@@ -439,10 +445,14 @@ mod tests {
             ),
             format!(
                 "-DWRITABLE_ROOT_0_RO_0={}",
-                dot_git_canonical.to_string_lossy()
+                dot_git_hooks_canonical.to_string_lossy()
             ),
             format!(
                 "-DWRITABLE_ROOT_0_RO_1={}",
+                dot_git_config_canonical.to_string_lossy()
+            ),
+            format!(
+                "-DWRITABLE_ROOT_0_RO_2={}",
                 dot_codex_canonical.to_string_lossy()
             ),
             format!(
@@ -480,7 +490,8 @@ mod tests {
         /// have full privileges the next time it ran in that repo.
         vulnerable_root: PathBuf,
         vulnerable_root_canonical: PathBuf,
-        dot_git_canonical: PathBuf,
+        dot_git_config_canonical: PathBuf,
+        dot_git_hooks_canonical: PathBuf,
         dot_codex_canonical: PathBuf,
 
         /// Path without .git or .codex subfolders.
@@ -517,12 +528,15 @@ mod tests {
             .canonicalize()
             .expect("canonicalize vulnerable_root");
         let dot_git_canonical = vulnerable_root_canonical.join(".git");
+        let dot_git_config_canonical = dot_git_canonical.join("config");
+        let dot_git_hooks_canonical = dot_git_canonical.join("hooks");
         let dot_codex_canonical = vulnerable_root_canonical.join(".codex");
         let empty_root_canonical = empty_root.canonicalize().expect("canonicalize empty_root");
         PopulatedTmp {
             vulnerable_root,
             vulnerable_root_canonical,
-            dot_git_canonical,
+            dot_git_config_canonical,
+            dot_git_hooks_canonical,
             dot_codex_canonical,
             empty_root,
             empty_root_canonical,

--- a/codex-rs/core/src/seatbelt.rs
+++ b/codex-rs/core/src/seatbelt.rs
@@ -296,7 +296,7 @@ mod tests {
         );
 
         // Create a similar Seatbelt command that tries to write to a file in
-        // the .git/hooks folder, which should also be blocked.
+        // the .git folder, which should also be blocked.
         let pre_commit_hook = dot_git_canonical.join("hooks").join("pre-commit");
         let shell_command_git: Vec<String> = [
             "bash",

--- a/codex-rs/linux-sandbox/README.md
+++ b/codex-rs/linux-sandbox/README.md
@@ -10,10 +10,9 @@ This crate is responsible for producing:
 ## Git safety mounts (Linux)
 
 When the sandbox policy allows workspace writes, the Linux sandbox now uses a
-user namespace plus a mount namespace to bind-mount a handful of high-risk
-paths read-only before applying Landlock rules. This keeps `.git/hooks/` and
-`.git/config` immutable while still allowing writes to `.git/index`, refs, and
-objects.
+user namespace plus a mount namespace to bind-mount `.git` read-only before
+applying Landlock rules. This keeps Git metadata immutable while still
+allowing writes to other workspace files.
 
 ### How this plays with Landlock
 
@@ -36,7 +35,7 @@ set -euo pipefail
 
 echo "should fail" > .git/config && exit 1 || true
 echo "should fail" > .git/hooks/pre-commit && exit 1 || true
-echo "ok" > .git/index.lock
+echo "should fail" > .git/index.lock && exit 1 || true
 echo "ok" > sandbox-write-test.txt
 '
 ```
@@ -45,5 +44,5 @@ Expected behavior:
 
 - Writes to `.git/config` fail with `Read-only file system`.
 - Creating or modifying files under `.git/hooks/` fails.
-- Writing `.git/index.lock` succeeds.
+- Writing `.git/index.lock` fails (since `.git` is read-only).
 - Writing a normal repo file succeeds.

--- a/codex-rs/linux-sandbox/README.md
+++ b/codex-rs/linux-sandbox/README.md
@@ -12,7 +12,8 @@ This crate is responsible for producing:
 When the sandbox policy allows workspace writes, the Linux sandbox now uses a
 user namespace plus a mount namespace to bind-mount `.git` read-only before
 applying Landlock rules. This keeps Git metadata immutable while still
-allowing writes to other workspace files.
+allowing writes to other workspace files, including worktree setups where
+`.git` is a pointer file.
 
 ### How this plays with Landlock
 

--- a/codex-rs/linux-sandbox/README.md
+++ b/codex-rs/linux-sandbox/README.md
@@ -6,3 +6,44 @@ This crate is responsible for producing:
 - a lib crate that exposes the business logic of the executable as `run_main()` so that
   - the `codex-exec` CLI can check if its arg0 is `codex-linux-sandbox` and, if so, execute as if it were `codex-linux-sandbox`
   - this should also be true of the `codex` multitool CLI
+
+## Git safety mounts (Linux)
+
+When the sandbox policy allows workspace writes, the Linux sandbox now uses a
+user namespace plus a mount namespace to bind-mount a handful of high-risk
+paths read-only before applying Landlock rules. This keeps `.git/hooks/` and
+`.git/config` immutable while still allowing writes to `.git/index`, refs, and
+objects.
+
+### How this plays with Landlock
+
+Mount permissions and Landlock intersect: if a bind mount is read-only, writes
+are denied even if Landlock would allow them. For that reason, the sandbox sets
+up the read-only mounts *before* calling `landlock_restrict_self()` and then
+applies Landlock rules on top.
+
+### Quick manual test
+
+Run the sandbox directly with a workspace-write policy (from a Git repository
+root):
+
+```bash
+codex-linux-sandbox \
+  --sandbox-policy-cwd "$PWD" \
+  --sandbox-policy '{"type":"workspace-write"}' \
+  -- bash -lc '
+set -euo pipefail
+
+echo "should fail" > .git/config && exit 1 || true
+echo "should fail" > .git/hooks/pre-commit && exit 1 || true
+echo "ok" > .git/index.lock
+echo "ok" > sandbox-write-test.txt
+'
+```
+
+Expected behavior:
+
+- Writes to `.git/config` fail with `Read-only file system`.
+- Creating or modifying files under `.git/hooks/` fails.
+- Writing `.git/index.lock` succeeds.
+- Writing a normal repo file succeeds.

--- a/codex-rs/linux-sandbox/src/landlock.rs
+++ b/codex-rs/linux-sandbox/src/landlock.rs
@@ -7,6 +7,8 @@ use codex_core::error::SandboxErr;
 use codex_core::protocol::SandboxPolicy;
 use codex_utils_absolute_path::AbsolutePathBuf;
 
+use crate::mounts::apply_read_only_mounts;
+
 use landlock::ABI;
 use landlock::Access;
 use landlock::AccessFs;
@@ -31,6 +33,10 @@ pub(crate) fn apply_sandbox_policy_to_current_thread(
     sandbox_policy: &SandboxPolicy,
     cwd: &Path,
 ) -> Result<()> {
+    if !sandbox_policy.has_full_disk_write_access() {
+        apply_read_only_mounts(sandbox_policy, cwd)?;
+    }
+
     if !sandbox_policy.has_full_network_access() {
         install_network_seccomp_filter_on_current_thread()?;
     }

--- a/codex-rs/linux-sandbox/src/lib.rs
+++ b/codex-rs/linux-sandbox/src/lib.rs
@@ -2,6 +2,8 @@
 mod landlock;
 #[cfg(target_os = "linux")]
 mod linux_run_main;
+#[cfg(target_os = "linux")]
+mod mounts;
 
 #[cfg(target_os = "linux")]
 pub fn run_main() -> ! {

--- a/codex-rs/linux-sandbox/src/mounts.rs
+++ b/codex-rs/linux-sandbox/src/mounts.rs
@@ -1,0 +1,153 @@
+use std::ffi::CString;
+use std::os::unix::ffi::OsStrExt;
+use std::path::Path;
+
+use codex_core::error::CodexErr;
+use codex_core::error::Result;
+use codex_core::protocol::SandboxPolicy;
+use codex_core::protocol::WritableRoot;
+use codex_utils_absolute_path::AbsolutePathBuf;
+
+pub(crate) fn apply_read_only_mounts(sandbox_policy: &SandboxPolicy, cwd: &Path) -> Result<()> {
+    let writable_roots = sandbox_policy.get_writable_roots_with_cwd(cwd);
+    let mount_targets = collect_read_only_mount_targets(&writable_roots)?;
+    if mount_targets.is_empty() {
+        return Ok(());
+    }
+
+    if is_running_as_root() {
+        unshare_mount_namespace()?;
+    } else {
+        unshare_user_and_mount_namespaces()?;
+        write_user_namespace_maps()?;
+    }
+    make_mounts_private()?;
+
+    for target in mount_targets {
+        bind_mount_read_only(target.as_path())?;
+    }
+
+    Ok(())
+}
+
+fn collect_read_only_mount_targets(
+    writable_roots: &[WritableRoot],
+) -> Result<Vec<AbsolutePathBuf>> {
+    let mut targets = Vec::new();
+    for writable_root in writable_roots {
+        ensure_gitdir_is_directory(&writable_root.root)?;
+        for ro_subpath in &writable_root.read_only_subpaths {
+            if !ro_subpath.as_path().exists() {
+                return Err(CodexErr::UnsupportedOperation(format!(
+                    "Sandbox expected to protect {path}, but it does not exist. Ensure the repository contains this path or create it before running Codex.",
+                    path = ro_subpath.as_path().display()
+                )));
+            }
+            targets.push(ro_subpath.clone());
+        }
+    }
+    Ok(targets)
+}
+
+fn ensure_gitdir_is_directory(root: &AbsolutePathBuf) -> Result<()> {
+    #[allow(clippy::expect_used)]
+    let dot_git = root.join(".git").expect(".git is a valid relative path");
+    if dot_git.as_path().is_file() {
+        return Err(CodexErr::UnsupportedOperation(format!(
+            "Sandbox protection requires .git to be a directory, but {path} is a file. If this is a worktree, protect the real gitdir (from `git rev-parse --git-dir`) and consider making the .git pointer file read-only.",
+            path = dot_git.as_path().display()
+        )));
+    }
+    Ok(())
+}
+
+fn unshare_mount_namespace() -> Result<()> {
+    let result = unsafe { libc::unshare(libc::CLONE_NEWNS) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(())
+}
+
+fn unshare_user_and_mount_namespaces() -> Result<()> {
+    let result = unsafe { libc::unshare(libc::CLONE_NEWUSER | libc::CLONE_NEWNS) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(())
+}
+
+fn is_running_as_root() -> bool {
+    unsafe { libc::geteuid() == 0 }
+}
+
+fn write_user_namespace_maps() -> Result<()> {
+    write_proc_file("/proc/self/setgroups", "deny\n")?;
+
+    let uid = unsafe { libc::getuid() };
+    let gid = unsafe { libc::getgid() };
+    write_proc_file("/proc/self/uid_map", format!("0 {uid} 1\n"))?;
+    write_proc_file("/proc/self/gid_map", format!("0 {gid} 1\n"))?;
+    Ok(())
+}
+
+fn write_proc_file(path: &str, contents: impl AsRef<[u8]>) -> Result<()> {
+    std::fs::write(path, contents)?;
+    Ok(())
+}
+
+fn make_mounts_private() -> Result<()> {
+    let root = CString::new("/").map_err(|_| {
+        CodexErr::UnsupportedOperation("Sandbox mount path contains NUL byte: /".to_string())
+    })?;
+    let result = unsafe {
+        libc::mount(
+            std::ptr::null(),
+            root.as_ptr(),
+            std::ptr::null(),
+            libc::MS_REC | libc::MS_PRIVATE,
+            std::ptr::null(),
+        )
+    };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok(())
+}
+
+fn bind_mount_read_only(path: &Path) -> Result<()> {
+    let c_path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+        CodexErr::UnsupportedOperation(format!(
+            "Sandbox mount path contains NUL byte: {path}",
+            path = path.display()
+        ))
+    })?;
+
+    let bind_result = unsafe {
+        libc::mount(
+            c_path.as_ptr(),
+            c_path.as_ptr(),
+            std::ptr::null(),
+            libc::MS_BIND,
+            std::ptr::null(),
+        )
+    };
+    if bind_result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    let remount_result = unsafe {
+        libc::mount(
+            c_path.as_ptr(),
+            c_path.as_ptr(),
+            std::ptr::null(),
+            libc::MS_BIND | libc::MS_REMOUNT | libc::MS_RDONLY,
+            std::ptr::null(),
+        )
+    };
+    if remount_result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+
+    Ok(())
+}

--- a/codex-rs/linux-sandbox/tests/suite/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/suite/landlock.rs
@@ -10,6 +10,7 @@ use codex_core::sandboxing::SandboxPermissions;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use std::collections::HashMap;
 use std::path::PathBuf;
+use std::process::Command;
 use tempfile::NamedTempFile;
 
 // At least on GitHub CI, the arm64 tests appear to need longer timeouts.
@@ -79,6 +80,51 @@ async fn run_cmd(cmd: &[&str], writable_roots: &[PathBuf], timeout_ms: u64) {
     }
 }
 
+#[expect(clippy::expect_used)]
+async fn assert_write_blocked(cmd: &[&str], writable_roots: &[PathBuf], timeout_ms: u64) {
+    let cwd = std::env::current_dir().expect("cwd should exist");
+    let sandbox_cwd = cwd.clone();
+    let params = ExecParams {
+        command: cmd.iter().copied().map(str::to_owned).collect(),
+        cwd,
+        expiration: timeout_ms.into(),
+        env: create_env_from_core_vars(),
+        sandbox_permissions: SandboxPermissions::UseDefault,
+        justification: None,
+        arg0: None,
+    };
+
+    let sandbox_policy = SandboxPolicy::WorkspaceWrite {
+        writable_roots: writable_roots
+            .iter()
+            .map(|p| AbsolutePathBuf::try_from(p.as_path()).unwrap())
+            .collect(),
+        network_access: false,
+        exclude_tmpdir_env_var: true,
+        exclude_slash_tmp: true,
+    };
+    let sandbox_program = env!("CARGO_BIN_EXE_codex-linux-sandbox");
+    let codex_linux_sandbox_exe = Some(PathBuf::from(sandbox_program));
+    let result = process_exec_tool_call(
+        params,
+        &sandbox_policy,
+        sandbox_cwd.as_path(),
+        &codex_linux_sandbox_exe,
+        None,
+    )
+    .await;
+
+    match result {
+        Ok(output) => {
+            if output.exit_code == 0 {
+                panic!("expected command to fail, but exit code was 0");
+            }
+        }
+        Err(CodexErr::Sandbox(SandboxErr::Denied { .. })) => {}
+        Err(err) => panic!("expected sandbox denial, got: {err:?}"),
+    }
+}
+
 #[tokio::test]
 async fn test_root_read() {
     run_cmd(&["ls", "-l", "/bin"], &[], SHORT_TIMEOUT_MS).await;
@@ -122,6 +168,82 @@ async fn test_writable_root() {
         &[tmpdir.path().to_path_buf()],
         // We have seen timeouts when running this test in CI on GitHub,
         // so we are using a generous timeout until we can diagnose further.
+        LONG_TIMEOUT_MS,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_git_dir_write_blocked() {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let repo_root = tmpdir.path();
+    Command::new("git")
+        .arg("init")
+        .arg(".")
+        .current_dir(repo_root)
+        .output()
+        .expect("git init .");
+
+    let git_config = repo_root.join(".git").join("config");
+    let git_index_lock = repo_root.join(".git").join("index.lock");
+
+    assert_write_blocked(
+        &[
+            "bash",
+            "-lc",
+            &format!("echo pwned > {}", git_config.to_string_lossy()),
+        ],
+        &[repo_root.to_path_buf()],
+        LONG_TIMEOUT_MS,
+    )
+    .await;
+
+    assert_write_blocked(
+        &[
+            "bash",
+            "-lc",
+            &format!("echo pwned > {}", git_index_lock.to_string_lossy()),
+        ],
+        &[repo_root.to_path_buf()],
+        LONG_TIMEOUT_MS,
+    )
+    .await;
+}
+
+#[tokio::test]
+async fn test_git_pointer_file_blocks_gitdir_writes() {
+    let tmpdir = tempfile::tempdir().unwrap();
+    let repo_root = tmpdir.path();
+    let gitdir = repo_root.join("actual-gitdir");
+    std::fs::create_dir_all(&gitdir).unwrap();
+
+    let gitdir_config = gitdir.join("config");
+    std::fs::write(&gitdir_config, "[core]\n\trepositoryformatversion = 0\n").unwrap();
+
+    std::fs::write(
+        repo_root.join(".git"),
+        format!("gitdir: {}\n", gitdir.to_string_lossy()),
+    )
+    .unwrap();
+
+    assert_write_blocked(
+        &[
+            "bash",
+            "-lc",
+            &format!("echo pwned > {}", gitdir_config.to_string_lossy()),
+        ],
+        &[repo_root.to_path_buf()],
+        LONG_TIMEOUT_MS,
+    )
+    .await;
+
+    assert_write_blocked(
+        &[
+            "bash",
+            "-lc",
+            &format!("echo pwned > {}", repo_root.join(".git").to_string_lossy()),
+        ],
+        &[repo_root.to_path_buf()],
         LONG_TIMEOUT_MS,
     )
     .await;

--- a/codex-rs/linux-sandbox/tests/suite/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/suite/landlock.rs
@@ -1,4 +1,5 @@
 #![cfg(target_os = "linux")]
+#![allow(clippy::unwrap_used)]
 use codex_core::config::types::ShellEnvironmentPolicy;
 use codex_core::error::CodexErr;
 use codex_core::error::SandboxErr;

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -347,7 +347,7 @@ pub enum SandboxPolicy {
 /// A writable root path accompanied by a list of subpaths that should remain
 /// read‑only even when the root is writable. This is primarily used to ensure
 /// that folders containing files that could be modified to escalate the
-/// privileges of the agent (e.g. `.codex`, `.git`) under
+/// privileges of the agent (e.g. `.codex`, `.git`, notably `.git/hooks`) under
 /// a writable root are not modified by the agent.
 #[derive(Debug, Clone, PartialEq, Eq, JsonSchema)]
 pub struct WritableRoot {
@@ -500,6 +500,9 @@ impl SandboxPolicy {
                         let top_level_git = writable_root
                             .join(".git")
                             .expect(".git is a valid relative path");
+                        // This applies to typical repos (directory .git), worktrees/submodules
+                        // (file .git with gitdir pointer), and bare repos when the gitdir is the
+                        // writable root itself.
                         if top_level_git.as_path().is_dir() || top_level_git.as_path().is_file() {
                             subpaths.push(top_level_git);
                         }

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -4,6 +4,7 @@
 //! between user and agent.
 
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::fmt;
 use std::path::Path;
 use std::path::PathBuf;
@@ -495,7 +496,7 @@ impl SandboxPolicy {
                 roots
                     .into_iter()
                     .map(|writable_root| {
-                        let mut subpaths = Vec::new();
+                        let mut subpaths: Vec<AbsolutePathBuf> = Vec::new();
                         #[allow(clippy::expect_used)]
                         let top_level_git = writable_root
                             .join(".git")
@@ -503,7 +504,17 @@ impl SandboxPolicy {
                         // This applies to typical repos (directory .git), worktrees/submodules
                         // (file .git with gitdir pointer), and bare repos when the gitdir is the
                         // writable root itself.
-                        if top_level_git.as_path().is_dir() || top_level_git.as_path().is_file() {
+                        let top_level_git_is_file = top_level_git.as_path().is_file();
+                        let top_level_git_is_dir = top_level_git.as_path().is_dir();
+                        if top_level_git_is_dir || top_level_git_is_file {
+                            if top_level_git_is_file && is_git_pointer_file(&top_level_git)
+                                && let Some(gitdir) = resolve_gitdir_from_file(&top_level_git)
+                                    && !subpaths
+                                        .iter()
+                                        .any(|subpath| subpath.as_path() == gitdir.as_path())
+                                    {
+                                        subpaths.push(gitdir);
+                                    }
                             subpaths.push(top_level_git);
                         }
                         #[allow(clippy::expect_used)]
@@ -522,6 +533,71 @@ impl SandboxPolicy {
             }
         }
     }
+}
+
+fn is_git_pointer_file(path: &AbsolutePathBuf) -> bool {
+    path.as_path().is_file() && path.as_path().file_name() == Some(OsStr::new(".git"))
+}
+
+fn resolve_gitdir_from_file(dot_git: &AbsolutePathBuf) -> Option<AbsolutePathBuf> {
+    let contents = match std::fs::read_to_string(dot_git.as_path()) {
+        Ok(contents) => contents,
+        Err(err) => {
+            error!(
+                "Failed to read {path} for gitdir pointer: {err}",
+                path = dot_git.as_path().display()
+            );
+            return None;
+        }
+    };
+
+    let trimmed = contents.trim();
+    let (_, gitdir_raw) = match trimmed.split_once(':') {
+        Some(parts) => parts,
+        None => {
+            error!(
+                "Expected {path} to contain a gitdir pointer, but it did not match `gitdir: <path>`.",
+                path = dot_git.as_path().display()
+            );
+            return None;
+        }
+    };
+    let gitdir_raw = gitdir_raw.trim();
+    if gitdir_raw.is_empty() {
+        error!(
+            "Expected {path} to contain a gitdir pointer, but it was empty.",
+            path = dot_git.as_path().display()
+        );
+        return None;
+    }
+    let base = match dot_git.as_path().parent() {
+        Some(base) => base,
+        None => {
+            error!(
+                "Unable to resolve parent directory for {path}.",
+                path = dot_git.as_path().display()
+            );
+            return None;
+        }
+    };
+    let gitdir_path = match AbsolutePathBuf::resolve_path_against_base(gitdir_raw, base) {
+        Ok(path) => path,
+        Err(err) => {
+            error!(
+                "Failed to resolve gitdir path {gitdir_raw} from {path}: {err}",
+                path = dot_git.as_path().display()
+            );
+            return None;
+        }
+    };
+    if !gitdir_path.as_path().exists() {
+        error!(
+            "Resolved gitdir path {path} does not exist.",
+            path = gitdir_path.as_path().display()
+        );
+        return None;
+    }
+    Some(gitdir_path)
 }
 
 /// Event Queue Entry - events from agent

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -507,14 +507,15 @@ impl SandboxPolicy {
                         let top_level_git_is_file = top_level_git.as_path().is_file();
                         let top_level_git_is_dir = top_level_git.as_path().is_dir();
                         if top_level_git_is_dir || top_level_git_is_file {
-                            if top_level_git_is_file && is_git_pointer_file(&top_level_git)
+                            if top_level_git_is_file
+                                && is_git_pointer_file(&top_level_git)
                                 && let Some(gitdir) = resolve_gitdir_from_file(&top_level_git)
-                                    && !subpaths
-                                        .iter()
-                                        .any(|subpath| subpath.as_path() == gitdir.as_path())
-                                    {
-                                        subpaths.push(gitdir);
-                                    }
+                                && !subpaths
+                                    .iter()
+                                    .any(|subpath| subpath.as_path() == gitdir.as_path())
+                            {
+                                subpaths.push(gitdir);
+                            }
                             subpaths.push(top_level_git);
                         }
                         #[allow(clippy::expect_used)]

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -347,7 +347,7 @@ pub enum SandboxPolicy {
 /// A writable root path accompanied by a list of subpaths that should remain
 /// read‑only even when the root is writable. This is primarily used to ensure
 /// that folders containing files that could be modified to escalate the
-/// privileges of the agent (e.g. `.codex`, `.git`, notably `.git/hooks`) under
+/// privileges of the agent (e.g. `.codex`, `.git/hooks`, `.git/config`) under
 /// a writable root are not modified by the agent.
 #[derive(Debug, Clone, PartialEq, Eq, JsonSchema)]
 pub struct WritableRoot {
@@ -501,7 +501,16 @@ impl SandboxPolicy {
                             .join(".git")
                             .expect(".git is a valid relative path");
                         if top_level_git.as_path().is_dir() {
-                            subpaths.push(top_level_git);
+                            #[allow(clippy::expect_used)]
+                            let git_hooks = top_level_git
+                                .join("hooks")
+                                .expect(".git/hooks is a valid relative path");
+                            subpaths.push(git_hooks);
+                            #[allow(clippy::expect_used)]
+                            let git_config = top_level_git
+                                .join("config")
+                                .expect(".git/config is a valid relative path");
+                            subpaths.push(git_config);
                         }
                         #[allow(clippy::expect_used)]
                         let top_level_codex = writable_root

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -347,7 +347,7 @@ pub enum SandboxPolicy {
 /// A writable root path accompanied by a list of subpaths that should remain
 /// read‑only even when the root is writable. This is primarily used to ensure
 /// that folders containing files that could be modified to escalate the
-/// privileges of the agent (e.g. `.codex`, `.git/hooks`, `.git/config`) under
+/// privileges of the agent (e.g. `.codex`, `.git`) under
 /// a writable root are not modified by the agent.
 #[derive(Debug, Clone, PartialEq, Eq, JsonSchema)]
 pub struct WritableRoot {
@@ -500,17 +500,8 @@ impl SandboxPolicy {
                         let top_level_git = writable_root
                             .join(".git")
                             .expect(".git is a valid relative path");
-                        if top_level_git.as_path().is_dir() {
-                            #[allow(clippy::expect_used)]
-                            let git_hooks = top_level_git
-                                .join("hooks")
-                                .expect(".git/hooks is a valid relative path");
-                            subpaths.push(git_hooks);
-                            #[allow(clippy::expect_used)]
-                            let git_config = top_level_git
-                                .join("config")
-                                .expect(".git/config is a valid relative path");
-                            subpaths.push(git_config);
+                        if top_level_git.as_path().is_dir() || top_level_git.as_path().is_file() {
+                            subpaths.push(top_level_git);
                         }
                         #[allow(clippy::expect_used)]
                         let top_level_codex = writable_root


### PR DESCRIPTION
### Motivation

- Landlock alone cannot prevent writes to sensitive in-repo files like `.git/` when the repo root is writable, so explicit mount restrictions are required for those paths.
- The sandbox must set up any mounts before calling Landlock so Landlock can still be applied afterwards and the two mechanisms compose correctly.

### Description

- Add a new `linux-sandbox` helper `apply_read_only_mounts` in `linux-sandbox/src/mounts.rs` that: unshares namespaces, maps uids/gids when required, makes mounts private, bind-mounts targets, and remounts them read-only.
- Wire the mount step into the sandbox flow by calling `apply_read_only_mounts(...)` before network/seccomp and before applying Landlock rules in `linux-sandbox/src/landlock.rs`.