### PR TITLE
fix: prefer PathBuf to String for ParsePolicy::path field

### DIFF
--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -60,7 +60,7 @@ pub enum ExecPolicyError {
 
     #[error("failed to parse execpolicy file {path}: {source}")]
     ParsePolicy {
-        path: String,
+        path: PathBuf,
         source: codex_execpolicy::Error,
     },
 }
@@ -233,7 +233,7 @@ pub async fn load_exec_policy(config_stack: &ConfigLayerStack) -> Result<Policy,
         parser
             .parse(&identifier, &contents)
             .map_err(|source| ExecPolicyError::ParsePolicy {
-                path: identifier,
+                path: policy_path.clone(),
                 source,
             })?;
     }


### PR DESCRIPTION
Now all variants of `ExecPolicyError` have a `PathBuf` associated with them.