### PR TITLE
fix(app-server, core): fix thread rollbacks after compaction has occurred

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1356,7 +1356,7 @@ pub struct ThreadListParams {
     pub limit: Option<u32>,
     /// Optional sort key; defaults to created_at.
     pub sort_key: Option<ThreadSortKey>,
-    /// Optional provider filter; when set, only sessions recorded under these
+    /// Optional provider filter; when set, only threads recorded under these
     /// providers are returned. When present but empty, includes all providers.
     pub model_providers: Option<Vec<String>>,
     /// Optional source filter; when set, only sessions from these source kinds

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -84,7 +84,7 @@ Example (from OpenAI's official VSCode extension):
 - `thread/archive` — move a thread’s rollout file into the archived directory; returns `{}` on success.
 - `thread/name/set` — set or update a thread’s user-facing name; returns `{}` on success. Thread names are not required to be unique; name lookups resolve to the most recently updated thread.
 - `thread/unarchive` — move an archived rollout file back into the sessions directory; returns the restored `thread` on success.
-- `thread/rollback` — drop the last N turns from the agent’s in-memory context and persist a rollback marker in the rollout so future resumes see the pruned history; returns the updated `thread` (with `turns` populated) on success.
+- `thread/rollback` — drop the last N user turns from the thread’s effective history based on the rollout stream. If the rollback crosses a compaction marker, the compaction is undone (pre-compaction turns are restored). Persists a rollback marker so future resumes see the same history; returns the updated `thread` (with `turns` populated) on success.
 - `turn/start` — add user input to a thread and begin Codex generation; responds with the initial `turn` object and streams `turn/started`, `item/*`, and `turn/completed` notifications.
 - `turn/interrupt` — request cancellation of an in-flight turn by `(thread_id, turn_id)`; success is an empty `{}` response and the turn finishes with `status: "interrupted"`.
 - `review/start` — kick off Codex’s automated reviewer for a thread; responds like `turn/start` and emits `item/started`/`item/completed` notifications with `enteredReviewMode` and `exitedReviewMode` items, plus a final assistant `agentMessage` containing the review.

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -5623,6 +5623,7 @@ mod tests {
                 None,
                 SessionSource::Exec,
                 base_instructions,
+                Vec::new(),
             ),
             None,
             None,

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -31,7 +31,7 @@ use tracing::error;
 
 pub const SUMMARIZATION_PROMPT: &str = include_str!("../templates/compact/prompt.md");
 pub const SUMMARY_PREFIX: &str = include_str!("../templates/compact/summary_prefix.md");
-const COMPACT_USER_MESSAGE_MAX_TOKENS: usize = 20_000;
+pub(crate) const COMPACT_USER_MESSAGE_MAX_TOKENS: usize = 20_000;
 
 pub(crate) fn should_use_remote_compact_task(
     session: &Session,

--- a/codex-rs/core/src/rollout/truncation.rs
+++ b/codex-rs/core/src/rollout/truncation.rs
@@ -191,7 +191,7 @@ pub(crate) fn truncate_rollout_drop_last_n_user_turns(
 
     let n_from_end = usize::try_from(num_turns).unwrap_or(usize::MAX);
     if n_from_end >= user_turns.len() {
-        let Some(first_user_idx) = user_message_positions_in_rollout(items).first().copied() else {
+        let Some(first_user_idx) = user_turns.first().map(|turn| turn.source_index) else {
             return items.to_vec();
         };
         return items[..first_user_idx].to_vec();

--- a/codex-rs/core/src/rollout/truncation.rs
+++ b/codex-rs/core/src/rollout/truncation.rs
@@ -222,10 +222,10 @@ pub(crate) fn truncate_rollout_drop_last_n_user_turns(
     if let Some(replacement_item_index) = boundary.replacement_item_index {
         let compaction_index = boundary.source_index;
         let mut truncated = items[..=compaction_index].to_vec();
-        if let Some(RolloutItem::Compacted(compacted)) = truncated.last_mut() {
-            if let Some(replacement) = &mut compacted.replacement_history {
-                replacement.truncate(replacement_item_index);
-            }
+        if let Some(RolloutItem::Compacted(compacted)) = truncated.last_mut()
+            && let Some(replacement) = &mut compacted.replacement_history
+        {
+            replacement.truncate(replacement_item_index);
         }
         return truncated;
     }


### PR DESCRIPTION
## Summary
Fix a bug with `Op::Rollback` not dropping the correct context when the thread has been compacted.

We do this by using the on-disk rollout file as the source of truth, populating Codex's in-memory representation of the conversation from the file because it's not possible to do this reliably by mutating the in-memory representation directly (which is what we currently do).

With this fix, rollbacks now correctly restores pre‑compaction turns. This allows you to rollback any compactions that have occurred during the last N turns you are attempting to roll back.

## Problem / Root Cause
We maintain two representations of conversation history:
- In‑memory history (`ContextManager`): the current effective context used for prompting. After compaction, this is mutated (selected user messages + a summary message), so earlier assistant turns are no longer present.
- On‑disk rollout (append‑only stream): the authoritative event log. It still contains all original turns plus compaction markers and rollback markers.

The difference is that the in-memory history was **mutated** whereas the on-disk rollout representation is **append-only**. And previously, `Op::Rollback` only dropped N user turns from in‑memory history. If compaction had already happened, rollback could not restore pre‑compaction turns because those turns no longer existed in memory.

## Solution
When performing a rollback, rebuild thread history from the rollout file:
- Apply rollback markers to the rollout history first (`apply_rollbacks_to_rollout`).
- Compute “effective” user turns, factoring in compaction (including replacement history and summary fallback).
- Truncate the rollout stream by dropping the last N effective user turns.
- Reconstruct in‑memory history from that truncated rollout.

This makes rollback stable even when it crosses a compaction boundary.

## Illustrative Example
**Conversation:**
1. U1 / A1
2. U2 / A2
3. Compaction happens
4. U3 / A3
5. Rollback 2 user turns

**On‑disk rollout:**
U1 A1 U2 A2 | Compacted(SUM) | U3 A3

**In‑memory after compaction:**
U1 U2 SUM U3 A3

### Before
We modify the in‑memory history directly (incorrectly):
- Drop U3 and SUM → U1 U2
- A1/A2 are still missing because compaction had already removed them.

### After
Rollback uses the rollout file:
- Effective user turns = U1, U2, SUM, U3
- Drop last 2 → truncate stream before SUM
- Rebuild history → U1 A1 U2 A2
 
Pre‑compaction turns (including assistant replies) are restored.

## Tests
Unit tests: 
- rollback over compaction restores pre‑compaction history (core/src/codex.rs)

Integration tests:
- Remote compaction rollback restores pre‑compaction assistant reply and drops summary (core/tests/suite/compact_remote.rs)
- Resume/fork flow confirms pre‑compaction history appears after rollback (core/tests/suite/compact_resume_fork.rs)
- Added targeted unit tests for truncation edge cases in core/src/rollout/truncation.rs:
  - replacement_history path
  - empty summary fallback

