### PR TITLE
chore(arg0): advisory-lock janitor for codex tmp paths

### DIFF
--- a/codex-rs/arg0/src/lib.rs
+++ b/codex-rs/arg0/src/lib.rs
@@ -184,7 +184,7 @@ pub fn prepend_path_entry_for_codex_aliases() -> std::io::Result<Arg0PathEntryGu
 
     std::fs::create_dir_all(&codex_home)?;
     // Use a CODEX_HOME-scoped temp root to avoid cluttering the top-level directory.
-    let temp_root = codex_home.join("tmp").join("path2");
+    let temp_root = codex_home.join("tmp").join("arg0");
     std::fs::create_dir_all(&temp_root)?;
     #[cfg(unix)]
     {

--- a/codex-rs/core/tests/suite/mod.rs
+++ b/codex-rs/core/tests/suite/mod.rs
@@ -1,4 +1,6 @@
 // Aggregates all former standalone integration tests as modules.
+use std::ffi::OsString;
+
 use codex_arg0::Arg0PathEntryGuard;
 use codex_arg0::arg0_dispatch;
 use ctor::ctor;
@@ -7,6 +9,7 @@ use tempfile::TempDir;
 struct TestCodexAliasesGuard {
     _codex_home: TempDir,
     _arg0: Arg0PathEntryGuard,
+    _previous_codex_home: Option<OsString>,
 }
 
 const CODEX_HOME_ENV_VAR: &str = "CODEX_HOME";
@@ -22,19 +25,26 @@ pub static CODEX_ALIASES_TEMP_DIR: TestCodexAliasesGuard = unsafe {
         .prefix("codex-core-tests")
         .tempdir()
         .unwrap();
+    let previous_codex_home = std::env::var_os(CODEX_HOME_ENV_VAR);
     unsafe {
         std::env::set_var(CODEX_HOME_ENV_VAR, codex_home.path());
     }
 
     #[allow(clippy::unwrap_used)]
     let arg0 = arg0_dispatch().unwrap();
-    unsafe {
-        std::env::remove_var(CODEX_HOME_ENV_VAR);
+    match previous_codex_home.as_ref() {
+        Some(value) => unsafe {
+            std::env::set_var(CODEX_HOME_ENV_VAR, value);
+        },
+        None => unsafe {
+            std::env::remove_var(CODEX_HOME_ENV_VAR);
+        },
     }
 
     TestCodexAliasesGuard {
         _codex_home: codex_home,
         _arg0: arg0,
+        _previous_codex_home: previous_codex_home,
     }
 };
 


### PR DESCRIPTION
## Description

### What changed
- Switch the arg0 helper root from `~/.codex/tmp/path` to `~/.codex/tmp/path2`
- Add `Arg0PathEntryGuard` to keep both the `TempDir` and an exclusive `.lock` file alive for the process lifetime
- Add a startup janitor that scans `path2` and deletes only directories whose lock can be acquired

### Tests
- `cargo clippy -p codex-arg0`
- `cargo clippy -p codex-core`
- `cargo test -p codex-arg0`
- `cargo test -p codex-core` 