### PR TITLE
Configurable ANSI palette for custom collaboration modes

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -456,10 +456,17 @@ impl CodexMessageProcessor {
             ClientRequest::CollaborationModeList { request_id, params } => {
                 let outgoing = self.outgoing.clone();
                 let thread_manager = self.thread_manager.clone();
+                let config = self.config.clone();
 
                 tokio::spawn(async move {
-                    Self::list_collaboration_modes(outgoing, thread_manager, request_id, params)
-                        .await;
+                    Self::list_collaboration_modes(
+                        outgoing,
+                        thread_manager,
+                        config,
+                        request_id,
+                        params,
+                    )
+                    .await;
                 });
             }
             ClientRequest::McpServerOauthLogin { request_id, params } => {
@@ -2544,11 +2551,12 @@ impl CodexMessageProcessor {
     async fn list_collaboration_modes(
         outgoing: Arc<OutgoingMessageSender>,
         thread_manager: Arc<ThreadManager>,
+        config: Arc<Config>,
         request_id: RequestId,
         params: CollaborationModeListParams,
     ) {
         let CollaborationModeListParams {} = params;
-        let items = thread_manager.list_collaboration_modes();
+        let items = thread_manager.list_collaboration_modes(config.as_ref());
         let response = CollaborationModeListResponse { data: items };
         outgoing.send_response(request_id, response).await;
     }

--- a/codex-rs/app-server/tests/suite/v2/collaboration_mode_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/collaboration_mode_list.rs
@@ -16,8 +16,10 @@ use codex_app_server_protocol::CollaborationModeListResponse;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::RequestId;
 use codex_core::models_manager::test_builtin_collaboration_mode_presets;
+use codex_protocol::config_types::CollaborationModeColor;
 use codex_protocol::config_types::CollaborationModeMask;
 use codex_protocol::config_types::ModeKind;
+use codex_protocol::openai_models::ReasoningEffort;
 use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 use tokio::time::timeout;
@@ -61,6 +63,77 @@ async fn list_collaboration_modes_returns_presets() -> Result<()> {
             expected_mask.developer_instructions,
             actual_mask.developer_instructions
         );
+        assert_eq!(expected_mask.color, actual_mask.color);
+    }
+    Ok(())
+}
+
+/// Confirms the server appends custom presets after built-ins in stable name order.
+#[tokio::test]
+async fn list_collaboration_modes_includes_custom_presets() -> Result<()> {
+    let codex_home = TempDir::new()?;
+    let config_path = codex_home.path().join("config.toml");
+    std::fs::write(
+        &config_path,
+        r#"
+[collaboration_mode_presets."Research"]
+developer_instructions = "Focus on evidence."
+reasoning_effort = "high"
+
+[collaboration_mode_presets."Spec"]
+developer_instructions = "Write a precise spec."
+"#,
+    )?;
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+
+    timeout(DEFAULT_TIMEOUT, mcp.initialize()).await??;
+
+    let request_id = mcp
+        .send_list_collaboration_modes_request(CollaborationModeListParams {})
+        .await?;
+
+    let response: JSONRPCResponse = timeout(
+        DEFAULT_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(request_id)),
+    )
+    .await??;
+
+    let CollaborationModeListResponse { data: items } =
+        to_response::<CollaborationModeListResponse>(response)?;
+
+    let expected = [
+        plan_preset(),
+        code_preset(),
+        pair_programming_preset(),
+        execute_preset(),
+        CollaborationModeMask {
+            name: "Research".to_string(),
+            mode: Some(ModeKind::Custom),
+            model: None,
+            reasoning_effort: Some(Some(ReasoningEffort::High)),
+            developer_instructions: Some(Some("Focus on evidence.".to_string())),
+            color: Some(CollaborationModeColor::for_preset_name("Research")),
+        },
+        CollaborationModeMask {
+            name: "Spec".to_string(),
+            mode: Some(ModeKind::Custom),
+            model: None,
+            reasoning_effort: None,
+            developer_instructions: Some(Some("Write a precise spec.".to_string())),
+            color: Some(CollaborationModeColor::for_preset_name("Spec")),
+        },
+    ];
+    assert_eq!(expected.len(), items.len());
+    for (expected_mask, actual_mask) in expected.iter().zip(items.iter()) {
+        assert_eq!(expected_mask.name, actual_mask.name);
+        assert_eq!(expected_mask.mode, actual_mask.mode);
+        assert_eq!(expected_mask.model, actual_mask.model);
+        assert_eq!(expected_mask.reasoning_effort, actual_mask.reasoning_effort);
+        assert_eq!(
+            expected_mask.developer_instructions,
+            actual_mask.developer_instructions
+        );
+        assert_eq!(expected_mask.color, actual_mask.color);
     }
     Ok(())
 }

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -114,6 +114,37 @@
         }
       ]
     },
