### PR TITLE
fix: update file search directory when session CWD changes

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1370,10 +1370,7 @@ impl App {
                                 self.shutdown_current_thread().await;
                                 self.config = resume_config;
                                 tui.set_notification_method(self.config.tui_notification_method);
-                                self.file_search = FileSearchManager::new(
-                                    self.config.cwd.clone(),
-                                    self.app_event_tx.clone(),
-                                );
+                                self.file_search.update_search_dir(self.config.cwd.clone());
                                 let init = self.chatwidget_init_for_forked_or_resumed_thread(
                                     tui,
                                     self.config.clone(),

--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -43,7 +43,7 @@ impl FileSearchManager {
     }
 
     /// Updates the directory used for file searches.
-    /// This should be called when the session's CWD changes (e.g., on new session, resume, or fork).
+    /// This should be called when the session's CWD changes on resume.
     /// Drops the current session so it will be recreated with the new directory on next query.
     pub fn update_search_dir(&mut self, new_dir: PathBuf) {
         self.search_dir = new_dir;

--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -42,6 +42,17 @@ impl FileSearchManager {
         }
     }
 
+    /// Updates the directory used for file searches.
+    /// This should be called when the session's CWD changes (e.g., on new session, resume, or fork).
+    /// Drops the current session so it will be recreated with the new directory on next query.
+    pub fn update_search_dir(&mut self, new_dir: PathBuf) {
+        self.search_dir = new_dir;
+        #[expect(clippy::unwrap_used)]
+        let mut st = self.state.lock().unwrap();
+        st.session.take();
+        st.latest_query.clear();
+    }
+
     /// Call whenever the user edits the `@` token.
     pub fn on_user_query(&self, query: String) {
         #[expect(clippy::unwrap_used)]


### PR DESCRIPTION
## Summary

Fixes #9041

- Adds update_search_dir() method to FileSearchManager to allow updating the search directory after initialization
- Calls this method when the session CWD changes: new session, resume, or fork

## Problem

The FileSearchManager was created once with the initial search_dir and never updated. When a user:

1. Starts Codex in a non-git directory (e.g., /tmp/random)
2. Resumes or forks a session from a different workspace
3. The @filename lookup still searched the original directory

This caused no matches to be returned even when files existed in the current workspace.

## Solution

Update FileSearchManager.search_dir whenever the session working directory changes:
- AppEvent::NewSession: Use current config CWD
- SessionSelection::Resume: Use resumed session CWD
- SessionSelection::Fork: Use forked session CWD

## Test plan

- [ ] Start Codex in /tmp/test-dir (non-git)
- [ ] Resume a session from a project with actual files
- [ ] Verify @filename returns matches from the resumed session directory