### PR TITLE
Remove inaccurate/redundant Steer Conversation tooltip

### DIFF
--- a/codex-rs/tui/tooltips.txt
+++ b/codex-rs/tui/tooltips.txt
@@ -12,6 +12,5 @@ Use /mcp to list configured MCP tools.
 You can run any shell command from Codex using `!` (e.g. `!ls`)
 Type / to open the command popup; Tab autocompletes slash commands.
 When the composer is empty, press Esc to step back and edit your last message; Enter confirms.
-Press Tab to queue a message instead of sending it immediately; Enter always sends immediately.
 Paste an image with Ctrl+V to attach it to your next message.
 You can resume a previous conversation by running `codex resume`


### PR DESCRIPTION
Steer Conversation is currently experimental and disabled by
default, yet this tooltip is randomly displayed to all users.

Additionally, this feature is already cycled into tooltips
(with correct instructions to enable) as a
spec.stage.experimental_announcement in tooltips.rs

Fixes https://github.com/openai/codex/issues/10027

# External (non-OpenAI) Pull Request Requirements

Before opening this Pull Request, please read the dedicated "Contributing" markdown file or your PR may be closed:
https://github.com/openai/codex/blob/main/docs/contributing.md

If your PR conforms to our contribution guidelines, replace this text with a detailed and high quality description of your changes.

I have not been invited, I understand this may be closed. That said: I would appreciate said invite!

Include a link to a bug report or enhancement request: https://github.com/openai/codex/issues/10027
