### PR TITLE
Remove stale TODO comment from defs.bzl

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -89,8 +89,6 @@ def codex_rust_crate(
 
     binaries = DEP_DATA.get(native.package_name())["binaries"]
 
-    # TODO(zbarsky): cargo_build_script support?
-
     lib_srcs = crate_srcs or native.glob(["src/**/*.rs"], exclude = binaries.values(), allow_empty = True)
 
     if native.glob(["build.rs"], allow_empty = True):


### PR DESCRIPTION
### Motivation
- Remove an outdated comment in `defs.bzl` referencing `cargo_build_script` that is no longer relevant.

### Description
- Delete the stale `# TODO(zbarsky): cargo_build_script support?` line so the logic flows directly from `binaries` to `lib_srcs` in `defs.bzl`.

### Testing
- Ran `git diff --check` which produced no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_6973d9ac757c8331be475a8fb0f90a88)