### PR TITLE
feat(app-server): add prompt/list API

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -133,6 +133,10 @@ client_request_definitions! {
         params: v2::SkillsListParams,
         response: v2::SkillsListResponse,
     },
+    PromptList => "prompt/list" {
+        params: v2::PromptListParams,
+        response: v2::PromptListResponse,
+    },
     TurnStart => "turn/start" {
         params: v2::TurnStartParams,
         response: v2::TurnStartResponse,

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1231,6 +1231,58 @@ pub struct SkillsListResponse {
     pub data: Vec<SkillsListEntry>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct PromptListParams {
+    /// When empty, defaults to the current session `CODEX_HOME/prompts`.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub roots: Vec<PathBuf>,
+
+    /// When true, bypass the prompt cache and re-scan prompts from disk.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub force_reload: bool,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct PromptListResponse {
+    pub data: Vec<PromptListEntry>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct PromptMetadata {
+    pub id: String,
+    pub path: PathBuf,
+    pub content: String,
+    #[ts(optional)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    #[ts(optional)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub argument_hint: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct PromptErrorInfo {
+    pub path: PathBuf,
+    pub message: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct PromptListEntry {
+    pub root: PathBuf,
+    pub prompts: Vec<PromptMetadata>,
+    pub errors: Vec<PromptErrorInfo>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, JsonSchema, TS)]
 #[serde(rename_all = "snake_case")]
 #[ts(rename_all = "snake_case")]

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1235,11 +1235,11 @@ pub struct SkillsListResponse {
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct PromptListParams {
-    /// When empty, defaults to the current session `CODEX_HOME/prompts`.
-    pub roots: Vec<PathBuf>,
+    /// When empty or null, defaults to the current session `CODEX_HOME/prompts`.
+    pub roots: Option<Vec<PathBuf>>,
 
     /// When true, bypass the prompt cache and re-scan prompts from disk.
-    pub force_reload: bool,
+    pub force_reload: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1263,18 +1263,9 @@ pub struct PromptMetadata {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
-pub struct PromptErrorInfo {
-    pub path: PathBuf,
-    pub message: String,
-}
-
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
-#[serde(rename_all = "camelCase")]
-#[ts(export_to = "v2/")]
 pub struct PromptListEntry {
     pub root: PathBuf,
     pub prompts: Vec<PromptMetadata>,
-    pub errors: Vec<PromptErrorInfo>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, JsonSchema, TS)]

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1235,11 +1235,8 @@ pub struct SkillsListResponse {
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
 pub struct PromptListParams {
-    /// When empty or null, defaults to the current session `CODEX_HOME/prompts`.
+    /// When empty or null, defaults to `$CODEX_HOME/prompts`.
     pub roots: Option<Vec<PathBuf>>,
-
-    /// When true, bypass the prompt cache and re-scan prompts from disk.
-    pub force_reload: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1236,11 +1236,9 @@ pub struct SkillsListResponse {
 #[ts(export_to = "v2/")]
 pub struct PromptListParams {
     /// When empty, defaults to the current session `CODEX_HOME/prompts`.
-    #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub roots: Vec<PathBuf>,
 
     /// When true, bypass the prompt cache and re-scan prompts from disk.
-    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub force_reload: bool,
 }
 
@@ -1258,11 +1256,7 @@ pub struct PromptMetadata {
     pub id: String,
     pub path: PathBuf,
     pub content: String,
-    #[ts(optional)]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub description: Option<String>,
-    #[ts(optional)]
-    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub argument_hint: Option<String>,
 }
 

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1249,7 +1249,7 @@ pub struct PromptListResponse {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
-pub struct PromptMetadata {
+pub struct Prompt {
     pub id: String,
     pub path: PathBuf,
     pub content: String,
@@ -1262,7 +1262,7 @@ pub struct PromptMetadata {
 #[ts(export_to = "v2/")]
 pub struct PromptListEntry {
     pub root: PathBuf,
-    pub prompts: Vec<PromptMetadata>,
+    pub prompts: Vec<Prompt>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, JsonSchema, TS)]

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -492,30 +492,42 @@ Use `skills/list` to fetch the available skills (optionally scoped by `cwd` and/
         { "name": "skill-creator", "description": "Create or update a Codex skill" }
     ]
 } }
+```
 
 ## Prompts
 
-Use `prompt/list` to fetch user-defined prompt templates from `$CODEX_HOME/prompts`.
+Use `prompt/list` to fetch user-defined custom prompt templates from `$CODEX_HOME/prompts`.
+For additional details, please see:
 
-```json
-{ "method": "prompt/list", "id": 26, "params": {} }
-{ "id": 26, "result": {
-    "data": [
-      {
-        "root": "/Users/me/.codex/prompts",
-        "prompts": [
-          {
-            "id": "review",
-            "path": "/Users/me/.codex/prompts/review.md",
-            "content": "Review the following changes...",
-            "description": "Quick review command",
-            "argumentHint": "[file]"
-          }
-        ],
-        "errors": []
-      }
-    ]
-} }
+```
+https://developers.openai.com/codex/custom-prompts
+```
+
+Example end-to-end flow for clients implementing custom prompts:
+1. User saves a prompt file at `$CODEX_HOME/prompts/<id>.md`.
+   - Optional front matter keys: `description`, `argument-hint`.
+   - The prompt body is everything after the front matter.
+2. Client calls `prompt/list` and caches the returned templates.
+3. Client exposes a UI affordance to show and expand prompts. As an example,
+the VSCode IDE extension exposes it as a slash command like `/prompts:<id>`, which
+is populated from the cached list.
+4. When a user selects a prompt, the client expands `/prompts:<id>` to the prompt `content`.
+   - Any trailing arguments are appended to the expanded content.
+5. Client submits the expanded prompt text in the normal `turn/start` request.
+
+### Example: Draft PR custom prompt
+
+User creates `~/.codex/prompts/draftpr.md` with the following content:
+```text
+---
+description: Prep a branch, commit, and open a draft PR
+argument-hint: [FILES=<paths>] [PR_TITLE="<title>"]
+---
+
+Create a branch named `dev/<feature_name>` for this work.
+If files are specified, stage them first: $FILES.
+Commit the staged changes with a clear message.
+Open a draft PR on the same branch. Use $PR_TITLE when supplied; otherwise write a concise summary yourself.
 ```
 
 ## Auth endpoints

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -504,9 +504,8 @@ Example end-to-end flow for clients implementing custom prompts:
    - Optional front matter keys: `description`, `argument-hint`.
    - The prompt body is everything after the front matter.
 2. Client calls `prompt/list` and caches the returned templates.
-3. Client exposes a UI affordance to show and expand prompts. As an example,
-the VSCode IDE extension exposes it as a slash command like `/prompts:<id>`, which
-is populated from the cached list.
+3. Client exposes a UI affordance to show and expand prompts. 
+   - As an example, the VSCode IDE extension exposes it as a slash command like `/prompts:<id>`, which is populated from the cached list.
 4. When a user selects a prompt, the client expands `/prompts:<id>` to the prompt `content`.
    - Any trailing arguments are appended to the expanded content.
 5. Client submits the expanded prompt text in the normal `turn/start` request.

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -530,6 +530,28 @@ Commit the staged changes with a clear message.
 Open a draft PR on the same branch. Use $PR_TITLE when supplied; otherwise write a concise summary yourself.
 ```
 
+The corresponding `prompt/list` response:
+```json
+{ "method": "prompt/list", "id": 26, "params": {} }
+{ "id": 26, "result": {
+    "data": [
+      {
+        "root": "/Users/me/.codex/prompts",
+        "prompts": [
+          {
+            "id": "draftpr",
+            "path": "/Users/me/.codex/prompts/draftpr.md",
+            "content": "Create a branch named `dev/<feature_name>` for this work.\nIf files are specified, stage them first: $FILES.\nCommit the staged changes with a clear message.\nOpen a draft PR on the same branch. Use $PR_TITLE when supplied; otherwise write a concise summary yourself.",
+            "description": "Prep a branch, commit, and open a draft PR",
+            "argumentHint": "[FILES=<paths>] [PR_TITLE=\"<title>\"]"
+          }
+        ],
+        "errors": []
+      }
+    ]
+} }
+```
+
 ## Auth endpoints
 
 The JSON-RPC auth/account surface exposes request/response methods plus server-initiated notifications (no `id`). Use these to determine auth state, start or cancel logins, logout, and inspect ChatGPT rate limits.

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -497,11 +497,7 @@ Use `skills/list` to fetch the available skills (optionally scoped by `cwd` and/
 ## Prompts
 
 Use `prompt/list` to fetch user-defined custom prompt templates from `$CODEX_HOME/prompts`.
-For additional details, please see:
-
-```
-https://developers.openai.com/codex/custom-prompts
-```
+For additional details, please see: https://developers.openai.com/codex/custom-prompts
 
 Example end-to-end flow for clients implementing custom prompts:
 1. User saves a prompt file at `$CODEX_HOME/prompts/<id>.md`.

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -545,8 +545,7 @@ The corresponding `prompt/list` response:
             "description": "Prep a branch, commit, and open a draft PR",
             "argumentHint": "[FILES=<paths>] [PR_TITLE=\"<title>\"]"
           }
-        ],
-        "errors": []
+        ]
       }
     ]
 } }

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -492,6 +492,30 @@ Use `skills/list` to fetch the available skills (optionally scoped by `cwd` and/
         { "name": "skill-creator", "description": "Create or update a Codex skill" }
     ]
 } }
+
+## Prompts
+
+Use `prompt/list` to fetch user-defined prompt templates from `$CODEX_HOME/prompts`.
+
+```json
+{ "method": "prompt/list", "id": 26, "params": {} }
+{ "id": 26, "result": {
+    "data": [
+      {
+        "root": "/Users/me/.codex/prompts",
+        "prompts": [
+          {
+            "id": "review",
+            "path": "/Users/me/.codex/prompts/review.md",
+            "content": "Review the following changes...",
+            "description": "Quick review command",
+            "argumentHint": "[file]"
+          }
+        ],
+        "errors": []
+      }
+    ]
+} }
 ```
 
 ## Auth endpoints

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -66,10 +66,10 @@ use codex_app_server_protocol::ModelListParams;
 use codex_app_server_protocol::ModelListResponse;
 use codex_app_server_protocol::NewConversationParams;
 use codex_app_server_protocol::NewConversationResponse;
+use codex_app_server_protocol::Prompt;
 use codex_app_server_protocol::PromptListEntry;
 use codex_app_server_protocol::PromptListParams;
 use codex_app_server_protocol::PromptListResponse;
-use codex_app_server_protocol::PromptMetadata;
 use codex_app_server_protocol::RemoveConversationListenerParams;
 use codex_app_server_protocol::RemoveConversationSubscriptionResponse;
 use codex_app_server_protocol::RequestId;
@@ -3242,7 +3242,7 @@ impl CodexMessageProcessor {
             let prompts = codex_core::custom_prompts::discover_prompts_in(&root).await;
             let prompts = prompts
                 .into_iter()
-                .map(|prompt| PromptMetadata {
+                .map(|prompt| Prompt {
                     id: prompt.name,
                     path: prompt.path,
                     content: prompt.content,

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -3228,10 +3228,7 @@ impl CodexMessageProcessor {
     }
 
     async fn prompt_list(&self, request_id: RequestId, params: PromptListParams) {
-        let PromptListParams {
-            roots,
-            force_reload: _,
-        } = params;
+        let roots = params.roots.unwrap_or_default();
         let roots = if roots.is_empty() {
             codex_core::custom_prompts::default_prompts_dir()
                 .map(|root| vec![root])

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -3253,11 +3253,7 @@ impl CodexMessageProcessor {
                     argument_hint: prompt.argument_hint,
                 })
                 .collect();
-            data.push(PromptListEntry {
-                root,
-                prompts,
-                errors: Vec::new(),
-            });
+            data.push(PromptListEntry { root, prompts });
         }
 
         self.outgoing

--- a/codex-rs/app-server/tests/common/mcp_process.rs
+++ b/codex-rs/app-server/tests/common/mcp_process.rs
@@ -554,7 +554,7 @@ impl McpProcess {
         self.send_request("fuzzyFileSearch", Some(params)).await
     }
 
-    async fn send_request(
+    pub async fn send_request(
         &mut self,
         method: &str,
         params: Option<serde_json::Value>,

--- a/codex-rs/app-server/tests/common/mcp_process.rs
+++ b/codex-rs/app-server/tests/common/mcp_process.rs
@@ -35,6 +35,7 @@ use codex_app_server_protocol::ListConversationsParams;
 use codex_app_server_protocol::LoginApiKeyParams;
 use codex_app_server_protocol::ModelListParams;
 use codex_app_server_protocol::NewConversationParams;
+use codex_app_server_protocol::PromptListParams;
 use codex_app_server_protocol::RemoveConversationListenerParams;
 use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ResumeConversationParams;
@@ -394,6 +395,15 @@ impl McpProcess {
     ) -> anyhow::Result<i64> {
         let params = Some(serde_json::to_value(params)?);
         self.send_request("model/list", params).await
+    }
+
+    /// Send a `prompt/list` JSON-RPC request.
+    pub async fn send_prompt_list_request(
+        &mut self,
+        params: PromptListParams,
+    ) -> anyhow::Result<i64> {
+        let params = Some(serde_json::to_value(params)?);
+        self.send_request("prompt/list", params).await
     }
 
     /// Send a `resumeConversation` JSON-RPC request.

--- a/codex-rs/app-server/tests/suite/v2/mod.rs
+++ b/codex-rs/app-server/tests/suite/v2/mod.rs
@@ -4,6 +4,7 @@ mod config_rpc;
 mod initialize;
 mod model_list;
 mod output_schema;
+mod prompt_list;
 mod rate_limits;
 mod review;
 mod thread_archive;

--- a/codex-rs/app-server/tests/suite/v2/prompt_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/prompt_list.rs
@@ -2,8 +2,8 @@ use anyhow::Result;
 use app_test_support::McpProcess;
 use app_test_support::to_response;
 use codex_app_server_protocol::JSONRPCResponse;
+use codex_app_server_protocol::Prompt;
 use codex_app_server_protocol::PromptListResponse;
-use codex_app_server_protocol::PromptMetadata;
 use codex_app_server_protocol::RequestId;
 use pretty_assertions::assert_eq;
 use serde_json::json;
@@ -50,7 +50,7 @@ Open a draft PR on the same branch. Use $PR_TITLE when supplied; otherwise write
 
     let prompts = entry.prompts;
     let expected_content = "\nCreate a branch named `dev/<feature_name>` for this work.\nIf files are specified, stage them first: $FILES.\nCommit the staged changes with a clear message.\nOpen a draft PR on the same branch. Use $PR_TITLE when supplied; otherwise write a concise summary yourself.".to_string();
-    let expected = vec![PromptMetadata {
+    let expected = vec![Prompt {
         id: "draftpr".to_string(),
         path: expected_root.join("draftpr.md"),
         content: expected_content,

--- a/codex-rs/app-server/tests/suite/v2/prompt_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/prompt_list.rs
@@ -52,7 +52,6 @@ Open a draft PR on the same branch. Use $PR_TITLE when supplied; otherwise write
     let entry = data.pop().expect("prompt list entry");
     let expected_root = std::fs::canonicalize(&prompts_dir).unwrap_or_else(|_| prompts_dir.clone());
     assert_eq!(entry.root, expected_root);
-    assert_eq!(entry.errors, Vec::new());
 
     let prompts = entry.prompts;
     let expected_content = "\nCreate a branch named `dev/<feature_name>` for this work.\nIf files are specified, stage them first: $FILES.\nCommit the staged changes with a clear message.\nOpen a draft PR on the same branch. Use $PR_TITLE when supplied; otherwise write a concise summary yourself.".to_string();

--- a/codex-rs/app-server/tests/suite/v2/prompt_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/prompt_list.rs
@@ -1,0 +1,87 @@
+use anyhow::Result;
+use app_test_support::McpProcess;
+use app_test_support::to_response;
+use codex_app_server_protocol::JSONRPCResponse;
+use codex_app_server_protocol::PromptListParams;
+use codex_app_server_protocol::PromptListResponse;
+use codex_app_server_protocol::PromptMetadata;
+use codex_app_server_protocol::RequestId;
+use pretty_assertions::assert_eq;
+use std::path::Path;
+use tempfile::TempDir;
+use tokio::time::timeout;
+
+const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+#[tokio::test]
+async fn prompt_list_reads_prompts_from_codex_home() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path())?;
+    let prompts_dir = codex_home.path().join("prompts");
+    std::fs::create_dir_all(&prompts_dir)?;
+
+    let review_body = r#"---
+description: "Quick review command"
+argument-hint: "[file]"
+---
+Review the following changes..."#;
+    std::fs::write(prompts_dir.join("review.md"), review_body)?;
+    std::fs::write(prompts_dir.join("note.txt"), "ignore")?;
+    std::fs::write(prompts_dir.join("quick.md"), "Quick check")?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let req_id = mcp
+        .send_prompt_list_request(PromptListParams {
+            roots: Vec::new(),
+            force_reload: false,
+        })
+        .await?;
+    let resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(req_id)),
+    )
+    .await??;
+    let PromptListResponse { mut data } = to_response::<PromptListResponse>(resp)?;
+    assert_eq!(data.len(), 1);
+
+    let entry = data.pop().expect("prompt list entry");
+    let expected_root = std::fs::canonicalize(&prompts_dir).unwrap_or_else(|_| prompts_dir.clone());
+    assert_eq!(entry.root, expected_root);
+    assert_eq!(entry.errors, Vec::new());
+
+    let mut prompts = entry.prompts;
+    prompts.sort_by(|left, right| left.id.cmp(&right.id));
+    let expected = vec![
+        PromptMetadata {
+            id: "quick".to_string(),
+            path: expected_root.join("quick.md"),
+            content: "Quick check".to_string(),
+            description: None,
+            argument_hint: None,
+        },
+        PromptMetadata {
+            id: "review".to_string(),
+            path: expected_root.join("review.md"),
+            content: "Review the following changes...".to_string(),
+            description: Some("Quick review command".to_string()),
+            argument_hint: Some("[file]".to_string()),
+        },
+    ];
+    assert_eq!(prompts, expected);
+
+    Ok(())
+}
+
+fn create_config_toml(codex_home: &Path) -> std::io::Result<()> {
+    let config_toml = codex_home.join("config.toml");
+    std::fs::write(config_toml, config_contents())
+}
+
+fn config_contents() -> &'static str {
+    r#"model = "mock-model"
+approval_policy = "never"
+sandbox_mode = "read-only"
+"#
+}


### PR DESCRIPTION
Add a new `prompt/list` API that fetches the user's custom prompts from `$CODEX_HOME/prompts`. https://developers.openai.com/codex/custom-prompts

Currently our VSCode IDE extension reads it directly from disk, but it'll be better for app-server to provide a proper API for this. We currently only support `list` (no API for creating) since we expect users to manually create the markdown files.