### PR TITLE
lookup system SIDs instead of hardcoding English strings.

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
@@ -26,7 +26,7 @@ use windows_sys::Win32::Security::CheckTokenMembership;
 use windows_sys::Win32::Security::FreeSid;
 use windows_sys::Win32::Security::SECURITY_NT_AUTHORITY;
 
-pub const SETUP_VERSION: u32 = 3;
+pub const SETUP_VERSION: u32 = 4;
 pub const OFFLINE_USERNAME: &str = "CodexSandboxOffline";
 pub const ONLINE_USERNAME: &str = "CodexSandboxOnline";
 const SECURITY_BUILTIN_DOMAIN_RID: u32 = 0x0000_0020;


### PR DESCRIPTION
The elevated setup does not work on non-English windows installs where Users/Administrators/etc are in different languages. This PR uses the well-known SIDs instead, which do not vary based on locale