### PR TITLE
Add features enable/disable subcommands

### DIFF
--- a/codex-rs/cli/tests/features.rs
+++ b/codex-rs/cli/tests/features.rs
@@ -1,0 +1,58 @@
+use std::path::Path;
+
+use anyhow::Result;
+use predicates::str::contains;
+use tempfile::TempDir;
+
+fn codex_command(codex_home: &Path) -> Result<assert_cmd::Command> {
+    let mut cmd = assert_cmd::Command::new(codex_utils_cargo_bin::cargo_bin("codex")?);
+    cmd.env("CODEX_HOME", codex_home);
+    Ok(cmd)
+}
+
+#[tokio::test]
+async fn features_enable_writes_feature_flag_to_config() -> Result<()> {
+    let codex_home = TempDir::new()?;
+
+    let mut cmd = codex_command(codex_home.path())?;
+    cmd.args(["features", "enable", "unified_exec"])
+        .assert()
+        .success()
+        .stdout(contains("Enabled feature `unified_exec` in config.toml."));
+
+    let config = std::fs::read_to_string(codex_home.path().join("config.toml"))?;
+    assert!(config.contains("[features]"));
+    assert!(config.contains("unified_exec = true"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn features_disable_writes_feature_flag_to_config() -> Result<()> {
+    let codex_home = TempDir::new()?;
+
+    let mut cmd = codex_command(codex_home.path())?;
+    cmd.args(["features", "disable", "shell_tool"])
+        .assert()
+        .success()
+        .stdout(contains("Disabled feature `shell_tool` in config.toml."));
+
+    let config = std::fs::read_to_string(codex_home.path().join("config.toml"))?;
+    assert!(config.contains("[features]"));
+    assert!(config.contains("shell_tool = false"));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn features_enable_under_development_feature_prints_warning() -> Result<()> {
+    let codex_home = TempDir::new()?;
+
+    let mut cmd = codex_command(codex_home.path())?;
+    cmd.args(["features", "enable", "sqlite"])
+        .assert()
+        .success()
+        .stderr(contains("Under-development features enabled: sqlite."));
+
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- add `codex features enable <feature>` and `codex features disable <feature>`
- persist feature flag changes to `config.toml` (respecting profile)
- print the under-development feature warning when enabling prerelease features
- keep `features list` behavior unchanged and add unit/integration tests

## Testing
- cargo test -p codex-cli