### PR TITLE
feat(tui): add ask_user_question tool UI

### DIFF
--- a/codex-rs/core/prompt.md
+++ b/codex-rs/core/prompt.md
@@ -182,6 +182,8 @@ The messages you send before tool calls should describe what is immediately abou
 
 Your final message should read naturally, like an update from a concise teammate. For casual conversation, brainstorming tasks, or quick questions from the user, respond in a friendly, conversational tone. You should ask questions, suggest ideas, and adapt to the user’s style. If you've finished a large amount of work, when describing what you've done to the user, you should follow the final answer formatting guidelines to communicate substantive changes. You don't need to add structured formatting for one-word answers, greetings, or purely conversational exchanges.
 
+When you need to ask the user a question (e.g., to resolve ambiguity or choose between approaches), prefer using the `ask_user_question` tool instead of asking in free text. When it's appropriate and you have enough context to do so, include one clearly marked recommendation by putting it first and suffixing its label with `(Recommended)`
+
 You can skip heavy formatting for single, simple actions or confirmations. In these cases, respond in plain sentences with any relevant next step or quick option. Reserve multi-section structured responses for results that need grouping or explanation.
 
 The user is working on the same computer as you, and has access to your work. As such there's no need to show the full contents of large files you have already written unless the user explicitly asks for them. Similarly, if you've created or modified files using `apply_patch`, there's no need to tell users to "save the file" or "copy the code into a file"—just reference the file path.

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -597,6 +597,7 @@ impl Session {
         );
 
         let tools_config = ToolsConfig::new(&ToolsConfigParams {
+            session_source: session_configuration.session_source.clone(),
             model_info: &model_info,
             features: &per_turn_config.features,
             web_search_mode: per_turn_config.web_search_mode,
@@ -2846,6 +2847,7 @@ async fn spawn_review_thread(
         .disable(crate::features::Feature::WebSearchCached);
     let review_web_search_mode = WebSearchMode::Disabled;
     let tools_config = ToolsConfig::new(&ToolsConfigParams {
+        session_source: parent_turn_context.client.get_session_source(),
         model_info: &review_model_info,
         features: &review_features,
         web_search_mode: Some(review_web_search_mode),

--- a/codex-rs/core/src/rollout/policy.rs
+++ b/codex-rs/core/src/rollout/policy.rs
@@ -68,6 +68,7 @@ pub(crate) fn should_persist_event_msg(ev: &EventMsg) -> bool {
         | EventMsg::ExecCommandEnd(_)
         | EventMsg::ExecApprovalRequest(_)
         | EventMsg::RequestUserInput(_)
+        | EventMsg::AskUserQuestion(_)
         | EventMsg::DynamicToolCallRequest(_)
         | EventMsg::ElicitationRequest(_)
         | EventMsg::ApplyPatchApprovalRequest(_)

--- a/codex-rs/core/src/tools/handlers/ask_user_question.rs
+++ b/codex-rs/core/src/tools/handlers/ask_user_question.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 
 use crate::function_tool::FunctionCallError;
+use crate::protocol::SessionSource;
 use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolOutput;
 use crate::tools::context::ToolPayload;
@@ -25,6 +26,13 @@ impl ToolHandler for AskUserQuestionHandler {
             payload,
             ..
         } = invocation;
+
+        let session_source = turn.client.get_session_source();
+        if !matches!(session_source, SessionSource::Cli | SessionSource::VSCode) {
+            return Err(FunctionCallError::RespondToModel(format!(
+                "ask_user_question is unavailable in non-interactive mode (session source: {session_source})"
+            )));
+        }
 
         let arguments = match payload {
             ToolPayload::Function { arguments } => arguments,

--- a/codex-rs/core/src/tools/handlers/ask_user_question.rs
+++ b/codex-rs/core/src/tools/handlers/ask_user_question.rs
@@ -1,0 +1,60 @@
+use async_trait::async_trait;
+
+use crate::function_tool::FunctionCallError;
+use crate::tools::context::ToolInvocation;
+use crate::tools::context::ToolOutput;
+use crate::tools::context::ToolPayload;
+use crate::tools::handlers::parse_arguments;
+use crate::tools::registry::ToolHandler;
+use crate::tools::registry::ToolKind;
+use codex_protocol::ask_user_question::AskUserQuestionArgs;
+
+pub struct AskUserQuestionHandler;
+
+#[async_trait]
+impl ToolHandler for AskUserQuestionHandler {
+    fn kind(&self) -> ToolKind {
+        ToolKind::Function
+    }
+
+    async fn handle(&self, invocation: ToolInvocation) -> Result<ToolOutput, FunctionCallError> {
+        let ToolInvocation {
+            session,
+            turn,
+            call_id,
+            payload,
+            ..
+        } = invocation;
+
+        let arguments = match payload {
+            ToolPayload::Function { arguments } => arguments,
+            _ => {
+                return Err(FunctionCallError::RespondToModel(
+                    "ask_user_question handler received unsupported payload".to_string(),
+                ));
+            }
+        };
+
+        let args: AskUserQuestionArgs = parse_arguments(&arguments)?;
+        let response = session
+            .ask_user_question(turn.as_ref(), call_id, args)
+            .await
+            .ok_or_else(|| {
+                FunctionCallError::RespondToModel(
+                    "ask_user_question was cancelled before receiving a response".to_string(),
+                )
+            })?;
+
+        let content = serde_json::to_string(&response).map_err(|err| {
+            FunctionCallError::Fatal(format!(
+                "failed to serialize ask_user_question response: {err}"
+            ))
+        })?;
+
+        Ok(ToolOutput::Function {
+            content,
+            content_items: None,
+            success: Some(true),
+        })
+    }
+}

--- a/codex-rs/core/src/tools/handlers/mod.rs
+++ b/codex-rs/core/src/tools/handlers/mod.rs
@@ -1,4 +1,5 @@
 pub mod apply_patch;
+mod ask_user_question;
 pub(crate) mod collab;
 mod dynamic;
 mod grep_files;
@@ -18,6 +19,7 @@ use serde::Deserialize;
 
 use crate::function_tool::FunctionCallError;
 pub use apply_patch::ApplyPatchHandler;
+pub use ask_user_question::AskUserQuestionHandler;
 pub use collab::CollabHandler;
 pub use dynamic::DynamicToolHandler;
 pub use grep_files::GrepFilesHandler;

--- a/codex-rs/core/src/tools/handlers/request_user_input.rs
+++ b/codex-rs/core/src/tools/handlers/request_user_input.rs
@@ -1,6 +1,7 @@
 use async_trait::async_trait;
 
 use crate::function_tool::FunctionCallError;
+use crate::protocol::SessionSource;
 use crate::tools::context::ToolInvocation;
 use crate::tools::context::ToolOutput;
 use crate::tools::context::ToolPayload;
@@ -26,6 +27,13 @@ impl ToolHandler for RequestUserInputHandler {
             payload,
             ..
         } = invocation;
+
+        let session_source = turn.client.get_session_source();
+        if !matches!(session_source, SessionSource::Cli | SessionSource::VSCode) {
+            return Err(FunctionCallError::RespondToModel(format!(
+                "request_user_input is unavailable in non-interactive mode (session source: {session_source})"
+            )));
+        }
 
         let arguments = match payload {
             ToolPayload::Function { arguments } => arguments,

--- a/codex-rs/exec/src/event_processor_with_human_output.rs
+++ b/codex-rs/exec/src/event_processor_with_human_output.rs
@@ -608,6 +608,7 @@ impl EventProcessor for EventProcessorWithHumanOutput {
             | EventMsg::UndoStarted(_)
             | EventMsg::ThreadRolledBack(_)
             | EventMsg::RequestUserInput(_)
+            | EventMsg::AskUserQuestion(_)
             | EventMsg::DynamicToolCallRequest(_) => {}
         }
         CodexStatus::Running

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -360,6 +360,7 @@ async fn run_codex_tool_session_inner(
                     | EventMsg::UndoCompleted(_)
                     | EventMsg::ExitedReviewMode(_)
                     | EventMsg::RequestUserInput(_)
+                    | EventMsg::AskUserQuestion(_)
                     | EventMsg::DynamicToolCallRequest(_)
                     | EventMsg::ContextCompacted(_)
                     | EventMsg::ThreadRolledBack(_)

--- a/codex-rs/protocol/src/ask_user_question.rs
+++ b/codex-rs/protocol/src/ask_user_question.rs
@@ -1,0 +1,49 @@
+use schemars::JsonSchema;
+use serde::Deserialize;
+use serde::Serialize;
+use ts_rs::TS;
+
+#[derive(Debug, Clone, Copy, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+#[serde(rename_all = "snake_case")]
+pub enum AskUserQuestionKind {
+    SingleChoice,
+    MultipleChoice,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+pub struct AskUserQuestionOption {
+    /// Placeholder label for a custom option when `custom` is true.
+    pub label: String,
+    /// One short sentence explaining impact/tradeoff if selected.
+    pub description: String,
+    /// When true, the user provides the option label text.
+    #[serde(default)]
+    pub custom: bool,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+pub struct AskUserQuestionQuestion {
+    pub id: String,
+    /// Short header label shown in the UI tab (ideally <= ~12 chars).
+    pub header: String,
+    /// Prompt shown to the user.
+    pub question: String,
+    pub kind: AskUserQuestionKind,
+    pub options: Vec<AskUserQuestionOption>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+pub struct AskUserQuestionArgs {
+    pub questions: Vec<AskUserQuestionQuestion>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq, JsonSchema, TS)]
+pub struct AskUserQuestionEvent {
+    /// Responses API call id for the associated tool call, if available.
+    pub call_id: String,
+    /// Turn ID that this request belongs to.
+    /// Uses `#[serde(default)]` for backwards compatibility.
+    #[serde(default)]
+    pub turn_id: String,
+    pub questions: Vec<AskUserQuestionQuestion>,
+}

--- a/codex-rs/protocol/src/lib.rs
+++ b/codex-rs/protocol/src/lib.rs
@@ -2,6 +2,7 @@ pub mod account;
 mod thread_id;
 pub use thread_id::ThreadId;
 pub mod approvals;
+pub mod ask_user_question;
 pub mod config_types;
 pub mod custom_prompts;
 pub mod dynamic_tools;

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -49,6 +49,7 @@ pub use crate::approvals::ApplyPatchApprovalRequestEvent;
 pub use crate::approvals::ElicitationAction;
 pub use crate::approvals::ExecApprovalRequestEvent;
 pub use crate::approvals::ExecPolicyAmendment;
+pub use crate::ask_user_question::AskUserQuestionEvent;
 pub use crate::request_user_input::RequestUserInputEvent;
 
 /// Open/close tags for special user-input blocks. Used across crates to avoid
@@ -760,6 +761,7 @@ pub enum EventMsg {
 
     RequestUserInput(RequestUserInputEvent),
 
+    AskUserQuestion(AskUserQuestionEvent),
     DynamicToolCallRequest(DynamicToolCallRequest),
 
     ElicitationRequest(ElicitationRequestEvent),

--- a/codex-rs/tui/src/bottom_pane/ask_user_question/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/ask_user_question/mod.rs
@@ -1,0 +1,882 @@
+//! Ask-user-question overlay state machine.
+//!
+//! This is a bottom-pane modal that mimics Claude Code's
+//! "AskUserQuestionTool" UX:
+//! - A tab per question plus a Submit tab.
+//! - Single-choice questions advance on selection (except custom option).
+//! - Multiple-choice questions advance only via Next (Enter).
+//! - Each question may include one custom option whose label is user-provided.
+use std::collections::HashMap;
+use std::collections::VecDeque;
+
+use codex_core::protocol::Op;
+use codex_protocol::ask_user_question::AskUserQuestionEvent;
+use codex_protocol::ask_user_question::AskUserQuestionKind;
+use codex_protocol::request_user_input::RequestUserInputAnswer;
+use codex_protocol::request_user_input::RequestUserInputResponse;
+use crossterm::event::KeyCode;
+use crossterm::event::KeyEvent;
+use crossterm::event::KeyEventKind;
+use crossterm::event::KeyModifiers;
+
+use crate::app_event::AppEvent;
+use crate::app_event_sender::AppEventSender;
+use crate::bottom_pane::CancellationEvent;
+use crate::bottom_pane::bottom_pane_view::BottomPaneView;
+use crate::bottom_pane::scroll_state::ScrollState;
+use crate::bottom_pane::textarea::TextArea;
+use crate::history_cell::AskUserQuestionAnswersHistoryCell;
+
+mod render;
+
+const CUSTOM_PLACEHOLDER_DEFAULT: &str = "Type something.";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Focus {
+    Options,
+    Custom,
+    SubmitButtons,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SubmitFocus {
+    Submit,
+    Cancel,
+}
+
+struct CustomEntry {
+    text: TextArea,
+}
+
+impl CustomEntry {
+    fn new() -> Self {
+        Self {
+            text: TextArea::new(),
+        }
+    }
+}
+
+struct QuestionState {
+    highlight: ScrollState,
+    selected_single: Option<usize>,
+    selected_multi: Vec<bool>,
+    custom_idx: Option<usize>,
+    custom_entry: Option<CustomEntry>,
+}
+
+pub(crate) struct AskUserQuestionOverlay {
+    app_event_tx: AppEventSender,
+    request: AskUserQuestionEvent,
+    queue: VecDeque<AskUserQuestionEvent>,
+    state: Vec<QuestionState>,
+    active_tab: usize,
+    focus: Focus,
+    submit_focus: SubmitFocus,
+    done: bool,
+}
+
+impl AskUserQuestionOverlay {
+    pub(crate) fn new(request: AskUserQuestionEvent, app_event_tx: AppEventSender) -> Self {
+        let mut overlay = Self {
+            app_event_tx,
+            request,
+            queue: VecDeque::new(),
+            state: Vec::new(),
+            active_tab: 0,
+            focus: Focus::Options,
+            submit_focus: SubmitFocus::Submit,
+            done: false,
+        };
+        overlay.reset_for_request();
+        overlay
+    }
+
+    fn reset_for_request(&mut self) {
+        self.state = self
+            .request
+            .questions
+            .iter()
+            .map(|question| {
+                let mut highlight = ScrollState::new();
+                highlight.selected_idx = (!question.options.is_empty()).then_some(0);
+                let custom_idx = question.options.iter().position(|opt| opt.custom);
+                QuestionState {
+                    highlight,
+                    selected_single: None,
+                    selected_multi: vec![false; question.options.len()],
+                    custom_idx,
+                    custom_entry: custom_idx.map(|_| CustomEntry::new()),
+                }
+            })
+            .collect();
+
+        self.active_tab = 0;
+        self.focus = Focus::Options;
+        self.submit_focus = SubmitFocus::Submit;
+    }
+
+    fn is_submit_tab(&self) -> bool {
+        self.active_tab >= self.request.questions.len()
+    }
+
+    fn tab_count(&self) -> usize {
+        self.request.questions.len().saturating_add(1)
+    }
+
+    fn current_question_index(&self) -> Option<usize> {
+        (!self.is_submit_tab()).then_some(self.active_tab)
+    }
+
+    fn current_question(
+        &self,
+    ) -> Option<&codex_protocol::ask_user_question::AskUserQuestionQuestion> {
+        let idx = self.current_question_index()?;
+        self.request.questions.get(idx)
+    }
+
+    fn current_state(&self) -> Option<&QuestionState> {
+        let idx = self.current_question_index()?;
+        self.state.get(idx)
+    }
+
+    fn current_kind(&self) -> AskUserQuestionKind {
+        self.current_question()
+            .map(|q| q.kind)
+            .unwrap_or(AskUserQuestionKind::SingleChoice)
+    }
+
+    fn move_tab(&mut self, next: bool) {
+        let len = self.tab_count().max(1);
+        let offset = if next { 1 } else { len.saturating_sub(1) };
+        self.active_tab = (self.active_tab + offset) % len;
+        self.focus = if self.is_submit_tab() {
+            Focus::SubmitButtons
+        } else {
+            Focus::Options
+        };
+
+        if let Some(idx) = self.current_question_index()
+            && let Some(question_state) = self.state.get_mut(idx)
+        {
+            if let Some(sel) = question_state.selected_single {
+                question_state.highlight.selected_idx = Some(sel);
+            } else {
+                question_state
+                    .highlight
+                    .clamp_selection(self.request.questions[idx].options.len());
+            }
+        }
+    }
+
+    fn select_single(&mut self, idx: usize) {
+        let Some(q_idx) = self.current_question_index() else {
+            return;
+        };
+        let question = &self.request.questions[q_idx];
+        let Some(question_state) = self.state.get_mut(q_idx) else {
+            return;
+        };
+        if idx >= question.options.len() {
+            return;
+        }
+
+        question_state.selected_single = Some(idx);
+        question_state.highlight.selected_idx = Some(idx);
+        if question.options.get(idx).is_some_and(|opt| opt.custom) {
+            self.focus = Focus::Custom;
+            return;
+        }
+        self.move_to_next_after_answer();
+    }
+
+    fn toggle_multiple(&mut self, idx: usize) {
+        let Some(q_idx) = self.current_question_index() else {
+            return;
+        };
+        let question = &self.request.questions[q_idx];
+        let Some(question_state) = self.state.get_mut(q_idx) else {
+            return;
+        };
+        if idx >= question.options.len() {
+            return;
+        }
+        if let Some(selected) = question_state.selected_multi.get_mut(idx) {
+            *selected = !*selected;
+        }
+        if question.options.get(idx).is_some_and(|opt| opt.custom)
+            && question_state
+                .selected_multi
+                .get(idx)
+                .copied()
+                .unwrap_or(false)
+        {
+            self.focus = Focus::Custom;
+        }
+    }
+
+    fn move_to_next_after_answer(&mut self) {
+        if self.is_submit_tab() {
+            return;
+        }
+        if self.active_tab + 1 >= self.tab_count() {
+            self.active_tab = self.tab_count().saturating_sub(1);
+        } else {
+            self.active_tab += 1;
+        }
+        self.focus = if self.is_submit_tab() {
+            Focus::SubmitButtons
+        } else {
+            Focus::Options
+        };
+    }
+
+    fn custom_is_selected(&self, q_idx: usize) -> bool {
+        let question = &self.request.questions[q_idx];
+        let question_state = &self.state[q_idx];
+        let Some(custom_idx) = question_state.custom_idx else {
+            return false;
+        };
+        match question.kind {
+            AskUserQuestionKind::SingleChoice => question_state.selected_single == Some(custom_idx),
+            AskUserQuestionKind::MultipleChoice => question_state
+                .selected_multi
+                .get(custom_idx)
+                .copied()
+                .unwrap_or(false),
+        }
+    }
+
+    fn custom_text(&self, q_idx: usize) -> Option<&str> {
+        self.state
+            .get(q_idx)?
+            .custom_entry
+            .as_ref()
+            .map(|entry| entry.text.text())
+    }
+
+    fn answer_for_question(&self, q_idx: usize) -> Vec<String> {
+        let question = &self.request.questions[q_idx];
+        let question_state = &self.state[q_idx];
+
+        let custom_idx = question_state.custom_idx;
+        let custom_text = question_state
+            .custom_entry
+            .as_ref()
+            .map(|e| e.text.text().trim().to_string())
+            .unwrap_or_default();
+
+        match question.kind {
+            AskUserQuestionKind::SingleChoice => {
+                let Some(selected) = question_state.selected_single else {
+                    return Vec::new();
+                };
+                if custom_idx == Some(selected) {
+                    if custom_text.is_empty() {
+                        return Vec::new();
+                    }
+                    return vec![custom_text];
+                }
+                question
+                    .options
+                    .get(selected)
+                    .map(|opt| vec![opt.label.clone()])
+                    .unwrap_or_default()
+            }
+            AskUserQuestionKind::MultipleChoice => {
+                let mut out = Vec::new();
+                for (idx, opt) in question.options.iter().enumerate() {
+                    if !question_state
+                        .selected_multi
+                        .get(idx)
+                        .copied()
+                        .unwrap_or(false)
+                    {
+                        continue;
+                    }
+                    if opt.custom {
+                        if !custom_text.is_empty() {
+                            out.push(custom_text.clone());
+                        }
+                    } else {
+                        out.push(opt.label.clone());
+                    }
+                }
+                out
+            }
+        }
+    }
+
+    fn question_answered(&self, q_idx: usize) -> bool {
+        !self.answer_for_question(q_idx).is_empty()
+    }
+
+    fn format_answers_for_chat(answers: &[String]) -> String {
+        match answers {
+            [] => String::new(),
+            [one] => one.clone(),
+            [a, b] => format!("{a} + {b}"),
+            _ => answers.join(", "),
+        }
+    }
+
+    fn submit_answers(&mut self) {
+        let mut items: Vec<(String, String)> = Vec::new();
+        let mut answers = HashMap::new();
+        for (idx, question) in self.request.questions.iter().enumerate() {
+            let answer_list = self.answer_for_question(idx);
+            items.push((
+                question.question.clone(),
+                Self::format_answers_for_chat(&answer_list),
+            ));
+            answers.insert(
+                question.id.clone(),
+                RequestUserInputAnswer {
+                    answers: answer_list,
+                },
+            );
+        }
+
+        self.app_event_tx.send(AppEvent::InsertHistoryCell(Box::new(
+            AskUserQuestionAnswersHistoryCell::new(items),
+        )));
+
+        self.app_event_tx
+            .send(AppEvent::CodexOp(Op::UserInputAnswer {
+                id: self.request.turn_id.clone(),
+                response: RequestUserInputResponse { answers },
+            }));
+
+        if let Some(next) = self.queue.pop_front() {
+            self.request = next;
+            self.reset_for_request();
+        } else {
+            self.done = true;
+        }
+    }
+
+    fn cancel(&mut self) {
+        self.app_event_tx.send(AppEvent::CodexOp(Op::Interrupt));
+        self.done = true;
+    }
+
+    fn digit_to_index(ch: char) -> Option<usize> {
+        if !ch.is_ascii_digit() {
+            return None;
+        }
+        let n = ch.to_digit(10)? as usize;
+        (n >= 1).then_some(n - 1)
+    }
+}
+
+impl BottomPaneView for AskUserQuestionOverlay {
+    fn handle_key_event(&mut self, key_event: KeyEvent) {
+        if key_event.kind == KeyEventKind::Release {
+            return;
+        }
+
+        // Global tab navigation.
+        match key_event.code {
+            KeyCode::Left => {
+                self.move_tab(false);
+                return;
+            }
+            KeyCode::Right => {
+                self.move_tab(true);
+                return;
+            }
+            _ => {}
+        }
+
+        if self.is_submit_tab() {
+            match key_event.code {
+                KeyCode::Tab => {
+                    self.submit_focus = match self.submit_focus {
+                        SubmitFocus::Submit => SubmitFocus::Cancel,
+                        SubmitFocus::Cancel => SubmitFocus::Submit,
+                    };
+                }
+                KeyCode::Left | KeyCode::Right => {
+                    self.submit_focus = match self.submit_focus {
+                        SubmitFocus::Submit => SubmitFocus::Cancel,
+                        SubmitFocus::Cancel => SubmitFocus::Submit,
+                    };
+                }
+                KeyCode::Enter => match self.submit_focus {
+                    SubmitFocus::Submit => self.submit_answers(),
+                    SubmitFocus::Cancel => self.cancel(),
+                },
+                KeyCode::Char('s') if key_event.modifiers == KeyModifiers::NONE => {
+                    self.submit_answers();
+                }
+                KeyCode::Char('c') if key_event.modifiers == KeyModifiers::NONE => {
+                    self.cancel();
+                }
+                _ => {}
+            }
+            return;
+        }
+
+        let kind = self.current_kind();
+        let Some(q_idx) = self.current_question_index() else {
+            return;
+        };
+
+        if matches!(self.focus, Focus::Custom) {
+            if matches!(key_event.code, KeyCode::Enter) {
+                self.move_to_next_after_answer();
+                return;
+            }
+            if let Some(custom) = self.state[q_idx].custom_entry.as_mut() {
+                custom.text.input(key_event);
+            }
+            return;
+        }
+
+        let options_len = self.request.questions[q_idx].options.len();
+
+        match key_event.code {
+            KeyCode::Up => {
+                if let Some(question_state) = self.state.get_mut(q_idx) {
+                    question_state.highlight.move_up_wrap(options_len);
+                }
+            }
+            KeyCode::Down => {
+                if let Some(question_state) = self.state.get_mut(q_idx) {
+                    question_state.highlight.move_down_wrap(options_len);
+                }
+            }
+            KeyCode::Char(' ') => {
+                let idx = self.state.get(q_idx).and_then(|s| s.highlight.selected_idx);
+                if let Some(idx) = idx {
+                    match kind {
+                        AskUserQuestionKind::SingleChoice => self.select_single(idx),
+                        AskUserQuestionKind::MultipleChoice => self.toggle_multiple(idx),
+                    }
+                }
+            }
+            KeyCode::Enter => {
+                let idx = self.state.get(q_idx).and_then(|s| s.highlight.selected_idx);
+                if let Some(idx) = idx {
+                    match kind {
+                        AskUserQuestionKind::SingleChoice => self.select_single(idx),
+                        AskUserQuestionKind::MultipleChoice => self.move_to_next_after_answer(),
+                    }
+                }
+            }
+            KeyCode::Char(ch) => {
+                if let Some(idx) = Self::digit_to_index(ch) {
+                    match kind {
+                        AskUserQuestionKind::SingleChoice => self.select_single(idx),
+                        AskUserQuestionKind::MultipleChoice => self.toggle_multiple(idx),
+                    }
+                    return;
+                }
+
+                let highlighted_idx = self.state.get(q_idx).and_then(|s| s.highlight.selected_idx);
+                let highlighted_custom = highlighted_idx
+                    .and_then(|idx| self.request.questions[q_idx].options.get(idx))
+                    .is_some_and(|opt| opt.custom);
+                if highlighted_custom {
+                    let idx = highlighted_idx.unwrap_or(0);
+                    match kind {
+                        AskUserQuestionKind::SingleChoice => self.select_single(idx),
+                        AskUserQuestionKind::MultipleChoice => {
+                            if !self.state[q_idx]
+                                .selected_multi
+                                .get(idx)
+                                .copied()
+                                .unwrap_or(false)
+                            {
+                                self.toggle_multiple(idx);
+                            } else {
+                                self.focus = Focus::Custom;
+                            }
+                        }
+                    }
+                    if let Some(custom) = self.state[q_idx].custom_entry.as_mut() {
+                        custom.text.input(key_event);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn on_ctrl_c(&mut self) -> CancellationEvent {
+        self.cancel();
+        CancellationEvent::Handled
+    }
+
+    fn is_complete(&self) -> bool {
+        self.done
+    }
+
+    fn handle_paste(&mut self, pasted: String) -> bool {
+        let Some(q_idx) = self.current_question_index() else {
+            return false;
+        };
+
+        if pasted.is_empty() {
+            return false;
+        }
+        if !self.custom_is_selected(q_idx) {
+            return false;
+        }
+        let Some(custom) = self.state[q_idx].custom_entry.as_mut() else {
+            return false;
+        };
+
+        self.focus = Focus::Custom;
+        custom.text.insert_str(&pasted);
+        true
+    }
+
+    fn try_consume_ask_user_question_request(
+        &mut self,
+        request: AskUserQuestionEvent,
+    ) -> Option<AskUserQuestionEvent> {
+        self.queue.push_back(request);
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::app_event::AppEvent;
+    use crate::app_event_sender::AppEventSender;
+    use crate::history_cell::HistoryCell;
+    use crate::render::renderable::Renderable;
+    use codex_protocol::ask_user_question::AskUserQuestionKind;
+    use codex_protocol::ask_user_question::AskUserQuestionOption;
+    use codex_protocol::ask_user_question::AskUserQuestionQuestion;
+    use crossterm::event::KeyEvent;
+    use crossterm::event::KeyModifiers;
+    use insta::assert_snapshot;
+    use ratatui::buffer::Buffer;
+    use ratatui::layout::Rect;
+    use ratatui::style::Color;
+    use ratatui::text::Text;
+    use ratatui::widgets::Paragraph;
+    use ratatui::widgets::Widget;
+    use tokio::sync::mpsc::unbounded_channel;
+
+    fn test_sender() -> (
+        AppEventSender,
+        tokio::sync::mpsc::UnboundedReceiver<AppEvent>,
+    ) {
+        let (tx_raw, rx) = unbounded_channel::<AppEvent>();
+        (AppEventSender::new(tx_raw), rx)
+    }
+
+    fn event(questions: Vec<AskUserQuestionQuestion>) -> AskUserQuestionEvent {
+        AskUserQuestionEvent {
+            call_id: "call-1".to_string(),
+            turn_id: "turn-1".to_string(),
+            questions,
+        }
+    }
+
+    fn single_backend_question(kind: AskUserQuestionKind) -> AskUserQuestionQuestion {
+        AskUserQuestionQuestion {
+            id: "backend".to_string(),
+            header: "Backend".to_string(),
+            question: "Какой фреймворк ты предпочитаешь для бэкенда?".to_string(),
+            kind,
+            options: vec![
+                AskUserQuestionOption {
+                    label: "Next.js API Routes".to_string(),
+                    description: "Встроенные API routes в Next.js, удобно для full-stack"
+                        .to_string(),
+                    custom: false,
+                },
+                AskUserQuestionOption {
+                    label: "Express.js".to_string(),
+                    description: "Классический Node.js фреймворк".to_string(),
+                    custom: false,
+                },
+                AskUserQuestionOption {
+                    label: "Type something.".to_string(),
+                    description: "".to_string(),
+                    custom: true,
+                },
+            ],
+        }
+    }
+
+    fn snapshot_buffer(buf: &Buffer) -> String {
+        let mut lines = Vec::new();
+        for y in 0..buf.area().height {
+            let mut row = String::new();
+            for x in 0..buf.area().width {
+                row.push(buf[(x, y)].symbol().chars().next().unwrap_or(' '));
+            }
+            lines.push(row);
+        }
+        lines.join("\n")
+    }
+
+    fn render_snapshot(overlay: &AskUserQuestionOverlay, area: Rect) -> String {
+        let mut buf = Buffer::empty(area);
+        overlay.render(area, &mut buf);
+        snapshot_buffer(&buf)
+    }
+
+    fn render_history_snapshot(cell: &dyn HistoryCell, area: Rect) -> String {
+        let mut buf = Buffer::empty(area);
+        Paragraph::new(Text::from(cell.display_lines(area.width))).render(area, &mut buf);
+        snapshot_buffer(&buf)
+    }
+
+    #[test]
+    fn ask_user_question_single_choice_autoadvance_to_submit() {
+        let (tx, _rx) = test_sender();
+        let mut overlay = AskUserQuestionOverlay::new(
+            event(vec![single_backend_question(
+                AskUserQuestionKind::SingleChoice,
+            )]),
+            tx,
+        );
+
+        // Pick Express.js, which should auto-advance to Submit tab.
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Char('2'), KeyModifiers::NONE));
+
+        let area = Rect::new(0, 0, 90, 16);
+        assert_snapshot!(render_snapshot(&overlay, area));
+    }
+
+    #[test]
+    fn ask_user_question_selected_tab_uses_background_fill() {
+        let (tx, _rx) = test_sender();
+        let overlay = AskUserQuestionOverlay::new(
+            event(vec![single_backend_question(
+                AskUserQuestionKind::SingleChoice,
+            )]),
+            tx,
+        );
+
+        let area = Rect::new(0, 0, 80, 18);
+        let mut buf = Buffer::empty(area);
+        overlay.render(area, &mut buf);
+
+        let mut found_bg = false;
+        for x in 0..area.width {
+            if buf[(x, 0)].style().bg == Some(Color::LightBlue) {
+                found_bg = true;
+                break;
+            }
+        }
+        assert!(found_bg, "expected selected tab background fill");
+    }
+
+    #[test]
+    fn ask_user_question_single_choice_custom_stays_on_tab_for_edit() {
+        let (tx, _rx) = test_sender();
+        let mut overlay = AskUserQuestionOverlay::new(
+            event(vec![single_backend_question(
+                AskUserQuestionKind::SingleChoice,
+            )]),
+            tx,
+        );
+
+        // Pick custom option and type a value; should not auto-advance until Enter.
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Char('3'), KeyModifiers::NONE));
+        for ch in "FastAPI".chars() {
+            overlay.handle_key_event(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+        }
+
+        let area = Rect::new(0, 0, 90, 16);
+        assert_snapshot!(render_snapshot(&overlay, area));
+    }
+
+    #[test]
+    fn ask_user_question_multiple_choice_custom_and_next() {
+        let (tx, _rx) = test_sender();
+        let question = AskUserQuestionQuestion {
+            id: "features".to_string(),
+            header: "Features".to_string(),
+            question: "Какие фичи нужны в первую очередь?".to_string(),
+            kind: AskUserQuestionKind::MultipleChoice,
+            options: vec![
+                AskUserQuestionOption {
+                    label: "Auth".to_string(),
+                    description: "Логин/регистрация и роли".to_string(),
+                    custom: false,
+                },
+                AskUserQuestionOption {
+                    label: "Payments".to_string(),
+                    description: "Подписки и биллинг".to_string(),
+                    custom: false,
+                },
+                AskUserQuestionOption {
+                    label: "Other".to_string(),
+                    description: "".to_string(),
+                    custom: true,
+                },
+            ],
+        };
+
+        let mut overlay = AskUserQuestionOverlay::new(event(vec![question]), tx);
+
+        // Toggle Auth and custom.
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
+        for ch in "Realtime".chars() {
+            overlay.handle_key_event(KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+        }
+        // Next -> Submit tab
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        let area = Rect::new(0, 0, 90, 16);
+        assert_snapshot!(render_snapshot(&overlay, area));
+    }
+
+    #[test]
+    fn ask_user_question_submit_shows_blank_for_unanswered() {
+        let (tx, _rx) = test_sender();
+        let q1 = single_backend_question(AskUserQuestionKind::SingleChoice);
+        let q2 = AskUserQuestionQuestion {
+            id: "database".to_string(),
+            header: "Database".to_string(),
+            question: "Какую БД использовать?".to_string(),
+            kind: AskUserQuestionKind::MultipleChoice,
+            options: vec![
+                AskUserQuestionOption {
+                    label: "Postgres".to_string(),
+                    description: "Реляционная БД".to_string(),
+                    custom: false,
+                },
+                AskUserQuestionOption {
+                    label: "SQLite".to_string(),
+                    description: "Файл, локально".to_string(),
+                    custom: false,
+                },
+                AskUserQuestionOption {
+                    label: "Other".to_string(),
+                    description: "".to_string(),
+                    custom: true,
+                },
+            ],
+        };
+
+        let mut overlay = AskUserQuestionOverlay::new(event(vec![q1, q2]), tx);
+
+        // Answer first question and move to Database tab.
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Char('1'), KeyModifiers::NONE));
+        // Move to Submit without answering Database.
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Right, KeyModifiers::NONE));
+
+        let area = Rect::new(0, 0, 90, 16);
+        assert_snapshot!(render_snapshot(&overlay, area));
+    }
+
+    #[test]
+    fn ask_user_question_submit_inserts_chat_summary_cell() {
+        let (tx, mut rx) = test_sender();
+        let q1 = AskUserQuestionQuestion {
+            id: "tool_type".to_string(),
+            header: "Tool Type".to_string(),
+            question: "Какой тип инструмента вы хотите реализовать первым?".to_string(),
+            kind: AskUserQuestionKind::SingleChoice,
+            options: vec![
+                AskUserQuestionOption {
+                    label: "getBlockingTree".to_string(),
+                    description: "".to_string(),
+                    custom: false,
+                },
+                AskUserQuestionOption {
+                    label: "getDeadlockCount".to_string(),
+                    description: "".to_string(),
+                    custom: false,
+                },
+            ],
+        };
+        let q2 = AskUserQuestionQuestion {
+            id: "providers".to_string(),
+            header: "Providers".to_string(),
+            question: "Какие провайдеры нужно поддерживать?".to_string(),
+            kind: AskUserQuestionKind::MultipleChoice,
+            options: vec![
+                AskUserQuestionOption {
+                    label: "AWS".to_string(),
+                    description: "".to_string(),
+                    custom: false,
+                },
+                AskUserQuestionOption {
+                    label: "GCP".to_string(),
+                    description: "".to_string(),
+                    custom: false,
+                },
+            ],
+        };
+        let q3 = AskUserQuestionQuestion {
+            id: "features".to_string(),
+            header: "Features".to_string(),
+            question: "Какие дополнительные функции включить?".to_string(),
+            kind: AskUserQuestionKind::MultipleChoice,
+            options: vec![
+                AskUserQuestionOption {
+                    label: "Version detection".to_string(),
+                    description: "".to_string(),
+                    custom: false,
+                },
+                AskUserQuestionOption {
+                    label: "Token budget".to_string(),
+                    description: "".to_string(),
+                    custom: false,
+                },
+                AskUserQuestionOption {
+                    label: "Playbook integration".to_string(),
+                    description: "".to_string(),
+                    custom: false,
+                },
+            ],
+        };
+
+        let mut overlay = AskUserQuestionOverlay::new(event(vec![q1, q2, q3]), tx);
+
+        // Q1: pick first option, auto-advances.
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Char('1'), KeyModifiers::NONE));
+
+        // Q2: select AWS + GCP, then Next.
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        // Q3: select all, then Next to Submit.
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Down, KeyModifiers::NONE));
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Char(' '), KeyModifiers::NONE));
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        // Submit.
+        overlay.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        let mut summary_cell: Option<Box<dyn HistoryCell>> = None;
+        let mut saw_codex_op = false;
+        while let Ok(ev) = rx.try_recv() {
+            match ev {
+                AppEvent::InsertHistoryCell(cell) => summary_cell = Some(cell),
+                AppEvent::CodexOp(Op::UserInputAnswer { .. }) => saw_codex_op = true,
+                _ => {}
+            }
+        }
+
+        assert!(saw_codex_op);
+        let summary_cell = summary_cell.expect("missing InsertHistoryCell");
+
+        let width = 110u16;
+        let height = HistoryCell::display_lines(summary_cell.as_ref(), width)
+            .len()
+            .max(1) as u16;
+        assert_snapshot!(render_history_snapshot(
+            summary_cell.as_ref(),
+            Rect::new(0, 0, width, height)
+        ));
+    }
+}

--- a/codex-rs/tui/src/bottom_pane/ask_user_question/render.rs
+++ b/codex-rs/tui/src/bottom_pane/ask_user_question/render.rs
@@ -1,0 +1,494 @@
+use ratatui::buffer::Buffer;
+use ratatui::layout::Constraint;
+use ratatui::layout::Layout;
+use ratatui::layout::Rect;
+use ratatui::style::Color;
+use ratatui::style::Style;
+use ratatui::style::Stylize as _;
+use ratatui::text::Line;
+use ratatui::text::Span;
+use ratatui::widgets::Clear;
+use ratatui::widgets::Paragraph;
+use ratatui::widgets::Tabs;
+use ratatui::widgets::Widget;
+use unicode_width::UnicodeWidthStr;
+
+use codex_protocol::ask_user_question::AskUserQuestionKind;
+use crossterm::event::KeyCode;
+
+use crate::key_hint;
+use crate::render::renderable::Renderable;
+
+use super::AskUserQuestionOverlay;
+use super::CUSTOM_PLACEHOLDER_DEFAULT;
+use super::Focus;
+use super::SubmitFocus;
+
+const TAB_ICON_UNANSWERED: &str = "☐";
+const TAB_ICON_ANSWERED: &str = "☑";
+
+const TAB_SELECTED_BG: Color = Color::LightBlue;
+const TAB_SELECTED_FG: Color = Color::Black;
+
+impl Renderable for AskUserQuestionOverlay {
+    fn desired_height(&self, _width: u16) -> u16 {
+        let header_height = 1usize; // tabs
+        let spacer_height = 1usize;
+        let body_spacer_height = 1usize;
+        let poll_input_separator_height = 1usize;
+        let input_height = 1usize;
+        let controls_separator_height = 1usize;
+        let controls_height = 1usize;
+        let controls_bottom_separator_height = 1usize;
+
+        let body_height = if self.is_submit_tab() {
+            let list_height = self.request.questions.len().max(1);
+            // title(2) + list + buttons(2)
+            2usize.saturating_add(list_height).saturating_add(2)
+        } else {
+            let options_len = self
+                .current_question()
+                .map(|q| q.options.len())
+                .unwrap_or(0);
+            let visible_items = options_len.clamp(1, 4);
+            let options_height = visible_items.saturating_mul(2); // label + description
+            // question(2) + options
+            2usize.saturating_add(options_height)
+        };
+
+        let height = header_height
+            .saturating_add(spacer_height)
+            .saturating_add(body_height)
+            .saturating_add(body_spacer_height)
+            .saturating_add(poll_input_separator_height)
+            .saturating_add(input_height)
+            .saturating_add(controls_separator_height)
+            .saturating_add(controls_height)
+            .saturating_add(controls_bottom_separator_height)
+            .max(14);
+        height.try_into().unwrap_or(u16::MAX)
+    }
+
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        self.render_ui(area, buf);
+    }
+
+    fn cursor_pos(&self, area: Rect) -> Option<(u16, u16)> {
+        self.cursor_pos_impl(area)
+    }
+}
+
+impl AskUserQuestionOverlay {
+    fn render_ui(&self, area: Rect, buf: &mut Buffer) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+        Clear.render(area, buf);
+
+        let [
+            tabs_area,
+            spacer_area,
+            body_area,
+            body_spacer_area,
+            poll_input_separator_area,
+            input_area,
+            controls_top_separator_area,
+            controls_area,
+            controls_bottom_separator_area,
+        ] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .areas(area);
+
+        self.render_tabs(tabs_area, buf);
+        Paragraph::new(Line::from("")).render(spacer_area, buf);
+
+        if self.is_submit_tab() {
+            self.render_submit(body_area, buf);
+        } else {
+            self.render_question(body_area, buf);
+        }
+
+        Paragraph::new(Line::from("")).render(body_spacer_area, buf);
+        self.render_rule(poll_input_separator_area, buf);
+        self.render_progress_hint(input_area, buf);
+        self.render_rule(controls_top_separator_area, buf);
+        self.render_controls(controls_area, buf);
+        self.render_rule(controls_bottom_separator_area, buf);
+    }
+
+    fn render_tabs(&self, area: Rect, buf: &mut Buffer) {
+        let [left_area, tabs_area, right_area] = Layout::horizontal([
+            Constraint::Length(3),
+            Constraint::Min(1),
+            Constraint::Length(3),
+        ])
+        .areas(area);
+
+        Paragraph::new(Line::from("←".dim())).render(left_area, buf);
+        Paragraph::new(Line::from("→".dim())).render(right_area, buf);
+
+        let mut titles: Vec<Line<'static>> = Vec::new();
+        for (idx, q) in self.request.questions.iter().enumerate() {
+            let icon = if self.question_answered(idx) {
+                TAB_ICON_ANSWERED
+            } else {
+                TAB_ICON_UNANSWERED
+            };
+            titles.push(Line::from(vec![
+                " ".into(),
+                icon.into(),
+                "  ".into(),
+                q.header.clone().into(),
+                " ".into(),
+            ]));
+        }
+        titles.push(Line::from(vec![
+            " ".into(),
+            "✓".into(),
+            "  ".into(),
+            "Submit".into(),
+            " ".into(),
+        ]));
+
+        let tabs = Tabs::new(titles)
+            .select(self.active_tab)
+            .style(Style::default().dim())
+            .highlight_style(
+                Style::default()
+                    .fg(TAB_SELECTED_FG)
+                    .bg(TAB_SELECTED_BG)
+                    .bold(),
+            )
+            .divider(" ")
+            .padding("", "");
+        tabs.render(tabs_area, buf);
+    }
+
+    fn render_question(&self, area: Rect, buf: &mut Buffer) {
+        let [question_area, options_area] =
+            Layout::vertical([Constraint::Length(2), Constraint::Min(1)]).areas(area);
+
+        let Some(question) = self.current_question() else {
+            Paragraph::new(Line::from("No questions".dim())).render(question_area, buf);
+            return;
+        };
+
+        Paragraph::new(Line::from(question.question.clone()).bold()).render(question_area, buf);
+
+        self.render_options(options_area, buf);
+    }
+
+    fn render_options(&self, area: Rect, buf: &mut Buffer) {
+        let Some(q_idx) = self.current_question_index() else {
+            return;
+        };
+        let question = &self.request.questions[q_idx];
+        let Some(question_state) = self.current_state() else {
+            return;
+        };
+
+        let options_len = question.options.len();
+        let visible_items = (area.height as usize / 2).max(1).min(options_len.max(1));
+        let mut state = question_state.highlight;
+        state.ensure_visible(options_len, visible_items);
+        let start_idx = state.scroll_top.min(options_len.saturating_sub(1));
+
+        for (i, opt) in question
+            .options
+            .iter()
+            .enumerate()
+            .skip(start_idx)
+            .take(visible_items)
+        {
+            let row = (i - start_idx) as u16;
+            let y = area.y.saturating_add(row.saturating_mul(2));
+            if y >= area.y + area.height {
+                break;
+            }
+
+            let highlighted = state.selected_idx == Some(i);
+            let selected_multi = question_state
+                .selected_multi
+                .get(i)
+                .copied()
+                .unwrap_or(false);
+            let selected_single = question_state.selected_single == Some(i);
+
+            let arrow = if highlighted { ">" } else { " " };
+            let (prefix_string, prefix_spans): (String, Vec<Span<'static>>) = match question.kind {
+                AskUserQuestionKind::SingleChoice => {
+                    let prefix_string = format!("{arrow} {}. ", i + 1);
+                    (
+                        prefix_string.clone(),
+                        vec![format!("{arrow} ").into(), format!("{}. ", i + 1).dim()],
+                    )
+                }
+                AskUserQuestionKind::MultipleChoice => {
+                    let checkbox = if selected_multi { "[x]" } else { "[ ]" };
+                    let prefix_string = format!("{arrow} {checkbox} {}. ", i + 1);
+                    (
+                        prefix_string.clone(),
+                        vec![
+                            format!("{arrow} ").into(),
+                            checkbox.into(),
+                            " ".into(),
+                            format!("{}. ", i + 1).dim(),
+                        ],
+                    )
+                }
+            };
+            let prefix_width = UnicodeWidthStr::width(prefix_string.as_str());
+
+            let (label_text, label_dim) = if opt.custom {
+                let text = self
+                    .custom_text(q_idx)
+                    .map(str::trim)
+                    .filter(|s| !s.is_empty())
+                    .map(ToString::to_string)
+                    .unwrap_or_else(|| {
+                        if opt.label.is_empty() {
+                            CUSTOM_PLACEHOLDER_DEFAULT.to_string()
+                        } else {
+                            opt.label.clone()
+                        }
+                    });
+                let dim = self
+                    .custom_text(q_idx)
+                    .map(str::trim)
+                    .unwrap_or_default()
+                    .is_empty();
+                (text, dim)
+            } else {
+                (opt.label.clone(), false)
+            };
+
+            let is_selected = match question.kind {
+                AskUserQuestionKind::SingleChoice => selected_single,
+                AskUserQuestionKind::MultipleChoice => selected_multi,
+            };
+
+            let mut spans: Vec<Span<'static>> = Vec::new();
+            spans.extend(prefix_spans);
+            let mut label_span: Span<'static> = label_text.into();
+            if highlighted || is_selected {
+                label_span = label_span.cyan().bold();
+            } else if label_dim {
+                label_span = label_span.dim();
+            }
+            spans.push(label_span);
+
+            Paragraph::new(Line::from(spans)).render(
+                Rect {
+                    x: area.x,
+                    y,
+                    width: area.width,
+                    height: 1,
+                },
+                buf,
+            );
+
+            let desc_y = y.saturating_add(1);
+            if desc_y >= area.y + area.height {
+                break;
+            }
+            let desc = opt.description.as_str();
+            let desc_line = if desc.is_empty() {
+                Line::from("")
+            } else {
+                let indent = " ".repeat(prefix_width);
+                Line::from(vec![indent.into(), desc.to_string().dim()])
+            };
+            Paragraph::new(desc_line).render(
+                Rect {
+                    x: area.x,
+                    y: desc_y,
+                    width: area.width,
+                    height: 1,
+                },
+                buf,
+            );
+        }
+    }
+
+    fn render_submit(&self, area: Rect, buf: &mut Buffer) {
+        let [title_area, list_area, buttons_area] = Layout::vertical([
+            Constraint::Length(2),
+            Constraint::Min(1),
+            Constraint::Length(2),
+        ])
+        .areas(area);
+
+        Paragraph::new(Line::from("Review your answers".bold())).render(title_area, buf);
+
+        let mut lines: Vec<Line<'static>> = Vec::new();
+        for (idx, q) in self.request.questions.iter().enumerate() {
+            let answers = self.answer_for_question(idx).join(", ");
+            let mut spans: Vec<Span<'static>> = vec![q.header.clone().bold(), ": ".into()];
+            if !answers.is_empty() {
+                spans.push(answers.cyan());
+            }
+            lines.push(Line::from(spans));
+        }
+        Paragraph::new(lines).render(list_area, buf);
+
+        let submit_selected = matches!(self.submit_focus, SubmitFocus::Submit);
+        let cancel_selected = matches!(self.submit_focus, SubmitFocus::Cancel);
+        let submit = if submit_selected {
+            "[ Submit ]".cyan().bold()
+        } else {
+            "[ Submit ]".dim()
+        };
+        let cancel = if cancel_selected {
+            "[ Cancel ]".cyan().bold()
+        } else {
+            "[ Cancel ]".dim()
+        };
+        let buttons = Line::from(vec![submit, "  ".into(), cancel]);
+        Paragraph::new(buttons).render(buttons_area, buf);
+    }
+
+    fn render_rule(&self, area: Rect, buf: &mut Buffer) {
+        if area.height == 0 || area.width == 0 {
+            return;
+        }
+        let width = usize::from(area.width);
+        let line = "─".repeat(width.max(1)).dim();
+        Paragraph::new(Line::from(line)).render(area, buf);
+    }
+
+    fn render_progress_hint(&self, area: Rect, buf: &mut Buffer) {
+        if area.height == 0 || area.width == 0 {
+            return;
+        }
+
+        let hint = if let Some(question) = self.current_question() {
+            match question.kind {
+                AskUserQuestionKind::SingleChoice => Line::from(vec![
+                    "Select to continue. ".dim(),
+                    key_hint::plain(KeyCode::Left).into(),
+                    "/".into(),
+                    key_hint::plain(KeyCode::Right).into(),
+                    " tabs".dim(),
+                ]),
+                AskUserQuestionKind::MultipleChoice => Line::from(vec![
+                    "Press ".dim(),
+                    key_hint::plain(KeyCode::Enter).into(),
+                    " for Next. ".dim(),
+                    key_hint::plain(KeyCode::Left).into(),
+                    "/".into(),
+                    key_hint::plain(KeyCode::Right).into(),
+                    " tabs".dim(),
+                ]),
+            }
+        } else {
+            Line::from(vec![
+                key_hint::plain(KeyCode::Left).into(),
+                "/".into(),
+                key_hint::plain(KeyCode::Right).into(),
+                " tabs".dim(),
+            ])
+        };
+
+        Paragraph::new(hint).render(area, buf);
+    }
+
+    fn render_controls(&self, area: Rect, buf: &mut Buffer) {
+        let hint = Line::from(vec![
+            key_hint::plain(KeyCode::Up).into(),
+            "/".into(),
+            key_hint::plain(KeyCode::Down).into(),
+            " move | ".into(),
+            key_hint::plain(KeyCode::Enter).into(),
+            " select/next | ".into(),
+            key_hint::plain(KeyCode::Esc).into(),
+            " cancel".into(),
+        ])
+        .dim();
+        Paragraph::new(hint).render(area, buf);
+    }
+
+    fn cursor_pos_impl(&self, area: Rect) -> Option<(u16, u16)> {
+        if self.is_submit_tab() {
+            return None;
+        }
+        if !matches!(self.focus, Focus::Custom) {
+            return None;
+        }
+
+        let [_, _, body_area, _, _, _, _, _, _] = Layout::vertical([
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Min(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+            Constraint::Length(1),
+        ])
+        .areas(area);
+        let [_, options_area] =
+            Layout::vertical([Constraint::Length(2), Constraint::Min(1)]).areas(body_area);
+
+        let q_idx = self.current_question_index()?;
+        let question = &self.request.questions[q_idx];
+        let question_state = self.current_state()?;
+        let custom_idx = question_state.custom_idx?;
+
+        if !self.custom_is_selected(q_idx) {
+            return None;
+        }
+
+        let options_len = question.options.len();
+        let visible_items = (options_area.height as usize / 2)
+            .max(1)
+            .min(options_len.max(1));
+        let mut state = question_state.highlight;
+        state.ensure_visible(options_len, visible_items);
+        let start_idx = state.scroll_top.min(options_len.saturating_sub(1));
+
+        if state.selected_idx != Some(custom_idx) {
+            return None;
+        }
+
+        let row = (custom_idx - start_idx) as u16;
+        let y = options_area.y.saturating_add(row.saturating_mul(2));
+
+        let selected_multi = question_state
+            .selected_multi
+            .get(custom_idx)
+            .copied()
+            .unwrap_or(false);
+        let highlighted = true;
+        let arrow = if highlighted { ">" } else { " " };
+        let prefix_string = match question.kind {
+            AskUserQuestionKind::SingleChoice => format!("{arrow} {}. ", custom_idx + 1),
+            AskUserQuestionKind::MultipleChoice => {
+                let checkbox = if selected_multi { "[x]" } else { "[ ]" };
+                format!("{arrow} {checkbox} {}. ", custom_idx + 1)
+            }
+        };
+
+        let prefix_width = UnicodeWidthStr::width(prefix_string.as_str()) as u16;
+        let entry = question_state.custom_entry.as_ref()?;
+        let cursor_bytes = entry.text.cursor().min(entry.text.text().len());
+        let cursor_col = UnicodeWidthStr::width(&entry.text.text()[..cursor_bytes]) as u16;
+
+        Some((
+            options_area
+                .x
+                .saturating_add(prefix_width)
+                .saturating_add(cursor_col),
+            y,
+        ))
+    }
+}

--- a/codex-rs/tui/src/bottom_pane/ask_user_question/snapshots/codex_tui__bottom_pane__ask_user_question__tests__ask_user_question_multiple_choice_custom_and_next.snap
+++ b/codex-rs/tui/src/bottom_pane/ask_user_question/snapshots/codex_tui__bottom_pane__ask_user_question__tests__ask_user_question_multiple_choice_custom_and_next.snap
@@ -1,0 +1,21 @@
+---
+source: tui/src/bottom_pane/ask_user_question/mod.rs
+assertion_line: 733
+expression: "render_snapshot(&overlay, area)"
+---
+←   ☑  Features   ✓  Submit                                                            →  
+                                                                                          
+Review your answers                                                                       
+                                                                                          
+Features: Auth, Realtime                                                                  
+                                                                                          
+                                                                                          
+                                                                                          
+[ Submit ]  [ Cancel ]                                                                    
+                                                                                          
+                                                                                          
+──────────────────────────────────────────────────────────────────────────────────────────
+←/→ tabs                                                                                  
+──────────────────────────────────────────────────────────────────────────────────────────
+↑/↓ move | enter select/next | esc cancel                                                 
+──────────────────────────────────────────────────────────────────────────────────────────

--- a/codex-rs/tui/src/bottom_pane/ask_user_question/snapshots/codex_tui__bottom_pane__ask_user_question__tests__ask_user_question_single_choice_autoadvance_to_submit.snap
+++ b/codex-rs/tui/src/bottom_pane/ask_user_question/snapshots/codex_tui__bottom_pane__ask_user_question__tests__ask_user_question_single_choice_autoadvance_to_submit.snap
@@ -1,0 +1,21 @@
+---
+source: tui/src/bottom_pane/ask_user_question/mod.rs
+assertion_line: 645
+expression: "render_snapshot(&overlay, area)"
+---
+←   ☑  Backend   ✓  Submit                                                             →  
+                                                                                          
+Review your answers                                                                       
+                                                                                          
+Backend: Express.js                                                                       
+                                                                                          
+                                                                                          
+                                                                                          
+[ Submit ]  [ Cancel ]                                                                    
+                                                                                          
+                                                                                          
+──────────────────────────────────────────────────────────────────────────────────────────
+←/→ tabs                                                                                  
+──────────────────────────────────────────────────────────────────────────────────────────
+↑/↓ move | enter select/next | esc cancel                                                 
+──────────────────────────────────────────────────────────────────────────────────────────

--- a/codex-rs/tui/src/bottom_pane/ask_user_question/snapshots/codex_tui__bottom_pane__ask_user_question__tests__ask_user_question_single_choice_custom_stays_on_tab_for_edit.snap
+++ b/codex-rs/tui/src/bottom_pane/ask_user_question/snapshots/codex_tui__bottom_pane__ask_user_question__tests__ask_user_question_single_choice_custom_stays_on_tab_for_edit.snap
@@ -1,0 +1,21 @@
+---
+source: tui/src/bottom_pane/ask_user_question/mod.rs
+assertion_line: 689
+expression: "render_snapshot(&overlay, area)"
+---
+←   ☑  Backend   ✓  Submit                                                             →  
+                                                                                          
+Какой фреймворк ты предпочитаешь для бэкенда?                                             
+                                                                                          
+  1. Next.js API Routes                                                                   
+     Встроенные API routes в Next.js, удобно для full-stack                               
+  2. Express.js                                                                           
+     Классический Node.js фреймворк                                                       
+> 3. FastAPI                                                                              
+                                                                                          
+                                                                                          
+──────────────────────────────────────────────────────────────────────────────────────────
+Select to continue. ←/→ tabs                                                              
+──────────────────────────────────────────────────────────────────────────────────────────
+↑/↓ move | enter select/next | esc cancel                                                 
+──────────────────────────────────────────────────────────────────────────────────────────

--- a/codex-rs/tui/src/bottom_pane/ask_user_question/snapshots/codex_tui__bottom_pane__ask_user_question__tests__ask_user_question_submit_inserts_chat_summary_cell.snap
+++ b/codex-rs/tui/src/bottom_pane/ask_user_question/snapshots/codex_tui__bottom_pane__ask_user_question__tests__ask_user_question_submit_inserts_chat_summary_cell.snap
@@ -1,0 +1,9 @@
+---
+source: tui/src/bottom_pane/ask_user_question/mod.rs
+assertion_line: 850
+expression: "render_history_snapshot(&summary_cell, Rect::new(0, 0, width, height))"
+---
+● User answered:                                                                                              
+  ⎿  · Какой тип инструмента вы хотите реализовать первым? → getBlockingTree                                  
+     · Какие провайдеры нужно поддерживать? → AWS + GCP                                                       
+     · Какие дополнительные функции включить? → Version detection, Token budget, Playbook integration

--- a/codex-rs/tui/src/bottom_pane/ask_user_question/snapshots/codex_tui__bottom_pane__ask_user_question__tests__ask_user_question_submit_shows_blank_for_unanswered.snap
+++ b/codex-rs/tui/src/bottom_pane/ask_user_question/snapshots/codex_tui__bottom_pane__ask_user_question__tests__ask_user_question_submit_shows_blank_for_unanswered.snap
@@ -1,0 +1,21 @@
+---
+source: tui/src/bottom_pane/ask_user_question/mod.rs
+assertion_line: 772
+expression: "render_snapshot(&overlay, area)"
+---
+←   ☑  Backend   ☐  Database   ✓  Submit                                               →  
+                                                                                          
+Review your answers                                                                       
+                                                                                          
+Backend: Next.js API Routes                                                               
+Database:                                                                                 
+                                                                                          
+                                                                                          
+[ Submit ]  [ Cancel ]                                                                    
+                                                                                          
+                                                                                          
+──────────────────────────────────────────────────────────────────────────────────────────
+←/→ tabs                                                                                  
+──────────────────────────────────────────────────────────────────────────────────────────
+↑/↓ move | enter select/next | esc cancel                                                 
+──────────────────────────────────────────────────────────────────────────────────────────

--- a/codex-rs/tui/src/bottom_pane/bottom_pane_view.rs
+++ b/codex-rs/tui/src/bottom_pane/bottom_pane_view.rs
@@ -1,5 +1,6 @@
 use crate::bottom_pane::ApprovalRequest;
 use crate::render::renderable::Renderable;
+use codex_protocol::ask_user_question::AskUserQuestionEvent;
 use codex_protocol::request_user_input::RequestUserInputEvent;
 use crossterm::event::KeyEvent;
 
@@ -42,6 +43,14 @@ pub(crate) trait BottomPaneView: Renderable {
         &mut self,
         request: RequestUserInputEvent,
     ) -> Option<RequestUserInputEvent> {
+        Some(request)
+    }
+
+    /// Try to handle ask_user_question; return the original value if not consumed.
+    fn try_consume_ask_user_question_request(
+        &mut self,
+        request: AskUserQuestionEvent,
+    ) -> Option<AskUserQuestionEvent> {
         Some(request)
     }
 }

--- a/codex-rs/tui/src/chatwidget/interrupts.rs
+++ b/codex-rs/tui/src/chatwidget/interrupts.rs
@@ -8,6 +8,7 @@ use codex_core::protocol::McpToolCallBeginEvent;
 use codex_core::protocol::McpToolCallEndEvent;
 use codex_core::protocol::PatchApplyEndEvent;
 use codex_protocol::approvals::ElicitationRequestEvent;
+use codex_protocol::ask_user_question::AskUserQuestionEvent;
 use codex_protocol::request_user_input::RequestUserInputEvent;
 
 use super::ChatWidget;
@@ -18,6 +19,7 @@ pub(crate) enum QueuedInterrupt {
     ApplyPatchApproval(String, ApplyPatchApprovalRequestEvent),
     Elicitation(ElicitationRequestEvent),
     RequestUserInput(RequestUserInputEvent),
+    AskUserQuestion(AskUserQuestionEvent),
     ExecBegin(ExecCommandBeginEvent),
     ExecEnd(ExecCommandEndEvent),
     McpBegin(McpToolCallBeginEvent),
@@ -63,6 +65,10 @@ impl InterruptManager {
         self.queue.push_back(QueuedInterrupt::RequestUserInput(ev));
     }
 
+    pub(crate) fn push_ask_user_question(&mut self, ev: AskUserQuestionEvent) {
+        self.queue.push_back(QueuedInterrupt::AskUserQuestion(ev));
+    }
+
     pub(crate) fn push_exec_begin(&mut self, ev: ExecCommandBeginEvent) {
         self.queue.push_back(QueuedInterrupt::ExecBegin(ev));
     }
@@ -92,6 +98,7 @@ impl InterruptManager {
                 }
                 QueuedInterrupt::Elicitation(ev) => chat.handle_elicitation_request_now(ev),
                 QueuedInterrupt::RequestUserInput(ev) => chat.handle_request_user_input_now(ev),
+                QueuedInterrupt::AskUserQuestion(ev) => chat.handle_ask_user_question_now(ev),
                 QueuedInterrupt::ExecBegin(ev) => chat.handle_exec_begin_now(ev),
                 QueuedInterrupt::ExecEnd(ev) => chat.handle_exec_end_now(ev),
                 QueuedInterrupt::McpBegin(ev) => chat.handle_mcp_begin_now(ev),


### PR DESCRIPTION
Adds a new tool, `ask_user_question`, for structured Q&A in the Codex CLI.

## What it is / why
`ask_user_question` lets the agent ask the user a small set of clarifying questions with constrained answers, instead of relying on free-form chat back-and-forth.
This is useful for resolving ambiguity quickly (e.g. picking a backend/framework, providers, feature set, etc.) while keeping the model input structured.

## UX (what the user sees)
- The prompt appears in the bottom input area.
- A row of tabs: one tab per question + a `Submit` tab.
- You can navigate tabs with keyboard only (←/→), and can move forward without answering.
- **Single choice**: selecting an option advances to the next tab (returning lets you change it).
- **Multiple choice**: select/deselect options, then press `Enter` for Next.
- Each question can include a **custom option**; if selected, the user types their own label.
- The bottom area shows a short progress hint (e.g. `Select to continue. ←/→ tabs` / `Press Enter for Next. ←/→ tabs`) and the usual key-hint footer.
- On `Submit`, the tool returns only the structured answers, and the chat transcript gets a summary block like:
  - `● User answered:`
  - `  ⎿  · <question> → <answer(s)>`

## Non-interactive exec safety
`codex exec` is non-interactive and must not hang waiting for user input.
This PR ensures that by:
- Removing human-input tools (`ask_user_question`, `request_user_input`) from the toolset when `SessionSource::Exec` is used.
- Adding a defensive fail-fast in both handlers: tool calls return a clear error in non-interactive session sources instead of waiting on a response channel.

## Implementation notes
- Keeps existing `request_user_input` unchanged.
- Supports multi-question prompts with tabs + Submit tab.
- Cancel aborts the tool call; Submit returns answers only.
- Includes minimal snapshot coverage for the new UI.

Notes:
- Adds a protocol event (`AskUserQuestion`) to drive the TUI overlay.
