### PR TITLE
fix: increase timeout for release builds from 30 to 60 minutes

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -49,7 +49,7 @@ jobs:
     needs: tag-check
     name: Build - ${{ matrix.runner }} - ${{ matrix.target }}
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    timeout-minutes: 60
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
Windows builds have been tripping the 30 minute timeout. For sure, we need to improve this, but as a quick fix, let's just increase the timeout.

Perhaps we should switch to `lto = "thin"` for release builds, at least for Windows:

https://github.com/openai/codex/blob/3728db11b87cb8490bcf6bf2cdf0e13dcfb0c28b/codex-rs/Cargo.toml#L288

See https://doc.rust-lang.org/cargo/reference/profiles.html#lto for details.