### PR TITLE
Ask for cwd choice when resuming session from different cwd

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1224,7 +1224,7 @@ impl App {
                         match self
                             .server
                             .resume_thread_from_rollout(
-                                resume_config,
+                                resume_config.clone(),
                                 path.clone(),
                                 self.auth_manager.clone(),
                             )
@@ -1232,6 +1232,11 @@ impl App {
                         {
                             Ok(resumed) => {
                                 self.shutdown_current_thread().await;
+                                self.config = resume_config;
+                                self.file_search = FileSearchManager::new(
+                                    self.config.cwd.clone(),
+                                    self.app_event_tx.clone(),
+                                );
                                 let init = self.chatwidget_init_for_forked_or_resumed_thread(
                                     tui,
                                     self.config.clone(),

--- a/codex-rs/tui/src/cwd_prompt.rs
+++ b/codex-rs/tui/src/cwd_prompt.rs
@@ -1,0 +1,266 @@
+use std::path::Path;
+
+use crate::key_hint;
+use crate::render::Insets;
+use crate::render::renderable::ColumnRenderable;
+use crate::render::renderable::Renderable;
+use crate::render::renderable::RenderableExt as _;
+use crate::selection_list::selection_option_row;
+use crate::tui::FrameRequester;
+use crate::tui::Tui;
+use crate::tui::TuiEvent;
+use color_eyre::Result;
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use crossterm::event::KeyEventKind;
+use crossterm::event::KeyModifiers;
+use ratatui::buffer::Buffer;
+use ratatui::layout::Rect;
+use ratatui::prelude::Widget;
+use ratatui::style::Stylize as _;
+use ratatui::text::Line;
+use ratatui::widgets::Clear;
+use ratatui::widgets::WidgetRef;
+use tokio_stream::StreamExt;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CwdPromptAction {
+    Resume,
+    Fork,
+}
+
+impl CwdPromptAction {
+    fn verb(self) -> &'static str {
+        match self {
+            CwdPromptAction::Resume => "resume",
+            CwdPromptAction::Fork => "fork",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum CwdSelection {
+    Current,
+    Session,
+}
+
+impl CwdSelection {
+    fn next(self) -> Self {
+        match self {
+            CwdSelection::Current => CwdSelection::Session,
+            CwdSelection::Session => CwdSelection::Current,
+        }
+    }
+
+    fn prev(self) -> Self {
+        match self {
+            CwdSelection::Current => CwdSelection::Session,
+            CwdSelection::Session => CwdSelection::Current,
+        }
+    }
+}
+
+pub(crate) async fn run_cwd_selection_prompt(
+    tui: &mut Tui,
+    action: CwdPromptAction,
+    current_cwd: &Path,
+    session_cwd: &Path,
+) -> Result<CwdSelection> {
+    let mut screen = CwdPromptScreen::new(
+        tui.frame_requester(),
+        action,
+        current_cwd.display().to_string(),
+        session_cwd.display().to_string(),
+    );
+    tui.draw(u16::MAX, |frame| {
+        frame.render_widget_ref(&screen, frame.area());
+    })?;
+
+    let events = tui.event_stream();
+    tokio::pin!(events);
+
+    while !screen.is_done() {
+        if let Some(event) = events.next().await {
+            match event {
+                TuiEvent::Key(key_event) => screen.handle_key(key_event),
+                TuiEvent::Paste(_) => {}
+                TuiEvent::Draw => {
+                    tui.draw(u16::MAX, |frame| {
+                        frame.render_widget_ref(&screen, frame.area());
+                    })?;
+                }
+            }
+        } else {
+            break;
+        }
+    }
+
+    Ok(screen.selection().unwrap_or(CwdSelection::Current))
+}
+
+struct CwdPromptScreen {
+    request_frame: FrameRequester,
+    action: CwdPromptAction,
+    current_cwd: String,
+    session_cwd: String,
+    highlighted: CwdSelection,
+    selection: Option<CwdSelection>,
+}
+
+impl CwdPromptScreen {
+    fn new(
+        request_frame: FrameRequester,
+        action: CwdPromptAction,
+        current_cwd: String,
+        session_cwd: String,
+    ) -> Self {
+        Self {
+            request_frame,
+            action,
+            current_cwd,
+            session_cwd,
+            highlighted: CwdSelection::Current,
+            selection: None,
+        }
+    }
+
+    fn handle_key(&mut self, key_event: KeyEvent) {
+        if key_event.kind == KeyEventKind::Release {
+            return;
+        }
+        if key_event.modifiers.contains(KeyModifiers::CONTROL)
+            && matches!(key_event.code, KeyCode::Char('c') | KeyCode::Char('d'))
+        {
+            self.select(CwdSelection::Current);
+            return;
+        }
+        match key_event.code {
+            KeyCode::Up | KeyCode::Char('k') => self.set_highlight(self.highlighted.prev()),
+            KeyCode::Down | KeyCode::Char('j') => self.set_highlight(self.highlighted.next()),
+            KeyCode::Char('1') => self.select(CwdSelection::Current),
+            KeyCode::Char('2') => self.select(CwdSelection::Session),
+            KeyCode::Enter => self.select(self.highlighted),
+            KeyCode::Esc => self.select(CwdSelection::Current),
+            _ => {}
+        }
+    }
+
+    fn set_highlight(&mut self, highlight: CwdSelection) {
+        if self.highlighted != highlight {
+            self.highlighted = highlight;
+            self.request_frame.schedule_frame();
+        }
+    }
+
+    fn select(&mut self, selection: CwdSelection) {
+        self.highlighted = selection;
+        self.selection = Some(selection);
+        self.request_frame.schedule_frame();
+    }
+
+    fn is_done(&self) -> bool {
+        self.selection.is_some()
+    }
+
+    fn selection(&self) -> Option<CwdSelection> {
+        self.selection
+    }
+}
+
+impl WidgetRef for &CwdPromptScreen {
+    fn render_ref(&self, area: Rect, buf: &mut Buffer) {
+        Clear.render(area, buf);
+        let mut column = ColumnRenderable::new();
+
+        let action_verb = self.action.verb();
+        let current_cwd = self.current_cwd.as_str();
+        let session_cwd = self.session_cwd.as_str();
+
+        column.push("");
+        column.push(Line::from(vec![
+            "Choose working directory to ".into(),
+            action_verb.bold(),
+            " this session".into(),
+        ]));
+        column.push("");
+        column.push(
+            Line::from(vec![
+                "Session directory: ".dim(),
+                self.session_cwd.clone().into(),
+            ])
+            .inset(Insets::tlbr(0, 2, 0, 0)),
+        );
+        column.push(
+            Line::from(vec![
+                "Current directory: ".dim(),
+                self.current_cwd.clone().into(),
+            ])
+            .inset(Insets::tlbr(0, 2, 0, 0)),
+        );
+        column.push("");
+        column.push(selection_option_row(
+            0,
+            format!("Use current directory ({current_cwd})"),
+            self.highlighted == CwdSelection::Current,
+        ));
+        column.push(selection_option_row(
+            1,
+            format!("Use session directory ({session_cwd})"),
+            self.highlighted == CwdSelection::Session,
+        ));
+        column.push("");
+        column.push(
+            Line::from(vec![
+                "Press ".dim(),
+                key_hint::plain(KeyCode::Enter).into(),
+                " to continue".dim(),
+            ])
+            .inset(Insets::tlbr(0, 2, 0, 0)),
+        );
+        column.render(area, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::test_backend::VT100Backend;
+    use crossterm::event::KeyEvent;
+    use crossterm::event::KeyModifiers;
+    use pretty_assertions::assert_eq;
+    use ratatui::Terminal;
+
+    fn new_prompt() -> CwdPromptScreen {
+        CwdPromptScreen::new(
+            FrameRequester::test_dummy(),
+            CwdPromptAction::Resume,
+            "/Users/example/current".to_string(),
+            "/Users/example/session".to_string(),
+        )
+    }
+
+    #[test]
+    fn cwd_prompt_snapshot() {
+        let screen = new_prompt();
+        let mut terminal = Terminal::new(VT100Backend::new(80, 14)).expect("terminal");
+        terminal
+            .draw(|frame| frame.render_widget_ref(&screen, frame.area()))
+            .expect("render cwd prompt");
+        insta::assert_snapshot!("cwd_prompt_modal", terminal.backend());
+    }
+
+    #[test]
+    fn cwd_prompt_selects_current_by_default() {
+        let mut screen = new_prompt();
+        screen.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(screen.selection(), Some(CwdSelection::Current));
+    }
+
+    #[test]
+    fn cwd_prompt_can_select_session() {
+        let mut screen = new_prompt();
+        screen.handle_key(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        screen.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        assert_eq!(screen.selection(), Some(CwdSelection::Session));
+    }
+}

--- a/codex-rs/tui/src/cwd_prompt.rs
+++ b/codex-rs/tui/src/cwd_prompt.rs
@@ -250,6 +250,21 @@ mod tests {
     }
 
     #[test]
+    fn cwd_prompt_fork_snapshot() {
+        let screen = CwdPromptScreen::new(
+            FrameRequester::test_dummy(),
+            CwdPromptAction::Fork,
+            "/Users/example/current".to_string(),
+            "/Users/example/session".to_string(),
+        );
+        let mut terminal = Terminal::new(VT100Backend::new(80, 14)).expect("terminal");
+        terminal
+            .draw(|frame| frame.render_widget_ref(&screen, frame.area()))
+            .expect("render cwd prompt");
+        insta::assert_snapshot!("cwd_prompt_fork_modal", terminal.backend());
+    }
+
+    #[test]
     fn cwd_prompt_selects_current_by_default() {
         let mut screen = new_prompt();
         screen.handle_key(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));

--- a/codex-rs/tui/src/cwd_prompt.rs
+++ b/codex-rs/tui/src/cwd_prompt.rs
@@ -183,21 +183,6 @@ impl WidgetRef for &CwdPromptScreen {
             " this session".into(),
         ]));
         column.push("");
-        column.push(
-            Line::from(vec![
-                "Session directory: ".dim(),
-                self.session_cwd.clone().into(),
-            ])
-            .inset(Insets::tlbr(0, 2, 0, 0)),
-        );
-        column.push(
-            Line::from(vec![
-                "Current directory: ".dim(),
-                self.current_cwd.clone().into(),
-            ])
-            .inset(Insets::tlbr(0, 2, 0, 0)),
-        );
-        column.push("");
         column.push(selection_option_row(
             0,
             format!("Use current directory ({current_cwd})"),

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -1039,8 +1039,9 @@ mod tests {
         std::fs::create_dir_all(&trusted)?;
         std::fs::create_dir_all(&untrusted)?;
 
-        let trusted_display = trusted.display();
-        let untrusted_display = untrusted.display();
+        // TOML keys need escaped backslashes on Windows paths.
+        let trusted_display = trusted.display().to_string().replace('\\', "\\\\");
+        let untrusted_display = untrusted.display().to_string().replace('\\', "\\\\");
         let config_toml = format!(
             r#"[projects."{trusted_display}"]
 trust_level = "trusted"

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -1051,8 +1051,10 @@ trust_level = "untrusted"
         );
         std::fs::write(temp_dir.path().join("config.toml"), config_toml)?;
 
-        let mut trusted_overrides = ConfigOverrides::default();
-        trusted_overrides.cwd = Some(trusted.clone());
+        let trusted_overrides = ConfigOverrides {
+            cwd: Some(trusted.clone()),
+            ..Default::default()
+        };
         let trusted_config = ConfigBuilder::default()
             .codex_home(codex_home.clone())
             .harness_overrides(trusted_overrides.clone())
@@ -1063,8 +1065,10 @@ trust_level = "untrusted"
             AskForApproval::OnRequest
         );
 
-        let mut untrusted_overrides = trusted_overrides;
-        untrusted_overrides.cwd = Some(untrusted);
+        let untrusted_overrides = ConfigOverrides {
+            cwd: Some(untrusted),
+            ..trusted_overrides
+        };
         let untrusted_config = ConfigBuilder::default()
             .codex_home(codex_home)
             .harness_overrides(untrusted_overrides)

--- a/codex-rs/tui/src/snapshots/codex_tui__cwd_prompt__tests__cwd_prompt_fork_modal.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__cwd_prompt__tests__cwd_prompt_fork_modal.snap
@@ -1,0 +1,14 @@
+---
+source: tui/src/cwd_prompt.rs
+expression: terminal.backend()
+---
+
+Choose working directory to fork this session
+
+  Session directory: /Users/example/session
+  Current directory: /Users/example/current
+
+› 1. Use current directory (/Users/example/current)                             
+  2. Use session directory (/Users/example/session)
+
+  Press enter to continue

--- a/codex-rs/tui/src/snapshots/codex_tui__cwd_prompt__tests__cwd_prompt_fork_modal.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__cwd_prompt__tests__cwd_prompt_fork_modal.snap
@@ -5,10 +5,10 @@ expression: terminal.backend()
 
 Choose working directory to fork this session
 
-  Session directory: /Users/example/session
-  Current directory: /Users/example/current
+  Session = latest cwd recorded in the forked session                           
+  Current = your current working directory
 
-› 1. Use current directory (/Users/example/current)                             
-  2. Use session directory (/Users/example/session)
+› 1. Use session directory (/Users/example/session)                             
+  2. Use current directory (/Users/example/current)
 
   Press enter to continue

--- a/codex-rs/tui/src/snapshots/codex_tui__cwd_prompt__tests__cwd_prompt_modal.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__cwd_prompt__tests__cwd_prompt_modal.snap
@@ -1,0 +1,14 @@
+---
+source: tui/src/cwd_prompt.rs
+expression: terminal.backend()
+---
+
+Choose working directory to resume this session
+
+  Session directory: /Users/example/session
+  Current directory: /Users/example/current
+
+› 1. Use current directory (/Users/example/current)                             
+  2. Use session directory (/Users/example/session)
+
+  Press enter to continue

--- a/codex-rs/tui/src/snapshots/codex_tui__cwd_prompt__tests__cwd_prompt_modal.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__cwd_prompt__tests__cwd_prompt_modal.snap
@@ -5,10 +5,10 @@ expression: terminal.backend()
 
 Choose working directory to resume this session
 
-  Session directory: /Users/example/session
-  Current directory: /Users/example/current
+  Session = latest cwd recorded in the resumed session                          
+  Current = your current working directory
 
-› 1. Use current directory (/Users/example/current)                             
-  2. Use session directory (/Users/example/session)
+› 1. Use session directory (/Users/example/session)                             
+  2. Use current directory (/Users/example/current)
 
   Press enter to continue


### PR DESCRIPTION
# Summary
- Fix resume/fork config rebuild so cwd changes inside the TUI produce a fully rebuilt Config (trust/approval/sandbox) instead of mutating only the cwd.
- Preserve `--add-dir` behavior across resume/fork by normalizing relative roots to absolute paths once (based on the original cwd).
- Prefer latest `TurnContext.cwd` for resume/fork prompts but fall back to `SessionMeta.cwd` if the latest cwd no longer exists.
- Align resume/fork selection handling and ensure UI config matches the resumed thread config.
- Fix Windows test TOML path escaping in trust-level test.

# Details
- Rebuild Config via `ConfigBuilder` when resuming into a different cwd; carry forward runtime approval/sandbox overrides.
- Add `normalize_harness_overrides_for_cwd` to resolve relative `additional_writable_roots` against the initial cwd before reuse.
- Guard `read_session_cwd` with filesystem existence check for the latest `TurnContext.cwd`.
- Update naming/flow around cwd comparison and prompt selection.

<img width="603" height="150" alt="Screenshot 2026-01-23 at 5 42 13 PM" src="https://github.com/user-attachments/assets/d1897386-bb28-4e8a-98cf-187fdebbecb0" />

And proof the model understands the new cwd:

<img width="828" height="353" alt="Screenshot 2026-01-22 at 5 36 45 PM" src="https://github.com/user-attachments/assets/12aed8ca-dec3-4b64-8dae-c6b8cff78387" />