### PR TITLE
feat: better sorting of shell commands

### DIFF
--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__slash_popup_mo.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__slash_popup_mo.snap
@@ -5,5 +5,5 @@ expression: terminal.backend()
 "                                                            "
 "› /mo                                                       "
 "                                                            "
-"  /model    choose what model and reasoning effort to use   "
-"  /mention  mention a file                                  "
+"                                                            "
+"  /model  choose what model and reasoning effort to use     "


### PR DESCRIPTION
This PR changes the way we sort slash command by going in this order:
1. Exact match
2. Prefix
3. Fuzzy

As a result, we you type `/ps` the default command is not `/approvals`