### PR TITLE
Load exec policy rules from requirements

### DIFF
--- a/codex-rs/app-server/src/config_api.rs
+++ b/codex-rs/app-server/src/config_api.rs
@@ -136,6 +136,7 @@ mod tests {
                 CoreSandboxModeRequirement::ExternalSandbox,
             ]),
             mcp_servers: None,
+            rules: None,
         };
 
         let mapped = map_requirements_toml_to_api(requirements);

--- a/codex-rs/cloud-requirements/src/lib.rs
+++ b/codex-rs/cloud-requirements/src/lib.rs
@@ -317,6 +317,7 @@ mod tests {
                 allowed_approval_policies: Some(vec![AskForApproval::Never]),
                 allowed_sandbox_modes: None,
                 mcp_servers: None,
+                rules: None,
             })
         );
     }

--- a/codex-rs/core/src/config/constraint.rs
+++ b/codex-rs/core/src/config/constraint.rs
@@ -18,6 +18,12 @@ pub enum ConstraintError {
 
     #[error("field `{field_name}` cannot be empty")]
     EmptyField { field_name: String },
+
+    #[error("invalid rules in requirements (set by {requirement_source}): {reason}")]
+    ExecPolicyParse {
+        requirement_source: RequirementSource,
+        reason: String,
+    },
 }
 
 impl ConstraintError {

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1512,6 +1512,7 @@ impl Config {
             approval_policy: mut constrained_approval_policy,
             sandbox_policy: mut constrained_sandbox_policy,
             mcp_servers,
+            exec_policy: _,
         } = requirements;
 
         constrained_approval_policy

--- a/codex-rs/core/src/config_loader/mod.rs
+++ b/codex-rs/core/src/config_loader/mod.rs
@@ -7,7 +7,6 @@ mod layer_io;
 mod macos;
 mod merge;
 mod overrides;
-#[cfg(test)]
 mod requirements_exec_policy;
 mod state;
 

--- a/codex-rs/core/src/exec_policy.rs
+++ b/codex-rs/core/src/exec_policy.rs
@@ -280,7 +280,18 @@ pub async fn load_exec_policy(config_stack: &ConfigLayerStack) -> Result<Policy,
     let policy = parser.build();
     tracing::debug!("loaded rules from {} files", policy_paths.len());
 
-    Ok(policy)
+    let Some(requirements_policy) = config_stack.requirements().exec_policy.as_deref() else {
+        return Ok(policy);
+    };
+
+    let mut combined_rules = policy.rules().clone();
+    for (program, rules) in requirements_policy.as_ref().rules().iter_all() {
+        for rule in rules {
+            combined_rules.insert(program.clone(), rule.clone());
+        }
+    }
+
+    Ok(Policy::new(combined_rules))
 }
 
 /// If a command is not matched by any execpolicy rule, derive a [`Decision`].


### PR DESCRIPTION
`requirements.toml` should be able to specify rules which always run. 

My intention here was that these rules could only ever be restrictive, which means the decision can be "prompt" or "forbidden" but never "allow". A requirement of "you must always allow this command" didn't make sense to me, but happy to be gaveled otherwise.

Rules already applies the most restrictive decision, so we can safely merge these with rules found in other config folders. 