### PR TITLE
Hide mode cycle hint while a task is running

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -2541,6 +2541,7 @@ impl Renderable for ChatComposer {
                     hint_rect,
                     buf,
                     self.collaboration_mode_indicator,
+                    !footer_props.is_task_running,
                     left_content_width,
                 );
             }

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_mode_indicator_running_hides_hint.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__footer__tests__footer_mode_indicator_running_hides_hint.snap
@@ -1,0 +1,5 @@
+---
+source: tui/src/bottom_pane/footer.rs
+expression: terminal.backend()
+---
+"  100% context left · ? for shortcuts                                                                        Plan mode  "


### PR DESCRIPTION
## Summary
- hide the “(shift+tab to cycle)” suffix on the collaboration mode label while a task is running
- keep the cycle hint visible when idle
- add a snapshot to cover the running-task label state