### PR TITLE
Document composer reuse and paste-burst routing

### DIFF
--- a/codex-rs/tui/src/bottom_pane/bottom_pane_view.rs
+++ b/codex-rs/tui/src/bottom_pane/bottom_pane_view.rs
@@ -28,11 +28,17 @@ pub(crate) trait BottomPaneView: Renderable {
     }
 
     /// Flush any pending paste-burst state. Return true if state changed.
+    ///
+    /// This lets a modal that reuses `ChatComposer` participate in the same
+    /// time-based paste burst flushing as the primary composer.
     fn flush_paste_burst_if_due(&mut self) -> bool {
         false
     }
 
     /// Whether the view is currently holding paste-burst transient state.
+    ///
+    /// When `true`, the bottom pane will schedule a short delayed redraw to
+    /// give the burst time window a chance to flush.
     fn is_in_paste_burst(&self) -> bool {
         false
     }

--- a/codex-rs/tui/src/bottom_pane/request_user_input/layout.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/layout.rs
@@ -97,6 +97,8 @@ impl RequestUserInputOverlay {
                     .saturating_add(notes_input_height);
                 options_height = remaining_content.saturating_sub(reserved);
                 if options_height > options_len {
+                    // Expand the notes composer with any leftover rows so we
+                    // do not leave a large blank gap between options and notes.
                     let extra_rows = options_height.saturating_sub(options_len);
                     options_height = options_len;
                     notes_input_height = notes_input_height.saturating_add(extra_rows);

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -65,7 +65,10 @@ pub(crate) struct RequestUserInputOverlay {
     request: RequestUserInputEvent,
     // Queue of incoming requests to process after the current one.
     queue: VecDeque<RequestUserInputEvent>,
+    // Reuse the shared chat composer so notes/freeform answers match the
+    // primary input styling and behavior.
     composer: ChatComposer,
+    // One entry per question: selection state plus a stored notes draft.
     answers: Vec<AnswerState>,
     current_idx: usize,
     focus: Focus,
@@ -80,6 +83,8 @@ impl RequestUserInputOverlay {
         enhanced_keys_supported: bool,
         disable_paste_burst: bool,
     ) -> Self {
+        // Use the same composer widget, but disable popups/slash-commands and
+        // image-path attachment so it behaves like a focused notes field.
         let mut composer = ChatComposer::new_with_config(
             has_input_focus,
             app_event_tx.clone(),
@@ -88,6 +93,7 @@ impl RequestUserInputOverlay {
             disable_paste_burst,
             ChatComposerConfig::plain_text(),
         );
+        // The overlay renders its own footer hints, so keep the composer footer empty.
         composer.set_footer_hint_override(Some(Vec::new()));
         let mut overlay = Self {
             app_event_tx,

--- a/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
@@ -57,6 +57,8 @@ impl RequestUserInputOverlay {
         if area.width == 0 || area.height == 0 {
             return;
         }
+        // Paint the same menu surface used by other bottom-pane overlays and
+        // then render the overlay content inside its inset area.
         let content_area = render_menu_surface(area, buf);
         if content_area.width == 0 || content_area.height == 0 {
             return;


### PR DESCRIPTION
Add in-code docs that explain the composer reuse approach and paste-burst routing.

- Document paste-burst hooks on BottomPaneView and the view-first flush checks.
- Clarify request_user_input layout choices (notes sizing and footer override).