### PR TITLE
fix: try to fix freezes of TUI

### DIFF
--- a/codex-rs/core/src/mcp/mod.rs
+++ b/codex-rs/core/src/mcp/mod.rs
@@ -97,6 +97,7 @@ fn codex_apps_mcp_server_config(config: &Config, auth: Option<&CodexAuth>) -> Mc
         tool_timeout_sec: None,
         enabled_tools: None,
         disabled_tools: None,
+        scopes: None,
     }
 }
 


### PR DESCRIPTION
## Potential issue
- When the terminal regains focus (alt-tab), `crossterm` emits `FocusGained`
- TUI handler synchronously calls `requery_default_colors()`, which sends OSC color queries and waits for replies on stdin.
- `crossterm` EventStream also uses a global stdin reader; the query and the event stream can contend for the same input/reply, causing the query to stall and the UI to “freeze”.

## Proposed fix
- On `FocusGained`, we now pause the EventStream, run the palette query, then resume the EventStream. This releases stdin while the OSC query runs, avoiding the contention that can hang the UI.