### PR TITLE
fix(tui) fix user message light mode background

### DIFF
--- a/codex-rs/tui/src/style.rs
+++ b/codex-rs/tui/src/style.rs
@@ -19,10 +19,10 @@ pub fn user_message_style_for(terminal_bg: Option<(u8, u8, u8)>) -> Style {
 
 #[allow(clippy::disallowed_methods)]
 pub fn user_message_bg(terminal_bg: (u8, u8, u8)) -> Color {
-    let top = if is_light(terminal_bg) {
-        (0, 0, 0)
+    let (top, alpha) = if is_light(terminal_bg) {
+        ((0, 0, 0), 0.04)
     } else {
-        (255, 255, 255)
+        ((255, 255, 255), 0.12)
     };
-    best_color(blend(top, terminal_bg, 0.1))
+    best_color(blend(top, terminal_bg, alpha))
 }


### PR DESCRIPTION
## Summary
Fixes the user message styles for light mode.

## Testing
Attaching 2 screenshots from ghostty, but I also tried various styles in Terminal.app and iTerm2.
**Before**
<img width="888" height="560" alt="Screenshot 2026-01-16 at 5 22 36 PM" src="https://github.com/user-attachments/assets/73d9decb-a01a-4ece-b88e-ea49a33cc0c6" />

**After**
<img width="890" height="281" alt="Screenshot 2026-01-16 at 5 22 59 PM" src="https://github.com/user-attachments/assets/6689e286-d699-4ceb-b0cb-579a31b047bf" />
