### PR TITLE
Add Topics column to resume picker

### DIFF
--- a/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_screen.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_screen.snap
@@ -1,11 +1,10 @@
 ---
 source: tui/src/resume_picker.rs
-assertion_line: 1438
 expression: snapshot
 ---
 Resume a previous session
 Type to search
-  Updated  Branch  CWD  Conversation
+  Updated  Branch  CWD  Topics  Conversation
 No sessions yet
 
 

--- a/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_table.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_table.snap
@@ -2,7 +2,7 @@
 source: tui/src/resume_picker.rs
 expression: snapshot
 ---
-  Updated         Branch  CWD  Conversation
-  42 seconds ago  -       -    Fix resume picker timestamps
-> 35 minutes ago  -       -    Investigate lazy pagination cap
-  2 hours ago     -       -    Explain the codebase
+  Updated         Branch  CWD  Topics                    Conversation
+  42 seconds ago  -       -    fix resume picker tim...  Fix resume picker ti...
+> 35 minutes ago  -       -    investigate lazy pagi...  Investigate lazy pag...
+  2 hours ago     -       -    explain the codebase      Explain the codebase

--- a/codex-rs/tui2/src/snapshots/codex_tui2__resume_picker__tests__resume_picker_screen.snap
+++ b/codex-rs/tui2/src/snapshots/codex_tui2__resume_picker__tests__resume_picker_screen.snap
@@ -4,7 +4,7 @@ expression: snapshot
 ---
 Resume a previous session
 Type to search
-  Updated  Branch  CWD  Conversation
+  Updated  Branch  CWD  Topics  Conversation
 No sessions yet
 
 

--- a/codex-rs/tui2/src/snapshots/codex_tui2__resume_picker__tests__resume_picker_table.snap
+++ b/codex-rs/tui2/src/snapshots/codex_tui2__resume_picker__tests__resume_picker_table.snap
@@ -2,7 +2,7 @@
 source: tui2/src/resume_picker.rs
 expression: snapshot
 ---
-  Updated         Branch  CWD  Conversation
-  42 seconds ago  -       -    Fix resume picker timestamps
-> 35 minutes ago  -       -    Investigate lazy pagination cap
-  2 hours ago     -       -    Explain the codebase
+  Updated         Branch  CWD  Topics                    Conversation
+  42 seconds ago  -       -    fix resume picker tim...  Fix resume picker ti...
+> 35 minutes ago  -       -    investigate lazy pagi...  Investigate lazy pag...
+  2 hours ago     -       -    explain the codebase      Explain the codebase


### PR DESCRIPTION
Contributing guide: https://github.com/openai/codex/blob/main/docs/contributing.md

Related: N/A (UX improvement)

## Summary
Add a Topics column to the resume picker that shows the five most frequent user keywords from the recorded head of each session. This helps distinguish sessions that currently show identical short prompts (e.g., hola) in the Conversation column.

## Changes
- Extract up to five keywords from user messages (frequency-based, language-agnostic tokenization) and display them as Topics.
- Include Topics in the picker search filter.
- Update snapshot tests for both TUI and TUI2.

## Why This Is Safe
- The topics are derived only from already-loaded head entries, so no additional file I/O is required.
- Keyword extraction is bounded (five words) and uses simple tokenization without external dependencies.
- Existing layout behavior is preserved; topics are truncated to fit the column width.

## Testing
- INSTA_UPDATE=always cargo test -p codex-tui resume_table_snapshot
- INSTA_UPDATE=always cargo test -p codex-tui resume_picker_screen_snapshot
- INSTA_UPDATE=always cargo test -p codex-tui2 resume_table_snapshot
- INSTA_UPDATE=always cargo test -p codex-tui2 resume_picker_screen_snapshot