### PR TITLE
Fix: Respect global + per-mode model overrides for collaboration modes

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -455,10 +455,17 @@ impl CodexMessageProcessor {
             ClientRequest::CollaborationModeList { request_id, params } => {
                 let outgoing = self.outgoing.clone();
                 let thread_manager = self.thread_manager.clone();
+                let config = self.config.clone();
 
                 tokio::spawn(async move {
-                    Self::list_collaboration_modes(outgoing, thread_manager, request_id, params)
-                        .await;
+                    Self::list_collaboration_modes(
+                        outgoing,
+                        thread_manager,
+                        config,
+                        request_id,
+                        params,
+                    )
+                    .await;
                 });
             }
             ClientRequest::McpServerOauthLogin { request_id, params } => {
@@ -2505,11 +2512,12 @@ impl CodexMessageProcessor {
     async fn list_collaboration_modes(
         outgoing: Arc<OutgoingMessageSender>,
         thread_manager: Arc<ThreadManager>,
+        config: Arc<Config>,
         request_id: RequestId,
         params: CollaborationModeListParams,
     ) {
         let CollaborationModeListParams {} = params;
-        let items = thread_manager.list_collaboration_modes();
+        let items = thread_manager.list_collaboration_modes(config.as_ref());
         let response = CollaborationModeListResponse { data: items };
         outgoing.send_response(request_id, response).await;
     }

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -114,6 +114,33 @@
         }
       ]
     },
+    "CollaborationModeConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "model": {
+          "type": "string"
+        },
+        "model_reasoning_effort": {
+          "$ref": "#/definitions/ReasoningEffort"
+        }
+      },
+      "type": "object"
+    },
+    "CollaborationModesConfig": {
+      "additionalProperties": false,
+      "properties": {
+        "execute": {
+          "$ref": "#/definitions/CollaborationModeConfig"
+        },
+        "pair_programming": {
+          "$ref": "#/definitions/CollaborationModeConfig"
+        },
+        "plan": {
+          "$ref": "#/definitions/CollaborationModeConfig"
+        }
+      },
+      "type": "object"
+    },
     "ConfigProfile": {
       "additionalProperties": false,
       "description": "Collection of common configuration options that a user can define as a unit in `config.toml`.",
@@ -126,6 +153,9 @@
         },
         "chatgpt_base_url": {
           "type": "string"
+        },
+        "collaboration_modes": {
+          "$ref": "#/definitions/CollaborationModesConfig"
         },
         "experimental_compact_prompt_file": {
           "$ref": "#/definitions/AbsolutePathBuf"
@@ -1098,6 +1128,9 @@
       ],
       "default": null,
       "description": "Preferred backend for storing CLI auth credentials. file (default): Use a file in the Codex home directory. keyring: Use an OS-specific keyring service. auto: Use the keyring if available, otherwise use a file."
