### PR TITLE
feat(app-server): support archived threads in thread/list

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1205,6 +1205,9 @@ pub struct ThreadListParams {
     /// Optional provider filter; when set, only sessions recorded under these
     /// providers are returned. When present but empty, includes all providers.
     pub model_providers: Option<Vec<String>>,
+    /// Optional archived filter; when set to true, only archived threads are returned.
+    /// If false or null, only non-archived threads are returned.
+    pub archived: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, JsonSchema, TS)]

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -147,6 +147,7 @@ To branch from a stored session, call `thread/fork` with the `thread.id`. This c
 - `limit` — server defaults to a reasonable page size if unset.
 - `sortKey` — `created_at` (default) or `updated_at`.
 - `modelProviders` — restrict results to specific providers; unset, null, or an empty array will include all providers.
+- `archived` — when `true`, list archived threads only. When `false` or `null`, list non-archived threads (default).
 
 Example:
 
@@ -187,7 +188,7 @@ Use `thread/archive` to move the persisted rollout (stored as a JSONL file on di
 { "id": 21, "result": {} }
 ```
 
-An archived thread will not appear in future calls to `thread/list`.
+An archived thread will not appear in `thread/list` unless `archived` is set to `true`.
 
 ### Example: Start a turn (send user input)
 

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1621,6 +1621,7 @@ impl CodexMessageProcessor {
             limit,
             sort_key,
             model_providers,
+            archived,
         } = params;
 
         let requested_page_size = limit
@@ -1632,7 +1633,13 @@ impl CodexMessageProcessor {
             ThreadSortKey::UpdatedAt => CoreThreadSortKey::UpdatedAt,
         };
         let (summaries, next_cursor) = match self
-            .list_threads_common(requested_page_size, cursor, model_providers, core_sort_key)
+            .list_threads_common(
+                requested_page_size,
+                cursor,
+                model_providers,
+                core_sort_key,
+                archived.unwrap_or(false),
+            )
             .await
         {
             Ok(r) => r,
@@ -2198,6 +2205,7 @@ impl CodexMessageProcessor {
                 cursor,
                 model_providers,
                 CoreThreadSortKey::UpdatedAt,
+                false,
             )
             .await
         {
@@ -2217,6 +2225,7 @@ impl CodexMessageProcessor {
         cursor: Option<String>,
         model_providers: Option<Vec<String>>,
         sort_key: CoreThreadSortKey,
+        archived: bool,
     ) -> Result<(Vec<ConversationSummary>, Option<String>), JSONRPCErrorError> {
         let mut cursor_obj: Option<RolloutCursor> = match cursor.as_ref() {
             Some(cursor_str) => {
@@ -2247,21 +2256,39 @@ impl CodexMessageProcessor {
 
         while remaining > 0 {
             let page_size = remaining.min(THREAD_LIST_MAX_LIMIT);
-            let page = RolloutRecorder::list_threads(
-                &self.config.codex_home,
-                page_size,
-                cursor_obj.as_ref(),
-                sort_key,
-                INTERACTIVE_SESSION_SOURCES,
-                model_provider_filter.as_deref(),
-                fallback_provider.as_str(),
-            )
-            .await
-            .map_err(|err| JSONRPCErrorError {
-                code: INTERNAL_ERROR_CODE,
-                message: format!("failed to list threads: {err}"),
-                data: None,
-            })?;
+            let page = if archived {
+                RolloutRecorder::list_archived_threads(
+                    &self.config.codex_home,
+                    page_size,
+                    cursor_obj.as_ref(),
+                    sort_key,
+                    INTERACTIVE_SESSION_SOURCES,
+                    model_provider_filter.as_deref(),
+                    fallback_provider.as_str(),
+                )
+                .await
+                .map_err(|err| JSONRPCErrorError {
+                    code: INTERNAL_ERROR_CODE,
+                    message: format!("failed to list threads: {err}"),
+                    data: None,
+                })?
+            } else {
+                RolloutRecorder::list_threads(
+                    &self.config.codex_home,
+                    page_size,
+                    cursor_obj.as_ref(),
+                    sort_key,
+                    INTERACTIVE_SESSION_SOURCES,
+                    model_provider_filter.as_deref(),
+                    fallback_provider.as_str(),
+                )
+                .await
+                .map_err(|err| JSONRPCErrorError {
+                    code: INTERNAL_ERROR_CODE,
+                    message: format!("failed to list threads: {err}"),
+                    data: None,
+                })?
+            };
 
             let mut filtered = page
                 .items

--- a/codex-rs/core/src/rollout/recorder.rs
+++ b/codex-rs/core/src/rollout/recorder.rs
@@ -19,11 +19,15 @@ use tokio::sync::oneshot;
 use tracing::info;
 use tracing::warn;
 
+use super::ARCHIVED_SESSIONS_SUBDIR;
 use super::SESSIONS_SUBDIR;
 use super::list::Cursor;
+use super::list::ThreadListConfig;
+use super::list::ThreadListLayout;
 use super::list::ThreadSortKey;
 use super::list::ThreadsPage;
 use super::list::get_threads;
+use super::list::get_threads_in_root;
 use super::policy::is_persisted_response_item;
 use crate::config::Config;
 use crate::default_client::originator;
@@ -115,6 +119,32 @@ impl RolloutRecorder {
             allowed_sources,
             model_providers,
             default_provider,
+        )
+        .await
+    }
+
+    /// List archived threads (rollout files) under the archived sessions directory.
+    pub async fn list_archived_threads(
+        codex_home: &Path,
+        page_size: usize,
+        cursor: Option<&Cursor>,
+        sort_key: ThreadSortKey,
+        allowed_sources: &[SessionSource],
+        model_providers: Option<&[String]>,
+        default_provider: &str,
+    ) -> std::io::Result<ThreadsPage> {
+        let root = codex_home.join(ARCHIVED_SESSIONS_SUBDIR);
+        get_threads_in_root(
+            root,
+            page_size,
+            cursor,
+            sort_key,
+            ThreadListConfig {
+                allowed_sources,
+                model_providers,
+                default_provider,
+                layout: ThreadListLayout::Flat,
+            },
         )
         .await
     }

--- a/codex-rs/debug-client/src/client.rs
+++ b/codex-rs/debug-client/src/client.rs
@@ -173,6 +173,7 @@ impl AppServerClient {
                 limit: None,
                 sort_key: None,
                 model_providers: None,
+                archived: None,
             },
         };
         self.send(&request)?;


### PR DESCRIPTION
Add an `archived` bool filter to `thread/list` to support showing archived threads.

Archived threads are stored in `$CODEX_HOME/archived_sessions/` without the `YYYY/MM/DD` directory nesting that regular threads do, so we needed to update core's rollout listing code to deal with the flat structure.
