### PR TITLE
Fixed config merging issue with profiles

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -2313,9 +2313,11 @@ trust_level = "trusted"
     #[tokio::test]
     async fn project_profile_overrides_user_profile() -> std::io::Result<()> {
         let codex_home = TempDir::new()?;
+        let workspace = TempDir::new()?;
         std::fs::write(
             codex_home.path().join(CONFIG_TOML_FILE),
-            r#"
+            format!(
+                r#"
 profile = "global"
 
 [profiles.global]
@@ -2323,10 +2325,13 @@ model = "gpt-global"
 
 [profiles.project]
 model = "gpt-project"
-"#,
-        )?;
 
-        let workspace = TempDir::new()?;
+[projects."{path}"]
+trust_level = "trusted"
+"#,
+                path = workspace.path().display()
+            ),
+        )?;
         let project_config_dir = workspace.path().join(".codex");
         std::fs::create_dir_all(&project_config_dir)?;
         std::fs::write(

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -441,14 +441,7 @@ impl ConfigBuilder {
             Some(path) => AbsolutePathBuf::try_from(path)?,
             None => AbsolutePathBuf::current_dir()?,
         };
-        if harness_overrides.cwd.is_none()
-            || harness_overrides
-                .cwd
-                .as_ref()
-                .is_some_and(|p| !p.is_absolute())
-        {
-            harness_overrides.cwd = Some(cwd.to_path_buf());
-        }
+        harness_overrides.cwd = Some(cwd.to_path_buf());
         let config_layer_stack =
             load_config_layers_state(&codex_home, Some(cwd), &cli_overrides, loader_overrides)
                 .await?;

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -2314,6 +2314,7 @@ trust_level = "trusted"
     async fn project_profile_overrides_user_profile() -> std::io::Result<()> {
         let codex_home = TempDir::new()?;
         let workspace = TempDir::new()?;
+        let workspace_key = workspace.path().to_string_lossy().replace('\\', "\\\\");
         std::fs::write(
             codex_home.path().join(CONFIG_TOML_FILE),
             format!(
@@ -2326,10 +2327,9 @@ model = "gpt-global"
 [profiles.project]
 model = "gpt-project"
 
-[projects."{path}"]
+[projects."{workspace_key}"]
 trust_level = "trusted"
 "#,
-                path = workspace.path().display()
             ),
         )?;
         let project_config_dir = workspace.path().join(".codex");

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -104,6 +104,7 @@ pub use rollout::list::ThreadSortKey;
 pub use rollout::list::ThreadsPage;
 pub use rollout::list::parse_cursor;
 pub use rollout::list::read_head_for_summary;
+pub use rollout::list::read_session_meta_line;
 mod function_tool;
 mod state;
 mod tasks;

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -21,10 +21,12 @@ use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
 use codex_core::config::find_codex_home;
 use codex_core::config::load_config_as_toml_with_cli_overrides;
+use codex_core::config::load_with_cli_overrides_and_fallback_cwd;
 use codex_core::config::resolve_oss_provider;
 use codex_core::find_thread_path_by_id_str;
 use codex_core::get_platform_sandbox;
 use codex_core::protocol::AskForApproval;
+use codex_core::read_session_meta_line;
 use codex_core::terminal::Multiplexer;
 use codex_protocol::config_types::AltScreenMode;
 use codex_protocol::config_types::SandboxMode;
@@ -246,7 +248,6 @@ pub async fn run_main(
         std::process::exit(1);
     }
 
-    let active_profile = config.active_profile.clone();
     let log_dir = codex_core::config::log_dir(&config)?;
     std::fs::create_dir_all(&log_dir)?;
     // Open (or create) your log file, appending to it.
@@ -336,16 +337,9 @@ pub async fn run_main(
         .with(otel_tracing_layer)
         .try_init();
 
-    run_ratatui_app(
-        cli,
-        config,
-        overrides,
-        cli_kv_overrides,
-        active_profile,
-        feedback,
-    )
-    .await
-    .map_err(|err| std::io::Error::other(err.to_string()))
+    run_ratatui_app(cli, config, overrides, cli_kv_overrides, feedback)
+        .await
+        .map_err(|err| std::io::Error::other(err.to_string()))
 }
 
 async fn run_ratatui_app(
@@ -353,7 +347,6 @@ async fn run_ratatui_app(
     initial_config: Config,
     overrides: ConfigOverrides,
     cli_kv_overrides: Vec<(String, toml::Value)>,
-    active_profile: Option<String>,
     feedback: codex_feedback::CodexFeedback,
 ) -> color_eyre::Result<AppExitInfo> {
     color_eyre::install()?;
@@ -404,15 +397,15 @@ async fn run_ratatui_app(
         initial_config.cli_auth_credentials_store_mode,
     );
     let login_status = get_login_status(&initial_config);
-    let should_show_trust_screen = should_show_trust_screen(&initial_config);
+    let should_show_trust_screen_flag = should_show_trust_screen(&initial_config);
     let should_show_onboarding =
-        should_show_onboarding(login_status, &initial_config, should_show_trust_screen);
+        should_show_onboarding(login_status, &initial_config, should_show_trust_screen_flag);
 
     let config = if should_show_onboarding {
         let onboarding_result = run_onboarding_app(
             OnboardingScreenArgs {
                 show_login_screen: should_show_login_screen(login_status, &initial_config),
-                show_trust_screen: should_show_trust_screen,
+                show_trust_screen: should_show_trust_screen_flag,
                 login_status,
                 auth_manager: auth_manager.clone(),
                 config: initial_config.clone(),
@@ -437,7 +430,7 @@ async fn run_ratatui_app(
             .map(|d| d == TrustDirectorySelection::Trust)
             .unwrap_or(false)
         {
-            load_config_or_exit(cli_kv_overrides, overrides).await
+            load_config_or_exit(cli_kv_overrides.clone(), overrides.clone()).await
         } else {
             initial_config
         }
@@ -570,6 +563,33 @@ async fn run_ratatui_app(
         resume_picker::SessionSelection::StartFresh
     };
 
+    let config = match &session_selection {
+        resume_picker::SessionSelection::Resume(path)
+        | resume_picker::SessionSelection::Fork(path) => {
+            let history_cwd = match read_session_meta_line(path).await {
+                Ok(meta_line) => Some(meta_line.meta.cwd),
+                Err(err) => {
+                    let rollout_path = path.display().to_string();
+                    tracing::warn!(
+                        %rollout_path,
+                        %err,
+                        "Failed to read session metadata from rollout"
+                    );
+                    None
+                }
+            };
+            load_config_or_exit_with_fallback_cwd(
+                cli_kv_overrides.clone(),
+                overrides.clone(),
+                history_cwd,
+            )
+            .await
+        }
+        _ => config,
+    };
+    let active_profile = config.active_profile.clone();
+    let should_show_trust_screen = should_show_trust_screen(&config);
+
     let Cli {
         prompt,
         images,
@@ -672,8 +692,17 @@ async fn load_config_or_exit(
     cli_kv_overrides: Vec<(String, toml::Value)>,
     overrides: ConfigOverrides,
 ) -> Config {
+    load_config_or_exit_with_fallback_cwd(cli_kv_overrides, overrides, None).await
+}
+
+async fn load_config_or_exit_with_fallback_cwd(
+    cli_kv_overrides: Vec<(String, toml::Value)>,
+    overrides: ConfigOverrides,
+    fallback_cwd: Option<PathBuf>,
+) -> Config {
     #[allow(clippy::print_stderr)]
-    match Config::load_with_cli_overrides_and_harness_overrides(cli_kv_overrides, overrides).await {
+    match load_with_cli_overrides_and_fallback_cwd(cli_kv_overrides, overrides, fallback_cwd).await
+    {
         Ok(config) => config,
         Err(err) => {
             eprintln!("Error loading configuration: {err}");

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -18,10 +18,10 @@ use codex_core::RolloutRecorder;
 use codex_core::ThreadSortKey;
 use codex_core::auth::enforce_login_restrictions;
 use codex_core::config::Config;
+use codex_core::config::ConfigBuilder;
 use codex_core::config::ConfigOverrides;
 use codex_core::config::find_codex_home;
 use codex_core::config::load_config_as_toml_with_cli_overrides;
-use codex_core::config::load_with_cli_overrides_and_fallback_cwd;
 use codex_core::config::resolve_oss_provider;
 use codex_core::find_thread_path_by_id_str;
 use codex_core::get_platform_sandbox;
@@ -701,7 +701,12 @@ async fn load_config_or_exit_with_fallback_cwd(
     fallback_cwd: Option<PathBuf>,
 ) -> Config {
     #[allow(clippy::print_stderr)]
-    match load_with_cli_overrides_and_fallback_cwd(cli_kv_overrides, overrides, fallback_cwd).await
+    match ConfigBuilder::default()
+        .cli_overrides(cli_kv_overrides)
+        .harness_overrides(overrides)
+        .fallback_cwd(fallback_cwd)
+        .build()
+        .await
     {
         Ok(config) => config,
         Err(err) => {

--- a/codex-rs/tui2/src/lib.rs
+++ b/codex-rs/tui2/src/lib.rs
@@ -21,10 +21,12 @@ use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
 use codex_core::config::find_codex_home;
 use codex_core::config::load_config_as_toml_with_cli_overrides;
+use codex_core::config::load_with_cli_overrides_and_fallback_cwd;
 use codex_core::config::resolve_oss_provider;
 use codex_core::find_thread_path_by_id_str;
 use codex_core::get_platform_sandbox;
 use codex_core::protocol::AskForApproval;
+use codex_core::read_session_meta_line;
 use codex_core::terminal::Multiplexer;
 use codex_protocol::config_types::AltScreenMode;
 use codex_protocol::config_types::SandboxMode;
@@ -262,7 +264,6 @@ pub async fn run_main(
         std::process::exit(1);
     }
 
-    let active_profile = config.active_profile.clone();
     let log_dir = codex_core::config::log_dir(&config)?;
     std::fs::create_dir_all(&log_dir)?;
     // Open (or create) your log file, appending to it.
@@ -355,16 +356,9 @@ pub async fn run_main(
     let terminal_info = codex_core::terminal::terminal_info();
     tracing::info!(terminal = ?terminal_info, "Detected terminal info");
 
-    run_ratatui_app(
-        cli,
-        config,
-        overrides,
-        cli_kv_overrides,
-        active_profile,
-        feedback,
-    )
-    .await
-    .map_err(|err| std::io::Error::other(err.to_string()))
+    run_ratatui_app(cli, config, overrides, cli_kv_overrides, feedback)
+        .await
+        .map_err(|err| std::io::Error::other(err.to_string()))
 }
 
 async fn run_ratatui_app(
@@ -372,7 +366,6 @@ async fn run_ratatui_app(
     initial_config: Config,
     overrides: ConfigOverrides,
     cli_kv_overrides: Vec<(String, toml::Value)>,
-    active_profile: Option<String>,
     feedback: codex_feedback::CodexFeedback,
 ) -> color_eyre::Result<AppExitInfo> {
     color_eyre::install()?;
@@ -424,15 +417,15 @@ async fn run_ratatui_app(
         initial_config.cli_auth_credentials_store_mode,
     );
     let login_status = get_login_status(&initial_config);
-    let should_show_trust_screen = should_show_trust_screen(&initial_config);
+    let should_show_trust_screen_flag = should_show_trust_screen(&initial_config);
     let should_show_onboarding =
-        should_show_onboarding(login_status, &initial_config, should_show_trust_screen);
+        should_show_onboarding(login_status, &initial_config, should_show_trust_screen_flag);
 
     let config = if should_show_onboarding {
         let onboarding_result = run_onboarding_app(
             OnboardingScreenArgs {
                 show_login_screen: should_show_login_screen(login_status, &initial_config),
-                show_trust_screen: should_show_trust_screen,
+                show_trust_screen: should_show_trust_screen_flag,
                 login_status,
                 auth_manager: auth_manager.clone(),
                 config: initial_config.clone(),
@@ -458,7 +451,7 @@ async fn run_ratatui_app(
             .map(|d| d == TrustDirectorySelection::Trust)
             .unwrap_or(false)
         {
-            load_config_or_exit(cli_kv_overrides, overrides).await
+            load_config_or_exit(cli_kv_overrides.clone(), overrides.clone()).await
         } else {
             initial_config
         }
@@ -594,6 +587,33 @@ async fn run_ratatui_app(
         resume_picker::SessionSelection::StartFresh
     };
 
+    let config = match &session_selection {
+        resume_picker::SessionSelection::Resume(path)
+        | resume_picker::SessionSelection::Fork(path) => {
+            let history_cwd = match read_session_meta_line(path).await {
+                Ok(meta_line) => Some(meta_line.meta.cwd),
+                Err(err) => {
+                    let rollout_path = path.display().to_string();
+                    tracing::warn!(
+                        %rollout_path,
+                        %err,
+                        "Failed to read session metadata from rollout"
+                    );
+                    None
+                }
+            };
+            load_config_or_exit_with_fallback_cwd(
+                cli_kv_overrides.clone(),
+                overrides.clone(),
+                history_cwd,
+            )
+            .await
+        }
+        _ => config,
+    };
+    let active_profile = config.active_profile.clone();
+    let should_show_trust_screen = should_show_trust_screen(&config);
+
     let Cli {
         prompt,
         images,
@@ -700,8 +720,17 @@ async fn load_config_or_exit(
     cli_kv_overrides: Vec<(String, toml::Value)>,
     overrides: ConfigOverrides,
 ) -> Config {
+    load_config_or_exit_with_fallback_cwd(cli_kv_overrides, overrides, None).await
+}
+
+async fn load_config_or_exit_with_fallback_cwd(
+    cli_kv_overrides: Vec<(String, toml::Value)>,
+    overrides: ConfigOverrides,
+    fallback_cwd: Option<PathBuf>,
+) -> Config {
     #[allow(clippy::print_stderr)]
-    match Config::load_with_cli_overrides_and_harness_overrides(cli_kv_overrides, overrides).await {
+    match load_with_cli_overrides_and_fallback_cwd(cli_kv_overrides, overrides, fallback_cwd).await
+    {
         Ok(config) => config,
         Err(err) => {
             eprintln!("Error loading configuration: {err}");

--- a/codex-rs/tui2/src/lib.rs
+++ b/codex-rs/tui2/src/lib.rs
@@ -18,10 +18,10 @@ use codex_core::RolloutRecorder;
 use codex_core::ThreadSortKey;
 use codex_core::auth::enforce_login_restrictions;
 use codex_core::config::Config;
+use codex_core::config::ConfigBuilder;
 use codex_core::config::ConfigOverrides;
 use codex_core::config::find_codex_home;
 use codex_core::config::load_config_as_toml_with_cli_overrides;
-use codex_core::config::load_with_cli_overrides_and_fallback_cwd;
 use codex_core::config::resolve_oss_provider;
 use codex_core::find_thread_path_by_id_str;
 use codex_core::get_platform_sandbox;
@@ -729,7 +729,12 @@ async fn load_config_or_exit_with_fallback_cwd(
     fallback_cwd: Option<PathBuf>,
 ) -> Config {
     #[allow(clippy::print_stderr)]
-    match load_with_cli_overrides_and_fallback_cwd(cli_kv_overrides, overrides, fallback_cwd).await
+    match ConfigBuilder::default()
+        .cli_overrides(cli_kv_overrides)
+        .harness_overrides(overrides)
+        .fallback_cwd(fallback_cwd)
+        .build()
+        .await
     {
         Ok(config) => config,
         Err(err) => {


### PR DESCRIPTION
This PR fixes a small issue with chained (layered) config.toml file merging. The old logic didn't properly handle profiles.

In particular, if a lower-layer config overrides a profile defined in a higher-layer config, the override did not take effect. This prevents users from having project-specific profile overrides and contradicts the (soon-to-be) documented behavior of config merging.

The change adds a unit test for this case. It also exposes a function from the config crate that is needed by the app server code paths to implement support for layered configs.
