### PR TITLE
Feat: add isOther to question returned by request user input tool

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -2381,6 +2381,8 @@ pub struct FileChangeRequestApprovalResponse {
 pub struct ToolRequestUserInputOption {
     pub label: String,
     pub description: String,
+    #[serde(default)]
+    pub is_other: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -2381,8 +2381,6 @@ pub struct FileChangeRequestApprovalResponse {
 pub struct ToolRequestUserInputOption {
     pub label: String,
     pub description: String,
-    #[serde(default)]
-    pub is_other: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
@@ -2393,6 +2391,8 @@ pub struct ToolRequestUserInputQuestion {
     pub id: String,
     pub header: String,
     pub question: String,
+    #[serde(default)]
+    pub is_other: bool,
     pub options: Option<Vec<ToolRequestUserInputOption>>,
 }
 

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -282,6 +282,7 @@ pub(crate) async fn apply_bespoke_event_handling(
                                 .map(|option| ToolRequestUserInputOption {
                                     label: option.label,
                                     description: option.description,
+                                    is_other: option.is_other,
                                 })
                                 .collect()
                         }),

--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -276,13 +276,13 @@ pub(crate) async fn apply_bespoke_event_handling(
                         id: question.id,
                         header: question.header,
                         question: question.question,
+                        is_other: question.is_other,
                         options: question.options.map(|options| {
                             options
                                 .into_iter()
                                 .map(|option| ToolRequestUserInputOption {
                                     label: option.label,
                                     description: option.description,
-                                    is_other: option.is_other,
                                 })
                                 .collect()
                         }),

--- a/codex-rs/app-server/tests/common/responses.rs
+++ b/codex-rs/app-server/tests/common/responses.rs
@@ -69,10 +69,12 @@ pub fn create_request_user_input_sse_response(call_id: &str) -> anyhow::Result<S
             "question": "Proceed with the plan?",
             "options": [{
                 "label": "Yes (Recommended)",
-                "description": "Continue the current plan."
+                "description": "Continue the current plan.",
+                "isOther": false
             }, {
                 "label": "No",
-                "description": "Stop and revisit the approach."
+                "description": "Stop and revisit the approach.",
+                "isOther": false
             }]
         }]
     }))?;

--- a/codex-rs/app-server/tests/common/responses.rs
+++ b/codex-rs/app-server/tests/common/responses.rs
@@ -67,14 +67,13 @@ pub fn create_request_user_input_sse_response(call_id: &str) -> anyhow::Result<S
             "id": "confirm_path",
             "header": "Confirm",
             "question": "Proceed with the plan?",
+            "isOther": false,
             "options": [{
                 "label": "Yes (Recommended)",
-                "description": "Continue the current plan.",
-                "isOther": false
+                "description": "Continue the current plan."
             }, {
                 "label": "No",
-                "description": "Stop and revisit the approach.",
-                "isOther": false
+                "description": "Stop and revisit the approach."
             }]
         }]
     }))?;

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -551,28 +551,15 @@ fn create_request_user_input_tool() -> ToolSpec {
             ),
         },
     );
-    option_props.insert(
-        "isOther".to_string(),
-        JsonSchema::Boolean {
-            description: Some(
-                "True when this option is the free-form \"Other\" choice (label meaning \"Other\" in any language). Otherwise false."
-                    .to_string(),
-            ),
-        },
-    );
 
     let options_schema = JsonSchema::Array {
         description: Some(
-            "Optional 2-3 mutually exclusive choices. Put the recommended option first and suffix its label with \"(Recommended)\". Only include an \"Other\" option if we want a free form choice; set isOther=true only for that option. If the question is free form in nature, please do not have any option."
+            "Optional 2-3 mutually exclusive choices. Put the recommended option first and suffix its label with \"(Recommended)\". Do not include an \"Other\" option in this list; use isOther on the question to request a free form choice. If the question is free form in nature, please do not have any option."
                 .to_string(),
         ),
         items: Box::new(JsonSchema::Object {
             properties: option_props,
-            required: Some(vec![
-                "label".to_string(),
-                "description".to_string(),
-                "isOther".to_string(),
-            ]),
+            required: Some(vec!["label".to_string(), "description".to_string()]),
             additional_properties: Some(false.into()),
         }),
     };
@@ -598,6 +585,15 @@ fn create_request_user_input_tool() -> ToolSpec {
             description: Some("Single-sentence prompt shown to the user.".to_string()),
         },
     );
+    question_props.insert(
+        "isOther".to_string(),
+        JsonSchema::Boolean {
+            description: Some(
+                "True when this question should include a free-form \"Other\" option. Otherwise false."
+                    .to_string(),
+            ),
+        },
+    );
     question_props.insert("options".to_string(), options_schema);
 
     let questions_schema = JsonSchema::Array {
@@ -608,6 +604,7 @@ fn create_request_user_input_tool() -> ToolSpec {
                 "id".to_string(),
                 "header".to_string(),
                 "question".to_string(),
+                "isOther".to_string(),
             ]),
             additional_properties: Some(false.into()),
         }),

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -551,15 +551,28 @@ fn create_request_user_input_tool() -> ToolSpec {
             ),
         },
     );
