### PR TITLE
fix: unify `npm publish` call across shell-tool-mcp.yml and rust-release.yml

### DIFF
--- a/.github/workflows/shell-tool-mcp.yml
+++ b/.github/workflows/shell-tool-mcp.yml
@@ -436,20 +436,16 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          run_install: false
-
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
           registry-url: https://registry.npmjs.org
           scope: "@openai"
+
+      # Trusted publishing requires npm CLI version 11.5.1 or later.
+      - name: Update npm
+        run: npm install -g npm@latest
 
       - name: Download npm tarball
         uses: actions/download-artifact@v7


### PR DESCRIPTION
We are seeing flakiness in the `npm publish` step for https://www.npmjs.com/package/@openai/codex-shell-tool-mcp, so this is a shot in the dark for a fix:

https://github.com/openai/codex/actions/runs/21490679301/job/61913765060

Note this removes `actions/checkout@v6` and `pnpm/action-setup@v4` steps, which I believe are superflous for the `npm publish` call.