### PR TITLE
tui: add one-time personality nudge NUX with persisted hide flag

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -456,6 +456,10 @@
           "description": "Tracks whether the user has seen the model migration prompt",
           "type": "boolean"
         },
+        "hide_personality_nudge": {
+          "description": "Tracks whether the user has already seen the personality selection nudge.",
+          "type": "boolean"
+        },
         "hide_rate_limit_model_nudge": {
           "description": "Tracks whether the user opted out of the rate limit model switch reminder.",
           "type": "boolean"

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -480,6 +480,8 @@ pub struct Notice {
     pub hide_world_writable_warning: Option<bool>,
     /// Tracks whether the user opted out of the rate limit model switch reminder.
     pub hide_rate_limit_model_nudge: Option<bool>,
+    /// Tracks whether the user has already seen the personality selection nudge.
+    pub hide_personality_nudge: Option<bool>,
     /// Tracks whether the user has seen the model migration prompt
     pub hide_gpt5_1_migration_prompt: Option<bool>,
     /// Tracks whether the user has seen the gpt-5.1-codex-max migration prompt

--- a/codex-rs/core/src/models_manager/manager.rs
+++ b/codex-rs/core/src/models_manager/manager.rs
@@ -103,36 +103,12 @@ impl ModelsManager {
         Ok(self.build_available_models(remote_models))
     }
 
-    /// Determine whether a model supports personalities, with a local fallback when
-    /// remote metadata omits the instructions template.
+    /// Determine whether a model supports personalities based on remote metadata.
     pub fn supports_personality(&self, model: &str, config: &Config) -> bool {
-        let remote_supports = self
-            .try_get_remote_models(config)
+        self.try_get_remote_models(config)
             .ok()
             .and_then(|remote_models| remote_models.into_iter().find(|info| info.slug == model))
-            .is_some_and(|info| info.supports_personality());
-        if remote_supports {
-            return true;
-        }
-
-        if self
-            .local_models
-            .iter()
-            .find(|preset| preset.model == model)
-            .is_some_and(|preset| preset.supports_personality)
-        {
-            return true;
-        }
-
-        self.try_list_models(config)
-            .ok()
-            .and_then(|models| {
-                models
-                    .into_iter()
-                    .find(|preset| preset.model == model)
-                    .map(|preset| preset.supports_personality)
-            })
-            .unwrap_or(false)
+            .is_some_and(|info| info.supports_personality())
     }
 
     // todo(aibrahim): should be visible to core only and sent on session_configured event
@@ -174,14 +150,7 @@ impl ModelsManager {
             .await
             .into_iter()
             .find(|m| m.slug == model);
-        let model = if let Some(mut remote) = remote {
-            if !remote.supports_personality() && local.supports_personality() {
-                remote.model_instructions_template = local.model_instructions_template.clone();
-            }
-            remote
-        } else {
-            local
-        };
+        let model = remote.unwrap_or(local);
         model_info::with_config_overrides(model, config)
     }
 
@@ -358,6 +327,12 @@ impl ModelsManager {
             cache_manager,
             provider,
         }
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    /// Override remote model metadata for tests.
+    pub async fn set_remote_models_for_testing(&self, models: Vec<ModelInfo>) {
+        *self.remote_models.write().await = models;
     }
 
     #[cfg(any(test, feature = "test-support"))]
@@ -737,7 +712,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn supports_personality_falls_back_to_local_presets() {
+    async fn supports_personality_requires_remote_metadata() {
         let codex_home = tempdir().expect("temp dir");
         let mut config = ConfigBuilder::default()
             .codex_home(codex_home.path().to_path_buf())
@@ -751,7 +726,7 @@ mod tests {
         let manager =
             ModelsManager::with_provider(codex_home.path().to_path_buf(), auth_manager, provider);
 
-        // Remote metadata without personality messages should not disable local support.
+        // Remote metadata must explicitly include personality support.
         let mut remote = remote_model("gpt-5.2-codex", "Remote gpt-5.2-codex", 0);
         remote.model_instructions_template = Some(ModelInstructionsTemplate {
             template: "{{ personality_message }}".to_string(),
@@ -759,9 +734,9 @@ mod tests {
         });
         *manager.remote_models.write().await = vec![remote];
 
-        assert!(manager.supports_personality("gpt-5.2-codex", &config));
+        assert!(!manager.supports_personality("gpt-5.2-codex", &config));
         let model = manager.get_model_info("gpt-5.2-codex", &config).await;
-        assert!(model.supports_personality());
+        assert!(!model.supports_personality());
     }
 
     #[test]

--- a/codex-rs/core/src/models_manager/manager.rs
+++ b/codex-rs/core/src/models_manager/manager.rs
@@ -150,7 +150,11 @@ impl ModelsManager {
             .await
             .into_iter()
             .find(|m| m.slug == model);
-        let model = remote.unwrap_or(local);
+        let remote_supports = remote.as_ref().is_some_and(ModelInfo::supports_personality);
+        let mut model = remote.unwrap_or(local);
+        if !remote_supports {
+            model.model_instructions_template = None;
+        }
         model_info::with_config_overrides(model, config)
     }
 
@@ -353,7 +357,10 @@ impl ModelsManager {
     #[cfg(any(test, feature = "test-support"))]
     /// Build `ModelInfo` without consulting remote state or cache.
     pub fn construct_model_info_offline(model: &str, config: &Config) -> ModelInfo {
-        model_info::with_config_overrides(model_info::find_model_info_for_slug(model), config)
+        let mut model_info =
+            model_info::with_config_overrides(model_info::find_model_info_for_slug(model), config);
+        model_info.model_instructions_template = None;
+        model_info
     }
 }
 

--- a/codex-rs/core/src/models_manager/manager.rs
+++ b/codex-rs/core/src/models_manager/manager.rs
@@ -149,13 +149,15 @@ impl ModelsManager {
     // todo(aibrahim): look if we can tighten it to pub(crate)
     /// Look up model metadata, applying remote overrides and config adjustments.
     pub async fn get_model_info(&self, model: &str, config: &Config) -> ModelInfo {
-        let local = model_info::find_model_info_for_slug(model);
         let remote = self
             .get_remote_models(config)
             .await
             .into_iter()
             .find(|m| m.slug == model);
-        let model = remote.unwrap_or(local);
+        let model = match remote {
+            Some(remote) => remote,
+            None => model_info::find_model_info_for_slug(model),
+        };
         model_info::with_config_overrides(model, config)
     }
 

--- a/codex-rs/core/src/models_manager/model_info.rs
+++ b/codex-rs/core/src/models_manager/model_info.rs
@@ -1,13 +1,8 @@
-use std::collections::BTreeMap;
-
-use codex_protocol::config_types::Personality;
 use codex_protocol::config_types::Verbosity;
 use codex_protocol::openai_models::ApplyPatchToolType;
 use codex_protocol::openai_models::ConfigShellToolType;
 use codex_protocol::openai_models::ModelInfo;
-use codex_protocol::openai_models::ModelInstructionsTemplate;
 use codex_protocol::openai_models::ModelVisibility;
-use codex_protocol::openai_models::PersonalityMessages;
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::openai_models::ReasoningEffortPreset;
 use codex_protocol::openai_models::TruncationMode;
@@ -27,22 +22,8 @@ const GPT_5_2_INSTRUCTIONS: &str = include_str!("../../gpt_5_2_prompt.md");
 const GPT_5_1_CODEX_MAX_INSTRUCTIONS: &str = include_str!("../../gpt-5.1-codex-max_prompt.md");
 
 const GPT_5_2_CODEX_INSTRUCTIONS: &str = include_str!("../../gpt-5.2-codex_prompt.md");
-const GPT_5_2_CODEX_INSTRUCTIONS_TEMPLATE: &str =
-    include_str!("../../templates/model_instructions/gpt-5.2-codex_instructions_template.md");
-const PERSONALITY_FRIENDLY: &str = include_str!("../../templates/personalities/friendly.md");
-const PERSONALITY_PRAGMATIC: &str = include_str!("../../templates/personalities/pragmatic.md");
 
 pub(crate) const CONTEXT_WINDOW_272K: i64 = 272_000;
-
-fn gpt_5_2_codex_personality_template() -> ModelInstructionsTemplate {
-    ModelInstructionsTemplate {
-        template: GPT_5_2_CODEX_INSTRUCTIONS_TEMPLATE.to_string(),
-        personality_messages: Some(PersonalityMessages(BTreeMap::from([
-            (Personality::Friendly, PERSONALITY_FRIENDLY.to_string()),
-            (Personality::Pragmatic, PERSONALITY_PRAGMATIC.to_string()),
-        ]))),
-    }
-}
 
 macro_rules! model_info {
     (
@@ -179,7 +160,6 @@ pub(crate) fn find_model_info_for_slug(slug: &str) -> ModelInfo {
         model_info!(
             slug,
             base_instructions: GPT_5_2_CODEX_INSTRUCTIONS.to_string(),
-            model_instructions_template: Some(gpt_5_2_codex_personality_template()),
             apply_patch_tool_type: Some(ApplyPatchToolType::Freeform),
             shell_type: ConfigShellToolType::ShellCommand,
             supports_parallel_tool_calls: true,
@@ -206,7 +186,6 @@ pub(crate) fn find_model_info_for_slug(slug: &str) -> ModelInfo {
         model_info!(
             slug,
             base_instructions: GPT_5_2_CODEX_INSTRUCTIONS.to_string(),
-            model_instructions_template: Some(gpt_5_2_codex_personality_template()),
             apply_patch_tool_type: Some(ApplyPatchToolType::Freeform),
             shell_type: ConfigShellToolType::ShellCommand,
             supports_parallel_tool_calls: true,

--- a/codex-rs/core/src/models_manager/model_info.rs
+++ b/codex-rs/core/src/models_manager/model_info.rs
@@ -34,6 +34,16 @@ const PERSONALITY_PRAGMATIC: &str = include_str!("../../templates/personalities/
 
 pub(crate) const CONTEXT_WINDOW_272K: i64 = 272_000;
 
+fn gpt_5_2_codex_personality_template() -> ModelInstructionsTemplate {
+    ModelInstructionsTemplate {
+        template: GPT_5_2_CODEX_INSTRUCTIONS_TEMPLATE.to_string(),
+        personality_messages: Some(PersonalityMessages(BTreeMap::from([
+            (Personality::Friendly, PERSONALITY_FRIENDLY.to_string()),
+            (Personality::Pragmatic, PERSONALITY_PRAGMATIC.to_string()),
+        ]))),
+    }
+}
+
 macro_rules! model_info {
     (
         $slug:expr $(, $key:ident : $value:expr )* $(,)?
@@ -169,16 +179,7 @@ pub(crate) fn find_model_info_for_slug(slug: &str) -> ModelInfo {
         model_info!(
             slug,
             base_instructions: GPT_5_2_CODEX_INSTRUCTIONS.to_string(),
-            model_instructions_template: Some(ModelInstructionsTemplate {
-                template: GPT_5_2_CODEX_INSTRUCTIONS_TEMPLATE.to_string(),
-                personality_messages: Some(PersonalityMessages(BTreeMap::from([(
-                    Personality::Friendly,
-                    PERSONALITY_FRIENDLY.to_string(),
-                ), (
-                    Personality::Pragmatic,
-                    PERSONALITY_PRAGMATIC.to_string(),
-                )]))),
-            }),
+            model_instructions_template: Some(gpt_5_2_codex_personality_template()),
             apply_patch_tool_type: Some(ApplyPatchToolType::Freeform),
             shell_type: ConfigShellToolType::ShellCommand,
             supports_parallel_tool_calls: true,
@@ -205,6 +206,7 @@ pub(crate) fn find_model_info_for_slug(slug: &str) -> ModelInfo {
         model_info!(
             slug,
             base_instructions: GPT_5_2_CODEX_INSTRUCTIONS.to_string(),
+            model_instructions_template: Some(gpt_5_2_codex_personality_template()),
             apply_patch_tool_type: Some(ApplyPatchToolType::Freeform),
             shell_type: ConfigShellToolType::ShellCommand,
             supports_parallel_tool_calls: true,

--- a/codex-rs/core/src/models_manager/model_info.rs
+++ b/codex-rs/core/src/models_manager/model_info.rs
@@ -1,8 +1,13 @@
+use std::collections::BTreeMap;
+
+use codex_protocol::config_types::Personality;
 use codex_protocol::config_types::Verbosity;
 use codex_protocol::openai_models::ApplyPatchToolType;
 use codex_protocol::openai_models::ConfigShellToolType;
 use codex_protocol::openai_models::ModelInfo;
+use codex_protocol::openai_models::ModelInstructionsTemplate;
 use codex_protocol::openai_models::ModelVisibility;
+use codex_protocol::openai_models::PersonalityMessages;
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::openai_models::ReasoningEffortPreset;
 use codex_protocol::openai_models::TruncationMode;
@@ -22,6 +27,10 @@ const GPT_5_2_INSTRUCTIONS: &str = include_str!("../../gpt_5_2_prompt.md");
 const GPT_5_1_CODEX_MAX_INSTRUCTIONS: &str = include_str!("../../gpt-5.1-codex-max_prompt.md");
 
 const GPT_5_2_CODEX_INSTRUCTIONS: &str = include_str!("../../gpt-5.2-codex_prompt.md");
+const GPT_5_2_CODEX_INSTRUCTIONS_TEMPLATE: &str =
+    include_str!("../../templates/model_instructions/gpt-5.2-codex_instructions_template.md");
+const PERSONALITY_FRIENDLY: &str = include_str!("../../templates/personalities/friendly.md");
+const PERSONALITY_PRAGMATIC: &str = include_str!("../../templates/personalities/pragmatic.md");
 
 pub(crate) const CONTEXT_WINDOW_272K: i64 = 272_000;
 
@@ -160,6 +169,16 @@ pub(crate) fn find_model_info_for_slug(slug: &str) -> ModelInfo {
         model_info!(
             slug,
             base_instructions: GPT_5_2_CODEX_INSTRUCTIONS.to_string(),
+            model_instructions_template: Some(ModelInstructionsTemplate {
+                template: GPT_5_2_CODEX_INSTRUCTIONS_TEMPLATE.to_string(),
+                personality_messages: Some(PersonalityMessages(BTreeMap::from([(
+                    Personality::Friendly,
+                    PERSONALITY_FRIENDLY.to_string(),
+                ), (
+                    Personality::Pragmatic,
+                    PERSONALITY_PRAGMATIC.to_string(),
+                )]))),
+            }),
             apply_patch_tool_type: Some(ApplyPatchToolType::Freeform),
             shell_type: ConfigShellToolType::ShellCommand,
             supports_parallel_tool_calls: true,

--- a/codex-rs/core/tests/suite/personality.rs
+++ b/codex-rs/core/tests/suite/personality.rs
@@ -38,6 +38,9 @@ use tokio::time::sleep;
 use wiremock::BodyPrintLimit;
 use wiremock::MockServer;
 
+const LOCAL_FRIENDLY_TEMPLATE: &str =
+    "You optimize for team morale and being a supportive teammate as much as code quality.";
+
 fn sse_completed(id: &str) -> String {
     sse(vec![ev_response_created(id), ev_completed(id)])
 }
@@ -113,7 +116,7 @@ async fn user_turn_personality_none_does_not_add_update_message() -> anyhow::Res
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn config_personality_some_ignores_without_remote_template() -> anyhow::Result<()> {
+async fn config_personality_some_sets_instructions_template() -> anyhow::Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
@@ -148,12 +151,10 @@ async fn config_personality_some_ignores_without_remote_template() -> anyhow::Re
 
     let request = resp_mock.single_request();
     let instructions_text = request.instructions_text();
-    let model_info =
-        ModelsManager::construct_model_info_offline("exp-codex-personality", &test.config);
 
     assert!(
-        instructions_text == model_info.base_instructions,
-        "expected base instructions without a remote personality template, got: {instructions_text:?}"
+        instructions_text.contains(LOCAL_FRIENDLY_TEMPLATE),
+        "expected personality update to include the local friendly template, got: {instructions_text:?}"
     );
 
     let developer_texts = request.message_input_texts("developer");
@@ -168,7 +169,7 @@ async fn config_personality_some_ignores_without_remote_template() -> anyhow::Re
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn user_turn_personality_some_ignores_without_remote_template() -> anyhow::Result<()> {
+async fn user_turn_personality_some_adds_update_message() -> anyhow::Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
@@ -245,11 +246,18 @@ async fn user_turn_personality_some_ignores_without_remote_template() -> anyhow:
         .expect("expected personality update request");
 
     let developer_texts = request.message_input_texts("developer");
+    let personality_text = developer_texts
+        .iter()
+        .find(|text| text.contains("<personality_spec>"))
+        .expect("expected personality update message in developer input");
+
     assert!(
-        !developer_texts
-            .iter()
-            .any(|text| text.contains("<personality_spec>")),
-        "did not expect a personality update message without a remote template"
+        personality_text.contains("The user has requested a new communication style."),
+        "expected personality update preamble, got {personality_text:?}"
+    );
+    assert!(
+        personality_text.contains(LOCAL_FRIENDLY_TEMPLATE),
+        "expected personality update to include the local friendly template, got: {personality_text:?}"
     );
 
     Ok(())

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1532,6 +1532,9 @@ impl App {
             AppEvent::OpenReasoningPopup { model } => {
                 self.chat_widget.open_reasoning_popup(model);
             }
+            AppEvent::OpenPersonalityPopup => {
+                self.chat_widget.open_personality_popup();
+            }
             AppEvent::OpenAllModelsPopup { models } => {
                 self.chat_widget.open_all_models_popup(models);
             }
@@ -1976,6 +1979,9 @@ impl App {
             AppEvent::UpdateRateLimitSwitchPromptHidden(hidden) => {
                 self.chat_widget.set_rate_limit_switch_prompt_hidden(hidden);
             }
+            AppEvent::UpdatePersonalityNudgeHidden(hidden) => {
+                self.chat_widget.set_personality_nudge_hidden(hidden);
+            }
             AppEvent::PersistFullAccessWarningAcknowledged => {
                 if let Err(err) = ConfigEditsBuilder::new(&self.config.codex_home)
                     .set_hide_full_access_warning(true)
@@ -2018,6 +2024,21 @@ impl App {
                     );
                     self.chat_widget.add_error_message(format!(
                         "Failed to save rate limit reminder preference: {err}"
+                    ));
+                }
+            }
+            AppEvent::PersistPersonalityNudgeHidden => {
+                if let Err(err) = ConfigEditsBuilder::new(&self.config.codex_home)
+                    .set_hide_personality_nudge(true)
+                    .apply()
+                    .await
+                {
+                    tracing::error!(
+                        error = %err,
+                        "failed to persist personality nudge preference"
+                    );
+                    self.chat_widget.add_error_message(format!(
+                        "Failed to save personality nudge preference: {err}"
                     ));
                 }
             }

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -126,6 +126,9 @@ pub(crate) enum AppEvent {
         model: ModelPreset,
     },
 
+    /// Open the personality selection popup.
+    OpenPersonalityPopup,
+
     /// Open the full model picker (non-auto models).
     OpenAllModelsPopup {
         models: Vec<ModelPreset>,
@@ -202,6 +205,9 @@ pub(crate) enum AppEvent {
     /// Update whether the rate limit switch prompt has been acknowledged for the session.
     UpdateRateLimitSwitchPromptHidden(bool),
 
+    /// Update whether the personality nudge has been acknowledged for the session.
+    UpdatePersonalityNudgeHidden(bool),
+
     /// Persist the acknowledgement flag for the full access warning prompt.
     PersistFullAccessWarningAcknowledged,
 
@@ -211,6 +217,9 @@ pub(crate) enum AppEvent {
 
     /// Persist the acknowledgement flag for the rate limit switch prompt.
     PersistRateLimitSwitchPromptHidden,
+
+    /// Persist the acknowledgement flag for the personality nudge.
+    PersistPersonalityNudgeHidden,
 
     /// Persist the acknowledgement flag for the model migration prompt.
     PersistModelMigrationPromptAcknowledged {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3483,11 +3483,7 @@ impl ChatWidget {
         if !self.is_session_configured() {
             return;
         }
-        if self.personality_nudge_hidden() {
-            self.personality_nudge = PersonalityNudgeState::Idle;
-            return;
-        }
-        if self.config.model_personality.is_some() || !self.current_model_supports_personality() {
+        if !self.personality_nudge_is_eligible() {
             self.personality_nudge = PersonalityNudgeState::Idle;
             return;
         }
@@ -3498,15 +3494,11 @@ impl ChatWidget {
     }
 
     fn maybe_show_pending_personality_nudge(&mut self) {
-        if self.personality_nudge_hidden() {
+        if !self.personality_nudge_is_eligible() {
             self.personality_nudge = PersonalityNudgeState::Idle;
             return;
         }
         if !matches!(self.personality_nudge, PersonalityNudgeState::Pending) {
-            return;
-        }
-        if self.config.model_personality.is_some() || !self.current_model_supports_personality() {
-            self.personality_nudge = PersonalityNudgeState::Idle;
             return;
         }
         if !self.bottom_pane.no_modal_or_popup_active() {
@@ -3515,6 +3507,12 @@ impl ChatWidget {
 
         self.open_personality_nudge();
         self.personality_nudge = PersonalityNudgeState::Shown;
+    }
+
+    fn personality_nudge_is_eligible(&self) -> bool {
+        !self.personality_nudge_hidden()
+            && self.config.model_personality.is_none()
+            && self.current_model_supports_personality()
     }
 
     fn open_personality_nudge(&mut self) {

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__personality_nudge_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__personality_nudge_popup.snap
@@ -1,0 +1,11 @@
+---
+source: tui/src/chatwidget/tests.rs
+expression: popup
+---
+  New: response personalities
+  Prefer a different style? Try /personality.
+
+› 1. Choose a personality  Pick Friendly or Pragmatic for future responses.
+  2. Not now               You can run /personality any time.
+
+  Press enter to confirm or esc to go back


### PR DESCRIPTION
## Summary

<img width="856" height="98" alt="Screenshot 2026-01-27 at 12 27 00 PM" src="https://github.com/user-attachments/assets/1c92e03f-b416-43d0-806a-741f359e9062" />

## Summary

- Add a one‑time personality NUX (shown on startup or when switching into a personality‑capable model) with “Not now”
  persistence.
- Refine personality availability checks to respect config overrides (e.g., base_instructions disables personalities)
  and preserve local fallback behavior when remote metadata is missing.
- Avoid misleading “Unknown model” warnings when a model slug exists only in remote metadata.
- Align tests and supporting infra for personality behaviors across core/app‑server/tui.

## Codex Author
`codex fork 019bfbc6-ee42-78b3-a337-f8af41cfce1e`