### PR TITLE
don't ask for approval for `just fix`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,8 +18,7 @@ In the codex-rs folder where the rust code lives:
 Run `just fmt` (in `codex-rs` directory) automatically after making Rust code changes; do not ask for approval to run it. Before finalizing a change to `codex-rs`, run `just fix -p <project>` (in `codex-rs` directory) to fix any linter issues in the code. Prefer scoping with `-p` to avoid slow workspace‑wide Clippy builds; only run `just fix` without `-p` if you changed shared crates. Additionally, run the tests:
 
 1. Run the test for the specific project that was changed. For example, if changes were made in `codex-rs/tui`, run `cargo test -p codex-tui`.
-2. Once those pass, if any changes were made in common, core, or protocol, run the complete test suite with `cargo test --all-features`.
-   When running interactively, ask the user before running `just fix` to finalize. `just fmt` does not require approval. project-specific or individual tests can be run without asking the user, but do ask the user before running the complete test suite.
+2. Once those pass, if any changes were made in common, core, or protocol, run the complete test suite with `cargo test --all-features`. project-specific or individual tests can be run without asking the user, but do ask the user before running the complete test suite.
 
 ## TUI style conventions
 


### PR DESCRIPTION
It blocks all my skills from executing because it asks to run just fmt. It's quick command that doesn't need approval.


<img width="967" height="120" alt="image" src="https://github.com/user-attachments/assets/f8e6ca76-a650-49e9-beb2-ce98ba48d310" />
