### PR TITLE
feat(tui): add Ctrl+Enter backtrack undo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,6 @@
+# Changelog
+
+## Unreleased
+- TUI: backtrack preview supports Ctrl+Enter to roll back the conversation and undo file changes.
+
 The changelog can be found on the [releases page](https://github.com/openai/codex/releases).

--- a/codex-rs/tui2/src/app.rs
+++ b/codex-rs/tui2/src/app.rs
@@ -2334,6 +2334,7 @@ mod tests {
     use codex_core::protocol::EventMsg;
     use codex_core::protocol::SandboxPolicy;
     use codex_core::protocol::SessionConfiguredEvent;
+    use codex_core::protocol::ThreadRolledBackEvent;
     use codex_protocol::ThreadId;
     use insta::assert_snapshot;
     use pretty_assertions::assert_eq;
@@ -2447,6 +2448,83 @@ mod tests {
             rx,
             op_rx,
         )
+    }
+
+    #[tokio::test]
+    async fn backtrack_with_undo_requests_undo_after_rollback() {
+        let (mut app, _app_event_rx, mut op_rx) = make_test_app_with_channels().await;
+
+        let user_cell = |text: &str| -> Arc<dyn HistoryCell> {
+            Arc::new(UserHistoryCell {
+                message: text.to_string(),
+            }) as Arc<dyn HistoryCell>
+        };
+        let agent_cell = |text: &str| -> Arc<dyn HistoryCell> {
+            Arc::new(AgentMessageCell::new(
+                vec![Line::from(text.to_string())],
+                true,
+            )) as Arc<dyn HistoryCell>
+        };
+
+        app.transcript_cells = vec![
+            user_cell("first question"),
+            agent_cell("answer first"),
+            user_cell("follow-up"),
+            agent_cell("answer follow-up"),
+        ];
+
+        let base_id = ThreadId::new();
+        app.chat_widget.handle_codex_event(Event {
+            id: String::new(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id: base_id,
+                forked_from_id: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                approval_policy: AskForApproval::Never,
+                sandbox_policy: SandboxPolicy::ReadOnly,
+                cwd: PathBuf::from("/home/user/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                rollout_path: PathBuf::new(),
+            }),
+        });
+
+        app.backtrack.base_id = Some(base_id);
+        app.backtrack.primed = true;
+        app.backtrack.nth_user_message = user_count(&app.transcript_cells).saturating_sub(1);
+
+        let selection = app
+            .confirm_backtrack_from_main()
+            .expect("backtrack selection");
+        app.apply_backtrack_rollback_with_undo(selection);
+
+        let mut saw_rollback = false;
+        let mut saw_undo = false;
+        while let Ok(op) = op_rx.try_recv() {
+            match op {
+                Op::ThreadRollback { .. } => saw_rollback = true,
+                Op::Undo => saw_undo = true,
+                _ => {}
+            }
+        }
+
+        assert_eq!(saw_rollback, true);
+        assert_eq!(saw_undo, false);
+
+        app.handle_backtrack_event(&EventMsg::ThreadRolledBack(ThreadRolledBackEvent {
+            num_turns: 1,
+        }));
+
+        while let Ok(op) = op_rx.try_recv() {
+            if matches!(op, Op::Undo) {
+                saw_undo = true;
+            }
+        }
+
+        assert_eq!(saw_undo, true);
     }
 
     fn all_model_presets() -> Vec<ModelPreset> {

--- a/codex-rs/tui2/src/app_backtrack.rs
+++ b/codex-rs/tui2/src/app_backtrack.rs
@@ -41,6 +41,7 @@ use color_eyre::eyre::Result;
 use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyEventKind;
+use crossterm::event::KeyModifiers;
 
 /// Aggregates all backtrack-related state used by the App.
 #[derive(Default)]
@@ -89,6 +90,7 @@ pub(crate) struct BacktrackSelection {
 pub(crate) struct PendingBacktrackRollback {
     pub(crate) selection: BacktrackSelection,
     pub(crate) thread_id: Option<ThreadId>,
+    pub(crate) undo_after_rollback: bool,
 }
 
 impl App {
@@ -126,6 +128,15 @@ impl App {
                     ..
                 }) => {
                     self.overlay_step_backtrack_forward(tui, event)?;
+                    Ok(true)
+                }
+                TuiEvent::Key(KeyEvent {
+                    code: KeyCode::Enter,
+                    modifiers,
+                    kind: KeyEventKind::Press,
+                    ..
+                }) if modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.overlay_confirm_backtrack_with_undo(tui);
                     Ok(true)
                 }
                 TuiEvent::Key(KeyEvent {
@@ -181,6 +192,18 @@ impl App {
     /// The composer prefill is applied immediately as a UX convenience; it does not imply that
     /// core has accepted the rollback.
     pub(crate) fn apply_backtrack_rollback(&mut self, selection: BacktrackSelection) {
+        self.apply_backtrack_rollback_internal(selection, false);
+    }
+
+    pub(crate) fn apply_backtrack_rollback_with_undo(&mut self, selection: BacktrackSelection) {
+        self.apply_backtrack_rollback_internal(selection, true);
+    }
+
+    fn apply_backtrack_rollback_internal(
+        &mut self,
+        selection: BacktrackSelection,
+        undo_after_rollback: bool,
+    ) {
         let user_total = user_count(&self.transcript_cells);
         if user_total == 0 {
             return;
@@ -202,6 +225,7 @@ impl App {
         self.backtrack.pending_rollback = Some(PendingBacktrackRollback {
             selection,
             thread_id: self.chat_widget.conversation_id(),
+            undo_after_rollback,
         });
         self.chat_widget.submit_op(Op::ThreadRollback { num_turns });
         if !prefill.is_empty() {
@@ -406,11 +430,27 @@ impl App {
 
     /// Handle Enter in overlay backtrack preview: confirm selection and reset state.
     fn overlay_confirm_backtrack(&mut self, tui: &mut tui::Tui) {
+        self.overlay_confirm_backtrack_internal(tui, false);
+    }
+
+    fn overlay_confirm_backtrack_with_undo(&mut self, tui: &mut tui::Tui) {
+        self.overlay_confirm_backtrack_internal(tui, true);
+    }
+
+    fn overlay_confirm_backtrack_internal(
+        &mut self,
+        tui: &mut tui::Tui,
+        undo_after_rollback: bool,
+    ) {
         let nth_user_message = self.backtrack.nth_user_message;
         let selection = self.backtrack_selection(nth_user_message);
         self.close_transcript_overlay(tui);
         if let Some(selection) = selection {
-            self.apply_backtrack_rollback(selection);
+            if undo_after_rollback {
+                self.apply_backtrack_rollback_with_undo(selection);
+            } else {
+                self.apply_backtrack_rollback(selection);
+            }
             tui.frame_requester().schedule_frame();
         }
     }
@@ -493,6 +533,9 @@ impl App {
         }
         self.trim_transcript_for_backtrack(pending.selection.nth_user_message);
         self.backtrack_render_pending = true;
+        if pending.undo_after_rollback {
+            self.chat_widget.submit_op(Op::Undo);
+        }
     }
     fn backtrack_selection(&self, nth_user_message: usize) -> Option<BacktrackSelection> {
         let base_id = self.backtrack.base_id?;


### PR DESCRIPTION
## Summary
- add Ctrl+Enter in backtrack preview to roll back conversation and then undo file changes
- queue undo only after rollback confirmation
- add tests for the undo-after-rollback flow

## Changelog
- TUI: backtrack preview supports Ctrl+Enter to roll back the conversation and undo file changes.

Ref #9344

## Testing
- just fmt
- just fix -p codex-tui
- just fix -p codex-tui2
- cargo test -p codex-tui --all-features
- cargo test -p codex-tui2 --all-features
