### PR TITLE
perf: optimize text truncation using Cow to avoid unnecessary allocate

### DIFF
--- a/codex-rs/core/dfa_unless_trusted_5_1.txt
+++ b/codex-rs/core/dfa_unless_trusted_5_1.txt
@@ -1,1 +1,0 @@
-danger-unless-trusted

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -291,7 +291,7 @@ fn build_compacted_history_with_limit(
                 remaining = remaining.saturating_sub(tokens);
             } else {
                 let truncated = truncate_text(message, TruncationPolicy::Tokens(remaining));
-                selected_messages.push(truncated);
+                selected_messages.push(truncated.into_owned());
                 break;
             }
         }

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -278,7 +278,7 @@ impl ContextManager {
                 ResponseItem::FunctionCallOutput {
                     call_id: call_id.clone(),
                     output: FunctionCallOutputPayload {
-                        content: truncated,
+                        content: truncated.into_owned(),
                         content_items: truncated_items,
                         success: output.success,
                     },
@@ -288,7 +288,7 @@ impl ContextManager {
                 let truncated = truncate_text(output, policy_with_serialization_budget);
                 ResponseItem::CustomToolCallOutput {
                     call_id: call_id.clone(),
-                    output: truncated,
+                    output: truncated.into_owned(),
                 }
             }
             ResponseItem::Message { .. }

--- a/codex-rs/core/src/context_manager/history_tests.rs
+++ b/codex-rs/core/src/context_manager/history_tests.rs
@@ -79,7 +79,7 @@ fn reasoning_with_encrypted_content(len: usize) -> ResponseItem {
 }
 
 fn truncate_exec_output(content: &str) -> String {
-    truncate::truncate_text(content, TruncationPolicy::Tokens(EXEC_FORMAT_MAX_TOKENS))
+    truncate::truncate_text(content, TruncationPolicy::Tokens(EXEC_FORMAT_MAX_TOKENS)).into_owned()
 }
 
 #[test]

--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -567,6 +567,7 @@ pub fn get_error_message_ui(e: &CodexErr) -> String {
         &message,
         TruncationPolicy::Bytes(ERROR_MESSAGE_UI_MAX_BYTES),
     )
+    .into_owned()
 }
 
 #[cfg(test)]

--- a/codex-rs/core/src/tools/mod.rs
+++ b/codex-rs/core/src/tools/mod.rs
@@ -85,7 +85,7 @@ pub fn format_exec_output_for_model_freeform(
     }
 
     sections.push("Output:".to_string());
-    sections.push(formatted_output);
+    sections.push(formatted_output.into_owned());
 
     sections.join("\n")
 }


### PR DESCRIPTION
Fixes #9684 

I have read the CLA Document and I hereby sign the CLA

Previously, the code always returned a String even when truncation wasn't needed, leading to redundant heap memory allocation. I've refactored the utility function in `core/src/truncate.rs` to use `Cow<'a, str>`, providing a zero-copy fast path for undisturbed text. This reduces both memory pressure and the time spent on CPU allocation.