+    option_props.insert(
+        "isOther".to_string(),
+        JsonSchema::Boolean {
+            description: Some(
+                "True when this option is the free-form \"Other\" choice (label meaning \"Other\" in any language). Otherwise false."
+                    .to_string(),
+            ),
+        },
+    );
 
     let options_schema = JsonSchema::Array {
         description: Some(
-            "Optional 2-3 mutually exclusive choices. Put the recommended option first and suffix its label with \"(Recommended)\". Only include \"Other\" option if we want to include a free form option. If the question is free form in nature, please do not have any option."
+            "Optional 2-3 mutually exclusive choices. Put the recommended option first and suffix its label with \"(Recommended)\". Only include an \"Other\" option if we want a free form choice; set isOther=true only for that option. If the question is free form in nature, please do not have any option."
                 .to_string(),
         ),
         items: Box::new(JsonSchema::Object {
             properties: option_props,
-            required: Some(vec!["label".to_string(), "description".to_string()]),
+            required: Some(vec![
+                "label".to_string(),
+                "description".to_string(),
+                "isOther".to_string(),
+            ]),
             additional_properties: Some(false.into()),
         }),
     };

--- a/codex-rs/core/tests/suite/request_user_input.rs
+++ b/codex-rs/core/tests/suite/request_user_input.rs
@@ -94,14 +94,13 @@ async fn request_user_input_round_trip_resolves_pending() -> anyhow::Result<()> 
             "id": "confirm_path",
             "header": "Confirm",
             "question": "Proceed with the plan?",
+            "isOther": false,
             "options": [{
                 "label": "Yes (Recommended)",
-                "description": "Continue the current plan.",
-                "isOther": false
+                "description": "Continue the current plan."
             }, {
                 "label": "No",
-                "description": "Stop and revisit the approach.",
-                "isOther": false
+                "description": "Stop and revisit the approach."
             }]
         }]
     })
@@ -215,14 +214,13 @@ where
             "id": "confirm_path",
             "header": "Confirm",
             "question": "Proceed with the plan?",
+            "isOther": false,
             "options": [{
                 "label": "Yes (Recommended)",
-                "description": "Continue the current plan.",
-                "isOther": false
+                "description": "Continue the current plan."
             }, {
                 "label": "No",
-                "description": "Stop and revisit the approach.",
-                "isOther": false
+                "description": "Stop and revisit the approach."
             }]
         }]
     })

--- a/codex-rs/core/tests/suite/request_user_input.rs
+++ b/codex-rs/core/tests/suite/request_user_input.rs
@@ -96,10 +96,12 @@ async fn request_user_input_round_trip_resolves_pending() -> anyhow::Result<()> 
             "question": "Proceed with the plan?",
             "options": [{
                 "label": "Yes (Recommended)",
-                "description": "Continue the current plan."
+                "description": "Continue the current plan.",
+                "isOther": false
             }, {
                 "label": "No",
-                "description": "Stop and revisit the approach."
+                "description": "Stop and revisit the approach.",
+                "isOther": false
             }]
         }]
     })
@@ -215,10 +217,12 @@ where
             "question": "Proceed with the plan?",
             "options": [{
                 "label": "Yes (Recommended)",
-                "description": "Continue the current plan."
+                "description": "Continue the current plan.",
+                "isOther": false
             }, {
                 "label": "No",
-                "description": "Stop and revisit the approach."
+                "description": "Stop and revisit the approach.",
+                "isOther": false
             }]
         }]
     })

