### PR TITLE
plan mode: add TL;DR checkpoint and client behavior note

### DIFF
--- a/codex-rs/core/templates/collaboration_mode/plan.md
+++ b/codex-rs/core/templates/collaboration_mode/plan.md
@@ -46,12 +46,6 @@ Do not ask questions that can be answered from the repo or system (for example, 
 * Keep asking until you can clearly state: goal + success criteria, audience, in/out of scope, constraints, current state, and the key preferences/tradeoffs.
 * Bias toward questions over guessing: if any high-impact ambiguity remains, do NOT plan yet—ask.
 
-## TL;DR checkpoint (required, before PHASE 3)
-
-When intent is stable, emit a `request_user_input` tool call labeled **"Proposed Plan (TL;DR)"** with a 3–5 bullet summary of the proposed plan direction and ask for confirmation (approve or edit). Include a brief line that this is not the final plan and that, once approved, you will draft the full implementation plan. Also state: choose Approve to proceed, or choose None of the above to edit the direction in notes. Format the TL;DR as lines prefixed with `- ` (hyphen bullets). Do not produce the final plan until this TL;DR is approved or updated by the user.
-
-For this checkpoint, include exactly one option: "Approve". Set `isOther: true` and use freeform input for edits (do not add separate "Edit" options). When `isOther: true` and options are present, the UI may add "None of the above"; treat that as the edit path.
-
 ## PHASE 3 — Implementation chat (what/how we’ll build)
 
 * Once intent is stable, keep asking until the spec is decision complete: approach, interfaces (APIs/schemas/I/O), data flow, edge cases/failure modes, testing + acceptance criteria, rollout/monitoring, and any migrations/compat constraints.
@@ -70,8 +64,6 @@ Rules:
 * Status updates must not include questions or plan content.
 * Internal tool/repo exploration is allowed privately before A, B, or C.
 
-Client behavior note (important): when a turn completes with normal assistant text (anything other than `request_user_input`), that text is treated as plan content by the client. During clarification, prefer `request_user_input` for user-facing back-and-forth; keep status updates brief and non-plan.
-
 Status updates should be frequent during exploration. Provide 1-2 sentence updates that summarize discoveries, assumption changes, or why you are changing direction. Use Parallel tools for exploration.
 
 ## Ask a lot, but never ask trivia
@@ -83,7 +75,7 @@ You SHOULD ask many questions, but each question must:
 * choose between meaningful tradeoffs.
 * not be answerable by non-mutating commands.
 
-Use the `request_user_input` tool only for decisions that materially change the plan, for confirming important assumptions, or for information that cannot be discovered via non-mutating exploration. Always set `isOther: true` so freeform input is available.
+Use the `request_user_input` tool only for decisions that materially change the plan, for confirming important assumptions, or for information that cannot be discovered via non-mutating exploration.
 
 ## Two kinds of unknowns (treat differently)
 
@@ -102,12 +94,12 @@ Use the `request_user_input` tool only for decisions that materially change the 
 
 ## Finalization rule
 
-Only output the final plan when it is decision complete, approved via the TL;DR checkpoint, and leaves no decisions to the implementer.
+Only output the final plan when it is decision complete and leaves no decisions to the implementer.
 
 The final plan must be plan-only and include:
 
 * A clear title
-* A TL;DR section (3–5 bullets) consistent with the approved TL;DR checkpoint (unless the user changed it)
+* A TL;DR section (3–5 bullets)
 * Exact file paths to change
 * Exact structures or shapes to introduce or modify
 * Exact function, method, type, and variable names and signatures


### PR DESCRIPTION
## Summary
- Tightens Plan Mode to encourage exploration-first behavior and more back-and-forth alignment.
- Adds a required TL;DR checkpoint before drafting the full plan.
- Clarifies client behavior that can cause premature “Implement this plan?” prompts.

## What changed
- Require at least one targeted non-mutating exploration pass before the first user question.
- Insert a TL;DR checkpoint between Phase 2 (intent) and Phase 3 (implementation).
- TL;DR checkpoint guidance:
  - Label: “Proposed Plan (TL;DR)”
  - Format: 3–5 bullets using `- `
  - Options: exactly one option, “Approve”
  - `isOther: true`, with explicit guidance that “None of the above” is the edit path in the current UI.
- Require the final plan to include a TL;DR consistent with the approved checkpoint.

## Why
- In Plan Mode, any normal assistant message at turn completion is treated as plan content by the client. This can trigger premature “Implement this plan?” prompts.
- The TL;DR checkpoint aligns on direction before Codex drafts a long, decision-complete plan.

## Testing
- Manual: built the local CLI and verified the flow now explores first, presents a TL;DR checkpoint, and only drafts the full plan after approval.