### PR TITLE
Restore read-only mounts before Landlock

### DIFF
--- a/codex-rs/linux-sandbox/src/landlock.rs
+++ b/codex-rs/linux-sandbox/src/landlock.rs
@@ -7,6 +7,8 @@ use codex_core::error::SandboxErr;
 use codex_core::protocol::SandboxPolicy;
 use codex_utils_absolute_path::AbsolutePathBuf;
 
+use crate::mounts::apply_read_only_mounts;
+
 use landlock::ABI;
 use landlock::Access;
 use landlock::AccessFs;
@@ -40,6 +42,7 @@ pub(crate) fn apply_sandbox_policy_to_current_thread(
     }
 
     if !sandbox_policy.has_full_disk_write_access() {
+        apply_read_only_mounts(sandbox_policy, cwd)?;
         let writable_roots = sandbox_policy
             .get_writable_roots_with_cwd(cwd)
             .into_iter()


### PR DESCRIPTION
### Motivation
- Re-enable the pre‑Landlock read‑only bind mounts so protected subpaths (e.g. `.git`, `.codex`) are made immutable before Landlock rules are applied, restoring the previous protection that prevented tampering under `WorkspaceWrite` policies.

### Description
- Import and call `apply_read_only_mounts(...)` from `codex-rs/linux-sandbox/src/mounts.rs` at the start of `apply_sandbox_policy_to_current_thread` in `codex-rs/linux-sandbox/src/landlock.rs` so read‑only mounts are installed before constructing and applying Landlock rules.

### Testing
- Ran `just fmt` and `just fix -p codex-linux-sandbox` successfully and then `cargo test -p codex-linux-sandbox`; unit tests for the mounts helpers passed (`mounts` tests: 3 passed) but the full sandbox test suite had failures (overall: 8 passed; 5 failed) due to `Sandbox(LandlockRestrict)` errors observed when applying the Landlock rules in this test environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_6969ab2b22a0832da09ab6e21288d62b)