### PR TITLE
feat(core): add elapsed-ms to notify payload

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 use std::sync::atomic::AtomicBool;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
+use std::time::Instant;
 
 use crate::AuthManager;
 use crate::CodexAuth;
@@ -2798,6 +2799,8 @@ pub(crate) async fn run_turn(
         return None;
     }
 
+    let turn_start = Instant::now();
+
     let model_info = turn_context.client.get_model_info();
     let auto_compact_limit = model_info.auto_compact_token_limit().unwrap_or(i64::MAX);
     let total_usage_tokens = sess.get_total_token_usage().await;
@@ -2905,6 +2908,7 @@ pub(crate) async fn run_turn(
                             cwd: turn_context.cwd.display().to_string(),
                             input_messages: sampling_request_input_messages,
                             last_assistant_message: last_agent_message.clone(),
+                            elapsed_ms: turn_start.elapsed().as_millis() as u64,
                         });
                     break;
                 }

--- a/codex-rs/core/src/user_notification.rs
+++ b/codex-rs/core/src/user_notification.rs
@@ -58,6 +58,9 @@ pub(crate) enum UserNotification {
 
         /// The last message sent by the assistant in the turn.
         last_assistant_message: Option<String>,
+
+        /// Time elapsed since the turn started, in milliseconds.
+        elapsed_ms: u64,
     },
 }
 
@@ -76,11 +79,12 @@ mod tests {
             last_assistant_message: Some(
                 "Rename complete and verified `cargo build` succeeds.".to_string(),
             ),
+            elapsed_ms: 15432,
         };
         let serialized = serde_json::to_string(&notification)?;
         assert_eq!(
             serialized,
-            r#"{"type":"agent-turn-complete","thread-id":"b5f6c1c2-1111-2222-3333-444455556666","turn-id":"12345","cwd":"/Users/example/project","input-messages":["Rename `foo` to `bar` and update the callsites."],"last-assistant-message":"Rename complete and verified `cargo build` succeeds."}"#
+            r#"{"type":"agent-turn-complete","thread-id":"b5f6c1c2-1111-2222-3333-444455556666","turn-id":"12345","cwd":"/Users/example/project","input-messages":["Rename `foo` to `bar` and update the callsites."],"last-assistant-message":"Rename complete and verified `cargo build` succeeds.","elapsed-ms":15432}"#
         );
         Ok(())
     }

--- a/codex-rs/core/tests/suite/user_notification.rs
+++ b/codex-rs/core/tests/suite/user_notification.rs
@@ -75,6 +75,11 @@ echo -n "${@: -1}" > $(dirname "${0}")/notify.txt"#,
     assert_eq!(payload["type"], json!("agent-turn-complete"));
     assert_eq!(payload["input-messages"], json!(["hello world"]));
     assert_eq!(payload["last-assistant-message"], json!("Done"));
+    assert!(
+        payload["elapsed-ms"].is_u64(),
+        "expected elapsed-ms to be a u64, got {:?}",
+        payload["elapsed-ms"]
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes #9657

Adds an `elapsed-ms` field to the `agent-turn-complete` notification payload. This allows users to conditionally enable desktop notifications based on task duration - for example, only triggering notifications when a task takes longer than a specified threshold.

## Changes

- Added `elapsed_ms: u64` field to `UserNotification::AgentTurnComplete` in `user_notification.rs`
- Track turn start time using `std::time::Instant` in `run_turn()` function
- Include elapsed time (in milliseconds) when emitting the notification
- Updated unit test to verify the new field is serialized correctly
- Updated integration test to verify the field is present in the notification payload

## Example payload

```json
{
  "type": "agent-turn-complete",
  "thread-id": "...",
  "turn-id": "...",
  "cwd": "/path/to/project",
  "input-messages": ["hello world"],
  "last-assistant-message": "Done",
  "elapsed-ms": 15432
}
```

## Test plan

- [x] Unit test `test_user_notification` passes
- [x] Builds successfully
- [ ] Integration test (requires network, marked flaky)

---
🤖 Generated with Claude Code