### PR TITLE
chore: add preconfig hooks to test and add web search integration test

### DIFF
--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -78,4 +78,4 @@ mod unstable_features_warning;
 mod user_notification;
 mod user_shell_cmd;
 mod view_image;
-mod web_search_cached;
+mod web_search;


### PR DESCRIPTION
Add integration test for #10008 (live `web_search` when sandbox policy is `DangerFullAccess`).

This required adding preconfig hooks to `test_codex`, so I split it into a new PR.

We need preconfig hooks because the existing prebuild hooks run after the config is looaded and therefore cannot seed `config.toml` early enough to affect sandbox policy, which is what this test requires.