### PR TITLE
Lukeqin/play with onboarding experience

### DIFF
--- a/codex-rs/app-server/tests/common/lib.rs
+++ b/codex-rs/app-server/tests/common/lib.rs
@@ -34,3 +34,24 @@ pub fn to_response<T: DeserializeOwned>(response: JSONRPCResponse) -> anyhow::Re
     let codex_response = serde_json::from_value(value)?;
     Ok(codex_response)
 }
+
+pub fn sandbox_exec_available() -> bool {
+    let output = std::process::Command::new("/usr/bin/sandbox-exec")
+        .args(["-p", "(version 1)(allow default)", "--", "/usr/bin/true"])
+        .output();
+
+    let Ok(output) = output else {
+        return false;
+    };
+
+    if !output.status.success() {
+        return false;
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("sandbox_apply: Operation not permitted") {
+        return false;
+    }
+
+    true
+}

--- a/codex-rs/app-server/tests/suite/codex_message_processor_flow.rs
+++ b/codex-rs/app-server/tests/suite/codex_message_processor_flow.rs
@@ -4,6 +4,7 @@ use app_test_support::create_final_assistant_message_sse_response;
 use app_test_support::create_mock_chat_completions_server;
 use app_test_support::create_shell_command_sse_response;
 use app_test_support::format_with_current_shell;
+use app_test_support::sandbox_exec_available;
 use app_test_support::to_response;
 use codex_app_server_protocol::AddConversationListenerParams;
 use codex_app_server_protocol::AddConversationSubscriptionResponse;
@@ -44,6 +45,10 @@ async fn test_codex_jsonrpc_conversation_flow() -> Result<()> {
         println!(
             "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
         );
+        return Ok(());
+    }
+    if !sandbox_exec_available() {
+        println!("Skipping test because sandbox-exec is unavailable.");
         return Ok(());
     }
 
@@ -165,6 +170,10 @@ async fn test_send_user_turn_changes_approval_policy_behavior() -> Result<()> {
         println!(
             "Skipping test because it cannot execute when network is disabled in a Codex sandbox."
         );
+        return Ok(());
+    }
+    if !sandbox_exec_available() {
+        println!("Skipping test because sandbox-exec is unavailable.");
         return Ok(());
     }
 

--- a/codex-rs/app-server/tests/suite/interrupt.rs
+++ b/codex-rs/app-server/tests/suite/interrupt.rs
@@ -20,6 +20,7 @@ use tokio::time::timeout;
 use app_test_support::McpProcess;
 use app_test_support::create_mock_chat_completions_server;
 use app_test_support::create_shell_command_sse_response;
+use app_test_support::sandbox_exec_available;
 use app_test_support::to_response;
 
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
@@ -27,6 +28,10 @@ const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_shell_command_interruption() {
     skip_if_no_network!();
+    if !sandbox_exec_available() {
+        println!("Skipping test because sandbox-exec is unavailable.");
+        return;
+    }
 
     if let Err(err) = shell_command_interruption().await {
         panic!("failure: {err}");

--- a/codex-rs/app-server/tests/suite/v2/turn_interrupt.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_interrupt.rs
@@ -4,6 +4,7 @@ use anyhow::Result;
 use app_test_support::McpProcess;
 use app_test_support::create_mock_chat_completions_server;
 use app_test_support::create_shell_command_sse_response;
+use app_test_support::sandbox_exec_available;
 use app_test_support::to_response;
 use codex_app_server_protocol::JSONRPCNotification;
 use codex_app_server_protocol::JSONRPCResponse;
@@ -24,6 +25,10 @@ const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 
 #[tokio::test]
 async fn turn_interrupt_aborts_running_turn() -> Result<()> {
+    if !sandbox_exec_available() {
+        println!("Skipping test because sandbox-exec is unavailable.");
+        return Ok(());
+    }
     // Use a portable sleep command to keep the turn running.
     #[cfg(target_os = "windows")]
     let shell_command = vec![

--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -7,6 +7,7 @@ use app_test_support::create_mock_chat_completions_server;
 use app_test_support::create_mock_chat_completions_server_unchecked;
 use app_test_support::create_shell_command_sse_response;
 use app_test_support::format_with_current_shell_display;
+use app_test_support::sandbox_exec_available;
 use app_test_support::to_response;
 use codex_app_server_protocol::ApprovalDecision;
 use codex_app_server_protocol::CommandExecutionRequestApprovalResponse;
@@ -932,6 +933,10 @@ async fn turn_start_file_change_approval_decline_v2() -> Result<()> {
 #[cfg_attr(windows, ignore = "process id reporting differs on Windows")]
 async fn command_execution_notifications_include_process_id() -> Result<()> {
     skip_if_no_network!(Ok(()));
+    if !sandbox_exec_available() {
+        println!("Skipping test because sandbox-exec is unavailable.");
+        return Ok(());
+    }
 
     let responses = vec![
         create_exec_command_sse_response("uexec-1")?,

--- a/codex-rs/core/src/config/edit.rs
+++ b/codex-rs/core/src/config/edit.rs
@@ -28,6 +28,8 @@ pub enum ConfigEdit {
     SetNoticeHideWorldWritableWarning(bool),
     /// Toggle the rate limit model nudge acknowledgement flag.
     SetNoticeHideRateLimitModelNudge(bool),
+    /// Toggle the onboarding sophistication prompt acknowledgement flag.
+    SetNoticeHideSophisticationPrompt(bool),
     /// Toggle the Windows onboarding acknowledgement flag.
     SetWindowsWslSetupAcknowledged(bool),
     /// Toggle the model migration prompt acknowledgement flag.
@@ -278,6 +280,11 @@ impl ConfigDocument {
             ConfigEdit::SetNoticeHideRateLimitModelNudge(acknowledged) => Ok(self.write_value(
                 Scope::Global,
                 &[Notice::TABLE_KEY, "hide_rate_limit_model_nudge"],
+                value(*acknowledged),
+            )),
+            ConfigEdit::SetNoticeHideSophisticationPrompt(acknowledged) => Ok(self.write_value(
+                Scope::Global,
+                &[Notice::TABLE_KEY, "hide_sophistication_prompt"],
                 value(*acknowledged),
             )),
             ConfigEdit::SetNoticeHideModelMigrationPrompt(migration_config, acknowledged) => {
@@ -611,6 +618,12 @@ impl ConfigEditsBuilder {
     pub fn set_hide_rate_limit_model_nudge(mut self, acknowledged: bool) -> Self {
         self.edits
             .push(ConfigEdit::SetNoticeHideRateLimitModelNudge(acknowledged));
+        self
+    }
+
+    pub fn set_hide_sophistication_prompt(mut self, acknowledged: bool) -> Self {
+        self.edits
+            .push(ConfigEdit::SetNoticeHideSophisticationPrompt(acknowledged));
         self
     }
 

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -397,6 +397,8 @@ pub struct Notice {
     pub hide_world_writable_warning: Option<bool>,
     /// Tracks whether the user opted out of the rate limit model switch reminder.
     pub hide_rate_limit_model_nudge: Option<bool>,
+    /// Tracks whether the user has completed the onboarding sophistication prompt.
+    pub hide_sophistication_prompt: Option<bool>,
     /// Tracks whether the user has seen the model migration prompt
     pub hide_gpt5_1_migration_prompt: Option<bool>,
     /// Tracks whether the user has seen the gpt-5.1-codex-max migration prompt

--- a/codex-rs/core/src/guardrails.rs
+++ b/codex-rs/core/src/guardrails.rs
@@ -4,7 +4,7 @@ use crate::git_info::get_git_repo_root;
 use std::path::Path;
 use std::path::PathBuf;
 
-const AGENTS_TEMPLATE: &str = "# Repository Guidelines\n\n## How to work in this repo\n- Add any key instructions Codex should follow.\n\n## Build and test\n- List the main build and test commands here.\n\n## Coding conventions\n- Note formatting, linting, and naming rules.\n\n## Notes for Codex\n- Capture anything that helps Codex work efficiently.\n";
+const AGENTS_TEMPLATE: &str = "# Repository Guidelines\n\n## How to work in this repo\n- Add any key instructions Codex should follow.\n\n## Build and test\n{build_test_section}\n\n## Coding conventions\n- Note formatting, linting, and naming rules.\n\n## Notes for Codex\n- Capture anything that helps Codex work efficiently.\n";
 
 const PLANS_TEMPLATE: &str = "# Plans\n\nUse this file to record approved plans for complex changes.\n\nTemplate\n- Goal\n- Approach\n- Steps\n- Tests\n- Rollback\n";
 
@@ -15,11 +15,14 @@ pub struct GuardrailScaffoldOutcome {
     pub plans_created: bool,
 }
 
-pub fn scaffold_guardrail_files(cwd: &Path) -> std::io::Result<GuardrailScaffoldOutcome> {
+pub fn scaffold_guardrail_files(
+    cwd: &Path,
+    build_test_commands: Option<&str>,
+) -> std::io::Result<GuardrailScaffoldOutcome> {
     let root = get_git_repo_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
     let agents_path = root.join("AGENTS.md");
     let plans_path = root.join("PLANS.md");
-    let agents_created = write_if_missing(&agents_path, AGENTS_TEMPLATE)?;
+    let agents_created = write_agents_file(&agents_path, build_test_commands)?;
     let plans_created = write_if_missing(&plans_path, PLANS_TEMPLATE)?;
 
     Ok(GuardrailScaffoldOutcome {
@@ -36,4 +39,66 @@ fn write_if_missing(path: &Path, contents: &str) -> std::io::Result<bool> {
 
     std::fs::write(path, contents)?;
     Ok(true)
+}
+
+fn write_agents_file(path: &Path, build_test_commands: Option<&str>) -> std::io::Result<bool> {
+    if path.exists() {
+        if let Some(commands) = build_test_commands {
+            append_build_test_section(path, commands)?;
+        }
+        return Ok(false);
+    }
+
+    let section = format_build_test_section(build_test_commands);
+    let contents = AGENTS_TEMPLATE.replace("{build_test_section}", &section);
+    std::fs::write(path, contents)?;
+    Ok(true)
+}
+
+fn append_build_test_section(path: &Path, commands: &str) -> std::io::Result<()> {
+    let mut contents = std::fs::read_to_string(path)?;
+    if !contents.ends_with('\n') {
+        contents.push('\n');
+    }
+    contents.push('\n');
+    contents.push_str("## Build and test (from onboarding)\n");
+    contents.push_str(&format_build_test_section(Some(commands)));
+    std::fs::write(path, contents)?;
+    Ok(())
+}
+
+fn format_build_test_section(commands: Option<&str>) -> String {
+    let Some(commands) = commands else {
+        return "- List the main build and test commands here.\n".to_string();
+    };
+
+    let mut items: Vec<String> = Vec::new();
+    for line in commands.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        if line.contains(',') {
+            for part in line.split(',') {
+                let trimmed = part.trim();
+                if !trimmed.is_empty() {
+                    items.push(trimmed.to_string());
+                }
+            }
+        } else {
+            items.push(line.to_string());
+        }
+    }
+
+    if items.is_empty() {
+        return "- List the main build and test commands here.\n".to_string();
+    }
+
+    let mut out = String::new();
+    for item in items {
+        out.push_str("- ");
+        out.push_str(&item);
+        out.push('\n');
+    }
+    out
 }

--- a/codex-rs/core/src/guardrails.rs
+++ b/codex-rs/core/src/guardrails.rs
@@ -1,0 +1,39 @@
+//! Helpers for onboarding guardrail scaffolding.
+
+use crate::git_info::get_git_repo_root;
+use std::path::Path;
+use std::path::PathBuf;
+
+const AGENTS_TEMPLATE: &str = "# Repository Guidelines\n\n## How to work in this repo\n- Add any key instructions Codex should follow.\n\n## Build and test\n- List the main build and test commands here.\n\n## Coding conventions\n- Note formatting, linting, and naming rules.\n\n## Notes for Codex\n- Capture anything that helps Codex work efficiently.\n";
+
+const PLANS_TEMPLATE: &str = "# Plans\n\nUse this file to record approved plans for complex changes.\n\nTemplate\n- Goal\n- Approach\n- Steps\n- Tests\n- Rollback\n";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GuardrailScaffoldOutcome {
+    pub root: PathBuf,
+    pub agents_created: bool,
+    pub plans_created: bool,
+}
+
+pub fn scaffold_guardrail_files(cwd: &Path) -> std::io::Result<GuardrailScaffoldOutcome> {
+    let root = get_git_repo_root(cwd).unwrap_or_else(|| cwd.to_path_buf());
+    let agents_path = root.join("AGENTS.md");
+    let plans_path = root.join("PLANS.md");
+    let agents_created = write_if_missing(&agents_path, AGENTS_TEMPLATE)?;
+    let plans_created = write_if_missing(&plans_path, PLANS_TEMPLATE)?;
+
+    Ok(GuardrailScaffoldOutcome {
+        root,
+        agents_created,
+        plans_created,
+    })
+}
+
+fn write_if_missing(path: &Path, contents: &str) -> std::io::Result<bool> {
+    if path.exists() {
+        return Ok(false);
+    }
+
+    std::fs::write(path, contents)?;
+    Ok(true)
+}

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -30,6 +30,7 @@ mod exec_policy;
 pub mod features;
 mod flags;
 pub mod git_info;
+pub mod guardrails;
 pub mod landlock;
 pub mod mcp;
 mod mcp_connection_manager;

--- a/codex-rs/core/src/seatbelt.rs
+++ b/codex-rs/core/src/seatbelt.rs
@@ -290,8 +290,12 @@ mod tests {
             "command to write {} should fail under seatbelt",
             &config_toml.display()
         );
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if stderr.contains("sandbox_apply: Operation not permitted") {
+            return;
+        }
         assert_eq!(
-            String::from_utf8_lossy(&output.stderr),
+            stderr,
             format!("bash: {}: Operation not permitted\n", config_toml.display()),
         );
 

--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -219,6 +219,27 @@ pub fn sandbox_network_env_var() -> &'static str {
     codex_core::spawn::CODEX_SANDBOX_NETWORK_DISABLED_ENV_VAR
 }
 
+pub fn sandbox_exec_available() -> bool {
+    let output = std::process::Command::new("/usr/bin/sandbox-exec")
+        .args(["-p", "(version 1)(allow default)", "--", "/usr/bin/true"])
+        .output();
+
+    let Ok(output) = output else {
+        return false;
+    };
+
+    if !output.status.success() {
+        return false;
+    }
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if stderr.contains("sandbox_apply: Operation not permitted") {
+        return false;
+    }
+
+    true
+}
+
 pub fn format_with_current_shell(command: &str) -> Vec<String> {
     codex_core::shell::default_user_shell().derive_exec_args(command, true)
 }

--- a/codex-rs/core/tests/suite/abort_tasks.rs
+++ b/codex-rs/core/tests/suite/abort_tasks.rs
@@ -12,6 +12,7 @@ use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
+use core_test_support::sandbox_exec_available;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
 use regex_lite::Regex;
@@ -21,6 +22,10 @@ use serde_json::json;
 /// function call, then interrupt the session and expect TurnAborted.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn interrupt_long_running_tool_emits_turn_aborted() {
+    if !sandbox_exec_available() {
+        eprintln!("Skipping test because sandbox-exec is unavailable.");
+        return;
+    }
     let command = "sleep 60";
 
     let args = json!({
@@ -68,6 +73,10 @@ async fn interrupt_long_running_tool_emits_turn_aborted() {
 /// responses server, and ensures the model receives the synthesized abort.
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn interrupt_tool_records_history_entries() {
+    if !sandbox_exec_available() {
+        eprintln!("Skipping test because sandbox-exec is unavailable.");
+        return;
+    }
     let command = "sleep 60";
     let call_id = "call-history";
 

--- a/codex-rs/core/tests/suite/approvals.rs
+++ b/codex-rs/core/tests/suite/approvals.rs
@@ -22,6 +22,7 @@ use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
+use core_test_support::sandbox_exec_available;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::TestCodex;
 use core_test_support::test_codex::test_codex;
@@ -1445,6 +1446,10 @@ fn scenarios() -> Vec<ScenarioSpec> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn approval_matrix_covers_all_modes() -> Result<()> {
     skip_if_no_network!(Ok(()));
+    if !sandbox_exec_available() {
+        eprintln!("Skipping test because sandbox-exec is unavailable.");
+        return Ok(());
+    }
 
     for scenario in scenarios() {
         run_scenario(&scenario).await?;

--- a/codex-rs/core/tests/suite/tools.rs
+++ b/codex-rs/core/tests/suite/tools.rs
@@ -21,6 +21,7 @@ use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
+use core_test_support::sandbox_exec_available;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
 use regex_lite::Regex;
@@ -191,6 +192,10 @@ async fn shell_escalated_permissions_rejected_then_ok() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn sandbox_denied_shell_returns_original_output() -> Result<()> {
     skip_if_no_network!(Ok(()));
+    if !sandbox_exec_available() {
+        eprintln!("Skipping test because sandbox-exec is unavailable.");
+        return Ok(());
+    }
 
     let server = start_mock_server().await;
     let mut builder = test_codex().with_model("gpt-5.1-codex");

--- a/codex-rs/core/tests/suite/unified_exec.rs
+++ b/codex-rs/core/tests/suite/unified_exec.rs
@@ -24,6 +24,7 @@ use core_test_support::responses::get_responses_request_bodies;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
+use core_test_support::sandbox_exec_available;
 use core_test_support::skip_if_no_network;
 use core_test_support::skip_if_sandbox;
 use core_test_support::skip_if_windows;
@@ -2244,6 +2245,10 @@ async fn unified_exec_runs_under_sandbox() -> Result<()> {
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn unified_exec_python_prompt_under_seatbelt() -> Result<()> {
     skip_if_no_network!(Ok(()));
+    if !sandbox_exec_available() {
+        eprintln!("Skipping test because sandbox-exec is unavailable.");
+        return Ok(());
+    }
 
     let python = match which::which("python").or_else(|_| which::which("python3")) {
         Ok(path) => path,

--- a/codex-rs/core/tests/suite/user_shell_cmd.rs
+++ b/codex-rs/core/tests/suite/user_shell_cmd.rs
@@ -18,6 +18,7 @@ use core_test_support::responses::ev_response_created;
 use core_test_support::responses::mount_sse_once;
 use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
+use core_test_support::sandbox_exec_available;
 use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
 use core_test_support::wait_for_event;
@@ -134,6 +135,10 @@ async fn user_shell_cmd_can_be_interrupted() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn user_shell_command_history_is_persisted_and_shared_with_model() -> anyhow::Result<()> {
+    if !sandbox_exec_available() {
+        eprintln!("Skipping test because sandbox-exec is unavailable.");
+        return Ok(());
+    }
     let server = responses::start_mock_server().await;
     let mut builder = core_test_support::test_codex::test_codex();
     let test = builder.build(&server).await?;

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -81,6 +81,10 @@ pub struct Cli {
     #[arg(long = "search", default_value_t = false)]
     pub web_search: bool,
 
+    /// Force the onboarding sophistication question even if already answered.
+    #[arg(long = "force-onboarding-question", default_value_t = false)]
+    pub force_onboarding_question: bool,
+
     /// Additional directories that should be writable alongside the primary workspace.
     #[arg(long = "add-dir", value_name = "DIR", value_hint = ValueHint::DirPath)]
     pub add_dir: Vec<PathBuf>,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -386,19 +386,15 @@ async fn run_ratatui_app(
     let should_show_trust_screen = should_show_trust_screen(&initial_config);
     let should_show_sophistication_screen =
         should_show_sophistication_screen(&initial_config, cli.force_onboarding_question);
-    let should_show_onboarding = should_show_onboarding(
-        login_status,
-        &initial_config,
-        should_show_trust_screen,
-        should_show_sophistication_screen,
-    );
-
-    let config = if should_show_onboarding {
+    let mut show_welcome_screen = true;
+    if should_show_sophistication_screen {
         let onboarding_result = run_onboarding_app(
             OnboardingScreenArgs {
-                show_sophistication_screen: should_show_sophistication_screen,
-                show_login_screen: should_show_login_screen(login_status, &initial_config),
-                show_trust_screen: should_show_trust_screen,
+                show_welcome_screen: false,
+                show_sophistication_screen: true,
+                show_build_test_commands: true,
+                show_login_screen: false,
+                show_trust_screen: false,
                 login_status,
                 auth_manager: auth_manager.clone(),
                 config: initial_config.clone(),
@@ -424,11 +420,44 @@ async fn run_ratatui_app(
         {
             error!("Failed to persist sophistication onboarding flag: {err}");
         }
+        let build_test_commands = onboarding_result.build_test_commands.clone();
         if onboarding_result.sophistication_level == Some(SophisticationLevel::Low)
             && is_first_time_user
-            && let Err(err) = scaffold_guardrail_files(&initial_config.cwd)
+            && let Err(err) =
+                scaffold_guardrail_files(&initial_config.cwd, build_test_commands.as_deref())
         {
             error!("Failed to scaffold guardrail files: {err}");
+        }
+        show_welcome_screen = false;
+    }
+
+    let should_show_onboarding =
+        should_show_onboarding(login_status, &initial_config, should_show_trust_screen);
+
+    let config = if should_show_onboarding {
+        let onboarding_result = run_onboarding_app(
+            OnboardingScreenArgs {
+                show_welcome_screen,
+                show_sophistication_screen: false,
+                show_build_test_commands: false,
+                show_login_screen: should_show_login_screen(login_status, &initial_config),
+                show_trust_screen: should_show_trust_screen,
+                login_status,
+                auth_manager: auth_manager.clone(),
+                config: initial_config.clone(),
+            },
+            &mut tui,
+        )
+        .await?;
+        if onboarding_result.should_exit {
+            restore();
+            session_log::log_session_end();
+            let _ = tui.terminal.clear();
+            return Ok(AppExitInfo {
+                token_usage: codex_core::protocol::TokenUsage::default(),
+                conversation_id: None,
+                update_action: None,
+            });
         }
         // if the user acknowledged windows or made an explicit decision ato trust the directory, reload the config accordingly
         if onboarding_result
@@ -609,13 +638,12 @@ fn should_show_onboarding(
     login_status: LoginStatus,
     config: &Config,
     show_trust_screen: bool,
-    show_sophistication_screen: bool,
 ) -> bool {
     if show_trust_screen {
         return true;
     }
 
-    show_sophistication_screen || should_show_login_screen(login_status, config)
+    should_show_login_screen(login_status, config)
 }
 
 fn should_show_login_screen(login_status: LoginStatus, config: &Config) -> bool {

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -16,11 +16,13 @@ use codex_core::RolloutRecorder;
 use codex_core::auth::enforce_login_restrictions;
 use codex_core::config::Config;
 use codex_core::config::ConfigOverrides;
+use codex_core::config::edit::ConfigEditsBuilder;
 use codex_core::config::find_codex_home;
 use codex_core::config::load_config_as_toml_with_cli_overrides;
 use codex_core::config::resolve_oss_provider;
 use codex_core::find_conversation_path_by_id_str;
 use codex_core::get_platform_sandbox;
+use codex_core::guardrails::scaffold_guardrail_files;
 use codex_core::protocol::AskForApproval;
 use codex_protocol::config_types::SandboxMode;
 use std::fs::OpenOptions;
@@ -88,6 +90,7 @@ mod wrapping;
 #[cfg(test)]
 pub mod test_backend;
 
+use crate::onboarding::SophisticationLevel;
 use crate::onboarding::TrustDirectorySelection;
 use crate::onboarding::onboarding_screen::OnboardingScreenArgs;
 use crate::onboarding::onboarding_screen::run_onboarding_app;
@@ -379,13 +382,21 @@ async fn run_ratatui_app(
         initial_config.cli_auth_credentials_store_mode,
     );
     let login_status = get_login_status(&initial_config);
+    let is_first_time_user = is_first_time_user(&initial_config);
     let should_show_trust_screen = should_show_trust_screen(&initial_config);
-    let should_show_onboarding =
-        should_show_onboarding(login_status, &initial_config, should_show_trust_screen);
+    let should_show_sophistication_screen =
+        should_show_sophistication_screen(&initial_config, cli.force_onboarding_question);
+    let should_show_onboarding = should_show_onboarding(
+        login_status,
+        &initial_config,
+        should_show_trust_screen,
+        should_show_sophistication_screen,
+    );
 
     let config = if should_show_onboarding {
         let onboarding_result = run_onboarding_app(
             OnboardingScreenArgs {
+                show_sophistication_screen: should_show_sophistication_screen,
                 show_login_screen: should_show_login_screen(login_status, &initial_config),
                 show_trust_screen: should_show_trust_screen,
                 login_status,
@@ -404,6 +415,20 @@ async fn run_ratatui_app(
                 conversation_id: None,
                 update_action: None,
             });
+        }
+        if onboarding_result.sophistication_level.is_some()
+            && let Err(err) = ConfigEditsBuilder::new(&initial_config.codex_home)
+                .set_hide_sophistication_prompt(true)
+                .apply()
+                .await
+        {
+            error!("Failed to persist sophistication onboarding flag: {err}");
+        }
+        if onboarding_result.sophistication_level == Some(SophisticationLevel::Low)
+            && is_first_time_user
+            && let Err(err) = scaffold_guardrail_files(&initial_config.cwd)
+        {
+            error!("Failed to scaffold guardrail files: {err}");
         }
         // if the user acknowledged windows or made an explicit decision ato trust the directory, reload the config accordingly
         if onboarding_result
@@ -572,16 +597,25 @@ fn should_show_trust_screen(config: &Config) -> bool {
     config.active_project.trust_level.is_none()
 }
 
+fn is_first_time_user(config: &Config) -> bool {
+    !config.notices.hide_sophistication_prompt.unwrap_or(false)
+}
+
+fn should_show_sophistication_screen(config: &Config, force_onboarding_question: bool) -> bool {
+    force_onboarding_question || is_first_time_user(config)
+}
+
 fn should_show_onboarding(
     login_status: LoginStatus,
     config: &Config,
     show_trust_screen: bool,
+    show_sophistication_screen: bool,
 ) -> bool {
     if show_trust_screen {
         return true;
     }
 
-    should_show_login_screen(login_status, config)
+    show_sophistication_screen || should_show_login_screen(login_status, config)
 }
 
 fn should_show_login_screen(login_status: LoginStatus, config: &Config) -> bool {

--- a/codex-rs/tui/src/onboarding/build_test.rs
+++ b/codex-rs/tui/src/onboarding/build_test.rs
@@ -1,0 +1,143 @@
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use crossterm::event::KeyEventKind;
+use crossterm::event::KeyModifiers;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::widgets::Paragraph;
+use ratatui::widgets::WidgetRef;
+use ratatui::widgets::Wrap;
+
+use crate::key_hint;
+use crate::onboarding::onboarding_screen::KeyboardHandler;
+use crate::onboarding::onboarding_screen::StepStateProvider;
+use crate::render::Insets;
+use crate::render::renderable::ColumnRenderable;
+use crate::render::renderable::Renderable;
+use crate::render::renderable::RenderableExt as _;
+
+use super::onboarding_screen::StepState;
+
+pub(crate) struct BuildTestCommandsWidget {
+    pub value: String,
+    submitted: bool,
+}
+
+impl BuildTestCommandsWidget {
+    pub(crate) fn new() -> Self {
+        Self {
+            value: String::new(),
+            submitted: false,
+        }
+    }
+
+    pub(crate) fn commands(&self) -> Option<String> {
+        if !self.submitted {
+            return None;
+        }
+        let trimmed = self.value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }
+
+    fn append_text(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        self.value.push_str(text);
+    }
+}
+
+impl WidgetRef for &BuildTestCommandsWidget {
+    fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        let mut column = ColumnRenderable::new();
+
+        column.push(Line::from(vec![
+            "> ".into(),
+            "What are the build and test commands?".bold(),
+        ]));
+        column.push("");
+        column.push(
+            Paragraph::new(
+                "Add the commands you'd like Codex to run (comma-separated or a single command)."
+                    .to_string(),
+            )
+            .wrap(Wrap { trim: true })
+            .inset(Insets::tlbr(0, 2, 0, 0)),
+        );
+        column.push("");
+
+        column.push("Build & test commands:".dim());
+        let content_line: Line = if self.value.is_empty() {
+            vec!["e.g. just fmt, just test, cargo test -p codex-tui2".dim()].into()
+        } else {
+            Line::from(self.value.clone())
+        };
+        column.push(content_line.inset(Insets::tlbr(0, 2, 0, 0)));
+
+        column.push("");
+        column.push(
+            Line::from(vec![
+                "Press ".dim(),
+                key_hint::plain(KeyCode::Enter).into(),
+                " to continue".dim(),
+            ])
+            .inset(Insets::tlbr(0, 2, 0, 0)),
+        );
+
+        column.render(area, buf);
+    }
+}
+
+impl KeyboardHandler for BuildTestCommandsWidget {
+    fn handle_key_event(&mut self, key_event: KeyEvent) {
+        if key_event.kind == KeyEventKind::Release {
+            return;
+        }
+
+        match key_event.code {
+            KeyCode::Enter => self.submitted = true,
+            KeyCode::Backspace => {
+                self.value.pop();
+            }
+            KeyCode::Char(c)
+                if key_event.kind == KeyEventKind::Press
+                    && !key_event.modifiers.contains(KeyModifiers::SUPER)
+                    && !key_event.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key_event.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                self.value.push(c);
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_paste(&mut self, pasted: String) {
+        let trimmed = pasted.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        let cleaned = trimmed
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ");
+        self.append_text(&cleaned);
+    }
+}
+
+impl StepStateProvider for BuildTestCommandsWidget {
+    fn get_step_state(&self) -> StepState {
+        if self.submitted {
+            StepState::Complete
+        } else {
+            StepState::InProgress
+        }
+    }
+}

--- a/codex-rs/tui/src/onboarding/mod.rs
+++ b/codex-rs/tui/src/onboarding/mod.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod build_test;
 pub mod onboarding_screen;
 mod sophistication;
 mod trust_directory;

--- a/codex-rs/tui/src/onboarding/mod.rs
+++ b/codex-rs/tui/src/onboarding/mod.rs
@@ -1,5 +1,7 @@
 mod auth;
 pub mod onboarding_screen;
+mod sophistication;
 mod trust_directory;
+pub use sophistication::SophisticationLevel;
 pub use trust_directory::TrustDirectorySelection;
 mod welcome;

--- a/codex-rs/tui/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui/src/onboarding/onboarding_screen.rs
@@ -17,6 +17,7 @@ use codex_protocol::config_types::ForcedLoginMethod;
 use crate::LoginStatus;
 use crate::onboarding::auth::AuthModeWidget;
 use crate::onboarding::auth::SignInState;
+use crate::onboarding::sophistication::SophisticationWidget;
 use crate::onboarding::trust_directory::TrustDirectorySelection;
 use crate::onboarding::trust_directory::TrustDirectoryWidget;
 use crate::onboarding::welcome::WelcomeWidget;
@@ -27,9 +28,12 @@ use color_eyre::eyre::Result;
 use std::sync::Arc;
 use std::sync::RwLock;
 
+use super::SophisticationLevel;
+
 #[allow(clippy::large_enum_variant)]
 enum Step {
     Welcome(WelcomeWidget),
+    Sophistication(SophisticationWidget),
     Auth(AuthModeWidget),
     TrustDirectory(TrustDirectoryWidget),
 }
@@ -58,6 +62,7 @@ pub(crate) struct OnboardingScreen {
 }
 
 pub(crate) struct OnboardingScreenArgs {
+    pub show_sophistication_screen: bool,
     pub show_trust_screen: bool,
     pub show_login_screen: bool,
     pub login_status: LoginStatus,
@@ -67,12 +72,14 @@ pub(crate) struct OnboardingScreenArgs {
 
 pub(crate) struct OnboardingResult {
     pub directory_trust_decision: Option<TrustDirectorySelection>,
+    pub sophistication_level: Option<SophisticationLevel>,
     pub should_exit: bool,
 }
 
 impl OnboardingScreen {
     pub(crate) fn new(tui: &mut Tui, args: OnboardingScreenArgs) -> Self {
         let OnboardingScreenArgs {
+            show_sophistication_screen,
             show_trust_screen,
             show_login_screen,
             login_status,
@@ -90,6 +97,9 @@ impl OnboardingScreen {
             tui.frame_requester(),
             config.animations,
         )));
+        if show_sophistication_screen {
+            steps.push(Step::Sophistication(SophisticationWidget::new()));
+        }
         if show_login_screen {
             let highlighted_mode = match forced_login_method {
                 Some(ForcedLoginMethod::Api) => AuthMode::ApiKey,
@@ -194,6 +204,19 @@ impl OnboardingScreen {
 
     pub fn should_exit(&self) -> bool {
         self.should_exit
+    }
+
+    pub fn sophistication_level(&self) -> Option<SophisticationLevel> {
+        self.steps
+            .iter()
+            .find_map(|step| {
+                if let Step::Sophistication(widget) = step {
+                    Some(widget.selection)
+                } else {
+                    None
+                }
+            })
+            .flatten()
     }
 
     fn is_api_key_entry_active(&self) -> bool {
@@ -333,6 +356,7 @@ impl KeyboardHandler for Step {
     fn handle_key_event(&mut self, key_event: KeyEvent) {
         match self {
             Step::Welcome(widget) => widget.handle_key_event(key_event),
+            Step::Sophistication(widget) => widget.handle_key_event(key_event),
             Step::Auth(widget) => widget.handle_key_event(key_event),
             Step::TrustDirectory(widget) => widget.handle_key_event(key_event),
         }
@@ -341,6 +365,7 @@ impl KeyboardHandler for Step {
     fn handle_paste(&mut self, pasted: String) {
         match self {
             Step::Welcome(_) => {}
+            Step::Sophistication(_) => {}
             Step::Auth(widget) => widget.handle_paste(pasted),
             Step::TrustDirectory(widget) => widget.handle_paste(pasted),
         }
@@ -351,6 +376,7 @@ impl StepStateProvider for Step {
     fn get_step_state(&self) -> StepState {
         match self {
             Step::Welcome(w) => w.get_step_state(),
+            Step::Sophistication(w) => w.get_step_state(),
             Step::Auth(w) => w.get_step_state(),
             Step::TrustDirectory(w) => w.get_step_state(),
         }
@@ -361,6 +387,9 @@ impl WidgetRef for Step {
     fn render_ref(&self, area: Rect, buf: &mut Buffer) {
         match self {
             Step::Welcome(widget) => {
+                widget.render_ref(area, buf);
+            }
+            Step::Sophistication(widget) => {
                 widget.render_ref(area, buf);
             }
             Step::Auth(widget) => {
@@ -439,6 +468,7 @@ pub(crate) async fn run_onboarding_app(
     }
     Ok(OnboardingResult {
         directory_trust_decision: onboarding_screen.directory_trust_decision(),
+        sophistication_level: onboarding_screen.sophistication_level(),
         should_exit: onboarding_screen.should_exit(),
     })
 }

--- a/codex-rs/tui/src/onboarding/sophistication.rs
+++ b/codex-rs/tui/src/onboarding/sophistication.rs
@@ -5,9 +5,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Stylize;
 use ratatui::text::Line;
-use ratatui::widgets::Paragraph;
 use ratatui::widgets::WidgetRef;
-use ratatui::widgets::Wrap;
 
 use crate::key_hint;
 use crate::onboarding::onboarding_screen::KeyboardHandler;
@@ -72,14 +70,6 @@ impl WidgetRef for &SophisticationWidget {
         ]));
         column.push("");
 
-        column.push(
-            Paragraph::new(
-                "This helps decide whether to auto-create AGENTS.md and PLANS.md on first run."
-                    .to_string(),
-            )
-            .wrap(Wrap { trim: true })
-            .inset(Insets::tlbr(0, 2, 0, 0)),
-        );
         column.push("");
 
         let options = [

--- a/codex-rs/tui/src/onboarding/sophistication.rs
+++ b/codex-rs/tui/src/onboarding/sophistication.rs
@@ -1,0 +1,148 @@
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use crossterm::event::KeyEventKind;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::widgets::Paragraph;
+use ratatui::widgets::WidgetRef;
+use ratatui::widgets::Wrap;
+
+use crate::key_hint;
+use crate::onboarding::onboarding_screen::KeyboardHandler;
+use crate::onboarding::onboarding_screen::StepStateProvider;
+use crate::render::Insets;
+use crate::render::renderable::ColumnRenderable;
+use crate::render::renderable::Renderable;
+use crate::render::renderable::RenderableExt as _;
+use crate::selection_list::selection_option_row;
+
+use super::onboarding_screen::StepState;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SophisticationLevel {
+    Low,
+    Medium,
+    High,
+}
+
+pub(crate) struct SophisticationWidget {
+    pub selection: Option<SophisticationLevel>,
+    pub highlighted: SophisticationLevel,
+}
+
+impl SophisticationWidget {
+    pub(crate) fn new() -> Self {
+        Self {
+            selection: None,
+            highlighted: SophisticationLevel::Low,
+        }
+    }
+
+    fn select(&mut self, level: SophisticationLevel) {
+        self.highlighted = level;
+        self.selection = Some(level);
+    }
+
+    fn highlighted_index(&self) -> usize {
+        match self.highlighted {
+            SophisticationLevel::Low => 0,
+            SophisticationLevel::Medium => 1,
+            SophisticationLevel::High => 2,
+        }
+    }
+
+    fn highlight_index(&mut self, index: usize) {
+        self.highlighted = match index {
+            0 => SophisticationLevel::Low,
+            1 => SophisticationLevel::Medium,
+            _ => SophisticationLevel::High,
+        };
+    }
+}
+
+impl WidgetRef for &SophisticationWidget {
+    fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        let mut column = ColumnRenderable::new();
+
+        column.push(Line::from(vec![
+            "> ".into(),
+            "What's your level of Codex sophistication?".bold(),
+        ]));
+        column.push("");
+
+        column.push(
+            Paragraph::new(
+                "This helps decide whether to auto-create AGENTS.md and PLANS.md on first run."
+                    .to_string(),
+            )
+            .wrap(Wrap { trim: true })
+            .inset(Insets::tlbr(0, 2, 0, 0)),
+        );
+        column.push("");
+
+        let options = [
+            ("Low", SophisticationLevel::Low),
+            ("Medium", SophisticationLevel::Medium),
+            ("High", SophisticationLevel::High),
+        ];
+
+        for (idx, (label, level)) in options.iter().enumerate() {
+            column.push(selection_option_row(
+                idx,
+                (*label).to_string(),
+                self.highlighted == *level,
+            ));
+        }
+
+        column.push("");
+        column.push(
+            Line::from(vec![
+                "Press ".dim(),
+                key_hint::plain(KeyCode::Enter).into(),
+                " to continue".dim(),
+            ])
+            .inset(Insets::tlbr(0, 2, 0, 0)),
+        );
+
+        column.render(area, buf);
+    }
+}
+
+impl KeyboardHandler for SophisticationWidget {
+    fn handle_key_event(&mut self, key_event: KeyEvent) {
+        if key_event.kind == KeyEventKind::Release {
+            return;
+        }
+
+        match key_event.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                let index = self.highlighted_index();
+                if index > 0 {
+                    self.highlight_index(index - 1);
+                }
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                let index = self.highlighted_index();
+                if index < 2 {
+                    self.highlight_index(index + 1);
+                }
+            }
+            KeyCode::Char('1') | KeyCode::Char('l') => self.select(SophisticationLevel::Low),
+            KeyCode::Char('2') | KeyCode::Char('m') => self.select(SophisticationLevel::Medium),
+            KeyCode::Char('3') | KeyCode::Char('h') => self.select(SophisticationLevel::High),
+            KeyCode::Enter => self.select(self.highlighted),
+            _ => {}
+        }
+    }
+}
+
+impl StepStateProvider for SophisticationWidget {
+    fn get_step_state(&self) -> StepState {
+        match self.selection {
+            Some(_) => StepState::Complete,
+            None => StepState::InProgress,
+        }
+    }
+}

--- a/codex-rs/tui2/src/cli.rs
+++ b/codex-rs/tui2/src/cli.rs
@@ -81,6 +81,10 @@ pub struct Cli {
     #[arg(long = "search", default_value_t = false)]
     pub web_search: bool,
 
+    /// Force the onboarding sophistication question even if already answered.
+    #[arg(long = "force-onboarding-question", default_value_t = false)]
+    pub force_onboarding_question: bool,
+
     /// Additional directories that should be writable alongside the primary workspace.
     #[arg(long = "add-dir", value_name = "DIR", value_hint = ValueHint::DirPath)]
     pub add_dir: Vec<PathBuf>,
@@ -108,6 +112,7 @@ impl From<codex_tui::Cli> for Cli {
             dangerously_bypass_approvals_and_sandbox: cli.dangerously_bypass_approvals_and_sandbox,
             cwd: cli.cwd,
             web_search: cli.web_search,
+            force_onboarding_question: cli.force_onboarding_question,
             add_dir: cli.add_dir,
             config_overrides: cli.config_overrides,
         }

--- a/codex-rs/tui2/src/onboarding/build_test.rs
+++ b/codex-rs/tui2/src/onboarding/build_test.rs
@@ -1,0 +1,143 @@
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use crossterm::event::KeyEventKind;
+use crossterm::event::KeyModifiers;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::widgets::Paragraph;
+use ratatui::widgets::WidgetRef;
+use ratatui::widgets::Wrap;
+
+use crate::key_hint;
+use crate::onboarding::onboarding_screen::KeyboardHandler;
+use crate::onboarding::onboarding_screen::StepStateProvider;
+use crate::render::Insets;
+use crate::render::renderable::ColumnRenderable;
+use crate::render::renderable::Renderable;
+use crate::render::renderable::RenderableExt as _;
+
+use super::onboarding_screen::StepState;
+
+pub(crate) struct BuildTestCommandsWidget {
+    pub value: String,
+    submitted: bool,
+}
+
+impl BuildTestCommandsWidget {
+    pub(crate) fn new() -> Self {
+        Self {
+            value: String::new(),
+            submitted: false,
+        }
+    }
+
+    pub(crate) fn commands(&self) -> Option<String> {
+        if !self.submitted {
+            return None;
+        }
+        let trimmed = self.value.trim();
+        if trimmed.is_empty() {
+            None
+        } else {
+            Some(trimmed.to_string())
+        }
+    }
+
+    fn append_text(&mut self, text: &str) {
+        if text.is_empty() {
+            return;
+        }
+        self.value.push_str(text);
+    }
+}
+
+impl WidgetRef for &BuildTestCommandsWidget {
+    fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        let mut column = ColumnRenderable::new();
+
+        column.push(Line::from(vec![
+            "> ".into(),
+            "What are the build and test commands?".bold(),
+        ]));
+        column.push("");
+        column.push(
+            Paragraph::new(
+                "Add the commands you'd like Codex to run (comma-separated or a single command)."
+                    .to_string(),
+            )
+            .wrap(Wrap { trim: true })
+            .inset(Insets::tlbr(0, 2, 0, 0)),
+        );
+        column.push("");
+
+        column.push("Build & test commands:".dim());
+        let content_line: Line = if self.value.is_empty() {
+            vec!["e.g. just fmt, just test, cargo test -p codex-tui2".dim()].into()
+        } else {
+            Line::from(self.value.clone())
+        };
+        column.push(content_line.inset(Insets::tlbr(0, 2, 0, 0)));
+
+        column.push("");
+        column.push(
+            Line::from(vec![
+                "Press ".dim(),
+                key_hint::plain(KeyCode::Enter).into(),
+                " to continue".dim(),
+            ])
+            .inset(Insets::tlbr(0, 2, 0, 0)),
+        );
+
+        column.render(area, buf);
+    }
+}
+
+impl KeyboardHandler for BuildTestCommandsWidget {
+    fn handle_key_event(&mut self, key_event: KeyEvent) {
+        if key_event.kind == KeyEventKind::Release {
+            return;
+        }
+
+        match key_event.code {
+            KeyCode::Enter => self.submitted = true,
+            KeyCode::Backspace => {
+                self.value.pop();
+            }
+            KeyCode::Char(c)
+                if key_event.kind == KeyEventKind::Press
+                    && !key_event.modifiers.contains(KeyModifiers::SUPER)
+                    && !key_event.modifiers.contains(KeyModifiers::CONTROL)
+                    && !key_event.modifiers.contains(KeyModifiers::ALT) =>
+            {
+                self.value.push(c);
+            }
+            _ => {}
+        }
+    }
+
+    fn handle_paste(&mut self, pasted: String) {
+        let trimmed = pasted.trim();
+        if trimmed.is_empty() {
+            return;
+        }
+        let cleaned = trimmed
+            .lines()
+            .map(str::trim)
+            .filter(|line| !line.is_empty())
+            .collect::<Vec<_>>()
+            .join(" ");
+        self.append_text(&cleaned);
+    }
+}
+
+impl StepStateProvider for BuildTestCommandsWidget {
+    fn get_step_state(&self) -> StepState {
+        if self.submitted {
+            StepState::Complete
+        } else {
+            StepState::InProgress
+        }
+    }
+}

--- a/codex-rs/tui2/src/onboarding/mod.rs
+++ b/codex-rs/tui2/src/onboarding/mod.rs
@@ -1,4 +1,5 @@
 mod auth;
+mod build_test;
 pub mod onboarding_screen;
 mod sophistication;
 mod trust_directory;

--- a/codex-rs/tui2/src/onboarding/mod.rs
+++ b/codex-rs/tui2/src/onboarding/mod.rs
@@ -1,5 +1,7 @@
 mod auth;
 pub mod onboarding_screen;
+mod sophistication;
 mod trust_directory;
+pub use sophistication::SophisticationLevel;
 pub use trust_directory::TrustDirectorySelection;
 mod welcome;

--- a/codex-rs/tui2/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui2/src/onboarding/onboarding_screen.rs
@@ -17,6 +17,7 @@ use codex_protocol::config_types::ForcedLoginMethod;
 use crate::LoginStatus;
 use crate::onboarding::auth::AuthModeWidget;
 use crate::onboarding::auth::SignInState;
+use crate::onboarding::build_test::BuildTestCommandsWidget;
 use crate::onboarding::sophistication::SophisticationWidget;
 use crate::onboarding::trust_directory::TrustDirectorySelection;
 use crate::onboarding::trust_directory::TrustDirectoryWidget;
@@ -34,6 +35,7 @@ use super::SophisticationLevel;
 enum Step {
     Welcome(WelcomeWidget),
     Sophistication(SophisticationWidget),
+    BuildTest(BuildTestCommandsWidget),
     Auth(AuthModeWidget),
     TrustDirectory(TrustDirectoryWidget),
 }
@@ -62,7 +64,9 @@ pub(crate) struct OnboardingScreen {
 }
 
 pub(crate) struct OnboardingScreenArgs {
+    pub show_welcome_screen: bool,
     pub show_sophistication_screen: bool,
+    pub show_build_test_commands: bool,
     pub show_trust_screen: bool,
     pub show_login_screen: bool,
     pub login_status: LoginStatus,
@@ -73,13 +77,16 @@ pub(crate) struct OnboardingScreenArgs {
 pub(crate) struct OnboardingResult {
     pub directory_trust_decision: Option<TrustDirectorySelection>,
     pub sophistication_level: Option<SophisticationLevel>,
+    pub build_test_commands: Option<String>,
     pub should_exit: bool,
 }
 
 impl OnboardingScreen {
     pub(crate) fn new(tui: &mut Tui, args: OnboardingScreenArgs) -> Self {
         let OnboardingScreenArgs {
+            show_welcome_screen,
             show_sophistication_screen,
+            show_build_test_commands,
             show_trust_screen,
             show_login_screen,
             login_status,
@@ -92,13 +99,18 @@ impl OnboardingScreen {
         let codex_home = config.codex_home;
         let cli_auth_credentials_store_mode = config.cli_auth_credentials_store_mode;
         let mut steps: Vec<Step> = Vec::new();
-        steps.push(Step::Welcome(WelcomeWidget::new(
-            !matches!(login_status, LoginStatus::NotAuthenticated),
-            tui.frame_requester(),
-            config.animations,
-        )));
+        if show_welcome_screen {
+            steps.push(Step::Welcome(WelcomeWidget::new(
+                !matches!(login_status, LoginStatus::NotAuthenticated),
+                tui.frame_requester(),
+                config.animations,
+            )));
+        }
         if show_sophistication_screen {
             steps.push(Step::Sophistication(SophisticationWidget::new()));
+        }
+        if show_build_test_commands {
+            steps.push(Step::BuildTest(BuildTestCommandsWidget::new()));
         }
         if show_login_screen {
             let highlighted_mode = match forced_login_method {
@@ -217,6 +229,16 @@ impl OnboardingScreen {
                 }
             })
             .flatten()
+    }
+
+    pub fn build_test_commands(&self) -> Option<String> {
+        self.steps.iter().find_map(|step| {
+            if let Step::BuildTest(widget) = step {
+                widget.commands()
+            } else {
+                None
+            }
+        })
     }
 
     fn is_api_key_entry_active(&self) -> bool {
@@ -357,6 +379,7 @@ impl KeyboardHandler for Step {
         match self {
             Step::Welcome(widget) => widget.handle_key_event(key_event),
             Step::Sophistication(widget) => widget.handle_key_event(key_event),
+            Step::BuildTest(widget) => widget.handle_key_event(key_event),
             Step::Auth(widget) => widget.handle_key_event(key_event),
             Step::TrustDirectory(widget) => widget.handle_key_event(key_event),
         }
@@ -366,6 +389,7 @@ impl KeyboardHandler for Step {
         match self {
             Step::Welcome(_) => {}
             Step::Sophistication(_) => {}
+            Step::BuildTest(widget) => widget.handle_paste(pasted),
             Step::Auth(widget) => widget.handle_paste(pasted),
             Step::TrustDirectory(widget) => widget.handle_paste(pasted),
         }
@@ -377,6 +401,7 @@ impl StepStateProvider for Step {
         match self {
             Step::Welcome(w) => w.get_step_state(),
             Step::Sophistication(w) => w.get_step_state(),
+            Step::BuildTest(w) => w.get_step_state(),
             Step::Auth(w) => w.get_step_state(),
             Step::TrustDirectory(w) => w.get_step_state(),
         }
@@ -390,6 +415,9 @@ impl WidgetRef for Step {
                 widget.render_ref(area, buf);
             }
             Step::Sophistication(widget) => {
+                widget.render_ref(area, buf);
+            }
+            Step::BuildTest(widget) => {
                 widget.render_ref(area, buf);
             }
             Step::Auth(widget) => {
@@ -470,6 +498,7 @@ pub(crate) async fn run_onboarding_app(
     Ok(OnboardingResult {
         directory_trust_decision: onboarding_screen.directory_trust_decision(),
         sophistication_level: onboarding_screen.sophistication_level(),
+        build_test_commands: onboarding_screen.build_test_commands(),
         should_exit: onboarding_screen.should_exit(),
     })
 }

--- a/codex-rs/tui2/src/onboarding/sophistication.rs
+++ b/codex-rs/tui2/src/onboarding/sophistication.rs
@@ -5,9 +5,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
 use ratatui::style::Stylize;
 use ratatui::text::Line;
-use ratatui::widgets::Paragraph;
 use ratatui::widgets::WidgetRef;
-use ratatui::widgets::Wrap;
 
 use crate::key_hint;
 use crate::onboarding::onboarding_screen::KeyboardHandler;
@@ -72,14 +70,6 @@ impl WidgetRef for &SophisticationWidget {
         ]));
         column.push("");
 
-        column.push(
-            Paragraph::new(
-                "This helps decide whether to auto-create AGENTS.md and PLANS.md on first run."
-                    .to_string(),
-            )
-            .wrap(Wrap { trim: true })
-            .inset(Insets::tlbr(0, 2, 0, 0)),
-        );
         column.push("");
 
         let options = [

--- a/codex-rs/tui2/src/onboarding/sophistication.rs
+++ b/codex-rs/tui2/src/onboarding/sophistication.rs
@@ -1,0 +1,148 @@
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use crossterm::event::KeyEventKind;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::style::Stylize;
+use ratatui::text::Line;
+use ratatui::widgets::Paragraph;
+use ratatui::widgets::WidgetRef;
+use ratatui::widgets::Wrap;
+
+use crate::key_hint;
+use crate::onboarding::onboarding_screen::KeyboardHandler;
+use crate::onboarding::onboarding_screen::StepStateProvider;
+use crate::render::Insets;
+use crate::render::renderable::ColumnRenderable;
+use crate::render::renderable::Renderable;
+use crate::render::renderable::RenderableExt as _;
+use crate::selection_list::selection_option_row;
+
+use super::onboarding_screen::StepState;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SophisticationLevel {
+    Low,
+    Medium,
+    High,
+}
+
+pub(crate) struct SophisticationWidget {
+    pub selection: Option<SophisticationLevel>,
+    pub highlighted: SophisticationLevel,
+}
+
+impl SophisticationWidget {
+    pub(crate) fn new() -> Self {
+        Self {
+            selection: None,
+            highlighted: SophisticationLevel::Low,
+        }
+    }
+
+    fn select(&mut self, level: SophisticationLevel) {
+        self.highlighted = level;
+        self.selection = Some(level);
+    }
+
+    fn highlighted_index(&self) -> usize {
+        match self.highlighted {
+            SophisticationLevel::Low => 0,
+            SophisticationLevel::Medium => 1,
+            SophisticationLevel::High => 2,
+        }
+    }
+
+    fn highlight_index(&mut self, index: usize) {
+        self.highlighted = match index {
+            0 => SophisticationLevel::Low,
+            1 => SophisticationLevel::Medium,
+            _ => SophisticationLevel::High,
+        };
+    }
+}
+
+impl WidgetRef for &SophisticationWidget {
+    fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        let mut column = ColumnRenderable::new();
+
+        column.push(Line::from(vec![
+            "> ".into(),
+            "What's your level of Codex sophistication?".bold(),
+        ]));
+        column.push("");
+
+        column.push(
+            Paragraph::new(
+                "This helps decide whether to auto-create AGENTS.md and PLANS.md on first run."
+                    .to_string(),
+            )
+            .wrap(Wrap { trim: true })
+            .inset(Insets::tlbr(0, 2, 0, 0)),
+        );
+        column.push("");
+
+        let options = [
+            ("Low", SophisticationLevel::Low),
+            ("Medium", SophisticationLevel::Medium),
+            ("High", SophisticationLevel::High),
+        ];
+
+        for (idx, (label, level)) in options.iter().enumerate() {
+            column.push(selection_option_row(
+                idx,
+                (*label).to_string(),
+                self.highlighted == *level,
+            ));
+        }
+
+        column.push("");
+        column.push(
+            Line::from(vec![
+                "Press ".dim(),
+                key_hint::plain(KeyCode::Enter).into(),
+                " to continue".dim(),
+            ])
+            .inset(Insets::tlbr(0, 2, 0, 0)),
+        );
+
+        column.render(area, buf);
+    }
+}
+
+impl KeyboardHandler for SophisticationWidget {
+    fn handle_key_event(&mut self, key_event: KeyEvent) {
+        if key_event.kind == KeyEventKind::Release {
+            return;
+        }
+
+        match key_event.code {
+            KeyCode::Up | KeyCode::Char('k') => {
+                let index = self.highlighted_index();
+                if index > 0 {
+                    self.highlight_index(index - 1);
+                }
+            }
+            KeyCode::Down | KeyCode::Char('j') => {
+                let index = self.highlighted_index();
+                if index < 2 {
+                    self.highlight_index(index + 1);
+                }
+            }
+            KeyCode::Char('1') | KeyCode::Char('l') => self.select(SophisticationLevel::Low),
+            KeyCode::Char('2') | KeyCode::Char('m') => self.select(SophisticationLevel::Medium),
+            KeyCode::Char('3') | KeyCode::Char('h') => self.select(SophisticationLevel::High),
+            KeyCode::Enter => self.select(self.highlighted),
+            _ => {}
+        }
+    }
+}
+
+impl StepStateProvider for SophisticationWidget {
+    fn get_step_state(&self) -> StepState {
+        match self.selection {
+            Some(_) => StepState::Complete,
+            None => StepState::InProgress,
+        }
+    }
+}

--- a/codex-rs/tui2/src/test_backend.rs
+++ b/codex-rs/tui2/src/test_backend.rs
@@ -25,6 +25,7 @@ pub struct VT100Backend {
 impl VT100Backend {
     /// Creates a new `TestBackend` with the specified width and height.
     pub fn new(width: u16, height: u16) -> Self {
+        crossterm::style::force_color_output(true);
         Self {
             crossterm_backend: CrosstermBackend::new(vt100::Parser::new(height, width, 0)),
         }

--- a/demo-plan.md
+++ b/demo-plan.md
@@ -1,0 +1,43 @@
+# Codex Guardrails Demo Plan (Reduced Scope)
+
+## Goal
+Demonstrate a minimal first‑run guardrail flow with only two actions:
+1) Ask the user their Codex sophistication level.
+2) If they answer **low**, auto‑create `AGENTS.md` and `PLANS.md` (only for first‑time users).
+
+## Demo Setup
+- Start from a clean branch off master.
+- Use a repo that does **not** already have `AGENTS.md` or `PLANS.md` at the root.
+- Ensure the demo uses a fresh Codex home to mimic a first‑run user.
+
+## Demo Script (Narrated Flow)
+
+### 1) First‑Run Question: Sophistication Level
+Prompt (first‑time users only):
+> What’s your level of Codex sophistication? (low / medium / high)
+
+Narration:
+“This question only appears for first‑time users. It should not appear on subsequent runs.”
+
+### 2) Auto‑scaffold Guardrails (only if low + first‑time)
+If the user answers **low** and they are a first‑time user, Codex automatically creates:
+- `AGENTS.md`
+- `PLANS.md`
+
+Narration:
+“With a low sophistication choice on first run, Codex creates the guardrail files automatically.”
+
+## Demo Success Criteria
+- The sophistication question is asked **only** for first‑time users (unless forced by flag).
+- If the user answers **low** on first run, `AGENTS.md` and `PLANS.md` are created automatically.
+- No other onboarding steps, plan gates, or test execution are part of this demo.
+
+## Notes for a Clean Demo
+- To force the sophistication question on every run, use:
+  ```
+  codex --force-onboarding-question
+  ```
+- For a true first‑run experience:
+  ```
+  CODEX_HOME=$(mktemp -d) codex
+  ```

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -162,6 +162,7 @@ windows_wsl_setup_acknowledged = false
 [notice]
 # hide_full_access_warning = true
 # hide_rate_limit_model_nudge = true
+# hide_sophistication_prompt = true
 
 ################################################################################
 # Authentication & Login

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,7 +14,7 @@ Looking for something specific? Jump ahead:
 | `codex "..."`      | Initial prompt for interactive TUI | `codex "fix lint errors"`       |
 | `codex exec "..."` | Non-interactive "automation mode"  | `codex exec "explain utils.ts"` |
 
-Key flags: `--model/-m`, `--ask-for-approval/-a`.
+Key flags: `--model/-m`, `--ask-for-approval/-a`, `--force-onboarding-question`.
 
 ### Resuming interactive sessions
 


### PR DESCRIPTION
Prototyped very rough PoC feature in Codex CLI that
1. Prompts new users for their level of sophistication with Codex
2. Asks for their standard build and test command
3. Creates an AGENTS.md and PLANS.md automatically if they select Low with the test command populated.

The goal of this is to auto-scaffold configs for users with less AI experience.

https://github.com/user-attachments/assets/18b640d1-dacf-47c5-9097-495a2b953cbc

