### PR TITLE
feat(mcp-server): Add image support to codex and codex-reply tools

### DIFF
--- a/codex-rs/docs/codex_mcp_interface.md
+++ b/codex-rs/docs/codex_mcp_interface.md
@@ -130,6 +130,48 @@ Example:
 }
 ```
 
+## Image support
+
+Both `codex` and `codex-reply` tools accept an optional `images` parameter to include images alongside text prompts. Each image URL must be either:
+
+- An HTTP/HTTPS URL pointing to an image
+- A base64 data URI (e.g., `data:image/png;base64,...`)
+
+Example with images:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "tools/call",
+  "params": {
+    "name": "codex",
+    "arguments": {
+      "prompt": "What's in this image?",
+      "images": ["https://example.com/image.png"]
+    }
+  }
+}
+```
+
+Example with base64 data URI:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 2,
+  "method": "tools/call",
+  "params": {
+    "name": "codex-reply",
+    "arguments": {
+      "threadId": "019bbed6-1e9e-7f31-984c-a05b65045719",
+      "prompt": "Compare this to the previous image",
+      "images": ["data:image/png;base64,iVBORw0KGgo..."]
+    }
+  }
+}
+```
+
 ## Approvals (server → client)
 
 When Codex needs approval to apply changes or run commands, the server issues JSON‑RPC requests to the client:

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -347,7 +347,7 @@ impl MessageProcessor {
         }
     }
     async fn handle_tool_call_codex(&self, id: RequestId, arguments: Option<serde_json::Value>) {
-        let (initial_prompt, config): (String, Config) = match arguments {
+        let (initial_prompt, images, config): (String, Vec<String>, Config) = match arguments {
             Some(json_val) => match serde_json::from_value::<CodexToolCallParam>(json_val) {
                 Ok(tool_cfg) => match tool_cfg
                     .into_config(self.codex_linux_sandbox_exe.clone())
@@ -416,6 +416,7 @@ impl MessageProcessor {
             crate::codex_tool_runner::run_codex_tool_session(
                 id,
                 initial_prompt,
+                images,
                 config,
                 outgoing,
                 thread_manager,
@@ -510,6 +511,7 @@ impl MessageProcessor {
 
         // Spawn the long-running reply handler.
         let prompt = codex_tool_call_reply_param.prompt.clone();
+        let images = codex_tool_call_reply_param.get_images();
         tokio::spawn({
             let outgoing = outgoing.clone();
             let running_requests_id_to_codex_uuid = running_requests_id_to_codex_uuid.clone();
@@ -521,6 +523,7 @@ impl MessageProcessor {
                     outgoing,
                     request_id,
                     prompt,
+                    images,
                     running_requests_id_to_codex_uuid,
                 )
                 .await;


### PR DESCRIPTION
## What

Add an `images` field to the `codex` and `codex-reply` MCP tools to support passing image URLs alongside text prompts. (#9608)

## Why

Enables multimodal interactions through the MCP server interface, allowing clients to send images (via HTTP/HTTPS URLs or base64 data URIs) for vision-based tasks.

## How

- Added optional `images: Vec<String>` field to `CodexToolCallParam` and `CodexToolCallReplyParam`
- Updated `run_codex_tool_session` and `run_codex_tool_session_reply` to build `UserInput::Image` items from the provided URLs
- Images are prepended to the user input items before the text prompt

## Testing

```bash
cargo build -p codex-mcp-server --manifest-path codex-rs/Cargo.toml
cargo test -p codex-mcp-server --manifest-path codex-rs/Cargo.toml
```

All 9 tests pass.
