### PR TITLE
chore: prefer indoc for multiline strings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@ In the codex-rs folder where the rust code lives:
 
 - Crate names are prefixed with `codex-`. For example, the `core` folder's crate is named `codex-core`
 - When using format! and you can inline variables into {}, always do that.
+- Use `indoc!` for multi-line strings instead of embedding `\n` escapes or using awkwardly-wrapped raw strings.
 - Install any commands the repo relies on (for example `just`, `rg`, or `cargo-insta`) if they aren't already available before running instructions here.
 - Never add or modify any code related to `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR` or `CODEX_SANDBOX_ENV_VAR`.
   - You operate in a sandbox where `CODEX_SANDBOX_NETWORK_DISABLED=1` will be set whenever you use the `shell` tool. Any existing code that uses `CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR` was authored with this fact in mind. It is often used to early exit out of tests that the author knew you would not be able to run given your sandbox limitations.

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1496,6 +1496,7 @@ name = "codex-git"
 version = "0.0.0"
 dependencies = [
  "assert_matches",
+ "indoc",
  "once_cell",
  "pretty_assertions",
  "regex",
@@ -1764,6 +1765,7 @@ dependencies = [
  "dirs",
  "dunce",
  "image",
+ "indoc",
  "insta",
  "itertools 0.14.0",
  "lazy_static",

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -89,6 +89,8 @@ mod tests {
 
     use super::*;
     use core_test_support::test_path_buf;
+    use indoc::formatdoc;
+    use indoc::indoc;
     use pretty_assertions::assert_eq;
 
     fn fake_shell() -> Shell {
@@ -104,13 +106,13 @@ mod tests {
         let cwd = test_path_buf("/repo");
         let context = EnvironmentContext::new(Some(cwd.clone()), fake_shell());
 
-        let expected = format!(
-            r#"<environment_context>
-  <cwd>{cwd}</cwd>
-  <shell>bash</shell>
-</environment_context>"#,
+        let expected = formatdoc! {"
+            <environment_context>
+              <cwd>{cwd}</cwd>
+              <shell>bash</shell>
+            </environment_context>",
             cwd = cwd.display(),
-        );
+        };
 
         assert_eq!(context.serialize_to_xml(), expected);
     }
@@ -119,9 +121,10 @@ mod tests {
     fn serialize_read_only_environment_context() {
         let context = EnvironmentContext::new(None, fake_shell());
 
-        let expected = r#"<environment_context>
-  <shell>bash</shell>
-</environment_context>"#;
+        let expected = indoc! {"
+            <environment_context>
+              <shell>bash</shell>
+            </environment_context>"};
 
         assert_eq!(context.serialize_to_xml(), expected);
     }
@@ -130,9 +133,10 @@ mod tests {
     fn serialize_external_sandbox_environment_context() {
         let context = EnvironmentContext::new(None, fake_shell());
 
-        let expected = r#"<environment_context>
-  <shell>bash</shell>
-</environment_context>"#;
+        let expected = indoc! {"
+            <environment_context>
+              <shell>bash</shell>
+            </environment_context>"};
 
         assert_eq!(context.serialize_to_xml(), expected);
     }
@@ -141,9 +145,10 @@ mod tests {
     fn serialize_external_sandbox_with_restricted_network_environment_context() {
         let context = EnvironmentContext::new(None, fake_shell());
 
-        let expected = r#"<environment_context>
-  <shell>bash</shell>
-</environment_context>"#;
+        let expected = indoc! {"
+            <environment_context>
+              <shell>bash</shell>
+            </environment_context>"};
 
         assert_eq!(context.serialize_to_xml(), expected);
     }
@@ -152,9 +157,10 @@ mod tests {
     fn serialize_full_access_environment_context() {
         let context = EnvironmentContext::new(None, fake_shell());
 
-        let expected = r#"<environment_context>
-  <shell>bash</shell>
-</environment_context>"#;
+        let expected = indoc! {"
+            <environment_context>
+              <shell>bash</shell>
+            </environment_context>"};
 
         assert_eq!(context.serialize_to_xml(), expected);
     }

--- a/codex-rs/core/src/models_manager/model_presets.rs
+++ b/codex-rs/core/src/models_manager/model_presets.rs
@@ -320,13 +320,13 @@ fn gpt_52_codex_upgrade() -> ModelUpgrade {
                 .to_string(),
         ),
         migration_markdown: Some(
-            indoc! {r#"
-                **Codex just got an upgrade. Introducing {model_to}.**
+            indoc! {"
+**Codex just got an upgrade. Introducing {model_to}.**
 
-                Codex is now powered by gpt-5.2-codex, our latest frontier agentic coding model. It is smarter and faster than its predecessors and capable of long-running project-scale work. Learn more about {model_to} at https://openai.com/index/introducing-gpt-5-2-codex
+Codex is now powered by gpt-5.2-codex, our latest frontier agentic coding model. It is smarter and faster than its predecessors and capable of long-running project-scale work. Learn more about {model_to} at https://openai.com/index/introducing-gpt-5-2-codex
 
-                You can continue using {model_from} if you prefer.
-            "#}
+You can continue using {model_from} if you prefer.
+"}
             .to_string(),
         ),
     }

--- a/codex-rs/core/src/project_doc.rs
+++ b/codex-rs/core/src/project_doc.rs
@@ -237,6 +237,8 @@ mod tests {
     use super::*;
     use crate::config::ConfigBuilder;
     use crate::skills::load_skills;
+    use indoc::formatdoc;
+    use indoc::indoc;
     use std::fs;
     use std::path::PathBuf;
     use tempfile::TempDir;
@@ -516,10 +518,32 @@ mod tests {
         )
         .unwrap_or_else(|_| cfg.codex_home.join("skills/pdf-processing/SKILL.md"));
         let expected_path_str = expected_path.to_string_lossy().replace('\\', "/");
-        let usage_rules = "- Discovery: The list above is the skills available in this session (name + description + file path). Skill bodies live on disk at the listed paths.\n- Trigger rules: If the user names a skill (with `$SkillName` or plain text) OR the task clearly matches a skill's description shown above, you must use that skill for that turn. Multiple mentions mean use them all. Do not carry skills across turns unless re-mentioned.\n- Missing/blocked: If a named skill isn't in the list or the path can't be read, say so briefly and continue with the best fallback.\n- How to use a skill (progressive disclosure):\n  1) After deciding to use a skill, open its `SKILL.md`. Read only enough to follow the workflow.\n  2) If `SKILL.md` points to extra folders such as `references/`, load only the specific files needed for the request; don't bulk-load everything.\n  3) If `scripts/` exist, prefer running or patching them instead of retyping large code blocks.\n  4) If `assets/` or templates exist, reuse them instead of recreating from scratch.\n- Coordination and sequencing:\n  - If multiple skills apply, choose the minimal set that covers the request and state the order you'll use them.\n  - Announce which skill(s) you're using and why (one short line). If you skip an obvious skill, say why.\n- Context hygiene:\n  - Keep context small: summarize long sections instead of pasting them; only load extra files when needed.\n  - Avoid deep reference-chasing: prefer opening only files directly linked from `SKILL.md` unless you're blocked.\n  - When variants exist (frameworks, providers, domains), pick only the relevant reference file(s) and note that choice.\n- Safety and fallback: If a skill can't be applied cleanly (missing files, unclear instructions), state the issue, pick the next-best approach, and continue.";
-        let expected = format!(
-            "base doc\n\n## Skills\nA skill is a set of local instructions to follow that is stored in a `SKILL.md` file. Below is the list of skills that can be used. Each entry includes a name, description, and file path so you can open the source for full instructions when using a specific skill.\n### Available skills\n- pdf-processing: extract from pdfs (file: {expected_path_str})\n### How to use skills\n{usage_rules}"
-        );
+        let usage_rules = indoc! {"
+- Discovery: The list above is the skills available in this session (name + description + file path). Skill bodies live on disk at the listed paths.
+- Trigger rules: If the user names a skill (with `$SkillName` or plain text) OR the task clearly matches a skill's description shown above, you must use that skill for that turn. Multiple mentions mean use them all. Do not carry skills across turns unless re-mentioned.
+- Missing/blocked: If a named skill isn't in the list or the path can't be read, say so briefly and continue with the best fallback.
+- How to use a skill (progressive disclosure):
+  1) After deciding to use a skill, open its `SKILL.md`. Read only enough to follow the workflow.
+  2) If `SKILL.md` points to extra folders such as `references/`, load only the specific files needed for the request; don't bulk-load everything.
+  3) If `scripts/` exist, prefer running or patching them instead of retyping large code blocks.
+  4) If `assets/` or templates exist, reuse them instead of recreating from scratch.
+- Coordination and sequencing:
+  - If multiple skills apply, choose the minimal set that covers the request and state the order you'll use them.
+  - Announce which skill(s) you're using and why (one short line). If you skip an obvious skill, say why.
+- Context hygiene:
+  - Keep context small: summarize long sections instead of pasting them; only load extra files when needed.
+  - Avoid deep reference-chasing: prefer opening only files directly linked from `SKILL.md` unless you're blocked.
+  - When variants exist (frameworks, providers, domains), pick only the relevant reference file(s) and note that choice.
+- Safety and fallback: If a skill can't be applied cleanly (missing files, unclear instructions), state the issue, pick the next-best approach, and continue."};
+        let expected = formatdoc! {"
+            base doc
+
+            ## Skills
+            A skill is a set of local instructions to follow that is stored in a `SKILL.md` file. Below is the list of skills that can be used. Each entry includes a name, description, and file path so you can open the source for full instructions when using a specific skill.
+            ### Available skills
+            - pdf-processing: extract from pdfs (file: {expected_path_str})
+            ### How to use skills
+            {usage_rules}"};
         assert_eq!(res, expected);
     }
 
@@ -540,17 +564,44 @@ mod tests {
             dunce::canonicalize(cfg.codex_home.join("skills/linting/SKILL.md").as_path())
                 .unwrap_or_else(|_| cfg.codex_home.join("skills/linting/SKILL.md"));
         let expected_path_str = expected_path.to_string_lossy().replace('\\', "/");
-        let usage_rules = "- Discovery: The list above is the skills available in this session (name + description + file path). Skill bodies live on disk at the listed paths.\n- Trigger rules: If the user names a skill (with `$SkillName` or plain text) OR the task clearly matches a skill's description shown above, you must use that skill for that turn. Multiple mentions mean use them all. Do not carry skills across turns unless re-mentioned.\n- Missing/blocked: If a named skill isn't in the list or the path can't be read, say so briefly and continue with the best fallback.\n- How to use a skill (progressive disclosure):\n  1) After deciding to use a skill, open its `SKILL.md`. Read only enough to follow the workflow.\n  2) If `SKILL.md` points to extra folders such as `references/`, load only the specific files needed for the request; don't bulk-load everything.\n  3) If `scripts/` exist, prefer running or patching them instead of retyping large code blocks.\n  4) If `assets/` or templates exist, reuse them instead of recreating from scratch.\n- Coordination and sequencing:\n  - If multiple skills apply, choose the minimal set that covers the request and state the order you'll use them.\n  - Announce which skill(s) you're using and why (one short line). If you skip an obvious skill, say why.\n- Context hygiene:\n  - Keep context small: summarize long sections instead of pasting them; only load extra files when needed.\n  - Avoid deep reference-chasing: prefer opening only files directly linked from `SKILL.md` unless you're blocked.\n  - When variants exist (frameworks, providers, domains), pick only the relevant reference file(s) and note that choice.\n- Safety and fallback: If a skill can't be applied cleanly (missing files, unclear instructions), state the issue, pick the next-best approach, and continue.";
-        let expected = format!(
-            "## Skills\nA skill is a set of local instructions to follow that is stored in a `SKILL.md` file. Below is the list of skills that can be used. Each entry includes a name, description, and file path so you can open the source for full instructions when using a specific skill.\n### Available skills\n- linting: run clippy (file: {expected_path_str})\n### How to use skills\n{usage_rules}"
-        );
+        let usage_rules = indoc! {"
+- Discovery: The list above is the skills available in this session (name + description + file path). Skill bodies live on disk at the listed paths.
+- Trigger rules: If the user names a skill (with `$SkillName` or plain text) OR the task clearly matches a skill's description shown above, you must use that skill for that turn. Multiple mentions mean use them all. Do not carry skills across turns unless re-mentioned.
+- Missing/blocked: If a named skill isn't in the list or the path can't be read, say so briefly and continue with the best fallback.
+- How to use a skill (progressive disclosure):
+  1) After deciding to use a skill, open its `SKILL.md`. Read only enough to follow the workflow.
+  2) If `SKILL.md` points to extra folders such as `references/`, load only the specific files needed for the request; don't bulk-load everything.
+  3) If `scripts/` exist, prefer running or patching them instead of retyping large code blocks.
+  4) If `assets/` or templates exist, reuse them instead of recreating from scratch.
+- Coordination and sequencing:
+  - If multiple skills apply, choose the minimal set that covers the request and state the order you'll use them.
+  - Announce which skill(s) you're using and why (one short line). If you skip an obvious skill, say why.
+- Context hygiene:
+  - Keep context small: summarize long sections instead of pasting them; only load extra files when needed.
+  - Avoid deep reference-chasing: prefer opening only files directly linked from `SKILL.md` unless you're blocked.
+  - When variants exist (frameworks, providers, domains), pick only the relevant reference file(s) and note that choice.
+- Safety and fallback: If a skill can't be applied cleanly (missing files, unclear instructions), state the issue, pick the next-best approach, and continue."};
+        let expected = formatdoc! {"
+            ## Skills
+            A skill is a set of local instructions to follow that is stored in a `SKILL.md` file. Below is the list of skills that can be used. Each entry includes a name, description, and file path so you can open the source for full instructions when using a specific skill.
+            ### Available skills
+            - linting: run clippy (file: {expected_path_str})
+            ### How to use skills
+            {usage_rules}"};
         assert_eq!(res, expected);
     }
 
     fn create_skill(codex_home: PathBuf, name: &str, description: &str) {
         let skill_dir = codex_home.join(format!("skills/{name}"));
         fs::create_dir_all(&skill_dir).unwrap();
-        let content = format!("---\nname: {name}\ndescription: {description}\n---\n\n# Body\n");
+        let content = formatdoc! {"
+            ---
+            name: {name}
+            description: {description}
+            ---
+
+            # Body
+            "};
         fs::write(skill_dir.join("SKILL.md"), content).unwrap();
     }
 }

--- a/codex-rs/core/src/skills/manager.rs
+++ b/codex-rs/core/src/skills/manager.rs
@@ -118,6 +118,7 @@ mod tests {
     use super::*;
     use crate::config::ConfigBuilder;
     use crate::config::ConfigOverrides;
+    use indoc::formatdoc;
     use pretty_assertions::assert_eq;
     use std::fs;
     use tempfile::TempDir;
@@ -125,7 +126,14 @@ mod tests {
     fn write_user_skill(codex_home: &TempDir, dir: &str, name: &str, description: &str) {
         let skill_dir = codex_home.path().join("skills").join(dir);
         fs::create_dir_all(&skill_dir).unwrap();
-        let content = format!("---\nname: {name}\ndescription: {description}\n---\n\n# Body\n");
+        let content = formatdoc! {"
+            ---
+            name: {name}
+            description: {description}
+            ---
+
+            # Body
+            "};
         fs::write(skill_dir.join("SKILL.md"), content).unwrap();
     }
 

--- a/codex-rs/core/src/tools/handlers/plan.rs
+++ b/codex-rs/core/src/tools/handlers/plan.rs
@@ -12,6 +12,7 @@ use crate::tools::spec::JsonSchema;
 use async_trait::async_trait;
 use codex_protocol::plan_tool::UpdatePlanArgs;
 use codex_protocol::protocol::EventMsg;
+use indoc::indoc;
 use std::collections::BTreeMap;
 use std::sync::LazyLock;
 
@@ -45,10 +46,11 @@ pub static PLAN_TOOL: LazyLock<ToolSpec> = LazyLock::new(|| {
 
     ToolSpec::Function(ResponsesApiTool {
         name: "update_plan".to_string(),
-        description: r#"Updates the task plan.
-Provide an optional explanation and a list of plan items, each with a step and status.
-At most one step can be in_progress at a time.
-"#
+        description: indoc! {"
+            Updates the task plan.
+            Provide an optional explanation and a list of plan items, each with a step and status.
+            At most one step can be in_progress at a time.
+            "}
         .to_string(),
         strict: false,
         parameters: JsonSchema::Object {

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -12,6 +12,7 @@ use codex_protocol::models::VIEW_IMAGE_TOOL_NAME;
 use codex_protocol::openai_models::ApplyPatchToolType;
 use codex_protocol::openai_models::ConfigShellToolType;
 use codex_protocol::openai_models::ModelInfo;
+use indoc::indoc;
 use serde::Deserialize;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
@@ -301,22 +302,27 @@ fn create_shell_tool() -> ToolSpec {
         ),
     ]);
 
-    let description  = if cfg!(windows) {
-        r#"Runs a Powershell command (Windows) and returns its output. Arguments to `shell` will be passed to CreateProcessW(). Most commands should be prefixed with ["powershell.exe", "-Command"].
-        
-Examples of valid command strings:
+    let description = if cfg!(windows) {
+        indoc! {r#"
+            Runs a Powershell command (Windows) and returns its output. Arguments to `shell` will be passed to CreateProcessW(). Most commands should be prefixed with ["powershell.exe", "-Command"].
 
-- ls -a (show hidden): ["powershell.exe", "-Command", "Get-ChildItem -Force"]
-- recursive find by name: ["powershell.exe", "-Command", "Get-ChildItem -Recurse -Filter *.py"]
-- recursive grep: ["powershell.exe", "-Command", "Get-ChildItem -Path C:\\myrepo -Recurse | Select-String -Pattern 'TODO' -CaseSensitive"]
-- ps aux | grep python: ["powershell.exe", "-Command", "Get-Process | Where-Object { $_.ProcessName -like '*python*' }"]
-- setting an env var: ["powershell.exe", "-Command", "$env:FOO='bar'; echo $env:FOO"]
-- running an inline Python script: ["powershell.exe", "-Command", "@'\\nprint('Hello, world!')\\n'@ | python -"]"#
+            Examples of valid command strings:
+
+            - ls -a (show hidden): ["powershell.exe", "-Command", "Get-ChildItem -Force"]
+            - recursive find by name: ["powershell.exe", "-Command", "Get-ChildItem -Recurse -Filter *.py"]
+            - recursive grep: ["powershell.exe", "-Command", "Get-ChildItem -Path C:\\myrepo -Recurse | Select-String -Pattern 'TODO' -CaseSensitive"]
+            - ps aux | grep python: ["powershell.exe", "-Command", "Get-Process | Where-Object { $_.ProcessName -like '*python*' }"]
+            - setting an env var: ["powershell.exe", "-Command", "$env:FOO='bar'; echo $env:FOO"]
+            - running an inline Python script: ["powershell.exe", "-Command", "@'\nprint('Hello, world!')\n'@ | python -"]
+            "#}
+        .to_string()
     } else {
-        r#"Runs a shell command and returns its output.
-- The arguments to `shell` will be passed to execvp(). Most terminal commands should be prefixed with ["bash", "-lc"].
-- Always set the `workdir` param when using the shell function. Do not use `cd` unless absolutely necessary."#
-    }.to_string();
+        indoc! {"
+            Runs a shell command and returns its output.
+            - The arguments to `shell` will be passed to execvp(). Most terminal commands should be prefixed with [\"bash\", \"-lc\"].
+            - Always set the `workdir` param when using the shell function. Do not use `cd` unless absolutely necessary."}
+        .to_string()
+    };
 
     ToolSpec::Function(ResponsesApiTool {
         name: "shell".to_string(),
@@ -376,20 +382,25 @@ fn create_shell_command_tool() -> ToolSpec {
     ]);
 
     let description = if cfg!(windows) {
-        r#"Runs a Powershell command (Windows) and returns its output.
-        
-Examples of valid command strings:
+        indoc! {r#"
+            Runs a Powershell command (Windows) and returns its output.
 
-- ls -a (show hidden): "Get-ChildItem -Force"
-- recursive find by name: "Get-ChildItem -Recurse -Filter *.py"
-- recursive grep: "Get-ChildItem -Path C:\\myrepo -Recurse | Select-String -Pattern 'TODO' -CaseSensitive"
-- ps aux | grep python: "Get-Process | Where-Object { $_.ProcessName -like '*python*' }"
-- setting an env var: "$env:FOO='bar'; echo $env:FOO"
-- running an inline Python script: "@'\\nprint('Hello, world!')\\n'@ | python -"#
+            Examples of valid command strings:
+
+            - ls -a (show hidden): "Get-ChildItem -Force"
+            - recursive find by name: "Get-ChildItem -Recurse -Filter *.py"
+            - recursive grep: "Get-ChildItem -Path C:\\myrepo -Recurse | Select-String -Pattern 'TODO' -CaseSensitive"
+            - ps aux | grep python: "Get-Process | Where-Object { $_.ProcessName -like '*python*' }"
+            - setting an env var: "$env:FOO='bar'; echo $env:FOO"
+            - running an inline Python script: "@'\nprint('Hello, world!')\n'@ | python -"
+            "#}
+        .to_string()
     } else {
-        r#"Runs a shell command and returns its output.
-- Always set the `workdir` param when using the shell_command function. Do not use `cd` unless absolutely necessary."#
-    }.to_string();
+        indoc! {"
+            Runs a shell command and returns its output.
+            - Always set the `workdir` param when using the shell_command function. Do not use `cd` unless absolutely necessary."}
+        .to_string()
+    };
 
     ToolSpec::Function(ResponsesApiTool {
         name: "shell_command".to_string(),
@@ -2148,21 +2159,26 @@ mod tests {
         assert_eq!(name, "shell");
 
         let expected = if cfg!(windows) {
-            r#"Runs a Powershell command (Windows) and returns its output. Arguments to `shell` will be passed to CreateProcessW(). Most commands should be prefixed with ["powershell.exe", "-Command"].
-        
-Examples of valid command strings:
+            indoc! {r#"
+                Runs a Powershell command (Windows) and returns its output. Arguments to `shell` will be passed to CreateProcessW(). Most commands should be prefixed with ["powershell.exe", "-Command"].
 
-- ls -a (show hidden): ["powershell.exe", "-Command", "Get-ChildItem -Force"]
-- recursive find by name: ["powershell.exe", "-Command", "Get-ChildItem -Recurse -Filter *.py"]
-- recursive grep: ["powershell.exe", "-Command", "Get-ChildItem -Path C:\\myrepo -Recurse | Select-String -Pattern 'TODO' -CaseSensitive"]
-- ps aux | grep python: ["powershell.exe", "-Command", "Get-Process | Where-Object { $_.ProcessName -like '*python*' }"]
-- setting an env var: ["powershell.exe", "-Command", "$env:FOO='bar'; echo $env:FOO"]
-- running an inline Python script: ["powershell.exe", "-Command", "@'\\nprint('Hello, world!')\\n'@ | python -"]"#
+                Examples of valid command strings:
+
+                - ls -a (show hidden): ["powershell.exe", "-Command", "Get-ChildItem -Force"]
+                - recursive find by name: ["powershell.exe", "-Command", "Get-ChildItem -Recurse -Filter *.py"]
+                - recursive grep: ["powershell.exe", "-Command", "Get-ChildItem -Path C:\\myrepo -Recurse | Select-String -Pattern 'TODO' -CaseSensitive"]
+                - ps aux | grep python: ["powershell.exe", "-Command", "Get-Process | Where-Object { $_.ProcessName -like '*python*' }"]
+                - setting an env var: ["powershell.exe", "-Command", "$env:FOO='bar'; echo $env:FOO"]
+                - running an inline Python script: ["powershell.exe", "-Command", "@'\nprint('Hello, world!')\n'@ | python -"]
+                "#}
+            .to_string()
         } else {
-            r#"Runs a shell command and returns its output.
-- The arguments to `shell` will be passed to execvp(). Most terminal commands should be prefixed with ["bash", "-lc"].
-- Always set the `workdir` param when using the shell function. Do not use `cd` unless absolutely necessary."#
-        }.to_string();
+            indoc! {"
+                Runs a shell command and returns its output.
+                - The arguments to `shell` will be passed to execvp(). Most terminal commands should be prefixed with [\"bash\", \"-lc\"].
+                - Always set the `workdir` param when using the shell function. Do not use `cd` unless absolutely necessary."}
+            .to_string()
+        };
         assert_eq!(description, &expected);
     }
 
@@ -2178,19 +2194,24 @@ Examples of valid command strings:
         assert_eq!(name, "shell_command");
 
         let expected = if cfg!(windows) {
-            r#"Runs a Powershell command (Windows) and returns its output.
-        
-Examples of valid command strings:
+            indoc! {r#"
+                Runs a Powershell command (Windows) and returns its output.
 
-- ls -a (show hidden): "Get-ChildItem -Force"
-- recursive find by name: "Get-ChildItem -Recurse -Filter *.py"
-- recursive grep: "Get-ChildItem -Path C:\\myrepo -Recurse | Select-String -Pattern 'TODO' -CaseSensitive"
-- ps aux | grep python: "Get-Process | Where-Object { $_.ProcessName -like '*python*' }"
-- setting an env var: "$env:FOO='bar'; echo $env:FOO"
-- running an inline Python script: "@'\\nprint('Hello, world!')\\n'@ | python -"#.to_string()
+                Examples of valid command strings:
+
+                - ls -a (show hidden): "Get-ChildItem -Force"
+                - recursive find by name: "Get-ChildItem -Recurse -Filter *.py"
+                - recursive grep: "Get-ChildItem -Path C:\\myrepo -Recurse | Select-String -Pattern 'TODO' -CaseSensitive"
+                - ps aux | grep python: "Get-Process | Where-Object { $_.ProcessName -like '*python*' }"
+                - setting an env var: "$env:FOO='bar'; echo $env:FOO"
+                - running an inline Python script: "@'\nprint('Hello, world!')\n'@ | python -"
+                "#}
+            .to_string()
         } else {
-            r#"Runs a shell command and returns its output.
-- Always set the `workdir` param when using the shell_command function. Do not use `cd` unless absolutely necessary."#.to_string()
+            indoc! {"
+                Runs a shell command and returns its output.
+                - Always set the `workdir` param when using the shell_command function. Do not use `cd` unless absolutely necessary."}
+            .to_string()
         };
         assert_eq!(description, &expected);
     }

--- a/codex-rs/core/src/user_shell_command.rs
+++ b/codex-rs/core/src/user_shell_command.rs
@@ -48,7 +48,7 @@ pub fn format_user_shell_command_record(
     turn_context: &TurnContext,
 ) -> String {
     let body = format_user_shell_command_body(command, exec_output, turn_context);
-    format!("{USER_SHELL_COMMAND_OPEN}\n{body}\n{USER_SHELL_COMMAND_CLOSE}")
+    [USER_SHELL_COMMAND_OPEN, &body, USER_SHELL_COMMAND_CLOSE].join("\n")
 }
 
 pub fn user_shell_command_record_item(
@@ -70,13 +70,15 @@ mod tests {
     use super::*;
     use crate::codex::make_session_and_context;
     use crate::exec::StreamOutput;
+    use indoc::indoc;
     use pretty_assertions::assert_eq;
 
     #[test]
     fn detects_user_shell_command_text_variants() {
-        assert!(is_user_shell_command_text(
-            "<user_shell_command>\necho hi\n</user_shell_command>"
-        ));
+        assert!(is_user_shell_command_text(indoc! {"
+                <user_shell_command>
+                echo hi
+                </user_shell_command>"}));
         assert!(!is_user_shell_command_text("echo hi"));
     }
 
@@ -100,7 +102,18 @@ mod tests {
         };
         assert_eq!(
             text,
-            "<user_shell_command>\n<command>\necho hi\n</command>\n<result>\nExit code: 0\nDuration: 1.0000 seconds\nOutput:\nhi\n</result>\n</user_shell_command>"
+            indoc! {"
+                <user_shell_command>
+                <command>
+                echo hi
+                </command>
+                <result>
+                Exit code: 0
+                Duration: 1.0000 seconds
+                Output:
+                hi
+                </result>
+                </user_shell_command>"}
         );
     }
 
@@ -118,7 +131,18 @@ mod tests {
         let record = format_user_shell_command_record("false", &exec_output, &turn_context);
         assert_eq!(
             record,
-            "<user_shell_command>\n<command>\nfalse\n</command>\n<result>\nExit code: 42\nDuration: 0.1200 seconds\nOutput:\ncombined output wins\n</result>\n</user_shell_command>"
+            indoc! {"
+                <user_shell_command>
+                <command>
+                false
+                </command>
+                <result>
+                Exit code: 42
+                Duration: 0.1200 seconds
+                Output:
+                combined output wins
+                </result>
+                </user_shell_command>"}
         );
     }
 }

--- a/codex-rs/core/tests/suite/list_models.rs
+++ b/codex-rs/core/tests/suite/list_models.rs
@@ -412,13 +412,13 @@ fn gpt52_codex_upgrade() -> codex_protocol::openai_models::ModelUpgrade {
                 .to_string(),
         ),
         migration_markdown: Some(
-            indoc! {r#"
-                **Codex just got an upgrade. Introducing {model_to}.**
+            indoc! {"
+**Codex just got an upgrade. Introducing {model_to}.**
 
-                Codex is now powered by gpt-5.2-codex, our latest frontier agentic coding model. It is smarter and faster than its predecessors and capable of long-running project-scale work. Learn more about {model_to} at https://openai.com/index/introducing-gpt-5-2-codex
+Codex is now powered by gpt-5.2-codex, our latest frontier agentic coding model. It is smarter and faster than its predecessors and capable of long-running project-scale work. Learn more about {model_to} at https://openai.com/index/introducing-gpt-5-2-codex
 
-                You can continue using {model_from} if you prefer.
-            "#}
+You can continue using {model_from} if you prefer.
+"}
             .to_string(),
         ),
     }

--- a/codex-rs/core/tests/suite/permissions_messages.rs
+++ b/codex-rs/core/tests/suite/permissions_messages.rs
@@ -14,6 +14,7 @@ use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
+use indoc::indoc;
 use pretty_assertions::assert_eq;
 use std::collections::HashSet;
 use tempfile::TempDir;
@@ -403,7 +404,19 @@ async fn permissions_message_includes_writable_roots() -> Result<()> {
     let input = body["input"].as_array().expect("input array");
     let permissions = permissions_texts(input);
     let sandbox_text = "Filesystem sandboxing defines which files can be read or written. `sandbox_mode` is `workspace-write`: The sandbox permits reading files, and editing files in `cwd` and `writable_roots`. Editing files in other directories requires approval. Network access is restricted.";
-    let approval_text = " Approvals are your mechanism to get user consent to run shell commands without the sandbox. `approval_policy` is `on-request`: Commands will be run in the sandbox by default, and you can specify in your tool call if you want to escalate a command to run without sandboxing. If the completing the task requires escalated permissions, Do not let these settings or the sandbox deter you from attempting to accomplish the user's task.\n\nHere are scenarios where you'll need to request approval:\n- You need to run a command that writes to a directory that requires it (e.g. running tests that write to /var)\n- You need to run a GUI app (e.g., open/xdg-open/osascript) to open browsers or files.\n- You are running sandboxed and need to run a command that requires network access (e.g. installing packages)\n- If you run a command that is important to solving the user's query, but it fails because of sandboxing, rerun the command with approval. ALWAYS proceed to use the `sandbox_permissions` and `justification` parameters - do not message the user before requesting approval for the command.\n- You are about to take a potentially destructive action such as an `rm` or `git reset` that the user did not explicitly ask for.\n\nWhen requesting approval to execute a command that will require escalated privileges:\n  - Provide the `sandbox_permissions` parameter with the value `\"require_escalated\"`\n  - Include a short, 1 sentence explanation for why you need escalated permissions in the justification parameter";
+    let approval_text = indoc! {"
+         Approvals are your mechanism to get user consent to run shell commands without the sandbox. `approval_policy` is `on-request`: Commands will be run in the sandbox by default, and you can specify in your tool call if you want to escalate a command to run without sandboxing. If the completing the task requires escalated permissions, Do not let these settings or the sandbox deter you from attempting to accomplish the user's task.
+
+        Here are scenarios where you'll need to request approval:
+        - You need to run a command that writes to a directory that requires it (e.g. running tests that write to /var)
+        - You need to run a GUI app (e.g., open/xdg-open/osascript) to open browsers or files.
+        - You are running sandboxed and need to run a command that requires network access (e.g. installing packages)
+        - If you run a command that is important to solving the user's query, but it fails because of sandboxing, rerun the command with approval. ALWAYS proceed to use the `sandbox_permissions` and `justification` parameters - do not message the user before requesting approval for the command.
+        - You are about to take a potentially destructive action such as an `rm` or `git reset` that the user did not explicitly ask for.
+
+        When requesting approval to execute a command that will require escalated privileges:
+          - Provide the `sandbox_permissions` parameter with the value `\"require_escalated\"`
+          - Include a short, 1 sentence explanation for why you need escalated permissions in the justification parameter"};
     // Normalize paths by removing trailing slashes to match AbsolutePathBuf behavior
     let normalize_path =
         |p: &std::path::Path| -> String { p.to_string_lossy().trim_end_matches('/').to_string() };

--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -120,6 +120,7 @@ codex-utils-pty = { workspace = true }
 assert_matches = { workspace = true }
 chrono = { workspace = true, features = ["serde"] }
 insta = { workspace = true }
+indoc = { workspace = true }
 pretty_assertions = { workspace = true }
 rand = { workspace = true }
 serial_test = { workspace = true }

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -69,6 +69,7 @@ use codex_utils_absolute_path::AbsolutePathBuf;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyModifiers;
+use indoc::indoc;
 use insta::assert_snapshot;
 use pretty_assertions::assert_eq;
 #[cfg(target_os = "windows")]
@@ -3811,7 +3812,7 @@ async fn chatwidget_markdown_code_blocks_vt100_snapshot() {
     term.set_viewport_area(Rect::new(0, height - 1, width, 1));
 
     // Simulate streaming via AgentMessageDelta in 2-character chunks (no final AgentMessage).
-    let source: &str = r#"
+    let source: &str = indoc! {r#"
 
     -- Indented code block (4 spaces)
     SELECT *
@@ -3831,7 +3832,7 @@ printf 'fenced within fenced\n'
   "regex": "^foo.*(bar)?$"
 }
 ```
-"#;
+"#};
 
     let mut it = source.chars();
     loop {

--- a/codex-rs/tui/src/insert_history.rs
+++ b/codex-rs/tui/src/insert_history.rs
@@ -287,6 +287,7 @@ mod tests {
     use super::*;
     use crate::markdown_render::render_markdown_text;
     use crate::test_backend::VT100Backend;
+    use indoc::indoc;
     use ratatui::layout::Rect;
     use ratatui::style::Color;
 
@@ -480,7 +481,13 @@ mod tests {
     #[test]
     fn vt100_deep_nested_mixed_list_third_level_marker_is_colored() {
         // Markdown with five levels (ordered → unordered → ordered → unordered → unordered).
-        let md = "1. First\n   - Second level\n     1. Third level (ordered)\n        - Fourth level (bullet)\n          - Fifth level to test indent consistency\n";
+        let md = indoc! {"
+            1. First
+               - Second level
+                 1. Third level (ordered)
+                    - Fourth level (bullet)
+                      - Fifth level to test indent consistency
+            "};
         let text = render_markdown_text(md);
         let lines: Vec<Line<'static>> = text.lines.clone();
 

--- a/codex-rs/tui/src/tooltips.rs
+++ b/codex-rs/tui/src/tooltips.rs
@@ -189,6 +189,7 @@ pub(crate) mod announcement {
 mod tests {
     use super::*;
     use crate::tooltips::announcement::parse_announcement_tip_toml;
+    use indoc::indoc;
     use rand::SeedableRng;
     use rand::rngs::StdRng;
 
@@ -211,40 +212,40 @@ mod tests {
 
     #[test]
     fn announcement_tip_toml_picks_last_matching() {
-        let toml = r#"
-[[announcements]]
-content = "first"
-from_date = "2000-01-01"
+        let toml = indoc! {r#"
+            [[announcements]]
+            content = "first"
+            from_date = "2000-01-01"
 
-[[announcements]]
-content = "latest match"
-version_regex = ".*"
-target_app = "cli"
+            [[announcements]]
+            content = "latest match"
+            version_regex = ".*"
+            target_app = "cli"
 
-[[announcements]]
-content = "should not match"
-to_date = "2000-01-01"
-        "#;
+            [[announcements]]
+            content = "should not match"
+            to_date = "2000-01-01"
+            "#};
 
         assert_eq!(
             Some("latest match".to_string()),
             parse_announcement_tip_toml(toml)
         );
 
-        let toml = r#"
-[[announcements]]
-content = "first"
-from_date = "2000-01-01"
-target_app = "cli"
+        let toml = indoc! {r#"
+            [[announcements]]
+            content = "first"
+            from_date = "2000-01-01"
+            target_app = "cli"
 
-[[announcements]]
-content = "latest match"
-version_regex = ".*"
+            [[announcements]]
+            content = "latest match"
+            version_regex = ".*"
 
-[[announcements]]
-content = "should not match"
-to_date = "2000-01-01"
-        "#;
+            [[announcements]]
+            content = "should not match"
+            to_date = "2000-01-01"
+            "#};
 
         assert_eq!(
             Some("latest match".to_string()),
@@ -254,54 +255,54 @@ to_date = "2000-01-01"
 
     #[test]
     fn announcement_tip_toml_picks_no_match() {
-        let toml = r#"
-[[announcements]]
-content = "first"
-from_date = "2000-01-01"
-to_date = "2000-01-05"
+        let toml = indoc! {r#"
+            [[announcements]]
+            content = "first"
+            from_date = "2000-01-01"
+            to_date = "2000-01-05"
 
-[[announcements]]
-content = "latest match"
-version_regex = "invalid_version_name"
+            [[announcements]]
+            content = "latest match"
+            version_regex = "invalid_version_name"
 
-[[announcements]]
-content = "should not match either "
-target_app = "vsce"
-        "#;
+            [[announcements]]
+            content = "should not match either "
+            target_app = "vsce"
+            "#};
 
         assert_eq!(None, parse_announcement_tip_toml(toml));
     }
 
     #[test]
     fn announcement_tip_toml_bad_deserialization() {
-        let toml = r#"
-[[announcements]]
-content = 123
-from_date = "2000-01-01"
-        "#;
+        let toml = indoc! {r#"
+            [[announcements]]
+            content = 123
+            from_date = "2000-01-01"
+            "#};
 
         assert_eq!(None, parse_announcement_tip_toml(toml));
     }
 
     #[test]
     fn announcement_tip_toml_parse_comments() {
-        let toml = r#"
-# Example announcement tips for Codex TUI.
-# Each [[announcements]] entry is evaluated in order; the last matching one is shown.
-# Dates are UTC, formatted as YYYY-MM-DD. The from_date is inclusive and the to_date is exclusive.
-# version_regex matches against the CLI version (env!("CARGO_PKG_VERSION")); omit to apply to all versions.
-# target_app specify which app should display the announcement (cli, vsce, ...).
+        let toml = indoc! {r#"
+            # Example announcement tips for Codex TUI.
+            # Each [[announcements]] entry is evaluated in order; the last matching one is shown.
+            # Dates are UTC, formatted as YYYY-MM-DD. The from_date is inclusive and the to_date is exclusive.
+            # version_regex matches against the CLI version (env!("CARGO_PKG_VERSION")); omit to apply to all versions.
+            # target_app specify which app should display the announcement (cli, vsce, ...).
 
-[[announcements]]
-content = "Welcome to Codex! Check out the new onboarding flow."
-from_date = "2024-10-01"
-to_date = "2024-10-15"
-target_app = "cli"
-version_regex = "^0\\.0\\.0$"
+            [[announcements]]
+            content = "Welcome to Codex! Check out the new onboarding flow."
+            from_date = "2024-10-01"
+            to_date = "2024-10-15"
+            target_app = "cli"
+            version_regex = "^0\\.0\\.0$"
 
-[[announcements]]
-content = "This is a test announcement"
-        "#;
+            [[announcements]]
+            content = "This is a test announcement"
+            "#};
 
         assert_eq!(
             Some("This is a test announcement".to_string()),

--- a/codex-rs/utils/git/Cargo.toml
+++ b/codex-rs/utils/git/Cargo.toml
@@ -24,4 +24,5 @@ walkdir = { workspace = true }
 
 [dev-dependencies]
 assert_matches = { workspace = true }
+indoc = { workspace = true }
 pretty_assertions = { workspace = true }


### PR DESCRIPTION
**Summary**
- Add `AGENTS.md` guidance to prefer `indoc!`/`formatdoc!` over embedded `\n` escapes and awkward raw-string wrapping.
- Refactor multi-line literals in core/tui/utils to use indoc macros consistently.
- Keep raw strings where needed (e.g. `create_apply_patch_json_tool` has interior quotes).

**Tests**
- `cd codex-rs && just fmt`
- `cargo test -p codex-tui` (pass)
- `cargo test -p codex-git` (pass)
- `cargo test -p codex-core` (fails 12 tests in `core/tests/all.rs`; appears pre-existing in this environment)