### PR TITLE
Detach non-tty child spawns

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -512,17 +512,22 @@ pub struct ConfigEdit {
 #[ts(export_to = "v2/")]
 pub enum CommandExecutionApprovalDecision {
     /// User approved the command.
+    #[serde(alias = "approved")]
     Accept,
     /// User approved the command and future identical commands should run without prompting.
+    #[serde(alias = "approved_for_session")]
     AcceptForSession,
     /// User approved the command, and wants to apply the proposed execpolicy amendment so future
     /// matching commands can run without prompting.
+    #[serde(alias = "approved_with_amendment")]
     AcceptWithExecpolicyAmendment {
         execpolicy_amendment: ExecPolicyAmendment,
     },
     /// User denied the command. The agent will continue the turn.
+    #[serde(alias = "denied")]
     Decline,
     /// User denied the command. The turn will also be immediately interrupted.
+    #[serde(alias = "abort")]
     Cancel,
 }
 
@@ -531,12 +536,16 @@ pub enum CommandExecutionApprovalDecision {
 #[ts(export_to = "v2/")]
 pub enum FileChangeApprovalDecision {
     /// User approved the file changes.
+    #[serde(alias = "approved")]
     Accept,
     /// User approved the file changes and future changes to the same files should run without prompting.
+    #[serde(alias = "approved_for_session")]
     AcceptForSession,
     /// User denied the file changes. The agent will continue the turn.
+    #[serde(alias = "denied")]
     Decline,
     /// User denied the file changes. The turn will also be immediately interrupted.
+    #[serde(alias = "abort")]
     Cancel,
 }
 

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1215,6 +1215,7 @@ impl CodexMessageProcessor {
         let timeout_ms = params
             .timeout_ms
             .and_then(|timeout_ms| u64::try_from(timeout_ms).ok());
+        let detach_from_tty = self.config.features.enabled(Feature::DetachNonTty);
         let exec_params = ExecParams {
             command: params.command,
             cwd,
@@ -1223,6 +1224,7 @@ impl CodexMessageProcessor {
             sandbox_permissions: SandboxPermissions::UseDefault,
             justification: None,
             arg0: None,
+            detach_from_tty,
         };
 
         let requested_policy = params.sandbox_policy.map(|policy| policy.to_core());

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -75,7 +75,13 @@
         "apply_patch_freeform": {
           "type": "boolean"
         },
+        "child_agents_md": {
+          "type": "boolean"
+        },
         "collab": {
+          "type": "boolean"
+        },
+        "detach_non_tty": {
           "type": "boolean"
         },
         "elevated_windows_sandbox": {
@@ -97,9 +103,6 @@
           "type": "boolean"
         },
         "experimental_windows_sandbox": {
-          "type": "boolean"
-        },
-        "child_agents_md": {
           "type": "boolean"
         },
         "include_apply_patch_tool": {
@@ -543,7 +546,13 @@
             "apply_patch_freeform": {
               "type": "boolean"
             },
+            "child_agents_md": {
+              "type": "boolean"
+            },
             "collab": {
+              "type": "boolean"
+            },
+            "detach_non_tty": {
               "type": "boolean"
             },
             "elevated_windows_sandbox": {
@@ -565,9 +574,6 @@
               "type": "boolean"
             },
             "experimental_windows_sandbox": {
-              "type": "boolean"
-            },
-            "child_agents_md": {
               "type": "boolean"
             },
             "include_apply_patch_tool": {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4286,6 +4286,7 @@ mod tests {
             sandbox_permissions,
             justification: Some("test".to_string()),
             arg0: None,
+            detach_from_tty: false,
         };
 
         let params2 = ExecParams {
@@ -4296,6 +4297,7 @@ mod tests {
             env: HashMap::new(),
             justification: params.justification.clone(),
             arg0: None,
+            detach_from_tty: false,
         };
 
         let turn_diff_tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));

--- a/codex-rs/core/src/exec.rs
+++ b/codex-rs/core/src/exec.rs
@@ -549,6 +549,7 @@ async fn exec(
         ))
     })?;
     let arg0_ref = arg0.as_deref();
+    let detach_from_tty = matches!(sandbox, SandboxType::None);
     let child = spawn_child_async(
         PathBuf::from(program),
         args.into(),
@@ -557,6 +558,7 @@ async fn exec(
         sandbox_policy,
         StdioPolicy::RedirectForShellTool,
         env,
+        detach_from_tty,
     )
     .await?;
     consume_truncated_output(child, expiration, stdout_stream).await

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -88,6 +88,8 @@ pub enum Feature {
     RemoteModels,
     /// Experimental shell snapshotting.
     ShellSnapshot,
+    /// Detach non-interactive child processes from the controlling TTY.
+    DetachNonTty,
     /// Append additional AGENTS.md guidance to user instructions.
     ChildAgentsMd,
     /// Experimental TUI v2 (viewport) implementation.
@@ -355,6 +357,16 @@ pub const FEATURES: &[FeatureSpec] = &[
             name: "Shell snapshot",
             menu_description: "Snapshot your shell environment to avoid re-running login scripts for every command.",
             announcement: "NEW! Try shell snapshotting to make your Codex faster. Enable in /experimental!",
+        },
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::DetachNonTty,
+        key: "detach_non_tty",
+        stage: Stage::Beta {
+            name: "Detach non-PTY commands",
+            menu_description: "Run non-interactive commands without inheriting the controlling TTY.",
+            announcement: "NEW! Try detaching non-PTY commands to avoid TTY issues. Enable in /experimental!",
         },
         default_enabled: false,
     },

--- a/codex-rs/core/src/landlock.rs
+++ b/codex-rs/core/src/landlock.rs
@@ -35,6 +35,7 @@ where
         sandbox_policy,
         stdio_policy,
         env,
+        false,
     )
     .await
 }

--- a/codex-rs/core/src/sandboxing/mod.rs
+++ b/codex-rs/core/src/sandboxing/mod.rs
@@ -35,6 +35,7 @@ pub struct CommandSpec {
     pub expiration: ExecExpiration,
     pub sandbox_permissions: SandboxPermissions,
     pub justification: Option<String>,
+    pub detach_from_tty: bool,
 }
 
 #[derive(Debug)]
@@ -47,6 +48,7 @@ pub struct ExecEnv {
     pub sandbox_permissions: SandboxPermissions,
     pub justification: Option<String>,
     pub arg0: Option<String>,
+    pub detach_from_tty: bool,
 }
 
 pub enum SandboxPreference {
@@ -163,6 +165,7 @@ impl SandboxManager {
             sandbox_permissions: spec.sandbox_permissions,
             justification: spec.justification,
             arg0: arg0_override,
+            detach_from_tty: spec.detach_from_tty,
         })
     }
 

