### PR TITLE
chore: close pipe on non-pty processes

### DIFF
--- a/codex-rs/core/src/tools/handlers/unified_exec.rs
+++ b/codex-rs/core/src/tools/handlers/unified_exec.rs
@@ -202,7 +202,7 @@ impl ToolHandler for UnifiedExecHandler {
                     })
                     .await
                     .map_err(|err| {
-                        FunctionCallError::RespondToModel(format!("write_stdin failed: {err:?}"))
+                        FunctionCallError::RespondToModel(format!("write_stdin failed: {err}"))
                     })?;
 
                 let interaction = TerminalInteractionEvent {

--- a/codex-rs/core/src/unified_exec/errors.rs
+++ b/codex-rs/core/src/unified_exec/errors.rs
@@ -10,6 +10,10 @@ pub(crate) enum UnifiedExecError {
     UnknownProcessId { process_id: String },
     #[error("failed to write to stdin")]
     WriteToStdin,
+    #[error(
+        "stdin is closed for this session; rerun exec_command with tty=true to keep stdin open"
+    )]
+    StdinClosed,
     #[error("missing command line for unified exec request")]
     MissingCommandLine,
     #[error("Command denied by sandbox: {message}")]

--- a/codex-rs/core/src/unified_exec/mod.rs
+++ b/codex-rs/core/src/unified_exec/mod.rs
@@ -136,6 +136,7 @@ struct ProcessEntry {
     call_id: String,
     process_id: String,
     command: Vec<String>,
+    tty: bool,
     last_used: tokio::time::Instant,
 }
 

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -460,7 +460,7 @@ impl UnifiedExecProcessManager {
             )
             .await
         } else {
-            codex_utils_pty::pipe::spawn_process(
+            codex_utils_pty::pipe::spawn_process_no_stdin(
                 program,
                 args,
                 env.cwd.as_path(),

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -805,6 +805,7 @@ async fn unified_exec_emits_terminal_interaction_for_write_stdin() -> Result<()>
     let open_args = json!({
         "cmd": "/bin/bash -i",
         "yield_time_ms": 200,
+        "tty": true,
     });
 
     let stdin_call_id = "uexec-stdin-delta";
@@ -905,6 +906,7 @@ async fn unified_exec_terminal_interaction_captures_delayed_output() -> Result<(
     let open_args = json!({
         "cmd": "sleep 3 && echo MARKER1 && sleep 3 && echo MARKER2",
         "yield_time_ms": 10,
+        "tty": true,
     });
 
     // Poll stdin three times: first for no output, second after the first marker,
@@ -1966,6 +1968,7 @@ async fn unified_exec_reuses_session_via_stdin() -> Result<()> {
     let first_args = serde_json::json!({
         "cmd": "/bin/cat",
         "yield_time_ms": 200,
+        "tty": true,
     });
 
     let second_call_id = "uexec-stdin";
@@ -2678,6 +2681,7 @@ async fn unified_exec_prunes_exited_sessions_first() -> Result<()> {
     let keep_args = serde_json::json!({
         "cmd": "/bin/cat",
         "yield_time_ms": 250,
+        "tty": true,
     });
 
     let prune_call_id = "uexec-prune-target";
@@ -2685,6 +2689,7 @@ async fn unified_exec_prunes_exited_sessions_first() -> Result<()> {
     let prune_args = serde_json::json!({
         "cmd": "sleep 1",
         "yield_time_ms": 1_250,
+        "tty": true,
     });
 
     let mut events = vec![ev_response_created("resp-prune-1")];

--- a/codex-rs/utils/pty/README.md
+++ b/codex-rs/utils/pty/README.md
@@ -6,6 +6,7 @@ Lightweight helpers for spawning interactive processes either under a PTY (pseud
 
 - `spawn_pty_process(program, args, cwd, env, arg0)` → `SpawnedProcess`
 - `spawn_pipe_process(program, args, cwd, env, arg0)` → `SpawnedProcess`
+- `spawn_pipe_process_no_stdin(program, args, cwd, env, arg0)` → `SpawnedProcess`
 - `conpty_supported()` → `bool` (Windows only; always true elsewhere)
 - `ProcessHandle` exposes:
   - `writer_sender()` → `mpsc::Sender<Vec<u8>>` (stdin)
@@ -46,6 +47,7 @@ let exit_code = spawned.exit_rx.await.unwrap_or(-1);
 ```
 
 Swap in `spawn_pipe_process` for a non-TTY subprocess; the rest of the API stays the same.
+Use `spawn_pipe_process_no_stdin` to force stdin closed (commands that read stdin will see EOF immediately).
 
 ## Tests
 

--- a/codex-rs/utils/pty/src/lib.rs
+++ b/codex-rs/utils/pty/src/lib.rs
@@ -9,6 +9,8 @@ mod win;
 
 /// Spawn a non-interactive process using regular pipes for stdin/stdout/stderr.
 pub use pipe::spawn_process as spawn_pipe_process;
+/// Spawn a non-interactive process using regular pipes, but close stdin immediately.
+pub use pipe::spawn_process_no_stdin as spawn_pipe_process_no_stdin;
 /// Handle for interacting with a spawned process (PTY or pipe).
 pub use process::ProcessHandle;
 /// Bundle of process handles plus output and exit receivers returned by spawn helpers.


### PR DESCRIPTION
Closing the STDIN of piped process when starting them to avoid commands like `rg` to wait for content on STDIN and hangs for ever