### PR TITLE
Fix: Add shell quoting instructions for paths with special characters

### DIFF
--- a/codex-rs/core/prompt_with_apply_patch_instructions.md
+++ b/codex-rs/core/prompt_with_apply_patch_instructions.md
@@ -263,6 +263,12 @@ When using the shell, you must adhere to the following guidelines:
 
 - When searching for text or files, prefer using `rg` or `rg --files` respectively because `rg` is much faster than alternatives like `grep`. (If the `rg` command is not found, then use alternatives.)
 - Do not use python scripts to attempt to output larger chunks of a file.
+- **Always quote file paths that contain spaces or special characters with double quotes.** For example:
+  - ✓ Correct: `sed -n '1,220p' "portal/app/(home)/_ui/ActivityList.tsx"`
+  - ✗ Wrong: `sed -n '1,220p' portal/app/(home)/_ui/ActivityList.tsx`
+  - ✓ Correct: `cat "src/routes/[id]/page.tsx"`
+  - ✗ Wrong: `cat src/routes/[id]/page.tsx`
+  - Special characters include: parentheses `()`, brackets `[]`, asterisks `*`, question marks `?`, spaces, and other glob metacharacters
 
 ## `update_plan`
 

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -311,11 +311,14 @@ Examples of valid command strings:
 - recursive grep: ["powershell.exe", "-Command", "Get-ChildItem -Path C:\\myrepo -Recurse | Select-String -Pattern 'TODO' -CaseSensitive"]
 - ps aux | grep python: ["powershell.exe", "-Command", "Get-Process | Where-Object { $_.ProcessName -like '*python*' }"]
 - setting an env var: ["powershell.exe", "-Command", "$env:FOO='bar'; echo $env:FOO"]
-- running an inline Python script: ["powershell.exe", "-Command", "@'\\nprint('Hello, world!')\\n'@ | python -"]"#
+- running an inline Python script: ["powershell.exe", "-Command", "@'\\\nprint('Hello, world!')\\\n'@ | python -"]
+
+Important: Always quote file paths containing spaces or special characters with single quotes in PowerShell."#
     } else {
         r#"Runs a shell command and returns its output.
 - The arguments to `shell` will be passed to execvp(). Most terminal commands should be prefixed with ["bash", "-lc"].
-- Always set the `workdir` param when using the shell function. Do not use `cd` unless absolutely necessary."#
+- Always set the `workdir` param when using the shell function. Do not use `cd` unless absolutely necessary.
+- Always quote file paths containing spaces or glob metacharacters (parentheses, brackets, asterisks, question marks) with double quotes."#
     }.to_string();
 
     ToolSpec::Function(ResponsesApiTool {
@@ -385,10 +388,13 @@ Examples of valid command strings:
 - recursive grep: "Get-ChildItem -Path C:\\myrepo -Recurse | Select-String -Pattern 'TODO' -CaseSensitive"
 - ps aux | grep python: "Get-Process | Where-Object { $_.ProcessName -like '*python*' }"
 - setting an env var: "$env:FOO='bar'; echo $env:FOO"
-- running an inline Python script: "@'\\nprint('Hello, world!')\\n'@ | python -"#
+- running an inline Python script: "@'\\\nprint('Hello, world!')\\\n'@ | python -"
+
+Important: Always quote file paths containing spaces or special characters with single quotes in PowerShell."#
     } else {
         r#"Runs a shell command and returns its output.
-- Always set the `workdir` param when using the shell_command function. Do not use `cd` unless absolutely necessary."#
+- Always set the `workdir` param when using the shell_command function. Do not use `cd` unless absolutely necessary.
+- Always quote file paths containing spaces or glob metacharacters (parentheses, brackets, asterisks, question marks) with double quotes."#
     }.to_string();
 
     ToolSpec::Function(ResponsesApiTool {


### PR DESCRIPTION
Fixes #7979

This PR addresses the issue where Codex CLI generates shell commands with unquoted file paths containing glob metacharacters (parentheses, brackets, asterisks, question marks), causing zsh and other shells to fail with "no matches found" errors.
The fix adds explicit instructions to the system prompt and tool descriptions to teach the model proper shell quoting practices for file paths with special characters.

Changes
- **System Prompt** (`codex-rs/core/prompt_with_apply_patch_instructions.md`): Added clear guidance with examples showing correct vs incorrect quoting
- **Shell Tool Descriptions** (`codex-rs/core/src/tools/spec.rs`): Updated both Unix and Windows tool descriptions for `shell` and `shell_command` tools to include quoting instructions
 Impact

This particularly benefits:
- Next.js projects with route groups: `app/(dashboard)/page.tsx`
- Next.js projects with dynamic routes: `app/[id]/page.tsx`
- Any codebase with spaces or special characters in file paths

Why This Approach?
Instead of adding an automated escaping layer (which could break valid glob patterns or add complexity), this fix teaches the model to generate correct commands from the start. This is:
- More flexible (model can intelligently decide when quoting is needed)
- Less error-prone (no risk of breaking intentional glob usage like `rm *.log`)
- More maintainable (simple instruction changes vs complex escaping logic)
- Zero runtime overhead

Testing
Since this is a prompt/instruction change, testing requires running Codex with the updated instructions. The model should now generate commands like:
- ✅ `cat "app/(home)/page.tsx"` instead of ❌ `cat app/(home)/page.tsx`
- ✅ `sed -n '1,220p' "routes/[id]/layout.tsx"` instead of ❌ `sed -n '1,220p' routes/[id]/layout.tsx`

Notes
Users who added workarounds to their `AGENTS.md` files can now remove them as this fix is applied globally across all Codex instances.