### PR TITLE
fix: MCP cwd use absolute path

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -1104,7 +1104,11 @@
         },
         "cwd": {
           "default": null,
-          "type": "string"
+          "allOf": [
+            {
+              "$ref": "#/definitions/AbsolutePathBuf"
+            }
+          ]
         },
         "disabled_tools": {
           "default": null,

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -2864,7 +2864,7 @@ ZIG_VAR = "3"
     async fn replace_mcp_servers_serializes_cwd() -> anyhow::Result<()> {
         let codex_home = TempDir::new()?;
 
-        let cwd_path = PathBuf::from("/tmp/codex-mcp");
+        let cwd_path = AbsolutePathBuf::from_absolute_path("/tmp/codex-mcp").expect("expected cwd");
         let servers = BTreeMap::from([(
             "docs".to_string(),
             McpServerConfig {
@@ -2901,7 +2901,10 @@ ZIG_VAR = "3"
         let docs = loaded.get("docs").expect("docs entry");
         match &docs.transport {
             McpServerTransportConfig::Stdio { cwd, .. } => {
-                assert_eq!(cwd.as_deref(), Some(Path::new("/tmp/codex-mcp")));
+                assert_eq!(
+                    cwd.as_ref().map(AbsolutePathBuf::as_path),
+                    Some(Path::new("/tmp/codex-mcp"))
+                );
             }
             other => panic!("unexpected transport {other:?}"),
         }

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -865,6 +865,7 @@ async fn make_rmcp_client(
         } => {
             let command_os: OsString = command.into();
             let args_os: Vec<OsString> = args.into_iter().map(Into::into).collect();
+            let cwd = cwd.map(codex_utils_absolute_path::AbsolutePathBuf::into_path_buf);
             RmcpClient::new_stdio_client(command_os, args_os, env, &env_vars, cwd)
                 .await
                 .map_err(|err| StartupOutcomeError::from(anyhow!(err)))


### PR DESCRIPTION
### Issue
When using MCP with cwd, `~` in cwd path is not expanded. Reproduce with the following steps:

`~/.codex/config.toml`
```
[mcp_servers.context7Local]
command = "./scripts/context7-script.sh"
cwd = "~/Documents"
```

`~/Documents/scripts/context7-script.sh`
```
#!/bin/bash
set -euo pipefail

cd "$(dirname "$0")/.."
set -a && source .env && set +a

API_KEY="${CONTEXT7_API_KEY:-${CONTEXT_API_KEY:-}}"
if [ -z "$API_KEY" ]; then
  echo "CONTEXT7_API_KEY (or CONTEXT_API_KEY) is not set in $BASE_DIR/.env" >&2
  exit 1
fi

exec npx -y @upstash/context7-mcp --api-key "$API_KEY"
```

`~/Documents/.env`
```
CONTEXT_API_KEY="key_from_https://context7.com/"
```


### Summary
* Converted cwd for mcp config  to use absolute path so that we can handle `~` and relative path based on the config layer. 
* Ensure that we mcp command for MCP is correctly concatenated if there is a cwd detected and the command is a relative path. 