### PR TITLE
chore: rename ChatGpt -> Chatgpt in type names

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -30,7 +30,7 @@ pub enum AuthMode {
     /// OpenAI API key provided by the caller and stored by Codex.
     ApiKey,
     /// ChatGPT OAuth managed by Codex (tokens persisted and refreshed by Codex).
-    ChatGPT,
+    Chatgpt,
     /// [UNSTABLE] FOR OPENAI INTERNAL USE ONLY - DO NOT USE.
     ///
     /// ChatGPT auth tokens are supplied by an external host app and are only

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1246,7 +1246,7 @@ impl CodexMessageProcessor {
         let account = match self.auth_manager.auth_cached() {
             Some(auth) => Some(match auth {
                 CodexAuth::ApiKey(_) => Account::ApiKey {},
-                CodexAuth::ChatGpt(_) | CodexAuth::ChatGptAuthTokens(_) => {
+                CodexAuth::Chatgpt(_) | CodexAuth::ChatgptAuthTokens(_) => {
                     let email = auth.get_account_email();
                     let plan_type = auth.account_plan_type();
 

--- a/codex-rs/app-server/tests/common/auth_fixtures.rs
+++ b/codex-rs/app-server/tests/common/auth_fixtures.rs
@@ -159,7 +159,7 @@ pub fn write_chatgpt_auth(
     let last_refresh = fixture.last_refresh.unwrap_or_else(|| Some(Utc::now()));
 
     let auth = AuthDotJson {
-        auth_mode: Some(AuthMode::ChatGPT),
+        auth_mode: Some(AuthMode::Chatgpt),
         openai_api_key: None,
         tokens: Some(tokens),
         last_refresh,

--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -236,7 +236,7 @@ pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {
                     std::process::exit(1);
                 }
             },
-            AuthMode::ChatGPT => {
+            AuthMode::Chatgpt => {
                 eprintln!("Logged in using ChatGPT");
                 std::process::exit(0);
             }

--- a/codex-rs/core/src/auth/storage.rs
+++ b/codex-rs/core/src/auth/storage.rs
@@ -565,7 +565,7 @@ mod tests {
         let auth_file = get_auth_file(codex_home.path());
         std::fs::write(&auth_file, "stale")?;
         let auth = AuthDotJson {
-            auth_mode: Some(AuthMode::ChatGPT),
+            auth_mode: Some(AuthMode::Chatgpt),
             openai_api_key: None,
             tokens: Some(TokenData {
                 id_token: Default::default(),

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4838,7 +4838,7 @@ mod tests {
             model_info.slug.as_str(),
             None,
             Some("test@test.com".to_string()),
-            Some(AuthMode::ChatGPT),
+            Some(AuthMode::Chatgpt),
             false,
             "test".to_string(),
             session_source,

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -137,7 +137,7 @@ impl ModelProviderInfo {
         &self,
         auth_mode: Option<AuthMode>,
     ) -> crate::error::Result<ApiProvider> {
-        let default_base_url = if matches!(auth_mode, Some(AuthMode::ChatGPT)) {
+        let default_base_url = if matches!(auth_mode, Some(AuthMode::Chatgpt)) {
             "https://chatgpt.com/backend-api/codex"
         } else {
             "https://api.openai.com/v1"

--- a/codex-rs/core/src/models_manager/manager.rs
+++ b/codex-rs/core/src/models_manager/manager.rs
@@ -274,7 +274,7 @@ impl ModelsManager {
         let mut merged_presets = ModelPreset::merge(remote_presets, existing_presets);
         let chatgpt_mode = matches!(
             self.auth_manager.get_internal_auth_mode(),
-            Some(AuthMode::ChatGPT)
+            Some(AuthMode::Chatgpt)
         );
         merged_presets = ModelPreset::filter_by_auth(merged_presets, chatgpt_mode);
 

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -71,7 +71,7 @@ async fn responses_stream_includes_subagent_header_on_review() {
     let config = Arc::new(config);
 
     let conversation_id = ThreadId::new();
-    let auth_mode = AuthMode::ChatGPT;
+    let auth_mode = AuthMode::Chatgpt;
     let session_source = SessionSource::SubAgent(SubAgentSource::Review);
     let model_info = ModelsManager::construct_model_info_offline(model.as_str(), &config);
     let otel_manager = OtelManager::new(
@@ -169,7 +169,7 @@ async fn responses_stream_includes_subagent_header_on_other() {
     let config = Arc::new(config);
 
     let conversation_id = ThreadId::new();
-    let auth_mode = AuthMode::ChatGPT;
+    let auth_mode = AuthMode::Chatgpt;
     let session_source = SessionSource::SubAgent(SubAgentSource::Other("my-task".to_string()));
     let model_info = ModelsManager::construct_model_info_offline(model.as_str(), &config);
 

--- a/codex-rs/core/tests/suite/auth_refresh.rs
+++ b/codex-rs/core/tests/suite/auth_refresh.rs
@@ -51,7 +51,7 @@ async fn refresh_token_succeeds_updates_storage() -> Result<()> {
     let initial_last_refresh = Utc::now() - Duration::days(1);
     let initial_tokens = build_tokens(INITIAL_ACCESS_TOKEN, INITIAL_REFRESH_TOKEN);
     let initial_auth = AuthDotJson {
-        auth_mode: Some(AuthMode::ChatGPT),
+        auth_mode: Some(AuthMode::Chatgpt),
         openai_api_key: None,
         tokens: Some(initial_tokens.clone()),
         last_refresh: Some(initial_last_refresh),
@@ -113,7 +113,7 @@ async fn returns_fresh_tokens_as_is() -> Result<()> {
     let initial_last_refresh = Utc::now() - Duration::days(1);
     let initial_tokens = build_tokens(INITIAL_ACCESS_TOKEN, INITIAL_REFRESH_TOKEN);
     let initial_auth = AuthDotJson {
-        auth_mode: Some(AuthMode::ChatGPT),
+        auth_mode: Some(AuthMode::Chatgpt),
         openai_api_key: None,
         tokens: Some(initial_tokens.clone()),
         last_refresh: Some(initial_last_refresh),
@@ -159,7 +159,7 @@ async fn refreshes_token_when_last_refresh_is_stale() -> Result<()> {
     let stale_refresh = Utc::now() - Duration::days(9);
     let initial_tokens = build_tokens(INITIAL_ACCESS_TOKEN, INITIAL_REFRESH_TOKEN);
     let initial_auth = AuthDotJson {
-        auth_mode: Some(AuthMode::ChatGPT),
+        auth_mode: Some(AuthMode::Chatgpt),
         openai_api_key: None,
         tokens: Some(initial_tokens.clone()),
         last_refresh: Some(stale_refresh),
@@ -218,7 +218,7 @@ async fn refresh_token_returns_permanent_error_for_expired_refresh_token() -> Re
     let initial_last_refresh = Utc::now() - Duration::days(1);
     let initial_tokens = build_tokens(INITIAL_ACCESS_TOKEN, INITIAL_REFRESH_TOKEN);
     let initial_auth = AuthDotJson {
-        auth_mode: Some(AuthMode::ChatGPT),
+        auth_mode: Some(AuthMode::Chatgpt),
         openai_api_key: None,
         tokens: Some(initial_tokens.clone()),
         last_refresh: Some(initial_last_refresh),
@@ -268,7 +268,7 @@ async fn refresh_token_returns_transient_error_on_server_failure() -> Result<()>
     let initial_last_refresh = Utc::now() - Duration::days(1);
     let initial_tokens = build_tokens(INITIAL_ACCESS_TOKEN, INITIAL_REFRESH_TOKEN);
     let initial_auth = AuthDotJson {
-        auth_mode: Some(AuthMode::ChatGPT),
+        auth_mode: Some(AuthMode::Chatgpt),
         openai_api_key: None,
         tokens: Some(initial_tokens.clone()),
         last_refresh: Some(initial_last_refresh),
@@ -320,7 +320,7 @@ async fn unauthorized_recovery_reloads_then_refreshes_tokens() -> Result<()> {
     let initial_last_refresh = Utc::now() - Duration::days(1);
     let initial_tokens = build_tokens(INITIAL_ACCESS_TOKEN, INITIAL_REFRESH_TOKEN);
     let initial_auth = AuthDotJson {
-        auth_mode: Some(AuthMode::ChatGPT),
+        auth_mode: Some(AuthMode::Chatgpt),
         openai_api_key: None,
         tokens: Some(initial_tokens.clone()),
         last_refresh: Some(initial_last_refresh),
@@ -329,7 +329,7 @@ async fn unauthorized_recovery_reloads_then_refreshes_tokens() -> Result<()> {
 
     let disk_tokens = build_tokens("disk-access-token", "disk-refresh-token");
     let disk_auth = AuthDotJson {
-        auth_mode: Some(AuthMode::ChatGPT),
+        auth_mode: Some(AuthMode::Chatgpt),
         openai_api_key: None,
         tokens: Some(disk_tokens.clone()),
         last_refresh: Some(initial_last_refresh),
@@ -412,7 +412,7 @@ async fn unauthorized_recovery_skips_reload_on_account_mismatch() -> Result<()> 
     let initial_last_refresh = Utc::now() - Duration::days(1);
     let initial_tokens = build_tokens(INITIAL_ACCESS_TOKEN, INITIAL_REFRESH_TOKEN);
     let initial_auth = AuthDotJson {
-        auth_mode: Some(AuthMode::ChatGPT),
+        auth_mode: Some(AuthMode::Chatgpt),
         openai_api_key: None,
         tokens: Some(initial_tokens.clone()),
         last_refresh: Some(initial_last_refresh),
@@ -427,7 +427,7 @@ async fn unauthorized_recovery_skips_reload_on_account_mismatch() -> Result<()> 
         ..disk_tokens.clone()
     };
     let disk_auth = AuthDotJson {
-        auth_mode: Some(AuthMode::ChatGPT),
+        auth_mode: Some(AuthMode::Chatgpt),
         openai_api_key: None,
         tokens: Some(disk_tokens),
         last_refresh: Some(initial_last_refresh),

--- a/codex-rs/login/src/server.rs
+++ b/codex-rs/login/src/server.rs
@@ -560,7 +560,7 @@ pub(crate) async fn persist_tokens_async(
             tokens.account_id = Some(acc.to_string());
         }
         let auth = AuthDotJson {
-            auth_mode: Some(AuthMode::ChatGPT),
+            auth_mode: Some(AuthMode::Chatgpt),
             openai_api_key: api_key,
             tokens: Some(tokens),
             last_refresh: Some(Utc::now()),

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -663,7 +663,7 @@ impl AuthModeWidget {
     fn handle_existing_chatgpt_login(&mut self) -> bool {
         if matches!(
             self.login_status,
-            LoginStatus::AuthMode(AuthMode::ChatGPT | AuthMode::ChatgptAuthTokens)
+            LoginStatus::AuthMode(AuthMode::Chatgpt | AuthMode::ChatgptAuthTokens)
         ) {
             *self.sign_in_state.write().unwrap() = SignInState::ChatGptSuccess;
             self.request_frame.schedule_frame();

--- a/codex-rs/tui/src/status/helpers.rs
+++ b/codex-rs/tui/src/status/helpers.rs
@@ -91,7 +91,7 @@ pub(crate) fn compose_account_display(
     let auth = auth_manager.auth_cached()?;
 
     match auth {
-        CodexAuth::ChatGpt(_) | CodexAuth::ChatGptAuthTokens(_) => {
+        CodexAuth::Chatgpt(_) | CodexAuth::ChatgptAuthTokens(_) => {
             let email = auth.get_account_email();
             let plan = plan
                 .map(|plan_type| title_case(format!("{plan_type:?}").as_str()))


### PR DESCRIPTION
When using ChatGPT in names of types, we should be consistent, so this renames some types with `ChatGpt` in the name to `Chatgpt`. From https://rust-lang.github.io/api-guidelines/naming.html:

> In `UpperCamelCase`, acronyms and contractions of compound words count as one word: use `Uuid` rather than `UUID`, `Usize` rather than `USize` or `Stdin` rather than `StdIn`. In `snake_case`, acronyms and contractions are lower-cased: `is_xid_start`.

This PR updates existing uses of `ChatGpt` and changes them to `Chatgpt`. Though in all cases where it could affect the wire format, I visually inspected that we don't change anything there. That said, this _will_ change the codegen because it will affect the spelling of type names.

For example, this renames `AuthMode::ChatGPT` to `AuthMode::Chatgpt` in  `app-server-protocol`, but the wire format is still `"chatgpt"`.

This PR also updates a number of types in `codex-rs/core/src/auth.rs`.
