### PR TITLE
MCP: add resume-path support for Codex sessions

### DIFF
--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -231,12 +231,8 @@ impl ThreadManager {
         config: Config,
         rollout_path: PathBuf,
     ) -> CodexResult<NewThread> {
-        self.resume_thread_from_rollout(
-            config,
-            rollout_path,
-            Arc::clone(&self.state.auth_manager),
-        )
-        .await
+        self.resume_thread_from_rollout(config, rollout_path, Arc::clone(&self.state.auth_manager))
+            .await
     }
 
     pub async fn resume_thread_with_history(

--- a/codex-rs/core/src/thread_manager.rs
+++ b/codex-rs/core/src/thread_manager.rs
@@ -226,6 +226,19 @@ impl ThreadManager {
             .await
     }
 
+    pub async fn resume_thread_from_rollout_with_auth(
+        &self,
+        config: Config,
+        rollout_path: PathBuf,
+    ) -> CodexResult<NewThread> {
+        self.resume_thread_from_rollout(
+            config,
+            rollout_path,
+            Arc::clone(&self.state.auth_manager),
+        )
+        .await
+    }
+
     pub async fn resume_thread_with_history(
         &self,
         config: Config,

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -330,6 +330,10 @@ mod tests {
                 "description": "The *initial user prompt* to start the Codex conversation.",
                 "type": "string"
               },
+              "resume-path": {
+                "description": "Optional path to a rollout file to resume the session from.",
+                "type": "string"
+              },
               "sandbox": {
                 "description": "Sandbox mode: `read-only`, `workspace-write`, or `danger-full-access`.",
                 "enum": [
@@ -411,5 +415,22 @@ mod tests {
           "title": "Codex Reply",
         });
         assert_eq!(expected_tool_json, tool_json);
+    }
+
+    #[test]
+    fn codex_tool_accepts_pre_change_payload() {
+        let payload = serde_json::json!({
+            "prompt": "hello",
+            "model": "gpt-5.2",
+            "sandbox": "workspace-write",
+            "approval-policy": "untrusted",
+        });
+
+        let parsed: CodexToolCallParam = serde_json::from_value(payload).expect("payload parses");
+        assert_eq!(parsed.prompt, "hello");
+        assert_eq!(parsed.model.as_deref(), Some("gpt-5.2"));
+        assert_eq!(parsed.sandbox, Some(CodexToolCallSandboxMode::WorkspaceWrite));
+        assert_eq!(parsed.approval_policy, Some(CodexToolCallApprovalPolicy::Untrusted));
+        assert!(parsed.resume_path.is_none());
     }
 }

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -429,8 +429,14 @@ mod tests {
         let parsed: CodexToolCallParam = serde_json::from_value(payload).expect("payload parses");
         assert_eq!(parsed.prompt, "hello");
         assert_eq!(parsed.model.as_deref(), Some("gpt-5.2"));
-        assert_eq!(parsed.sandbox, Some(CodexToolCallSandboxMode::WorkspaceWrite));
-        assert_eq!(parsed.approval_policy, Some(CodexToolCallApprovalPolicy::Untrusted));
+        assert_eq!(
+            parsed.sandbox,
+            Some(CodexToolCallSandboxMode::WorkspaceWrite)
+        );
+        assert_eq!(
+            parsed.approval_policy,
+            Some(CodexToolCallApprovalPolicy::Untrusted)
+        );
         assert!(parsed.resume_path.is_none());
     }
 }

--- a/codex-rs/mcp-server/src/codex_tool_config.rs
+++ b/codex-rs/mcp-server/src/codex_tool_config.rs
@@ -61,6 +61,10 @@ pub struct CodexToolCallParam {
     /// Prompt used when compacting the conversation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub compact_prompt: Option<String>,
+
+    /// Optional path to a rollout file to resume the session from.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub resume_path: Option<PathBuf>,
 }
 
 /// Custom enum mirroring [`AskForApproval`], but has an extra dependency on
