### PR TITLE
Fix up config disabled err msg

### DIFF
--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -134,7 +134,7 @@ fn project_config_warning(config: &Config) -> Option<ConfigWarningNotification> 
                     .disabled_reason
                     .as_ref()
                     .map(ToString::to_string)
-                    .unwrap_or_else(|| "Config folder disabled.".to_string()),
+                    .unwrap_or_else(|| "config.toml is disabled.".to_string()),
             ));
         }
     }
@@ -143,7 +143,11 @@ fn project_config_warning(config: &Config) -> Option<ConfigWarningNotification> 
         return None;
     }
 
-    let mut message = "The following config folders are disabled:\n".to_string();
+    let mut message = concat!(
+        "Project config.toml files are disabled in the following folders. ",
+        "Settings in those files are ignored, but skills and exec policies still load.\n",
+    )
+    .to_string();
     for (index, (folder, reason)) in disabled_folders.iter().enumerate() {
         let display_index = index + 1;
         message.push_str(&format!("    {display_index}. {folder}\n"));

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -201,7 +201,7 @@ fn emit_project_config_warnings(app_event_tx: &AppEventSender, config: &Config) 
                 .disabled_reason
                 .as_ref()
                 .map(ToString::to_string)
-                .unwrap_or_else(|| "Config folder disabled.".to_string()),
+                .unwrap_or_else(|| "config.toml is disabled.".to_string()),
         ));
     }
 
@@ -209,7 +209,11 @@ fn emit_project_config_warnings(app_event_tx: &AppEventSender, config: &Config) 
         return;
     }
 
-    let mut message = "The following config folders are disabled:\n".to_string();
+    let mut message = concat!(
+        "Project config.toml files are disabled in the following folders. ",
+        "Settings in those files are ignored, but skills and exec policies still load.\n",
+    )
+    .to_string();
     for (index, (folder, reason)) in disabled_folders.iter().enumerate() {
         let display_index = index + 1;
         message.push_str(&format!("    {display_index}. {folder}\n"));


### PR DESCRIPTION
**Before:**
<img width="745" height="375" alt="image" src="https://github.com/user-attachments/assets/d6c23562-b87f-4af9-8642-329aab8e594d" />

**After:**
<img width="1042" height="354" alt="image" src="https://github.com/user-attachments/assets/c9a2413c-c945-4c34-8b7e-c6c9b8fbf762" />

Two changes:
1. only display if there is a `config.toml` that is skipped (i.e. if there is just `.codex/skills` but no `.codex/config.toml` we do not display the error)
2. clarify the implications and the fix in the error message.