### PR TITLE
Mark subagent threads as SessionSource::SubAgent to prevent app sidebar spam

### DIFF
--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -314,11 +314,23 @@ impl ThreadManagerState {
         config: Config,
         agent_control: AgentControl,
     ) -> CodexResult<NewThread> {
-        self.spawn_thread(
+        self.spawn_new_thread_with_source(config, agent_control, self.session_source.clone())
+            .await
+    }
+
+    /// Spawn a new thread with no history using a provided config and source.
+    pub(crate) async fn spawn_new_thread_with_source(
+        &self,
+        config: Config,
+        agent_control: AgentControl,
+        session_source: SessionSource,
+    ) -> CodexResult<NewThread> {
+        self.spawn_thread_with_source(
             config,
             InitialHistory::New,
             Arc::clone(&self.auth_manager),
             agent_control,
+            session_source,
         )
         .await
     }
@@ -331,6 +343,24 @@ impl ThreadManagerState {
         auth_manager: Arc<AuthManager>,
         agent_control: AgentControl,
     ) -> CodexResult<NewThread> {
+        self.spawn_thread_with_source(
+            config,
+            initial_history,
+            auth_manager,
+            agent_control,
+            self.session_source.clone(),
+        )
+        .await
+    }
+
+    async fn spawn_thread_with_source(
+        &self,
+        config: Config,
+        initial_history: InitialHistory,
+        auth_manager: Arc<AuthManager>,
+        agent_control: AgentControl,
+        session_source: SessionSource,
+    ) -> CodexResult<NewThread> {
         let CodexSpawnOk {
             codex, thread_id, ..
         } = Codex::spawn(
@@ -339,7 +369,7 @@ impl ThreadManagerState {
             Arc::clone(&self.models_manager),
             Arc::clone(&self.skills_manager),
             initial_history,
-            self.session_source.clone(),
+            session_source,
             agent_control,
         )
         .await?;


### PR DESCRIPTION
## Summary
- Tag subagent-spawned threads with `SessionSource::SubAgent` instead of inheriting the parent session source.
- Add a unit test to assert the subagent session source is persisted in rollout metadata.

## Why
Subagent threads were being recorded as interactive sessions (CLI/VSCode), which caused them to appear in
`thread/list` and clutter app-server UIs. Marking them as subagent sessions keeps the default thread list clean
without changing the public app-server API.

## Changes
- `codex-rs/core/src/thread_manager.rs`
  - Add helpers to spawn threads with an explicit `SessionSource`.
- `codex-rs/core/src/agent/control.rs`
  - Spawn subagents with `SessionSource::SubAgent(SubAgentSource::Other("spawn_agent"))`.
  - New test: `spawn_agent_sets_subagent_session_source`.