### PR TITLE
Added "codex." prefix to "conversation.turn.count" metric name

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2576,7 +2576,7 @@ mod handlers {
             .filter(|item| is_user_turn_boundary(item))
             .count();
         sess.services.otel_manager.counter(
-            "conversation.turn.count",
+            "codex.conversation.turn.count",
             i64::try_from(turn_count).unwrap_or(0),
             &[],
         );


### PR DESCRIPTION
All other metrics names start with "codex.", so I presume this was an unintended omission.
