### PR TITLE
Fixed symlink support for config.toml

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -763,12 +763,7 @@ pub fn set_default_oss_provider(codex_home: &Path, provider: &str) -> std::io::R
     ConfigEditsBuilder::new(codex_home)
         .with_edits(edits)
         .apply_blocking()
-        .map_err(|err| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("failed to persist config.toml: {err}"),
-            )
-        })
+        .map_err(|err| std::io::Error::other(format!("failed to persist config.toml: {err}")))
 }
 
 /// Base config deserialized from ~/.codex/config.toml.

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1,4 +1,6 @@
 use crate::auth::AuthCredentialsStoreMode;
+use crate::config::edit::ConfigEdit;
+use crate::config::edit::ConfigEditsBuilder;
 use crate::config::types::DEFAULT_OTEL_ENVIRONMENT;
 use crate::config::types::History;
 use crate::config::types::McpServerConfig;
@@ -751,30 +753,22 @@ pub fn set_default_oss_provider(codex_home: &Path, provider: &str) -> std::io::R
             ));
         }
     }
-    let config_path = codex_home.join(CONFIG_TOML_FILE);
-
-    // Read existing config or create empty string if file doesn't exist
-    let content = match std::fs::read_to_string(&config_path) {
-        Ok(content) => content,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
-        Err(e) => return Err(e),
-    };
-
-    // Parse as DocumentMut for editing while preserving structure
-    let mut doc = content.parse::<DocumentMut>().map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("failed to parse config.toml: {e}"),
-        )
-    })?;
-
-    // Set the default_oss_provider at root level
     use toml_edit::value;
-    doc["oss_provider"] = value(provider);
 
-    // Write the modified document back
-    std::fs::write(&config_path, doc.to_string())?;
-    Ok(())
+    let edits = [ConfigEdit::SetPath {
+        segments: vec!["oss_provider".to_string()],
+        value: value(provider),
+    }];
+
+    ConfigEditsBuilder::new(codex_home)
+        .with_edits(edits)
+        .apply_blocking()
+        .map_err(|err| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("failed to persist config.toml: {err}"),
+            )
+        })
 }
 
 /// Base config deserialized from ~/.codex/config.toml.

--- a/codex-rs/core/src/config/service.rs
+++ b/codex-rs/core/src/config/service.rs
@@ -9,6 +9,9 @@ use crate::config_loader::LoaderOverrides;
 use crate::config_loader::load_config_layers_state;
 use crate::config_loader::merge_toml_values;
 use crate::path_utils;
+use crate::path_utils::SymlinkWritePaths;
+use crate::path_utils::resolve_symlink_write_paths;
+use crate::path_utils::write_atomically;
 use codex_app_server_protocol::Config as ApiConfig;
 use codex_app_server_protocol::ConfigBatchWriteParams;
 use codex_app_server_protocol::ConfigLayerMetadata;
@@ -27,6 +30,7 @@ use std::borrow::Cow;
 use std::path::Path;
 use std::path::PathBuf;
 use thiserror::Error;
+use tokio::task;
 use toml::Value as TomlValue;
 use toml_edit::Item as TomlItem;
 
