### PR TITLE
fix(tui2): running /mcp was not printing any output until another event triggered a flush

### DIFF
--- a/codex-rs/tui2/src/app.rs
+++ b/codex-rs/tui2/src/app.rs
@@ -1608,6 +1608,8 @@ impl App {
                 self.transcript_cells.push(cell.clone());
                 if self.overlay.is_some() {
                     self.deferred_history_cells.push(cell);
+                } else {
+                    tui.frame_requester().schedule_frame();
                 }
             }
             AppEvent::StartCommitAnimation => {


### PR DESCRIPTION
This seems to fix things, but I'm not sure if this is the correct/minimal fix.