### PR TITLE
Add CLI flag to list models and reasoning efforts

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1240,6 +1240,7 @@ dependencies = [
  "codex-rmcp-client",
  "codex-stdio-to-uds",
  "codex-tui",
+ "codex-utils-absolute-path",
  "codex-utils-cargo-bin",
  "codex-windows-sandbox",
  "libc",

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -35,6 +35,7 @@ codex-responses-api-proxy = { workspace = true }
 codex-rmcp-client = { workspace = true }
 codex-stdio-to-uds = { workspace = true }
 codex-tui = { workspace = true }
+codex-utils-absolute-path = { workspace = true }
 libc = { workspace = true }
 owo-colors = { workspace = true }
 regex-lite = { workspace = true }

--- a/docs/install.md
+++ b/docs/install.md
@@ -35,6 +35,9 @@ cargo build
 # Launch the TUI with a sample prompt.
 cargo run --bin codex -- "explain this codebase to me"
 
+# List available models and supported reasoning efforts.
+cargo run --bin codex -- --list-models
+
 # After making changes, use the root justfile helpers (they default to codex-rs):
 just fmt
 just fix -p <crate-you-touched>


### PR DESCRIPTION
## Summary
- add --list-models flag to print available models and reasoning efforts
- validate list-models invocation and cover it with unit tests
- document the flag in install guide

## Testing
- cargo test -p codex-cli
