### PR TITLE
fix(windows-sandbox-rs) bump SETUP_VERSION

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
@@ -26,7 +26,7 @@ use windows_sys::Win32::Security::CheckTokenMembership;
 use windows_sys::Win32::Security::FreeSid;
 use windows_sys::Win32::Security::SECURITY_NT_AUTHORITY;
 
-pub const SETUP_VERSION: u32 = 2;
+pub const SETUP_VERSION: u32 = 3;
 pub const OFFLINE_USERNAME: &str = "CodexSandboxOffline";
 pub const ONLINE_USERNAME: &str = "CodexSandboxOnline";
 const SECURITY_BUILTIN_DOMAIN_RID: u32 = 0x0000_0020;


### PR DESCRIPTION
## Summary
Bumps the windows setup version, to re-trigger windows sandbox setup for users in the experimental sandbox. We've seen some drift in the ACL controls, amongst a few other changes. Hopefully this should fix #9062.

## Testing
- [x] Tested locally