### PR TITLE
Only load config from trusted folders

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -531,7 +531,7 @@ pub async fn load_config_as_toml_with_cli_overrides(
     Ok(cfg)
 }
 
-fn deserialize_config_toml_with_base(
+pub(crate) fn deserialize_config_toml_with_base(
     root_value: TomlValue,
     config_base_dir: &Path,
 ) -> std::io::Result<ConfigToml> {


### PR DESCRIPTION
Config includes multiple code execution entrypoints. 

Now, we load the config from predetermined locations first (~/.codex/config.toml etc), use those to learn which folders are 'trusted', and only load additional config from the CWD if it is trusted.