### PR TITLE
removing quit from dropdown menu, but not autocomplete [cli]

### DIFF
--- a/codex-rs/tui/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/command_popup.rs
@@ -120,6 +120,10 @@ impl CommandPopup {
         if filter.is_empty() {
             // Built-ins first, in presentation order.
             for (_, cmd) in self.builtins.iter() {
+                // Skipping quit as it's a duplicate of exit.
+                if *cmd == SlashCommand::Quit {
+                    continue;
+                }
                 out.push((CommandItem::Builtin(*cmd), None));
             }
             // Then prompts, already sorted by name.
@@ -435,6 +439,18 @@ mod tests {
             !cmds.contains(&"compact"),
             "expected prefix search for '/ac' to exclude 'compact', got {cmds:?}"
         );
+    }
+
+    #[test]
+    fn quit_hidden_in_empty_filter_but_shown_for_prefix() {
+        let mut popup = CommandPopup::new(Vec::new(), CommandPopupFlags::default());
+        popup.on_composer_text_change("/".to_string());
+        let items = popup.filtered_items();
+        assert!(!items.contains(&CommandItem::Builtin(SlashCommand::Quit)));
+
+        popup.on_composer_text_change("/qu".to_string());
+        let items = popup.filtered_items();
+        assert!(items.contains(&CommandItem::Builtin(SlashCommand::Quit)));
     }
 
     #[test]


### PR DESCRIPTION
Currently we have both `\quit` and `\exit` which do the same thing. This removes `\quit` from the slash command menu but allows it to still be an autocomplete option & working for those used to that command.

`/quit` autocomplete:
<img width="232" height="108" alt="Screenshot 2026-01-28 at 4 32 53 PM" src="https://github.com/user-attachments/assets/d71e079f-77f6-4edc-9590-44a01e2a4ff5" />

slash command menu:
<img width="425" height="191" alt="Screenshot 2026-01-28 at 4 32 36 PM" src="https://github.com/user-attachments/assets/a9458cff-1784-4ce0-927d-43ad13d2a97c" />