--- a/codex-rs/core/src/seatbelt.rs
+++ b/codex-rs/core/src/seatbelt.rs
@@ -39,6 +39,7 @@ pub async fn spawn_command_under_seatbelt(
         sandbox_policy,
         stdio_policy,
         env,
+        false,
     )
     .await
 }

--- a/codex-rs/core/src/spawn.rs
+++ b/codex-rs/core/src/spawn.rs
@@ -44,7 +44,7 @@ pub(crate) async fn spawn_child_async(
     sandbox_policy: &SandboxPolicy,
     stdio_policy: StdioPolicy,
     env: HashMap<String, String>,
-    detach_from_tty: bool,
+    #[cfg_attr(not(unix), allow(unused_variables))] detach_from_tty: bool,
 ) -> std::io::Result<Child> {
     trace!(
         "spawn_child_async: {program:?} {args:?} {arg0:?} {cwd:?} {sandbox_policy:?} {stdio_policy:?} {env:?}"

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -16,6 +16,7 @@ use crate::exec::StdoutStream;
 use crate::exec::StreamOutput;
 use crate::exec::execute_exec_env;
 use crate::exec_env::create_env;
+use crate::features::Feature;
 use crate::parse_command::parse_command;
 use crate::protocol::EventMsg;
 use crate::protocol::ExecCommandBeginEvent;
@@ -111,6 +112,7 @@ impl SessionTask for UserShellCommandTask {
             sandbox_permissions: SandboxPermissions::UseDefault,
             justification: None,
             arg0: None,
+            detach_from_tty: session.features().enabled(Feature::DetachNonTty),
         };
 
         let stdout_stream = Some(StdoutStream {

--- a/codex-rs/core/src/tools/runtimes/apply_patch.rs
+++ b/codex-rs/core/src/tools/runtimes/apply_patch.rs
@@ -64,6 +64,7 @@ impl ApplyPatchRuntime {
             env: HashMap::new(),
             sandbox_permissions: SandboxPermissions::UseDefault,
             justification: None,
+            detach_from_tty: false,
         })
     }
 

--- a/codex-rs/core/src/tools/runtimes/mod.rs
+++ b/codex-rs/core/src/tools/runtimes/mod.rs
@@ -25,6 +25,7 @@ pub(crate) fn build_command_spec(
     expiration: ExecExpiration,
     sandbox_permissions: SandboxPermissions,
     justification: Option<String>,
+    detach_from_tty: bool,
 ) -> Result<CommandSpec, ToolError> {
     let (program, args) = command
         .split_first()
@@ -37,6 +38,7 @@ pub(crate) fn build_command_spec(
         expiration,
         sandbox_permissions,
         justification,
+        detach_from_tty,
     })
 }
 

--- a/codex-rs/core/src/tools/runtimes/shell.rs
+++ b/codex-rs/core/src/tools/runtimes/shell.rs
@@ -162,6 +162,7 @@ impl ToolRuntime<ShellRequest, ExecToolCallOutput> for ShellRuntime {
             req.timeout_ms.into(),
             req.sandbox_permissions,
             req.justification.clone(),
+            ctx.session.features().enabled(Feature::DetachNonTty),
         )?;
         let env = attempt
             .env_for(spec)

--- a/codex-rs/core/src/tools/runtimes/unified_exec.rs
+++ b/codex-rs/core/src/tools/runtimes/unified_exec.rs
@@ -181,6 +181,7 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
             command
         };
 
