### PR TITLE
feat: allow config overrides for collaboration modes

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -442,10 +442,17 @@ impl CodexMessageProcessor {
             ClientRequest::CollaborationModeList { request_id, params } => {
                 let outgoing = self.outgoing.clone();
                 let thread_manager = self.thread_manager.clone();
+                let config = self.config.clone();
 
                 tokio::spawn(async move {
-                    Self::list_collaboration_modes(outgoing, thread_manager, request_id, params)
-                        .await;
+                    Self::list_collaboration_modes(
+                        outgoing,
+                        thread_manager,
+                        config,
+                        request_id,
+                        params,
+                    )
+                    .await;
                 });
             }
             ClientRequest::McpServerOauthLogin { request_id, params } => {
@@ -2382,11 +2389,12 @@ impl CodexMessageProcessor {
     async fn list_collaboration_modes(
         outgoing: Arc<OutgoingMessageSender>,
         thread_manager: Arc<ThreadManager>,
+        config: Arc<Config>,
         request_id: RequestId,
         params: CollaborationModeListParams,
     ) {
         let CollaborationModeListParams {} = params;
-        let items = thread_manager.list_collaboration_modes();
+        let items = thread_manager.list_collaboration_modes(&config);
         let response = CollaborationModeListResponse { data: items };
         outgoing.send_response(request_id, response).await;
     }

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -127,6 +127,9 @@
         "chatgpt_base_url": {
           "type": "string"
         },
+        "collaboration_modes": {
+          "$ref": "#/definitions/CollaborationModesToml"
+        },
         "experimental_compact_prompt_file": {
           "$ref": "#/definitions/AbsolutePathBuf"
         },
@@ -260,6 +263,42 @@
         },
         "web_search": {
           "$ref": "#/definitions/WebSearchMode"
+        }
+      },
+      "type": "object"
+    },
+    "CollaborationModeOverrideToml": {
+      "additionalProperties": false,
+      "properties": {
+        "developer_instructions": {
+          "type": "string"
+        },
+        "developer_instructions_file": {
+          "$ref": "#/definitions/AbsolutePathBuf"
+        },
+        "model": {
+          "type": "string"
+        },
+        "reasoning_effort": {
+          "$ref": "#/definitions/ReasoningEffort"
+        }
+      },
+      "type": "object"
+    },
+    "CollaborationModesToml": {
+      "additionalProperties": false,
+      "properties": {
+        "custom": {
+          "$ref": "#/definitions/CollaborationModeOverrideToml"
+        },
+        "execute": {
+          "$ref": "#/definitions/CollaborationModeOverrideToml"
+        },
+        "pair_programming": {
+          "$ref": "#/definitions/CollaborationModeOverrideToml"
+        },
+        "plan": {
+          "$ref": "#/definitions/CollaborationModeOverrideToml"
         }
       },
       "type": "object"
@@ -1472,6 +1511,14 @@
         }
       ],
       "description": "Collection of settings that are specific to the TUI."
+    },
+    "collaboration_modes": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CollaborationModesToml"
+        }
+      ],
+      "description": "Optional collaboration mode preset overrides."
     },
     "web_search": {
       "allOf": [

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -114,6 +114,56 @@
         }
       ]
     },
