### PR TITLE
mcp-server: add optional resume-path to codex tool

### DIFF
--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -212,6 +212,19 @@ impl ThreadManager {
             .await
     }
 
+    pub async fn resume_thread_from_rollout_with_auth(
+        &self,
+        config: Config,
+        rollout_path: PathBuf,
+    ) -> CodexResult<NewThread> {
+        self.resume_thread_from_rollout(
+            config,
+            rollout_path,
+            Arc::clone(&self.state.auth_manager),
+        )
+        .await
+    }
+
     pub async fn resume_thread_with_history(
         &self,
         config: Config,

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -319,6 +319,10 @@ mod tests {
                 "description": "The *initial user prompt* to start the Codex conversation.",
                 "type": "string"
               },
+              "resume-path": {
+                "description": "Optional path to a rollout file to resume the session from.",
+                "type": "string"
+              },
               "sandbox": {
                 "description": "Sandbox mode: `read-only`, `workspace-write`, or `danger-full-access`.",
                 "enum": [
@@ -370,5 +374,22 @@ mod tests {
           "title": "Codex Reply",
         });
         assert_eq!(expected_tool_json, tool_json);
+    }
+
+    #[test]
+    fn codex_tool_accepts_pre_change_payload() {
+        let payload = serde_json::json!({
+            "prompt": "hello",
+            "model": "gpt-5.2",
+            "sandbox": "workspace-write",
+            "approval-policy": "untrusted",
+        });
+
+        let parsed: CodexToolCallParam = serde_json::from_value(payload).expect("payload parses");
+        assert_eq!(parsed.prompt, "hello");
+        assert_eq!(parsed.model.as_deref(), Some("gpt-5.2"));
+        assert_eq!(parsed.sandbox, Some(CodexToolCallSandboxMode::WorkspaceWrite));
+        assert_eq!(parsed.approval_policy, Some(CodexToolCallApprovalPolicy::Untrusted));
+        assert!(parsed.resume_path.is_none());
     }
 }

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -60,6 +60,10 @@ pub struct CodexToolCallParam {
     /// Prompt used when compacting the conversation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compact_prompt: Option<String>,
+
+    /// Optional path to a rollout file to resume the session from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resume_path: Option<PathBuf>,
 }
 
 /// Custom enum mirroring [`AskForApproval`], but has an extra dependency on
@@ -142,7 +146,7 @@ impl CodexToolCallParam {
     pub async fn into_config(
         self,
         codex_linux_sandbox_exe: Option<PathBuf>,
-    ) -> std::io::Result<(String, Config)> {
+    ) -> std::io::Result<(String, Config, Option<PathBuf>)> {
         let Self {
             prompt,
             model,
@@ -154,6 +158,7 @@ impl CodexToolCallParam {
             base_instructions,
             developer_instructions,
             compact_prompt,
+            resume_path,
         } = self;
 
         // Build the `ConfigOverrides` recognized by codex-core.
@@ -179,7 +184,7 @@ impl CodexToolCallParam {
         let cfg =
             Config::load_with_cli_overrides_and_harness_overrides(cli_overrides, overrides).await?;
 
-        Ok((prompt, cfg))
+        Ok((prompt, cfg, resume_path))
     }
 }
 

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -347,7 +347,8 @@ impl MessageProcessor {
         }
     }
     async fn handle_tool_call_codex(&self, id: RequestId, arguments: Option<serde_json::Value>) {
-        let (initial_prompt, config): (String, Config) = match arguments {
+        let (initial_prompt, config, resume_path): (String, Config, Option<PathBuf>) =
+            match arguments {
             Some(json_val) => match serde_json::from_value::<CodexToolCallParam>(json_val) {
                 Ok(tool_cfg) => match tool_cfg
                     .into_config(self.codex_linux_sandbox_exe.clone())
@@ -417,6 +418,7 @@ impl MessageProcessor {
                 id,
                 initial_prompt,
                 config,
+                resume_path,
                 outgoing,
                 thread_manager,
                 running_requests_id_to_codex_uuid,


### PR DESCRIPTION
Adds an optional  argument to the MCP  tool so external clients can resume an existing Codex session from a rollout file instead of always creating a new thread.\n\n- Extends  with  and updates schema tests.\n- Plumbs  through the MCP message processor and tool runner.\n- Uses  when  is provided.\n- Includes a backward-compat test ensuring pre-change payloads still parse (no ).\n\nCompanion PR (Happy CLI) depends on this capability to correctly resume the selected Codex session from mobile/remote. I’ll link it here once opened.