+        let detach_from_tty = ctx.session.features().enabled(Feature::DetachNonTty) && !req.tty;
         let spec = build_command_spec(
             &command,
             &req.cwd,
@@ -188,6 +189,7 @@ impl<'a> ToolRuntime<UnifiedExecRequest, UnifiedExecProcess> for UnifiedExecRunt
             ExecExpiration::DefaultTimeout,
             req.sandbox_permissions,
             req.justification.clone(),
+            detach_from_tty,
         )
         .map_err(|_| ToolError::Rejected("missing command line for PTY".to_string()))?;
         let exec_env = attempt

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -471,7 +471,7 @@ impl UnifiedExecProcessManager {
             )
             .await
         } else {
-            let detach_from_tty = matches!(env.sandbox, SandboxType::None);
+            let detach_from_tty = env.detach_from_tty && matches!(env.sandbox, SandboxType::None);
             if detach_from_tty {
                 codex_utils_pty::pipe::spawn_process_no_stdin_detached(
                     program,

--- a/codex-rs/core/tests/suite/exec.rs
+++ b/codex-rs/core/tests/suite/exec.rs
@@ -38,6 +38,7 @@ async fn run_test_cmd(tmp: TempDir, cmd: Vec<&str>) -> Result<ExecToolCallOutput
         sandbox_permissions: SandboxPermissions::UseDefault,
         justification: None,
         arg0: None,
+        detach_from_tty: false,
     };
 
     let policy = SandboxPolicy::new_read_only_policy();

--- a/codex-rs/exec-server/src/posix/escalate_server.rs
+++ b/codex-rs/exec-server/src/posix/escalate_server.rs
@@ -89,6 +89,7 @@ impl EscalateServer {
                 sandbox_permissions: SandboxPermissions::UseDefault,
                 justification: None,
                 arg0: None,
+                detach_from_tty: false,
             },
             &sandbox_state.sandbox_policy,
             &sandbox_state.sandbox_cwd,

--- a/codex-rs/linux-sandbox/tests/suite/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/suite/landlock.rs
@@ -62,6 +62,7 @@ async fn run_cmd_output(
         sandbox_permissions: SandboxPermissions::UseDefault,
         justification: None,
         arg0: None,
+        detach_from_tty: false,
     };
 
     let sandbox_policy = SandboxPolicy::WorkspaceWrite {
@@ -179,6 +180,7 @@ async fn assert_network_blocked(cmd: &[&str]) {
         sandbox_permissions: SandboxPermissions::UseDefault,
         justification: None,
         arg0: None,
+        detach_from_tty: false,
     };
 
     let sandbox_policy = SandboxPolicy::new_read_only_policy();

--- a/codex-rs/utils/pty/src/pipe.rs
+++ b/codex-rs/utils/pty/src/pipe.rs
@@ -103,7 +103,7 @@ async fn spawn_process_with_stdin_mode(
     env: &HashMap<String, String>,
     arg0: &Option<String>,
     stdin_mode: PipeStdinMode,
-    detach_from_tty: bool,
+    #[cfg_attr(not(unix), allow(unused_variables))] detach_from_tty: bool,
 ) -> Result<SpawnedProcess> {
     if program.is_empty() {
         anyhow::bail!("missing program for pipe spawn");


### PR DESCRIPTION
## Why

Sometimes codex gets into a bad state when running scripts. I see `zsh: suspended (tty input)` and `fg` will crash shell/terminal emulator. I can repro this reliably on iTerm2, Ghostty, inside and outside tmux etc.

After trial and error codex (haha) suggested this is related to the way child process handles tty. Either way bad programs shouldn't crash codex.

## Repro

```python
#!/usr/bin/env python
import os
import signal
import time

tty_fd = os.open('/dev/tty', os.O_RDWR)
time.sleep(2)
os.killpg(os.tcgetpgrp(tty_fd), signal.SIGTTIN)
```


## Summary
- gate non-PTY detaching *behind the experimental flag* `detach_non_tty` (default off)
- thread detach flag through exec/unified exec/app server/user shell paths; only applies to non-tty + no-sandbox spawns
- update config schema for the new feature flag
- silence unused detach flag warning on non-unix in utils/pty
- silence unused detach flag warning on non-unix in core spawn path

## Testing
- just fmt
- just fix -p codex-core
- just fix -p codex-app-server
- just fix -p codex-exec-server
- just fix -p codex-linux-sandbox
- just fix -p codex-utils-pty
- cargo test -p codex-core
- cargo test -p codex-app-server
- cargo test -p codex-exec-server
- cargo test -p codex-linux-sandbox
- cargo test -p codex-utils-pty
- cargo test --all-features
- cargo build -p codex-cli
- just write-config-schema
