### PR TITLE
chore(windows) Enable Powershell UTF8 feature

### DIFF
--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -405,9 +405,9 @@ pub const FEATURES: &[FeatureSpec] = &[
         key: "powershell_utf8",
         #[cfg(windows)]
         stage: Stage::Beta {
-            name: "Powershell UTF8",
-            menu_description: "Enable UTF8 output in Powershell.",
-            announcement: "Try UTF8 output in Powershell for better Unicode support. Enable in /experimental!",
+            name: "Powershell UTF-8 support",
+            menu_description: "Enable UTF-8 output in Powershell.",
+            announcement: "Try UTF-8 output in Powershell for better Unicode support. Enable in /experimental!",
         },
         #[cfg(windows)]
         default_enabled: false,

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -403,7 +403,17 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::PowershellUtf8,
         key: "powershell_utf8",
+        #[cfg(windows)]
+        stage: Stage::Beta {
+            name: "Powershell UTF8",
+            menu_description: "Enable UTF8 output in Powershell.",
+            announcement: "Try UTF8 output in Powershell for better Unicode support. Enable in /experimental!",
+        },
+        #[cfg(windows)]
+        default_enabled: false,
+        #[cfg(not(windows))]
         stage: Stage::Experimental,
+        #[cfg(not(windows))]
         default_enabled: false,
     },
     FeatureSpec {

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -407,6 +407,7 @@ pub const FEATURES: &[FeatureSpec] = &[
         stage: Stage::Beta {
             name: "Powershell UTF-8 support",
             menu_description: "Enable UTF-8 output in Powershell.",
+            announcement: "Codex now supports UTF-8 output in Powershell. If you are seeing problems, disable in /experimental.",
         },
         #[cfg(windows)]
         default_enabled: true,

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -407,10 +407,9 @@ pub const FEATURES: &[FeatureSpec] = &[
         stage: Stage::Beta {
             name: "Powershell UTF-8 support",
             menu_description: "Enable UTF-8 output in Powershell.",
-            announcement: "Try UTF-8 output in Powershell for better Unicode support. Enable in /experimental!",
         },
         #[cfg(windows)]
-        default_enabled: false,
+        default_enabled: true,
         #[cfg(not(windows))]
         stage: Stage::Experimental,
         #[cfg(not(windows))]


### PR DESCRIPTION
## Summary
We've received a lot of positive feedback about this feature, so we're going to enable it by default.