### PR TITLE
fix: ignore key release events during onboarding

### DIFF
--- a/codex-rs/tui/src/onboarding/onboarding_screen.rs
+++ b/codex-rs/tui/src/onboarding/onboarding_screen.rs
@@ -211,6 +211,9 @@ impl OnboardingScreen {
 
 impl KeyboardHandler for OnboardingScreen {
     fn handle_key_event(&mut self, key_event: KeyEvent) {
+        if !matches!(key_event.kind, KeyEventKind::Press | KeyEventKind::Repeat) {
+            return;
+        }
         let is_api_key_entry_active = self.is_api_key_entry_active();
         let should_quit = match key_event {
             KeyEvent {


### PR DESCRIPTION
## Summary
- guard onboarding key handling to ignore KeyEventKind::Release
- handle key events at the onboarding screen boundary to avoid double-triggering widgets

## Related
- https://github.com/ratatui/ratatui/issues/347

## Testing
- cd codex-rs && just fmt
- cd codex-rs && cargo test -p codex-tui
