### PR TITLE
update the ci pnpm workflow for shell-tool-mcp to use corepack for pnpm versioning

### DIFF
--- a/.github/workflows/shell-tool-mcp-ci.yml
+++ b/.github/workflows/shell-tool-mcp-ci.yml
@@ -24,16 +24,17 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: "pnpm"
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Verify pnpm version
+        run: pnpm --version
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/shell-tool-mcp-ci.yml
+++ b/.github/workflows/shell-tool-mcp-ci.yml
@@ -24,11 +24,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: "npm"
+          cache: "pnpm"
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/shell-tool-mcp-ci.yml
+++ b/.github/workflows/shell-tool-mcp-ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      - name: Activate pnpm from package.json
+        run: corepack prepare --activate
+
       - name: Verify pnpm version
         run: pnpm --version
 

--- a/.github/workflows/shell-tool-mcp-ci.yml
+++ b/.github/workflows/shell-tool-mcp-ci.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: "pnpm"
+          cache: "npm"
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/shell-tool-mcp.yml
+++ b/.github/workflows/shell-tool-mcp.yml
@@ -349,6 +349,9 @@ jobs:
       - name: Enable Corepack
         run: corepack enable
 
+      - name: Activate pnpm from package.json
+        run: corepack prepare --activate
+
       - name: Verify pnpm version
         run: pnpm --version
 
@@ -446,6 +449,9 @@ jobs:
 
       - name: Enable Corepack
         run: corepack enable
+
+      - name: Activate pnpm from package.json
+        run: corepack prepare --activate
 
       - name: Verify pnpm version
         run: pnpm --version

--- a/.github/workflows/shell-tool-mcp.yml
+++ b/.github/workflows/shell-tool-mcp.yml
@@ -449,7 +449,7 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           run_install: false
-:
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/shell-tool-mcp.yml
+++ b/.github/workflows/shell-tool-mcp.yml
@@ -341,15 +341,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Verify pnpm version
+        run: pnpm --version
 
       - name: Install JavaScript dependencies
         run: pnpm install --frozen-lockfile
@@ -436,11 +437,6 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -448,8 +444,11 @@ jobs:
           registry-url: https://registry.npmjs.org
           scope: "@openai"
 
-      - name: Update npm
-        run: npm install -g npm@latest
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Verify pnpm version
+        run: pnpm --version
 
       - name: Download npm tarball
         uses: actions/download-artifact@v7

--- a/.github/workflows/shell-tool-mcp.yml
+++ b/.github/workflows/shell-tool-mcp.yml
@@ -341,6 +341,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
@@ -439,7 +444,12 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    steps:
+    steps
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
+:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/shell-tool-mcp.yml
+++ b/.github/workflows/shell-tool-mcp.yml
@@ -444,7 +444,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    steps
+    steps:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "engines": {
     "node": ">=22",
-    "pnpm": ">=9.0.0"
+    "pnpm": ">=10.28.0"
   },
   "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264"
 }

--- a/shell-tool-mcp/package.json
+++ b/shell-tool-mcp/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-dev",
   "description": "Codex MCP server for the shell tool with patched Bash and exec wrappers.",
   "license": "Apache-2.0",
+  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
   "bin": {
     "codex-shell-tool-mcp": "bin/mcp-server.js"
   },


### PR DESCRIPTION
This updates the CI workflows for shell-tool-mcp to use the pnpm version from package.json and print it in the build for verification.

I have read the CLA Document and I hereby sign the CLA