### PR TITLE
feat: add threadId to MCP server messages

### DIFF
--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -32,6 +32,26 @@ use tokio::sync::Mutex;
 
 pub(crate) const INVALID_PARAMS_ERROR_CODE: i64 = -32602;
 
+/// To adhere to MCP `tools/call` response format, include the Codex
+/// `threadId` in the `structured_content` field of the response.
+fn create_call_tool_result_with_thread_id(
+    thread_id: ThreadId,
+    text: String,
+    is_error: Option<bool>,
+) -> CallToolResult {
+    CallToolResult {
+        content: vec![ContentBlock::TextContent(TextContent {
+            r#type: "text".to_string(),
+            text,
+            annotations: None,
+        })],
+        is_error,
+        structured_content: Some(json!({
+            "threadId": thread_id,
+        })),
+    }
+}
+
 /// Run a complete Codex session and stream events back to the client.
 ///
 /// On completion (success or error) the function sends the appropriate
@@ -73,7 +93,10 @@ pub async fn run_codex_tool_session(
     outgoing
         .send_event_as_notification(
             &session_configured_event,
-            Some(OutgoingNotificationMeta::new(Some(id.clone()))),
+            Some(OutgoingNotificationMeta {
+                request_id: Some(id.clone()),
+                thread_id: Some(thread_id),
+            }),
         )
         .await;
 
@@ -100,27 +123,40 @@ pub async fn run_codex_tool_session(
 
     if let Err(e) = thread.submit_with_id(submission).await {
         tracing::error!("Failed to submit initial prompt: {e}");
+        let result = create_call_tool_result_with_thread_id(
+            thread_id,
+            format!("Failed to submit initial prompt: {e}"),
+            Some(true),
+        );
+        outgoing.send_response(id.clone(), result).await;
         // unregister the id so we don't keep it in the map
         running_requests_id_to_codex_uuid.lock().await.remove(&id);
         return;
     }
 
-    run_codex_tool_session_inner(thread, outgoing, id, running_requests_id_to_codex_uuid).await;
+    run_codex_tool_session_inner(
+        thread_id,
+        thread,
+        outgoing,
+        id,
+        running_requests_id_to_codex_uuid,
+    )
+    .await;
 }
 
 pub async fn run_codex_tool_session_reply(
-    conversation: Arc<CodexThread>,
+    thread_id: ThreadId,
+    thread: Arc<CodexThread>,
     outgoing: Arc<OutgoingMessageSender>,
     request_id: RequestId,
     prompt: String,
     running_requests_id_to_codex_uuid: Arc<Mutex<HashMap<RequestId, ThreadId>>>,
-    conversation_id: ThreadId,
 ) {
     running_requests_id_to_codex_uuid
         .lock()
         .await
-        .insert(request_id.clone(), conversation_id);
-    if let Err(e) = conversation
+        .insert(request_id.clone(), thread_id);
+    if let Err(e) = thread
         .submit(Op::UserInput {
             items: vec![UserInput::Text { text: prompt }],
             final_output_json_schema: None,
@@ -128,6 +164,12 @@ pub async fn run_codex_tool_session_reply(
         .await
     {
         tracing::error!("Failed to submit user input: {e}");
+        let result = create_call_tool_result_with_thread_id(
+            thread_id,
+            format!("Failed to submit user input: {e}"),
+            Some(true),
+        );
+        outgoing.send_response(request_id.clone(), result).await;
         // unregister the id so we don't keep it in the map
         running_requests_id_to_codex_uuid
             .lock()
@@ -137,7 +179,8 @@ pub async fn run_codex_tool_session_reply(
     }
 
     run_codex_tool_session_inner(
-        conversation,
+        thread_id,
+        thread,
         outgoing,
         request_id,
         running_requests_id_to_codex_uuid,
@@ -146,7 +189,8 @@ pub async fn run_codex_tool_session_reply(
 }
 
 async fn run_codex_tool_session_inner(
-    codex: Arc<CodexThread>,
+    thread_id: ThreadId,
+    thread: Arc<CodexThread>,
     outgoing: Arc<OutgoingMessageSender>,
     request_id: RequestId,
     running_requests_id_to_codex_uuid: Arc<Mutex<HashMap<RequestId, ThreadId>>>,
@@ -159,12 +203,15 @@ async fn run_codex_tool_session_inner(
     // Stream events until the task needs to pause for user interaction or
     // completes.
     loop {
-        match codex.next_event().await {
+        match thread.next_event().await {
             Ok(event) => {
                 outgoing
                     .send_event_as_notification(
                         &event,
-                        Some(OutgoingNotificationMeta::new(Some(request_id.clone()))),
+                        Some(OutgoingNotificationMeta {
+                            request_id: Some(request_id.clone()),
+                            thread_id: Some(thread_id),
+                        }),
                     )
                     .await;
 
@@ -182,21 +229,24 @@ async fn run_codex_tool_session_inner(
                             command,
                             cwd,
                             outgoing.clone(),
-                            codex.clone(),
+                            thread.clone(),
                             request_id.clone(),
                             request_id_str.clone(),
                             event.id.clone(),
                             call_id,
                             parsed_cmd,
+                            thread_id,
                         )
                         .await;
                         continue;
                     }
                     EventMsg::Error(err_event) => {
-                        // Return a response to conclude the tool call when the Codex session reports an error (e.g., interruption).
-                        let result = json!({
-                            "error": err_event.message,
-                        });
+                        // Always respond in tools/call's expected shape, and include conversationId so the client can resume.
+                        let result = create_call_tool_result_with_thread_id(
+                            thread_id,
+                            err_event.message,
+                            Some(true),
+                        );
                         outgoing.send_response(request_id.clone(), result).await;
                         break;
                     }
@@ -220,10 +270,11 @@ async fn run_codex_tool_session_inner(
                             grant_root,
                             changes,
                             outgoing.clone(),
-                            codex.clone(),
+                            thread.clone(),
                             request_id.clone(),
                             request_id_str.clone(),
                             event.id.clone(),
+                            thread_id,
                         )
                         .await;
                         continue;
@@ -233,15 +284,7 @@ async fn run_codex_tool_session_inner(
                             Some(msg) => msg,
                             None => "".to_string(),
                         };
-                        let result = CallToolResult {
-                            content: vec![ContentBlock::TextContent(TextContent {
-                                r#type: "text".to_string(),
-                                text,
-                                annotations: None,
-                            })],
-                            is_error: None,
-                            structured_content: None,
-                        };
+                        let result = create_call_tool_result_with_thread_id(thread_id, text, None);
                         outgoing.send_response(request_id.clone(), result).await;
                         // unregister the id so we don't keep it in the map
                         running_requests_id_to_codex_uuid
@@ -317,20 +360,32 @@ async fn run_codex_tool_session_inner(
                 }
             }
             Err(e) => {
-                let result = CallToolResult {
-                    content: vec![ContentBlock::TextContent(TextContent {
-                        r#type: "text".to_string(),
-                        text: format!("Codex runtime error: {e}"),
-                        annotations: None,
-                    })],
-                    is_error: Some(true),
-                    // TODO(mbolin): Could present the error in a more
-                    // structured way.
-                    structured_content: None,
-                };
+                let result = create_call_tool_result_with_thread_id(
+                    thread_id,
+                    format!("Codex runtime error: {e}"),
+                    Some(true),
+                );
                 outgoing.send_response(request_id.clone(), result).await;
                 break;
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn call_tool_result_includes_thread_id_in_structured_content() {
+        let thread_id = ThreadId::new();
+        let result = create_call_tool_result_with_thread_id(thread_id, "done".to_string(), None);
+        assert_eq!(
+            result.structured_content,
+            Some(json!({
+                "threadId": thread_id,
+            }))
+        );
     }
 }

--- a/codex-rs/mcp-server/src/exec_approval.rs
+++ b/codex-rs/mcp-server/src/exec_approval.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use codex_core::CodexThread;
 use codex_core::protocol::Op;
 use codex_core::protocol::ReviewDecision;
+use codex_protocol::ThreadId;
 use codex_protocol::parse_command::ParsedCommand;
 use mcp_types::ElicitRequest;
 use mcp_types::ElicitRequestParamsRequestedSchema;
@@ -30,6 +31,8 @@ pub struct ExecApprovalElicitRequestParams {
 
     // These are additional fields the client can use to
     // correlate the request with the codex tool call.
+    #[serde(rename = "threadId")]
+    pub thread_id: ThreadId,
     pub codex_elicitation: String,
     pub codex_mcp_tool_call_id: String,
     pub codex_event_id: String,
@@ -59,6 +62,7 @@ pub(crate) async fn handle_exec_approval_request(
     event_id: String,
     call_id: String,
     codex_parsed_cmd: Vec<ParsedCommand>,
+    thread_id: ThreadId,
 ) {
     let escaped_command =
         shlex::try_join(command.iter().map(String::as_str)).unwrap_or_else(|_| command.join(" "));
@@ -74,6 +78,7 @@ pub(crate) async fn handle_exec_approval_request(
             properties: json!({}),
             required: None,
         },
+        thread_id,
         codex_elicitation: "exec-approval".to_string(),
         codex_mcp_tool_call_id: tool_call_id.clone(),
         codex_event_id: event_id.clone(),

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -433,10 +433,7 @@ impl MessageProcessor {
         tracing::info!("tools/call -> params: {:?}", arguments);
 
         // parse arguments
-        let CodexToolCallReplyParam {
-            conversation_id,
-            prompt,
-        } = match arguments {
+        let codex_tool_call_reply_param: CodexToolCallReplyParam = match arguments {
             Some(json_val) => match serde_json::from_value::<CodexToolCallReplyParam>(json_val) {
                 Ok(params) => params,
                 Err(e) => {
@@ -457,12 +454,12 @@ impl MessageProcessor {
             },
             None => {
                 tracing::error!(
-                    "Missing arguments for codex-reply tool-call; the `conversation_id` and `prompt` fields are required."
+                    "Missing arguments for codex-reply tool-call; the `thread_id` and `prompt` fields are required."
                 );
                 let result = CallToolResult {
                     content: vec![ContentBlock::TextContent(TextContent {
                         r#type: "text".to_owned(),
-                        text: "Missing arguments for codex-reply tool-call; the `conversation_id` and `prompt` fields are required.".to_owned(),
+                        text: "Missing arguments for codex-reply tool-call; the `thread_id` and `prompt` fields are required.".to_owned(),
                         annotations: None,
                     })],
                     is_error: Some(true),
@@ -473,14 +470,15 @@ impl MessageProcessor {
                 return;
             }
         };
-        let conversation_id = match ThreadId::from_string(&conversation_id) {
+
+        let thread_id = match codex_tool_call_reply_param.get_thread_id() {
             Ok(id) => id,
             Err(e) => {
-                tracing::error!("Failed to parse conversation_id: {e}");
+                tracing::error!("Failed to parse thread_id: {e}");
                 let result = CallToolResult {
                     content: vec![ContentBlock::TextContent(TextContent {
                         r#type: "text".to_owned(),
-                        text: format!("Failed to parse conversation_id: {e}"),
+                        text: format!("Failed to parse thread_id: {e}"),
                         annotations: None,
                     })],
                     is_error: Some(true),
@@ -496,18 +494,20 @@ impl MessageProcessor {
         let outgoing = self.outgoing.clone();
         let running_requests_id_to_codex_uuid = self.running_requests_id_to_codex_uuid.clone();
 
-        let codex = match self.thread_manager.get_thread(conversation_id).await {
+        let codex = match self.thread_manager.get_thread(thread_id).await {
             Ok(c) => c,
             Err(_) => {
-                tracing::warn!("Session not found for conversation_id: {conversation_id}");
+                tracing::warn!("Session not found for thread_id: {thread_id}");
                 let result = CallToolResult {
                     content: vec![ContentBlock::TextContent(TextContent {
                         r#type: "text".to_owned(),
-                        text: format!("Session not found for conversation_id: {conversation_id}"),
+                        text: format!("Session not found for thread_id: {thread_id}"),
                         annotations: None,
                     })],
                     is_error: Some(true),
-                    structured_content: None,
+                    structured_content: Some(json!({
+                        "threadId": thread_id,
+                    })),
                 };
                 outgoing.send_response(request_id, result).await;
                 return;
@@ -515,19 +515,19 @@ impl MessageProcessor {
         };
 
         // Spawn the long-running reply handler.
+        let prompt = codex_tool_call_reply_param.prompt.clone();
         tokio::spawn({
             let outgoing = outgoing.clone();
-            let prompt = prompt.clone();
             let running_requests_id_to_codex_uuid = running_requests_id_to_codex_uuid.clone();
 
             async move {
                 crate::codex_tool_runner::run_codex_tool_session_reply(
+                    thread_id,
                     codex,
                     outgoing,
                     request_id,
                     prompt,
                     running_requests_id_to_codex_uuid,
-                    conversation_id,
                 )
                 .await;
             }
@@ -563,8 +563,8 @@ impl MessageProcessor {
             RequestId::Integer(i) => i.to_string(),
         };
 
-        // Obtain the conversation id while holding the first lock, then release.
-        let conversation_id = {
+        // Obtain the thread id while holding the first lock, then release.
+        let thread_id = {
             let map_guard = self.running_requests_id_to_codex_uuid.lock().await;
             match map_guard.get(&request_id) {
                 Some(id) => *id,
@@ -574,13 +574,13 @@ impl MessageProcessor {
                 }
             }
         };
-        tracing::info!("conversation_id: {conversation_id}");
+        tracing::info!("thread_id: {thread_id}");
 
-        // Obtain the Codex conversation from the server.
-        let codex_arc = match self.thread_manager.get_thread(conversation_id).await {
+        // Obtain the Codex thread from the server.
+        let codex_arc = match self.thread_manager.get_thread(thread_id).await {
             Ok(c) => c,
             Err(_) => {
-                tracing::warn!("Session not found for conversation_id: {conversation_id}");
+                tracing::warn!("Session not found for thread_id: {thread_id}");
                 return;
             }
         };

--- a/codex-rs/mcp-server/src/patch_approval.rs
+++ b/codex-rs/mcp-server/src/patch_approval.rs
@@ -6,6 +6,7 @@ use codex_core::CodexThread;
 use codex_core::protocol::FileChange;
 use codex_core::protocol::Op;
 use codex_core::protocol::ReviewDecision;
+use codex_protocol::ThreadId;
 use mcp_types::ElicitRequest;
 use mcp_types::ElicitRequestParamsRequestedSchema;
 use mcp_types::JSONRPCErrorError;
@@ -19,11 +20,13 @@ use tracing::error;
 use crate::codex_tool_runner::INVALID_PARAMS_ERROR_CODE;
 use crate::outgoing_message::OutgoingMessageSender;
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Deserialize, Serialize)]
 pub struct PatchApprovalElicitRequestParams {
     pub message: String,
     #[serde(rename = "requestedSchema")]
     pub requested_schema: ElicitRequestParamsRequestedSchema,
+    #[serde(rename = "threadId")]
+    pub thread_id: ThreadId,
     pub codex_elicitation: String,
     pub codex_mcp_tool_call_id: String,
     pub codex_event_id: String,
@@ -51,6 +54,7 @@ pub(crate) async fn handle_patch_approval_request(
     request_id: RequestId,
     tool_call_id: String,
     event_id: String,
+    thread_id: ThreadId,
 ) {
     let mut message_lines = Vec::new();
     if let Some(r) = &reason {
@@ -65,6 +69,7 @@ pub(crate) async fn handle_patch_approval_request(
             properties: json!({}),
             required: None,
         },
+        thread_id,
         codex_elicitation: "patch-approval".to_string(),
         codex_mcp_tool_call_id: tool_call_id.clone(),
         codex_event_id: event_id.clone(),


### PR DESCRIPTION
This favors `threadId` instead of `conversationId` so we use the same terms as https://developers.openai.com/codex/sdk/.

To test the local build:

```
cd codex-rs
cargo build --bin codex
npx -y @modelcontextprotocol/inspector ./target/debug/codex mcp-server
```

I sent:

```json
{
  "method": "tools/call",
  "params": {
    "name": "codex",
    "arguments": {
      "prompt": "favorite ls option?"
    },
    "_meta": {
      "progressToken": 0
    }
  }
}
```

and got:

```json
{
  "content": [
    {
      "type": "text",
      "text": "`ls -lah` (or `ls -alh`) — long listing, includes dotfiles, human-readable sizes."
    }
  ],
  "structuredContent": {
    "threadId": "019bbb20-bff6-7130-83aa-bf45ab33250e"
  }
}
```

and successfully used the `threadId` in the follow-up with the `codex-reply` tool call:

```json
{
  "method": "tools/call",
  "params": {
    "name": "codex-reply",
    "arguments": {
      "prompt": "what is the long versoin",
      "threadId": "019bbb20-bff6-7130-83aa-bf45ab33250e"
    },
    "_meta": {
      "progressToken": 1
    }
  }
}
```

whose response also has the `threadId`:

```json
{
  "content": [
    {
      "type": "text",
      "text": "Long listing is `ls -l` (adds permissions, owner/group, size, timestamp)."
    }
  ],
  "structuredContent": {
    "threadId": "019bbb20-bff6-7130-83aa-bf45ab33250e"
  }
}
```

Fixes https://github.com/openai/codex/issues/3712.