### PR TITLE
fix(tui): improve diff view visibility on dark themes

### DIFF
--- a/codex-rs/tui/src/diff_render.rs
+++ b/codex-rs/tui/src/diff_render.rs
@@ -126,9 +126,9 @@ fn collect_rows(changes: &HashMap<PathBuf, FileChange>) -> Vec<Row> {
 fn render_line_count_summary(added: usize, removed: usize) -> Vec<RtSpan<'static>> {
     let mut spans = Vec::new();
     spans.push("(".into());
-    spans.push(format!("+{added}").green());
+    spans.push(format!("+{added}").light_green());
     spans.push(" ".into());
-    spans.push(format!("-{removed}").red());
+    spans.push(format!("-{removed}").light_red());
     spans.push(")".into());
     spans
 }
@@ -420,11 +420,11 @@ fn style_context() -> Style {
 }
 
 fn style_add() -> Style {
-    Style::default().fg(Color::Green)
+    Style::default().fg(Color::LightGreen)
 }
 
 fn style_del() -> Style {
-    Style::default().fg(Color::Red)
+    Style::default().fg(Color::LightRed)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Fixes #9694

This PR improves the visibility of diff text in the TUI diff view when using dark terminal themes. The issue was that the diff view used `Color::Green` and `Color::Red` from ratatui's basic ANSI palette, which can render as dark shades on some terminal configurations, making text difficult to read on dark backgrounds.

## Changes

- Changed `style_add()` from `Color::Green` to `Color::LightGreen`
- Changed `style_del()` from `Color::Red` to `Color::LightRed`
- Updated `render_line_count_summary()` to use `.light_green()` and `.light_red()` stylize methods

The "light" color variants are the bright ANSI colors (indices 10 and 9) which have significantly better visibility on dark terminal themes while still working well on light themes.

## Test plan

- [x] All existing `diff_render` tests pass (11 tests)
- [ ] Manual testing with dark terminal theme to verify improved visibility

---
🤖 Generated with Claude Code