### PR TITLE
Add support for project-level custom prompts

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -224,6 +224,11 @@ client_request_definitions! {
         response: v2::ConfigRequirementsReadResponse,
     },
 
+    CustomPromptsList => "custom-prompts/list" {
+        params: v2::CustomPromptsListParams,
+        response: v2::CustomPromptsListResponse,
+    },
+
     GetAccount => "account/read" {
         params: v2::GetAccountParams,
         response: v2::GetAccountResponse,

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -461,6 +461,32 @@ pub struct ConfigReadResponse {
     pub layers: Option<Vec<ConfigLayer>>,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct CustomPrompt {
+    pub name: String,
+    pub path: PathBuf,
+    pub content: String,
+    pub description: Option<String>,
+    pub argument_hint: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct CustomPromptsListParams {
+    #[serde(default)]
+    pub cwd: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
+pub struct CustomPromptsListResponse {
+    pub custom_prompts: Vec<CustomPrompt>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -380,6 +380,15 @@ impl CodexMessageProcessor {
             ClientRequest::Initialize { .. } => {
                 panic!("Initialize should be handled in MessageProcessor");
             }
+            ClientRequest::CustomPromptsList { request_id, .. } => {
+                let error = JSONRPCErrorError {
+                    code: INVALID_REQUEST_ERROR_CODE,
+                    message: "custom-prompts/list should be handled in MessageProcessor"
+                        .to_string(),
+                    data: None,
+                };
+                self.outgoing.send_error(request_id, error).await;
+            }
             // === v2 Thread/Turn APIs ===
             ClientRequest::ThreadStart { request_id, params } => {
                 self.thread_start(request_id, params).await;

--- a/codex-rs/app-server/src/custom_prompts_api.rs
+++ b/codex-rs/app-server/src/custom_prompts_api.rs
@@ -1,0 +1,108 @@
+use crate::error_code::INTERNAL_ERROR_CODE;
+use crate::error_code::INVALID_REQUEST_ERROR_CODE;
+use codex_app_server_protocol::CustomPrompt;
+use codex_app_server_protocol::CustomPromptsListParams;
+use codex_app_server_protocol::CustomPromptsListResponse;
+use codex_app_server_protocol::JSONRPCErrorError;
+use codex_core::config_loader::LoaderOverrides;
+use codex_core::config_loader::load_config_layers_state;
+use codex_core::custom_prompts::default_prompts_dir;
+use codex_core::custom_prompts::discover_layered_prompts_for_cwd;
+use codex_core::custom_prompts::discover_prompts_in;
+use codex_core::env;
+use codex_utils_absolute_path::AbsolutePathBuf;
+use std::path::PathBuf;
+use toml::Value as TomlValue;
+
+#[derive(Clone)]
+pub(crate) struct CustomPromptsApi {
+    codex_home: PathBuf,
+    cli_overrides: Vec<(String, TomlValue)>,
+    loader_overrides: LoaderOverrides,
+}
+
+impl CustomPromptsApi {
+    pub(crate) fn new(
+        codex_home: PathBuf,
+        cli_overrides: Vec<(String, TomlValue)>,
+        loader_overrides: LoaderOverrides,
+    ) -> Self {
+        Self {
+            codex_home,
+            cli_overrides,
+            loader_overrides,
+        }
+    }
+
+    pub(crate) async fn list(
+        &self,
+        params: CustomPromptsListParams,
+    ) -> Result<CustomPromptsListResponse, JSONRPCErrorError> {
+        let prompts = if let Some(cwd) = params.cwd {
+            let normalized = normalize_for_wsl(&cwd);
+            let cwd_path = PathBuf::from(normalized);
+            let cwd_abs = AbsolutePathBuf::from_absolute_path(&cwd_path).map_err(|err| {
+                JSONRPCErrorError {
+                    code: INVALID_REQUEST_ERROR_CODE,
+                    message: format!("cwd must be an absolute path: {err}"),
+                    data: None,
+                }
+            })?;
+            let layers = load_config_layers_state(
+                &self.codex_home,
+                Some(cwd_abs.clone()),
+                &self.cli_overrides,
+                self.loader_overrides.clone(),
+            )
+            .await
+            .map_err(|err| JSONRPCErrorError {
+                code: INTERNAL_ERROR_CODE,
+                message: format!("failed to load config layers: {err}"),
+                data: None,
+            })?;
+            discover_layered_prompts_for_cwd(cwd_abs.as_path(), &layers).await
+        } else if let Some(dir) = default_prompts_dir() {
+            discover_prompts_in(&dir).await
+        } else {
+            Vec::new()
+        };
+
+        Ok(CustomPromptsListResponse {
+            custom_prompts: prompts.into_iter().map(map_custom_prompt).collect(),
+        })
+    }
+}
+
+fn map_custom_prompt(prompt: codex_protocol::custom_prompts::CustomPrompt) -> CustomPrompt {
+    CustomPrompt {
+        name: prompt.name,
+        path: prompt.path,
+        content: prompt.content,
+        description: prompt.description,
+        argument_hint: prompt.argument_hint,
+    }
+}
+
+fn normalize_for_wsl(path: &str) -> String {
+    if !env::is_wsl() {
+        return path.to_string();
+    }
+    win_path_to_wsl(path).unwrap_or_else(|| path.to_string())
+}
+
+fn win_path_to_wsl(path: &str) -> Option<String> {
+    let bytes = path.as_bytes();
+    if bytes.len() < 3
+        || bytes[1] != b':'
+        || !(bytes[2] == b'\\' || bytes[2] == b'/')
+        || !bytes[0].is_ascii_alphabetic()
+    {
+        return None;
+    }
+    let drive = (bytes[0] as char).to_ascii_lowercase();
+    let tail = path[3..].replace('\\', "/");
+    if tail.is_empty() {
+        return Some(format!("/mnt/{drive}"));
+    }
+    Some(format!("/mnt/{drive}/{tail}"))
+}

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -33,6 +33,7 @@ use tracing_subscriber::util::SubscriberInitExt;
 mod bespoke_event_handling;
 mod codex_message_processor;
 mod config_api;
+mod custom_prompts_api;
 mod error_code;
 mod fuzzy_file_search;
 mod message_processor;

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -83,7 +83,7 @@ impl MessageProcessor {
         );
         let custom_prompts_api = CustomPromptsApi::new(
             config.codex_home.clone(),
-            cli_overrides.clone(),
+            cli_overrides,
             loader_overrides_for_custom_prompts,
         );
 

--- a/codex-rs/app-server/tests/common/mcp_process.rs
+++ b/codex-rs/app-server/tests/common/mcp_process.rs
@@ -503,6 +503,14 @@ impl McpProcess {
         self.send_request("config/batchWrite", params).await
     }
 
+    pub async fn send_custom_prompts_list_request(
+        &mut self,
+        params: codex_app_server_protocol::CustomPromptsListParams,
+    ) -> anyhow::Result<i64> {
+        let params = Some(serde_json::to_value(params)?);
+        self.send_request("custom-prompts/list", params).await
+    }
+
     /// Send an `account/logout` JSON-RPC request.
     pub async fn send_logout_account_request(&mut self) -> anyhow::Result<i64> {
         self.send_request("account/logout", None).await

--- a/codex-rs/app-server/tests/suite/v2/custom_prompts_rpc.rs
+++ b/codex-rs/app-server/tests/suite/v2/custom_prompts_rpc.rs
@@ -1,0 +1,98 @@
+use anyhow::Result;
+use app_test_support::McpProcess;
+use app_test_support::to_response;
+use codex_app_server_protocol::CustomPromptsListParams;
+use codex_app_server_protocol::CustomPromptsListResponse;
+use codex_app_server_protocol::JSONRPCResponse;
+use codex_app_server_protocol::RequestId;
+use pretty_assertions::assert_eq;
+use tempfile::TempDir;
+use tokio::time::timeout;
+
+const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+fn write_prompt(dir: &std::path::Path, name: &str, content: &str) -> Result<()> {
+    std::fs::create_dir_all(dir)?;
+    std::fs::write(dir.join(format!("{name}.md")), content)?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn custom_prompts_list_defaults_to_global_only() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    write_prompt(&codex_home.path().join("prompts"), "global", "global")?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = mcp
+        .send_custom_prompts_list_request(CustomPromptsListParams { cwd: None })
+        .await?;
+    let resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    let response: CustomPromptsListResponse = to_response(resp)?;
+
+    assert_eq!(response.custom_prompts.len(), 1);
+    assert_eq!(response.custom_prompts[0].name, "global");
+    assert_eq!(response.custom_prompts[0].content, "global");
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn custom_prompts_list_respects_layered_project_prompts() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    write_prompt(&codex_home.path().join("prompts"), "global", "global")?;
+
+    let project_root = TempDir::new()?;
+    std::fs::write(project_root.path().join(".git"), "")?;
+    write_prompt(
+        &project_root.path().join(".codex/prompts"),
+        "shared",
+        "root shared",
+    )?;
+
+    let child = project_root.path().join("child");
+    write_prompt(&child.join(".codex/prompts"), "shared", "child shared")?;
+    write_prompt(&child.join(".codex/prompts"), "child-only", "child only")?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = mcp
+        .send_custom_prompts_list_request(CustomPromptsListParams {
+            cwd: Some(child.to_string_lossy().to_string()),
+        })
+        .await?;
+    let resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+    let response: CustomPromptsListResponse = to_response(resp)?;
+
+    let mut by_name = response
+        .custom_prompts
+        .into_iter()
+        .map(|prompt| {
+            let name = prompt.name.clone();
+            (name, prompt)
+        })
+        .collect::<std::collections::HashMap<_, _>>();
+
+    assert_eq!(
+        by_name.remove("shared").expect("shared").content,
+        "child shared"
+    );
+    assert_eq!(
+        by_name.remove("child-only").expect("child-only").content,
+        "child only"
+    );
+    assert_eq!(by_name.remove("global").expect("global").content, "global");
+    assert_eq!(by_name.len(), 0);
+
+    Ok(())
+}

--- a/codex-rs/app-server/tests/suite/v2/mod.rs
+++ b/codex-rs/app-server/tests/suite/v2/mod.rs
@@ -2,6 +2,7 @@ mod account;
 mod analytics;
 mod collaboration_mode_list;
 mod config_rpc;
+mod custom_prompts_rpc;
 mod initialize;
 mod model_list;
 mod output_schema;


### PR DESCRIPTION
This PR adds support for project-layered discovery of custom prompts. It exposes a new app-server API so the discovery logic can be consolidated in the CLI.

Added new API "custom-prompts/list" (takes an optional cwd). It returns prompt metadata including path, with WSL-aware cwd normalization and thread-agnostic behavior when cwd is omitted.

Added app-server tests covering global-only and layered prompt precedence.

This addresses the highly-upvoted feature request #4734.

Tested manually with CLI and (not-yet-committed) modifications in IDE extension.
