### PR TITLE
fix(exec): skip git repo check when --yolo flag is used

### DIFF
--- a/codex-rs/exec/src/lib.rs
+++ b/codex-rs/exec/src/lib.rs
@@ -296,7 +296,12 @@ pub async fn run_main(cli: Cli, codex_linux_sandbox_exe: Option<PathBuf>) -> any
     let default_effort = config.model_reasoning_effort;
     let default_summary = config.model_reasoning_summary;
 
-    if !skip_git_repo_check && get_git_repo_root(&default_cwd).is_none() {
+    // When --yolo (dangerously_bypass_approvals_and_sandbox) is set, also skip the git repo check
+    // since the user is explicitly running in an externally sandboxed environment.
+    if !skip_git_repo_check
+        && !dangerously_bypass_approvals_and_sandbox
+        && get_git_repo_root(&default_cwd).is_none()
+    {
         eprintln!("Not inside a trusted directory and --skip-git-repo-check was not specified.");
         std::process::exit(1);
     }


### PR DESCRIPTION
## Summary

Fixes #7522

The `--yolo` (`--dangerously-bypass-approvals-and-sandbox`) flag is documented to skip all confirmation prompts and execute commands without sandboxing, intended solely for running in environments that are externally sandboxed. However, it was not bypassing the trusted directory (git repo) check, requiring users to also specify `--skip-git-repo-check`.

This change makes `--yolo` also skip the git repo check, matching the documented behavior and user expectations.

## Changes

- Modified `codex-rs/exec/src/lib.rs` to check for `dangerously_bypass_approvals_and_sandbox` flag in addition to `skip_git_repo_check` when determining whether to skip the git repo check

## Testing

- Verified the code compiles with `cargo check -p codex-exec`
- Ran existing tests with `cargo test -p codex-exec` (34 passed, 8 integration tests failed due to unrelated API connectivity issues)

---
🤖 Generated with [Claude Code](https://claude.ai/code)