### PR TITLE
Fix large paste placeholder numbering after deletion

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -37,6 +37,17 @@
 //! The numeric auto-submit path used by the slash popup performs the same pending-paste expansion
 //! and attachment pruning, and clears pending paste state on success.
 //!
+//! # Large Paste Placeholders
+//!
+//! Large pastes insert an element placeholder in the buffer and store the full text in
+//! `pending_pastes`. The placeholder label is derived from the pasted character count:
+//!
+//! - First paste of a given size uses `[Pasted Content N chars]`.
+//! - Additional pending pastes of the same size add a numeric suffix (`#2`, `#3`, ...), where the
+//!   next suffix is computed from the placeholders that still exist in `pending_pastes`.
+//! - When all placeholders for a size are deleted (which removes their pending entries), the next
+//!   paste of that size reuses the base label without a suffix.
+//!
 //! # Non-bracketed Paste Bursts
 //!
 //! On some terminals (especially on Windows), pastes arrive as a rapid sequence of

--- a/docs/tui-chat-composer.md
+++ b/docs/tui-chat-composer.md
@@ -115,6 +115,17 @@ positional args, Enter auto-submits without calling `prepare_submission_text`. T
 - Prunes attachments based on expanded placeholders.
 - Clears pending pastes after a successful auto-submit.
 
+### Large paste placeholders
+
+Large pastes (over `LARGE_PASTE_CHAR_THRESHOLD`) insert an element placeholder and store the full
+text in `pending_pastes`. Placeholder labels are derived from the pasted character count:
+
+- First paste of a given size uses `[Pasted Content N chars]`.
+- Additional pending pastes of the same size add a numeric suffix (`#2`, `#3`, ...), where the
+  next suffix is computed from placeholders that still exist in `pending_pastes`.
+- When all placeholders for a size are deleted (which removes their pending entries), the next
+  paste of that size reuses the base label without a suffix.
+
 ## Paste burst: concepts and assumptions
 
 The burst detector is intentionally conservative: it only processes “plain” character input


### PR DESCRIPTION
- derive large-paste placeholder suffixes from live pending_pastes instead of a monotonic counter
- reuse the base placeholder once all placeholders of that length are deleted (no unnecessary “#2”)
- add regression test for delete‑then‑repaste behavior

`codex fork 019c0183-a69a-7c41-919a-348f8462cddc`