### PR TITLE
fix: send non-null content on elicitation Accept

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2064,10 +2064,13 @@ mod handlers {
             codex_protocol::approvals::ElicitationAction::Decline => ElicitationAction::Decline,
             codex_protocol::approvals::ElicitationAction::Cancel => ElicitationAction::Cancel,
         };
-        let response = ElicitationResponse {
-            action,
-            content: None,
+        // When accepting, send an empty object as content to satisfy MCP servers
+        // that expect non-null content on Accept. For Decline/Cancel, content is None.
+        let content = match action {
+            ElicitationAction::Accept => Some(serde_json::json!({})),
+            ElicitationAction::Decline | ElicitationAction::Cancel => None,
         };
+        let response = ElicitationResponse { action, content };
         if let Err(err) = sess
             .resolve_elicitation(server_name, request_id, response)
             .await


### PR DESCRIPTION
## Summary

- When a user accepts an MCP elicitation request, send `content: Some(json!({}))` instead of `None`
- MCP servers that use elicitation expect content to be present when action is Accept
- This matches the expected behavior shown in tests at `exec-server/tests/common/lib.rs:171`

## Root Cause

In `codex-rs/core/src/codex.rs`, the `resolve_elicitation` function always sent `content: None`:

```rust
let response = ElicitationResponse {
    action,
    content: None,  // Always None, even for Accept
};
```

## Fix

Send an empty object when accepting:

```rust
let content = match action {
    ElicitationAction::Accept => Some(serde_json::json!({})),
    ElicitationAction::Decline | ElicitationAction::Cancel => None,
};
```

## Test plan

- [x] Code compiles with `cargo check -p codex-core`
- [x] Formatted with `just fmt`
- [ ] Integration test `accept_elicitation_for_prompt_rule` (requires MCP server binary)

Fixes #9053