### PR TITLE
Normalize tool call names for Responses API

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -220,9 +220,10 @@ impl ModelClient {
         let instructions = prompt
             .get_full_instructions(&self.state.model_info)
             .into_owned();
+        let formatted_input = prompt.get_formatted_input();
         let payload = ApiCompactionInput {
             model: &self.state.model_info.slug,
-            input: &prompt.input,
+            input: &formatted_input,
             instructions: &instructions,
         };
 


### PR DESCRIPTION
Fixes #6540

### What
Normalize legacy/namespaced tool call names in the transcript before sending request history to the OpenAI Responses API.

This avoids 400s like:

- `Invalid 'input[N].name': string does not match pattern '^[a-zA-Z0-9_-]+$'`

### How
- Map legacy `container.exec` -> `shell`.
- If tool name is namespaced (e.g. `functions.exec_command`), drop the prefix when the suffix matches a known tool in the current prompt.
- Otherwise, replace invalid characters with `_` as a fallback.
- Apply the same formatting to compaction payloads as well.

### Tests
- `cargo test -p codex-core tool_name_tests`

### Manual verification
- Resumed a session containing tool calls named `functions.exec_command`; patched CLI continues without triggering `input[*].name` validation errors.