+    "CollaborationModeColor": {
+      "description": "Allowed ANSI colors for collaboration mode presets.",
+      "enum": [
+        "cyan",
+        "magenta",
+        "green",
+        "red"
+      ],
+      "type": "string"
+    },
+    "CollaborationModePresetToml": {
+      "additionalProperties": false,
+      "properties": {
+        "color": {
+          "$ref": "#/definitions/CollaborationModeColor"
+        },
+        "developer_instructions": {
+          "type": "string"
+        },
+        "developer_instructions_file": {
+          "$ref": "#/definitions/AbsolutePathBuf"
+        },
+        "model": {
+          "type": "string"
+        },
+        "reasoning_effort": {
+          "$ref": "#/definitions/ReasoningEffort"
+        }
+      },
+      "type": "object"
+    },
     "ConfigProfile": {
       "additionalProperties": false,
       "description": "Collection of common configuration options that a user can define as a unit in `config.toml`.",
@@ -1099,6 +1130,21 @@
       ],
       "default": null,
       "description": "Preferred backend for storing CLI auth credentials. file (default): Use a file in the Codex home directory. keyring: Use an OS-specific keyring service. auto: Use the keyring if available, otherwise use a file."
+    },
+    "collaboration_mode_palette": {
+      "description": "Optional palette used to assign default colors to custom collaboration modes.",
+      "items": {
+        "$ref": "#/definitions/CollaborationModeColor"
+      },
+      "type": "array"
+    },
+    "collaboration_mode_presets": {
+      "additionalProperties": {
+        "$ref": "#/definitions/CollaborationModePresetToml"
+      },
+      "default": {},
+      "description": "User-defined collaboration mode presets.",
+      "type": "object"
     },
     "compact_prompt": {
       "description": "Compact prompt used for history compaction.",

--- a/codex-rs/core/src/models_manager/collaboration_mode_presets.rs
+++ b/codex-rs/core/src/models_manager/collaboration_mode_presets.rs
@@ -30,6 +30,7 @@ fn plan_preset() -> CollaborationModeMask {
         model: None,
         reasoning_effort: Some(Some(ReasoningEffort::High)),
         developer_instructions: Some(Some(COLLABORATION_MODE_PLAN.to_string())),
+        color: None,
     }
 }
 
@@ -40,6 +41,7 @@ fn code_preset() -> CollaborationModeMask {
         model: None,
         reasoning_effort: None,
         developer_instructions: Some(Some(COLLABORATION_MODE_CODE.to_string())),
+        color: None,
     }
 }
 
@@ -50,6 +52,7 @@ fn pair_programming_preset() -> CollaborationModeMask {
         model: None,
         reasoning_effort: Some(Some(ReasoningEffort::Medium)),
         developer_instructions: Some(Some(COLLABORATION_MODE_PAIR_PROGRAMMING.to_string())),
+        color: None,
     }
 }
 
@@ -60,5 +63,6 @@ fn execute_preset() -> CollaborationModeMask {
         model: None,
         reasoning_effort: Some(Some(ReasoningEffort::High)),
         developer_instructions: Some(Some(COLLABORATION_MODE_EXECUTE.to_string())),
+        color: None,
     }
 }

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -158,8 +158,10 @@ impl ThreadManager {
             .await
     }
 
