### PR TITLE
fix(tui): disable REPORT_ALTERNATE_KEYS on Windows to prevent Mouse Properties dialog

### DIFF
--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -65,14 +65,16 @@ pub fn set_modes() -> Result<()> {
     // Some terminals (notably legacy Windows consoles) do not support
     // keyboard enhancement flags. Attempt to enable them, but continue
     // gracefully if unsupported.
-    let _ = execute!(
-        stdout(),
-        PushKeyboardEnhancementFlags(
-            KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
-                | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
-        )
-    );
+    let flags = KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+        | KeyboardEnhancementFlags::REPORT_EVENT_TYPES;
+
+    // REPORT_ALTERNATE_KEYS causes issues on Windows Terminal/conpty where certain
+    // escape sequences can be misinterpreted as system keyboard shortcuts that
+    // trigger control panel applets (e.g., Mouse Properties dialog).
+    #[cfg(not(windows))]
+    let flags = flags | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS;
+
+    let _ = execute!(stdout(), PushKeyboardEnhancementFlags(flags));
 
     let _ = execute!(stdout(), EnableFocusChange);
     Ok(())

--- a/codex-rs/tui2/src/tui.rs
+++ b/codex-rs/tui2/src/tui.rs
@@ -66,14 +66,16 @@ pub fn set_modes() -> Result<()> {
     // Some terminals (notably legacy Windows consoles) do not support
     // keyboard enhancement flags. Attempt to enable them, but continue
     // gracefully if unsupported.
-    let _ = execute!(
-        stdout(),
-        PushKeyboardEnhancementFlags(
-            KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
-                | KeyboardEnhancementFlags::REPORT_EVENT_TYPES
-                | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS
-        )
-    );
+    let flags = KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
+        | KeyboardEnhancementFlags::REPORT_EVENT_TYPES;
+
+    // REPORT_ALTERNATE_KEYS causes issues on Windows Terminal/conpty where certain
+    // escape sequences can be misinterpreted as system keyboard shortcuts that
+    // trigger control panel applets (e.g., Mouse Properties dialog).
+    #[cfg(not(windows))]
+    let flags = flags | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS;
+
+    let _ = execute!(stdout(), PushKeyboardEnhancementFlags(flags));
 
     let _ = execute!(stdout(), EnableFocusChange);
     // Enable application mouse mode so scroll events are delivered as


### PR DESCRIPTION
## Summary

Fixes #9370

When running Codex on Windows, the **Mouse Properties** control panel dialog (`main.cpl`) sometimes opens unexpectedly during normal TUI usage.

<!-- Screenshot to be added in comment -->

## Root Cause

The `REPORT_ALTERNATE_KEYS` keyboard enhancement flag (part of Kitty Keyboard Protocol) causes issues on Windows Terminal/conpty. When enabled, certain escape sequences can be misinterpreted as system keyboard shortcuts that trigger control panel applets.

## Solution

Conditionally disable `REPORT_ALTERNATE_KEYS` on Windows using `#[cfg(not(windows))]`:

```rust
let flags = KeyboardEnhancementFlags::DISAMBIGUATE_ESCAPE_CODES
    | KeyboardEnhancementFlags::REPORT_EVENT_TYPES;

// REPORT_ALTERNATE_KEYS causes issues on Windows Terminal/conpty where certain
// escape sequences can be misinterpreted as system keyboard shortcuts that
// trigger control panel applets (e.g., Mouse Properties dialog).
#[cfg(not(windows))]
let flags = flags | KeyboardEnhancementFlags::REPORT_ALTERNATE_KEYS;

let _ = execute!(stdout(), PushKeyboardEnhancementFlags(flags));
```

The other two flags (`DISAMBIGUATE_ESCAPE_CODES` and `REPORT_EVENT_TYPES`) are sufficient for Shift+Return functionality on Windows.

## Files Changed

- `codex-rs/tui/src/tui.rs` - Original TUI
- `codex-rs/tui2/src/tui.rs` - New TUI  
- `codex-rs/cloud-tasks/src/lib.rs` - Cloud tasks UI

## Testing

- [x] Built and tested locally on Windows 11
- [x] Verified Shift+Return still works for newlines
- [x] Mouse Properties dialog no longer appears during usage