### PR TITLE
Gate tab queueing to active tasks

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1943,12 +1943,17 @@ impl ChatWidget {
                         }
                     }
                     InputResult::Queued(text) => {
-                        // Tab queues the message if a task is running, otherwise submits immediately
-                        let user_message = UserMessage {
-                            text,
-                            image_paths: self.bottom_pane.take_recent_submission_images(),
-                        };
-                        self.queue_user_message(user_message);
+                        if self.bottom_pane.is_task_running() {
+                            // Tab queues the message only while a task is active.
+                            let user_message = UserMessage {
+                                text,
+                                image_paths: self.bottom_pane.take_recent_submission_images(),
+                            };
+                            self.queue_user_message(user_message);
+                        } else {
+                            self.bottom_pane.set_composer_text(text);
+                            self.request_redraw();
+                        }
                     }
                     InputResult::Command(cmd) => {
                         self.dispatch_command(cmd);

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1103,6 +1103,18 @@ async fn enqueueing_history_prompt_multiple_times_is_stable() {
 }
 
 #[tokio::test]
+async fn tab_noop_when_no_task_running() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
+    chat.thread_id = Some(ThreadId::new());
+
+    chat.bottom_pane.set_composer_text("keep me".to_string());
+    chat.handle_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+
+    assert_eq!(chat.bottom_pane.composer_text(), "keep me");
+    assert!(chat.queued_user_messages.is_empty());
+}
+
+#[tokio::test]
 async fn streaming_final_answer_keeps_task_running_state() {
     let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(None).await;
     chat.thread_id = Some(ThreadId::new());

--- a/codex-rs/tui2/src/chatwidget.rs
+++ b/codex-rs/tui2/src/chatwidget.rs
@@ -1743,12 +1743,17 @@ impl ChatWidget {
                         }
                     }
                     InputResult::Queued(text) => {
-                        // Tab queues the message if a task is running, otherwise submits immediately
-                        let user_message = UserMessage {
-                            text,
-                            image_paths: self.bottom_pane.take_recent_submission_images(),
-                        };
-                        self.queue_user_message(user_message);
+                        if self.bottom_pane.is_task_running() {
+                            // Tab queues the message only while a task is active.
+                            let user_message = UserMessage {
+                                text,
+                                image_paths: self.bottom_pane.take_recent_submission_images(),
+                            };
+                            self.queue_user_message(user_message);
+                        } else {
+                            self.bottom_pane.set_composer_text(text);
+                            self.request_redraw();
+                        }
                     }
                     InputResult::Command(cmd) => {
                         self.dispatch_command(cmd);

--- a/codex-rs/tui2/src/chatwidget/tests.rs
+++ b/codex-rs/tui2/src/chatwidget/tests.rs
@@ -1054,6 +1054,18 @@ async fn enqueueing_history_prompt_multiple_times_is_stable() {
 }
 
 #[tokio::test]
+async fn tab_noop_when_no_task_running() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
+    chat.conversation_id = Some(ThreadId::new());
+
+    chat.bottom_pane.set_composer_text("keep me".to_string());
+    chat.handle_key_event(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE));
+
+    assert_eq!(chat.bottom_pane.composer_text(), "keep me");
+    assert!(chat.queued_user_messages.is_empty());
+}
+
+#[tokio::test]
 async fn streaming_final_answer_keeps_task_running_state() {
     let (mut chat, _rx, mut op_rx) = make_chatwidget_manual(None).await;
     chat.conversation_id = Some(ThreadId::new());


### PR DESCRIPTION
- Only queue on Tab when a task is running; otherwise keep the draft intact.