@@ -153,7 +157,7 @@ impl CodexToolCallParam {
     pub async fn into_config(
         self,
         codex_linux_sandbox_exe: Option<PathBuf>,
-    ) -> std::io::Result<(String, Config)> {
+    ) -> std::io::Result<(String, Config, Option<PathBuf>)> {
         let Self {
             prompt,
             model,
@@ -165,6 +169,7 @@ impl CodexToolCallParam {
             base_instructions,
             developer_instructions,
             compact_prompt,
+            resume_path,
         } = self;
 
         // Build the `ConfigOverrides` recognized by codex-core.
@@ -190,7 +195,7 @@ impl CodexToolCallParam {
         let cfg =
             Config::load_with_cli_overrides_and_harness_overrides(cli_overrides, overrides).await?;
 
-        Ok((prompt, cfg))
+        Ok((prompt, cfg, resume_path))
     }
 }
 

--- a/codex-rs/mcp-server/src/codex_tool_runner.rs
+++ b/codex-rs/mcp-server/src/codex_tool_runner.rs
@@ -3,6 +3,7 @@
 //! and to make future feature-growth easier to manage.
 
 use std::collections::HashMap;
+use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::exec_approval::handle_exec_approval_request;
@@ -66,6 +67,7 @@ pub async fn run_codex_tool_session(
     id: RequestId,
     initial_prompt: String,
     config: CodexConfig,
+    resume_path: Option<PathBuf>,
     outgoing: Arc<OutgoingMessageSender>,
     thread_manager: Arc<ThreadManager>,
     running_requests_id_to_codex_uuid: Arc<Mutex<HashMap<RequestId, ThreadId>>>,
@@ -74,21 +76,42 @@ pub async fn run_codex_tool_session(
         thread_id,
         thread,
         session_configured,
-    } = match thread_manager.start_thread(config).await {
-        Ok(res) => res,
-        Err(e) => {
-            let result = CallToolResult {
-                content: vec![ContentBlock::TextContent(TextContent {
-                    r#type: "text".to_string(),
-                    text: format!("Failed to start Codex session: {e}"),
-                    annotations: None,
-                })],
-                is_error: Some(true),
-                structured_content: None,
-            };
-            outgoing.send_response(id.clone(), result).await;
-            return;
-        }
+    } = match resume_path {
+        Some(path) => match thread_manager
+            .resume_thread_from_rollout_with_auth(config, path)
+            .await
+        {
+            Ok(res) => res,
+            Err(e) => {
+                let result = CallToolResult {
+                    content: vec![ContentBlock::TextContent(TextContent {
+                        r#type: "text".to_string(),
+                        text: format!("Failed to resume Codex session: {e}"),
+                        annotations: None,
+                    })],
+                    is_error: Some(true),
+                    structured_content: None,
+                };
+                outgoing.send_response(id.clone(), result).await;
+                return;
+            }
+        },
+        None => match thread_manager.start_thread(config).await {
+            Ok(res) => res,
+            Err(e) => {
+                let result = CallToolResult {
+                    content: vec![ContentBlock::TextContent(TextContent {
+                        r#type: "text".to_string(),
+                        text: format!("Failed to start Codex session: {e}"),
+                        annotations: None,
+                    })],
+                    is_error: Some(true),
+                    structured_content: None,
+                };
+                outgoing.send_response(id.clone(), result).await;
+                return;
+            }
+        },
     };
 
     let session_configured_event = Event {

--- a/codex-rs/mcp-server/src/message_processor.rs
+++ b/codex-rs/mcp-server/src/message_processor.rs
@@ -347,7 +347,8 @@ impl MessageProcessor {
         }
     }
     async fn handle_tool_call_codex(&self, id: RequestId, arguments: Option<serde_json::Value>) {
-        let (initial_prompt, config): (String, Config) = match arguments {
+        let (initial_prompt, config, resume_path): (String, Config, Option<PathBuf>) =
+            match arguments {
             Some(json_val) => match serde_json::from_value::<CodexToolCallParam>(json_val) {
                 Ok(tool_cfg) => match tool_cfg
                     .into_config(self.codex_linux_sandbox_exe.clone())
@@ -417,6 +418,7 @@ impl MessageProcessor {
                 id,
                 initial_prompt,
                 config,
+                resume_path,
                 outgoing,
                 thread_manager,
                 running_requests_id_to_codex_uuid,


### PR DESCRIPTION
## Summary
- Add `resume_path` to the Codex MCP tool schema + implementation
- Cover the schema update in tests
- Run rustfmt

## Context
Happy CLI can resume Codex sessions by passing a resume path through MCP. This enables a smooth “pick up where you left off” flow across desktop + mobile. The intent is to make Codex feel first‑class in Happy, approaching parity with other CLI workflows (e.g., Claude Code), without altering the existing Codex CLI UX.

## Implementation notes
- MCP schema and tool wiring accept an explicit resume path
- Tests updated to match the new schema

## Testing
- python scripts/asciicheck.py
- python scripts/readme_toc.py
- python scripts/format.py
- python scripts/stage_npm_packages.py
- cargo fmt --all
- cargo clippy --all-targets --all-features
- cargo shear
- cargo check --all-targets --all-features
- cargo nextest run --all-targets --all-features
- cargo deny check
- pnpm --filter @openai/codex-sdk lint
- pnpm --filter @openai/codex-sdk test -- --runInBand
- pnpm --filter @openai/codex-sdk build
- pnpm --filter @openai/codex-cli shell-tool-mcp:format
- pnpm --filter @openai/codex-cli shell-tool-mcp:test
- pnpm --filter @openai/codex-cli shell-tool-mcp:build

## Companion PR
- slopus/happy-cli#151
