### PR TITLE
fix: fallback to Landlock-only when user namespaces unavailable and set PR_SET_NO_NEW_PRIVS early

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1524,6 +1524,7 @@ dependencies = [
  "codex-utils-absolute-path",
  "landlock",
  "libc",
+ "pretty_assertions",
  "seccompiler",
  "tempfile",
  "tokio",

--- a/codex-rs/linux-sandbox/Cargo.toml
+++ b/codex-rs/linux-sandbox/Cargo.toml
@@ -24,6 +24,7 @@ libc = { workspace = true }
 seccompiler = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dev-dependencies]
+pretty_assertions = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = [
     "io-std",

--- a/codex-rs/linux-sandbox/src/landlock.rs
+++ b/codex-rs/linux-sandbox/src/landlock.rs
@@ -37,6 +37,10 @@ pub(crate) fn apply_sandbox_policy_to_current_thread(
         apply_read_only_mounts(sandbox_policy, cwd)?;
     }
 
+    if !sandbox_policy.has_full_disk_write_access() || !sandbox_policy.has_full_network_access() {
+        set_no_new_privs()?;
+    }
+
     if !sandbox_policy.has_full_network_access() {
         install_network_seccomp_filter_on_current_thread()?;
     }
@@ -53,6 +57,14 @@ pub(crate) fn apply_sandbox_policy_to_current_thread(
     // TODO(ragona): Add appropriate restrictions if
     // `sandbox_policy.has_full_disk_read_access()` is `false`.
 
+    Ok(())
+}
+
+fn set_no_new_privs() -> Result<()> {
+    let result = unsafe { libc::prctl(libc::PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) };
+    if result != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
     Ok(())
 }
 

--- a/codex-rs/linux-sandbox/src/mounts.rs
+++ b/codex-rs/linux-sandbox/src/mounts.rs
@@ -27,7 +27,14 @@ pub(crate) fn apply_read_only_mounts(sandbox_policy: &SandboxPolicy, cwd: &Path)
     } else {
         let original_euid = unsafe { libc::geteuid() };
         let original_egid = unsafe { libc::getegid() };
-        unshare_user_and_mount_namespaces()?;
+        if let Err(err) = unshare_user_and_mount_namespaces() {
+            if is_permission_denied(&err) {
+                // Unprivileged user namespaces can be disabled on some systems; fall back
+                // to Landlock-only protections when we cannot set up the mount namespace.
+                return Ok(());
+            }
+            return Err(err);
+        }
         write_user_namespace_maps(original_euid, original_egid)?;
     }
     make_mounts_private()?;
@@ -137,6 +144,16 @@ fn unshare_user_and_mount_namespaces() -> Result<()> {
 
 fn is_running_as_root() -> bool {
     unsafe { libc::geteuid() == 0 }
+}
+
+fn is_permission_denied(err: &CodexErr) -> bool {
+    match err {
+        CodexErr::Io(io_err) => {
+            io_err.kind() == std::io::ErrorKind::PermissionDenied
+                || io_err.raw_os_error() == Some(libc::EPERM)
+        }
+        _ => false,
+    }
 }
 
 #[repr(C)]

--- a/codex-rs/linux-sandbox/tests/suite/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/suite/landlock.rs
@@ -9,6 +9,7 @@ use codex_core::exec_env::create_env;
 use codex_core::protocol::SandboxPolicy;
 use codex_core::sandboxing::SandboxPermissions;
 use codex_utils_absolute_path::AbsolutePathBuf;
+use pretty_assertions::assert_eq;
 use std::collections::HashMap;
 use std::path::PathBuf;
 use tempfile::NamedTempFile;
@@ -36,8 +37,22 @@ fn create_env_from_core_vars() -> HashMap<String, String> {
     create_env(&policy)
 }
 
-#[expect(clippy::print_stdout, clippy::expect_used, clippy::unwrap_used)]
+#[expect(clippy::print_stdout)]
 async fn run_cmd(cmd: &[&str], writable_roots: &[PathBuf], timeout_ms: u64) {
+    let output = run_cmd_output(cmd, writable_roots, timeout_ms).await;
+    if output.exit_code != 0 {
+        println!("stdout:\n{}", output.stdout.text);
+        println!("stderr:\n{}", output.stderr.text);
+        panic!("exit code: {}", output.exit_code);
+    }
+}
+
+#[expect(clippy::expect_used, clippy::unwrap_used)]
+async fn run_cmd_output(
+    cmd: &[&str],
+    writable_roots: &[PathBuf],
+    timeout_ms: u64,
+) -> codex_core::exec::ExecToolCallOutput {
     let cwd = std::env::current_dir().expect("cwd should exist");
     let sandbox_cwd = cwd.clone();
     let params = ExecParams {
@@ -64,7 +79,8 @@ async fn run_cmd(cmd: &[&str], writable_roots: &[PathBuf], timeout_ms: u64) {
     };
     let sandbox_program = env!("CARGO_BIN_EXE_codex-linux-sandbox");
     let codex_linux_sandbox_exe = Some(PathBuf::from(sandbox_program));
-    let res = process_exec_tool_call(
+
+    process_exec_tool_call(
         params,
         &sandbox_policy,
         sandbox_cwd.as_path(),
@@ -72,13 +88,7 @@ async fn run_cmd(cmd: &[&str], writable_roots: &[PathBuf], timeout_ms: u64) {
         None,
     )
     .await
-    .unwrap();
-
-    if res.exit_code != 0 {
-        println!("stdout:\n{}", res.stdout.text);
-        println!("stderr:\n{}", res.stderr.text);
-        panic!("exit code: {}", res.exit_code);
-    }
+    .unwrap()
 }
 
 #[expect(clippy::expect_used)]
@@ -172,6 +182,23 @@ async fn test_writable_root() {
         LONG_TIMEOUT_MS,
     )
     .await;
+}
+
+#[tokio::test]
+async fn test_no_new_privs_is_enabled() {
+    let output = run_cmd_output(
+        &["bash", "-lc", "grep '^NoNewPrivs:' /proc/self/status"],
+        &[],
+        SHORT_TIMEOUT_MS,
+    )
+    .await;
+    let line = output
+        .stdout
+        .text
+        .lines()
+        .find(|line| line.starts_with("NoNewPrivs:"))
+        .unwrap_or("");
+    assert_eq!(line.trim(), "NoNewPrivs:\t1");
 }
 
 #[tokio::test]


### PR DESCRIPTION
fixes https://github.com/openai/codex/issues/9236

### Motivation
- Prevent sandbox setup from failing when unprivileged user namespaces are denied so Landlock-only protections can still be applied.
- Ensure `PR_SET_NO_NEW_PRIVS` is set before installing seccomp and Landlock restrictions to avoid kernel `EPERM`/`LandlockRestrict` ordering issues.

### Description
- Add `is_permission_denied` helper that detects `EPERM` / `PermissionDenied` from `CodexErr` to drive fallback logic.
- In `apply_read_only_mounts` skip read-only bind-mount setup and return `Ok(())` when `unshare_user_and_mount_namespaces()` fails with permission-denied so Landlock rules can still be installed.
- Add `set_no_new_privs()` and call it from `apply_sandbox_policy_to_current_thread` before installing seccomp filters and Landlock rules when disk or network access is restricted.