+    "CollaborationModeOverrideToml": {
+      "additionalProperties": false,
+      "description": "Overrides for a collaboration mode preset loaded from config.toml.",
+      "properties": {
+        "developer_instructions": {
+          "description": "Optional inline developer instructions for this mode.",
+          "type": "string"
+        },
+        "developer_instructions_file": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/AbsolutePathBuf"
+            }
+          ],
+          "description": "Optional path to a file containing developer instructions for this mode."
+        },
+        "model": {
+          "description": "Optional model override.",
+          "type": "string"
+        },
+        "reasoning_effort": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/ReasoningEffort"
+            }
+          ],
+          "description": "Optional reasoning effort override."
+        }
+      },
+      "type": "object"
+    },
+    "CollaborationModesToml": {
+      "additionalProperties": false,
+      "description": "Optional collaboration mode presets loaded from config.toml.",
+      "properties": {
+        "custom": {
+          "$ref": "#/definitions/CollaborationModeOverrideToml"
+        },
+        "execute": {
+          "$ref": "#/definitions/CollaborationModeOverrideToml"
+        },
+        "pair_programming": {
+          "$ref": "#/definitions/CollaborationModeOverrideToml"
+        },
+        "plan": {
+          "$ref": "#/definitions/CollaborationModeOverrideToml"
+        }
+      },
+      "type": "object"
+    },
     "ConfigProfile": {
       "additionalProperties": false,
       "description": "Collection of common configuration options that a user can define as a unit in `config.toml`.",
@@ -128,7 +178,12 @@
           "type": "string"
         },
         "collaboration_modes": {
-          "$ref": "#/definitions/CollaborationModesToml"
+          "allOf": [
+            {
+              "$ref": "#/definitions/CollaborationModesToml"
+            }
+          ],
+          "description": "Optional collaboration mode preset overrides."
         },
         "experimental_compact_prompt_file": {
           "$ref": "#/definitions/AbsolutePathBuf"
@@ -263,42 +318,6 @@
         },
         "web_search": {
           "$ref": "#/definitions/WebSearchMode"
-        }
-      },
-      "type": "object"
-    },
-    "CollaborationModeOverrideToml": {
-      "additionalProperties": false,
-      "properties": {
-        "developer_instructions": {
-          "type": "string"
-        },
-        "developer_instructions_file": {
-          "$ref": "#/definitions/AbsolutePathBuf"
-        },
-        "model": {
-          "type": "string"
-        },
-        "reasoning_effort": {
-          "$ref": "#/definitions/ReasoningEffort"
-        }
-      },
-      "type": "object"
-    },
-    "CollaborationModesToml": {
-      "additionalProperties": false,
-      "properties": {
-        "custom": {
-          "$ref": "#/definitions/CollaborationModeOverrideToml"
-        },
-        "execute": {
-          "$ref": "#/definitions/CollaborationModeOverrideToml"
-        },
-        "pair_programming": {
-          "$ref": "#/definitions/CollaborationModeOverrideToml"
-        },
-        "plan": {
-          "$ref": "#/definitions/CollaborationModeOverrideToml"
         }
       },
       "type": "object"
@@ -1135,6 +1154,14 @@
       "default": null,
       "description": "Preferred backend for storing CLI auth credentials. file (default): Use a file in the Codex home directory. keyring: Use an OS-specific keyring service. auto: Use the keyring if available, otherwise use a file."
     },
+    "collaboration_modes": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/CollaborationModesToml"
+        }
+      ],
+      "description": "Optional collaboration mode preset overrides."
+    },
     "compact_prompt": {
       "description": "Compact prompt used for history compaction.",
       "type": "string"
@@ -1511,14 +1538,6 @@
         }
       ],
       "description": "Collection of settings that are specific to the TUI."
