### PR TITLE
tui: remove unused helpers

### DIFF
--- a/codex-rs/tui/src/ascii_animation.rs
+++ b/codex-rs/tui/src/ascii_animation.rs
@@ -90,11 +90,6 @@ impl AsciiAnimation {
         true
     }
 
-    #[allow(dead_code)]
-    pub(crate) fn request_frame(&self) {
-        self.request_frame.schedule_frame();
-    }
-
     fn frames(&self) -> &'static [&'static str] {
         self.variants[self.variant_idx]
     }

--- a/codex-rs/tui/src/custom_terminal.rs
+++ b/codex-rs/tui/src/custom_terminal.rs
@@ -352,14 +352,6 @@ where
         Ok(())
     }
 
-    /// Gets the current cursor position.
-    ///
-    /// This is the position of the cursor after the last draw call.
-    #[allow(dead_code)]
-    pub fn get_cursor_position(&mut self) -> io::Result<Position> {
-        self.backend.get_cursor_position()
-    }
-
     /// Sets the cursor position.
     pub fn set_cursor_position<P: Into<Position>>(&mut self, position: P) -> io::Result<()> {
         let position = position.into();

--- a/codex-rs/tui/src/render/renderable.rs
+++ b/codex-rs/tui/src/render/renderable.rs
@@ -200,15 +200,6 @@ impl<'a> ColumnRenderable<'a> {
     pub fn push(&mut self, child: impl Into<Box<dyn Renderable + 'a>>) {
         self.children.push(RenderableItem::Owned(child.into()));
     }
-
-    #[allow(dead_code)]
-    pub fn push_ref<R>(&mut self, child: &'a R)
-    where
-        R: Renderable + 'a,
-    {
-        self.children
-            .push(RenderableItem::Borrowed(child as &'a dyn Renderable));
-    }
 }
 
 pub struct FlexChild<'a> {
@@ -374,15 +365,6 @@ impl<'a> RowRenderable<'a> {
     pub fn push(&mut self, width: u16, child: impl Into<Box<dyn Renderable>>) {
         self.children
             .push((width, RenderableItem::Owned(child.into())));
-    }
-
-    #[allow(dead_code)]
-    pub fn push_ref<R>(&mut self, width: u16, child: &'a R)
-    where
-        R: Renderable + 'a,
-    {
-        self.children
-            .push((width, RenderableItem::Borrowed(child as &'a dyn Renderable)));
     }
 }
 

--- a/codex-rs/tui/src/wrapping.rs
+++ b/codex-rs/tui/src/wrapping.rs
@@ -82,7 +82,6 @@ impl From<usize> for RtOptions<'_> {
     }
 }
 
-#[allow(dead_code)]
 impl<'a> RtOptions<'a> {
     pub fn new(width: usize) -> Self {
         RtOptions {
@@ -99,17 +98,6 @@ impl<'a> RtOptions<'a> {
             }),
             word_splitter: textwrap::WordSplitter::HyphenSplitter,
         }
-    }
-
-    pub fn line_ending(self, line_ending: textwrap::LineEnding) -> Self {
-        RtOptions {
-            line_ending,
-            ..self
-        }
-    }
-
-    pub fn width(self, width: usize) -> Self {
-        RtOptions { width, ..self }
     }
 
     pub fn initial_indent(self, initial_indent: Line<'a>) -> Self {
@@ -129,20 +117,6 @@ impl<'a> RtOptions<'a> {
     pub fn break_words(self, break_words: bool) -> Self {
         RtOptions {
             break_words,
-            ..self
-        }
-    }
-
-    pub fn word_separator(self, word_separator: textwrap::WordSeparator) -> RtOptions<'a> {
-        RtOptions {
-            word_separator,
-            ..self
-        }
-    }
-
-    pub fn wrap_algorithm(self, wrap_algorithm: textwrap::WrapAlgorithm) -> RtOptions<'a> {
-        RtOptions {
-            wrap_algorithm,
             ..self
         }
     }


### PR DESCRIPTION
## Summary
- remove unused TUI helper methods and dead-code allowances
- drop unused RtOptions setters to simplify wrapping configuration
- trim unused cursor/animation helpers for cleaner public surface

## Testing
- 
-  *(failed: sandbox denied writing to Cargo registry cache)*
-  *(failed: sandbox denied writing to Cargo registry cache)*