### PR TITLE
[fix-myself] Show latest user message in resume preview

### DIFF
--- a/codex-rs/tui2/src/resume_picker.rs
+++ b/codex-rs/tui2/src/resume_picker.rs
@@ -96,7 +96,7 @@ enum BackgroundEvent {
 }
 
 /// Interactive session picker that lists recorded rollout files with simple
-/// search and pagination. Shows the first user input as the preview, relative
+/// search and pagination. Shows the latest user input as the preview, relative
 /// time (e.g., "5 seconds ago"), and the absolute path.
 pub async fn run_resume_picker(
     tui: &mut Tui,
@@ -763,6 +763,7 @@ fn extract_timestamp(value: &serde_json::Value) -> Option<DateTime<Utc>> {
 
 fn preview_from_head(head: &[serde_json::Value]) -> Option<String> {
     head.iter()
+        .rev()
         .filter_map(|value| serde_json::from_value::<ResponseItem>(value.clone()).ok())
         .find_map(|item| match codex_core::parse_turn_item(&item) {
             Some(TurnItem::UserMessage(user)) => Some(user.message()),
@@ -1171,7 +1172,7 @@ mod tests {
     }
 
     #[test]
-    fn preview_uses_first_message_input_text() {
+    fn preview_uses_latest_message_input_text() {
         let head = vec![
             json!({ "timestamp": "2025-01-01T00:00:00Z" }),
             json!({
@@ -1203,7 +1204,7 @@ mod tests {
             }),
         ];
         let preview = preview_from_head(&head);
-        assert_eq!(preview.as_deref(), Some("real question"));
+        assert_eq!(preview.as_deref(), Some("later text"));
     }
 
     #[test]


### PR DESCRIPTION
Summary:
- Use the latest user message as the resume picker preview text.
- Update resume picker preview test coverage for latest-message selection.

Tests:
- `cargo test -p codex-tui2` (fails: suite::no_panic_on_startup::malformed_rules_should_not_panic; expected nonzero exit code, got 0)

Tickets:
- Fixes #9347

Love from Codex