### PR TITLE
feat: implement alt-d readline keybinding

### DIFF
--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -310,6 +310,11 @@ impl TextArea {
                 ..
             }  => self.delete_forward_word(),
             KeyEvent {
+                code: KeyCode::Char('d'),
+                modifiers: KeyModifiers::ALT,
+                ..
+            } => self.delete_forward_word(),
+            KeyEvent {
                 code: KeyCode::Delete,
                 ..
             }
@@ -1618,6 +1623,12 @@ mod tests {
         let mut t = ta_with("hello world");
         t.set_cursor(0);
         t.input(KeyEvent::new(KeyCode::Delete, KeyModifiers::ALT));
+        assert_eq!(t.text(), " world");
+        assert_eq!(t.cursor(), 0);
+
+        let mut t = ta_with("hello world");
+        t.set_cursor(0);
+        t.input(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::ALT));
         assert_eq!(t.text(), " world");
         assert_eq!(t.cursor(), 0);
 

--- a/codex-rs/tui2/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui2/src/bottom_pane/textarea.rs
@@ -307,6 +307,11 @@ impl TextArea {
                 ..
             }  => self.delete_forward_word(),
             KeyEvent {
+                code: KeyCode::Char('d'),
+                modifiers: KeyModifiers::ALT,
+                ..
+            } => self.delete_forward_word(),
+            KeyEvent {
                 code: KeyCode::Delete,
                 ..
             }
@@ -1615,6 +1620,12 @@ mod tests {
         let mut t = ta_with("hello world");
         t.set_cursor(0);
         t.input(KeyEvent::new(KeyCode::Delete, KeyModifiers::ALT));
+        assert_eq!(t.text(), " world");
+        assert_eq!(t.cursor(), 0);
+
+        let mut t = ta_with("hello world");
+        t.set_cursor(0);
+        t.input(KeyEvent::new(KeyCode::Char('d'), KeyModifiers::ALT));
         assert_eq!(t.text(), " world");
         assert_eq!(t.cursor(), 0);
 


### PR DESCRIPTION
Allow using ALT+D to delete from the cursor to the end of the current word.

This is a standard readline keybinding that does not exist in the OpenAI TUI implementation, and its lack has been very annoying for me coming from Claude Code. Fixes #5018.