### PR TITLE
fix(tui): handle SIGINT in main event loop for graceful shutdown

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -619,6 +619,19 @@ impl App {
                 Some(event) = tui_events.next() => {
                     app.handle_tui_event(tui, event).await?
                 }
+                // Handle SIGINT (Ctrl+C delivered as signal rather than key event).
+                // On some platforms/terminals (notably WSL2), Ctrl+C may be delivered
+                // as SIGINT instead of a key event. We synthesize a key event so the
+                // existing double-press quit logic and session summary printing work.
+                _ = tokio::signal::ctrl_c() => {
+                    tracing::debug!("Received SIGINT, synthesizing Ctrl+C key event");
+                    let ctrl_c_event = TuiEvent::Key(KeyEvent::new_with_kind(
+                        KeyCode::Char('c'),
+                        crossterm::event::KeyModifiers::CONTROL,
+                        KeyEventKind::Press,
+                    ));
+                    app.handle_tui_event(tui, ctrl_c_event).await?
+                }
                 // Listen on new thread creation due to collab tools.
                 created = thread_created_rx.recv(), if listen_for_threads => {
                     match created {


### PR DESCRIPTION
## Summary

On some platforms/terminals (notably WSL2), Ctrl+C may be delivered as SIGINT instead of a key event. When this happens, the TUI exits immediately (status 130) without printing the session summary or resume hint.

This change adds a `tokio::signal::ctrl_c()` branch to the main `select!` loop that synthesizes a Ctrl+C key event and routes it through the existing handler. This preserves the double-press quit semantics and ensures the session summary is printed.

Fixes #9448

## Changes

- Added SIGINT handling to the TUI's main event loop in `codex-rs/tui/src/app.rs`
- When SIGINT is received, synthesizes a Ctrl+C key event and routes it through `handle_tui_event`
- This follows the same pattern already used in `codex-rs/exec/src/lib.rs` and `codex-rs/core/src/exec.rs`

## Test Plan

- [x] Verified build compiles with `cargo check -p codex-tui`
- [x] Verified all 649 unit tests pass with `cargo test -p codex-tui`
- [x] Verified all Ctrl+C related tests pass
- [ ] Manual testing on WSL2 to verify SIGINT now triggers graceful shutdown

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)