### PR TITLE
Add append-only clear-context operation and marker

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -99,6 +99,7 @@ pub enum CodexErrorInfo {
     Unauthorized,
     BadRequest,
     ThreadRollbackFailed,
+    ContextClearFailed,
     SandboxError,
     /// The response SSE stream disconnected in the middle of a turn before completion.
     ResponseStreamDisconnected {
@@ -130,6 +131,7 @@ impl From<CoreCodexErrorInfo> for CodexErrorInfo {
             CoreCodexErrorInfo::Unauthorized => CodexErrorInfo::Unauthorized,
             CoreCodexErrorInfo::BadRequest => CodexErrorInfo::BadRequest,
             CoreCodexErrorInfo::ThreadRollbackFailed => CodexErrorInfo::ThreadRollbackFailed,
+            CoreCodexErrorInfo::ContextClearFailed => CodexErrorInfo::ContextClearFailed,
             CoreCodexErrorInfo::SandboxError => CodexErrorInfo::SandboxError,
             CoreCodexErrorInfo::ResponseStreamDisconnected { http_status_code } => {
                 CodexErrorInfo::ResponseStreamDisconnected { http_status_code }

--- a/codex-rs/codex-api/src/requests/chat.rs
+++ b/codex-rs/codex-api/src/requests/chat.rs
@@ -75,6 +75,7 @@ impl<'a> ChatRequestBuilder<'a> {
                 ResponseItem::WebSearchCall { .. } => {}
                 ResponseItem::GhostSnapshot { .. } => {}
                 ResponseItem::Compaction { .. } => {}
+                ResponseItem::ContextCleared => last_emitted_role = None,
             }
         }
 
@@ -280,6 +281,10 @@ impl<'a> ChatRequestBuilder<'a> {
                     }));
                 }
                 ResponseItem::GhostSnapshot { .. } => {
+                    continue;
+                }
+                ResponseItem::ContextCleared => {
+                    last_assistant_text = None;
                     continue;
                 }
                 ResponseItem::Reasoning { .. }

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -171,7 +171,7 @@ async fn run_compact_task_inner(
     }
 
     let history_snapshot = sess.clone_history().await;
-    let history_items = history_snapshot.raw_items();
+    let history_items = history_snapshot.active_items();
     let summary_suffix = get_last_assistant_message_from_turn(history_items).unwrap_or_default();
     let summary_text = format!("{SUMMARY_PREFIX}\n{summary_suffix}");
     let user_messages = collect_user_messages(history_items);

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -44,7 +44,7 @@ async fn run_remote_compact_task_inner_impl(
 
     // Required to keep `/undo` available after compaction
     let ghost_snapshots: Vec<ResponseItem> = history
-        .raw_items()
+        .active_items()
         .iter()
         .filter(|item| matches!(item, ResponseItem::GhostSnapshot { .. }))
         .cloned()

--- a/codex-rs/core/src/rollout/policy.rs
+++ b/codex-rs/core/src/rollout/policy.rs
@@ -28,7 +28,8 @@ pub(crate) fn should_persist_response_item(item: &ResponseItem) -> bool {
         | ResponseItem::CustomToolCallOutput { .. }
         | ResponseItem::WebSearchCall { .. }
         | ResponseItem::GhostSnapshot { .. }
-        | ResponseItem::Compaction { .. } => true,
+        | ResponseItem::Compaction { .. }
+        | ResponseItem::ContextCleared => true,
         ResponseItem::Other => false,
     }
 }
