### PR TITLE
Sync collaboration mode with /model

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -26,6 +26,13 @@ use codex_core::protocol::SandboxPolicy;
 use codex_protocol::openai_models::ReasoningEffort;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CollaborationModePreset {
+    Plan,
+    PairProgramming,
+    Execute,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub(crate) enum WindowsSandboxEnableMode {
     Elevated,
@@ -117,6 +124,12 @@ pub(crate) enum AppEvent {
     OpenAllModelsPopup {
         models: Vec<ModelPreset>,
     },
+
+    /// Open the collaboration mode picker.
+    OpenCollaborationModePopup,
+
+    /// Apply a collaboration mode preset for the current session.
+    ApplyCollaborationModePreset(CollaborationModePreset),
 
     /// Open the confirmation prompt before enabling full access mode.
     OpenFullAccessConfirmation {

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -404,6 +404,7 @@ async fn make_chatwidget_manual(
         active_cell_revision: 0,
         config: cfg,
         model: Some(resolved_model.clone()),
+        collaboration_mode: None,
         auth_manager: auth_manager.clone(),
         models_manager: Arc::new(ModelsManager::new(codex_home, auth_manager)),
         session_header: SessionHeader::new(resolved_model),


### PR DESCRIPTION
- Selecting a collaboration mode now updates the TUI model + reasoning effort and schedules an OverrideTurnContext with that mode.
- /model updates now keep the active collaboration mode's embedded model/effort in sync so subsequent turns use the latest state.