### PR TITLE
Fix resume picker bug where it shows "no message yet"

### DIFF
--- a/codex-rs/core/src/rollout/tests.rs
+++ b/codex-rs/core/src/rollout/tests.rs
@@ -724,7 +724,7 @@ async fn test_head_summary_includes_first_user_message_beyond_head_limit() {
         .iter()
         .filter_map(|value| serde_json::from_value::<ResponseItem>(value.clone()).ok())
         .find_map(|item| match event_mapping::parse_turn_item(&item) {
-            Some(TurnItem::UserMessage(user)) => Some(user.message().to_string()),
+            Some(TurnItem::UserMessage(user)) => Some(user.message()),
             _ => None,
         });
 


### PR DESCRIPTION
Fix "the resume-picker list sometimes incorrectly shows "(no message yet)" under conversation"

I'm not an expert on the events that comprise a rollout, so I'm not 100% confident this is the correct fix. It was recommended by Codex.

Summary
- ensure the head preview always includes at least one user message even if it appears beyond the initial record limit, by tracking the first user response seen while scanning
- reuse that delayed user message if the clipped preview lacks any user turn, so session summaries reply faster with meaningful context
- add regression coverage that writes a rollout file where the first user response occurs past the head limit and verify it shows up in the preview

Testing
I don't have a repro case for this problem, so I didn't manually test it. If we're concerned about the fix, I could ask the user to provide a rollout that repros the problem. Otherwise I'll just have the user confirm the fix once we roll out the next alpha.

This addresses #10216