### PR TITLE
Fix typo in prompt files: "command execution" -> "see command execution"

### DIFF
--- a/codex-rs/core/gpt-5.1-codex-max_prompt.md
+++ b/codex-rs/core/gpt-5.1-codex-max_prompt.md
@@ -57,7 +57,7 @@ You are producing plain text that will later be styled by the CLI. Follow these 
   * Lead with a quick explanation of the change, and then give more details on the context covering where and why a change was made. Do not start this explanation with "summary", just jump right in.
   * If there are natural next steps the user may want to take, suggest them at the end of your response. Do not make suggestions if there are no natural next steps.
   * When suggesting multiple options, use numeric lists for the suggestions so the user can quickly respond with a single number.
-- The user does not command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
+- The user does not see command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
 
 ### Final answer structure and style guidelines
 

--- a/codex-rs/core/gpt-5.2-codex_prompt.md
+++ b/codex-rs/core/gpt-5.2-codex_prompt.md
@@ -57,7 +57,7 @@ You are producing plain text that will later be styled by the CLI. Follow these 
   * Lead with a quick explanation of the change, and then give more details on the context covering where and why a change was made. Do not start this explanation with "summary", just jump right in.
   * If there are natural next steps the user may want to take, suggest them at the end of your response. Do not make suggestions if there are no natural next steps.
   * When suggesting multiple options, use numeric lists for the suggestions so the user can quickly respond with a single number.
-- The user does not command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
+- The user does not see command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
 
 ### Final answer structure and style guidelines
 

--- a/codex-rs/core/gpt_5_codex_prompt.md
+++ b/codex-rs/core/gpt_5_codex_prompt.md
@@ -45,7 +45,7 @@ You are producing plain text that will later be styled by the CLI. Follow these 
   * Lead with a quick explanation of the change, and then give more details on the context covering where and why a change was made. Do not start this explanation with "summary", just jump right in.
   * If there are natural next steps the user may want to take, suggest them at the end of your response. Do not make suggestions if there are no natural next steps.
   * When suggesting multiple options, use numeric lists for the suggestions so the user can quickly respond with a single number.
-- The user does not command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
+- The user does not see command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
 
 ### Final answer structure and style guidelines
 


### PR DESCRIPTION
The current phrasing "The user does not command execution outputs" appears to be a typo (missing verb). Based on the context of the following instructions, the missing verb should be "see".