### PR TITLE
Fix invalid input error on Azure endpoint

### DIFF
--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -190,8 +190,8 @@ pub(crate) async fn exit_review_mode(
     review_output: Option<ReviewOutputEvent>,
     ctx: Arc<TurnContext>,
 ) {
-    const REVIEW_USER_MESSAGE_ID: &str = "review:rollout:user";
-    const REVIEW_ASSISTANT_MESSAGE_ID: &str = "review:rollout:assistant";
+    const REVIEW_USER_MESSAGE_ID: &str = "review_rollout_user";
+    const REVIEW_ASSISTANT_MESSAGE_ID: &str = "review_rollout_assistant";
     let (user_message, assistant_message) = if let Some(out) = review_output.clone() {
         let mut findings_str = String::new();
         let text = out.overall_explanation.trim();


### PR DESCRIPTION
Users of Azure endpoints are reporting that when they use `/review`, they sometimes see an error "Invalid 'input[3].id". I suspect this is specific to the Azure implementation of the `responses` API. The Azure team generally copies the OpenAI code for this endpoint, but they do have minor differences and sometimes lag in rolling out bug fixes or updates.

The error appears to be triggered because the `/review` implementation is using a user ID with a colon in it.

Addresses #9360
