### PR TITLE
[search] allow explicitly disabling web search

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -31,6 +31,7 @@ use codex_otel::OtelManager;
 
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::ReasoningSummary as ReasoningSummaryConfig;
+use codex_protocol::config_types::WebSearchMode;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::openai_models::ModelInfo;
 use codex_protocol::openai_models::ReasoningEffort as ReasoningEffortConfig;
@@ -641,11 +642,13 @@ fn build_responses_headers(config: &Config) -> ApiHeaderMap {
     let mut headers = beta_feature_headers(config);
     headers.insert(
         WEB_SEARCH_ELIGIBLE_HEADER,
-        HeaderValue::from_static(if config.web_search_eligible {
-            "true"
-        } else {
-            "false"
-        }),
+        HeaderValue::from_static(
+            if matches!(config.web_search_mode, Some(WebSearchMode::Disabled)) {
+                "false"
+            } else {
+                "true"
+            },
+        ),
     );
     headers
 }

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -639,7 +639,7 @@ fn beta_feature_headers(config: &Config) -> ApiHeaderMap {
 
 fn build_responses_headers(config: &Config) -> ApiHeaderMap {
     let mut headers = beta_feature_headers(config);
-    if config.explicit_web_search_disabled {
+    if config.explicit_web_search_disabled == Some(true) {
         headers.insert(WEB_SEARCH_DISABLED_HEADER, HeaderValue::from_static("true"));
     }
     headers

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -64,7 +64,7 @@ use crate::model_provider_info::WireApi;
 use crate::tools::spec::create_tools_json_for_chat_completions_api;
 use crate::tools::spec::create_tools_json_for_responses_api;
 
-pub const WEB_SEARCH_DISABLED_HEADER: &str = "x-openai-web-search-disabled";
+pub const WEB_SEARCH_ELIGIBLE_HEADER: &str = "x-oai-web-search-eligible";
 
 #[derive(Debug)]
 struct ModelClientState {
@@ -639,9 +639,14 @@ fn beta_feature_headers(config: &Config) -> ApiHeaderMap {
 
 fn build_responses_headers(config: &Config) -> ApiHeaderMap {
     let mut headers = beta_feature_headers(config);
-    if config.explicit_web_search_disabled == Some(true) {
-        headers.insert(WEB_SEARCH_DISABLED_HEADER, HeaderValue::from_static("true"));
-    }
+    headers.insert(
+        WEB_SEARCH_ELIGIBLE_HEADER,
+        HeaderValue::from_static(if config.web_search_eligible {
+            "true"
+        } else {
+            "false"
+        }),
+    );
     headers
 }
 

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -64,6 +64,8 @@ use crate::model_provider_info::WireApi;
 use crate::tools::spec::create_tools_json_for_chat_completions_api;
 use crate::tools::spec::create_tools_json_for_responses_api;
 
+pub const WEB_SEARCH_DISABLED_HEADER: &str = "x-openai-web-search-disabled";
+
 #[derive(Debug)]
 struct ModelClientState {
     config: Arc<Config>,
@@ -319,7 +321,7 @@ impl ModelClientSession {
             store_override: None,
             conversation_id: Some(conversation_id),
             session_source: Some(self.state.session_source.clone()),
-            extra_headers: beta_feature_headers(&self.state.config),
+            extra_headers: build_responses_headers(&self.state.config),
             compression,
         }
     }
@@ -631,6 +633,14 @@ fn beta_feature_headers(config: &Config) -> ApiHeaderMap {
         && let Ok(header_value) = HeaderValue::from_str(value.as_str())
     {
         headers.insert("x-codex-beta-features", header_value);
+    }
+    headers
+}
+
+fn build_responses_headers(config: &Config) -> ApiHeaderMap {
+    let mut headers = beta_feature_headers(config);
+    if config.explicit_web_search_disabled {
+        headers.insert(WEB_SEARCH_DISABLED_HEADER, HeaderValue::from_static("true"));
     }
     headers
 }

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2416,7 +2416,7 @@ async fn spawn_review_thread(
     let tools_config = ToolsConfig::new(&ToolsConfigParams {
         model_info: &review_model_info,
         features: &review_features,
-        web_search_mode: review_web_search_mode,
+        web_search_mode: Some(review_web_search_mode),
     });
 
     let base_instructions = REVIEW_PROMPT.to_string();
@@ -2429,7 +2429,7 @@ async fn spawn_review_thread(
     let mut per_turn_config = (*config).clone();
     per_turn_config.model = Some(model.clone());
     per_turn_config.features = review_features.clone();
-    per_turn_config.web_search_mode = review_web_search_mode;
+    per_turn_config.web_search_mode = Some(review_web_search_mode);
 
     let otel_manager = parent_turn_context
         .client

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -2201,7 +2201,7 @@ trust_level = "trusted"
     }
 
     #[test]
-    fn web_search_mode_uses_default_if_unset() {
+    fn web_search_mode_uses_none_if_unset() {
         let cfg = ConfigToml::default();
         let profile = ConfigProfile::default();
         let features = Features::with_defaults();

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -339,7 +339,7 @@ pub struct Config {
 
     pub web_search_mode: WebSearchMode,
     /// Set when the user explicitly disables web search in config.
-    pub explicit_web_search_disabled: bool,
+    pub explicit_web_search_disabled: Option<bool>,
 
     /// If set to `true`, used only the experimental unified exec tool.
     pub use_experimental_unified_exec_tool: bool,
@@ -1207,20 +1207,25 @@ fn resolve_web_search_mode(
 fn resolve_explicit_web_search_disabled(
     config_toml: &ConfigToml,
     config_profile: &ConfigProfile,
-) -> bool {
+) -> Option<bool> {
     if let Some(mode) = config_profile.web_search.or(config_toml.web_search) {
-        return mode == WebSearchMode::Disabled;
+        return (mode == WebSearchMode::Disabled).then_some(true);
     }
 
     if config_profile.tools_web_search == Some(false) {
-        return true;
+        return Some(true);
     }
 
-    config_toml
+    if config_toml
         .tools
         .as_ref()
         .and_then(|tools| tools.web_search)
         == Some(false)
+    {
+        return Some(true);
+    }
+
+    None
 }
 
 impl Config {
@@ -2277,7 +2282,10 @@ trust_level = "trusted"
         };
         let profile = ConfigProfile::default();
 
-        assert!(resolve_explicit_web_search_disabled(&cfg, &profile));
+        assert_eq!(
+            resolve_explicit_web_search_disabled(&cfg, &profile),
+            Some(true)
+        );
     }
 
     #[test]
@@ -2291,7 +2299,7 @@ trust_level = "trusted"
             ..Default::default()
         };
 
-        assert!(!resolve_explicit_web_search_disabled(&cfg, &profile));
+        assert_eq!(resolve_explicit_web_search_disabled(&cfg, &profile), None);
     }
 
     #[test]
@@ -2305,7 +2313,10 @@ trust_level = "trusted"
         };
         let profile = ConfigProfile::default();
 
-        assert!(resolve_explicit_web_search_disabled(&cfg, &profile));
+        assert_eq!(
+            resolve_explicit_web_search_disabled(&cfg, &profile),
+            Some(true)
+        );
     }
 
     #[test]
@@ -3645,7 +3656,7 @@ model_verbosity = "high"
                 forced_login_method: None,
                 include_apply_patch_tool: false,
                 web_search_mode: WebSearchMode::default(),
-                explicit_web_search_disabled: false,
+                explicit_web_search_disabled: None,
                 use_experimental_unified_exec_tool: false,
                 ghost_snapshot: GhostSnapshotConfig::default(),
                 features: Features::with_defaults(),
@@ -3733,7 +3744,7 @@ model_verbosity = "high"
             forced_login_method: None,
             include_apply_patch_tool: false,
             web_search_mode: WebSearchMode::default(),
-            explicit_web_search_disabled: false,
+            explicit_web_search_disabled: None,
             use_experimental_unified_exec_tool: false,
             ghost_snapshot: GhostSnapshotConfig::default(),
             features: Features::with_defaults(),
@@ -3836,7 +3847,7 @@ model_verbosity = "high"
             forced_login_method: None,
             include_apply_patch_tool: false,
             web_search_mode: WebSearchMode::default(),
-            explicit_web_search_disabled: false,
+            explicit_web_search_disabled: None,
             use_experimental_unified_exec_tool: false,
             ghost_snapshot: GhostSnapshotConfig::default(),
             features: Features::with_defaults(),
@@ -3925,7 +3936,7 @@ model_verbosity = "high"
             forced_login_method: None,
             include_apply_patch_tool: false,
             web_search_mode: WebSearchMode::default(),
-            explicit_web_search_disabled: false,
+            explicit_web_search_disabled: None,
             use_experimental_unified_exec_tool: false,
             ghost_snapshot: GhostSnapshotConfig::default(),
             features: Features::with_defaults(),

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -111,7 +111,7 @@ mod user_shell_command;
 pub mod util;
 
 pub use apply_patch::CODEX_APPLY_PATCH_ARG1;
-pub use client::WEB_SEARCH_DISABLED_HEADER;
+pub use client::WEB_SEARCH_ELIGIBLE_HEADER;
 pub use command_safety::is_dangerous_command;
 pub use command_safety::is_safe_command;
 pub use exec_policy::ExecPolicyError;

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -111,6 +111,7 @@ mod user_shell_command;
 pub mod util;
 
 pub use apply_patch::CODEX_APPLY_PATCH_ARG1;
+pub use client::WEB_SEARCH_DISABLED_HEADER;
 pub use command_safety::is_dangerous_command;
 pub use command_safety::is_safe_command;
 pub use exec_policy::ExecPolicyError;

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -86,7 +86,7 @@ async fn start_review_conversation(
     let mut sub_agent_config = config.as_ref().clone();
     // Carry over review-only feature restrictions so the delegate cannot
     // re-enable blocked tools (web search, view image).
-    sub_agent_config.web_search_mode = WebSearchMode::Disabled;
+    sub_agent_config.web_search_mode = Some(WebSearchMode::Disabled);
 
     // Set explicit review rubric for the sub-agent
     sub_agent_config.base_instructions = Some(crate::REVIEW_PROMPT.to_string());

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -9,7 +9,7 @@ use codex_core::ModelProviderInfo;
 use codex_core::Prompt;
 use codex_core::ResponseEvent;
 use codex_core::ResponseItem;
-use codex_core::WEB_SEARCH_DISABLED_HEADER;
+use codex_core::WEB_SEARCH_ELIGIBLE_HEADER;
 use codex_core::WireApi;
 use codex_core::models_manager::manager::ModelsManager;
 use codex_otel::OtelManager;
@@ -216,7 +216,7 @@ async fn responses_stream_includes_subagent_header_on_other() {
 }
 
 #[tokio::test]
-async fn responses_stream_includes_web_search_disabled_header() {
+async fn responses_stream_includes_web_search_eligible_header_true_by_default() {
     core_test_support::skip_if_no_network!();
 
     let server = responses::start_mock_server().await;
@@ -227,21 +227,51 @@ async fn responses_stream_includes_web_search_disabled_header() {
 
     let request_recorder = responses::mount_sse_once_match(
         &server,
-        header(WEB_SEARCH_DISABLED_HEADER, "true"),
+        header(WEB_SEARCH_ELIGIBLE_HEADER, "true"),
         response_body,
     )
     .await;
 
-    let mut builder = test_codex().with_config(|config| {
-        config.explicit_web_search_disabled = Some(true);
-    });
-    let test = builder.build(&server).await.expect("build test codex");
+    let test = test_codex().build(&server).await.expect("build test codex");
     test.submit_turn("hello").await.expect("submit test prompt");
 
     let request = request_recorder.single_request();
     assert_eq!(
-        request.header(WEB_SEARCH_DISABLED_HEADER).as_deref(),
+        request.header(WEB_SEARCH_ELIGIBLE_HEADER).as_deref(),
         Some("true")
+    );
+}
+
+#[tokio::test]
+async fn responses_stream_includes_web_search_eligible_header_false_when_disabled() {
+    core_test_support::skip_if_no_network!();
+
+    let server = responses::start_mock_server().await;
+    let response_body = responses::sse(vec![
+        responses::ev_response_created("resp-1"),
+        responses::ev_completed("resp-1"),
+    ]);
+
+    let request_recorder = responses::mount_sse_once_match(
+        &server,
+        header(WEB_SEARCH_ELIGIBLE_HEADER, "false"),
+        response_body,
+    )
+    .await;
+
+    let test = test_codex()
+        .with_config(|config| {
+            config.web_search_eligible = false;
+        })
+        .build(&server)
+        .await
+        .expect("build test codex");
+    test.submit_turn("hello").await.expect("submit test prompt");
+
+    let request = request_recorder.single_request();
+    assert_eq!(
+        request.header(WEB_SEARCH_ELIGIBLE_HEADER).as_deref(),
+        Some("false")
     );
 }
 

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -15,6 +15,7 @@ use codex_core::models_manager::manager::ModelsManager;
 use codex_otel::OtelManager;
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::ReasoningSummary;
+use codex_protocol::config_types::WebSearchMode;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
 use core_test_support::load_default_config_for_test;
@@ -261,7 +262,7 @@ async fn responses_stream_includes_web_search_eligible_header_false_when_disable
 
     let test = test_codex()
         .with_config(|config| {
-            config.web_search_eligible = false;
+            config.web_search_mode = Some(WebSearchMode::Disabled);
         })
         .build(&server)
         .await

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -9,6 +9,7 @@ use codex_core::ModelProviderInfo;
 use codex_core::Prompt;
 use codex_core::ResponseEvent;
 use codex_core::ResponseItem;
+use codex_core::WEB_SEARCH_DISABLED_HEADER;
 use codex_core::WireApi;
 use codex_core::models_manager::manager::ModelsManager;
 use codex_otel::OtelManager;
@@ -210,6 +211,103 @@ async fn responses_stream_includes_subagent_header_on_other() {
     assert_eq!(
         request.header("x-openai-subagent").as_deref(),
         Some("my-task")
+    );
+}
+
+#[tokio::test]
+async fn responses_stream_includes_web_search_disabled_header() {
+    core_test_support::skip_if_no_network!();
+
+    let server = responses::start_mock_server().await;
+    let response_body = responses::sse(vec![
+        responses::ev_response_created("resp-1"),
+        responses::ev_completed("resp-1"),
+    ]);
+
+    let request_recorder = responses::mount_sse_once_match(
+        &server,
+        header(WEB_SEARCH_DISABLED_HEADER, "true"),
+        response_body,
+    )
+    .await;
+
+    let provider = ModelProviderInfo {
+        name: "mock".into(),
+        base_url: Some(format!("{}/v1", server.uri())),
+        env_key: None,
+        env_key_instructions: None,
+        experimental_bearer_token: None,
+        wire_api: WireApi::Responses,
+        query_params: None,
+        http_headers: None,
+        env_http_headers: None,
+        request_max_retries: Some(0),
+        stream_max_retries: Some(0),
+        stream_idle_timeout_ms: Some(5_000),
+        requires_openai_auth: false,
+    };
+
+    let codex_home = TempDir::new().expect("failed to create TempDir");
+    let mut config = load_default_config_for_test(&codex_home).await;
+    config.model_provider_id = provider.name.clone();
+    config.model_provider = provider.clone();
+    config.explicit_web_search_disabled = true;
+    let effort = config.model_reasoning_effort;
+    let summary = config.model_reasoning_summary;
+    let model = ModelsManager::get_model_offline(config.model.as_deref());
+    config.model = Some(model.clone());
+    let config = Arc::new(config);
+
+    let conversation_id = ThreadId::new();
+    let auth_mode = AuthMode::ChatGPT;
+    let session_source = SessionSource::Cli;
+    let model_info = ModelsManager::construct_model_info_offline(model.as_str(), &config);
+
+    let otel_manager = OtelManager::new(
+        conversation_id,
+        model.as_str(),
+        model_info.slug.as_str(),
+        None,
+        Some("test@test.com".to_string()),
+        Some(auth_mode),
+        false,
+        "test".to_string(),
+        session_source.clone(),
+    );
+
+    let mut client_session = ModelClient::new(
+        Arc::clone(&config),
+        None,
+        model_info,
+        otel_manager,
+        provider,
+        effort,
+        summary,
+        conversation_id,
+        session_source,
+    )
+    .new_session();
+
+    let mut prompt = Prompt::default();
+    prompt.input = vec![ResponseItem::Message {
+        id: None,
+        role: "user".into(),
+        content: vec![ContentItem::InputText {
+            text: "hello".into(),
+        }],
+    }];
+
+    let mut stream = client_session.stream(&prompt).await.expect("stream failed");
+    while let Some(event) = stream.next().await {
+        if matches!(event, Ok(ResponseEvent::Completed { .. })) {
+            break;
+        }
+    }
+
+    let request = request_recorder.single_request();
+    assert_eq!(
+        request.header(WEB_SEARCH_DISABLED_HEADER).as_deref(),
+        Some("true")
     );
 }
 

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -14,6 +14,7 @@ use codex_core::ThreadManager;
 use codex_core::WireApi;
 use codex_core::auth::AuthCredentialsStoreMode;
 use codex_core::built_in_model_providers;
+use codex_core::default_client::originator;
 use codex_core::error::CodexErr;
 use codex_core::models_manager::manager::ModelsManager;
 use codex_core::protocol::EventMsg;
@@ -406,7 +407,7 @@ async fn includes_conversation_id_and_model_headers_in_request() {
     let request_originator = request.header("originator").expect("originator header");
 
     assert_eq!(request_session_id, session_id.to_string());
-    assert_eq!(request_originator, "codex_cli_rs");
+    assert_eq!(request_originator, originator().value);
     assert_eq!(request_authorization, "Bearer Test API Key");
 }
 
@@ -522,7 +523,7 @@ async fn chatgpt_auth_sends_correct_request() {
     let session_id = request.header("session_id").expect("session_id header");
     assert_eq!(session_id, thread_id.to_string());
 
-    assert_eq!(request_originator, "codex_cli_rs");
+    assert_eq!(request_originator, originator().value);
     assert_eq!(request_authorization, "Bearer Access Token");
     assert_eq!(request_chatgpt_account_id, "account_id");
     assert!(request_body["stream"].as_bool().unwrap());

--- a/codex-rs/core/tests/suite/model_tools.rs
+++ b/codex-rs/core/tests/suite/model_tools.rs
@@ -36,7 +36,7 @@ async fn collect_tool_identifiers_for_model(model: &str) -> Vec<String> {
     let mut builder = test_codex()
         .with_model(model)
         // Keep tool expectations stable when the default web_search mode changes.
-        .with_config(|config| config.web_search_mode = WebSearchMode::Cached);
+        .with_config(|config| config.web_search_mode = Some(WebSearchMode::Cached));
     let test = builder
         .build(&server)
         .await

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -88,7 +88,7 @@ async fn prompt_tools_are_consistent_across_requests() -> anyhow::Result<()> {
             config.user_instructions = Some("be consistent and helpful".to_string());
             config.model = Some("gpt-5.1-codex-max".to_string());
             // Keep tool expectations stable when the default web_search mode changes.
-            config.web_search_mode = WebSearchMode::Cached;
+            config.web_search_mode = Some(WebSearchMode::Cached);
         })
         .build(&server)
         .await?;

--- a/codex-rs/core/tests/suite/web_search_cached.rs
+++ b/codex-rs/core/tests/suite/web_search_cached.rs
@@ -35,7 +35,7 @@ async fn web_search_mode_cached_sets_external_web_access_false_in_request_body()
     let mut builder = test_codex()
         .with_model("gpt-5-codex")
         .with_config(|config| {
-            config.web_search_mode = WebSearchMode::Cached;
+            config.web_search_mode = Some(WebSearchMode::Cached);
         });
     let test = builder
         .build(&server)
@@ -67,7 +67,7 @@ async fn web_search_mode_takes_precedence_over_legacy_flags_in_request_body() {
         .with_model("gpt-5-codex")
         .with_config(|config| {
             config.features.enable(Feature::WebSearchRequest);
-            config.web_search_mode = WebSearchMode::Cached;
+            config.web_search_mode = Some(WebSearchMode::Cached);
         });
     let test = builder
         .build(&server)


### PR DESCRIPTION
moving `web_search` rollout serverside, so need a way to explicitly disable search + signal eligibility from the client.

- Add `x‑oai‑web‑search‑eligible` header that signifies whether the request can have web search.
- Only attach the `web_search` tool when the resolved `WebSearchMode` is `Live` or `Cached`.