### PR TITLE
make codex better at git

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1826,7 +1826,7 @@ impl Session {
 
             let hint = cwd.file_name().and_then(|name| name.to_str()).map_or_else(
                 || cwd.to_string_lossy().into_owned(),
-                |name| name.to_string(),
+                std::string::ToString::to_string,
             );
 
             let mut workspaces = BTreeMap::new();

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1816,7 +1816,7 @@ impl Session {
         fn build_workspace_configuration(
             cwd: &Path,
             git_info: Option<&codex_protocol::protocol::GitInfo>,
-            remote_urls: Option<&Vec<String>>,
+            remote_urls: Option<&BTreeMap<String, String>>,
         ) -> Option<WorkspaceConfiguration> {
             let latest_git_commit_hash = git_info.and_then(|info| info.commit_hash.clone());
             let associated_remote_urls = remote_urls.cloned();

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1876,7 +1876,11 @@ impl Session {
             );
         }
         let git_info = crate::git_info::collect_git_info(turn_context.cwd.as_path()).await;
-        let remote_urls = crate::git_info::get_git_remote_urls(turn_context.cwd.as_path()).await;
+        let remote_urls = if git_info.is_some() {
+            crate::git_info::get_git_remote_urls(turn_context.cwd.as_path()).await
+        } else {
+            None
+        };
         let workspace_configuration = build_workspace_configuration(
             turn_context.cwd.as_path(),
             git_info.as_ref(),

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -282,11 +282,8 @@ mod tests {
             },
         );
         let workspace_configuration = WorkspaceConfiguration { workspaces };
-        let context = EnvironmentContext::new(
-            Some(cwd.clone()),
-            fake_shell(),
-            Some(workspace_configuration),
-        );
+        let context =
+            EnvironmentContext::new(Some(cwd), fake_shell(), Some(workspace_configuration));
 
         let expected = r#"<environment_context>
   <cwd>/repo</cwd>

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -100,10 +100,8 @@ impl EnvironmentContext {
         if let Some(workspace_configuration) = self.workspace_configuration {
             lines.push("  <workspace_configuration>".to_string());
             for (path, workspace) in workspace_configuration.workspaces {
-                lines.push(format!(
-                    "    <workspace path=\"{path}\" hint=\"{}\">",
-                    workspace.hint
-                ));
+                let hint = workspace.hint;
+                lines.push(format!("    <workspace path=\"{path}\" hint=\"{hint}\">"));
 
                 if let Some(latest_git_commit_hash) = workspace.latest_git_commit_hash {
                     lines.push(format!(

--- a/codex-rs/core/src/git_info.rs
+++ b/codex-rs/core/src/git_info.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::collections::HashSet;
 use std::path::Path;
 use std::path::PathBuf;
@@ -107,6 +108,40 @@ pub async fn collect_git_info(cwd: &Path) -> Option<GitInfo> {
     }
 
     Some(git_info)
+}
+
+/// Collect fetch remotes in a multi-root-friendly format: ["origin: https://..."].
+pub async fn get_git_remote_urls(cwd: &Path) -> Option<Vec<String>> {
+    let is_git_repo = run_git_command_with_timeout(&["rev-parse", "--git-dir"], cwd)
+        .await?
+        .status
+        .success();
+    if !is_git_repo {
+        return None;
+    }
+
+    let output = run_git_command_with_timeout(&["remote", "-v"], cwd).await?;
+    if !output.status.success() {
+        return None;
+    }
+
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    let mut remotes = BTreeSet::new();
+    for line in stdout.lines() {
+        if !line.contains("(fetch)") {
+            continue;
+        }
+        let mut parts = line.split_whitespace();
+        if let (Some(name), Some(url)) = (parts.next(), parts.next()) {
+            remotes.insert(format!("{name}: {url}"));
+        }
+    }
+
+    if remotes.is_empty() {
+        None
+    } else {
+        Some(remotes.into_iter().collect())
+    }
 }
 
 /// A minimal commit summary entry used for pickers (subject + timestamp + sha).


### PR DESCRIPTION
adds basic git context to the session prefix so the model can anchor git actions and be a bit more version-aware. structured it in a multiroot-friendly shape even though we only have one root today