-    pub fn list_collaboration_modes(&self) -> Vec<CollaborationModeMask> {
-        self.state.models_manager.list_collaboration_modes()
+    pub fn list_collaboration_modes(&self, config: &Config) -> Vec<CollaborationModeMask> {
+        let mut presets = self.state.models_manager.list_collaboration_modes();
+        presets.extend(config.collaboration_mode_presets.clone());
+        presets
     }
 
     pub async fn list_thread_ids(&self) -> Vec<ThreadId> {

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -2512,7 +2512,7 @@ impl Renderable for ChatComposer {
                 render_mode_indicator(
                     hint_rect,
                     buf,
-                    self.collaboration_mode_indicator,
+                    self.collaboration_mode_indicator.clone(),
                     !footer_props.is_task_running,
                     left_content_width,
                 );

--- a/codex-rs/tui/src/bottom_pane/footer.rs
+++ b/codex-rs/tui/src/bottom_pane/footer.rs
@@ -15,6 +15,7 @@ use crate::key_hint::KeyBinding;
 use crate::render::line_utils::prefix_lines;
 use crate::status::format_tokens_compact;
 use crate::ui_consts::FOOTER_INDENT_COLS;
+use codex_protocol::config_types::CollaborationModeColor;
 use crossterm::event::KeyCode;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -46,18 +47,22 @@ pub(crate) struct FooterProps {
     pub(crate) context_window_used_tokens: Option<i64>,
 }
 
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub(crate) enum CollaborationModeIndicator {
     Plan,
     Code,
     PairProgramming,
     Execute,
+    Custom {
+        name: String,
+        color: CollaborationModeColor,
+    },
 }
 
 const MODE_CYCLE_HINT: &str = "shift+tab to cycle";
 
 impl CollaborationModeIndicator {
-    fn label(self, show_cycle_hint: bool) -> String {
+    fn label(&self, show_cycle_hint: bool) -> String {
         let suffix = if show_cycle_hint {
             format!(" ({MODE_CYCLE_HINT})")
         } else {
@@ -70,16 +75,23 @@ impl CollaborationModeIndicator {
                 format!("Pair Programming mode{suffix}")
             }
             CollaborationModeIndicator::Execute => format!("Execute mode{suffix}"),
+            CollaborationModeIndicator::Custom { name, .. } => format!("{name} mode{suffix}"),
         }
     }
 
-    fn styled_span(self, show_cycle_hint: bool) -> Span<'static> {
+    fn styled_span(&self, show_cycle_hint: bool) -> Span<'static> {
         let label = self.label(show_cycle_hint);
         match self {
             CollaborationModeIndicator::Plan => Span::from(label).magenta(),
             CollaborationModeIndicator::Code => Span::from(label).cyan(),
             CollaborationModeIndicator::PairProgramming => Span::from(label).cyan(),
             CollaborationModeIndicator::Execute => Span::from(label).dim(),
+            CollaborationModeIndicator::Custom { color, .. } => match color {
+                CollaborationModeColor::Cyan => Span::from(label).cyan(),
+                CollaborationModeColor::Magenta => Span::from(label).magenta(),
+                CollaborationModeColor::Green => Span::from(label).green(),
+                CollaborationModeColor::Red => Span::from(label).red(),
+            },
         }
     }
 }

--- a/codex-rs/tui/src/collaboration_modes.rs
+++ b/codex-rs/tui/src/collaboration_modes.rs
@@ -3,23 +3,39 @@ use codex_protocol::config_types::CollaborationModeMask;
 use codex_protocol::config_types::ModeKind;
 
 fn is_tui_mode(kind: ModeKind) -> bool {
-    matches!(kind, ModeKind::Plan | ModeKind::Code)
+    matches!(kind, ModeKind::Plan | ModeKind::Code | ModeKind::Custom)
 }
 
-fn filtered_presets(models_manager: &ModelsManager) -> Vec<CollaborationModeMask> {
-    models_manager
+fn filtered_presets(
+    models_manager: &ModelsManager,
+    custom_presets: &[CollaborationModeMask],
+) -> Vec<CollaborationModeMask> {
+    let mut presets: Vec<CollaborationModeMask> = models_manager
         .list_collaboration_modes()
         .into_iter()
         .filter(|mask| mask.mode.is_some_and(is_tui_mode))
-        .collect()
+        .collect();
+    presets.extend(
+        custom_presets
+            .iter()
+            .filter(|mask| mask.mode == Some(ModeKind::Custom))
+            .cloned(),
+    );
+    presets
 }
 
-pub(crate) fn presets_for_tui(models_manager: &ModelsManager) -> Vec<CollaborationModeMask> {
-    filtered_presets(models_manager)
+pub(crate) fn presets_for_tui(
+    models_manager: &ModelsManager,
+    custom_presets: &[CollaborationModeMask],
+) -> Vec<CollaborationModeMask> {
+    filtered_presets(models_manager, custom_presets)
 }
 
-pub(crate) fn default_mask(models_manager: &ModelsManager) -> Option<CollaborationModeMask> {
-    let presets = filtered_presets(models_manager);
+pub(crate) fn default_mask(
+    models_manager: &ModelsManager,
+    custom_presets: &[CollaborationModeMask],
+) -> Option<CollaborationModeMask> {
+    let presets = filtered_presets(models_manager, custom_presets);
     presets
         .iter()
         .find(|mask| mask.mode == Some(ModeKind::Code))
@@ -29,12 +45,13 @@ pub(crate) fn default_mask(models_manager: &ModelsManager) -> Option<Collaborati
 
 pub(crate) fn mask_for_kind(
     models_manager: &ModelsManager,
+    custom_presets: &[CollaborationModeMask],
     kind: ModeKind,
 ) -> Option<CollaborationModeMask> {
     if !is_tui_mode(kind) {
         return None;
     }
-    filtered_presets(models_manager)
+    filtered_presets(models_manager, custom_presets)
         .into_iter()
         .find(|mask| mask.mode == Some(kind))
 }
@@ -42,20 +59,24 @@ pub(crate) fn mask_for_kind(
 /// Cycle to the next collaboration mode preset in list order.
 pub(crate) fn next_mask(
     models_manager: &ModelsManager,
+    custom_presets: &[CollaborationModeMask],
     current: Option<&CollaborationModeMask>,
 ) -> Option<CollaborationModeMask> {
-    let presets = filtered_presets(models_manager);
+    let presets = filtered_presets(models_manager, custom_presets);
     if presets.is_empty() {
         return None;
     }
-    let current_kind = current.and_then(|mask| mask.mode);
+    let current_name = current.map(|mask| mask.name.as_str());
     let next_index = presets
         .iter()
-        .position(|mask| mask.mode == current_kind)
+        .position(|mask| Some(mask.name.as_str()) == current_name)
         .map_or(0, |idx| (idx + 1) % presets.len());
     presets.get(next_index).cloned()
 }
 
-pub(crate) fn code_mask(models_manager: &ModelsManager) -> Option<CollaborationModeMask> {
-    mask_for_kind(models_manager, ModeKind::Code)
+pub(crate) fn code_mask(
+    models_manager: &ModelsManager,
+    custom_presets: &[CollaborationModeMask],
+) -> Option<CollaborationModeMask> {
+    mask_for_kind(models_manager, custom_presets, ModeKind::Code)
 }

--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,30 @@ Codex can run a notification hook when the agent finishes a turn. See the config
 
 - https://developers.openai.com/codex/config-reference
 
+## Collaboration mode presets
+
+You can add custom collaboration modes that are selectable via Shift+Tab in the TUI:
+
+```toml
+collaboration_mode_palette = ["magenta", "cyan", "green", "red"]
+
+[collaboration_mode_presets."Research"]
+developer_instructions = "Focus on evidence and cite sources."
+reasoning_effort = "high"
+color = "magenta"
+
+[collaboration_mode_presets."Spec"]
+developer_instructions_file = "/path/to/spec.md"
+```
+
+Each preset must define exactly one of `developer_instructions` or `developer_instructions_file`.
+Colors are optional; supported values are `cyan`, `magenta`, `green`, and `red`. When a preset
+does not specify a color, Codex assigns a deterministic color based on the preset name and the
+`collaboration_mode_palette`. The palette must be non-empty; if omitted, Codex uses the default
+order shown above so the same mode keeps its color across sessions.
+Custom names cannot conflict with built-in modes (Plan, Code, Pair Programming, Execute). Built-ins
+appear first; custom presets follow in name order.
+
 ## JSON Schema
 
 The generated JSON Schema for `config.toml` lives at `codex-rs/core/config.schema.json`.


### PR DESCRIPTION
Fixes https://github.com/openai/codex/issues/9889

Problem
- Custom collaboration presets exist, but default colors are fixed and not user-configurable.

Solution
- Add `collaboration_mode_palette` (ANSI-only) and allow per-preset `color`.
- Deterministic default color per preset name + palette; validate non-empty palette.
- Update schema/docs/tests.

Testing
- cargo test -p codex-protocol
- cargo test -p codex-core (flaked once on read_file_tools_run_in_parallel; rerun passed)
- cargo test -p codex-core --test all suite::tool_parallelism::read_file_tools_run_in_parallel