@@ -43,6 +44,7 @@ pub(crate) fn should_persist_event_msg(ev: &EventMsg) -> bool {
         | EventMsg::AgentReasoningRawContent(_)
         | EventMsg::TokenCount(_)
         | EventMsg::ContextCompacted(_)
+        | EventMsg::ContextCleared(_)
         | EventMsg::EnteredReviewMode(_)
         | EventMsg::ExitedReviewMode(_)
         | EventMsg::ThreadRolledBack(_)

--- a/codex-rs/core/src/tasks/undo.rs
+++ b/codex-rs/core/src/tasks/undo.rs
@@ -66,19 +66,20 @@ impl SessionTask for UndoTask {
 
         let history = sess.clone_history().await;
         let mut items = history.raw_items().to_vec();
+        let active_start = items.len().saturating_sub(history.active_items().len());
         let mut completed = UndoCompletedEvent {
             success: false,
             message: None,
         };
 
         let Some((idx, ghost_commit)) =
-            items
+            items[active_start..]
                 .iter()
                 .enumerate()
                 .rev()
-                .find_map(|(idx, item)| match item {
+                .find_map(|(rel_idx, item)| match item {
                     ResponseItem::GhostSnapshot { ghost_commit } => {
-                        Some((idx, ghost_commit.clone()))
+                        Some((active_start + rel_idx, ghost_commit.clone()))
                     }
                     _ => None,
                 })

--- a/codex-rs/docs/protocol_v1.md
+++ b/codex-rs/docs/protocol_v1.md
@@ -68,6 +68,7 @@ For complete documentation of the `Op` and `EventMsg` variants, refer to [protoc
   - `Op::UserTurn` – Any input from the user to kick off a `Turn`
   - `Op::UserInput` – Legacy form of user input
   - `Op::Interrupt` – Interrupts a running turn
+  - `Op::ClearContext` – Reset the conversation back to the initial context boundary
   - `Op::ExecApproval` – Approve or deny code execution
   - `Op::UserInputAnswer` – Provide answers for a `request_user_input` tool call
   - `Op::ListSkills` – Request skills for one or more cwd values (optionally `force_reload`)
@@ -76,6 +77,7 @@ For complete documentation of the `Op` and `EventMsg` variants, refer to [protoc
   - `EventMsg::AgentMessage` – Messages from the `Model`
   - `EventMsg::ExecApprovalRequest` – Request approval from user to execute a command
   - `EventMsg::RequestUserInput` – Request user input for a tool call
+  - `EventMsg::ContextCleared` – Signals that prior conversation history should be cleared
   - `EventMsg::TurnComplete` – A turn completed successfully
   - `EventMsg::Error` – A turn stopped with an error
   - `EventMsg::Warning` – A non-fatal warning that the client should surface to the user

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -607,6 +607,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
             | EventMsg::UndoCompleted(_)
             | EventMsg::UndoStarted(_)
             | EventMsg::ThreadRolledBack(_)
+            | EventMsg::ContextCleared(_)
             | EventMsg::RequestUserInput(_) => {}
         }
         CodexStatus::Running

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -361,6 +361,7 @@ async fn run_codex_tool_session_inner(
                     | EventMsg::ExitedReviewMode(_)
                     | EventMsg::RequestUserInput(_)
                     | EventMsg::ContextCompacted(_)
+                    | EventMsg::ContextCleared(_)
                     | EventMsg::ThreadRolledBack(_)
                     | EventMsg::CollabAgentSpawnBegin(_)
                     | EventMsg::CollabAgentSpawnEnd(_)

--- a/codex-rs/otel/src/traces/otel_manager.rs
+++ b/codex-rs/otel/src/traces/otel_manager.rs
@@ -503,6 +503,7 @@ impl OtelManager {
             ResponseItem::WebSearchCall { .. } => "web_search_call".into(),
             ResponseItem::GhostSnapshot { .. } => "ghost_snapshot".into(),
             ResponseItem::Compaction { .. } => "compaction".into(),
+            ResponseItem::ContextCleared => "context_cleared".into(),
             ResponseItem::Other => "other".into(),
         }
     }

--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -163,6 +163,7 @@ pub enum ResponseItem {
     GhostSnapshot {
         ghost_commit: GhostCommit,
     },
+    ContextCleared,
     #[serde(alias = "compaction_summary")]
     Compaction {
         encrypted_content: String,

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -265,6 +265,13 @@ pub enum Op {
     /// responsible for undoing any edits on disk.
     ThreadRollback { num_turns: u32 },
 
+    /// Request Codex to clear the effective context while keeping initial context.
+    ///
+    /// This is append-only: a context-cleared marker is recorded alongside a
+    /// fresh copy of the initial context, and prompt construction ignores the
+    /// earlier conversation history.
+    ClearContext,
+
     /// Request a code review from the agent.
     Review { review_request: ReviewRequest },
 
@@ -675,6 +682,9 @@ pub enum EventMsg {
     /// Conversation history was compacted (either automatically or manually).
     ContextCompacted(ContextCompactedEvent),
 
+    /// Conversation context was cleared back to the initial context.
+    ContextCleared(ContextClearedEvent),
+
     /// Conversation history was rolled back by dropping the last N user turns.
     ThreadRolledBack(ThreadRolledBackEvent),
 
@@ -927,6 +937,7 @@ pub enum CodexErrorInfo {
         http_status_code: Option<u16>,
     },
     ThreadRollbackFailed,
+    ContextClearFailed,
     Other,
 }
 
@@ -1065,6 +1076,9 @@ pub struct WarningEvent {
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS)]
 pub struct ContextCompactedEvent;
+
+#[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS)]
+pub struct ContextClearedEvent;
 
 #[derive(Debug, Clone, Deserialize, Serialize, JsonSchema, TS)]
 pub struct TurnCompleteEvent {

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -2058,7 +2058,6 @@ impl App {
         self.reset_transcript_state();
         if let Some(thread_id) = self
             .active_thread_id
-            .clone()
             .or_else(|| self.chat_widget.thread_id())
         {
             let session_configured = self.session_configured_for_thread(thread_id);

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -454,6 +454,7 @@ impl App {
     pub(crate) fn handle_backtrack_event(&mut self, event: &EventMsg) {
         match event {
             EventMsg::ThreadRolledBack(_) => self.finish_pending_backtrack(),
+            EventMsg::ContextCleared(_) => self.backtrack.pending_rollback = None,
             EventMsg::Error(ErrorEvent {
                 codex_error_info: Some(CodexErrorInfo::ThreadRollbackFailed),
                 ..

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -800,7 +800,6 @@ impl ChatWidget {
         let model_for_header = event.model.clone();
         let reasoning_effort = event
             .reasoning_effort
-            .clone()
             .or_else(|| self.current_collaboration_mode.reasoning_effort());
         self.session_header.set_model(&model_for_header);
         self.current_collaboration_mode = self.current_collaboration_mode.with_updates(


### PR DESCRIPTION
## Summary
- add `Op::ClearContext` plus `EventMsg::ContextCleared` and a `ResponseItem::ContextCleared` marker
- keep history append-only while treating the marker as a hard boundary via `active_items()`
- scope compaction, truncation, and undo to the active suffix after the last clear
- reset the TUI transcript/session cells on `ContextCleared` so the UI clears immediately
- update protocol docs to describe the new operation/event

## Testing
- `just fix`
- `just fmt`
- `cargo test -p codex-core`
- `cargo test -p codex-protocol`
- `cargo test -p codex-api`
- `cargo test -p codex-app-server-protocol`
- `cargo test -p codex-otel`
- `cargo test -p codex-tui`
- `cargo test -p codex-mcp-server`
- `cargo test -p codex-exec`