+    },
+    "collaboration_modes": {
+      "$ref": "#/definitions/CollaborationModesConfig"
     },
     "compact_prompt": {
       "description": "Compact prompt used for history compaction.",

--- a/codex-rs/core/src/config/profile.rs
+++ b/codex-rs/core/src/config/profile.rs
@@ -3,6 +3,7 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde::Serialize;
 
+use crate::config::types::CollaborationModesConfig;
 use crate::config::types::Personality;
 use crate::protocol::AskForApproval;
 use codex_protocol::config_types::ReasoningSummary;
@@ -23,6 +24,7 @@ pub struct ConfigProfile {
     pub approval_policy: Option<AskForApproval>,
     pub sandbox_mode: Option<SandboxMode>,
     pub model_reasoning_effort: Option<ReasoningEffort>,
+    pub collaboration_modes: Option<CollaborationModesConfig>,
     pub model_reasoning_summary: Option<ReasoningSummary>,
     pub model_verbosity: Option<Verbosity>,
     pub model_personality: Option<Personality>,

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -8,6 +8,7 @@ pub use codex_protocol::config_types::AltScreenMode;
 pub use codex_protocol::config_types::ModeKind;
 pub use codex_protocol::config_types::Personality;
 pub use codex_protocol::config_types::WebSearchMode;
+use codex_protocol::openai_models::ReasoningEffort;
 use codex_utils_absolute_path::AbsolutePathBuf;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
@@ -23,6 +24,21 @@ use serde::Serialize;
 use serde::de::Error as SerdeError;
 
 pub const DEFAULT_OTEL_ENVIRONMENT: &str = "dev";
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct CollaborationModeConfig {
+    pub model: Option<String>,
+    pub model_reasoning_effort: Option<ReasoningEffort>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, Default, PartialEq, Eq, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct CollaborationModesConfig {
+    pub plan: Option<CollaborationModeConfig>,
+    pub pair_programming: Option<CollaborationModeConfig>,
+    pub execute: Option<CollaborationModeConfig>,
+}
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum McpServerDisabledReason {

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -158,8 +158,8 @@ impl ThreadManager {
             .await
     }
 
-    pub fn list_collaboration_modes(&self) -> Vec<CollaborationMode> {
-        self.state.models_manager.list_collaboration_modes()
+    pub fn list_collaboration_modes(&self, config: &Config) -> Vec<CollaborationMode> {
+        self.state.models_manager.list_collaboration_modes(config)
     }
 
     pub async fn list_thread_ids(&self) -> Vec<ThreadId> {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -933,7 +933,8 @@ impl ChatWidget {
     }
 
     fn open_plan_implementation_prompt(&mut self) {
-        let execute_mode = collaboration_modes::execute_mode(self.models_manager.as_ref());
+        let execute_mode =
+            collaboration_modes::execute_mode(self.models_manager.as_ref(), &self.config);
         let (implement_actions, implement_disabled_reason) = match execute_mode {
             Some(collaboration_mode) => {
                 let user_text = PLAN_IMPLEMENTATION_EXECUTE_MESSAGE.to_string();
@@ -1940,6 +1941,7 @@ impl ChatWidget {
         let stored_collaboration_mode = if config.features.enabled(Feature::CollaborationModes) {
             initial_collaboration_mode(
                 models_manager.as_ref(),
+                &config,
                 fallback_custom,
                 config.experimental_mode,
             )
@@ -2066,6 +2068,7 @@ impl ChatWidget {
         let stored_collaboration_mode = if config.features.enabled(Feature::CollaborationModes) {
             initial_collaboration_mode(
                 models_manager.as_ref(),
+                &config,
                 fallback_custom,
                 config.experimental_mode,
             )
@@ -3412,7 +3415,7 @@ impl ChatWidget {
     }
 
     pub(crate) fn open_collaboration_modes_popup(&mut self) {
-        let presets = self.models_manager.list_collaboration_modes();
+        let presets = self.models_manager.list_collaboration_modes(&self.config);
         if presets.is_empty() {
             self.add_info_message(
                 "No collaboration modes are available right now.".to_string(),
@@ -4420,6 +4423,7 @@ impl ChatWidget {
             self.stored_collaboration_mode = if enabled {
                 initial_collaboration_mode(
                     self.models_manager.as_ref(),
+                    &self.config,
                     fallback_custom,
                     self.config.experimental_mode,
                 )
@@ -4539,6 +4543,7 @@ impl ChatWidget {
 
         if let Some(next_mode) = collaboration_modes::next_mode(
             self.models_manager.as_ref(),
+            &self.config,
             &self.stored_collaboration_mode,
         ) {
             self.set_collaboration_mode(next_mode);
@@ -5177,6 +5182,7 @@ fn extract_first_bold(s: &str) -> Option<String> {
 
 fn initial_collaboration_mode(
     models_manager: &ModelsManager,
+    config: &Config,
     fallback_custom: Settings,
     desired_mode: Option<ModeKind>,
 ) -> CollaborationMode {
@@ -5184,12 +5190,12 @@ fn initial_collaboration_mode(
         if kind == ModeKind::Custom {
             return CollaborationMode::Custom(fallback_custom);
         }
-        if let Some(mode) = collaboration_modes::mode_for_kind(models_manager, kind) {
+        if let Some(mode) = collaboration_modes::mode_for_kind(models_manager, config, kind) {
             return mode;
         }
     }
 
-    collaboration_modes::default_mode(models_manager)
+    collaboration_modes::default_mode(models_manager, config)
         .unwrap_or(CollaborationMode::Custom(fallback_custom))
 }
 

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -778,7 +778,7 @@ async fn make_chatwidget_manual(
     let collaboration_modes_enabled = cfg.features.enabled(Feature::CollaborationModes);
     let reasoning_effort = None;
     let stored_collaboration_mode = if collaboration_modes_enabled {
-        collaboration_modes::default_mode(models_manager.as_ref()).unwrap_or_else(|| {
+        collaboration_modes::default_mode(models_manager.as_ref(), &cfg).unwrap_or_else(|| {
             CollaborationMode::Custom(Settings {
                 model: resolved_model.clone(),
                 reasoning_effort,
@@ -1215,8 +1215,9 @@ async fn submit_user_message_with_mode_sets_execute_collaboration_mode() {
     chat.thread_id = Some(ThreadId::new());
     chat.set_feature_enabled(Feature::CollaborationModes, true);
 
-    let execute_mode = collaboration_modes::execute_mode(chat.models_manager.as_ref())
-        .expect("expected execute collaboration mode");
+    let execute_mode =
+        collaboration_modes::execute_mode(chat.models_manager.as_ref(), &chat.config)
+            .expect("expected execute collaboration mode");
     chat.submit_user_message_with_mode("Implement the plan.".to_string(), execute_mode);
 
     match next_submit_op(&mut op_rx) {

--- a/codex-rs/tui/src/collaboration_modes.rs
+++ b/codex-rs/tui/src/collaboration_modes.rs
@@ -1,3 +1,4 @@
+use codex_core::config::Config;
 use codex_core::models_manager::manager::ModelsManager;
 use codex_protocol::config_types::CollaborationMode;
 use codex_protocol::config_types::ModeKind;
@@ -11,8 +12,11 @@ fn mode_kind(mode: &CollaborationMode) -> ModeKind {
     }
 }
 
-pub(crate) fn default_mode(models_manager: &ModelsManager) -> Option<CollaborationMode> {
-    let presets = models_manager.list_collaboration_modes();
+pub(crate) fn default_mode(
+    models_manager: &ModelsManager,
+    config: &Config,
+) -> Option<CollaborationMode> {
+    let presets = models_manager.list_collaboration_modes(config);
     presets
         .iter()
         .find(|preset| matches!(preset, CollaborationMode::PairProgramming(_)))
@@ -22,9 +26,10 @@ pub(crate) fn default_mode(models_manager: &ModelsManager) -> Option<Collaborati
 
 pub(crate) fn mode_for_kind(
     models_manager: &ModelsManager,
+    config: &Config,
     kind: ModeKind,
 ) -> Option<CollaborationMode> {
-    let presets = models_manager.list_collaboration_modes();
+    let presets = models_manager.list_collaboration_modes(config);
     presets.into_iter().find(|preset| mode_kind(preset) == kind)
 }
 
@@ -35,9 +40,10 @@ pub(crate) fn same_variant(a: &CollaborationMode, b: &CollaborationMode) -> bool
 /// Cycle to the next collaboration mode preset in list order.
 pub(crate) fn next_mode(
     models_manager: &ModelsManager,
+    config: &Config,
     current: &CollaborationMode,
 ) -> Option<CollaborationMode> {
-    let presets = models_manager.list_collaboration_modes();
+    let presets = models_manager.list_collaboration_modes(config);
     if presets.is_empty() {
         return None;
     }
@@ -49,9 +55,12 @@ pub(crate) fn next_mode(
     presets.get(next_index).cloned()
 }
 
-pub(crate) fn execute_mode(models_manager: &ModelsManager) -> Option<CollaborationMode> {
+pub(crate) fn execute_mode(
+    models_manager: &ModelsManager,
+    config: &Config,
+) -> Option<CollaborationMode> {
     models_manager
-        .list_collaboration_modes()
+        .list_collaboration_modes(config)
         .into_iter()
         .find(|preset| mode_kind(preset) == ModeKind::Execute)
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,26 @@ Codex can run a notification hook when the agent finishes a turn. See the config
 
 - https://developers.openai.com/codex/config-reference
 
+## Collaboration modes
+
+When the `collaboration_modes` feature is enabled, Codex uses built-in presets for `plan`, `pair_programming`, and `execute`.
+
+You can override the model and reasoning effort globally via `model` / `model_reasoning_effort`, and optionally per-mode:
+
+```toml
+model = "gpt-5.2"
+model_reasoning_effort = "xhigh"
+
+[collaboration_modes.plan]
+model = "gpt-5.2"
+model_reasoning_effort = "high"
+
+[collaboration_modes.execute]
+model_reasoning_effort = "xhigh"
+```
+
+Precedence is: built-in preset < global overrides < per-mode overrides.
+
 ## JSON Schema
 
 The generated JSON Schema for `config.toml` lives at `codex-rs/core/config.schema.json`.


### PR DESCRIPTION
This PR fixes https://github.com/openai/codex/issues/9783

When collaboration_modes is enabled, collaboration mode presets could override/ignore user-selected model and model_reasoning_effort (from config.toml and/or CLI overrides), leading to unexpected defaults when starting Codex or switching modes.

**Changes**

  - Add optional config.toml overrides for collaboration mode presets:
      - [collaboration_modes.{plan,pair_programming,execute}]
      - supported keys: model, model_reasoning_effort
  - Apply precedence when building collaboration mode presets:
      - built-in defaults < global config/CLI < per-mode overrides
  - Update JSON schema + docs
  - Add regression test covering precedence

**Manual test**

  - Start with --enable collaboration_modes and verify the active mode uses the configured model/effort and stays consistent when cycling modes.