### PR TITLE
feat: codex app-server --default-chatgpt-proxy-auth

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1084,6 +1084,7 @@ dependencies = [
  "axum",
  "base64",
  "chrono",
+ "clap",
  "codex-app-server-protocol",
  "codex-arg0",
  "codex-backend-client",

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -915,7 +915,7 @@ mod tests {
     #[test]
     fn serialize_get_account() -> Result<()> {
         let request = ClientRequest::GetAccount {
-            request_id: RequestId::Integer(6),
+            request_id: RequestId::Integer(7),
             params: v2::GetAccountParams {
                 refresh_token: false,
             },
@@ -923,7 +923,7 @@ mod tests {
         assert_eq!(
             json!({
                 "method": "account/read",
-                "id": 6,
+                "id": 7,
                 "params": {
                     "refreshToken": false
                 }

--- a/codex-rs/app-server/Cargo.toml
+++ b/codex-rs/app-server/Cargo.toml
@@ -32,6 +32,7 @@ codex-rmcp-client = { workspace = true }
 codex-utils-absolute-path = { workspace = true }
 codex-utils-json-to-toml = { workspace = true }
 chrono = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 mcp-types = { workspace = true }

--- a/codex-rs/app-server/src/main.rs
+++ b/codex-rs/app-server/src/main.rs
@@ -1,3 +1,4 @@
+use clap::Parser;
 use codex_app_server::run_main;
 use codex_arg0::arg0_dispatch_or_else;
 use codex_common::CliConfigOverrides;
@@ -8,8 +9,20 @@ use std::path::PathBuf;
 // managed config file without writing to /etc.
 const MANAGED_CONFIG_PATH_ENV_VAR: &str = "CODEX_APP_SERVER_MANAGED_CONFIG_PATH";
 
+#[derive(Debug, Parser, Default, Clone)]
+#[command(bin_name = "codex-app-server")]
+struct AppServerCli {
+    #[clap(flatten)]
+    config_overrides: CliConfigOverrides,
+
+    /// Seed ChatGPT proxy auth (tokenless) on startup when no auth is present.
+    #[arg(long = "default-chatgpt-proxy-auth")]
+    default_chatgpt_proxy_auth: bool,
+}
+
 fn main() -> anyhow::Result<()> {
     arg0_dispatch_or_else(|codex_linux_sandbox_exe| async move {
+        let cli = AppServerCli::parse();
         let managed_config_path = managed_config_path_from_debug_env();
         let loader_overrides = LoaderOverrides {
             managed_config_path,
@@ -18,9 +31,10 @@ fn main() -> anyhow::Result<()> {
 
         run_main(
             codex_linux_sandbox_exe,
-            CliConfigOverrides::default(),
+            cli.config_overrides,
             loader_overrides,
             false,
+            cli.default_chatgpt_proxy_auth,
         )
         .await?;
         Ok(())

--- a/codex-rs/app-server/tests/common/auth_fixtures.rs
+++ b/codex-rs/app-server/tests/common/auth_fixtures.rs
@@ -163,6 +163,7 @@ pub fn write_chatgpt_auth(
         openai_api_key: None,
         tokens: Some(tokens),
         last_refresh,
+        chatgpt_proxy: None,
     };
 
     save_auth(codex_home, &auth, cli_auth_credentials_store_mode).context("write auth.json")

--- a/codex-rs/backend-client/src/lib.rs
+++ b/codex-rs/backend-client/src/lib.rs
@@ -2,6 +2,7 @@ mod client;
 pub mod types;
 
 pub use client::Client;
+pub use client::UsageMetadata;
 pub use types::CodeTaskDetailsResponse;
 pub use types::CodeTaskDetailsResponseExt;
 pub use types::ConfigFileResponse;

--- a/codex-rs/cli/src/main.rs
+++ b/codex-rs/cli/src/main.rs
@@ -283,6 +283,10 @@ struct AppServerCommand {
     /// See https://developers.openai.com/codex/config-advanced/#metrics for more details.
     #[arg(long = "analytics-default-enabled")]
     analytics_default_enabled: bool,
+
+    /// Seed ChatGPT proxy auth (tokenless) on startup when no auth is present.
+    #[arg(long = "default-chatgpt-proxy-auth")]
+    default_chatgpt_proxy_auth: bool,
 }
 
 #[derive(Debug, clap::Subcommand)]
@@ -535,6 +539,7 @@ async fn cli_main(codex_linux_sandbox_exe: Option<PathBuf>) -> anyhow::Result<()
                     root_config_overrides,
                     codex_core::config_loader::LoaderOverrides::default(),
                     app_server_cli.analytics_default_enabled,
+                    app_server_cli.default_chatgpt_proxy_auth,
                 )
                 .await?;
             }
@@ -1261,6 +1266,19 @@ mod tests {
         let app_server =
             app_server_from_args(["codex", "app-server", "--analytics-default-enabled"].as_ref());
         assert!(app_server.analytics_default_enabled);
+    }
+
+    #[test]
+    fn app_server_default_chatgpt_proxy_auth_disabled_without_flag() {
+        let app_server = app_server_from_args(["codex", "app-server"].as_ref());
+        assert!(!app_server.default_chatgpt_proxy_auth);
+    }
+
+    #[test]
+    fn app_server_default_chatgpt_proxy_auth_enabled_with_flag() {
+        let app_server =
+            app_server_from_args(["codex", "app-server", "--default-chatgpt-proxy-auth"].as_ref());
+        assert!(app_server.default_chatgpt_proxy_auth);
     }
 
     #[test]

--- a/codex-rs/codex-backend-openapi-models/src/models/rate_limit_status_payload.rs
+++ b/codex-rs/codex-backend-openapi-models/src/models/rate_limit_status_payload.rs
@@ -16,6 +16,16 @@ use serde::Serialize;
 pub struct RateLimitStatusPayload {
     #[serde(rename = "plan_type")]
     pub plan_type: PlanType,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "user_id")]
+    pub user_id: Option<String>,
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "account_id"
+    )]
+    pub account_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none", rename = "email")]
+    pub email: Option<String>,
     #[serde(
         rename = "rate_limit",
         default,
@@ -36,6 +46,9 @@ impl RateLimitStatusPayload {
     pub fn new(plan_type: PlanType) -> RateLimitStatusPayload {
         RateLimitStatusPayload {
             plan_type,
+            user_id: None,
+            account_id: None,
+            email: None,
             rate_limit: None,
             credits: None,
         }

--- a/codex-rs/core/src/api_bridge.rs
+++ b/codex-rs/core/src/api_bridge.rs
@@ -177,9 +177,9 @@ pub(crate) fn auth_provider_from_auth(
     }
 
     if let Some(auth) = auth {
-        let token = auth.get_token()?;
+        let token = auth.bearer_token()?;
         Ok(CoreAuthProvider {
-            token: Some(token),
+            token,
             account_id: auth.get_account_id(),
         })
     } else {

--- a/codex-rs/core/src/mcp/mod.rs
+++ b/codex-rs/core/src/mcp/mod.rs
@@ -39,7 +39,7 @@ fn codex_apps_mcp_bearer_token_env_var() -> Option<String> {
 }
 
 fn codex_apps_mcp_bearer_token(auth: Option<&CodexAuth>) -> Option<String> {
-    let token = auth.and_then(|auth| auth.get_token().ok())?;
+    let token = auth.and_then(|auth| auth.bearer_token().ok()).flatten()?;
     let token = token.trim();
     if token.is_empty() {
         None

--- a/codex-rs/core/tests/suite/auth_refresh.rs
+++ b/codex-rs/core/tests/suite/auth_refresh.rs
@@ -55,6 +55,7 @@ async fn refresh_token_succeeds_updates_storage() -> Result<()> {
         openai_api_key: None,
         tokens: Some(initial_tokens.clone()),
         last_refresh: Some(initial_last_refresh),
+        chatgpt_proxy: None,
     };
     ctx.write_auth(&initial_auth)?;
 
@@ -117,6 +118,7 @@ async fn returns_fresh_tokens_as_is() -> Result<()> {
         openai_api_key: None,
         tokens: Some(initial_tokens.clone()),
         last_refresh: Some(initial_last_refresh),
+        chatgpt_proxy: None,
     };
     ctx.write_auth(&initial_auth)?;
 
@@ -163,6 +165,7 @@ async fn refreshes_token_when_last_refresh_is_stale() -> Result<()> {
         openai_api_key: None,
         tokens: Some(initial_tokens.clone()),
         last_refresh: Some(stale_refresh),
+        chatgpt_proxy: None,
     };
     ctx.write_auth(&initial_auth)?;
 
@@ -222,6 +225,7 @@ async fn refresh_token_returns_permanent_error_for_expired_refresh_token() -> Re
         openai_api_key: None,
         tokens: Some(initial_tokens.clone()),
         last_refresh: Some(initial_last_refresh),
+        chatgpt_proxy: None,
     };
     ctx.write_auth(&initial_auth)?;
 
@@ -272,6 +276,7 @@ async fn refresh_token_returns_transient_error_on_server_failure() -> Result<()>
         openai_api_key: None,
         tokens: Some(initial_tokens.clone()),
         last_refresh: Some(initial_last_refresh),
+        chatgpt_proxy: None,
     };
     ctx.write_auth(&initial_auth)?;
 
@@ -324,6 +329,7 @@ async fn unauthorized_recovery_reloads_then_refreshes_tokens() -> Result<()> {
         openai_api_key: None,
         tokens: Some(initial_tokens.clone()),
         last_refresh: Some(initial_last_refresh),
+        chatgpt_proxy: None,
     };
     ctx.write_auth(&initial_auth)?;
 
@@ -333,6 +339,7 @@ async fn unauthorized_recovery_reloads_then_refreshes_tokens() -> Result<()> {
         openai_api_key: None,
         tokens: Some(disk_tokens.clone()),
         last_refresh: Some(initial_last_refresh),
+        chatgpt_proxy: None,
     };
     save_auth(
         ctx.codex_home.path(),
@@ -416,6 +423,7 @@ async fn unauthorized_recovery_skips_reload_on_account_mismatch() -> Result<()> 
         openai_api_key: None,
         tokens: Some(initial_tokens.clone()),
         last_refresh: Some(initial_last_refresh),
+        chatgpt_proxy: None,
     };
     ctx.write_auth(&initial_auth)?;
 
@@ -431,6 +439,7 @@ async fn unauthorized_recovery_skips_reload_on_account_mismatch() -> Result<()> 
         openai_api_key: None,
         tokens: Some(disk_tokens),
         last_refresh: Some(initial_last_refresh),
+        chatgpt_proxy: None,
     };
     save_auth(
         ctx.codex_home.path(),
@@ -495,6 +504,7 @@ async fn unauthorized_recovery_requires_chatgpt_auth() -> Result<()> {
         openai_api_key: Some("sk-test".to_string()),
         tokens: None,
         last_refresh: None,
+        chatgpt_proxy: None,
     };
     ctx.write_auth(&auth)?;
 

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -564,6 +564,7 @@ pub(crate) async fn persist_tokens_async(
             openai_api_key: api_key,
             tokens: Some(tokens),
             last_refresh: Some(Utc::now()),
+            chatgpt_proxy: None,
         };
         save_auth(&codex_home, &auth, auth_credentials_store_mode)
     })

--- a/codex-rs/tui/src/status/helpers.rs
+++ b/codex-rs/tui/src/status/helpers.rs
@@ -91,7 +91,7 @@ pub(crate) fn compose_account_display(
     let auth = auth_manager.auth_cached()?;
 
     match auth {
-        CodexAuth::Chatgpt(_) | CodexAuth::ChatgptAuthTokens(_) => {
+        CodexAuth::Chatgpt(_) | CodexAuth::ChatgptAuthTokens(_) | CodexAuth::ChatgptProxy(_) => {
             let email = auth.get_account_email();
             let plan = plan
                 .map(|plan_type| title_case(format!("{plan_type:?}").as_str()))


### PR DESCRIPTION
# Add tokenless ChatGPT proxy auth + best-effort account metadata

## Why

Codex currently assumes a “ChatGPT auth” session always has bearer tokens available (either from a managed login flow or via externally supplied tokens). In some environments we want Codex to run behind a *trusted proxy* that already authenticates requests out-of-band (so the client never sees/holds tokens), while still being able to:

- Treat the session as ChatGPT-authenticated for UI/product decisions.
- Enforce workspace restrictions where configured.
- Show a reasonable account display (email + plan type), even if those details aren’t present locally.

This PR adds a **tokenless ChatGPT proxy auth mode** that carries only account metadata and (optionally) uses the existing usage endpoint to fill in missing metadata on a best-effort basis.

## What changed

### Core auth (`codex-rs/core`)

- Introduces `CodexAuth::ChatgptProxy` (`codex-rs/core/src/auth.rs`) backed by a new optional `chatgptProxy` object in `auth.json` (`codex-rs/core/src/auth/storage.rs`).
  - This auth mode is **tokenless**: `CodexAuth::bearer_token()` returns `Ok(None)` for `ChatgptProxy`.
  - Existing callers that *require* a bearer token can still use `get_token()`, which now returns an error if no token is available.
- Adds `login_with_chatgpt_proxy(...)` helper to seed an `AuthDotJson` payload for this mode.
- Updates workspace restriction enforcement to use `CodexAuth::chatgpt_workspace_id()` so it works consistently for both token-backed ChatGPT auth and proxy auth.
- Updates auth precedence rules (`load_auth`) so that **ephemeral proxy auth is treated as a fallback** rather than taking precedence over persisted credentials. This enables “seed proxy auth on startup” without preventing later/real logins from being used.
- Adds `AuthManager::update_chatgpt_proxy_account_metadata(...)` to fill in missing proxy metadata in-memory (no disk writes).

### App-server (`codex-rs/app-server` + CLI wiring)

- Adds a new CLI flag: `--default-chatgpt-proxy-auth`
  - Wired through both the `codex app-server` command (`codex-rs/cli/src/main.rs`) and the standalone `codex-app-server` binary (`codex-rs/app-server/src/main.rs`).
- When enabled, `MessageProcessor::new(...)` seeds ephemeral proxy auth **only if**:
  - no auth is currently present, and
  - login is not forced to API key (`forced_login_method != api`).
  - If a forced ChatGPT workspace id is configured, it’s included in the proxy auth seed.
- Improves `getAuthStatus` reporting in the presence of tokenless auth:
  - `auth_method` is now reported based on the current auth mode even when no token is returned/available.
- When `ChatgptProxy` auth is active, `account/read` (“GetAccount”) now returns account info by:
  - Using the proxy metadata if present.
  - Otherwise, making a best-effort call to the usage endpoint (5s timeout) to retrieve email/plan/account id, then caching it in-memory for the remainder of the process.

### Backend client + models (`codex-rs/backend-client`, `codex-rs/codex-backend-openapi-models`)

- `backend-client::Client::from_auth(...)` now attaches an `Authorization` header only if `CodexAuth::bearer_token()` is available, enabling tokenless proxy sessions to still use the client when the underlying environment supports it.
- Adds `get_rate_limits_with_metadata()` returning `(RateLimitSnapshot, UsageMetadata)`, where `UsageMetadata` includes:
  - `user_id`, `account_id`, `email`, and `plan_type`.
- Extends `RateLimitStatusPayload` model to include optional `user_id`, `account_id`, and `email`.

### TUI

- Treats `ChatgptProxy` as ChatGPT for composing account display (`codex-rs/tui/src/status/helpers.rs`).

## Behavior notes / guarantees

- Backwards-compatible on disk: `auth.json` gains a new optional `chatgptProxy` field; existing auth payloads continue to deserialize.
- No bearer tokens are persisted or exposed for proxy auth (by design).
- Proxy metadata updates are best-effort and **in-memory only**; we don’t persist enriched metadata back to disk.
- The usage endpoint lookup is explicitly time-bounded (`PLAN_TYPE_FETCH_TIMEOUT = 5s`) and failures only log a warning.

## How to test

### Unit/integration tests

From `codex-rs/`:

- `cargo test -p codex-core`
- `cargo test -p codex-backend-client`
- `cargo test -p codex-app-server`
- `cargo test -p codex-cli`

### Manual testing

1. Start the app-server with proxy auth seeding enabled:
   - `codex app-server --default-chatgpt-proxy-auth`
   - or `codex-app-server --default-chatgpt-proxy-auth`
2. Verify `getAuthStatus` reports an auth method (ChatGPT) even though no token is returned.
3. Call `account/read` and confirm:
   - it returns `planType`/`email` when present in proxy metadata, and
   - it falls back to a best-effort usage lookup when proxy metadata is missing.
4. Verify auth precedence:
   - Seed proxy auth (via flag), then log in with an API key persisted to disk; subsequent loads should prefer the persisted API key over the ephemeral proxy auth.

## Related work

- #10208 — “refactor CodexAuth so invalid state cannot be represented” (this PR extends that model with an explicit tokenless variant).
- #7610 — “taking plan type from usage endpoint instead of thru auth token” (this PR uses the same idea to fill in proxy metadata when tokens aren’t available).
- #5302 / #5477 — app-server rate limit read + notifications groundwork that this continues to build on.

## Follow-ups (optional)

- Consider whether any token-required call sites should switch from `get_token()` to `bearer_token()` for clearer intent (token required vs optional).
- If proxy auth becomes common, add focused integration coverage for `ChatgptProxy` in the app-server auth tests suite.

