### PR TITLE
feat(core): add network config surface for proxy

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1711,6 +1711,7 @@ dependencies = [
  "tempfile",
  "time",
  "tokio",
+ "toml 0.9.5",
  "tracing",
  "tracing-subscriber",
  "url",

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -455,6 +455,29 @@
       ],
       "type": "object"
     },
+    "NetworkConfigToml": {
+      "additionalProperties": false,
+      "description": "Network proxy configuration layer from `[[network]]` entries in `config.toml`.\n\nMultiple `[[network]]` entries are merged in order (later entries win).",
+      "properties": {
+        "enabled": {
+          "description": "Enable proxy configuration for sandboxed tool execution.",
+          "type": "boolean"
+        },
+        "no_proxy": {
+          "default": null,
+          "description": "Optional NO_PROXY entries.",
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "socks_proxy": {
+          "description": "SOCKS proxy URL (for example: `socks5h://127.0.0.1:1080`).",
+          "type": "string"
+        }
+      },
+      "type": "object"
+    },
     "Notice": {
       "description": "Settings for notices we display to users via the tui and app-server clients (primarily the Codex IDE extension). NOTE: these are different from notifications - notices are warnings, NUX screens, acknowledgements, etc.",
       "properties": {
@@ -1396,6 +1419,14 @@
         }
       ],
       "description": "Optional verbosity control for GPT-5 models (Responses API `text.verbosity`)."
+    },
+    "network": {
+      "default": [],
+      "description": "Ordered proxy config layers. Later entries win.",
+      "items": {
+        "$ref": "#/definitions/NetworkConfigToml"
+      },
+      "type": "array"
     },
     "notice": {
       "allOf": [

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -475,6 +475,12 @@
           "description": "Enable proxy configuration for sandboxed tool execution.",
           "type": "boolean"
         },
+        "http_port": {
+          "description": "HTTP proxy listener port (loopback).",
+          "format": "uint16",
+          "minimum": 0.0,
+          "type": "integer"
+        },
         "mode": {
           "allOf": [
             {
@@ -491,6 +497,12 @@
           ],
           "default": null,
           "description": "Policy configuration."
+        },
+        "socks_port": {
+          "description": "SOCKS5 proxy listener port (loopback).",
+          "format": "uint16",
+          "minimum": 0.0,
+          "type": "integer"
         }
       },
       "type": "object"

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -459,21 +459,72 @@
       "additionalProperties": false,
       "description": "Network proxy configuration layer from `[[network]]` entries in `config.toml`.\n\nMultiple `[[network]]` entries are merged in order (later entries win).",
       "properties": {
+        "allow_upstream_proxy": {
+          "description": "Allow upstream proxy env vars to be honored by the network proxy.",
+          "type": "boolean"
+        },
+        "dangerously_allow_non_loopback_admin": {
+          "description": "Allow non-loopback binding for admin listener (dangerous).",
+          "type": "boolean"
+        },
+        "dangerously_allow_non_loopback_proxy": {
+          "description": "Allow non-loopback binding for proxy listeners (dangerous).",
+          "type": "boolean"
+        },
         "enabled": {
           "description": "Enable proxy configuration for sandboxed tool execution.",
           "type": "boolean"
         },
-        "no_proxy": {
+        "mode": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/NetworkMode"
+            }
+          ],
+          "description": "Network proxy mode."
+        },
+        "policy": {
+          "allOf": [
+            {
+              "$ref": "#/definitions/NetworkPolicyToml"
+            }
+          ],
           "default": null,
-          "description": "Optional NO_PROXY entries.",
+          "description": "Policy configuration."
+        }
+      },
+      "type": "object"
+    },
+    "NetworkMode": {
+      "enum": [
+        "limited",
+        "full"
+      ],
+      "type": "string"
+    },
+    "NetworkPolicyToml": {
+      "additionalProperties": false,
+      "properties": {
+        "allow_local_binding": {
+          "type": "boolean"
+        },
+        "allow_unix_sockets": {
           "items": {
             "type": "string"
           },
           "type": "array"
         },
-        "socks_proxy": {
-          "description": "SOCKS proxy URL (for example: `socks5h://127.0.0.1:1080`).",
-          "type": "string"
+        "allowed_domains": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
+        },
+        "denied_domains": {
+          "items": {
+            "type": "string"
+          },
+          "type": "array"
         }
       },
       "type": "object"

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -457,7 +457,7 @@
     },
     "NetworkConfigToml": {
       "additionalProperties": false,
-      "description": "Network proxy configuration layer from `[[network]]` entries in `config.toml`.\n\nMultiple `[[network]]` entries are merged in order (later entries win).",
+      "description": "Network proxy configuration from the `[network]` table in `config.toml`.",
       "properties": {
         "allow_upstream_proxy": {
           "description": "Allow upstream proxy env vars to be honored by the network proxy.",
@@ -1484,12 +1484,13 @@
       "description": "Optional verbosity control for GPT-5 models (Responses API `text.verbosity`)."
     },
     "network": {
-      "default": [],
-      "description": "Ordered proxy config layers. Later entries win.",
-      "items": {
-        "$ref": "#/definitions/NetworkConfigToml"
-      },
-      "type": "array"
+      "allOf": [
+        {
+          "$ref": "#/definitions/NetworkConfigToml"
+        }
+      ],
+      "default": null,
+      "description": "Network proxy configuration."
     },
     "notice": {
       "allOf": [

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1267,6 +1267,12 @@ fn resolve_network_config(entries: &[NetworkConfigToml]) -> std::io::Result<Netw
         if let Some(value) = entry.dangerously_allow_non_loopback_admin {
             resolved.dangerously_allow_non_loopback_admin = value;
         }
+        if let Some(http_port) = entry.http_port {
+            resolved.http_port = Some(http_port);
+        }
+        if let Some(socks_port) = entry.socks_port {
+            resolved.socks_port = Some(socks_port);
+        }
         if let Some(policy) = entry.policy.as_ref() {
             if let Some(allowed_domains) = policy.allowed_domains.as_ref() {
                 resolved.policy.allowed_domains = allowed_domains.clone();
@@ -1912,6 +1918,7 @@ persistence = "none"
 [[network]]
 enabled = false
 allow_upstream_proxy = false
+http_port = 8080
 [network.policy]
 allowed_domains = ["example.com"]
 allow_local_binding = false
@@ -1920,6 +1927,7 @@ allow_local_binding = false
 enabled = true
 mode = "limited"
 allow_upstream_proxy = true
+socks_port = 1080
 [network.policy]
 denied_domains = ["internal.local"]
 allow_unix_sockets = ["/var/run/docker.sock"]
@@ -1937,6 +1945,8 @@ allow_unix_sockets = ["/var/run/docker.sock"]
                 allow_upstream_proxy: true,
                 dangerously_allow_non_loopback_proxy: false,
                 dangerously_allow_non_loopback_admin: false,
+                http_port: Some(8080),
+                socks_port: Some(1080),
                 policy: crate::config::types::NetworkPolicy {
                     allowed_domains: vec!["example.com".to_string()],
                     denied_domains: vec!["internal.local".to_string()],

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -556,9 +556,7 @@ impl From<SandboxWorkspaceWrite> for codex_app_server_protocol::SandboxSettings 
     }
 }
 
-/// Network proxy configuration layer from `[[network]]` entries in `config.toml`.
-///
-/// Multiple `[[network]]` entries are merged in order (later entries win).
+/// Network proxy configuration from the `[network]` table in `config.toml`.
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]
 #[schemars(deny_unknown_fields)]
 pub struct NetworkConfigToml {

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -556,6 +556,33 @@ impl From<SandboxWorkspaceWrite> for codex_app_server_protocol::SandboxSettings 
     }
 }
 
+/// Network proxy configuration layer from `[[network]]` entries in `config.toml`.
+///
+/// Multiple `[[network]]` entries are merged in order (later entries win).
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct NetworkConfigToml {
+    /// Enable proxy configuration for sandboxed tool execution.
+    pub enabled: Option<bool>,
+
+    /// SOCKS proxy URL (for example: `socks5h://127.0.0.1:1080`).
+    pub socks_proxy: Option<String>,
+
+    /// Optional NO_PROXY entries.
+    #[serde(default)]
+    pub no_proxy: Option<Vec<String>>,
+}
+
+/// Resolved network proxy configuration.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct NetworkConfig {
+    pub enabled: bool,
+    pub socks_proxy: Option<String>,
+    #[serde(default)]
+    pub no_proxy: Vec<String>,
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum ShellEnvironmentPolicyInherit {

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -565,12 +565,21 @@ pub struct NetworkConfigToml {
     /// Enable proxy configuration for sandboxed tool execution.
     pub enabled: Option<bool>,
 
-    /// SOCKS proxy URL (for example: `socks5h://127.0.0.1:1080`).
-    pub socks_proxy: Option<String>,
+    /// Network proxy mode.
+    pub mode: Option<NetworkMode>,
 
-    /// Optional NO_PROXY entries.
+    /// Allow upstream proxy env vars to be honored by the network proxy.
+    pub allow_upstream_proxy: Option<bool>,
+
+    /// Allow non-loopback binding for proxy listeners (dangerous).
+    pub dangerously_allow_non_loopback_proxy: Option<bool>,
+
+    /// Allow non-loopback binding for admin listener (dangerous).
+    pub dangerously_allow_non_loopback_admin: Option<bool>,
+
+    /// Policy configuration.
     #[serde(default)]
-    pub no_proxy: Option<Vec<String>>,
+    pub policy: Option<NetworkPolicyToml>,
 }
 
 /// Resolved network proxy configuration.
@@ -578,9 +587,40 @@ pub struct NetworkConfigToml {
 #[schemars(deny_unknown_fields)]
 pub struct NetworkConfig {
     pub enabled: bool,
-    pub socks_proxy: Option<String>,
+    pub mode: NetworkMode,
+    pub allow_upstream_proxy: bool,
+    pub dangerously_allow_non_loopback_proxy: bool,
+    pub dangerously_allow_non_loopback_admin: bool,
+    pub policy: NetworkPolicy,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default, JsonSchema)]
+#[serde(rename_all = "lowercase")]
+pub enum NetworkMode {
+    Limited,
+    #[default]
+    Full,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct NetworkPolicyToml {
+    pub allowed_domains: Option<Vec<String>>,
+    pub denied_domains: Option<Vec<String>>,
+    pub allow_unix_sockets: Option<Vec<String>>,
+    pub allow_local_binding: Option<bool>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, Default, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct NetworkPolicy {
     #[serde(default)]
-    pub no_proxy: Vec<String>,
+    pub allowed_domains: Vec<String>,
+    #[serde(default)]
+    pub denied_domains: Vec<String>,
+    #[serde(default)]
+    pub allow_unix_sockets: Vec<String>,
+    pub allow_local_binding: bool,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -577,6 +577,12 @@ pub struct NetworkConfigToml {
     /// Allow non-loopback binding for admin listener (dangerous).
     pub dangerously_allow_non_loopback_admin: Option<bool>,
 
+    /// HTTP proxy listener port (loopback).
+    pub http_port: Option<u16>,
+
+    /// SOCKS5 proxy listener port (loopback).
+    pub socks_port: Option<u16>,
+
     /// Policy configuration.
     #[serde(default)]
     pub policy: Option<NetworkPolicyToml>,
@@ -591,6 +597,8 @@ pub struct NetworkConfig {
     pub allow_upstream_proxy: bool,
     pub dangerously_allow_non_loopback_proxy: bool,
     pub dangerously_allow_non_loopback_admin: bool,
+    pub http_port: Option<u16>,
+    pub socks_port: Option<u16>,
     pub policy: NetworkPolicy,
 }
 

--- a/codex-rs/network-proxy/Cargo.toml
+++ b/codex-rs/network-proxy/Cargo.toml
@@ -27,6 +27,7 @@ serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 time = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
+toml = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 url = { workspace = true }

--- a/codex-rs/network-proxy/README.md
+++ b/codex-rs/network-proxy/README.md
@@ -17,14 +17,12 @@ It enforces an allow/deny policy and a "limited" mode intended for read-only net
 Example config:
 
 ```toml
-[network_proxy]
+[network]
 enabled = true
-proxy_url = "http://127.0.0.1:3128"
-admin_url = "http://127.0.0.1:8080"
-# Optional SOCKS5 listener (disabled by default).
-enable_socks5 = false
-socks_url = "http://127.0.0.1:8081"
-enable_socks5_udp = false
+# Optional override for HTTP proxy port (default 3128).
+http_port = 3128
+# Optional SOCKS5 port. When set, SOCKS5 listener is enabled.
+socks_port = 8081
 # When `enabled` is false, the proxy no-ops and does not bind listeners.
 # When true, respect HTTP(S)_PROXY/ALL_PROXY for upstream requests (HTTP(S) proxies only),
 # including CONNECT tunnels in full mode.
@@ -35,7 +33,7 @@ dangerously_allow_non_loopback_proxy = false
 dangerously_allow_non_loopback_admin = false
 mode = "full" # default when unset; use "limited" for read-only mode
 
-[network_proxy.policy]
+[network.policy]
 # Hosts must match the allowlist (unless denied).
 # If `allowed_domains` is empty, the proxy blocks requests until an allowlist is configured.
 allowed_domains = ["*.openai.com"]

--- a/codex-rs/network-proxy/src/proxy.rs
+++ b/codex-rs/network-proxy/src/proxy.rs
@@ -96,7 +96,7 @@ impl NetworkProxy {
     pub async fn run(&self) -> Result<NetworkProxyHandle> {
         let current_cfg = self.state.current_cfg().await?;
         if !current_cfg.network_proxy.enabled {
-            warn!("network_proxy.enabled is false; skipping proxy listeners");
+            warn!("network.enabled is false; skipping proxy listeners");
             return Ok(NetworkProxyHandle::noop());
         }
 

--- a/codex-rs/network-proxy/src/state.rs
+++ b/codex-rs/network-proxy/src/state.rs
@@ -88,31 +88,6 @@ fn collect_layer_mtimes(stack: &ConfigLayerStack) -> Vec<LayerMtime> {
 struct PartialConfig {
     #[serde(default)]
     network: Option<NetworkConfigTable>,
-    #[serde(default)]
-    network_proxy: PartialNetworkProxyConfig,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct PartialNetworkProxyConfig {
-    enabled: Option<bool>,
-    mode: Option<NetworkMode>,
-    allow_upstream_proxy: Option<bool>,
-    dangerously_allow_non_loopback_proxy: Option<bool>,
-    dangerously_allow_non_loopback_admin: Option<bool>,
-    #[serde(default)]
-    policy: PartialNetworkPolicy,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct PartialNetworkPolicy {
-    #[serde(default)]
-    allowed_domains: Option<Vec<String>>,
-    #[serde(default)]
-    denied_domains: Option<Vec<String>>,
-    #[serde(default)]
-    allow_unix_sockets: Option<Vec<String>>,
-    #[serde(default)]
-    allow_local_binding: Option<bool>,
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -160,49 +135,9 @@ fn network_proxy_constraints_from_trusted_layers(
 
         if let Some(network) = partial.network.as_ref() {
             apply_network_constraints(&mut constraints, network);
-        } else {
-            apply_legacy_constraints(&mut constraints, &partial.network_proxy);
         }
     }
     Ok(constraints)
-}
-
-fn apply_legacy_constraints(
-    constraints: &mut NetworkProxyConstraints,
-    legacy: &PartialNetworkProxyConfig,
-) {
-    if let Some(enabled) = legacy.enabled {
-        constraints.enabled = Some(enabled);
-    }
-    if let Some(mode) = legacy.mode {
-        constraints.mode = Some(mode);
-    }
-    if let Some(allow_upstream_proxy) = legacy.allow_upstream_proxy {
-        constraints.allow_upstream_proxy = Some(allow_upstream_proxy);
-    }
-    if let Some(dangerously_allow_non_loopback_proxy) = legacy.dangerously_allow_non_loopback_proxy
-    {
-        constraints.dangerously_allow_non_loopback_proxy =
-            Some(dangerously_allow_non_loopback_proxy);
-    }
-    if let Some(dangerously_allow_non_loopback_admin) = legacy.dangerously_allow_non_loopback_admin
-    {
-        constraints.dangerously_allow_non_loopback_admin =
-            Some(dangerously_allow_non_loopback_admin);
-    }
-
-    if let Some(allowed_domains) = legacy.policy.allowed_domains.clone() {
-        constraints.allowed_domains = Some(allowed_domains);
-    }
-    if let Some(denied_domains) = legacy.policy.denied_domains.clone() {
-        constraints.denied_domains = Some(denied_domains);
-    }
-    if let Some(allow_unix_sockets) = legacy.policy.allow_unix_sockets.clone() {
-        constraints.allow_unix_sockets = Some(allow_unix_sockets);
-    }
-    if let Some(allow_local_binding) = legacy.policy.allow_local_binding {
-        constraints.allow_local_binding = Some(allow_local_binding);
-    }
 }
 
 fn apply_network_constraints(


### PR DESCRIPTION
## Description

This PR defines the `[network]` config surface in `codex-core` for proxy settings.

Specifically, `[network]` now supports:
- `enabled`
- `mode` (defaults to `full`)
- `allow_upstream_proxy`
- `dangerously_allow_non_loopback_proxy`
- `dangerously_allow_non_loopback_admin`
- `policy.allowed_domains`
- `policy.denied_domains`
- `policy.allow_unix_sockets`
- `policy.allow_local_binding`

I also regenerated `codex-rs/core/config.schema.json` and updated tests for defaults and merge behavior.

## Tests run

- `cargo test -p codex-core --lib`
- `cargo clippy -p codex-core --all-targets -- -D warnings`
