### PR TITLE
Refine request_user_input TUI interactions and option UX

### DIFF
--- a/codex-rs/tui/src/bottom_pane/bottom_pane_view.rs
+++ b/codex-rs/tui/src/bottom_pane/bottom_pane_view.rs
@@ -21,6 +21,12 @@ pub(crate) trait BottomPaneView: Renderable {
         CancellationEvent::NotHandled
     }
 
+    /// Return true if Esc should be routed through `handle_key_event` instead
+    /// of the `on_ctrl_c` cancellation path.
+    fn prefer_esc_to_handle_key_event(&self) -> bool {
+        false
+    }
+
     /// Optional paste handler. Return true if the view modified its state and
     /// needs a redraw.
     fn handle_paste(&mut self, _pasted: String) -> bool {

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -641,6 +641,18 @@ impl ChatComposer {
         text
     }
 
+    pub(crate) fn pending_pastes(&self) -> Vec<(String, String)> {
+        self.pending_pastes.clone()
+    }
+
+    pub(crate) fn set_pending_pastes(&mut self, pending_pastes: Vec<(String, String)>) {
+        let text = self.textarea.text().to_string();
+        self.pending_pastes = pending_pastes
+            .into_iter()
+            .filter(|(placeholder, _)| text.contains(placeholder))
+            .collect();
+    }
+
     /// Override the footer hint items displayed beneath the composer. Passing
     /// `None` restores the default shortcut footer.
     pub(crate) fn set_footer_hint_override(&mut self, items: Option<Vec<(String, String)>>) {

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -1421,7 +1421,7 @@ impl ChatComposer {
     }
 
     /// Expand large-paste placeholders using element ranges and rebuild other element spans.
-    fn expand_pending_pastes(
+    pub(crate) fn expand_pending_pastes(
         text: &str,
         mut elements: Vec<TextElement>,
         pending_pastes: &[(String, String)],

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -1257,6 +1257,14 @@ mod tests {
             handle_calls: Rc<Cell<usize>>,
         }
 
+        impl Renderable for EscRoutingView {
+            fn render(&self, _area: Rect, _buf: &mut Buffer) {}
+
+            fn desired_height(&self, _width: u16) -> u16 {
+                0
+            }
+        }
+
         impl BottomPaneView for EscRoutingView {
             fn handle_key_event(&mut self, _key_event: KeyEvent) {
                 self.handle_calls

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -269,7 +269,10 @@ impl BottomPane {
             let (ctrl_c_completed, view_complete, view_in_paste_burst) = {
                 let last_index = self.view_stack.len() - 1;
                 let view = &mut self.view_stack[last_index];
+                let prefer_esc =
+                    key_event.code == KeyCode::Esc && view.prefer_esc_to_handle_key_event();
                 let ctrl_c_completed = key_event.code == KeyCode::Esc
+                    && !prefer_esc
                     && matches!(view.on_ctrl_c(), CancellationEvent::Handled)
                     && view.is_complete();
                 if ctrl_c_completed {
@@ -338,6 +341,7 @@ impl BottomPane {
                     self.on_active_view_complete();
                 }
                 self.show_quit_shortcut_hint(key_hint::ctrl(KeyCode::Char('c')));
+                self.request_redraw();
             }
             event
         } else if self.composer_is_empty() {
@@ -346,6 +350,7 @@ impl BottomPane {
             self.view_stack.pop();
             self.clear_composer_for_ctrl_c();
             self.show_quit_shortcut_hint(key_hint::ctrl(KeyCode::Char('c')));
+            self.request_redraw();
             CancellationEvent::Handled
         }
     }
@@ -815,7 +820,9 @@ mod tests {
     use insta::assert_snapshot;
     use ratatui::buffer::Buffer;
     use ratatui::layout::Rect;
+    use std::cell::Cell;
     use std::path::PathBuf;
+    use std::rc::Rc;
     use tokio::sync::mpsc::unbounded_channel;
 
     fn snapshot_buffer(buf: &Buffer) -> String {
@@ -1240,5 +1247,56 @@ mod tests {
             matches!(rx.try_recv(), Ok(AppEvent::CodexOp(Op::Interrupt))),
             "expected Esc to send Op::Interrupt while a task is running"
         );
+    }
+
+    #[test]
+    fn esc_routes_to_handle_key_event_when_requested() {
+        #[derive(Default)]
+        struct EscRoutingView {
+            on_ctrl_c_calls: Rc<Cell<usize>>,
+            handle_calls: Rc<Cell<usize>>,
+        }
+
+        impl BottomPaneView for EscRoutingView {
+            fn handle_key_event(&mut self, _key_event: KeyEvent) {
+                self.handle_calls
+                    .set(self.handle_calls.get().saturating_add(1));
+            }
+
+            fn on_ctrl_c(&mut self) -> CancellationEvent {
+                self.on_ctrl_c_calls
+                    .set(self.on_ctrl_c_calls.get().saturating_add(1));
+                CancellationEvent::Handled
+            }
+
+            fn prefer_esc_to_handle_key_event(&self) -> bool {
+                true
+            }
+        }
+
+        let (tx_raw, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let mut pane = BottomPane::new(BottomPaneParams {
+            app_event_tx: tx,
+            frame_requester: FrameRequester::test_dummy(),
+            has_input_focus: true,
+            enhanced_keys_supported: false,
+            placeholder_text: "Ask Codex to do anything".to_string(),
+            disable_paste_burst: false,
+            animations_enabled: true,
+            skills: Some(Vec::new()),
+        });
+
+        let on_ctrl_c_calls = Rc::new(Cell::new(0));
+        let handle_calls = Rc::new(Cell::new(0));
+        pane.push_view(Box::new(EscRoutingView {
+            on_ctrl_c_calls: Rc::clone(&on_ctrl_c_calls),
+            handle_calls: Rc::clone(&handle_calls),
+        }));
+
+        pane.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+
+        assert_eq!(on_ctrl_c_calls.get(), 0);
+        assert_eq!(handle_calls.get(), 1);
     }
 }

--- a/codex-rs/tui/src/bottom_pane/request_user_input/layout.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/layout.rs
@@ -132,8 +132,8 @@ impl RequestUserInputOverlay {
         }
     }
 
-    /// Tight layout for options case: allocate header + question + options first
-    /// and drop everything else when space is constrained.
+    /// Tight layout for options case: allocate question + options first and drop
+    /// everything else when space is constrained.
     fn layout_with_options_tight(
         &self,
         available_height: u16,
@@ -141,12 +141,10 @@ impl RequestUserInputOverlay {
         min_options_height: u16,
         question_lines: &mut Vec<String>,
     ) -> (u16, u16, u16, u16, u16, u16, u16, u16) {
-        let max_question_height =
-            available_height.saturating_sub(1u16.saturating_add(min_options_height));
+        let max_question_height = available_height.saturating_sub(min_options_height);
         let adjusted_question_height = question_height.min(max_question_height);
         question_lines.truncate(adjusted_question_height as usize);
-        let options_height =
-            available_height.saturating_sub(1u16.saturating_add(adjusted_question_height));
+        let options_height = available_height.saturating_sub(adjusted_question_height);
 
         (adjusted_question_height, 0, 0, options_height, 0, 0, 0, 0)
     }
@@ -167,9 +165,7 @@ impl RequestUserInputOverlay {
         } = args;
         let min_options_height = 1u16;
         let mut options_height = options.preferred.max(min_options_height);
-        let used = 1u16
-            .saturating_add(question_height)
-            .saturating_add(options_height);
+        let used = question_height.saturating_add(options_height);
         let mut remaining = available_height.saturating_sub(used);
 
         // When notes are hidden, prefer to reserve room for progress, footer,
@@ -301,7 +297,7 @@ impl RequestUserInputOverlay {
         notes_pref_height: u16,
         footer_pref: u16,
     ) -> (u16, u16, u16, u16, u16, u16, u16, u16) {
-        let required = 1u16.saturating_add(question_height);
+        let required = question_height;
         let mut remaining = available_height.saturating_sub(required);
         let mut notes_height = notes_pref_height.min(remaining);
         remaining = remaining.saturating_sub(notes_height);
@@ -350,14 +346,12 @@ impl RequestUserInputOverlay {
             height: heights.progress_height,
         };
         cursor_y = cursor_y.saturating_add(heights.progress_height);
-        let header_height = area.height.saturating_sub(heights.progress_height).min(1);
         let header_area = Rect {
             x: area.x,
             y: cursor_y,
             width: area.width,
-            height: header_height,
+            height: 0,
         };
-        cursor_y = cursor_y.saturating_add(header_height);
         let question_area = Rect {
             x: area.x,
             y: cursor_y,

--- a/codex-rs/tui/src/bottom_pane/request_user_input/layout.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/layout.rs
@@ -3,8 +3,6 @@ use ratatui::layout::Rect;
 use super::DESIRED_SPACERS_BETWEEN_SECTIONS;
 use super::RequestUserInputOverlay;
 
-const SPACERS_WITH_VISIBLE_NOTES: u16 = 1;
-
 pub(super) struct LayoutSections {
     pub(super) progress_area: Rect,
     pub(super) question_area: Rect,
@@ -122,7 +120,9 @@ impl RequestUserInputOverlay {
         // When notes are hidden, prefer to reserve room for progress, footer,
         // and spacers by shrinking the options window if needed.
         let desired_spacers = if notes_visible {
-            SPACERS_WITH_VISIBLE_NOTES
+            // Notes already separate options from the footer, so only keep a
+            // single spacer between the question and options.
+            1
         } else {
             DESIRED_SPACERS_BETWEEN_SECTIONS
         };

--- a/codex-rs/tui/src/bottom_pane/request_user_input/layout.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/layout.rs
@@ -3,6 +3,8 @@ use ratatui::layout::Rect;
 use super::DESIRED_SPACERS_BETWEEN_SECTIONS;
 use super::RequestUserInputOverlay;
 
+const SPACERS_WITH_VISIBLE_NOTES: u16 = 1;
+
 pub(super) struct LayoutSections {
     pub(super) progress_area: Rect,
     pub(super) question_area: Rect,
@@ -120,7 +122,7 @@ impl RequestUserInputOverlay {
         // When notes are hidden, prefer to reserve room for progress, footer,
         // and spacers by shrinking the options window if needed.
         let desired_spacers = if notes_visible {
-            1
+            SPACERS_WITH_VISIBLE_NOTES
         } else {
             DESIRED_SPACERS_BETWEEN_SECTIONS
         };

--- a/codex-rs/tui/src/bottom_pane/request_user_input/layout.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/layout.rs
@@ -151,7 +151,11 @@ impl RequestUserInputOverlay {
 
         // When notes are hidden, prefer to reserve room for progress, footer,
         // and spacers by shrinking the options window if needed.
-        let desired_spacers = DESIRED_SPACERS_BETWEEN_SECTIONS;
+        let desired_spacers = if notes_visible {
+            1
+        } else {
+            DESIRED_SPACERS_BETWEEN_SECTIONS
+        };
         let required_extra = footer_pref
             .saturating_add(1) // progress line
             .saturating_add(desired_spacers);
@@ -204,11 +208,7 @@ impl RequestUserInputOverlay {
             spacer_after_question = 1;
             remaining = remaining.saturating_sub(1);
         }
-        let mut spacer_after_options = 0;
-        if remaining > 0 {
-            spacer_after_options = 1;
-            remaining = remaining.saturating_sub(1);
-        }
+        let spacer_after_options = 0;
         let mut notes_height = notes_pref_height.min(remaining);
         remaining = remaining.saturating_sub(notes_height);
 

--- a/codex-rs/tui/src/bottom_pane/request_user_input/layout.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/layout.rs
@@ -1,16 +1,14 @@
 use ratatui::layout::Rect;
 
-use super::DESIRED_SPACERS_WHEN_NOTES_HIDDEN;
+use super::DESIRED_SPACERS_BETWEEN_SECTIONS;
 use super::RequestUserInputOverlay;
 
 pub(super) struct LayoutSections {
     pub(super) progress_area: Rect,
-    pub(super) header_area: Rect,
     pub(super) question_area: Rect,
     // Wrapped question text lines to render in the question area.
     pub(super) question_lines: Vec<String>,
     pub(super) options_area: Rect,
-    pub(super) notes_title_area: Rect,
     pub(super) notes_area: Rect,
     // Number of footer rows (status + hints).
     pub(super) footer_lines: u16,
@@ -26,16 +24,7 @@ impl RequestUserInputOverlay {
         let mut question_lines = self.wrapped_question_lines(area.width);
         let question_height = question_lines.len() as u16;
 
-        let (
-            question_height,
-            progress_height,
-            spacer_after_question,
-            options_height,
-            spacer_after_options,
-            notes_title_height,
-            notes_height,
-            footer_lines,
-        ) = if has_options {
+        let layout = if has_options {
             self.layout_with_options(
                 OptionsLayoutArgs {
                     available_height: area.height,
@@ -57,29 +46,16 @@ impl RequestUserInputOverlay {
             )
         };
 
-        let (progress_area, header_area, question_area, options_area, notes_title_area, notes_area) =
-            self.build_layout_areas(
-                area,
-                LayoutHeights {
-                    progress_height,
-                    question_height,
-                    spacer_after_question,
-                    options_height,
-                    spacer_after_options,
-                    notes_title_height,
-                    notes_height,
-                },
-            );
+        let (progress_area, question_area, options_area, notes_area) =
+            self.build_layout_areas(area, layout);
 
         LayoutSections {
             progress_area,
-            header_area,
             question_area,
             question_lines,
             options_area,
-            notes_title_area,
             notes_area,
-            footer_lines,
+            footer_lines: layout.footer_lines,
         }
     }
 
@@ -88,12 +64,11 @@ impl RequestUserInputOverlay {
     /// Handles both tight layout (when space is constrained) and normal layout
     /// (when there's sufficient space for all elements).
     ///
-    /// Returns: (question_height, progress_height, spacer_after_question, options_height, spacer_after_options, notes_title_height, notes_height, footer_lines)
     fn layout_with_options(
         &self,
         args: OptionsLayoutArgs,
         question_lines: &mut Vec<String>,
-    ) -> (u16, u16, u16, u16, u16, u16, u16, u16) {
+    ) -> LayoutPlan {
         let OptionsLayoutArgs {
             available_height,
             width,
@@ -107,9 +82,7 @@ impl RequestUserInputOverlay {
             full: self.options_required_height(width),
         };
         let min_options_height = 1u16;
-        let required = 1u16
-            .saturating_add(question_height)
-            .saturating_add(options_heights.preferred);
+        let required = question_height.saturating_add(options_heights.preferred);
 
         if required > available_height {
             self.layout_with_options_tight(
@@ -140,13 +113,21 @@ impl RequestUserInputOverlay {
         question_height: u16,
         min_options_height: u16,
         question_lines: &mut Vec<String>,
-    ) -> (u16, u16, u16, u16, u16, u16, u16, u16) {
+    ) -> LayoutPlan {
         let max_question_height = available_height.saturating_sub(min_options_height);
         let adjusted_question_height = question_height.min(max_question_height);
         question_lines.truncate(adjusted_question_height as usize);
         let options_height = available_height.saturating_sub(adjusted_question_height);
 
-        (adjusted_question_height, 0, 0, options_height, 0, 0, 0, 0)
+        LayoutPlan {
+            question_height: adjusted_question_height,
+            progress_height: 0,
+            spacer_after_question: 0,
+            options_height,
+            spacer_after_options: 0,
+            notes_height: 0,
+            footer_lines: 0,
+        }
     }
 
     /// Normal layout for options case: allocate footer + progress first, and
@@ -155,7 +136,7 @@ impl RequestUserInputOverlay {
         &self,
         args: OptionsNormalArgs,
         options: OptionsHeights,
-    ) -> (u16, u16, u16, u16, u16, u16, u16, u16) {
+    ) -> LayoutPlan {
         let OptionsNormalArgs {
             available_height,
             question_height,
@@ -170,11 +151,7 @@ impl RequestUserInputOverlay {
 
         // When notes are hidden, prefer to reserve room for progress, footer,
         // and spacers by shrinking the options window if needed.
-        let desired_spacers = if notes_visible {
-            0
-        } else {
-            DESIRED_SPACERS_WHEN_NOTES_HIDDEN
-        };
+        let desired_spacers = DESIRED_SPACERS_BETWEEN_SECTIONS;
         let required_extra = footer_pref
             .saturating_add(1) // progress line
             .saturating_add(desired_spacers);
@@ -207,45 +184,45 @@ impl RequestUserInputOverlay {
             }
             let grow_by = remaining.min(options.full.saturating_sub(options_height));
             options_height = options_height.saturating_add(grow_by);
-            return (
+            return LayoutPlan {
                 question_height,
                 progress_height,
                 spacer_after_question,
                 options_height,
                 spacer_after_options,
-                0,
-                0,
+                notes_height: 0,
                 footer_lines,
-            );
+            };
         }
 
         let footer_lines = footer_pref.min(remaining);
         remaining = remaining.saturating_sub(footer_lines);
 
-        // Prefer notes next, then labels, with any leftover rows expanding notes.
-        let spacer_after_question = 0;
-        let spacer_after_options = 0;
+        // Prefer spacers before notes, then notes.
+        let mut spacer_after_question = 0;
+        if remaining > 0 {
+            spacer_after_question = 1;
+            remaining = remaining.saturating_sub(1);
+        }
+        let mut spacer_after_options = 0;
+        if remaining > 0 {
+            spacer_after_options = 1;
+            remaining = remaining.saturating_sub(1);
+        }
         let mut notes_height = notes_pref_height.min(remaining);
         remaining = remaining.saturating_sub(notes_height);
 
-        let mut notes_title_height = 0;
-        if remaining > 0 {
-            notes_title_height = 1;
-            remaining = remaining.saturating_sub(1);
-        }
-
         notes_height = notes_height.saturating_add(remaining);
 
-        (
+        LayoutPlan {
             question_height,
             progress_height,
             spacer_after_question,
             options_height,
             spacer_after_options,
-            notes_title_height,
             notes_height,
             footer_lines,
-        )
+        }
     }
 
     /// Layout calculation when no options are present.
@@ -253,7 +230,6 @@ impl RequestUserInputOverlay {
     /// Handles both tight layout (when space is constrained) and normal layout
     /// (when there's sufficient space for all elements).
     ///
-    /// Returns: (question_height, progress_height, spacer_after_question, options_height, spacer_after_options, notes_title_height, notes_height, footer_lines)
     fn layout_without_options(
         &self,
         available_height: u16,
@@ -261,8 +237,8 @@ impl RequestUserInputOverlay {
         notes_pref_height: u16,
         footer_pref: u16,
         question_lines: &mut Vec<String>,
-    ) -> (u16, u16, u16, u16, u16, u16, u16, u16) {
-        let required = 1u16.saturating_add(question_height);
+    ) -> LayoutPlan {
+        let required = question_height;
         if required > available_height {
             self.layout_without_options_tight(available_height, question_height, question_lines)
         } else {
@@ -281,12 +257,20 @@ impl RequestUserInputOverlay {
         available_height: u16,
         question_height: u16,
         question_lines: &mut Vec<String>,
-    ) -> (u16, u16, u16, u16, u16, u16, u16, u16) {
-        let max_question_height = available_height.saturating_sub(1);
+    ) -> LayoutPlan {
+        let max_question_height = available_height;
         let adjusted_question_height = question_height.min(max_question_height);
         question_lines.truncate(adjusted_question_height as usize);
 
-        (adjusted_question_height, 0, 0, 0, 0, 0, 0, 0)
+        LayoutPlan {
+            question_height: adjusted_question_height,
+            progress_height: 0,
+            spacer_after_question: 0,
+            options_height: 0,
+            spacer_after_options: 0,
+            notes_height: 0,
+            footer_lines: 0,
+        }
     }
 
     /// Normal layout for no-options case: allocate space for notes, footer, and progress.
@@ -296,7 +280,7 @@ impl RequestUserInputOverlay {
         question_height: u16,
         notes_pref_height: u16,
         footer_pref: u16,
-    ) -> (u16, u16, u16, u16, u16, u16, u16, u16) {
+    ) -> LayoutPlan {
         let required = question_height;
         let mut remaining = available_height.saturating_sub(required);
         let mut notes_height = notes_pref_height.min(remaining);
@@ -313,29 +297,26 @@ impl RequestUserInputOverlay {
 
         notes_height = notes_height.saturating_add(remaining);
 
-        (
+        LayoutPlan {
             question_height,
             progress_height,
-            0,
-            0,
-            0,
-            0,
+            spacer_after_question: 0,
+            options_height: 0,
+            spacer_after_options: 0,
             notes_height,
             footer_lines,
-        )
+        }
     }
 
     /// Build the final layout areas from computed heights.
     fn build_layout_areas(
         &self,
         area: Rect,
-        heights: LayoutHeights,
+        heights: LayoutPlan,
     ) -> (
         Rect, // progress_area
-        Rect, // header_area
         Rect, // question_area
         Rect, // options_area
-        Rect, // notes_title_area
         Rect, // notes_area
     ) {
         let mut cursor_y = area.y;
@@ -346,12 +327,6 @@ impl RequestUserInputOverlay {
             height: heights.progress_height,
         };
         cursor_y = cursor_y.saturating_add(heights.progress_height);
-        let header_area = Rect {
-            x: area.x,
-            y: cursor_y,
-            width: area.width,
-            height: 0,
-        };
         let question_area = Rect {
             x: area.x,
             y: cursor_y,
@@ -370,13 +345,6 @@ impl RequestUserInputOverlay {
         cursor_y = cursor_y.saturating_add(heights.options_height);
         cursor_y = cursor_y.saturating_add(heights.spacer_after_options);
 
-        let notes_title_area = Rect {
-            x: area.x,
-            y: cursor_y,
-            width: area.width,
-            height: heights.notes_title_height,
-        };
-        cursor_y = cursor_y.saturating_add(heights.notes_title_height);
         let notes_area = Rect {
             x: area.x,
             y: cursor_y,
@@ -384,26 +352,19 @@ impl RequestUserInputOverlay {
             height: heights.notes_height,
         };
 
-        (
-            progress_area,
-            header_area,
-            question_area,
-            options_area,
-            notes_title_area,
-            notes_area,
-        )
+        (progress_area, question_area, options_area, notes_area)
     }
 }
 
 #[derive(Clone, Copy, Debug)]
-struct LayoutHeights {
+struct LayoutPlan {
     progress_height: u16,
     question_height: u16,
     spacer_after_question: u16,
     options_height: u16,
     spacer_after_options: u16,
-    notes_title_height: u16,
     notes_height: u16,
+    footer_lines: u16,
 }
 
 #[derive(Clone, Copy, Debug)]

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -1083,10 +1083,8 @@ impl BottomPaneView for RequestUserInputOverlay {
                     let (result, _) = self.composer.handle_key_event(key_event);
                     if !self.handle_composer_input_result(result) {
                         self.pending_submission_draft = None;
-                        if self.has_options()
-                            && let Some(answer) = self.current_answer_mut()
-                        {
-                            answer.answer_committed = true;
+                        if self.has_options() {
+                            self.select_current_option(true);
                         }
                         self.go_next_or_submit();
                     }
@@ -1983,7 +1981,9 @@ mod tests {
             .composer
             .set_text_content("Notes for option 2".to_string(), Vec::new(), Vec::new());
         overlay.composer.move_cursor_to_end();
+        let draft = overlay.capture_composer_draft();
         if let Some(answer) = overlay.current_answer_mut() {
+            answer.draft = draft;
             answer.answer_committed = true;
         }
 
@@ -2066,7 +2066,9 @@ mod tests {
             .composer
             .set_text_content("Custom answer".to_string(), Vec::new(), Vec::new());
         overlay.composer.move_cursor_to_end();
+        let draft = overlay.capture_composer_draft();
         if let Some(answer) = overlay.current_answer_mut() {
+            answer.draft = draft;
             answer.answer_committed = true;
         }
 

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -2480,6 +2480,32 @@ mod tests {
     }
 
     #[test]
+    fn request_user_input_unanswered_confirmation_snapshot() {
+        let (tx, _rx) = test_sender();
+        let mut overlay = RequestUserInputOverlay::new(
+            request_event(
+                "turn-1",
+                vec![
+                    question_with_options("q1", "Area"),
+                    question_without_options("q2", "Goal"),
+                ],
+            ),
+            tx,
+            true,
+            false,
+            false,
+        );
+
+        overlay.open_unanswered_confirmation();
+
+        let area = Rect::new(0, 0, 80, 12);
+        insta::assert_snapshot!(
+            "request_user_input_unanswered_confirmation",
+            render_snapshot(&overlay, area)
+        );
+    }
+
+    #[test]
     fn options_scroll_while_editing_notes() {
         let (tx, _rx) = test_sender();
         let mut overlay = RequestUserInputOverlay::new(

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -337,9 +337,10 @@ impl RequestUserInputOverlay {
 
     fn save_current_draft(&mut self) {
         let draft = self.capture_composer_draft();
+        let has_options = self.has_options();
         let notes_empty = draft.text.trim().is_empty();
         if let Some(answer) = self.current_answer_mut() {
-            if !self.has_options() && answer.freeform_committed && answer.draft != draft {
+            if !has_options && answer.freeform_committed && answer.draft != draft {
                 answer.freeform_committed = false;
             }
             answer.draft = draft;

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -915,10 +915,8 @@ impl RequestUserInputOverlay {
                 self.close_unanswered_confirmation();
                 if selected == 0 {
                     self.submit_answers();
-                } else {
-                    if let Some(idx) = self.first_unanswered_index() {
-                        self.jump_to_question(idx);
-                    }
+                } else if let Some(idx) = self.first_unanswered_index() {
+                    self.jump_to_question(idx);
                 }
             }
             KeyCode::Char('1') | KeyCode::Char('2') => {
@@ -1085,10 +1083,10 @@ impl BottomPaneView for RequestUserInputOverlay {
                     let (result, _) = self.composer.handle_key_event(key_event);
                     if !self.handle_composer_input_result(result) {
                         self.pending_submission_draft = None;
-                        if self.has_options() {
-                            if let Some(answer) = self.current_answer_mut() {
-                                answer.answer_committed = true;
-                            }
+                        if self.has_options()
+                            && let Some(answer) = self.current_answer_mut()
+                        {
+                            answer.answer_committed = true;
                         }
                         self.go_next_or_submit();
                     }
@@ -1129,20 +1127,19 @@ impl BottomPaneView for RequestUserInputOverlay {
                 if matches!(
                     key_event.code,
                     KeyCode::Char(_) | KeyCode::Backspace | KeyCode::Delete
-                ) {
-                    if let Some(answer) = self.current_answer_mut() {
-                        answer.answer_committed = false;
-                    }
+                ) && let Some(answer) = self.current_answer_mut()
+                {
+                    answer.answer_committed = false;
                 }
                 let before = self.capture_composer_draft();
                 let (result, _) = self.composer.handle_key_event(key_event);
                 let submitted = self.handle_composer_input_result(result);
                 if !submitted {
                     let after = self.capture_composer_draft();
-                    if before != after {
-                        if let Some(answer) = self.current_answer_mut() {
-                            answer.answer_committed = false;
-                        }
+                    if before != after
+                        && let Some(answer) = self.current_answer_mut()
+                    {
+                        answer.answer_committed = false;
                     }
                 }
             }

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -449,8 +449,11 @@ impl RequestUserInputOverlay {
         };
         tips.push(enter_tip);
         if question_count > 1 {
-            tips.push(FooterTip::new("ctrl + p prev"));
-            tips.push(FooterTip::new("ctrl + n next"));
+            if is_last_question {
+                tips.push(FooterTip::new("ctrl + n first question"));
+            } else {
+                tips.push(FooterTip::new("ctrl + n next question"));
+            }
         }
         tips.push(FooterTip::new("esc to interrupt"));
         tips

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -393,27 +393,20 @@ impl RequestUserInputOverlay {
             } else {
                 tips.push(FooterTip::new("No option selected"));
             }
-            tips.push(FooterTip::new("\u{2191}/\u{2193} scroll"));
             if self.selected_option_index().is_some() && !notes_visible {
-                tips.push(FooterTip::highlighted("Tab: add notes"));
+                tips.push(FooterTip::highlighted("tab to add notes"));
             }
             if self.selected_option_index().is_some() && notes_visible && self.focus_is_notes() {
-                tips.push(FooterTip::new("Tab: clear notes"));
+                tips.push(FooterTip::new("tab to clear notes"));
             }
         }
 
         let question_count = self.question_count();
-        let is_last_question = question_count > 0 && self.current_index() + 1 >= question_count;
-        let enter_tip = if question_count > 1 && is_last_question {
-            "Enter: submit all answers"
-        } else {
-            "Enter: submit answer"
-        };
-        tips.push(FooterTip::new(enter_tip));
+        tips.push(FooterTip::new("enter to submit answer"));
         if question_count > 1 {
-            tips.push(FooterTip::new("Ctrl+n next"));
+            tips.push(FooterTip::new("ctrl + n next"));
         }
-        tips.push(FooterTip::new("Esc: interrupt"));
+        tips.push(FooterTip::new("esc to interrupt"));
         tips
     }
 

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -71,17 +71,10 @@ impl ComposerDraft {
         if self.pending_pastes.is_empty() {
             return self.text.clone();
         }
-        if self.text_elements.is_empty() {
-            return self.pending_pastes.iter().fold(
-                self.text.clone(),
-                |mut text, (placeholder, actual)| {
-                    if text.contains(placeholder) {
-                        text = text.replace(placeholder, actual);
-                    }
-                    text
-                },
-            );
-        }
+        debug_assert!(
+            !self.text_elements.is_empty(),
+            "pending pastes should always have matching text elements"
+        );
         let (expanded, _) = ChatComposer::expand_pending_pastes(
             &self.text,
             self.text_elements.clone(),

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -984,11 +984,21 @@ impl BottomPaneView for RequestUserInputOverlay {
                 code: KeyCode::Char('p'),
                 modifiers: KeyModifiers::CONTROL,
                 ..
+            }
+            | KeyEvent {
+                code: KeyCode::PageUp,
+                modifiers: KeyModifiers::NONE,
+                ..
             } => {
                 self.move_question(false);
                 return;
             }
             KeyEvent {
+                code: KeyCode::PageDown,
+                modifiers: KeyModifiers::NONE,
+                ..
+            }
+            | KeyEvent {
                 code: KeyCode::Char('n'),
                 modifiers: KeyModifiers::CONTROL,
                 ..

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -1048,7 +1048,7 @@ impl BottomPaneView for RequestUserInputOverlay {
                         }
                     }
                     KeyCode::Char(' ') => {
-                        self.select_current_option(false);
+                        self.select_current_option(true);
                     }
                     KeyCode::Backspace | KeyCode::Delete => {
                         self.clear_selection();

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -68,13 +68,26 @@ struct ComposerDraft {
 
 impl ComposerDraft {
     fn text_with_pending(&self) -> String {
-        let mut text = self.text.clone();
-        for (placeholder, actual) in &self.pending_pastes {
-            if text.contains(placeholder) {
-                text = text.replace(placeholder, actual);
-            }
+        if self.pending_pastes.is_empty() {
+            return self.text.clone();
         }
-        text
+        if self.text_elements.is_empty() {
+            return self.pending_pastes.iter().fold(
+                self.text.clone(),
+                |mut text, (placeholder, actual)| {
+                    if text.contains(placeholder) {
+                        text = text.replace(placeholder, actual);
+                    }
+                    text
+                },
+            );
+        }
+        let (expanded, _) = ChatComposer::expand_pending_pastes(
+            &self.text,
+            self.text_elements.clone(),
+            &self.pending_pastes,
+        );
+        expanded
     }
 }
 

--- a/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
@@ -22,6 +22,11 @@ use super::DESIRED_SPACERS_BETWEEN_SECTIONS;
 use super::RequestUserInputOverlay;
 use super::TIP_SEPARATOR;
 
+const MIN_OVERLAY_HEIGHT: usize = 8;
+const PROGRESS_ROW_HEIGHT: usize = 1;
+const SPACER_ROWS_WITH_NOTES: usize = 1;
+const SPACER_ROWS_NO_OPTIONS: usize = 0;
+
 impl Renderable for RequestUserInputOverlay {
     fn desired_height(&self, width: u16) -> u16 {
         if self.confirm_unanswered_active() {
@@ -43,14 +48,16 @@ impl Renderable for RequestUserInputOverlay {
         } else {
             0
         };
+        // When notes are visible, the composer already separates options from the footer.
+        // Without notes, we keep extra spacing so the footer hints don't crowd the options.
         let spacer_rows = if has_options {
             if notes_visible {
-                1
+                SPACER_ROWS_WITH_NOTES
             } else {
                 DESIRED_SPACERS_BETWEEN_SECTIONS as usize
             }
         } else {
-            0
+            SPACER_ROWS_NO_OPTIONS
         };
         let footer_height = self.footer_required_height(inner_width) as usize;
 
@@ -61,9 +68,9 @@ impl Renderable for RequestUserInputOverlay {
             .saturating_add(spacer_rows)
             .saturating_add(notes_height)
             .saturating_add(footer_height)
-            .saturating_add(1); // progress
+            .saturating_add(PROGRESS_ROW_HEIGHT); // progress
         height = height.saturating_add(menu_surface_padding_height() as usize);
-        height.max(8) as u16
+        height.max(MIN_OVERLAY_HEIGHT) as u16
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {

--- a/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
@@ -98,20 +98,7 @@ impl RequestUserInputOverlay {
         };
         Paragraph::new(progress_line).render(sections.progress_area, buf);
 
-        // Question title and wrapped prompt text.
-        let question_header = self.current_question().map(|q| q.header.clone());
-        let answered = self.current_question_answered();
-        let header_line = if let Some(header) = question_header {
-            if answered {
-                Line::from(header.bold())
-            } else {
-                Line::from(header.cyan().bold())
-            }
-        } else {
-            Line::from("No questions".dim())
-        };
-        Paragraph::new(header_line).render(sections.header_area, buf);
-
+        // Question prompt text.
         let question_y = sections.question_area.y;
         for (offset, line) in sections.question_lines.iter().enumerate() {
             if question_y.saturating_add(offset as u16)
@@ -119,7 +106,7 @@ impl RequestUserInputOverlay {
             {
                 break;
             }
-            Paragraph::new(Line::from(line.clone())).render(
+            Paragraph::new(Line::from(line.clone()).cyan()).render(
                 Rect {
                     x: sections.question_area.x,
                     y: question_y.saturating_add(offset as u16),

--- a/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
@@ -267,19 +267,19 @@ impl RequestUserInputOverlay {
         let option_rows = self.option_rows();
 
         if self.has_options() {
-            let mut options_ui_state = self
+            let mut options_state = self
                 .current_answer()
-                .map(|answer| answer.options_ui_state)
+                .map(|answer| answer.options_state)
                 .unwrap_or_default();
             if sections.options_area.height > 0 {
                 // Ensure the selected option is visible in the scroll window.
-                options_ui_state
+                options_state
                     .ensure_visible(option_rows.len(), sections.options_area.height as usize);
                 render_rows(
                     sections.options_area,
                     buf,
                     &option_rows,
-                    &options_ui_state,
+                    &options_state,
                     option_rows.len().max(1),
                     "No options",
                 );

--- a/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
@@ -37,7 +37,11 @@ impl Renderable for RequestUserInputOverlay {
             0
         };
         let spacer_rows = if has_options {
-            DESIRED_SPACERS_BETWEEN_SECTIONS as usize
+            if notes_visible {
+                1
+            } else {
+                DESIRED_SPACERS_BETWEEN_SECTIONS as usize
+            }
         } else {
             0
         };

--- a/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
@@ -14,7 +14,7 @@ use crate::bottom_pane::selection_popup_common::render_menu_surface;
 use crate::bottom_pane::selection_popup_common::render_rows;
 use crate::render::renderable::Renderable;
 
-use super::DESIRED_SPACERS_WHEN_NOTES_HIDDEN;
+use super::DESIRED_SPACERS_BETWEEN_SECTIONS;
 use super::RequestUserInputOverlay;
 use super::TIP_SEPARATOR;
 
@@ -36,24 +36,21 @@ impl Renderable for RequestUserInputOverlay {
         } else {
             0
         };
-        let spacer_rows = if has_options && !notes_visible {
-            DESIRED_SPACERS_WHEN_NOTES_HIDDEN as usize
+        let spacer_rows = if has_options {
+            DESIRED_SPACERS_BETWEEN_SECTIONS as usize
         } else {
             0
         };
         let footer_height = self.footer_required_height(inner_width) as usize;
 
-        // Tight minimum height: progress + header + question + (optional) titles/options
+        // Tight minimum height: progress + question + (optional) titles/options
         // + notes composer + footer + menu padding.
         let mut height = question_height
             .saturating_add(options_height)
             .saturating_add(spacer_rows)
             .saturating_add(notes_height)
             .saturating_add(footer_height)
-            .saturating_add(2); // progress + header
-        if has_options && notes_visible {
-            height = height.saturating_add(1); // notes title
-        }
+            .saturating_add(1); // progress
         height = height.saturating_add(menu_surface_padding_height() as usize);
         height.max(8) as u16
     }
@@ -138,29 +135,6 @@ impl RequestUserInputOverlay {
                     "No options",
                 );
             }
-        }
-
-        if notes_visible && sections.notes_title_area.height > 0 {
-            let notes_label = if self.has_options()
-                && self
-                    .current_answer()
-                    .is_some_and(|answer| answer.committed_option_idx.is_some())
-            {
-                if let Some(label) = self.current_option_label() {
-                    format!("Notes for {label}")
-                } else {
-                    "Notes".to_string()
-                }
-            } else {
-                "Notes".to_string()
-            };
-            let notes_active = self.focus_is_notes();
-            let notes_title = if notes_active {
-                notes_label.as_str().cyan().bold()
-            } else {
-                notes_label.as_str().dim()
-            };
-            Paragraph::new(Line::from(notes_title)).render(sections.notes_title_area, buf);
         }
 
         if notes_visible && sections.notes_area.height > 0 {

--- a/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
@@ -303,7 +303,17 @@ impl RequestUserInputOverlay {
         if footer_area.height == 0 {
             return;
         }
-        let tip_lines = self.footer_tip_lines(footer_area.width);
+        let options_hidden = self.has_options()
+            && sections.options_area.height > 0
+            && self.options_required_height(content_area.width) > sections.options_area.height;
+        let option_tip = if options_hidden {
+            let selected = self.selected_option_index().unwrap_or(0).saturating_add(1);
+            let total = self.options_len();
+            Some(super::FooterTip::new(format!("option {selected}/{total}")))
+        } else {
+            None
+        };
+        let tip_lines = self.footer_tip_lines_with_prefix(footer_area.width, option_tip);
         for (row_idx, tips) in tip_lines
             .into_iter()
             .take(footer_area.height as usize)

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
@@ -3,7 +3,7 @@ source: tui/src/bottom_pane/request_user_input/mod.rs
 expression: "render_snapshot(&overlay, area)"
 ---
                                                     
-  Question 1/2 (1 unanswered)                       
+  Question 1/2 (2 unanswered)                       
   Choose an option.                                 
                                                     
     1. Option 1  First choice.                      

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
@@ -10,6 +10,6 @@ expression: "render_snapshot(&overlay, area)"
   › 2. Option 2  Second choice.                     
     3. Option 3  Third choice.                      
                                                     
-  Option 2 of 3 | tab to add notes       
+  tab to add notes       
   enter to submit answer | ctrl + n next                
   esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
@@ -11,4 +11,4 @@ expression: "render_snapshot(&overlay, area)"
     3. Option 3  Third choice.                      
                                                     
   tab to add notes | enter to submit answer         
-  ctrl + n next | esc to interrupt
+  ctrl + p prev | ctrl + n next | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
@@ -10,6 +10,5 @@ expression: "render_snapshot(&overlay, area)"
   › 2. Option 2  Second choice.                     
     3. Option 3  Third choice.                      
                                                     
-  tab to add notes       
-  enter to submit answer | ctrl + n next                
-  esc to interrupt
+  tab to add notes | enter to submit answer         
+  ctrl + n next | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
@@ -4,12 +4,11 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                     
   Question 1/2 (1 unanswered)                       
-  Pick one                                          
   Choose an option.                                 
                                                     
-  ( ) Option 1  First choice.                       
-  (x) Option 2  Second choice.                      
-  ( ) Option 3  Third choice.                       
+    1. Option 1  First choice.                      
+  › 2. Option 2  Second choice.                     
+    3. Option 3  Third choice.                      
                                                     
   Option 2 of 3 | tab to add notes       
   enter to submit answer | ctrl + n next                

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
@@ -11,4 +11,4 @@ expression: "render_snapshot(&overlay, area)"
     3. Option 3  Third choice.                      
                                                     
   tab to add notes | enter to submit answer         
-  ctrl + p prev | ctrl + n next | esc to interrupt
+  ctrl + n next question | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
@@ -11,6 +11,6 @@ expression: "render_snapshot(&overlay, area)"
   (x) Option 2  Second choice.                      
   ( ) Option 3  Third choice.                       
                                                     
-  Option 2 of 3 | ↑/↓ scroll | Tab: add notes       
-  Enter: submit answer | Ctrl+n next                
-  Esc: interrupt
+  Option 2 of 3 | tab to add notes       
+  enter to submit answer | ctrl + n next                
+  esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_freeform.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_freeform.snap
@@ -9,4 +9,5 @@ expression: "render_snapshot(&overlay, area)"
   › Type your answer (optional)                                                                                         
                                                                                                                         
                                                                                                                         
+                                                                                                                        
   enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_freeform.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_freeform.snap
@@ -10,4 +10,4 @@ expression: "render_snapshot(&overlay, area)"
   › Type your answer (optional)                                                                                         
                                                                                                                         
                                                                                                                         
-  Enter: submit answer | Esc: interrupt
+  enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_freeform.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_freeform.snap
@@ -4,7 +4,6 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 1/1 (1 unanswered)                                                                                           
-  Goal                                                                                                                  
   Share details.                                                                                                        
                                                                                                                         
   › Type your answer (optional)                                                                                         

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_hidden_options_footer.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_hidden_options_footer.snap
@@ -1,0 +1,13 @@
+---
+source: tui/src/bottom_pane/request_user_input/mod.rs
+expression: "render_snapshot(&overlay, area)"
+---
+                                                                                
+  Question 1/1                                                                  
+  What would you like to do next?                                               
+                                                                                
+    2. Run tests      Pick a crate and run its tests.                           
+    3. Review a diff  Summarize or review current changes.                      
+  › 4. Refactor       Tighten structure and remove dead code.                   
+                                                                                
+  option 4/5 | tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_hidden_options_footer.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_hidden_options_footer.snap
@@ -3,7 +3,7 @@ source: tui/src/bottom_pane/request_user_input/mod.rs
 expression: "render_snapshot(&overlay, area)"
 ---
                                                                                 
-  Question 1/1                                                                  
+  Question 1/1 (1 unanswered)                                                   
   What would you like to do next?                                               
                                                                                 
     2. Run tests      Pick a crate and run its tests.                           

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_first.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_first.snap
@@ -10,4 +10,4 @@ expression: "render_snapshot(&overlay, area)"
     2. Option 2  Second choice.                                                                                         
     3. Option 3  Third choice.                                                                                          
                                                                                                                         
-  tab to add notes | enter to submit answer | ctrl + p prev | ctrl + n next | esc to interrupt
+  tab to add notes | enter to submit answer | ctrl + n next question | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_first.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_first.snap
@@ -10,4 +10,4 @@ expression: "render_snapshot(&overlay, area)"
     2. Option 2  Second choice.                                                                                         
     3. Option 3  Third choice.                                                                                          
                                                                                                                         
-  Option 1 of 3 | tab to add notes | enter to submit answer | ctrl + n next | esc to interrupt
+  tab to add notes | enter to submit answer | ctrl + n next | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_first.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_first.snap
@@ -4,11 +4,10 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 1/2 (2 unanswered)                                                                                           
-  Area                                                                                                                  
   Choose an option.                                                                                                     
                                                                                                                         
-  ( ) Option 1  First choice.                                                                                           
-  ( ) Option 2  Second choice.                                                                                          
-  ( ) Option 3  Third choice.                                                                                           
+  › 1. Option 1  First choice.                                                                                          
+    2. Option 2  Second choice.                                                                                         
+    3. Option 3  Third choice.                                                                                          
                                                                                                                         
   Option 1 of 3 | tab to add notes | enter to submit answer | ctrl + n next | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_first.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_first.snap
@@ -10,4 +10,4 @@ expression: "render_snapshot(&overlay, area)"
     2. Option 2  Second choice.                                                                                         
     3. Option 3  Third choice.                                                                                          
                                                                                                                         
-  tab to add notes | enter to submit answer | ctrl + n next | esc to interrupt
+  tab to add notes | enter to submit answer | ctrl + p prev | ctrl + n next | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_first.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_first.snap
@@ -11,4 +11,4 @@ expression: "render_snapshot(&overlay, area)"
   ( ) Option 2  Second choice.                                                                                          
   ( ) Option 3  Third choice.                                                                                           
                                                                                                                         
-  Option 1 of 3 | ↑/↓ scroll | Tab: add notes | Enter: submit answer | Ctrl+n next | Esc: interrupt
+  Option 1 of 3 | tab to add notes | enter to submit answer | ctrl + n next | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
@@ -4,7 +4,6 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 2/2 (2 unanswered)                                                                                           
-  Goal                                                                                                                  
   Share details.                                                                                                        
                                                                                                                         
   › Type your answer (optional)                                                                                         

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
@@ -11,4 +11,4 @@ expression: "render_snapshot(&overlay, area)"
                                                                                                                         
                                                                                                                         
                                                                                                                         
-  enter to submit answer | ctrl + n next | esc to interrupt
+  enter to submit all | ctrl + n next | esc to interrupt                                                               

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
@@ -12,4 +12,4 @@ expression: "render_snapshot(&overlay, area)"
                                                                                                                         
                                                                                                                         
                                                                                                                         
-  enter to submit all | ctrl + n next | esc to interrupt
+  enter to submit all | ctrl + p prev | ctrl + n next | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
@@ -12,4 +12,4 @@ expression: "render_snapshot(&overlay, area)"
                                                                                                                         
                                                                                                                         
                                                                                                                         
-  enter to submit all | ctrl + p prev | ctrl + n next | esc to interrupt
+  enter to submit all | ctrl + n first question | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
@@ -11,4 +11,5 @@ expression: "render_snapshot(&overlay, area)"
                                                                                                                         
                                                                                                                         
                                                                                                                         
-  enter to submit all | ctrl + n next | esc to interrupt                                                               
+                                                                                                                        
+  enter to submit all | ctrl + n next | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
@@ -12,4 +12,4 @@ expression: "render_snapshot(&overlay, area)"
                                                                                                                         
                                                                                                                         
                                                                                                                         
-  Enter: submit all answers | Ctrl+n next | Esc: interrupt
+  enter to submit answer | ctrl + n next | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options.snap
@@ -4,11 +4,10 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 1/1 (1 unanswered)                                                                                           
-  Area                                                                                                                  
   Choose an option.                                                                                                     
                                                                                                                         
-  ( ) Option 1  First choice.                                                                                           
-  ( ) Option 2  Second choice.                                                                                          
-  ( ) Option 3  Third choice.                                                                                           
+  › 1. Option 1  First choice.                                                                                          
+    2. Option 2  Second choice.                                                                                         
+    3. Option 3  Third choice.                                                                                          
                                                                                                                         
   Option 1 of 3 | tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options.snap
@@ -10,4 +10,4 @@ expression: "render_snapshot(&overlay, area)"
     2. Option 2  Second choice.                                                                                         
     3. Option 3  Third choice.                                                                                          
                                                                                                                         
-  Option 1 of 3 | tab to add notes | enter to submit answer | esc to interrupt
+  tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options.snap
@@ -11,4 +11,4 @@ expression: "render_snapshot(&overlay, area)"
   ( ) Option 2  Second choice.                                                                                          
   ( ) Option 3  Third choice.                                                                                           
                                                                                                                         
-  Option 1 of 3 | ↑/↓ scroll | Tab: add notes | Enter: submit answer | Esc: interrupt
+  Option 1 of 3 | tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
@@ -5,14 +5,14 @@ expression: "render_snapshot(&overlay, area)"
                                                                                                                         
   Question 1/1                                                                                                          
   Choose an option.                                                                                                     
+                                                                                                                        
   › 1. Option 1  First choice.                                                                                          
     2. Option 2  Second choice.                                                                                         
     3. Option 3  Third choice.                                                                                          
-  Notes for Option 1                                                                                                    
                                                                                                                         
   › Add notes                                                                                                           
                                                                                                                         
                                                                                                                         
                                                                                                                         
                                                                                                                         
-  Option 1 of 3 | tab to clear notes | enter to submit answer | esc to interrupt
+  tab to clear notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
@@ -3,7 +3,7 @@ source: tui/src/bottom_pane/request_user_input/mod.rs
 expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
-  Question 1/1                                                                                                          
+  Question 1/1 (1 unanswered)                                                                                           
   Choose an option.                                                                                                     
                                                                                                                         
   › 1. Option 1  First choice.                                                                                          

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
@@ -9,7 +9,9 @@ expression: "render_snapshot(&overlay, area)"
   › 1. Option 1  First choice.                                                                                          
     2. Option 2  Second choice.                                                                                         
     3. Option 3  Third choice.                                                                                          
+                                                                                                                        
   › Add notes                                                                                                           
+                                                                                                                        
                                                                                                                         
                                                                                                                         
                                                                                                                         

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
@@ -16,4 +16,4 @@ expression: "render_snapshot(&overlay, area)"
                                                                                                                         
                                                                                                                         
                                                                                                                         
-  Option 1 of 3 | ↑/↓ scroll | Tab: clear notes | Enter: submit answer | Esc: interrupt
+  Option 1 of 3 | tab to clear notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
@@ -4,11 +4,10 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 1/1                                                                                                          
-  Area                                                                                                                  
   Choose an option.                                                                                                     
-  (x) Option 1  First choice.                                                                                           
-  ( ) Option 2  Second choice.                                                                                          
-  ( ) Option 3  Third choice.                                                                                           
+  › 1. Option 1  First choice.                                                                                          
+    2. Option 2  Second choice.                                                                                         
+    3. Option 3  Third choice.                                                                                          
   Notes for Option 1                                                                                                    
                                                                                                                         
   › Add notes                                                                                                           

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
@@ -9,7 +9,6 @@ expression: "render_snapshot(&overlay, area)"
   › 1. Option 1  First choice.                                                                                          
     2. Option 2  Second choice.                                                                                         
     3. Option 3  Third choice.                                                                                          
-                                                                                                                        
   › Add notes                                                                                                           
                                                                                                                         
                                                                                                                         

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_scrolling_options.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_scrolling_options.snap
@@ -10,5 +10,6 @@ expression: "render_snapshot(&overlay, area)"
     2. Run tests                            Pick a crate and run its tests.                                             
     3. Review a diff                        Summarize or review current changes.                                        
   › 4. Refactor                             Tighten structure and remove dead code.                                     
+    5. Ship it                              Finalize and open a PR.                                                     
                                                                                                                         
   tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_scrolling_options.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_scrolling_options.snap
@@ -3,7 +3,7 @@ source: tui/src/bottom_pane/request_user_input/mod.rs
 expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
-  Question 1/1                                                                                                          
+  Question 1/1 (1 unanswered)                                                                                           
   What would you like to do next?                                                                                       
                                                                                                                         
     1. Discuss a code change (Recommended)  Walk through a plan and edit code together.                                 

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_scrolling_options.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_scrolling_options.snap
@@ -12,4 +12,4 @@ expression: "render_snapshot(&overlay, area)"
   ( ) Review a diff                        Summarize or review current changes.                                         
   (x) Refactor                             Tighten structure and remove dead code.                                      
                                                                                                                         
-  Option 4 of 5 | ↑/↓ scroll | Tab: add notes | Enter: submit answer | Esc: interrupt
+  Option 4 of 5 | tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_scrolling_options.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_scrolling_options.snap
@@ -4,12 +4,11 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 1/1                                                                                                          
-  Next Step                                                                                                             
   What would you like to do next?                                                                                       
                                                                                                                         
-  ( ) Discuss a code change (Recommended)  Walk through a plan and edit code together.                                  
-  ( ) Run tests                            Pick a crate and run its tests.                                              
-  ( ) Review a diff                        Summarize or review current changes.                                         
-  (x) Refactor                             Tighten structure and remove dead code.                                      
+    1. Discuss a code change (Recommended)  Walk through a plan and edit code together.                                 
+    2. Run tests                            Pick a crate and run its tests.                                             
+    3. Review a diff                        Summarize or review current changes.                                        
+  › 4. Refactor                             Tighten structure and remove dead code.                                     
                                                                                                                         
   Option 4 of 5 | tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_scrolling_options.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_scrolling_options.snap
@@ -11,4 +11,4 @@ expression: "render_snapshot(&overlay, area)"
     3. Review a diff                        Summarize or review current changes.                                        
   › 4. Refactor                             Tighten structure and remove dead code.                                     
                                                                                                                         
-  Option 4 of 5 | tab to add notes | enter to submit answer | esc to interrupt
+  tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_tight_height.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_tight_height.snap
@@ -9,4 +9,4 @@ expression: "render_snapshot(&overlay, area)"
   › 1. Option 1  First choice.                                                                                          
     2. Option 2  Second choice.                                                                                         
                                                                                                                         
-  Option 1 of 3 | tab to add notes | enter to submit answer | esc to interrupt
+  tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_tight_height.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_tight_height.snap
@@ -8,5 +8,6 @@ expression: "render_snapshot(&overlay, area)"
                                                                                                                         
   › 1. Option 1  First choice.                                                                                          
     2. Option 2  Second choice.                                                                                         
+    3. Option 3  Third choice.                                                                                          
                                                                                                                         
   tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_tight_height.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_tight_height.snap
@@ -10,4 +10,4 @@ expression: "render_snapshot(&overlay, area)"
   ( ) Option 1  First choice.                                                                                           
   ( ) Option 2  Second choice.                                                                                          
                                                                                                                         
-  Option 1 of 3 | ↑/↓ scroll | Tab: add notes | Enter: submit answer | Esc: interrupt
+  Option 1 of 3 | tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_tight_height.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_tight_height.snap
@@ -4,10 +4,9 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 1/1 (1 unanswered)                                                                                           
-  Area                                                                                                                  
   Choose an option.                                                                                                     
                                                                                                                         
-  ( ) Option 1  First choice.                                                                                           
-  ( ) Option 2  Second choice.                                                                                          
+  › 1. Option 1  First choice.                                                                                          
+    2. Option 2  Second choice.                                                                                         
                                                                                                                         
   Option 1 of 3 | tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_unanswered_confirmation.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_unanswered_confirmation.snap
@@ -1,0 +1,15 @@
+---
+source: tui/src/bottom_pane/request_user_input/mod.rs
+expression: "render_snapshot(&overlay, area)"
+---
+                                                                                
+  Submit with unanswered questions?                                             
+  2 unanswered questions                                                        
+                                                                                
+  › 1. Proceed  Submit with 2 unanswered questions.                             
+    2. Go back  Return to the first unanswered question.                        
+                                                                                
+                                                                                
+                                                                                
+                                                                                
+  Press enter to confirm or esc to go back

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_wrapped_options.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_wrapped_options.snap
@@ -4,11 +4,10 @@ expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                               
   Question 1/1                                                                                                
-  Next Step                                                                                                   
   Choose the next step for this task.                                                                         
                                                                                                               
-  (x) Discuss a code change  Walk through a plan, then implement it together with careful checks.             
-  ( ) Run targeted tests     Pick the most relevant crate and validate the current behavior first.            
-  ( ) Review the diff        Summarize the changes and highlight the most important risks and gaps.           
+  › 1. Discuss a code change  Walk through a plan, then implement it together with careful checks.            
+    2. Run targeted tests     Pick the most relevant crate and validate the current behavior first.           
+    3. Review the diff        Summarize the changes and highlight the most important risks and gaps.          
                                                                                                               
   Option 1 of 3 | tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_wrapped_options.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_wrapped_options.snap
@@ -3,7 +3,7 @@ source: tui/src/bottom_pane/request_user_input/mod.rs
 expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                               
-  Question 1/1                                                                                                
+  Question 1/1 (1 unanswered)                                                                                 
   Choose the next step for this task.                                                                         
                                                                                                               
   › 1. Discuss a code change  Walk through a plan, then implement it together with careful checks.            

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_wrapped_options.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_wrapped_options.snap
@@ -11,4 +11,4 @@ expression: "render_snapshot(&overlay, area)"
   ( ) Run targeted tests     Pick the most relevant crate and validate the current behavior first.            
   ( ) Review the diff        Summarize the changes and highlight the most important risks and gaps.           
                                                                                                               
-  Option 1 of 3 | ↑/↓ scroll | Tab: add notes | Enter: submit answer | Esc: interrupt
+  Option 1 of 3 | tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_wrapped_options.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_wrapped_options.snap
@@ -10,4 +10,4 @@ expression: "render_snapshot(&overlay, area)"
     2. Run targeted tests     Pick the most relevant crate and validate the current behavior first.           
     3. Review the diff        Summarize the changes and highlight the most important risks and gaps.          
                                                                                                               
-  Option 1 of 3 | tab to add notes | enter to submit answer | esc to interrupt
+  tab to add notes | enter to submit answer | esc to interrupt


### PR DESCRIPTION
## Summary
Overhaul the ask‑user‑questions TUI to support “Other/None” answers, better notes handling, improved option selection
UX, and a safer submission flow with confirmation for unanswered questions.

Resolves https://github.com/openai/codex/issues/10088

Multiple choice (number keys for quick selection, up/down or jk for cycling through options):
<img width="856" height="169" alt="Screenshot 2026-01-27 at 7 22 29 PM" src="https://github.com/user-attachments/assets/cabd1b0e-25e0-4859-bd8f-9941192ca274" />

Tab to add notes:
<img width="856" height="197" alt="Screenshot 2026-01-27 at 7 22 45 PM" src="https://github.com/user-attachments/assets/a807db5e-e966-412c-af91-6edc60062f35" />

Freeform (also note enter tooltip is highlighted on last question to indicate questions UI will be exited upon submission):
<img width="854" height="112" alt="Screenshot 2026-01-27 at 7 23 13 PM" src="https://github.com/user-attachments/assets/2e7b88bf-062b-4b9f-a9da-c9d8c8a59643" />

Confirmation dialogue (submitting with unanswered questions):
<img width="854" height="126" alt="Screenshot 2026-01-27 at 7 23 29 PM" src="https://github.com/user-attachments/assets/93965c8f-54ac-45bc-a660-9625bcd101f8" />

## Key Changes
- **Options UI refresh**
  - Render options as numbered entries; allow number keys to select & submit.
  - Remove “Option X/Y” header and allow the question UI height to expand naturally.
  - Keep spacing between question, options, and notes even when notes are visible.
  - Hide the title line and render the question prompt in cyan **only when uncommitted**.

- **“Other / None of the above” support**
  - Wire `isOther` to add “None of the above”.
  - Add guidance text: “Optionally, add details in notes (tab).”

- **Notes composer UX**
  - Remove “Notes” heading; place composer directly under the selected option.
  - Preserve pending paste placeholders across question navigation and after submission.
  - Ctrl+C clears notes **only when the notes composer has focus**.
  - Ctrl+C now triggers an immediate redraw so the clear is visible.

- **Committed vs uncommitted state**
  - Introduce a unified `answer_committed` flag per question.
  - Editing notes (including adding text or pastes) marks the answer uncommitted.
  - Changing the option highlight (j/k, up/down) marks the answer uncommitted.
  - Clearing options (Backspace/Delete) also clears pending notes.
  - Question prompt turns cyan only when the answer is uncommitted.

- **Submission safety & confirmation**
  - Only submit notes/freeform text once explicitly committed.
  - Last-question submit with unanswered questions shows a confirmation dialog.
  - Confirmation options:
    1. **Proceed** (default)
    2. **Go back**
  - Description reflects count: “Submit with N unanswered question(s).”
  - Esc/Backspace in confirmation returns to first unanswered question.
  - Ctrl+C in confirmation interrupts and exits the overlay.

- **Footer hints**
  - Cyan highlight restored for “enter to submit answer” / “enter to submit all”.

## Codex author
`codex fork 019c00ed-323a-7000-bdb5-9f9c5a635bd9`