### PR TITLE
fix windows paste behavior and add more test

### DIFF
--- a/codex-rs/tui/src/bottom_pane/paste_burst.rs
+++ b/codex-rs/tui/src/bottom_pane/paste_burst.rs
@@ -46,12 +46,15 @@
 //! - `pending_first_char`: a single held ASCII char used for flicker suppression. The caller must
 //!   not render this char until it either becomes part of a burst (`BeginBufferFromPending`) or
 //!   flushes as a normal typed char (`FlushResult::Typed`).
-//!   If an Enter arrives immediately after a held first char (within `PASTE_BURST_CHAR_INTERVAL`),
-//!   the state machine may promote the held char into the burst buffer before appending `\n` so
-//!   key-event paste streams preserve ordering (e.g. `h\ni`).
+//!   If an Enter arrives soon after a held first char (within `PASTE_BURST_ACTIVE_IDLE_TIMEOUT` on
+//!   Windows, `PASTE_BURST_CHAR_INTERVAL` elsewhere), the state machine may promote the held char
+//!   into the burst buffer before appending `\n` so key-event paste streams preserve ordering
+//!   (e.g. `h\ni`).
 //! - `last_plain_char_time`/`consecutive_plain_char_burst`: the timing/count heuristic for
 //!   "paste-like" streams. The timestamp is also used for a short "recent char → Enter becomes
-//!   newline" heuristic to avoid submitting mid-paste on very short key-event streams.
+//!   newline" heuristic to avoid submitting mid-paste on very short key-event streams. On Windows,
+//!   the single-ASCII-char case uses `PASTE_BURST_ACTIVE_IDLE_TIMEOUT` to tolerate a slower initial
+//!   gap before the first Enter in a multiline paste stream.
 //! - `burst_window_until`: the Enter suppression window ("Enter inserts newline") that outlives the
 //!   buffer itself.
 //!
@@ -103,9 +106,10 @@
 //! - **Pending first char**: `pending_first_char` holds one ASCII char for up to
 //!   `PASTE_BURST_CHAR_INTERVAL` while we wait to see if a burst follows.
 //! - **Active buffer**: `active`/`buffer` holds paste-like content until it times out and flushes.
-//! - **Recent plain char**: a very fast `Char` → `Enter` sequence (within `PASTE_BURST_CHAR_INTERVAL`)
-//!   is treated as "Enter inserts newline" even before we have committed to buffering, to avoid
-//!   submitting mid-paste on terminals that emit multiline pastes as key events.
+//! - **Recent plain char**: a very fast `Char` → `Enter` sequence is treated as "Enter inserts
+//!   newline" even before we have committed to buffering, to avoid submitting mid-paste on
+//!   terminals that emit multiline pastes as key events. On Windows, the single-ASCII-char case
+//!   tolerates a slightly slower initial gap (up to `PASTE_BURST_ACTIVE_IDLE_TIMEOUT`).
 //! - **Enter suppress window**: `burst_window_until` keeps Enter treated as newline briefly after
 //!   burst activity so multiline pastes stay grouped.
 //!
