### PR TITLE
cli/tui: add codex trust + warn on untrusted MCP config

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -8,7 +8,11 @@ For a full configuration reference, see [this documentation](https://developers.
 
 ## Connecting to MCP servers
 
-Codex can connect to MCP servers configured in `~/.codex/config.toml`. See the configuration reference for the latest MCP server options:
+Codex can connect to MCP servers configured in `~/.codex/config.toml` (global config) and `.codex/config.toml` (project-local config).
+
+For security, project-local config is only loaded for trusted projects. You can trust the current directory via the TUI prompt, or by running `codex trust`.
+
+See the configuration reference for the latest MCP server options:
 
 - https://developers.openai.com/codex/config-reference
 


### PR DESCRIPTION
Fixes #9676.

Project-local `.codex/config.toml` is intentionally only loaded for trusted projects. When `[mcp_servers]` is defined in an untrusted project config, MCP servers can appear to “disappear” after upgrading because the config layer is skipped.

Changes:
• Add `codex trust` to mark the current directory (or git root) as trusted (writes to `CODEX_HOME/config.toml`).
• Improve `codex mcp list` empty-state messaging for the untrusted project-local MCP config case.
• Improve the TUI `/mcp` empty-state with the same guidance.
• Add CLI regression tests covering the untrusted hint + `codex trust` flow.
• Update `docs/config.md` to mention project-local config trust.

Test plan:
```sh
just fmt
just fix -p codex-cli
just fix -p codex-tui
cargo test -p codex-cli
cargo test -p codex-tui
```

Tagging @AyinMostima and @etraut-openai for visibility.