### PR TITLE
feat: run user commands under user snapshot

### DIFF
--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -27,6 +27,7 @@ use crate::sandboxing::ExecEnv;
 use crate::sandboxing::SandboxPermissions;
 use crate::state::TaskKind;
 use crate::tools::format_exec_output_str;
+use crate::tools::runtimes::maybe_wrap_shell_lc_with_snapshot;
 use crate::user_shell_command::user_shell_command_record_item;
 
 use super::SessionTask;
@@ -74,9 +75,9 @@ impl SessionTask for UserShellCommandTask {
         // allows commands that use shell features (pipes, &&, redirects, etc.).
         // We do not source rc files or otherwise reformat the script.
         let use_login_shell = true;
-        let command = session
-            .user_shell()
-            .derive_exec_args(&self.command, use_login_shell);
+        let session_shell = session.user_shell();
+        let command = session_shell.derive_exec_args(&self.command, use_login_shell);
+        let command = maybe_wrap_shell_lc_with_snapshot(&command, session_shell.as_ref());
 
         let call_id = Uuid::new_v4().to_string();
         let raw_command = self.command.clone();


### PR DESCRIPTION
The initial goal is for user snapshots to have access to aliases etc