### PR TITLE
fix: set alt_screen_enabled before resume/fork pickers run

### DIFF
--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -371,6 +371,13 @@ async fn run_ratatui_app(
 
     let mut tui = Tui::new(terminal);
 
+    // Set alt screen mode EARLY, before any pickers or overlays run.
+    // This ensures resume_picker, fork_picker, onboarding, etc. all respect
+    // the setting when they call enter_alt_screen().
+    let use_alt_screen =
+        determine_alt_screen_mode(cli.no_alt_screen, initial_config.tui_alternate_screen);
+    tui.set_alt_screen_enabled(use_alt_screen);
+
     #[cfg(not(debug_assertions))]
     {
         use crate::update_prompt::UpdatePromptOutcome;
@@ -563,15 +570,7 @@ async fn run_ratatui_app(
         resume_picker::SessionSelection::StartFresh
     };
 
-    let Cli {
-        prompt,
-        images,
-        no_alt_screen,
-        ..
-    } = cli;
-
-    let use_alt_screen = determine_alt_screen_mode(no_alt_screen, config.tui_alternate_screen);
-    tui.set_alt_screen_enabled(use_alt_screen);
+    let Cli { prompt, images, .. } = cli;
 
     let app_result = App::run(
         &mut tui,


### PR DESCRIPTION
## Summary

The `alt_screen_enabled` flag was being set AFTER `resume_picker` and `fork_picker` ran, which meant those overlays would enter alternate screen even when `--no-alt-screen` was passed or when running in Zellij with auto-detection.

This moves the `set_alt_screen_enabled()` call to immediately after `Tui::new()`, before any pickers or overlays run, ensuring all `enter_alt_screen()` calls respect the setting.

**Before (broken order):**
1. `Tui::new()` - alt_screen_enabled defaults to `true`
2. `resume_picker::run_resume_picker()` - enters alt screen (ignores flag!)
3. `tui.set_alt_screen_enabled(false)` - too late

**After (fixed order):**
1. `Tui::new()` - alt_screen_enabled defaults to `true`
2. `tui.set_alt_screen_enabled(use_alt_screen)` - set flag early
3. `resume_picker::run_resume_picker()` - respects flag

Fixes #9115

## Test plan

- Run `codex --no-alt-screen` in Zellij and verify scrollback works
- Run `codex resume` in Zellij and verify the picker also respects the setting
- Run `codex` in a normal terminal and verify alternate screen still works