-    },
-    "collaboration_modes": {
-      "allOf": [
-        {
-          "$ref": "#/definitions/CollaborationModesToml"
-        }
-      ],
-      "description": "Optional collaboration mode preset overrides."
     },
     "web_search": {
       "allOf": [

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -313,6 +313,9 @@ pub struct Config {
     /// Optional verbosity control for GPT-5 models (Responses API `text.verbosity`).
     pub model_verbosity: Option<Verbosity>,
 
+    /// Optional collaboration mode preset overrides loaded from config.toml.
+    pub collaboration_modes: Option<CollaborationModesConfig>,
+
     /// Base URL for requests to ChatGPT (as opposed to the OpenAI API).
     pub chatgpt_base_url: String,
 
@@ -890,9 +893,6 @@ pub struct ConfigToml {
     /// Optional verbosity control for GPT-5 models (Responses API `text.verbosity`).
     pub model_verbosity: Option<Verbosity>,
 
-    /// Optional collaboration mode preset overrides loaded from config.toml.
-    pub collaboration_modes: Option<CollaborationModesConfig>,
-
     /// Override to force-enable reasoning summaries for the configured model.
     pub model_supports_reasoning_summaries: Option<bool>,
 
@@ -1372,6 +1372,8 @@ impl Config {
             None => ConfigProfile::default(),
         };
 
+        let collaboration_modes = resolve_collaboration_modes(&cfg, &config_profile)?;
+
         let feature_overrides = FeatureOverrides {
             include_apply_patch_tool: include_apply_patch_tool_override,
             web_search_request: override_tools_web_search_request,
@@ -1531,7 +1533,6 @@ impl Config {
         let forced_login_method = cfg.forced_login_method;
 
         let model = model.or(config_profile.model).or(cfg.model);
-        let collaboration_modes = resolve_collaboration_modes(&cfg, &config_profile)?;
 
         let compact_prompt = compact_prompt.or(cfg.compact_prompt).and_then(|value| {
             let trimmed = value.trim();

--- a/codex-rs/core/src/config/profile.rs
+++ b/codex-rs/core/src/config/profile.rs
@@ -3,6 +3,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::config::types::CollaborationModesToml;
 use crate::config::types::Personality;
 use crate::protocol::AskForApproval;
 use codex_protocol::config_types::ReasoningSummary;
@@ -27,6 +28,8 @@ pub struct ConfigProfile {
     pub model_verbosity: Option<Verbosity>,
     pub model_personality: Option<Personality>,
     pub chatgpt_base_url: Option<String>,
+    /// Optional collaboration mode preset overrides.
+    pub collaboration_modes: Option<CollaborationModesToml>,
     /// Optional path to a file containing model instructions.
     pub model_instructions_file: Option<AbsolutePathBuf>,
     /// Deprecated: ignored. Use `model_instructions_file`.

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -8,6 +8,7 @@ pub use codex_protocol::config_types::AltScreenMode;
 pub use codex_protocol::config_types::ModeKind;
 pub use codex_protocol::config_types::Personality;
 pub use codex_protocol::config_types::WebSearchMode;
+use codex_protocol::openai_models::ReasoningEffort;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -458,6 +459,31 @@ pub struct Tui {
 
 const fn default_true() -> bool {
     true
+}
+
+/// Overrides for a collaboration mode preset loaded from config.toml.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct CollaborationModeOverrideToml {
+    /// Optional model override.
+    pub model: Option<String>,
+    /// Optional reasoning effort override.
+    pub reasoning_effort: Option<ReasoningEffort>,
+    /// Optional inline developer instructions for this mode.
+    pub developer_instructions: Option<String>,
+    /// Optional path to a file containing developer instructions for this mode.
+    pub developer_instructions_file: Option<AbsolutePathBuf>,
+}
+
+/// Optional collaboration mode presets loaded from config.toml.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+#[schemars(deny_unknown_fields)]
+pub struct CollaborationModesToml {
+    pub plan: Option<CollaborationModeOverrideToml>,
+    pub pair_programming: Option<CollaborationModeOverrideToml>,
+    pub execute: Option<CollaborationModeOverrideToml>,
+    pub custom: Option<CollaborationModeOverrideToml>,
 }
 
 /// Settings for notices we display to users via the tui and app-server clients

--- a/codex-rs/core/src/models_manager/collaboration_mode_presets.rs
+++ b/codex-rs/core/src/models_manager/collaboration_mode_presets.rs
@@ -1,3 +1,5 @@
+use crate::config::CollaborationModeOverride;
+use crate::config::CollaborationModesConfig;
 use codex_protocol::config_types::CollaborationMode;
 use codex_protocol::config_types::Settings;
 use codex_protocol::openai_models::ReasoningEffort;
@@ -9,7 +11,23 @@ const COLLABORATION_MODE_EXECUTE: &str =
     include_str!("../../templates/collaboration_mode/execute.md");
 
 pub(super) fn builtin_collaboration_mode_presets() -> Vec<CollaborationMode> {
-    vec![plan_preset(), pair_programming_preset(), execute_preset()]
+    builtin_collaboration_mode_presets_with_overrides(None)
+}
+
+pub(super) fn builtin_collaboration_mode_presets_with_overrides(
+    overrides: Option<&CollaborationModesConfig>,
+) -> Vec<CollaborationMode> {
+    vec![
+        apply_override(plan_preset(), overrides.and_then(|modes| modes.plan.as_ref())),
+        apply_override(
+            pair_programming_preset(),
+            overrides.and_then(|modes| modes.pair_programming.as_ref()),
+        ),
+        apply_override(
+            execute_preset(),
+            overrides.and_then(|modes| modes.execute.as_ref()),
+        ),
+    ]
 }
 
 #[cfg(any(test, feature = "test-support"))]
@@ -39,4 +57,78 @@ fn execute_preset() -> CollaborationMode {
         reasoning_effort: Some(ReasoningEffort::XHigh),
         developer_instructions: Some(COLLABORATION_MODE_EXECUTE.to_string()),
     })
+}
+
+fn apply_override(
+    preset: CollaborationMode,
+    override_cfg: Option<&CollaborationModeOverride>,
+) -> CollaborationMode {
+    let Some(override_cfg) = override_cfg else {
+        return preset;
+    };
+
+    let (variant, settings) = match preset {
+        CollaborationMode::Plan(settings) => (ModeVariant::Plan, settings),
+        CollaborationMode::PairProgramming(settings) => (ModeVariant::PairProgramming, settings),
+        CollaborationMode::Execute(settings) => (ModeVariant::Execute, settings),
+        CollaborationMode::Custom(settings) => (ModeVariant::Custom, settings),
+    };
+
+    let merged = Settings {
+        model: override_cfg.model.clone().unwrap_or(settings.model),
+        reasoning_effort: override_cfg.reasoning_effort.or(settings.reasoning_effort),
+        developer_instructions: override_cfg
+            .developer_instructions
+            .clone()
+            .or(settings.developer_instructions),
+    };
+
+    match variant {
+        ModeVariant::Plan => CollaborationMode::Plan(merged),
+        ModeVariant::PairProgramming => CollaborationMode::PairProgramming(merged),
+        ModeVariant::Execute => CollaborationMode::Execute(merged),
+        ModeVariant::Custom => CollaborationMode::Custom(merged),
+    }
+}
+
+enum ModeVariant {
+    Plan,
+    PairProgramming,
+    Execute,
+    Custom,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn overrides_apply_to_presets() {
+        let overrides = CollaborationModesConfig {
+            plan: Some(CollaborationModeOverride {
+                model: Some("override-model".to_string()),
+                reasoning_effort: Some(ReasoningEffort::Low),
+                developer_instructions: Some("override plan".to_string()),
+            }),
+            ..Default::default()
+        };
+
+        let presets = builtin_collaboration_mode_presets_with_overrides(Some(&overrides));
+        let plan = presets
+            .into_iter()
+            .find(|preset| matches!(preset, CollaborationMode::Plan(_)))
+            .expect("plan preset");
+
+        match plan {
+            CollaborationMode::Plan(settings) => {
+                assert_eq!(settings.model, "override-model");
+                assert_eq!(settings.reasoning_effort, Some(ReasoningEffort::Low));
+                assert_eq!(
+                    settings.developer_instructions.as_deref(),
+                    Some("override plan")
+                );
+            }
+            _ => unreachable!("expected plan preset"),
+        }
+    }
 }

--- a/codex-rs/core/src/models_manager/manager.rs
+++ b/codex-rs/core/src/models_manager/manager.rs
@@ -2,13 +2,13 @@ use super::cache::ModelsCacheManager;
 use crate::api_bridge::auth_provider_from_auth;
 use crate::api_bridge::map_api_error;
 use crate::auth::AuthManager;
-use crate::config::Config;
 use crate::default_client::build_reqwest_client;
 use crate::error::CodexErr;
 use crate::error::Result as CoreResult;
 use crate::features::Feature;
 use crate::model_provider_info::ModelProviderInfo;
-use crate::models_manager::collaboration_mode_presets::builtin_collaboration_mode_presets;
+use crate::config::Config;
+use crate::models_manager::collaboration_mode_presets::builtin_collaboration_mode_presets_with_overrides;
 use crate::models_manager::model_info;
 use crate::models_manager::model_presets::builtin_model_presets;
 use codex_api::ModelsClient;
@@ -94,8 +94,9 @@ impl ModelsManager {
     /// List collaboration mode presets.
     ///
     /// Returns a static set of presets seeded with the configured model.
-    pub fn list_collaboration_modes(&self) -> Vec<CollaborationMode> {
-        builtin_collaboration_mode_presets()
+    pub fn list_collaboration_modes(&self, config: Option<&Config>) -> Vec<CollaborationMode> {
+        let overrides = config.and_then(|cfg| cfg.collaboration_modes.as_ref());
+        builtin_collaboration_mode_presets_with_overrides(overrides)
     }
 
     /// Attempt to list models without blocking, using the current cached state.

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -158,8 +158,8 @@ impl ThreadManager {
             .await
     }
 
-    pub fn list_collaboration_modes(&self) -> Vec<CollaborationMode> {
-        self.state.models_manager.list_collaboration_modes()
+    pub fn list_collaboration_modes(&self, config: &Config) -> Vec<CollaborationMode> {
+        self.state.models_manager.list_collaboration_modes(Some(config))
     }
 
     pub async fn list_thread_ids(&self) -> Vec<ThreadId> {

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -778,7 +778,7 @@ async fn make_chatwidget_manual(
     let collaboration_modes_enabled = cfg.features.enabled(Feature::CollaborationModes);
     let reasoning_effort = None;
     let stored_collaboration_mode = if collaboration_modes_enabled {
-        collaboration_modes::default_mode(models_manager.as_ref()).unwrap_or_else(|| {
+        collaboration_modes::default_mode(models_manager.as_ref(), cfg).unwrap_or_else(|| {
             CollaborationMode::Custom(Settings {
                 model: resolved_model.clone(),
                 reasoning_effort,

--- a/codex-rs/tui/src/collaboration_modes.rs
+++ b/codex-rs/tui/src/collaboration_modes.rs
@@ -1,6 +1,9 @@
+use codex_core::config::CollaborationModeOverride;
+use codex_core::config::Config;
 use codex_core::models_manager::manager::ModelsManager;
 use codex_protocol::config_types::CollaborationMode;
 use codex_protocol::config_types::ModeKind;
+use codex_protocol::config_types::Settings;
 
 fn mode_kind(mode: &CollaborationMode) -> ModeKind {
     match mode {
@@ -11,8 +14,11 @@ fn mode_kind(mode: &CollaborationMode) -> ModeKind {
     }
 }
 
-pub(crate) fn default_mode(models_manager: &ModelsManager) -> Option<CollaborationMode> {
-    let presets = models_manager.list_collaboration_modes();
+pub(crate) fn default_mode(
+    models_manager: &ModelsManager,
+    config: &Config,
+) -> Option<CollaborationMode> {
+    let presets = presets(models_manager, config);
     presets
         .iter()
         .find(|preset| matches!(preset, CollaborationMode::PairProgramming(_)))
@@ -22,9 +28,14 @@ pub(crate) fn default_mode(models_manager: &ModelsManager) -> Option<Collaborati
 
 pub(crate) fn mode_for_kind(
     models_manager: &ModelsManager,
+    config: &Config,
     kind: ModeKind,
+    fallback_custom: Settings,
 ) -> Option<CollaborationMode> {
-    let presets = models_manager.list_collaboration_modes();
+    if kind == ModeKind::Custom {
+        return Some(custom_mode(config, fallback_custom));
+    }
+    let presets = presets(models_manager, config);
     presets.into_iter().find(|preset| mode_kind(preset) == kind)
 }
 
@@ -35,9 +46,10 @@ pub(crate) fn same_variant(a: &CollaborationMode, b: &CollaborationMode) -> bool
 /// Cycle to the next collaboration mode preset in list order.
 pub(crate) fn next_mode(
     models_manager: &ModelsManager,
+    config: &Config,
     current: &CollaborationMode,
 ) -> Option<CollaborationMode> {
-    let presets = models_manager.list_collaboration_modes();
+    let presets = presets(models_manager, config);
     if presets.is_empty() {
         return None;
     }
@@ -47,4 +59,30 @@ pub(crate) fn next_mode(
         .position(|preset| mode_kind(preset) == current_kind)
         .map_or(0, |idx| (idx + 1) % presets.len());
     presets.get(next_index).cloned()
+}
+
+fn presets(models_manager: &ModelsManager, config: &Config) -> Vec<CollaborationMode> {
+    models_manager.list_collaboration_modes(Some(config))
+}
+
+fn custom_mode(config: &Config, fallback_custom: Settings) -> CollaborationMode {
+    let override_cfg = config
+        .collaboration_modes
+        .as_ref()
+        .and_then(|modes| modes.custom.as_ref());
+    CollaborationMode::Custom(apply_override(fallback_custom, override_cfg))
+}
+
+fn apply_override(settings: Settings, override_cfg: Option<&CollaborationModeOverride>) -> Settings {
+    let Some(override_cfg) = override_cfg else {
+        return settings;
+    };
+    Settings {
+        model: override_cfg.model.clone().unwrap_or(settings.model),
+        reasoning_effort: override_cfg.reasoning_effort.or(settings.reasoning_effort),
+        developer_instructions: override_cfg
+            .developer_instructions
+            .clone()
+            .or(settings.developer_instructions),
+    }
 }


### PR DESCRIPTION
## Summary
- add config.toml overrides for collaboration mode presets (plan/pair/execute/custom)
- apply overrides when listing presets in the TUI/app-server path
- fix instruction precedence so profile inline overrides base file
- regenerate config schema

## Testing
- cargo run -p codex-core --bin codex-write-config-schema
- cargo test -p codex-core overrides_apply_to_presets
- cargo test -p codex-core collaboration_mode_instructions_profile_inline_overrides_base_file