### PR TITLE
fix(tui): restore fuzzy matching fallback for slash-command popup

### DIFF
--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__slash_popup_mo.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__chat_composer__tests__slash_popup_mo.snap
@@ -1,9 +1,10 @@
 ---
 source: tui/src/bottom_pane/chat_composer.rs
+assertion_line: 3731
 expression: terminal.backend()
 ---
 "                                                            "
 "› /mo                                                       "
 "                                                            "
-"                                                            "
-"  /model  choose what model and reasoning effort to use     "
+"  /model    choose what model and reasoning effort to use   "
+"  /mention  mention a file                                  "


### PR DESCRIPTION
## Summary

Fixes #9741

Re-enable fuzzy/substring matching as a fallback in the slash-command autocomplete popup. 

PR #9629 was intended to implement "exact > prefix > fuzzy" ordering but actually removed fuzzy matching entirely. This PR restores the original behavior where fuzzy matches appear after exact and prefix matches.

## Changes

- Re-imported `fuzzy_match` from `codex_common::fuzzy_match`
- Modified the `filtered()` function to include fuzzy matches as a third tier
- Fuzzy matches are sorted by score (lower is better)
- Updated tests to verify fuzzy fallback works

## Test Plan

- [x] `cargo test -p codex-tui --lib -- command_popup` passes
- [x] Typing `/ac` now shows `/compact` as a fuzzy match
- [x] Prefix matches still appear before fuzzy matches (e.g., `/mo` shows `/model` first)
- [x] Clippy passes with no warnings

---
🤖 Generated with Claude Code (issue-hunter-pro)