### PR TITLE
fix: remove cli tooltip references to custom prompts

### DIFF
--- a/codex-rs/tui/tooltips.txt
+++ b/codex-rs/tui/tooltips.txt
@@ -10,8 +10,7 @@ Use /fork to branch the current chat into a new thread.
 Use /init to create an AGENTS.md with project-specific guidance.
 Use /mcp to list configured MCP tools.
 You can run any shell command from Codex using `!` (e.g. `!ls`)
-Type / to open the command popup; Tab autocompletes slash commands and saved prompts.
-You can define your own `/` commands with custom prompts. More info: https://developers.openai.com/codex/guides/slash-commands#create-your-own-slash-commands-with-custom-prompts
+Type / to open the command popup; Tab autocompletes slash commands.
 When the composer is empty, press Esc to step back and edit your last message; Enter confirms.
 Press Tab to queue a message instead of sending it immediately; Enter always sends immediately.
 Paste an image with Ctrl+V to attach it to your next message.


### PR DESCRIPTION
 Custom prompts are now deprecated, however are still references in tooltips. Remove the relevant tips from the repository.

Closes #9900 