--- a/codex-rs/docs/protocol_v1.md
+++ b/codex-rs/docs/protocol_v1.md
@@ -75,7 +75,7 @@ For complete documentation of the `Op` and `EventMsg` variants, refer to [protoc
 - `EventMsg`
   - `EventMsg::AgentMessage` – Messages from the `Model`
   - `EventMsg::ExecApprovalRequest` – Request approval from user to execute a command
-  - `EventMsg::RequestUserInput` – Request user input for a tool call
+  - `EventMsg::RequestUserInput` – Request user input for a tool call (questions can include options plus `isOther` to add a free-form choice)
   - `EventMsg::TurnComplete` – A turn completed successfully
   - `EventMsg::Error` – A turn stopped with an error
   - `EventMsg::Warning` – A non-fatal warning that the client should surface to the user

--- a/codex-rs/protocol/src/request_user_input.rs
+++ b/codex-rs/protocol/src/request_user_input.rs
@@ -9,6 +9,10 @@ use ts_rs::TS;
 pub struct RequestUserInputQuestionOption {
     pub label: String,
     pub description: String,
+    #[serde(rename = "isOther", default)]
+    #[schemars(rename = "isOther")]
+    #[ts(rename = "isOther")]
+    pub is_other: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]

--- a/codex-rs/protocol/src/request_user_input.rs
+++ b/codex-rs/protocol/src/request_user_input.rs
@@ -9,10 +9,6 @@ use ts_rs::TS;
 pub struct RequestUserInputQuestionOption {
     pub label: String,
     pub description: String,
-    #[serde(rename = "isOther", default)]
-    #[schemars(rename = "isOther")]
-    #[ts(rename = "isOther")]
-    pub is_other: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
@@ -20,6 +16,10 @@ pub struct RequestUserInputQuestion {
     pub id: String,
     pub header: String,
     pub question: String,
+    #[serde(rename = "isOther", default)]
+    #[schemars(rename = "isOther")]
+    #[ts(rename = "isOther")]
+    pub is_other: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub options: Option<Vec<RequestUserInputQuestionOption>>,
 }

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -508,21 +508,19 @@ mod tests {
             id: id.to_string(),
             header: header.to_string(),
             question: "Choose an option.".to_string(),
+            is_other: false,
             options: Some(vec![
                 RequestUserInputQuestionOption {
                     label: "Option 1".to_string(),
                     description: "First choice.".to_string(),
-                    is_other: false,
                 },
                 RequestUserInputQuestionOption {
                     label: "Option 2".to_string(),
                     description: "Second choice.".to_string(),
-                    is_other: false,
                 },
                 RequestUserInputQuestionOption {
                     label: "Option 3".to_string(),
                     description: "Third choice.".to_string(),
-                    is_other: false,
                 },
             ]),
         }
@@ -533,6 +531,7 @@ mod tests {
             id: id.to_string(),
             header: header.to_string(),
             question: "Share details.".to_string(),
+            is_other: false,
             options: None,
         }
     }
@@ -699,31 +698,27 @@ mod tests {
                     id: "q1".to_string(),
                     header: "Next Step".to_string(),
                     question: "What would you like to do next?".to_string(),
+                    is_other: false,
                     options: Some(vec![
                         RequestUserInputQuestionOption {
                             label: "Discuss a code change (Recommended)".to_string(),
                             description: "Walk through a plan and edit code together.".to_string(),
-                            is_other: false,
                         },
                         RequestUserInputQuestionOption {
                             label: "Run tests".to_string(),
                             description: "Pick a crate and run its tests.".to_string(),
-                            is_other: false,
                         },
                         RequestUserInputQuestionOption {
                             label: "Review a diff".to_string(),
                             description: "Summarize or review current changes.".to_string(),
-                            is_other: false,
                         },
                         RequestUserInputQuestionOption {
                             label: "Refactor".to_string(),
                             description: "Tighten structure and remove dead code.".to_string(),
-                            is_other: false,
                         },
                         RequestUserInputQuestionOption {
                             label: "Ship it".to_string(),
                             description: "Finalize and open a PR.".to_string(),
-                            is_other: false,
                         },
                     ]),
                 }],

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -512,14 +512,17 @@ mod tests {
                 RequestUserInputQuestionOption {
                     label: "Option 1".to_string(),
                     description: "First choice.".to_string(),
+                    is_other: false,
                 },
                 RequestUserInputQuestionOption {
                     label: "Option 2".to_string(),
                     description: "Second choice.".to_string(),
+                    is_other: false,
                 },
                 RequestUserInputQuestionOption {
                     label: "Option 3".to_string(),
                     description: "Third choice.".to_string(),
+                    is_other: false,
                 },
             ]),
         }
@@ -700,22 +703,27 @@ mod tests {
                         RequestUserInputQuestionOption {
                             label: "Discuss a code change (Recommended)".to_string(),
                             description: "Walk through a plan and edit code together.".to_string(),
+                            is_other: false,
                         },
                         RequestUserInputQuestionOption {
                             label: "Run tests".to_string(),
                             description: "Pick a crate and run its tests.".to_string(),
+                            is_other: false,
                         },
                         RequestUserInputQuestionOption {
                             label: "Review a diff".to_string(),
                             description: "Summarize or review current changes.".to_string(),
+                            is_other: false,
                         },
                         RequestUserInputQuestionOption {
                             label: "Refactor".to_string(),
                             description: "Tighten structure and remove dead code.".to_string(),
+                            is_other: false,
                         },
                         RequestUserInputQuestionOption {
                             label: "Ship it".to_string(),
                             description: "Finalize and open a PR.".to_string(),
+                            is_other: false,
                         },
                     ]),
                 }],


### PR DESCRIPTION
### Summary
Add `isOther` to question object from request_user_input tool input and remove `other` option from the tool prompt to better handle tool input. 