### PR TITLE
TUI: prompt to implement plan and switch to Execute

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1520,6 +1520,13 @@ impl App {
             AppEvent::OpenReviewCustomPrompt => {
                 self.chat_widget.show_review_custom_prompt();
             }
+            AppEvent::SubmitUserMessageWithMode {
+                text,
+                collaboration_mode,
+            } => {
+                self.chat_widget
+                    .submit_user_message_with_mode(text, collaboration_mode);
+            }
             AppEvent::ManageSkillsClosed => {
                 self.chat_widget.handle_manage_skills_closed();
             }

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -240,6 +240,12 @@ pub(crate) enum AppEvent {
     /// Open the custom prompt option from the review popup.
     OpenReviewCustomPrompt,
 
+    /// Submit a user message with an explicit collaboration mode.
+    SubmitUserMessageWithMode {
+        text: String,
+        collaboration_mode: CollaborationMode,
+    },
+
     /// Open the approval popup.
     FullScreenApprovalRequest(ApprovalRequest),
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -922,6 +922,13 @@ impl ChatWidget {
             return;
         }
 
+        if matches!(
+            self.rate_limit_switch_prompt,
+            RateLimitSwitchPromptState::Pending
+        ) {
+            return;
+        }
+
         self.open_plan_implementation_prompt();
     }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -927,8 +927,7 @@ impl ChatWidget {
     fn open_plan_implementation_prompt(&mut self) {
         let execute_mode = collaboration_modes::execute_mode(self.models_manager.as_ref());
         let (implement_actions, implement_disabled_reason) = match execute_mode {
-            Some(mode) => {
-                let collaboration_mode = mode.clone();
+            Some(collaboration_mode) => {
                 let user_text = PLAN_IMPLEMENTATION_EXECUTE_MESSAGE.to_string();
                 let actions: Vec<SelectionAction> = vec![Box::new(move |tx| {
                     tx.send(AppEvent::SubmitUserMessageWithMode {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -121,7 +121,7 @@ use tracing::debug;
 const DEFAULT_MODEL_DISPLAY_NAME: &str = "loading";
 const PLAN_IMPLEMENTATION_TITLE: &str = "Implement this plan?";
 const PLAN_IMPLEMENTATION_YES: &str = "Yes, implement this plan";
-const PLAN_IMPLEMENTATION_NO: &str = "No, and tell the model what to do differently";
+const PLAN_IMPLEMENTATION_NO: &str = "No, stay in Plan mode";
 const PLAN_IMPLEMENTATION_EXECUTE_MESSAGE: &str = "Implement the plan.";
 
 use crate::app_event::AppEvent;
@@ -961,7 +961,7 @@ impl ChatWidget {
             },
             SelectionItem {
                 name: PLAN_IMPLEMENTATION_NO.to_string(),
-                description: Some("Keep planning and share adjustments.".to_string()),
+                description: Some("Continue planning with the model.".to_string()),
                 selected_description: None,
                 is_current: false,
                 actions: Vec::new(),

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup.snap
@@ -4,9 +4,7 @@ expression: popup
 ---
   Implement this plan?
 
-› 1. Yes, implement this plan                       Switch to Execute and
-                                                    start coding.
-  2. No, and tell the model what to do differently  Keep planning and share
-                                                    adjustments.
+› 1. Yes, implement this plan  Switch to Execute and start coding.
+  2. No, stay in Plan mode     Continue planning with the model.
 
   Press enter to confirm or esc to go back

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup.snap
@@ -1,0 +1,12 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: popup
+---
+  Implement this plan?
+
+› 1. Yes, implement this plan                       Switch to Execute and start
+                                                    coding.
+  2. No, and tell the model what to do differently  Keep planning and share
+                                                    adjustments.
+
+  Press enter to confirm or esc to go back

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup.snap
@@ -4,8 +4,8 @@ expression: popup
 ---
   Implement this plan?
 
-› 1. Yes, implement this plan                       Switch to Execute and start
-                                                    coding.
+› 1. Yes, implement this plan                       Switch to Execute and
+                                                    start coding.
   2. No, and tell the model what to do differently  Keep planning and share
                                                     adjustments.
 

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup_no_selected.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup_no_selected.snap
@@ -4,9 +4,7 @@ expression: popup
 ---
   Implement this plan?
 
-  1. Yes, implement this plan                       Switch to Execute and
-                                                    start coding.
-› 2. No, and tell the model what to do differently  Keep planning and share
-                                                    adjustments.
+  1. Yes, implement this plan  Switch to Execute and start coding.
+› 2. No, stay in Plan mode     Continue planning with the model.
 
   Press enter to confirm or esc to go back

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup_no_selected.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup_no_selected.snap
@@ -1,0 +1,12 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: popup
+---
+  Implement this plan?
+
+  1. Yes, implement this plan                       Switch to Execute and
+                                                    start coding.
+› 2. No, and tell the model what to do differently  Keep planning and share
+                                                    adjustments.
+
+  Press enter to confirm or esc to go back

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1170,6 +1170,15 @@ async fn rate_limit_switch_prompt_popup_snapshot() {
     assert_snapshot!("rate_limit_switch_prompt_popup", popup);
 }
 
+#[tokio::test]
+async fn plan_implementation_popup_snapshot() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5")).await;
+    chat.open_plan_implementation_prompt();
+
+    let popup = render_bottom_popup(&chat, 80);
+    assert_snapshot!("plan_implementation_popup", popup);
+}
+
 // (removed experimental resize snapshot test)
 
 #[tokio::test]

--- a/codex-rs/tui/src/collaboration_modes.rs
+++ b/codex-rs/tui/src/collaboration_modes.rs
@@ -48,3 +48,10 @@ pub(crate) fn next_mode(
         .map_or(0, |idx| (idx + 1) % presets.len());
     presets.get(next_index).cloned()
 }
+
+pub(crate) fn execute_mode(models_manager: &ModelsManager) -> Option<CollaborationMode> {
+    models_manager
+        .list_collaboration_modes()
+        .into_iter()
+        .find(|preset| mode_kind(preset) == ModeKind::Execute)
+}


### PR DESCRIPTION
## Summary
- Replace the plan‑implementation prompt with a standard selection popup.
- “Yes” submits a user turn in Execute via a dedicated app event to preserve normal transcript behavior.
- “No” simply dismisses the popup.

<img width="977" height="433" alt="Screenshot 2026-01-22 at 2 00 54 PM" src="https://github.com/user-attachments/assets/91fad06f-7b7a-4cd8-9051-f28a19b750b2" />

## Changes
- Add a plan‑implementation popup using `SelectionViewParams`.
- Add `SubmitUserMessageWithMode` so “Yes” routes through `submit_user_message` (ensures user history + separator state).
- Track `saw_plan_update_this_turn` so the prompt appears even when only `update_plan` is emitted.
- Suppress the plan popup on replayed turns, when messages are queued, or when a rate‑limit prompt is pending.
- Add `execute_mode` helper for collaboration modes.
- Add tests for replay/queued/rate‑limit guards and plan update without final message.
- Add snapshots for both the default and “No”‑selected popup states.