### PR TITLE
docs: clarify notify config placement

### DIFF
--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -1,3 +1,5 @@
 # Sample configuration
 
 For a sample configuration file, see [this documentation](https://developers.openai.com/codex/config-sample).
+
+Note: `notify` is a top-level key in `~/.codex/config.toml` (not under `[tui]`).


### PR DESCRIPTION
Fixes #8030.

Adds a short note to `docs/example-config.md` clarifying that `notify` is a top-level `~/.codex/config.toml` key (not under `[tui]`).