### PR TITLE
tui: remove "Worked for" separators during assistant turns

### DIFF
--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -215,10 +215,6 @@ impl BottomPane {
         self.request_redraw();
     }
 
-    pub fn status_widget(&self) -> Option<&StatusIndicatorWidget> {
-        self.status.as_ref()
-    }
-
     pub fn skills(&self) -> Option<&Vec<SkillMetadata>> {
         self.composer.skills()
     }

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__binary_size_ideal_response.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__binary_size_ideal_response.snap
@@ -9,8 +9,6 @@ expression: "lines[start_idx..].join(\"\\n\")"
   is set up. I should look into the Cargo.toml file to confirm features and
   profiles without needing to edit any code. Let's get started on this!
 
-─ Worked for 0s ────────────────────────────────────────────────────────────────
-
 • I’m going to scan the workspace and Cargo manifests to see build profiles and
   dependencies that impact binary size. Then I’ll summarize the main causes.
 
@@ -111,8 +109,6 @@ expression: "lines[start_idx..].join(\"\\n\")"
   To present this clearly, I’ll format the final answer with two main sections:
   "Main Causes" and "Build-Mode Notes." I can also include brief suggestions for
   reducing size, but I want to stay focused on answering the user's question.
-
-─ Worked for 0s ────────────────────────────────────────────────────────────────
 
 • Here’s what’s driving size in this workspace’s binaries.
 

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1769,42 +1769,6 @@ pub(crate) fn new_reasoning_summary_block(full_reasoning_buffer: String) -> Box<
     ))
 }
 
-#[derive(Debug)]
-/// A visual divider between turns, optionally showing how long the assistant "worked for".
-///
-/// This separator is only emitted for turns that performed concrete work (e.g., running commands,
-/// applying patches, making MCP tool calls), so purely conversational turns do not show an empty
-/// divider.
-pub struct FinalMessageSeparator {
-    elapsed_seconds: Option<u64>,
-}
-impl FinalMessageSeparator {
-    /// Creates a separator; `elapsed_seconds` typically comes from the status indicator timer.
-    pub(crate) fn new(elapsed_seconds: Option<u64>) -> Self {
-        Self { elapsed_seconds }
-    }
-}
-impl HistoryCell for FinalMessageSeparator {
-    fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
-        let elapsed_seconds = self
-            .elapsed_seconds
-            .map(super::status_indicator_widget::fmt_elapsed_compact);
-        if let Some(elapsed_seconds) = elapsed_seconds {
-            let worked_for = format!("─ Worked for {elapsed_seconds} ─");
-            let worked_for_width = worked_for.width();
-            vec![
-                Line::from_iter([
-                    worked_for,
-                    "─".repeat((width as usize).saturating_sub(worked_for_width)),
-                ])
-                .dim(),
-            ]
-        } else {
-            vec![Line::from_iter(["─".repeat(width as usize).dim()])]
-        }
-    }
-}
-
 fn format_mcp_invocation<'a>(invocation: McpInvocation) -> Line<'a> {
     let args_str = invocation
         .arguments

--- a/codex-rs/tui/src/status_indicator_widget.rs
+++ b/codex-rs/tui/src/status_indicator_widget.rs
@@ -149,12 +149,9 @@ impl StatusIndicatorWidget {
         elapsed
     }
 
+    #[cfg(test)]
     fn elapsed_seconds_at(&self, now: Instant) -> u64 {
         self.elapsed_duration_at(now).as_secs()
-    }
-
-    pub fn elapsed_seconds(&self) -> u64 {
-        self.elapsed_seconds_at(Instant::now())
     }
 
     /// Wrap the details text into a fixed width and return the lines, truncating if necessary.


### PR DESCRIPTION
## Why
With preambles enabled, the TUI rendered the “Worked for …” divider before
each assistant preamble within a single turn, which looked noisy and janky.

## What changed
- Remove separator state + injection logic from `codex-rs/tui/src/chatwidget.rs`
- Remove the separator cell from `codex-rs/tui/src/history_cell.rs`
- Drop no-longer-used status timing getter from `codex-rs/tui/src/status_indicator_widget.rs`
- Remove the `status_widget()` accessor from `codex-rs/tui/src/bottom_pane/mod.rs`
- Update the affected snapshot in
  `codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__binary_size_ideal_response.snap`
- Adjust tests that relied on `status_widget()` in `codex-rs/tui/src/chatwidget/tests.rs`

## Notes / risks
- This removes a previously public method (`elapsed_seconds`) on
  `StatusIndicatorWidget`. If `codex-tui` is consumed externally, this is a
  breaking API change (likely fine if unshipped).

## Codex author
`codex fork 019bec5c-69ba-7011-b9d6-7f6b6b866a17`