### PR TITLE
[experimental] nit: try to speed up apt-install

### DIFF
--- a/.github/workflows/shell-tool-mcp.yml
+++ b/.github/workflows/shell-tool-mcp.yml
@@ -256,12 +256,12 @@ jobs:
               if [[ "${ID-}" == "ubuntu" ]]; then
                 codename="${VERSION_CODENAME:-}"
                 if [[ -n "$codename" ]]; then
-                  cat >/etc/apt/sources.list <<EOF
-deb http://ports.ubuntu.com/ubuntu-ports ${codename} main
-deb http://ports.ubuntu.com/ubuntu-ports ${codename}-updates main
-deb http://ports.ubuntu.com/ubuntu-ports ${codename}-backports main
-deb http://ports.ubuntu.com/ubuntu-ports ${codename}-security main
-EOF
+                  printf '%s\n' \
+                    "deb http://ports.ubuntu.com/ubuntu-ports ${codename} main" \
+                    "deb http://ports.ubuntu.com/ubuntu-ports ${codename}-updates main" \
+                    "deb http://ports.ubuntu.com/ubuntu-ports ${codename}-backports main" \
+                    "deb http://ports.ubuntu.com/ubuntu-ports ${codename}-security main" \
+                    >/etc/apt/sources.list
                 fi
               fi
             fi

--- a/.github/workflows/shell-tool-mcp.yml
+++ b/.github/workflows/shell-tool-mcp.yml
@@ -248,8 +248,14 @@ jobs:
         run: |
           set -euo pipefail
           if command -v apt-get >/dev/null 2>&1; then
-            apt-get update
-            DEBIAN_FRONTEND=noninteractive apt-get install -y git build-essential bison autoconf gettext
+            apt_opts=(
+              -o Acquire::Retries=3
+              -o Acquire::http::Timeout=30
+              -o Acquire::https::Timeout=30
+              -o Acquire::Languages=none
+            )
+            apt-get "${apt_opts[@]}" update
+            DEBIAN_FRONTEND=noninteractive apt-get "${apt_opts[@]}" install -y git build-essential bison autoconf gettext
           elif command -v dnf >/dev/null 2>&1; then
             dnf install -y git gcc gcc-c++ make bison autoconf gettext
           elif command -v yum >/dev/null 2>&1; then

--- a/.github/workflows/shell-tool-mcp.yml
+++ b/.github/workflows/shell-tool-mcp.yml
@@ -248,6 +248,24 @@ jobs:
         run: |
           set -euo pipefail
           if command -v apt-get >/dev/null 2>&1; then
+            # On Ubuntu ARM containers, apt metadata for universe/multiverse is large and
+            # can make `apt-get update` very slow. We only need packages from `main`, so
+            # trim sources to `main` for faster, more reliable updates.
+            if [[ "${{ matrix.target }}" == "aarch64-unknown-linux-musl" ]] && [[ -f /etc/os-release ]]; then
+              . /etc/os-release
+              if [[ "${ID-}" == "ubuntu" ]]; then
+                codename="${VERSION_CODENAME:-}"
+                if [[ -n "$codename" ]]; then
+                  cat >/etc/apt/sources.list <<EOF
+deb http://ports.ubuntu.com/ubuntu-ports ${codename} main
+deb http://ports.ubuntu.com/ubuntu-ports ${codename}-updates main
+deb http://ports.ubuntu.com/ubuntu-ports ${codename}-backports main
+deb http://ports.ubuntu.com/ubuntu-ports ${codename}-security main
+EOF
+                fi
+              fi
+            fi
+
             apt_opts=(
               -o Acquire::Retries=3
               -o Acquire::http::Timeout=30


### PR DESCRIPTION
Improved `apt` reliability/perf in `Build Bash (Linux)` jobs:
- Added apt options for retries/timeouts and reduced metadata overhead.
- Trimmed Ubuntu ARM apt sources to `main` only (to avoid large `universe/restricted/multiverse` index downloads)

(Scoped to `aarch64-unknown-linux-musl` jobs only)