### PR TITLE
fix(ci): add stapling and notarization verification for macOS binaries

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -225,6 +225,27 @@ jobs:
             cp target/${{ matrix.target }}/release/codex-${{ matrix.target }}.dmg "$dest/codex-${{ matrix.target }}.dmg"
           fi
 
+      - if: ${{ runner.os == 'macOS' }}
+        name: Staple and verify notarization (staged binaries)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          dest="dist/${{ matrix.target }}"
+          for binary in codex codex-responses-api-proxy; do
+            path="${dest}/${binary}-${{ matrix.target }}"
+            echo "Stapling: ${binary}"
+            xcrun stapler staple "$path"
+
+            if ! xcrun stapler validate "$path" >/dev/null 2>&1; then
+              echo "Stapling verification failed for ${binary}"
+              xcrun stapler validate "$path" 2>&1 || true
+              exit 1
+            fi
+
+            echo "${binary} is properly stapled"
+          done
+
       - if: ${{ matrix.runner == 'windows-11-arm' }}
         name: Install zstd
         shell: powershell

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -235,6 +235,7 @@ jobs:
           for binary in codex codex-responses-api-proxy; do
             path="${dest}/${binary}-${{ matrix.target }}"
             echo "Stapling: ${binary}"
+            test -f "$path" || { echo "Missing binary: $path"; exit 1; }
             xcrun stapler staple "$path"
 
             if ! xcrun stapler validate "$path" >/dev/null 2>&1; then


### PR DESCRIPTION
Fixes #9632

## Summary
- Add macOS stapling for staged binaries so the packaged artifacts retain the notarization ticket.
- Staple and validate the `dist/` macOS binaries before compression.
- Keep staging with `cp` while ensuring final artifacts are properly stapled.

## Problem
Homebrew-installed macOS binaries can fail Gatekeeper checks because the packaged artifacts are missing stapled notarization tickets.

## Solution
Staple the staged `dist/` binaries directly and validate them prior to compression, ensuring the distributed artifacts retain the ticket without relying on xattr-preserving copy.

## Testing
- CI will validate in release workflow

