### PR TITLE
Revert recent styling change for input prompt placeholder text

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -2230,7 +2230,7 @@ impl Renderable for ChatComposer {
                     .unwrap_or("Input disabled.")
                     .to_string()
             };
-            let placeholder = Span::from(text).dim().italic();
+            let placeholder = Span::from(text).dim();
             Line::from(vec![placeholder]).render_ref(textarea_rect.inner(Margin::new(0, 0)), buf);
         }
     }

--- a/codex-rs/tui2/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui2/src/bottom_pane/chat_composer.rs
@@ -2199,7 +2199,7 @@ impl Renderable for ChatComposer {
                     .unwrap_or("Input disabled.")
                     .to_string()
             };
-            let placeholder = Span::from(text).dim().italic();
+            let placeholder = Span::from(text).dim();
             Line::from(vec![placeholder]).render_ref(textarea_rect.inner(Margin::new(0, 0)), buf);
         }
     }


### PR DESCRIPTION
A recent change in commit ccba737d26 modified the styling of the placeholder text (e.g. "Implement {feature}") in the input box of the CLI, changing it from non-italic to italic. I think this was likely unintentional. It results in a bad display appearance on some terminal emulators, and several users have complained about it.

This change switches back to non-italic styling, restoring the older behavior.

It addresses #9262