### PR TITLE
fix: allow unknown fields on Notice in schema

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -441,7 +441,6 @@
       "type": "object"
     },
     "Notice": {
-      "additionalProperties": false,
       "description": "Settings for notices we display to users via the tui and app-server clients (primarily the Codex IDE extension). NOTE: these are different from notifications - notices are warnings, NUX screens, acknowledgements, etc.",
       "properties": {
         "hide_full_access_warning": {

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -472,7 +472,6 @@ const fn default_true() -> bool {
 /// (primarily the Codex IDE extension). NOTE: these are different from
 /// notifications - notices are warnings, NUX screens, acknowledgements, etc.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]
-#[schemars(deny_unknown_fields)]
 pub struct Notice {
     /// Tracks whether the user has acknowledged the full access warning prompt.
     pub hide_full_access_warning: Option<bool>,


### PR DESCRIPTION
the `notice` field didn't allow unknown fields in the schema, leading to issues where they shouldn't be.

Now we allow unknown fields.

<img width="2260" height="720" alt="image" src="https://github.com/user-attachments/assets/1de43b60-0d50-4a96-9c9c-34419270d722" />