### PR TITLE
TUI: add /theme picker with live preview

### DIFF
--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -856,6 +856,9 @@ fn merge_interactive_cli_flags(interactive: &mut TuiCli, subcommand_cli: TuiCli)
     if !subcommand_cli.add_dir.is_empty() {
         interactive.add_dir.extend(subcommand_cli.add_dir);
     }
+    if let Some(theme) = subcommand_cli.theme {
+        interactive.theme = Some(theme);
+    }
     if let Some(prompt) = subcommand_cli.prompt {
         // Normalize CRLF/CR to LF so CLI-provided text can't leak `\r` into TUI state.
         interactive.prompt = Some(prompt.replace("\r\n", "\n").replace('\r', "\n"));

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -28,6 +28,7 @@ use crate::pager_overlay::Overlay;
 use crate::render::highlight::highlight_bash_to_lines;
 use crate::render::renderable::Renderable;
 use crate::resume_picker::SessionSelection;
+use crate::theme;
 use crate::tui;
 use crate::tui::TuiEvent;
 use crate::update_action::UpdateAction;
@@ -1504,6 +1505,18 @@ impl App {
             }
             AppEvent::UpdatePersonality(personality) => {
                 self.on_update_personality(personality);
+            }
+            AppEvent::PreviewTheme(theme_name) => {
+                theme::set_theme(theme_name);
+                tui.terminal.clear()?;
+                tui.frame_requester().schedule_frame();
+            }
+            AppEvent::UpdateTheme(theme_name) => {
+                theme::set_theme(theme_name);
+                tui.terminal.clear()?;
+                self.chat_widget
+                    .add_info_message(format!("Theme set to {}.", theme_name.label()), None);
+                tui.frame_requester().schedule_frame();
             }
             AppEvent::OpenReasoningPopup { model } => {
                 self.chat_widget.open_reasoning_popup(model);

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -27,6 +27,8 @@ use codex_protocol::config_types::CollaborationModeMask;
 use codex_protocol::config_types::Personality;
 use codex_protocol::openai_models::ReasoningEffort;
 
+use crate::theme::ThemeName;
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
 pub(crate) enum WindowsSandboxEnableMode {
@@ -109,6 +111,12 @@ pub(crate) enum AppEvent {
 
     /// Update the current personality in the running app and widget.
     UpdatePersonality(Personality),
+
+    /// Update the current theme in the running app and widget.
+    UpdateTheme(ThemeName),
+
+    /// Preview a theme without committing UI messages.
+    PreviewTheme(ThemeName),
 
     /// Persist the selected model and reasoning effort to the appropriate config.
     PersistModelSelection {

--- a/codex-rs/tui/src/cli.rs
+++ b/codex-rs/tui/src/cli.rs
@@ -4,6 +4,8 @@ use codex_common::ApprovalModeCliArg;
 use codex_common::CliConfigOverrides;
 use std::path::PathBuf;
 
+use crate::theme::ThemeName;
+
 #[derive(Parser, Debug)]
 #[command(version)]
 pub struct Cli {
@@ -101,6 +103,10 @@ pub struct Cli {
     /// Additional directories that should be writable alongside the primary workspace.
     #[arg(long = "add-dir", value_name = "DIR", value_hint = ValueHint::DirPath)]
     pub add_dir: Vec<PathBuf>,
+
+    /// Select a color theme for the TUI. Defaults to `default`.
+    #[arg(long = "theme", value_enum)]
+    pub theme: Option<ThemeName>,
 
     /// Disable alternate screen mode
     ///

--- a/codex-rs/tui/src/custom_terminal.rs
+++ b/codex-rs/tui/src/custom_terminal.rs
@@ -497,6 +497,8 @@ where
         last_pos = Some(Position { x, y });
         match command {
             DrawCommand::Put { cell, .. } => {
+                let cell_fg = crate::theme::remap_color(cell.fg);
+                let cell_bg = crate::theme::remap_color(cell.bg);
                 if cell.modifier != modifier {
                     let diff = ModifierDiff {
                         from: modifier,
@@ -505,18 +507,19 @@ where
                     diff.queue(writer)?;
                     modifier = cell.modifier;
                 }
-                if cell.fg != fg || cell.bg != bg {
+                if cell_fg != fg || cell_bg != bg {
                     queue!(
                         writer,
-                        SetColors(Colors::new(cell.fg.into(), cell.bg.into()))
+                        SetColors(Colors::new(cell_fg.into(), cell_bg.into()))
                     )?;
-                    fg = cell.fg;
-                    bg = cell.bg;
+                    fg = cell_fg;
+                    bg = cell_bg;
                 }
 
                 queue!(writer, Print(cell.symbol()))?;
             }
             DrawCommand::ClearToEnd { bg: clear_bg, .. } => {
+                let clear_bg = crate::theme::remap_color(clear_bg);
                 queue!(writer, SetAttribute(crossterm::style::Attribute::Reset))?;
                 modifier = Modifier::empty();
                 queue!(writer, SetBackgroundColor(clear_bg.into()))?;

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -94,6 +94,7 @@ mod streaming;
 mod style;
 mod terminal_palette;
 mod text_formatting;
+mod theme;
 mod tooltips;
 mod tui;
 mod ui_consts;
@@ -115,12 +116,14 @@ pub use cli::Cli;
 pub use markdown_render::render_markdown_text;
 pub use public_widgets::composer_input::ComposerAction;
 pub use public_widgets::composer_input::ComposerInput;
+pub use theme::ThemeName;
 // (tests access modules directly within the crate)
 
 pub async fn run_main(
     mut cli: Cli,
     codex_linux_sandbox_exe: Option<PathBuf>,
 ) -> std::io::Result<AppExitInfo> {
+    theme::set_theme(cli.theme.unwrap_or_default());
     let (sandbox_mode, approval_policy) = if cli.full_auto {
         (
             Some(SandboxMode::WorkspaceWrite),

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -14,6 +14,7 @@ pub enum SlashCommand {
     // more frequently used commands should be listed first.
     Model,
     Personality,
+    Theme,
     Approvals,
     Permissions,
     #[strum(serialize = "setup-elevated-sandbox")]
@@ -62,6 +63,7 @@ impl SlashCommand {
             SlashCommand::Ps => "list background terminals",
             SlashCommand::Model => "choose what model and reasoning effort to use",
             SlashCommand::Personality => "choose a communication style for responses",
+            SlashCommand::Theme => "switch the active color theme",
             SlashCommand::Collab => "change collaboration mode (experimental)",
             SlashCommand::Agent => "switch the active agent thread",
             SlashCommand::Approvals => "choose what Codex can do without approval",
@@ -102,6 +104,7 @@ impl SlashCommand {
             | SlashCommand::Mention
             | SlashCommand::Skills
             | SlashCommand::Status
+            | SlashCommand::Theme
             | SlashCommand::Ps
             | SlashCommand::Mcp
             | SlashCommand::Feedback

--- a/codex-rs/tui/src/theme.rs
+++ b/codex-rs/tui/src/theme.rs
@@ -1,0 +1,95 @@
+use clap::ValueEnum;
+use ratatui::style::Color;
+use std::sync::atomic::AtomicU8;
+use std::sync::atomic::Ordering;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "kebab-case")]
+pub enum ThemeName {
+    #[default]
+    Default,
+    #[value(alias = "ember", alias = "ivory")]
+    IvoryEmber,
+    #[value(alias = "thames", alias = "fog")]
+    ThamesFog,
+}
+
+const THEMES: [ThemeName; 3] = [
+    ThemeName::Default,
+    ThemeName::IvoryEmber,
+    ThemeName::ThamesFog,
+];
+
+static THEME: AtomicU8 = AtomicU8::new(ThemeName::Default as u8);
+
+pub fn all_themes() -> &'static [ThemeName] {
+    &THEMES
+}
+
+impl ThemeName {
+    pub fn id(self) -> &'static str {
+        match self {
+            ThemeName::Default => "default",
+            ThemeName::IvoryEmber => "ivory-ember",
+            ThemeName::ThamesFog => "thames-fog",
+        }
+    }
+
+    pub fn label(self) -> &'static str {
+        match self {
+            ThemeName::Default => "Default",
+            ThemeName::IvoryEmber => "Ivory Ember",
+            ThemeName::ThamesFog => "Thames Fog",
+        }
+    }
+
+    pub fn description(self) -> &'static str {
+        match self {
+            ThemeName::Default => "Keep the classic Codex palette.",
+            ThemeName::IvoryEmber => "Warm amber accents with ivory foreground.",
+            ThemeName::ThamesFog => "Cool blue-gray accents with misty contrast.",
+        }
+    }
+}
+
+pub fn parse_theme_name(input: &str) -> Option<ThemeName> {
+    let normalized = input.trim().to_lowercase();
+    match normalized.as_str() {
+        "default" => Some(ThemeName::Default),
+        "ivory-ember" | "ivory" | "ember" => Some(ThemeName::IvoryEmber),
+        "thames-fog" | "thames" | "fog" | "thame" => Some(ThemeName::ThamesFog),
+        _ => None,
+    }
+}
+
+pub fn set_theme(theme: ThemeName) {
+    THEME.store(theme as u8, Ordering::Relaxed);
+}
+
+pub fn current_theme() -> ThemeName {
+    match THEME.load(Ordering::Relaxed) {
+        value if value == ThemeName::IvoryEmber as u8 => ThemeName::IvoryEmber,
+        value if value == ThemeName::ThamesFog as u8 => ThemeName::ThamesFog,
+        _ => ThemeName::Default,
+    }
+}
+
+pub(crate) fn remap_color(color: Color) -> Color {
+    match current_theme() {
+        ThemeName::Default => color,
+        ThemeName::IvoryEmber => match color {
+            Color::Cyan => Color::Yellow,
+            Color::LightCyan => Color::LightYellow,
+            Color::Magenta => Color::Yellow,
+            Color::LightMagenta => Color::LightYellow,
+            _ => color,
+        },
+        ThemeName::ThamesFog => match color {
+            Color::Cyan => Color::LightBlue,
+            Color::LightCyan => Color::LightBlue,
+            Color::Magenta => Color::LightCyan,
+            Color::LightMagenta => Color::LightCyan,
+            _ => color,
+        },
+    }
+}

--- a/codex-rs/tui/styles.md
+++ b/codex-rs/tui/styles.md
@@ -16,6 +16,6 @@
 
 - Avoid custom colors because there's no guarantee that they'll contrast well or look good in various terminal color themes. (`shimmer.rs` is an exception that works well because we take the default colors and just adjust their levels.)
 - Avoid ANSI `black` & `white` as foreground colors because the default terminal theme color will do a better job. (Use `reset` if you need to in order to get those.) The exception is if you need contrast rendering over a manually colored background.
-- Avoid ANSI `blue` and `yellow` because for now the style guide doesn't use them. Prefer a foreground color mentioned above.
+- Avoid ANSI `blue` and `yellow` in the default theme because the style guide doesn't use them. Theme remapping may translate semantic colors into these hues for optional themes.
 
 (There are some rules to try to catch this in `clippy.toml`.)

--- a/docs/tui-themes.md
+++ b/docs/tui-themes.md
@@ -1,0 +1,24 @@
+# TUI themes
+
+Codex TUI supports a small set of color themes selectable at runtime.
+
+Usage:
+
+```bash
+codex --theme default
+codex --theme ivory-ember
+codex --theme thames-fog
+```
+
+In the running TUI, use:
+
+```text
+/theme
+/theme thames-fog
+/thame thames-fog
+```
+
+Notes:
+
+- Themes remap ANSI colors used by the TUI (no custom RGB), so they adapt to your terminal palette.
+- The default theme matches the existing color scheme.


### PR DESCRIPTION
## Summary

Adds a `/theme` (and `/thame`) command plus a theme picker with live preview in the TUI. While navigating the
list, the selected theme applies immediately; pressing Enter confirms and logs an info message. Also documents
available themes and usage.

## Details

- Introduces theme metadata helpers and aliases for `default`, `ivory-ember` (white/orange), and `thames-fog`.
- Adds preview actions to selection lists and wires them into the theme picker.
- Adds `AppEvent::PreviewTheme` to apply a theme without spamming status messages.
- Updates docs for theme selection usage.


## I have read the CLA Document and I hereby sign the CLA

## Testing

- `just fmt`
- `cargo test -p codex-tui`
