### PR TITLE
fix: /approvals -> /permissions

### DIFF
--- a/codex-rs/tui/tooltips.txt
+++ b/codex-rs/tui/tooltips.txt
@@ -2,7 +2,7 @@ Use /compact when the conversation gets long to summarize history and free up co
 Start a fresh idea with /new; the previous session stays in history.
 Use /feedback to send logs to the maintainers when something looks off.
 Switch models or reasoning effort quickly with /model.
-Use /approvals to control when Codex asks for confirmation.
+Use /permissions to control when Codex asks for confirmation.
 Run /review to get a code review of your current changes.
 Use /skills to list available skills or ask Codex to use one.
 Use /status to see the current model, approvals, and token usage.


### PR DESCRIPTION
I believe we should be recommending `/permissions` in light of https://github.com/openai/codex/pull/9561.