### PR TITLE
Simplify end-to-end turn duration metric tagging

### DIFF
--- a/codex-rs/core/src/state/turn.rs
+++ b/codex-rs/core/src/state/turn.rs
@@ -3,6 +3,7 @@
 use indexmap::IndexMap;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Instant;
 use tokio::sync::Mutex;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
@@ -19,14 +20,12 @@ use crate::tasks::SessionTask;
 pub(crate) struct ActiveTurn {
     pub(crate) tasks: IndexMap<String, RunningTask>,
     pub(crate) turn_state: Arc<Mutex<TurnState>>,
+    pub(crate) started_at: Instant,
 }
 
 impl Default for ActiveTurn {
     fn default() -> Self {
-        Self {
-            tasks: IndexMap::new(),
-            turn_state: Arc::new(Mutex::new(TurnState::default())),
-        }
+        Self::new()
     }
 }
 
@@ -48,6 +47,14 @@ pub(crate) struct RunningTask {
 }
 
 impl ActiveTurn {
+    pub(crate) fn new() -> Self {
+        Self {
+            tasks: IndexMap::new(),
+            turn_state: Arc::new(Mutex::new(TurnState::default())),
+            started_at: Instant::now(),
+        }
+    }
+
     pub(crate) fn add_task(&mut self, task: RunningTask) {
         let sub_id = task.turn_context.sub_id.clone();
         self.tasks.insert(sub_id, task);


### PR DESCRIPTION
### Motivation
- Keep end-to-end turn duration recording simple by removing the per-turn `kind` tagging so metrics are emitted without extra tags.
- Avoid coupling turn lifecycle bookkeeping to metric tag logic and make the histogram emission minimal and robust.

### Description
- Stop storing task `kind` on `ActiveTurn` and keep only the `started_at: Instant` timestamp in `codex-rs/core/src/state/turn.rs` by adding `ActiveTurn::new` and updating `Default` to call it.
- Record the end-to-end duration histogram without tags in `Session::on_task_finished` by calling `OtelManager::record_duration("codex.turn.end_to_end_duration", ...)` with an empty tag slice in `codex-rs/core/src/tasks/mod.rs`.
- Update the Otel manager histogram test in `codex-rs/otel/tests/suite/manager_metrics.rs` (the `manager_records_turn_end_to_end_duration_histogram` test) to remove the `turn_kind` expectation and assert histogram buckets and standard metadata attributes instead.

### Testing
- Ran `just fmt` which completed successfully.
- Ran `just fix -p codex-core` (Clippy fixes) which completed successfully.
- Note: full test suites were not rerun as part of this update; the Otel histogram unit test was adjusted in the code but not executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_696693c5193c8327a1f94b059cf6318c)