### PR TITLE
s/mcp_server_requirements/mcp_servers

### DIFF
--- a/codex-rs/app-server/src/config_api.rs
+++ b/codex-rs/app-server/src/config_api.rs
@@ -135,7 +135,7 @@ mod tests {
                 CoreSandboxModeRequirement::ReadOnly,
                 CoreSandboxModeRequirement::ExternalSandbox,
             ]),
-            mcp_server_requirements: None,
+            mcp_servers: None,
         };
 
         let mapped = map_requirements_toml_to_api(requirements);

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1425,7 +1425,7 @@ impl Config {
         let ConfigRequirements {
             approval_policy: mut constrained_approval_policy,
             sandbox_policy: mut constrained_sandbox_policy,
-            mcp_server_requirements,
+            mcp_servers,
         } = requirements;
 
         constrained_approval_policy
@@ -1435,11 +1435,8 @@ impl Config {
             .set(sandbox_policy)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("{e}")))?;
 
-        let mcp_servers =
-            constrain_mcp_servers(cfg.mcp_servers.clone(), mcp_server_requirements.as_ref())
-                .map_err(|e| {
-                    std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("{e}"))
-                })?;
+        let mcp_servers = constrain_mcp_servers(cfg.mcp_servers.clone(), mcp_servers.as_ref())
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, format!("{e}")))?;
 
         let config = Self {
             model,


### PR DESCRIPTION
A simple `s/mcp_server_requirements/mcp_servers/g` for an unreleased feature. @bolinfest correctly pointed out, it's already in `requirements.toml` so the `_requirements` is redundant.