### PR TITLE
TUI: track user turns locally and drop OverrideTurnContext

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -26,6 +26,7 @@ use codex_core::protocol::SandboxPolicy;
 use codex_protocol::config_types::CollaborationModeMask;
 use codex_protocol::config_types::Personality;
 use codex_protocol::openai_models::ReasoningEffort;
+use codex_protocol::user_input::UserInput;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
@@ -93,6 +94,11 @@ pub(crate) enum AppEvent {
     DiffResult(String),
 
     InsertHistoryCell(Box<dyn HistoryCell>),
+
+    /// Record a submitted user turn for local backtrack state.
+    RecordUserTurn {
+        items: Vec<UserInput>,
+    },
 
     StartCommitAnimation,
     StopCommitAnimation,

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -3444,22 +3444,14 @@ async fn approvals_popup_navigation_skips_disabled() {
     assert!(
         app_events.iter().any(|ev| matches!(
             ev,
-            AppEvent::CodexOp(Op::OverrideTurnContext {
-                approval_policy: Some(AskForApproval::OnRequest),
-                personality: None,
-                ..
-            })
+            AppEvent::UpdateAskForApprovalPolicy(AskForApproval::OnRequest)
         )),
         "enter should select an enabled preset"
     );
     assert!(
         !app_events.iter().any(|ev| matches!(
             ev,
-            AppEvent::CodexOp(Op::OverrideTurnContext {
-                approval_policy: Some(AskForApproval::Never),
-                personality: None,
-                ..
-            })
+            AppEvent::UpdateAskForApprovalPolicy(AskForApproval::Never)
         )),
         "disabled preset should not be selected"
     );


### PR DESCRIPTION
- Track user turns locally for backtrack and image-only turns\n- Stop sending OverrideTurnContext and parse resume cwd from environment_context