### PR TITLE
fix(shell-snapshot): detach snapshot from tty

### DIFF
--- a/codex-rs/core/src/shell_snapshot.rs
+++ b/codex-rs/core/src/shell_snapshot.rs
@@ -1,7 +1,7 @@
 use std::io::ErrorKind;
-use std::process::Stdio;
 use std::path::Path;
 use std::path::PathBuf;
+use std::process::Stdio;
 use std::time::Duration;
 use std::time::SystemTime;
 

--- a/codex-rs/core/src/shell_snapshot.rs
+++ b/codex-rs/core/src/shell_snapshot.rs
@@ -172,6 +172,7 @@ else
   rc="$HOME/.zshrc"
 fi
 [[ -r "$rc" ]] && . "$rc"
+unset CODEX_SHELL_SNAPSHOT
 print '# Snapshot file'
 print '# Unset all aliases to avoid conflicts with functions'
 print 'unalias -a 2>/dev/null || true'
@@ -196,6 +197,7 @@ fn bash_snapshot_script() -> &'static str {
     r##"if [ -z "$BASH_ENV" ] && [ -r "$HOME/.bashrc" ]; then
   . "$HOME/.bashrc"
 fi
+unset CODEX_SHELL_SNAPSHOT
 echo '# Snapshot file'
 echo '# Unset all aliases to avoid conflicts with functions'
 unalias -a 2>/dev/null || true
@@ -223,6 +225,7 @@ fn sh_snapshot_script() -> &'static str {
     r##"if [ -n "$ENV" ] && [ -r "$ENV" ]; then
   . "$ENV"
 fi
+unset CODEX_SHELL_SNAPSHOT
 echo '# Snapshot file'
 echo '# Unset all aliases to avoid conflicts with functions'
 unalias -a 2>/dev/null || true


### PR DESCRIPTION
## Summary
- fix a macOS Terminal.app input regression when shell_snapshot is enabled by isolating the snapshot subprocess from the interactive TTY
- prevent snapshot shells/.zshrc from flipping terminal modes while the TUI is in raw mode
- add CODEX_SHELL_SNAPSHOT so users can guard tty-touching rc logic if needed

## Bug Details
When shell_snapshot is enabled, Codex spawns a login shell (zsh -lc) and sources ~/.zshrc to capture aliases/functions/env. On some setups (e.g., Terminal.app + a .zshrc that runs stty/tput or emits escape sequences), the snapshot shell writes to the live TTY and changes terminal modes. While the Codex TUI is in raw mode, this breaks input handling: Enter/backspace stop working and raw escape sequences like ^[[O appear (often after alt-tab). Disabling shell_snapshot avoids the issue.

## Repro Steps (macOS)
1. Enable `shell_snapshot` (TUI `/experimental` → “Shell snapshot”, or set `[features].shell_snapshot = true` in `~/.codex/config.toml` and restart).
2. Create a minimal zshrc that touches the tty:

   ```bash
   mkdir -p /tmp/codex-tty-repro
   cat > /tmp/codex-tty-repro/.zshrc <<'EOF'
   stty sane 2>/dev/null
   EOF
   ```
3. Launch Codex with that rc:

   ```bash
   ZDOTDIR=/tmp/codex-tty-repro codex
   ```
4. When the TUI appears, input is broken (Enter/Backspace don’t work). After alt‑tabbing, you may see raw escape sequences like `^[[O`.
5. Confirm that disabling snapshot restores input:

   ```bash
   ZDOTDIR=/tmp/codex-tty-repro codex --disable shell_snapshot
   ```

## Why It Failed Before
The snapshot subprocess inherited the controlling TTY and ran `.zshrc` while the TUI was in raw mode. Any tty mode changes or escape output from the snapshot shell hit the live terminal, which flips the terminal state out of raw mode and effectively “breaks” input handling for the running TUI. The failure is config-dependent, so it only shows up when shell_snapshot is enabled and `.zshrc` (or a plugin) touches the TTY.

## Fix
Detach the snapshot subprocess from the controlling terminal and avoid inheriting stdin:
- stdin set to /dev/null
- setsid() before exec on Unix
- env CODEX_SHELL_SNAPSHOT=1 for rc guards

This keeps snapshot output capture intact while preventing tty side effects.

## Testing
- not run (missing `just` tool in environment)

## Issue
- https://github.com/openai/codex/issues/9383
