### PR TITLE
fix: eliminate unnecessary clone() for each SSE event

### DIFF
--- a/codex-rs/codex-api/src/sse/responses.rs
+++ b/codex-rs/codex-api/src/sse/responses.rs
@@ -320,8 +320,7 @@ pub async fn process_sse(
             }
         };
 
-        let raw = sse.data.clone();
-        trace!("SSE event: {raw}");
+        trace!("SSE event: {}", &sse.data);
 
         let event: ResponsesStreamEvent = match serde_json::from_str(&sse.data) {
             Ok(event) => event,


### PR DESCRIPTION
Given how many SSE events we get, seems worth fixing.