### PR TITLE
feat: add session source as otel metadata tag

### DIFF
--- a/codex-rs/otel/src/lib.rs
+++ b/codex-rs/otel/src/lib.rs
@@ -31,6 +31,7 @@ pub struct OtelEventMetadata {
     pub(crate) auth_mode: Option<String>,
     pub(crate) account_id: Option<String>,
     pub(crate) account_email: Option<String>,
+    pub(crate) session_source: String,
     pub(crate) model: String,
     pub(crate) slug: String,
     pub(crate) log_user_prompts: bool,
@@ -149,8 +150,23 @@ impl OtelManager {
         if !self.metrics_use_metadata_tags {
             return Ok(Vec::new());
         }
-        let mut tags = Vec::with_capacity(5);
+        let mut tags = Vec::with_capacity(8);
         Self::push_metadata_tag(&mut tags, "auth_mode", self.metadata.auth_mode.as_deref())?;
+        Self::push_metadata_tag(
+            &mut tags,
+            "user.account_id",
+            self.metadata.account_id.as_deref(),
+        )?;
+        Self::push_metadata_tag(
+            &mut tags,
+            "user.email",
+            self.metadata.account_email.as_deref(),
+        )?;
+        Self::push_metadata_tag(
+            &mut tags,
+            "session.source",
+            Some(self.metadata.session_source.as_str()),
+        )?;
         Self::push_metadata_tag(&mut tags, "model", Some(self.metadata.model.as_str()))?;
         Self::push_metadata_tag(&mut tags, "app.version", Some(self.metadata.app_version))?;
         Ok(tags)

--- a/codex-rs/otel/src/lib.rs
+++ b/codex-rs/otel/src/lib.rs
@@ -154,7 +154,7 @@ impl OtelManager {
         Self::push_metadata_tag(&mut tags, "auth_mode", self.metadata.auth_mode.as_deref())?;
         Self::push_metadata_tag(
             &mut tags,
-            "session.source",
+            "session_source",
             Some(self.metadata.session_source.as_str()),
         )?;
         Self::push_metadata_tag(&mut tags, "model", Some(self.metadata.model.as_str()))?;

--- a/codex-rs/otel/src/lib.rs
+++ b/codex-rs/otel/src/lib.rs
@@ -150,17 +150,12 @@ impl OtelManager {
         if !self.metrics_use_metadata_tags {
             return Ok(Vec::new());
         }
-        let mut tags = Vec::with_capacity(8);
+        let mut tags = Vec::with_capacity(7);
         Self::push_metadata_tag(&mut tags, "auth_mode", self.metadata.auth_mode.as_deref())?;
         Self::push_metadata_tag(
             &mut tags,
             "user.account_id",
             self.metadata.account_id.as_deref(),
-        )?;
-        Self::push_metadata_tag(
-            &mut tags,
-            "user.email",
-            self.metadata.account_email.as_deref(),
         )?;
         Self::push_metadata_tag(
             &mut tags,

--- a/codex-rs/otel/src/lib.rs
+++ b/codex-rs/otel/src/lib.rs
@@ -150,13 +150,8 @@ impl OtelManager {
         if !self.metrics_use_metadata_tags {
             return Ok(Vec::new());
         }
-        let mut tags = Vec::with_capacity(7);
+        let mut tags = Vec::with_capacity(6);
         Self::push_metadata_tag(&mut tags, "auth_mode", self.metadata.auth_mode.as_deref())?;
-        Self::push_metadata_tag(
-            &mut tags,
-            "user.account_id",
-            self.metadata.account_id.as_deref(),
-        )?;
         Self::push_metadata_tag(
             &mut tags,
             "session.source",

--- a/codex-rs/otel/src/traces/otel_manager.rs
+++ b/codex-rs/otel/src/traces/otel_manager.rs
@@ -40,7 +40,7 @@ impl OtelManager {
         auth_mode: Option<AuthMode>,
         log_user_prompts: bool,
         terminal_type: String,
-        _session_source: SessionSource,
+        session_source: SessionSource,
     ) -> OtelManager {
         Self {
             metadata: OtelEventMetadata {
@@ -48,6 +48,7 @@ impl OtelManager {
                 auth_mode: auth_mode.map(|m| m.to_string()),
                 account_id,
                 account_email,
+                session_source: session_source.to_string(),
                 model: model.to_owned(),
                 slug: slug.to_owned(),
                 log_user_prompts,

--- a/codex-rs/otel/tests/suite/manager_metrics.rs
+++ b/codex-rs/otel/tests/suite/manager_metrics.rs
@@ -55,7 +55,9 @@ fn manager_attaches_metadata_tags_to_metrics() -> Result<()> {
         ("auth_mode".to_string(), AuthMode::ApiKey.to_string()),
         ("model".to_string(), "gpt-5.1".to_string()),
         ("service".to_string(), "codex-cli".to_string()),
+        ("session.source".to_string(), "cli".to_string()),
         ("source".to_string(), "tui".to_string()),
+        ("user.account_id".to_string(), "account-id".to_string()),
     ]);
     assert_eq!(attrs, expected);
 

--- a/codex-rs/otel/tests/suite/manager_metrics.rs
+++ b/codex-rs/otel/tests/suite/manager_metrics.rs
@@ -55,7 +55,7 @@ fn manager_attaches_metadata_tags_to_metrics() -> Result<()> {
         ("auth_mode".to_string(), AuthMode::ApiKey.to_string()),
         ("model".to_string(), "gpt-5.1".to_string()),
         ("service".to_string(), "codex-cli".to_string()),
-        ("session.source".to_string(), "cli".to_string()),
+        ("session_source".to_string(), "cli".to_string()),
         ("source".to_string(), "tui".to_string()),
     ]);
     assert_eq!(attrs, expected);

--- a/codex-rs/otel/tests/suite/manager_metrics.rs
+++ b/codex-rs/otel/tests/suite/manager_metrics.rs
@@ -57,7 +57,6 @@ fn manager_attaches_metadata_tags_to_metrics() -> Result<()> {
         ("service".to_string(), "codex-cli".to_string()),
         ("session.source".to_string(), "cli".to_string()),
         ("source".to_string(), "tui".to_string()),
-        ("user.account_id".to_string(), "account-id".to_string()),
     ]);
     assert_eq!(attrs, expected);
 


### PR DESCRIPTION
Add session_source as global OTEL metric tags to identify client surface