### PR TITLE
VS Code extension issue template: capture UI locale for localization bugs

### DIFF
--- a/.github/ISSUE_TEMPLATE/5-vs-code-extension.yml
+++ b/.github/ISSUE_TEMPLATE/5-vs-code-extension.yml
@@ -30,6 +30,11 @@ body:
     validations:
       required: true
   - type: input
+    id: locale
+    attributes:
+      label: What UI language/locale are you using?
+      description: Like `en-US`, `zh-CN`, etc.
+  - type: input
     id: platform
     attributes:
       label: What platform is your computer?
@@ -40,7 +45,7 @@ body:
     id: actual
     attributes:
       label: What issue are you seeing?
-      description: Please include the full error messages and prompts with PII redacted. If possible, please provide text instead of a screenshot. 
+      description: Please include the full error messages and prompts with PII redacted. If possible, please provide text instead of a screenshot. If this is a localization issue, include the message id/key and the exact rendered string.
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Fixes #9761 (process improvement)

Adds an explicit `locale` field to the VS Code Extension issue template and updates the description to request the i18n message id/key + rendered string for localization-related reports.

This makes localization bugs (like zh-CN Plan summary wording/order issues) much easier to triage and reproduce.