### PR TITLE
notify: emit agent-turn-start hook

### DIFF
--- a/codex-rs/README.md
+++ b/codex-rs/README.md
@@ -46,7 +46,7 @@ Use `codex mcp` to add/list/get/remove MCP server launchers defined in `config.t
 
 ### Notifications
 
-You can enable notifications by configuring a script that is run whenever the agent finishes a turn. The [notify documentation](../docs/config.md#notify) includes a detailed example that explains how to get desktop notifications via [terminal-notifier](https://github.com/julienXX/terminal-notifier) on macOS. When Codex detects that it is running under WSL 2 inside Windows Terminal (`WT_SESSION` is set), the TUI automatically falls back to native Windows toast notifications so approval prompts and completed turns surface even though Windows Terminal does not implement OSC 9.
+You can enable notifications by configuring a script that is run when the agent starts and finishes a turn. The [notify documentation](../docs/config.md#notify) includes a detailed example that explains how to get desktop notifications via [terminal-notifier](https://github.com/julienXX/terminal-notifier) on macOS. When Codex detects that it is running under WSL 2 inside Windows Terminal (`WT_SESSION` is set), the TUI automatically falls back to native Windows toast notifications so approval prompts and completed turns surface even though Windows Terminal does not implement OSC 9.
 
 ### `codex exec` to run Codex programmatically/non-interactively
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2675,6 +2675,19 @@ pub(crate) async fn run_turn(
         model_context_window: turn_context.client.get_model_context_window(),
     });
     sess.send_event(&turn_context, event).await;
+    let input_messages = input
+        .iter()
+        .filter_map(|item| match item {
+            UserInput::Text { text, .. } => Some(text.clone()),
+            _ => None,
+        })
+        .collect::<Vec<String>>();
+    sess.notifier().notify(&UserNotification::AgentTurnStart {
+        thread_id: sess.conversation_id.to_string(),
+        turn_id: turn_context.sub_id.clone(),
+        cwd: turn_context.cwd.display().to_string(),
+        input_messages,
+    });
 
     let skills_outcome = Some(
         sess.services

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -162,8 +162,9 @@ pub struct Config {
     pub compact_prompt: Option<String>,
 
     /// Optional external notifier command. When set, Codex will spawn this
-    /// program after each completed *turn* (i.e. when the agent finishes
-    /// processing a user submission). The value must be the full command
+    /// program when a turn starts and when a turn completes (i.e. when the
+    /// agent begins or finishes processing a user submission). The value must
+    /// be the full command
     /// broken into argv tokens **without** the trailing JSON argument - Codex
     /// appends one extra argument containing a JSON payload describing the
     /// event.
@@ -177,7 +178,7 @@ pub struct Config {
     /// which will be invoked as:
     ///
     /// ```shell
-    /// notify-send Codex '{"type":"agent-turn-complete","turn-id":"12345"}'
+    /// notify-send Codex '{"type":"agent-turn-start","turn-id":"12345"}'
     /// ```
     ///
     /// If unset the feature is disabled.

--- a/codex-rs/core/src/user_notification.rs
+++ b/codex-rs/core/src/user_notification.rs
@@ -48,6 +48,15 @@ impl UserNotifier {
 #[serde(tag = "type", rename_all = "kebab-case")]
 pub(crate) enum UserNotification {
     #[serde(rename_all = "kebab-case")]
+    AgentTurnStart {
+        thread_id: String,
+        turn_id: String,
+        cwd: String,
+
+        /// Messages that the user sent to the agent to initiate the turn.
+        input_messages: Vec<String>,
+    },
+    #[serde(rename_all = "kebab-case")]
     AgentTurnComplete {
         thread_id: String,
         turn_id: String,
@@ -68,6 +77,18 @@ mod tests {
 
     #[test]
     fn test_user_notification() -> Result<()> {
+        let notification = UserNotification::AgentTurnStart {
+            thread_id: "b5f6c1c2-1111-2222-3333-444455556666".to_string(),
+            turn_id: "12345".to_string(),
+            cwd: "/Users/example/project".to_string(),
+            input_messages: vec!["Rename `foo` to `bar` and update the callsites.".to_string()],
+        };
+        let serialized = serde_json::to_string(&notification)?;
+        assert_eq!(
+            serialized,
+            r#"{"type":"agent-turn-start","thread-id":"b5f6c1c2-1111-2222-3333-444455556666","turn-id":"12345","cwd":"/Users/example/project","input-messages":["Rename `foo` to `bar` and update the callsites."]}"#
+        );
+
         let notification = UserNotification::AgentTurnComplete {
             thread_id: "b5f6c1c2-1111-2222-3333-444455556666".to_string(),
             turn_id: "12345".to_string(),

--- a/docs/config.md
+++ b/docs/config.md
@@ -14,7 +14,12 @@ Codex can connect to MCP servers configured in `~/.codex/config.toml`. See the c
 
 ## Notify
 
-Codex can run a notification hook when the agent finishes a turn. See the configuration reference for the latest notification settings:
+Codex can run a notification hook when the agent starts and finishes a turn. The hook receives a JSON payload with a `type` field:
+
+- `agent-turn-start`
+- `agent-turn-complete`
+
+See the configuration reference for the latest notification settings:
 
 - https://developers.openai.com/codex/config-reference
 


### PR DESCRIPTION
External integrations (like lights) need a start signal, not just completion.


  - Add a new notify payload type agent-turn-start so scripts can react when a turn begins.
  - Emit it at the start of run_turn with thread/turn/cwd and user input messages.
  - Update docs and tests to cover the new event.
