### PR TITLE
feat: return an error if the image sent by the user is a bad image

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2613,9 +2613,18 @@ pub(crate) async fn run_turn(
             Err(CodexErr::InvalidImageRequest()) => {
                 let mut state = sess.state.lock().await;
                 error_or_panic(
-                    "Invalid image detected, replacing it in the last turn to prevent poisoning",
+                    "Invalid image detected; sanitizing tool output to prevent poisoning",
                 );
-                state.history.replace_last_turn_images("Invalid image");
+                if state.history.replace_last_turn_images("Invalid image") {
+                    continue;
+                }
+                let event = EventMsg::Error(ErrorEvent {
+                    message: "Invalid image in your last message. Please remove it and try again."
+                        .to_string(),
+                    codex_error_info: Some(CodexErrorInfo::BadRequest),
+                });
+                sess.send_event(&turn_context, event).await;
+                break;
             }
             Err(e) => {
                 info!("Turn error: {e:#}");

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -124,34 +124,35 @@ impl ContextManager {
         self.items = items;
     }
 
-    pub(crate) fn replace_last_turn_images(&mut self, placeholder: &str) {
-        let Some(last_item) = self.items.last_mut() else {
-            return;
+    /// Replace image content in the last turn if it originated from a tool output.
+    /// Returns true when a tool image was replaced, false otherwise.
+    pub(crate) fn replace_last_turn_images(&mut self, placeholder: &str) -> bool {
+        let Some(index) = self.items.iter().rposition(|item| {
+            matches!(item, ResponseItem::FunctionCallOutput { .. })
+                || matches!(item, ResponseItem::Message { role, .. } if role == "user")
+        }) else {
+            return false;
         };
 
-        match last_item {
-            ResponseItem::Message { role, content, .. } if role == "user" => {
-                for item in content.iter_mut() {
-                    if matches!(item, ContentItem::InputImage { .. }) {
-                        *item = ContentItem::InputText {
-                            text: placeholder.to_string(),
-                        };
-                    }
-                }
-            }
+        match &mut self.items[index] {
             ResponseItem::FunctionCallOutput { output, .. } => {
                 let Some(content_items) = output.content_items.as_mut() else {
-                    return;
+                    return false;
                 };
+                let mut replaced = false;
+                let placeholder = placeholder.to_string();
                 for item in content_items.iter_mut() {
                     if matches!(item, FunctionCallOutputContentItem::InputImage { .. }) {
                         *item = FunctionCallOutputContentItem::InputText {
-                            text: placeholder.to_string(),
+                            text: placeholder.clone(),
                         };
+                        replaced = true;
                     }
                 }
+                replaced
             }
-            _ => {}
+            ResponseItem::Message { role, .. } if role == "user" => false,
+            _ => false,
         }
     }
 


### PR DESCRIPTION
## Before
When we detect an `InvalidImageRequest`, we replace the image by a placeholder and keep going

## Now
In such `InvalidImageRequest`, we check if the image is due to a user message or a tool call output. For tool call output we still replace it with a placeholder to avoid breaking the agentic loop bu tif this is because of a user message, we send an error to the user