### PR TITLE
chore: introduce *Args types for new() methods

### DIFF
--- a/codex-rs/network-proxy/src/lib.rs
+++ b/codex-rs/network-proxy/src/lib.rs
@@ -17,6 +17,7 @@ use anyhow::Result;
 pub use network_policy::NetworkDecision;
 pub use network_policy::NetworkPolicyDecider;
 pub use network_policy::NetworkPolicyRequest;
+pub use network_policy::NetworkPolicyRequestArgs;
 pub use network_policy::NetworkProtocol;
 pub use proxy::Args;
 pub use proxy::NetworkProxy;

--- a/codex-rs/network-proxy/src/network_policy.rs
+++ b/codex-rs/network-proxy/src/network_policy.rs
@@ -26,16 +26,27 @@ pub struct NetworkPolicyRequest {
     pub exec_policy_hint: Option<String>,
 }
 
+pub struct NetworkPolicyRequestArgs {
+    pub protocol: NetworkProtocol,
+    pub host: String,
+    pub port: u16,
+    pub client_addr: Option<String>,
+    pub method: Option<String>,
+    pub command: Option<String>,
+    pub exec_policy_hint: Option<String>,
+}
+
 impl NetworkPolicyRequest {
-    pub fn new(
-        protocol: NetworkProtocol,
-        host: String,
-        port: u16,
-        client_addr: Option<String>,
-        method: Option<String>,
-        command: Option<String>,
-        exec_policy_hint: Option<String>,
-    ) -> Self {
+    pub fn new(args: NetworkPolicyRequestArgs) -> Self {
+        let NetworkPolicyRequestArgs {
+            protocol,
+            host,
+            port,
+            client_addr,
+            method,
+            command,
+            exec_policy_hint,
+        } = args;
         Self {
             protocol,
             host,
@@ -139,15 +150,15 @@ mod tests {
             }
         });
 
-        let request = NetworkPolicyRequest::new(
-            NetworkProtocol::Http,
-            "example.com".to_string(),
-            80,
-            None,
-            Some("GET".to_string()),
-            None,
-            None,
-        );
+        let request = NetworkPolicyRequest::new(NetworkPolicyRequestArgs {
+            protocol: NetworkProtocol::Http,
+            host: "example.com".to_string(),
+            port: 80,
+            client_addr: None,
+            method: Some("GET".to_string()),
+            command: None,
+            exec_policy_hint: None,
+        });
 
         let decision = evaluate_host_policy(&state, Some(&decider), &request)
             .await
@@ -172,15 +183,15 @@ mod tests {
             }
         });
 
-        let request = NetworkPolicyRequest::new(
-            NetworkProtocol::Http,
-            "blocked.com".to_string(),
-            80,
-            None,
-            Some("GET".to_string()),
-            None,
-            None,
-        );
+        let request = NetworkPolicyRequest::new(NetworkPolicyRequestArgs {
+            protocol: NetworkProtocol::Http,
+            host: "blocked.com".to_string(),
+            port: 80,
+            client_addr: None,
+            method: Some("GET".to_string()),
+            command: None,
+            exec_policy_hint: None,
+        });
 
         let decision = evaluate_host_policy(&state, Some(&decider), &request)
             .await
@@ -210,15 +221,15 @@ mod tests {
             }
         });
 
-        let request = NetworkPolicyRequest::new(
-            NetworkProtocol::Http,
-            "127.0.0.1".to_string(),
-            80,
-            None,
-            Some("GET".to_string()),
-            None,
-            None,
-        );
+        let request = NetworkPolicyRequest::new(NetworkPolicyRequestArgs {
+            protocol: NetworkProtocol::Http,
+            host: "127.0.0.1".to_string(),
+            port: 80,
+            client_addr: None,
+            method: Some("GET".to_string()),
+            command: None,
+            exec_policy_hint: None,
+        });
 
         let decision = evaluate_host_policy(&state, Some(&decider), &request)
             .await

--- a/codex-rs/network-proxy/src/runtime.rs
+++ b/codex-rs/network-proxy/src/runtime.rs
@@ -73,15 +73,25 @@ pub struct BlockedRequest {
     pub timestamp: i64,
 }
 
+pub struct BlockedRequestArgs {
+    pub host: String,
+    pub reason: String,
+    pub client: Option<String>,
+    pub method: Option<String>,
+    pub mode: Option<NetworkMode>,
+    pub protocol: String,
+}
+
 impl BlockedRequest {
-    pub fn new(
-        host: String,
-        reason: String,
-        client: Option<String>,
-        method: Option<String>,
-        mode: Option<NetworkMode>,
-        protocol: String,
-    ) -> Self {
+    pub fn new(args: BlockedRequestArgs) -> Self {
+        let BlockedRequestArgs {
+            host,
+            reason,
+            client,
+            method,
+            mode,
+            protocol,
+        } = args;
         Self {
             host,
             reason,

--- a/codex-rs/network-proxy/src/state.rs
+++ b/codex-rs/network-proxy/src/state.rs
@@ -20,6 +20,7 @@ use serde::Deserialize;
 use std::collections::HashSet;
 
 pub use crate::runtime::BlockedRequest;
+pub use crate::runtime::BlockedRequestArgs;
 pub use crate::runtime::NetworkProxyState;
 #[cfg(test)]
 pub(crate) use crate::runtime::network_proxy_state_for_policy;


### PR DESCRIPTION
Constructors with long param lists can be hard to reason about when a number of the args are `None`, in practice. Introducing a struct to use as the args type helps make things more self-documenting.