### PR TITLE
tui: complete directories in @ popup

### DIFF
--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -81,6 +81,7 @@ impl FileSearchManager {
                 threads: NUM_FILE_SEARCH_THREADS,
                 compute_indices: true,
                 respect_gitignore: true,
+                include_directories: true,
             },
             reporter,
         );


### PR DESCRIPTION
@ completion now includes directory entries so you can select a folder
and keep typing to reach a file. Directory matches are returned with a
trailing path separator to distinguish them from files, and the
composer avoids adding a trailing space when inserting a directory.

This is implemented in codex-file-search (new run_including_directories)
and wired into the TUI file search manager.

Tests: cargo test -p codex-file-search, cargo test -p codex-tui