@@ -170,6 +174,7 @@ const PASTE_BURST_ACTIVE_IDLE_TIMEOUT: Duration = Duration::from_millis(60);
 #[derive(Default)]
 pub(crate) struct PasteBurst {
     last_plain_char_time: Option<Instant>,
+    last_plain_char_is_ascii: bool,
     consecutive_plain_char_burst: u16,
     burst_window_until: Option<Instant>,
     buffer: String,
@@ -220,6 +225,7 @@ impl PasteBurst {
     /// Entry point: decide how to treat a plain char with current timing.
     pub fn on_plain_char(&mut self, ch: char, now: Instant) -> CharDecision {
         self.note_plain_char(now);
+        self.last_plain_char_is_ascii = true;
 
         if self.active {
             self.burst_window_until = Some(now + PASTE_ENTER_SUPPRESS_WINDOW);
@@ -258,6 +264,7 @@ impl PasteBurst {
     /// Note: This method will only ever return BufferAppend or BeginBuffer.
     pub fn on_plain_char_no_hold(&mut self, now: Instant) -> Option<CharDecision> {
         self.note_plain_char(now);
+        self.last_plain_char_is_ascii = false;
 
         if self.active {
             self.burst_window_until = Some(now + PASTE_ENTER_SUPPRESS_WINDOW);
@@ -354,10 +361,10 @@ impl PasteBurst {
             let Some((held, held_at)) = self.pending_first_char.take() else {
                 return false;
             };
-            if now.duration_since(held_at) <= PASTE_BURST_CHAR_INTERVAL {
+            if now.duration_since(held_at) <= PASTE_BURST_ACTIVE_IDLE_TIMEOUT {
                 // Windows terminals can emit pasted multiline text as `Char('h')` then `Enter`
                 // etc. If we were holding the first ASCII char (flicker suppression) and
-                // immediately see an Enter, treat it as paste-like input and preserve ordering by
+                // soon see an Enter, treat it as paste-like input and preserve ordering by
                 // promoting the held char into the burst buffer *before* the newline.
                 self.active = true;
                 self.buffer.push(held);
@@ -378,9 +385,14 @@ impl PasteBurst {
     /// Decide if Enter should insert a newline (burst context) vs submit.
     pub fn newline_should_insert_instead_of_submit(&self, now: Instant) -> bool {
         let in_burst_window = self.burst_window_until.is_some_and(|until| now <= until);
-        let recently_saw_plain_char = self
-            .last_plain_char_time
-            .is_some_and(|t| now.duration_since(t) <= PASTE_BURST_CHAR_INTERVAL);
+        let recently_saw_plain_char = self.last_plain_char_time.is_some_and(|t| {
+            let gap = now.duration_since(t);
+            if self.last_plain_char_is_ascii && self.consecutive_plain_char_burst == 1 {
+                gap <= PASTE_BURST_ACTIVE_IDLE_TIMEOUT
+            } else {
+                gap <= PASTE_BURST_CHAR_INTERVAL
+            }
+        });
         self.is_active() || in_burst_window || recently_saw_plain_char
     }
 
@@ -415,6 +427,7 @@ impl PasteBurst {
             // would not update `last_plain_char_time`, making `flush_if_due()` unable to time out
             // (or making it flaky until an ASCII char arrives).
             self.note_plain_char(now);
+            self.last_plain_char_is_ascii = false;
             self.append_char_to_buffer(ch, now);
             true
         } else {
@@ -475,6 +488,7 @@ impl PasteBurst {
     pub fn clear_window_after_non_char(&mut self) {
         self.consecutive_plain_char_burst = 0;
         self.last_plain_char_time = None;
+        self.last_plain_char_is_ascii = false;
         self.burst_window_until = None;
         self.active = false;
         self.pending_first_char = None;
@@ -493,6 +507,7 @@ impl PasteBurst {
 
     pub fn clear_after_explicit_paste(&mut self) {
         self.last_plain_char_time = None;
+        self.last_plain_char_is_ascii = false;
         self.consecutive_plain_char_burst = 0;
         self.burst_window_until = None;
         self.active = false;
@@ -588,6 +603,58 @@ mod tests {
             burst.flush_if_due(t3),
             FlushResult::Paste(ref s) if s == "h\ni"
         ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn slow_char_to_enter_paste_promotes_pending_first_char_on_windows() {
+        let mut burst = PasteBurst::default();
+        let t0 = Instant::now();
+        assert!(matches!(
+            burst.on_plain_char('h', t0),
+            CharDecision::RetainFirstChar
+        ));
+
+        // Windows terminals can show a slower initial gap between the first char and the
+        // following newline (Enter) in a key-event paste stream.
+        let t1 = t0 + PASTE_BURST_CHAR_INTERVAL + Duration::from_millis(1);
+        assert!(
+            t1.duration_since(t0) > PASTE_BURST_CHAR_INTERVAL
+                && t1.duration_since(t0) <= PASTE_BURST_ACTIVE_IDLE_TIMEOUT
+        );
+
+        assert!(burst.append_newline_if_active(t1));
+        assert!(burst.is_active());
+
+        let t2 = t1 + PasteBurst::recommended_active_flush_delay() + Duration::from_millis(1);
+        assert!(matches!(
+            burst.flush_if_due(t2),
+            FlushResult::Paste(ref s) if s == "h\n"
+        ));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn newline_should_insert_after_recent_plain_char_within_windows_paste_window() {
+        let mut burst = PasteBurst::default();
+        let t0 = Instant::now();
+        assert!(matches!(
+            burst.on_plain_char('h', t0),
+            CharDecision::RetainFirstChar
+        ));
+
+        // Simulate a UI tick flushing the held char as normal typing.
+        let t_flush = t0 + PasteBurst::recommended_flush_delay() + Duration::from_millis(1);
+        assert!(matches!(
+            burst.flush_if_due(t_flush),
+            FlushResult::Typed('h')
+        ));
+        assert!(!burst.is_active());
+
+        // Then a multiline paste stream can deliver Enter a bit later, still within the Windows
+        // paste-burst window. We should treat that Enter as "insert newline", not submit.
+        let t1 = t0 + Duration::from_millis(20);
+        assert!(burst.newline_should_insert_instead_of_submit(t1));
     }
 
     /// Behavior: when non-char input is about to be applied, we flush any transient burst state

--- a/docs/tui-chat-composer.md
+++ b/docs/tui-chat-composer.md
@@ -220,9 +220,11 @@ There are three distinct “Enter becomes newline” mechanisms:
   `newline_should_insert_instead_of_submit(now)` inserts `\n` into the textarea and calls
   `extend_window(now)` so a slightly-late Enter keeps behaving like “newline” rather than “submit”.
 - **Immediately after a plain char** (very fast `Char` → `Enter`): `newline_should_insert_instead_of_submit(now)`
-  also treats Enter as “newline” when the last plain char was seen within `PASTE_BURST_CHAR_INTERVAL`,
-  even if we haven’t started buffering or entered the suppression window yet. This prevents “submit
-  mid-paste” on terminals that emit very short multiline pastes as key events.
+  also treats Enter as “newline” when the last plain char was seen very recently, even if we
+  haven’t started buffering or entered the suppression window yet. This prevents “submit mid-paste”
+  on terminals that emit very short multiline pastes as key events. On Windows, the single-ASCII-
+  char case tolerates a slightly slower initial gap (up to `PASTE_BURST_ACTIVE_IDLE_TIMEOUT`) to
+  handle terminals that pause briefly before emitting the first newline in a multiline paste.
 
 All of the above are disabled inside slash-command context (command popup is active or the first line begins
 with `/`) so Enter keeps its normal “submit/execute” semantics while composing commands.

--- a/docs/tui-chat-composer.md
+++ b/docs/tui-chat-composer.md
@@ -215,7 +215,7 @@ There are three distinct “Enter becomes newline” mechanisms:
   `\n` into the burst buffer so multi-line pastes stay buffered as one explicit paste. If the ASCII
   path is still holding the first char (`pending_first_char`) and an Enter arrives immediately
   after (within `PASTE_BURST_CHAR_INTERVAL`), `append_newline_if_active` promotes the held char into
-  the burst buffer *before* appending `\n` (preserving ordering for streams like `h\ni`).
+  the burst buffer _before_ appending `\n` (preserving ordering for streams like `h\ni`).
 - **Immediately after burst activity** (enter suppression window):
   `newline_should_insert_instead_of_submit(now)` inserts `\n` into the textarea and calls
   `extend_window(now)` so a slightly-late Enter keeps behaving like “newline” rather than “submit”.

--- a/docs/tui-chat-composer.md
+++ b/docs/tui-chat-composer.md
@@ -209,15 +209,22 @@ enough run) to avoid misclassifying IME composition as paste.
 
 ### `KeyCode::Enter`: newline vs submit
 
-There are two distinct “Enter becomes newline” mechanisms:
+There are three distinct “Enter becomes newline” mechanisms:
 
 - **While in a burst context** (`paste_burst.is_active()`): `append_newline_if_active(now)` appends
-  `\n` into the burst buffer so multi-line pastes stay buffered as one explicit paste.
+  `\n` into the burst buffer so multi-line pastes stay buffered as one explicit paste. If the ASCII
+  path is still holding the first char (`pending_first_char`) and an Enter arrives immediately
+  after (within `PASTE_BURST_CHAR_INTERVAL`), `append_newline_if_active` promotes the held char into
+  the burst buffer *before* appending `\n` (preserving ordering for streams like `h\ni`).
 - **Immediately after burst activity** (enter suppression window):
   `newline_should_insert_instead_of_submit(now)` inserts `\n` into the textarea and calls
   `extend_window(now)` so a slightly-late Enter keeps behaving like “newline” rather than “submit”.
+- **Immediately after a plain char** (very fast `Char` → `Enter`): `newline_should_insert_instead_of_submit(now)`
+  also treats Enter as “newline” when the last plain char was seen within `PASTE_BURST_CHAR_INTERVAL`,
+  even if we haven’t started buffering or entered the suppression window yet. This prevents “submit
+  mid-paste” on terminals that emit very short multiline pastes as key events.
 
-Both are disabled inside slash-command context (command popup is active or the first line begins
+All of the above are disabled inside slash-command context (command popup is active or the first line begins
 with `/`) so Enter keeps its normal “submit/execute” semantics while composing commands.
 
 ### Non-char keys / Ctrl+modified input


### PR DESCRIPTION
A regression slipped in after #8021, and our existing tests did not catch it. This PR fixes that regression, tightens the PasteBurst / ChatComposer heuristics around Windows key-event pastes, and adds targeted regression tests to prevent similar breakages.

## changes

- Improve classification of Windows "key-event pastes", including slower initial inter-key gaps that previously caused pastes to be split or treated as normal typing.
- Preserve ordering for multiline pastes when the first ASCII char is temporarily held (pending_first_char) and an early Enter arrives, avoiding mid-stream submit or dropped newlines.
- Fix burst timeout accounting when Enter promotes a pending-first-char into an active burst, preventing premature flush and paste chunking.
- Narrowly scope any widened Enter/newline decision window to the single-ASCII-char (hold-capable) path, to avoid IME / non-ASCII behavior regressions.

## User-visible impact

- Windows: multiline key-event pastes are less likely to be submitted accidentally; Enter is more consistently treated as newline within the paste.
- Non-Windows (and environments where bracketed paste works): no intended behavior change.

## Tests and docs

- Add Windows-gated regression tests covering Char -> Enter slow-gap classification, ordering, Enter/newline boundaries, and large paste placeholder paths (no stray prefix chars).
- Update docs/tui-chat-composer.md and relevant docstrings to reflect the refined heuristics and rationale.