### PR TITLE
feat: truncate potential issue enhancement

### DIFF
--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -126,11 +126,13 @@ async fn run_compact_task_inner(
             }
             Err(e @ CodexErr::ContextWindowExceeded) => {
                 if turn_input_len > 1 {
-                    // Trim from the beginning to preserve cache (prefix-based) and keep recent messages intact.
+                    // Use importance-aware removal to preserve critical items like user messages
+                    // and error information while removing less important items first.
+                    // This helps maintain context quality during compaction.
                     error!(
-                        "Context window exceeded while compacting; removing oldest history item. Error: {e}"
+                        "Context window exceeded while compacting; removing least important history item. Error: {e}"
                     );
-                    history.remove_first_item();
+                    history.remove_least_important_item();
                     truncated_count += 1;
                     retries = 0;
                     continue;

--- a/codex-rs/core/src/tools/mod.rs
+++ b/codex-rs/core/src/tools/mod.rs
@@ -96,8 +96,106 @@ pub fn format_exec_output_str(
 ) -> String {
     let content = build_content_with_timeout(exec_output);
 
-    // Truncate for model consumption before serialization.
-    formatted_truncate_text(&content, truncation_policy)
+    // Apply error-priority formatting: extract and prioritize error information
+    // This ensures critical error messages from compilation failures, test failures,
+    // etc. are preserved even when output needs to be truncated.
+    format_exec_output_with_error_priority(&content, truncation_policy)
+}
+
+/// Format exec output with priority given to error information.
+/// Extracts error lines and ensures they are preserved during truncation,
+/// then truncates remaining content within the available budget.
+fn format_exec_output_with_error_priority(
+    content: &str,
+    policy: TruncationPolicy,
+) -> String {
+    // Get full output without truncation to analyze error patterns
+    let full_output = content;
+
+    // Extract error lines from the output
+    let errors = extract_errors(full_output);
+
+    // If errors are found, prioritize them in the output
+    if !errors.is_empty() {
+        let error_text = errors.join("\n");
+        let error_tokens = crate::truncate::approx_token_count(&error_text);
+        let budget = policy.token_budget();
+
+        // Calculate remaining budget after reserving space for errors
+        let remaining_budget = budget.saturating_sub(error_tokens);
+
+        if remaining_budget > 0 {
+            // We have budget for both errors and some other content
+            // Remove error lines from original content and truncate the rest
+            let content_without_errors = remove_error_lines(full_output, &errors);
+            let truncated_rest = if !content_without_errors.trim().is_empty() {
+                crate::truncate::truncate_text(
+                    &content_without_errors,
+                    match policy {
+                        TruncationPolicy::Bytes(_) => {
+                            TruncationPolicy::Bytes(policy.byte_budget().saturating_sub(
+                                crate::truncate::approx_bytes_for_tokens(error_tokens),
+                            ))
+                        }
+                        TruncationPolicy::Tokens(_) => TruncationPolicy::Tokens(remaining_budget),
+                    },
+                )
+            } else {
+                String::new()
+            };
+
+            if truncated_rest.is_empty() {
+                // Only errors fit, return just errors
+                crate::truncate::truncate_text(&error_text, policy)
+            } else {
+                // Combine errors and truncated rest
+                format!("{}\n\n--- Other Output ---\n{}", error_text, truncated_rest)
+            }
+        } else {
+            // Error information itself exceeds budget, truncate errors but keep them
+            crate::truncate::truncate_text(&error_text, policy)
+        }
+    } else {
+        // No errors found, use standard truncation
+        crate::truncate::formatted_truncate_text(content, policy)
+    }
+}
+
+/// Extract error lines from output content.
+/// Identifies lines containing error patterns (error, failed, exception, etc.)
+/// and returns them as a vector of strings.
+fn extract_errors(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .filter(|line| contains_error_patterns(line))
+        .map(|line| line.to_string())
+        .collect()
+}
+
+/// Remove error lines from content, returning the remaining text.
+fn remove_error_lines(content: &str, error_lines: &[String]) -> String {
+    let error_set: std::collections::HashSet<&str> =
+        error_lines.iter().map(|s| s.as_str()).collect();
+    content
+        .lines()
+        .filter(|line| !error_set.contains(line))
+        .collect::<Vec<&str>>()
+        .join("\n")
+}
+
+/// Check if a line contains error patterns.
+/// Uses case-insensitive matching for common error keywords.
+fn contains_error_patterns(line: &str) -> bool {
+    let lower = line.to_lowercase();
+    lower.contains("error")
+        || lower.contains("failed")
+        || lower.contains("exception")
+        || lower.contains("fatal")
+        || lower.contains("panic")
+        || lower.contains("abort")
+        || lower.contains("warning:")
+        || lower.contains("error:")
+        || lower.contains("failure")
 }
 
 /// Extracts exec output content and prepends a timeout message if the command timed out.
@@ -110,5 +208,110 @@ fn build_content_with_timeout(exec_output: &ExecToolCallOutput) -> String {
         )
     } else {
         exec_output.aggregated_output.text.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::exec::ExecToolCallOutput;
+    use crate::exec::StreamOutput;
+    use std::time::Duration;
+
+    fn make_exec_output(text: &str) -> ExecToolCallOutput {
+        ExecToolCallOutput {
+            exit_code: 0,
+            stdout: StreamOutput::new(String::new()),
+            stderr: StreamOutput::new(String::new()),
+            aggregated_output: StreamOutput::new(text.to_string()),
+            duration: Duration::from_millis(100),
+            timed_out: false,
+        }
+    }
+
+    #[test]
+    fn format_exec_output_str_preserves_error_lines() {
+        // Test that error lines are extracted and preserved
+        let content = "line 1\nline 2\nerror: compilation failed\nline 3\nline 4";
+        let exec_output = make_exec_output(content);
+        let result = format_exec_output_str(&exec_output, TruncationPolicy::Tokens(10));
+
+        // Error line should be preserved
+        assert!(result.contains("error: compilation failed"), "Error line should be preserved");
+    }
+
+    #[test]
+    fn format_exec_output_str_prioritizes_errors_over_regular_output() {
+        // Test that errors are prioritized when budget is limited
+        let content = "normal output line 1\nnormal output line 2\nerror: test failed\nnormal output line 3";
+        let exec_output = make_exec_output(content);
+        let result = format_exec_output_str(&exec_output, TruncationPolicy::Tokens(5));
+
+        // Error should be present even with limited budget
+        assert!(result.contains("error: test failed"), "Error should be preserved even with limited budget");
+    }
+
+    #[test]
+    fn format_exec_output_str_handles_multiple_errors() {
+        // Test that multiple error lines are all preserved
+        let content = "start\nerror: first error\nmiddle\nerror: second error\nend";
+        let exec_output = make_exec_output(content);
+        let result = format_exec_output_str(&exec_output, TruncationPolicy::Tokens(15));
+
+        // Both errors should be preserved
+        assert!(result.contains("error: first error"), "First error should be preserved");
+        assert!(result.contains("error: second error"), "Second error should be preserved");
+    }
+
+    #[test]
+    fn format_exec_output_str_detects_case_insensitive_errors() {
+        // Test case-insensitive error detection
+        let content = "Some output\nERROR: Something went wrong\nMore output";
+        let exec_output = make_exec_output(content);
+        let result = format_exec_output_str(&exec_output, TruncationPolicy::Tokens(10));
+
+        assert!(result.contains("ERROR: Something went wrong"), "Uppercase ERROR should be detected");
+    }
+
+    #[test]
+    fn format_exec_output_str_handles_no_errors() {
+        // Test that regular output is handled correctly when no errors present
+        let content = "normal output line 1\nnormal output line 2\nnormal output line 3";
+        let exec_output = make_exec_output(content);
+        let result = format_exec_output_str(&exec_output, TruncationPolicy::Tokens(20));
+
+        // Should contain the output (may be truncated if over budget)
+        assert!(!result.is_empty());
+    }
+
+    #[test]
+    fn format_exec_output_str_detects_failed_keyword() {
+        // Test detection of "failed" keyword
+        let content = "operation failed\nmore output";
+        let exec_output = make_exec_output(content);
+        let result = format_exec_output_str(&exec_output, TruncationPolicy::Tokens(10));
+
+        assert!(result.contains("failed"), "Failed keyword should be detected");
+    }
+
+    #[test]
+    fn format_exec_output_str_detects_exception_keyword() {
+        // Test detection of "exception" keyword
+        let content = "exception occurred\nmore output";
+        let exec_output = make_exec_output(content);
+        let result = format_exec_output_str(&exec_output, TruncationPolicy::Tokens(10));
+
+        assert!(result.contains("exception"), "Exception keyword should be detected");
+    }
+
+    #[test]
+    fn format_exec_output_str_separates_errors_from_other_output() {
+        // Test that errors are separated from other output when both fit
+        let content = "normal line 1\nerror: something wrong\nnormal line 2";
+        let exec_output = make_exec_output(content);
+        let result = format_exec_output_str(&exec_output, TruncationPolicy::Tokens(20));
+
+        // Should contain separator or error section
+        assert!(result.contains("error: something wrong"), "Error should be present");
     }
 }


### PR DESCRIPTION
I have read the CLA Document and I hereby sign the CLA..


This PR implements four enhancements to improve "truncation and context management: strategies in Codex. 

The first enhancement addresses a critical issue where compilation errors, test failures, and other error messages frequently get truncated when output exceeds token or byte budgets, making it difficult for users to diagnose issues. The problem occurs in scenarios such as when compiling large codebases where error messages appear in the middle or end of lengthy build output, or when running test suites where failure information is embedded within extensive test logs. The original truncation logic used a simple prefix-suffix approach that preserved the beginning and end of content but could easily remove critical error information located in the middle sections. The solution implements an error-aware truncation strategy that detects error patterns using case-insensitive keyword matching for terms like "error", "failed", "exception", "fatal", "panic", and "abort". When error patterns are detected, the new truncate_with_error_priority function extracts all lines containing errors along with two lines of context before and after each error line, ensuring that error information and its surrounding context are preserved even when the content exceeds the budget. The implementation scans through all lines to identify error patterns, builds a set of important line indices that include error lines and their context, and then prioritizes these important lines when constructing the truncated output while still attempting to include non-error lines if budget permits. The modifications were made in codex-rs/core/src/truncate.rs, where the truncate_text function was enhanced to first check for error patterns using the new contains_error_patterns helper function, and if errors are found, it delegates to truncate_with_error_priority instead of using the default truncation logic. The contains_error_patterns function performs case-insensitive matching by converting text to lowercase and checking for common error keywords, making it robust against variations in error message formatting. The truncate_with_error_priority function implements the core logic by collecting all lines, identifying error line indices, expanding each error index to include two lines of context on each side, and then building the result by always including important lines first and filling remaining budget with non-error lines. Comprehensive test cases were added to verify this functionality: truncate_text_preserves_error_lines tests that error lines are preserved during truncation and that context around errors is maintained, truncate_text_handles_multiple_error_lines verifies that multiple error lines throughout the content are all preserved, and truncate_text_detects_case_insensitive_errors ensures that error detection works regardless of case variations like "ERROR", "Error", or "error". These tests validate that the error-priority strategy correctly identifies and preserves critical error information even when the content is significantly larger than the available budget.

The second improvement handles the problem where JSON and XML structured data gets truncated in ways that break parseability, rendering the data useless for downstream processing or analysis. This issue commonly occurs when tool outputs return large JSON responses from APIs, configuration files in JSON format, or XML documents that exceed token budgets. The original truncation approach treated structured data as plain text, which could result in malformed JSON or XML that cannot be parsed, such as truncating in the middle of a string value or breaking object/array structures. The solution implements format-aware truncation that detects JSON and XML content and applies structure-preserving truncation strategies. For JSON content, the is_json function detects JSON by checking if trimmed content starts with '{' or '[', and then truncate_json_safely attempts to parse the JSON using serde_json. If parsing succeeds, the truncate_json_value function preserves the top-level structure by keeping all object keys or array elements but may truncate nested values or mark them as "[truncated]" when budget is exhausted, ensuring the result remains valid JSON that can still be parsed. For XML content, the is_xml function detects XML by checking if content starts with '<', and truncate_xml_safely provides a foundation for XML-aware truncation, though it currently falls back to regular truncation for complex cases. The modifications were made in codex-rs/core/src/truncate.rs, where the truncate_text function was enhanced to check for JSON and XML content before applying default truncation. The is_json and is_xml functions provide simple but effective heuristics for format detection, and the truncate_json_safely function implements the core JSON preservation logic by first checking if the content fits within budget (returning it unchanged if so), then attempting to parse it, and if parsing succeeds, using truncate_json_value to preserve structure while truncating content. The truncate_json_value function handles different JSON value types: for objects it preserves all keys but may truncate values, for arrays it preserves structure but may truncate elements, and for primitive values it uses standard truncation. Test cases were added to validate this functionality: truncate_json_preserves_structure_when_fits verifies that valid JSON is preserved unchanged when it fits within the budget, truncate_json_truncates_large_objects_safely tests that large JSON objects are truncated while maintaining valid JSON structure with opening braces and keys preserved, truncate_json_handles_arrays ensures that JSON arrays maintain their structure during truncation, truncate_json_falls_back_on_invalid_json verifies that invalid JSON gracefully falls back to regular truncation, truncate_xml_detects_xml_content tests XML detection, and truncate_text_prioritizes_errors_over_json ensures that error detection takes priority over JSON detection when both patterns are present. These tests ensure that structured data remains parseable after truncation and that the system gracefully handles edge cases.

The third enhancement solves the problem where important early context, such as user messages containing critical instructions or key decision points, gets deleted during context window compaction, leading to loss of important conversation context. The issue occurs during the compaction process when the context window is exceeded and the system needs to remove history items to fit within model limits. The original implementation used a simple remove_first_item method that always removed the oldest item regardless of its importance, which could delete crucial user messages or important assistant responses that establish the context for the conversation. The solution implements an importance-aware deletion strategy that identifies important items before deletion and prioritizes removing non-important items first. Important items are defined as user messages (which represent user intent and instructions), messages containing critical keywords like "important", "critical", "must" (in both English and Chinese), and function call outputs that contain error information. The new remove_least_important_item method in ContextManager first identifies all important items by iterating through the history and marking items that match importance criteria, then finds the oldest non-important item that is not part of a critical call/output pair, removes that item, and falls back to removing the first item only if all items are marked as important. The modifications were made in two files: codex-rs/core/src/context_manager/history.rs where the remove_least_important_item method was added along with helper functions is_important_item and is_call_output_pair_critical, and codex-rs/core/src/compact.rs where the context window exceeded error handler was updated to call remove_least_important_item instead of remove_first_item. The is_important_item function checks if an item is a user message or contains critical keywords in its content, and is_call_output_pair_critical identifies function call outputs with error patterns or failed shell calls as critical pairs that should be preserved. The contains_error_patterns helper function (specific to history management) detects error patterns in text content. Comprehensive test cases were added in codex-rs/core/src/context_manager/history_tests.rs: remove_least_important_item_preserves_user_messages verifies that user messages are preserved when removing items and that assistant messages are removed first, remove_least_important_item_preserves_messages_with_critical_keywords tests that messages containing keywords like "IMPORTANT" are preserved during deletion, remove_least_important_item_removes_non_important_items_first ensures that non-important items are removed before important ones, remove_least_important_item_falls_back_to_first_item_when_all_important validates the fallback behavior when all items are marked as important, and remove_least_important_item_preserves_error_outputs verifies that function call outputs containing errors are preserved. These tests ensure that important conversation context is maintained during compaction and that the system makes intelligent decisions about what to preserve.

The fourth improvement addresses the issue where error messages from command executions, compilation outputs, or test results get mixed with regular output and may be truncated when the combined output exceeds token budgets, making it difficult to quickly identify and address failures. The problem occurs when formatting exec tool call outputs for model consumption, where large outputs containing both normal content and error messages need to be truncated, and the original implementation could truncate away critical error information. The solution implements error extraction and prioritization by separating error lines from regular output, ensuring errors are always preserved even when budget is limited, and then truncating the remaining non-error content separately. The new format_exec_output_with_error_priority function first extracts all error lines using the extract_errors helper function, which scans through all lines and filters those containing error patterns. If errors are found, the function calculates the token cost of error lines, reserves budget for them, and then truncates the remaining content (with errors removed) using the remaining budget. The result combines error lines at the top with a separator ("--- Other Output ---") followed by truncated regular output, ensuring errors are always visible. If the error information itself exceeds the budget, only the errors are returned (truncated). The modifications were made in codex-rs/core/src/tools/mod.rs, where format_exec_output_str was updated to call format_exec_output_with_error_priority instead of directly using formatted_truncate_text. The format_exec_output_with_error_priority function implements the core logic, extract_errors identifies and collects error lines, remove_error_lines filters out error lines from content to prepare it for separate truncation, and contains_error_patterns detects error patterns including "error", "failed", "exception", "fatal", "panic", "abort", "warning:", "error:", and "failure". Test cases were added in a new test module within codex-rs/core/src/tools/mod.rs: format_exec_output_str_preserves_error_lines verifies that error lines are extracted and preserved in the output, format_exec_output_str_prioritizes_errors_over_regular_output tests that errors are preserved even when budget is very limited, format_exec_output_str_handles_multiple_errors ensures that multiple error lines throughout the output are all preserved, format_exec_output_str_detects_case_insensitive_errors validates case-insensitive error detection, format_exec_output_str_handles_no_errors tests normal output handling when no errors are present, format_exec_output_str_detects_failed_keyword and format_exec_output_str_detects_exception_keyword verify detection of specific error keywords, and format_exec_output_str_separates_errors_from_other_output ensures that errors are properly separated from regular output with appropriate formatting. These tests validate that error information is always accessible even in truncated outputs and that the separation makes it easy to identify failures quickly.