@@ -362,19 +366,30 @@ impl ConfigService {
 async fn create_empty_user_layer(
     config_toml: &AbsolutePathBuf,
 ) -> Result<ConfigLayerEntry, ConfigServiceError> {
-    let toml_value = match tokio::fs::read_to_string(config_toml).await {
-        Ok(contents) => toml::from_str(&contents).map_err(|e| {
-            ConfigServiceError::toml("failed to parse existing user config.toml", e)
-        })?,
-        Err(e) => {
-            if e.kind() == std::io::ErrorKind::NotFound {
-                tokio::fs::write(config_toml, "").await.map_err(|e| {
-                    ConfigServiceError::io("failed to create empty user config.toml", e)
-                })?;
+    let SymlinkWritePaths {
+        read_path,
+        write_path,
+    } = resolve_symlink_write_paths(config_toml.as_path())
+        .map_err(|err| ConfigServiceError::io("failed to resolve user config path", err))?;
+    let toml_value = match read_path {
+        Some(path) => match tokio::fs::read_to_string(&path).await {
+            Ok(contents) => toml::from_str(&contents).map_err(|e| {
+                ConfigServiceError::toml("failed to parse existing user config.toml", e)
+            })?,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                write_empty_user_config(write_path.clone()).await?;
                 TomlValue::Table(toml::map::Map::new())
-            } else {
-                return Err(ConfigServiceError::io("failed to read user config.toml", e));
             }
+            Err(err) => {
+                return Err(ConfigServiceError::io(
+                    "failed to read user config.toml",
+                    err,
+                ));
+            }
+        },
+        None => {
+            write_empty_user_config(write_path).await?;
+            TomlValue::Table(toml::map::Map::new())
         }
     };
     Ok(ConfigLayerEntry::new(
@@ -383,6 +398,13 @@ async fn create_empty_user_layer(
         },
         toml_value,
     ))
+}
+
+async fn write_empty_user_config(write_path: PathBuf) -> Result<(), ConfigServiceError> {
+    task::spawn_blocking(move || write_atomically(&write_path, ""))
+        .await
+        .map_err(|err| ConfigServiceError::anyhow("config persistence task panicked", err.into()))?
+        .map_err(|err| ConfigServiceError::io("failed to create empty user config.toml", err))
 }
 
 fn parse_value(value: JsonValue) -> Result<Option<TomlValue>, String> {

--- a/codex-rs/core/src/path_utils.rs
+++ b/codex-rs/core/src/path_utils.rs
@@ -1,11 +1,109 @@
+use codex_utils_absolute_path::AbsolutePathBuf;
+use std::collections::HashSet;
+use std::io;
 use std::path::Path;
 use std::path::PathBuf;
+use tempfile::NamedTempFile;
 
 use crate::env;
 
 pub fn normalize_for_path_comparison(path: impl AsRef<Path>) -> std::io::Result<PathBuf> {
     let canonical = path.as_ref().canonicalize()?;
     Ok(normalize_for_wsl(canonical))
+}
+
+pub struct SymlinkWritePaths {
+    pub read_path: Option<PathBuf>,
+    pub write_path: PathBuf,
+}
+
+pub fn resolve_symlink_write_paths(path: &Path) -> io::Result<SymlinkWritePaths> {
+    let root = AbsolutePathBuf::from_absolute_path(path)
+        .map(AbsolutePathBuf::into_path_buf)
+        .unwrap_or_else(|_| path.to_path_buf());
+    let mut current = root.clone();
+    let mut visited = HashSet::new();
+
+    // Follow symlink chains while guarding against cycles.
+    loop {
+        let meta = match std::fs::symlink_metadata(&current) {
+            Ok(meta) => meta,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => {
+                return Ok(SymlinkWritePaths {
+                    read_path: Some(current.clone()),
+                    write_path: current,
+                });
+            }
+            Err(_) => {
+                return Ok(SymlinkWritePaths {
+                    read_path: None,
+                    write_path: root,
+                });
+            }
+        };
+
+        if !meta.file_type().is_symlink() {
+            return Ok(SymlinkWritePaths {
+                read_path: Some(current.clone()),
+                write_path: current,
+            });
+        }
+
+        // If we've already seen this path, the chain cycles.
+        if !visited.insert(current.clone()) {
+            return Ok(SymlinkWritePaths {
+                read_path: None,
+                write_path: root,
+            });
+        }
+
+        let target = match std::fs::read_link(&current) {
+            Ok(target) => target,
+            Err(_) => {
+                return Ok(SymlinkWritePaths {
+                    read_path: None,
+                    write_path: root,
+                });
+            }
+        };
+
+        let next = if target.is_absolute() {
+            AbsolutePathBuf::from_absolute_path(&target)
+        } else if let Some(parent) = current.parent() {
+            AbsolutePathBuf::resolve_path_against_base(&target, parent)
+        } else {
+            return Ok(SymlinkWritePaths {
+                read_path: None,
+                write_path: root,
+            });
+        };
+
+        let next = match next {
+            Ok(path) => path.into_path_buf(),
+            Err(_) => {
+                return Ok(SymlinkWritePaths {
+                    read_path: None,
+                    write_path: root,
+                });
+            }
+        };
+
+        current = next;
+    }
+}
+
+pub fn write_atomically(write_path: &Path, contents: &str) -> io::Result<()> {
+    let parent = write_path.parent().ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::InvalidInput,
+            format!("path {} has no parent directory", write_path.display()),
+        )
+    })?;
+    std::fs::create_dir_all(parent)?;
+    let tmp = NamedTempFile::new_in(parent)?;
+    std::fs::write(tmp.path(), contents)?;
+    tmp.persist(write_path)?;
+    Ok(())
 }
 
 fn normalize_for_wsl(path: PathBuf) -> PathBuf {

--- a/codex-rs/core/src/path_utils.rs
+++ b/codex-rs/core/src/path_utils.rs
@@ -17,6 +17,12 @@ pub struct SymlinkWritePaths {
     pub write_path: PathBuf,
 }
 
+/// Resolve the final filesystem target for `path` while retaining a safe write path.
+///
+/// This follows symlink chains (including relative symlink targets) until it reaches a
+/// non-symlink path. If the chain cycles or any metadata/link resolution fails, it
+/// returns `read_path: None` and uses the original absolute path as `write_path`.
+/// There is no fixed max-resolution count; cycles are detected via a visited set.
 pub fn resolve_symlink_write_paths(path: &Path) -> io::Result<SymlinkWritePaths> {
     let root = AbsolutePathBuf::from_absolute_path(path)
         .map(AbsolutePathBuf::into_path_buf)
@@ -182,6 +188,29 @@ fn lower_ascii_path(path: PathBuf) -> PathBuf {
 
 #[cfg(test)]
 mod tests {
+    #[cfg(unix)]
+    mod symlinks {
+        use super::super::resolve_symlink_write_paths;
+        use pretty_assertions::assert_eq;
+        use std::os::unix::fs::symlink;
+
+        #[test]
+        fn symlink_cycles_fall_back_to_root_write_path() -> std::io::Result<()> {
+            let dir = tempfile::tempdir()?;
+            let a = dir.path().join("a");
+            let b = dir.path().join("b");
+
+            symlink(&b, &a)?;
+            symlink(&a, &b)?;
+
+            let resolved = resolve_symlink_write_paths(&a)?;
+
+            assert_eq!(resolved.read_path, None);
+            assert_eq!(resolved.write_path, a);
+            Ok(())
+        }
+    }
+
     #[cfg(target_os = "linux")]
     mod wsl {
         use super::super::normalize_for_wsl_with_flag;


### PR DESCRIPTION
We already support reading from `config.toml` through a symlink, but the code was not properly handling updates to a symlinked config file. This PR generalizes safe symlink-chain resolution and atomic writes into path_utils, updating all config write paths to use the shared logic (including set_default_oss_provider, which previously didn't use the common path), and adds tests for symlink chains and cycles.

This resolves #6646.

Notes:
* Symlink cycles or resolution failures replace the top-level symlink with a real file.
* Shared config write path now handles symlinks consistently across edits, defaults, and empty-user-layer creation.

This PR was inspired by https://github.com/openai/codex/pull/9437, which was contributed by @ryoppippi
