### PR TITLE
feat(mcp): add inherit_env option for stdio servers

### DIFF
--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -221,6 +221,7 @@ async fn run_add(config_overrides: &CliConfigOverrides, add_args: AddArgs) -> Re
                 args: command_args,
                 env: env_map,
                 env_vars: Vec::new(),
+                inherit_env: false,
                 cwd: None,
             }
         }
@@ -421,6 +422,7 @@ async fn run_list(config_overrides: &CliConfigOverrides, list_args: ListArgs) ->
                         args,
                         env,
                         env_vars,
+                        inherit_env,
                         cwd,
                     } => serde_json::json!({
                         "type": "stdio",
@@ -428,6 +430,7 @@ async fn run_list(config_overrides: &CliConfigOverrides, list_args: ListArgs) ->
                         "args": args,
                         "env": env,
                         "env_vars": env_vars,
+                        "inherit_env": inherit_env,
                         "cwd": cwd,
                     }),
                     McpServerTransportConfig::StreamableHttp {
@@ -482,6 +485,7 @@ async fn run_list(config_overrides: &CliConfigOverrides, list_args: ListArgs) ->
                 env,
                 env_vars,
                 cwd,
+                ..
             } => {
                 let args_display = if args.is_empty() {
                     "-".to_string()
@@ -660,6 +664,7 @@ async fn run_get(config_overrides: &CliConfigOverrides, get_args: GetArgs) -> Re
                 args,
                 env,
                 env_vars,
+                inherit_env,
                 cwd,
             } => serde_json::json!({
                 "type": "stdio",
@@ -667,6 +672,7 @@ async fn run_get(config_overrides: &CliConfigOverrides, get_args: GetArgs) -> Re
                 "args": args,
                 "env": env,
                 "env_vars": env_vars,
+                "inherit_env": inherit_env,
                 "cwd": cwd,
             }),
             McpServerTransportConfig::StreamableHttp {
@@ -732,6 +738,7 @@ async fn run_get(config_overrides: &CliConfigOverrides, get_args: GetArgs) -> Re
             args,
             env,
             env_vars,
+            inherit_env,
             cwd,
         } => {
             println!("  transport: stdio");
@@ -748,6 +755,9 @@ async fn run_get(config_overrides: &CliConfigOverrides, get_args: GetArgs) -> Re
                 .filter(|value| !value.is_empty())
                 .unwrap_or_else(|| "-".to_string());
             println!("  cwd: {cwd_display}");
+            if *inherit_env {
+                println!("  inherit_env: true");
+            }
             let env_display = format_env_display(env.as_ref(), env_vars);
             println!("  env: {env_display}");
         }

--- a/codex-rs/core/src/config/edit.rs
+++ b/codex-rs/core/src/config/edit.rs
@@ -107,6 +107,7 @@ mod document_helpers {
                 args,
                 env,
                 env_vars,
+                inherit_env,
                 cwd,
             } => {
                 entry["command"] = value(command.clone());
@@ -120,6 +121,9 @@ mod document_helpers {
                 }
                 if !env_vars.is_empty() {
                     entry["env_vars"] = array_from_iter(env_vars.iter().cloned());
+                }
+                if *inherit_env {
+                    entry["inherit_env"] = value(true);
                 }
                 if let Some(cwd) = cwd {
                     entry["cwd"] = value(cwd.to_string_lossy().to_string());

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -93,6 +93,8 @@ pub(crate) struct RawMcpServerConfig {
     #[serde(default)]
     pub env_vars: Option<Vec<String>>,
     #[serde(default)]
+    pub inherit_env: Option<bool>,
+    #[serde(default)]
     pub cwd: Option<PathBuf>,
     pub http_headers: Option<HashMap<String, String>>,
     #[serde(default)]
@@ -169,6 +171,7 @@ impl<'de> Deserialize<'de> for McpServerConfig {
                 args: raw.args.clone().unwrap_or_default(),
                 env: raw.env.clone(),
                 env_vars: raw.env_vars.clone().unwrap_or_default(),
+                inherit_env: raw.inherit_env.unwrap_or(false),
                 cwd: raw.cwd.take(),
             }
         } else if let Some(url) = raw.url.clone() {
@@ -216,6 +219,11 @@ pub enum McpServerTransportConfig {
         env: Option<HashMap<String, String>>,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         env_vars: Vec<String>,
+        /// When true, inherit the full environment from the parent process
+        /// instead of using a minimal whitelist. Useful for shell-like MCP
+        /// servers (e.g., nushell) that need access to user configuration.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        inherit_env: bool,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         cwd: Option<PathBuf>,
     },

--- a/codex-rs/core/src/mcp/skill_dependencies.rs
+++ b/codex-rs/core/src/mcp/skill_dependencies.rs
@@ -398,6 +398,7 @@ fn mcp_dependency_to_server_config(
                 args: Vec::new(),
                 env: None,
                 env_vars: Vec::new(),
+                inherit_env: false,
                 cwd: None,
             },
             enabled: true,

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -884,11 +884,12 @@ async fn make_rmcp_client(
             args,
             env,
             env_vars,
+            inherit_env,
             cwd,
         } => {
             let command_os: OsString = command.into();
             let args_os: Vec<OsString> = args.into_iter().map(Into::into).collect();
-            RmcpClient::new_stdio_client(command_os, args_os, env, &env_vars, cwd)
+            RmcpClient::new_stdio_client(command_os, args_os, env, &env_vars, inherit_env, cwd)
                 .await
                 .map_err(|err| StartupOutcomeError::from(anyhow!(err)))
         }

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -1601,6 +1601,7 @@ pub(crate) fn new_mcp_tools_output(
                 args,
                 env,
                 env_vars,
+                inherit_env,
                 cwd,
             } => {
                 let args_suffix = if args.is_empty() {
@@ -1613,6 +1614,10 @@ pub(crate) fn new_mcp_tools_output(
 
                 if let Some(cwd) = cwd.as_ref() {
                     lines.push(vec!["    • Cwd: ".into(), cwd.display().to_string().into()].into());
+                }
+
+                if *inherit_env {
+                    lines.push(vec!["    • Inherit Env: ".into(), "true".into()].into());
                 }
 
                 let env_display = format_env_display(env.as_ref(), env_vars);


### PR DESCRIPTION
## Summary

ai generated

Adds an opt-in `inherit_env` config option for MCP stdio servers to inherit the full parent environment instead of using a minimal whitelist.

### Problem

MCP stdio servers currently have their environment cleared (`env_clear()`) with only a small whitelist of variables passed through. This breaks shell-like MCP servers that need user environment variables to function:

- **[nushell](https://github.com/nushell/nushell)** (`nu --mcp`) needs `XDG_CONFIG_HOME` and similar variables to find its config
- Other shell-based MCP servers may have similar requirements

### Solution

Add an opt-in `inherit_env: true` config option:

```toml
[mcp_servers.nu]
command = "nu"
args = ["--mcp"]
inherit_env = true
```

When enabled, the full parent environment is inherited (with any explicit `env` overrides applied on top). The default remains secure - `env_clear()` with whitelist only.

This mirrors how shell commands have `shell_environment_policy.inherit = "all"` but for MCP servers.

### Related

- #3517 - Previous attempt that changed the default behavior (closed because it could leak secrets)
- This PR is opt-in, keeping the secure default

### Note

This PR was AI-generated with human review. I'm one of the contributors to nushell's MCP support and ran into this issue when testing `nu --mcp` with Codex.