### PR TITLE
make codex better at git

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -145,11 +145,7 @@ impl ModelClient {
         }
     }
 
-    pub fn new_session(
-        &self,
-        _turn_metadata_header: Option<String>,
-        turn_metadata_cwd: Option<PathBuf>,
-    ) -> ModelClientSession {
+    pub fn new_session(&self, turn_metadata_cwd: Option<PathBuf>) -> ModelClientSession {
         ModelClientSession {
             state: Arc::clone(&self.state),
             connection: None,

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -147,18 +147,7 @@ impl ModelClient {
         }
     }
 
-    pub fn new_session(&self) -> ModelClientSession {
-        self.new_session_with_turn_metadata_and_cwd(None, None)
-    }
-
-    pub fn new_session_with_turn_metadata(
-        &self,
-        turn_metadata_header: Option<String>,
-    ) -> ModelClientSession {
-        self.new_session_with_turn_metadata_and_cwd(turn_metadata_header, None)
-    }
-
-    pub fn new_session_with_turn_metadata_and_cwd(
+    pub fn new_session(
         &self,
         turn_metadata_header: Option<String>,
         turn_metadata_cwd: Option<PathBuf>,

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -1,3 +1,4 @@
+use std::path::PathBuf;
 use std::sync::Arc;
 use std::sync::OnceLock;
 
@@ -5,6 +6,7 @@ use crate::api_bridge::CoreAuthProvider;
 use crate::api_bridge::auth_provider_from_auth;
 use crate::api_bridge::map_api_error;
 use crate::auth::UnauthorizedRecovery;
+use crate::turn_metadata::build_turn_metadata_header;
 use codex_api::AggregateStreamExt;
 use codex_api::ChatClient as ApiChatClient;
 use codex_api::CompactClient as ApiCompactClient;
@@ -72,6 +74,7 @@ use crate::transport_manager::TransportManager;
 
 pub const WEB_SEARCH_ELIGIBLE_HEADER: &str = "x-oai-web-search-eligible";
 pub const X_CODEX_TURN_STATE_HEADER: &str = "x-codex-turn-state";
+pub const X_CODEX_TURN_METADATA_HEADER: &str = "x-codex-turn-metadata";
 
 #[derive(Debug)]
 struct ModelClientState {
@@ -108,6 +111,10 @@ pub struct ModelClientSession {
     /// keep sending it unchanged between turn requests (e.g., for retries, incremental
     /// appends, or continuation requests), and must not send it between different turns.
     turn_state: Arc<OnceLock<String>>,
+    /// Turn-scoped metadata attached to every request in the turn.
+    turn_metadata_header: Option<HeaderValue>,
+    /// Working directory used to lazily compute turn metadata at send time.
+    turn_metadata_cwd: Option<PathBuf>,
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -141,12 +148,31 @@ impl ModelClient {
     }
 
     pub fn new_session(&self) -> ModelClientSession {
+        self.new_session_with_turn_metadata_and_cwd(None, None)
+    }
+
+    pub fn new_session_with_turn_metadata(
+        &self,
+        turn_metadata_header: Option<String>,
+    ) -> ModelClientSession {
+        self.new_session_with_turn_metadata_and_cwd(turn_metadata_header, None)
+    }
+
+    pub fn new_session_with_turn_metadata_and_cwd(
+        &self,
+        turn_metadata_header: Option<String>,
+        turn_metadata_cwd: Option<PathBuf>,
+    ) -> ModelClientSession {
+        let turn_metadata_header =
+            turn_metadata_header.and_then(|value| HeaderValue::from_str(&value).ok());
         ModelClientSession {
             state: Arc::clone(&self.state),
             connection: None,
             websocket_last_items: Vec::new(),
             transport_manager: self.state.transport_manager.clone(),
             turn_state: Arc::new(OnceLock::new()),
+            turn_metadata_header,
+            turn_metadata_cwd,
         }
     }
 }
@@ -257,6 +283,21 @@ impl ModelClient {
 }
 
 impl ModelClientSession {
+    async fn ensure_turn_metadata_header(&mut self) {
+        if self.turn_metadata_header.is_some() {
+            return;
+        }
+        let Some(cwd) = self.turn_metadata_cwd.as_deref() else {
+            return;
+        };
+        let Some(value) = build_turn_metadata_header(cwd).await else {
+            return;
+        };
+        if let Ok(header_value) = HeaderValue::from_str(value.as_str()) {
+            self.turn_metadata_header = Some(header_value);
+        }
+    }
+
     /// Streams a single model turn using either the Responses or Chat
     /// Completions wire API, depending on the configured provider.
     ///
@@ -264,6 +305,9 @@ impl ModelClientSession {
     /// based on the `show_raw_agent_reasoning` flag in the config.
     pub async fn stream(&mut self, prompt: &Prompt) -> Result<ResponseStream> {
         let wire_api = self.state.provider.wire_api;
+        if matches!(wire_api, WireApi::Responses) {
+            self.ensure_turn_metadata_header().await;
+        }
         match wire_api {
             WireApi::Responses => {
                 let websocket_enabled = self.responses_websocket_enabled()
@@ -380,7 +424,11 @@ impl ModelClientSession {
             store_override: None,
             conversation_id: Some(conversation_id),
             session_source: Some(self.state.session_source.clone()),
-            extra_headers: build_responses_headers(&self.state.config, Some(&self.turn_state)),
+            extra_headers: build_responses_headers(
+                &self.state.config,
+                Some(&self.turn_state),
+                self.turn_metadata_header.as_ref(),
+            ),
             compression,
             turn_state: Some(Arc::clone(&self.turn_state)),
         }
@@ -713,6 +761,7 @@ fn experimental_feature_headers(config: &Config) -> ApiHeaderMap {
 fn build_responses_headers(
     config: &Config,
     turn_state: Option<&Arc<OnceLock<String>>>,
+    turn_metadata_header: Option<&HeaderValue>,
 ) -> ApiHeaderMap {
     let mut headers = experimental_feature_headers(config);
     headers.insert(
@@ -730,6 +779,9 @@ fn build_responses_headers(
         && let Ok(header_value) = HeaderValue::from_str(state)
     {
         headers.insert(X_CODEX_TURN_STATE_HEADER, header_value);
+    }
+    if let Some(header_value) = turn_metadata_header {
+        headers.insert(X_CODEX_TURN_METADATA_HEADER, header_value.clone());
     }
     headers
 }

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -264,12 +264,8 @@ impl ModelClient {
 
 impl ModelClientSession {
     async fn turn_metadata_header(&self) -> Option<HeaderValue> {
-        let Some(cwd) = self.turn_metadata_cwd.as_deref() else {
-            return None;
-        };
-        let Some(value) = build_turn_metadata_header(cwd).await else {
-            return None;
-        };
+        let cwd = self.turn_metadata_cwd.as_deref()?;
+        let value = build_turn_metadata_header(cwd).await?;
         HeaderValue::from_str(value.as_str()).ok()
     }
 

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -166,10 +166,6 @@ impl ModelClient {
     /// Refresh turn metadata in the background and update a cached header that request
     /// builders can read without blocking.
     fn prewarm_turn_metadata_header(&self, turn_metadata_cwd: Option<PathBuf>) {
-        if self.state.provider.wire_api != WireApi::Responses {
-            return;
-        }
-
         let turn_metadata_cwd =
             turn_metadata_cwd.map(|cwd| std::fs::canonicalize(&cwd).unwrap_or(cwd));
 

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -196,27 +196,7 @@ impl ModelClient {
                     cache.header = header;
                 }
             });
-            return;
         }
-
-        let _task = std::thread::spawn(move || {
-            let Ok(runtime) = tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-            else {
-                return;
-            };
-
-            let header = runtime
-                .block_on(build_turn_metadata_header(cwd.as_path()))
-                .and_then(|value| HeaderValue::from_str(value.as_str()).ok());
-
-            if let Ok(mut cache) = turn_metadata_cache.write()
-                && cache.cwd.as_ref() == Some(&cwd)
-            {
-                cache.header = header;
-            }
-        });
     }
 }
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3382,7 +3382,7 @@ pub(crate) async fn run_turn(
     // many turns, from the perspective of the user, it is a single turn.
     let turn_diff_tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));
 
-    let mut client_session = turn_context.client.new_session_with_turn_metadata_and_cwd(
+    let mut client_session = turn_context.client.new_session(
         turn_context.turn_metadata_header.clone(),
         Some(turn_context.cwd.clone()),
     );

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -504,7 +504,6 @@ pub(crate) struct TurnContext {
     pub(crate) tool_call_gate: Arc<ReadinessFlag>,
     pub(crate) truncation_policy: TruncationPolicy,
     pub(crate) dynamic_tools: Vec<DynamicToolSpec>,
-    pub(crate) turn_metadata_header: Option<String>,
 }
 impl TurnContext {
     pub(crate) fn resolve_path(&self, path: Option<String>) -> PathBuf {
@@ -706,7 +705,6 @@ impl Session {
             tool_call_gate: Arc::new(ReadinessFlag::new()),
             truncation_policy: model_info.truncation_policy.into(),
             dynamic_tools: session_configuration.dynamic_tools.clone(),
-            turn_metadata_header: None,
         }
     }
 
@@ -3178,7 +3176,6 @@ async fn spawn_review_thread(
         tool_call_gate: Arc::new(ReadinessFlag::new()),
         dynamic_tools: parent_turn_context.dynamic_tools.clone(),
         truncation_policy: model_info.truncation_policy.into(),
-        turn_metadata_header: None,
     };
 
     // Seed the child task with the review prompt as the initial user message.
@@ -3382,10 +3379,9 @@ pub(crate) async fn run_turn(
     // many turns, from the perspective of the user, it is a single turn.
     let turn_diff_tracker = Arc::new(tokio::sync::Mutex::new(TurnDiffTracker::new()));
 
-    let mut client_session = turn_context.client.new_session(
-        turn_context.turn_metadata_header.clone(),
-        Some(turn_context.cwd.clone()),
-    );
+    let mut client_session = turn_context
+        .client
+        .new_session(Some(turn_context.cwd.clone()));
 
     loop {
         // Note that pending_input would be something like a message the user

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -335,7 +335,7 @@ async fn drain_to_completed(
     turn_context: &TurnContext,
     prompt: &Prompt,
 ) -> CodexResult<()> {
-    let mut client_session = turn_context.client.new_session_with_turn_metadata_and_cwd(
+    let mut client_session = turn_context.client.new_session(
         turn_context.turn_metadata_header.clone(),
         Some(turn_context.cwd.clone()),
     );

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -335,7 +335,10 @@ async fn drain_to_completed(
     turn_context: &TurnContext,
     prompt: &Prompt,
 ) -> CodexResult<()> {
-    let mut client_session = turn_context.client.new_session();
+    let mut client_session = turn_context.client.new_session_with_turn_metadata_and_cwd(
+        turn_context.turn_metadata_header.clone(),
+        Some(turn_context.cwd.clone()),
+    );
     let mut stream = client_session.stream(prompt).await?;
     loop {
         let maybe_event = stream.next().await;

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -335,10 +335,9 @@ async fn drain_to_completed(
     turn_context: &TurnContext,
     prompt: &Prompt,
 ) -> CodexResult<()> {
-    let mut client_session = turn_context.client.new_session(
-        turn_context.turn_metadata_header.clone(),
-        Some(turn_context.cwd.clone()),
-    );
+    let mut client_session = turn_context
+        .client
+        .new_session(Some(turn_context.cwd.clone()));
     let mut stream = client_session.stream(prompt).await?;
     loop {
         let maybe_event = stream.next().await;

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -67,7 +67,6 @@ impl EnvironmentContext {
 
         let shell_name = self.shell.name();
         lines.push(format!("  <shell>{shell_name}</shell>"));
-
         lines.push(ENVIRONMENT_CONTEXT_CLOSE_TAG.to_string());
         lines.join("\n")
     }

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -28,6 +28,7 @@ impl EnvironmentContext {
             cwd,
             // should compare all fields except shell
             shell: _,
+            ..
         } = other;
 
         self.cwd == *cwd
@@ -66,6 +67,7 @@ impl EnvironmentContext {
 
         let shell_name = self.shell.name();
         lines.push(format!("  <shell>{shell_name}</shell>"));
+
         lines.push(ENVIRONMENT_CONTEXT_CLOSE_TAG.to_string());
         lines.join("\n")
     }

--- a/codex-rs/core/src/git_info.rs
+++ b/codex-rs/core/src/git_info.rs
@@ -125,16 +125,7 @@ pub async fn get_git_remote_urls(cwd: &Path) -> Option<BTreeMap<String, String>>
 
 /// Collect fetch remotes without checking whether `cwd` is in a git repo.
 pub async fn get_git_remote_urls_assume_git_repo(cwd: &Path) -> Option<BTreeMap<String, String>> {
-    get_git_remote_urls_assume_git_repo_with_timeout(cwd, GIT_COMMAND_TIMEOUT).await
-}
-
-/// Collect fetch remotes without checking whether `cwd` is in a git repo,
-/// using the provided timeout.
-pub async fn get_git_remote_urls_assume_git_repo_with_timeout(
-    cwd: &Path,
-    timeout_dur: TokioDuration,
-) -> Option<BTreeMap<String, String>> {
-    let output = run_git_command_with_timeout_override(&["remote", "-v"], cwd, timeout_dur).await?;
+    let output = run_git_command_with_timeout(&["remote", "-v"], cwd).await?;
     if !output.status.success() {
         return None;
     }
@@ -145,17 +136,7 @@ pub async fn get_git_remote_urls_assume_git_repo_with_timeout(
 
 /// Return the current HEAD commit hash without checking whether `cwd` is in a git repo.
 pub async fn get_head_commit_hash(cwd: &Path) -> Option<String> {
-    get_head_commit_hash_with_timeout(cwd, GIT_COMMAND_TIMEOUT).await
-}
-
-/// Return the current HEAD commit hash without checking whether `cwd` is in a
-/// git repo, using the provided timeout.
-pub async fn get_head_commit_hash_with_timeout(
-    cwd: &Path,
-    timeout_dur: TokioDuration,
-) -> Option<String> {
-    let output =
-        run_git_command_with_timeout_override(&["rev-parse", "HEAD"], cwd, timeout_dur).await?;
+    let output = run_git_command_with_timeout(&["rev-parse", "HEAD"], cwd).await?;
     if !output.status.success() {
         return None;
     }
@@ -272,19 +253,11 @@ pub async fn git_diff_to_remote(cwd: &Path) -> Option<GitDiffToRemote> {
 
 /// Run a git command with a timeout to prevent blocking on large repositories
 async fn run_git_command_with_timeout(args: &[&str], cwd: &Path) -> Option<std::process::Output> {
-    run_git_command_with_timeout_override(args, cwd, GIT_COMMAND_TIMEOUT).await
-}
-
-/// Run a git command with a caller-provided timeout.
-async fn run_git_command_with_timeout_override(
-    args: &[&str],
-    cwd: &Path,
-    timeout_dur: TokioDuration,
-) -> Option<std::process::Output> {
-    let mut command = Command::new("git");
-    command.args(args).current_dir(cwd);
-    command.kill_on_drop(true);
-    let result = timeout(timeout_dur, command.output()).await;
+    let result = timeout(
+        GIT_COMMAND_TIMEOUT,
+        Command::new("git").args(args).current_dir(cwd).output(),
+    )
+    .await;
 
     match result {
         Ok(Ok(output)) => Some(output),

--- a/codex-rs/core/src/git_info.rs
+++ b/codex-rs/core/src/git_info.rs
@@ -253,11 +253,9 @@ pub async fn git_diff_to_remote(cwd: &Path) -> Option<GitDiffToRemote> {
 
 /// Run a git command with a timeout to prevent blocking on large repositories
 async fn run_git_command_with_timeout(args: &[&str], cwd: &Path) -> Option<std::process::Output> {
-    let result = timeout(
-        GIT_COMMAND_TIMEOUT,
-        Command::new("git").args(args).current_dir(cwd).output(),
-    )
-    .await;
+    let mut command = Command::new("git");
+    command.args(args).current_dir(cwd).kill_on_drop(true);
+    let result = timeout(GIT_COMMAND_TIMEOUT, command.output()).await;
 
     match result {
         Ok(Ok(output)) => Some(output),

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -101,6 +101,7 @@ pub mod state_db;
 pub mod terminal;
 mod tools;
 pub mod turn_diff_tracker;
+mod turn_metadata;
 pub use rollout::ARCHIVED_SESSIONS_SUBDIR;
 pub use rollout::INTERACTIVE_SESSION_SOURCES;
 pub use rollout::RolloutRecorder;
@@ -131,6 +132,7 @@ pub mod util;
 
 pub use apply_patch::CODEX_APPLY_PATCH_ARG1;
 pub use client::WEB_SEARCH_ELIGIBLE_HEADER;
+pub use client::X_CODEX_TURN_METADATA_HEADER;
 pub use command_safety::is_dangerous_command;
 pub use command_safety::is_safe_command;
 pub use exec_policy::ExecPolicyError;

--- a/codex-rs/core/src/turn_metadata.rs
+++ b/codex-rs/core/src/turn_metadata.rs
@@ -1,0 +1,52 @@
+use std::collections::BTreeMap;
+use std::path::Path;
+
+use serde::Serialize;
+use tokio::time::Duration as TokioDuration;
+
+use crate::git_info::get_git_remote_urls_assume_git_repo_with_timeout;
+use crate::git_info::get_git_repo_root;
+use crate::git_info::get_head_commit_hash_with_timeout;
+
+const TURN_METADATA_TIMEOUT: TokioDuration = TokioDuration::from_millis(150);
+
+#[derive(Serialize)]
+struct TurnMetadataWorkspace {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    associated_remote_urls: Option<BTreeMap<String, String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    latest_git_commit_hash: Option<String>,
+}
+
+#[derive(Serialize)]
+struct TurnMetadata {
+    workspaces: BTreeMap<String, TurnMetadataWorkspace>,
+}
+
+/// Build a per-turn metadata header value for the given working directory.
+///
+/// This is intentionally evaluated lazily at request send time so turns that
+/// never reach the model do not pay the git subprocess cost.
+pub(crate) async fn build_turn_metadata_header(cwd: &Path) -> Option<String> {
+    let repo_root = get_git_repo_root(cwd)?;
+
+    // Keep git subprocess work bounded per command, without wrapping the
+    // entire metadata build in a separate timeout.
+    let (latest_git_commit_hash, associated_remote_urls) = tokio::join!(
+        get_head_commit_hash_with_timeout(cwd, TURN_METADATA_TIMEOUT),
+        get_git_remote_urls_assume_git_repo_with_timeout(cwd, TURN_METADATA_TIMEOUT)
+    );
+    if latest_git_commit_hash.is_none() && associated_remote_urls.is_none() {
+        return None;
+    }
+
+    let mut workspaces = BTreeMap::new();
+    workspaces.insert(
+        repo_root.to_string_lossy().into_owned(),
+        TurnMetadataWorkspace {
+            associated_remote_urls,
+            latest_git_commit_hash,
+        },
+    );
+    serde_json::to_string(&TurnMetadata { workspaces }).ok()
+}

--- a/codex-rs/core/src/turn_metadata.rs
+++ b/codex-rs/core/src/turn_metadata.rs
@@ -8,7 +8,7 @@ use crate::git_info::get_git_remote_urls_assume_git_repo_with_timeout;
 use crate::git_info::get_git_repo_root;
 use crate::git_info::get_head_commit_hash_with_timeout;
 
-const TURN_METADATA_TIMEOUT: TokioDuration = TokioDuration::from_millis(150);
+const TURN_METADATA_TIMEOUT: TokioDuration = TokioDuration::from_secs(5);
 
 #[derive(Serialize)]
 struct TurnMetadataWorkspace {

--- a/codex-rs/core/src/turn_metadata.rs
+++ b/codex-rs/core/src/turn_metadata.rs
@@ -20,7 +20,6 @@ struct TurnMetadata {
     workspaces: BTreeMap<String, TurnMetadataWorkspace>,
 }
 
-/// this happens at request send time only
 pub(crate) async fn build_turn_metadata_header(cwd: &Path) -> Option<String> {
     let repo_root = get_git_repo_root(cwd)?;
 

--- a/codex-rs/core/src/turn_metadata.rs
+++ b/codex-rs/core/src/turn_metadata.rs
@@ -2,13 +2,10 @@ use std::collections::BTreeMap;
 use std::path::Path;
 
 use serde::Serialize;
-use tokio::time::Duration as TokioDuration;
 
-use crate::git_info::get_git_remote_urls_assume_git_repo_with_timeout;
+use crate::git_info::get_git_remote_urls_assume_git_repo;
 use crate::git_info::get_git_repo_root;
-use crate::git_info::get_head_commit_hash_with_timeout;
-
-const TURN_METADATA_TIMEOUT: TokioDuration = TokioDuration::from_secs(5);
+use crate::git_info::get_head_commit_hash;
 
 #[derive(Serialize)]
 struct TurnMetadataWorkspace {
@@ -28,8 +25,8 @@ pub(crate) async fn build_turn_metadata_header(cwd: &Path) -> Option<String> {
     let repo_root = get_git_repo_root(cwd)?;
 
     let (latest_git_commit_hash, associated_remote_urls) = tokio::join!(
-        get_head_commit_hash_with_timeout(cwd, TURN_METADATA_TIMEOUT),
-        get_git_remote_urls_assume_git_repo_with_timeout(cwd, TURN_METADATA_TIMEOUT)
+        get_head_commit_hash(cwd),
+        get_git_remote_urls_assume_git_repo(cwd)
     );
     if latest_git_commit_hash.is_none() && associated_remote_urls.is_none() {
         return None;

--- a/codex-rs/core/tests/chat_completions_payload.rs
+++ b/codex-rs/core/tests/chat_completions_payload.rs
@@ -102,7 +102,7 @@ async fn run_request(input: Vec<ResponseItem>) -> Value {
         SessionSource::Exec,
         TransportManager::new(),
     )
-    .new_session(None, None);
+    .new_session(None);
 
     let mut prompt = Prompt::default();
     prompt.input = input;

--- a/codex-rs/core/tests/chat_completions_payload.rs
+++ b/codex-rs/core/tests/chat_completions_payload.rs
@@ -102,7 +102,7 @@ async fn run_request(input: Vec<ResponseItem>) -> Value {
         SessionSource::Exec,
         TransportManager::new(),
     )
-    .new_session();
+    .new_session(None, None);
 
     let mut prompt = Prompt::default();
     prompt.input = input;

--- a/codex-rs/core/tests/chat_completions_sse.rs
+++ b/codex-rs/core/tests/chat_completions_sse.rs
@@ -103,7 +103,7 @@ async fn run_stream_with_bytes(sse_body: &[u8]) -> Vec<ResponseEvent> {
         SessionSource::Exec,
         TransportManager::new(),
     )
-    .new_session();
+    .new_session(None, None);
 
     let mut prompt = Prompt::default();
     prompt.input = vec![ResponseItem::Message {

--- a/codex-rs/core/tests/chat_completions_sse.rs
+++ b/codex-rs/core/tests/chat_completions_sse.rs
@@ -103,7 +103,7 @@ async fn run_stream_with_bytes(sse_body: &[u8]) -> Vec<ResponseEvent> {
         SessionSource::Exec,
         TransportManager::new(),
     )
-    .new_session(None, None);
+    .new_session(None);
 
     let mut prompt = Prompt::default();
     prompt.input = vec![ResponseItem::Message {

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -99,7 +99,7 @@ async fn responses_stream_includes_subagent_header_on_review() {
         session_source,
         TransportManager::new(),
     )
-    .new_session();
+    .new_session(None, None);
 
     let mut prompt = Prompt::default();
     prompt.input = vec![ResponseItem::Message {
@@ -198,7 +198,7 @@ async fn responses_stream_includes_subagent_header_on_other() {
         session_source,
         TransportManager::new(),
     )
-    .new_session();
+    .new_session(None, None);
 
     let mut prompt = Prompt::default();
     prompt.input = vec![ResponseItem::Message {
@@ -355,7 +355,7 @@ async fn responses_respects_model_info_overrides_from_config() {
         session_source,
         TransportManager::new(),
     )
-    .new_session();
+    .new_session(None, None);
 
     let mut prompt = Prompt::default();
     prompt.input = vec![ResponseItem::Message {

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -493,10 +493,11 @@ async fn responses_stream_includes_turn_metadata_header_for_git_workspace_e2e() 
         None
     );
 
-    let null_device = if cfg!(windows) { "NUL" } else { "/dev/null" };
+    let git_config_global = cwd.join("empty-git-config");
+    std::fs::write(&git_config_global, "").expect("write empty git config");
     let run_git = |args: &[&str]| {
         let output = Command::new("git")
-            .env("GIT_CONFIG_GLOBAL", null_device)
+            .env("GIT_CONFIG_GLOBAL", &git_config_global)
             .env("GIT_CONFIG_NOSYSTEM", "1")
             .args(args)
             .current_dir(cwd)

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -23,6 +23,7 @@ use core_test_support::load_default_config_for_test;
 use core_test_support::responses;
 use core_test_support::test_codex::test_codex;
 use futures::StreamExt;
+use pretty_assertions::assert_eq;
 use tempfile::TempDir;
 use wiremock::matchers::header;
 

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -99,7 +99,7 @@ async fn responses_stream_includes_subagent_header_on_review() {
         session_source,
         TransportManager::new(),
     )
-    .new_session(None, None);
+    .new_session(None);
 
     let mut prompt = Prompt::default();
     prompt.input = vec![ResponseItem::Message {
@@ -198,7 +198,7 @@ async fn responses_stream_includes_subagent_header_on_other() {
         session_source,
         TransportManager::new(),
     )
-    .new_session(None, None);
+    .new_session(None);
 
     let mut prompt = Prompt::default();
     prompt.input = vec![ResponseItem::Message {
@@ -355,7 +355,7 @@ async fn responses_respects_model_info_overrides_from_config() {
         session_source,
         TransportManager::new(),
     )
-    .new_session(None, None);
+    .new_session(None);
 
     let mut prompt = Prompt::default();
     prompt.input = vec![ResponseItem::Message {

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -1190,7 +1190,7 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
         SessionSource::Exec,
         TransportManager::new(),
     )
-    .new_session(None, None);
+    .new_session(None);
 
     let mut prompt = Prompt::default();
     prompt.input.push(ResponseItem::Reasoning {

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -1190,7 +1190,7 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
         SessionSource::Exec,
         TransportManager::new(),
     )
-    .new_session();
+    .new_session(None, None);
 
     let mut prompt = Prompt::default();
     prompt.input.push(ResponseItem::Reasoning {

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -53,7 +53,7 @@ async fn responses_websocket_streams_request() {
     .await;
 
     let harness = websocket_harness(&server).await;
-    let mut session = harness.client.new_session();
+    let mut session = harness.client.new_session(None, None);
     let prompt = prompt_with_input(vec![message_item("hello")]);
 
     stream_until_complete(&mut session, &prompt).await;
@@ -83,7 +83,7 @@ async fn responses_websocket_emits_websocket_telemetry_events() {
 
     let harness = websocket_harness(&server).await;
     harness.otel_manager.reset_runtime_metrics();
-    let mut session = harness.client.new_session();
+    let mut session = harness.client.new_session(None, None);
     let prompt = prompt_with_input(vec![message_item("hello")]);
 
     stream_until_complete(&mut session, &prompt).await;
@@ -113,7 +113,7 @@ async fn responses_websocket_emits_reasoning_included_event() {
     .await;
 
     let harness = websocket_harness(&server).await;
-    let mut session = harness.client.new_session();
+    let mut session = harness.client.new_session(None, None);
     let prompt = prompt_with_input(vec![message_item("hello")]);
 
     let mut stream = session
@@ -147,7 +147,7 @@ async fn responses_websocket_appends_on_prefix() {
     .await;
 
     let harness = websocket_harness(&server).await;
-    let mut session = harness.client.new_session();
+    let mut session = harness.client.new_session(None, None);
     let prompt_one = prompt_with_input(vec![message_item("hello")]);
     let prompt_two = prompt_with_input(vec![message_item("hello"), message_item("second")]);
 
@@ -183,7 +183,7 @@ async fn responses_websocket_creates_on_non_prefix() {
     .await;
 
     let harness = websocket_harness(&server).await;
-    let mut session = harness.client.new_session();
+    let mut session = harness.client.new_session(None, None);
     let prompt_one = prompt_with_input(vec![message_item("hello")]);
     let prompt_two = prompt_with_input(vec![message_item("different")]);
 

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -53,7 +53,7 @@ async fn responses_websocket_streams_request() {
     .await;
 
     let harness = websocket_harness(&server).await;
-    let mut session = harness.client.new_session(None, None);
+    let mut session = harness.client.new_session(None);
     let prompt = prompt_with_input(vec![message_item("hello")]);
 
     stream_until_complete(&mut session, &prompt).await;
@@ -83,7 +83,7 @@ async fn responses_websocket_emits_websocket_telemetry_events() {
 
     let harness = websocket_harness(&server).await;
     harness.otel_manager.reset_runtime_metrics();
-    let mut session = harness.client.new_session(None, None);
+    let mut session = harness.client.new_session(None);
     let prompt = prompt_with_input(vec![message_item("hello")]);
 
     stream_until_complete(&mut session, &prompt).await;
@@ -113,7 +113,7 @@ async fn responses_websocket_emits_reasoning_included_event() {
     .await;
 
     let harness = websocket_harness(&server).await;
-    let mut session = harness.client.new_session(None, None);
+    let mut session = harness.client.new_session(None);
     let prompt = prompt_with_input(vec![message_item("hello")]);
 
     let mut stream = session
@@ -147,7 +147,7 @@ async fn responses_websocket_appends_on_prefix() {
     .await;
 
     let harness = websocket_harness(&server).await;
-    let mut session = harness.client.new_session(None, None);
+    let mut session = harness.client.new_session(None);
     let prompt_one = prompt_with_input(vec![message_item("hello")]);
     let prompt_two = prompt_with_input(vec![message_item("hello"), message_item("second")]);
 
@@ -183,7 +183,7 @@ async fn responses_websocket_creates_on_non_prefix() {
     .await;
 
     let harness = websocket_harness(&server).await;
-    let mut session = harness.client.new_session(None, None);
+    let mut session = harness.client.new_session(None);
     let prompt_one = prompt_with_input(vec![message_item("hello")]);
     let prompt_two = prompt_with_input(vec![message_item("different")]);
 


### PR DESCRIPTION
adds basic git context to the session prefix so the model can anchor git actions and be a bit more version-aware. structured it in a multiroot-friendly shape even though we only have one root today