### PR TITLE
feat(app-server-test-client): add test-external-auth-message cmd

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1144,6 +1144,7 @@ dependencies = [
  "clap",
  "codex-app-server-protocol",
  "codex-protocol",
+ "dirs",
  "serde",
  "serde_json",
  "uuid",

--- a/codex-rs/app-server-test-client/Cargo.toml
+++ b/codex-rs/app-server-test-client/Cargo.toml
@@ -12,6 +12,7 @@ anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive", "env"] }
 codex-app-server-protocol = { workspace = true }
 codex-protocol = { workspace = true }
+dirs = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }


### PR DESCRIPTION
Runs through an end-to-end turn using external auth mode.

Reads tokens from `~/.codex/auth.json`:
`cargo run -p codex-app-server-test-client -- --codex-bin target/debug/codex test-external-auth-message "hello"`

Or pass in tokens explicitly:
`cargo run -p codex-app-server-test-client -- --codex-bin target/debug/codex test-external-auth-message --id-token $ID_TOKEN --access-token $ACCESS_TOKEN "hello"`