### PR TITLE
[feat] persist thread_dynamic_tools in db

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -333,9 +333,36 @@ impl Codex {
             .clone()
             .or_else(|| conversation_history.get_base_instructions().map(|s| s.text))
             .unwrap_or_else(|| model_info.get_model_instructions(config.personality));
-        // Respect explicit thread-start tools; fall back to persisted tools when resuming a thread.
+
+        // Respect thread-start tools. When missing (resumed/forked threads), read from the db
+        // first, then fall back to rollout-file tools.
+        let persisted_tools = if dynamic_tools.is_empty()
+            && config.features.enabled(Feature::Sqlite)
+        {
+            let thread_id = match &conversation_history {
+                InitialHistory::Resumed(resumed) => Some(resumed.conversation_id),
+                InitialHistory::Forked(_) => conversation_history.forked_from_id(),
+                InitialHistory::New => None,
+            };
+            match thread_id {
+                Some(thread_id) => {
+                    let state_db_ctx = state_db::open_if_present(
+                        config.codex_home.as_path(),
+                        config.model_provider_id.as_str(),
+                    )
+                    .await;
+                    state_db::get_dynamic_tools(state_db_ctx.as_deref(), thread_id, "codex_spawn")
+                        .await
+                }
+                None => None,
+            }
+        } else {
+            None
+        };
         let dynamic_tools = if dynamic_tools.is_empty() {
-            conversation_history.get_dynamic_tools().unwrap_or_default()
+            persisted_tools
+                .or_else(|| conversation_history.get_dynamic_tools())
+                .unwrap_or_default()
         } else {
             dynamic_tools
         };

--- a/codex-rs/core/src/rollout/metadata.rs
+++ b/codex-rs/core/src/rollout/metadata.rs
@@ -189,12 +189,19 @@ pub(crate) async fn backfill_sessions(
                     stats.upserted = stats.upserted.saturating_add(1);
                     if let Ok(meta_line) = rollout::list::read_session_meta_line(&path).await {
                         if let Err(err) = runtime
-                            .replace_dynamic_tools(
+                            .persist_dynamic_tools(
                                 meta_line.meta.id,
                                 meta_line.meta.dynamic_tools.as_deref(),
                             )
                             .await
                         {
+                            if let Some(otel) = otel {
+                                otel.counter(
+                                    DB_ERROR_METRIC,
+                                    1,
+                                    &[("stage", "backfill_dynamic_tools")],
+                                );
+                            }
                             warn!("failed to backfill dynamic tools {}: {err}", path.display());
                         }
                     } else {

--- a/codex-rs/core/src/state_db.rs
+++ b/codex-rs/core/src/state_db.rs
@@ -213,8 +213,8 @@ pub async fn get_dynamic_tools(
     }
 }
 
-/// Replace dynamic tools for a thread id using SQLite.
-pub async fn replace_dynamic_tools(
+/// Persist dynamic tools for a thread id using SQLite, if none exist yet.
+pub async fn persist_dynamic_tools(
     context: Option<&codex_state::StateRuntime>,
     thread_id: ThreadId,
     tools: Option<&[DynamicToolSpec]>,
@@ -223,8 +223,8 @@ pub async fn replace_dynamic_tools(
     let Some(ctx) = context else {
         return;
     };
-    if let Err(err) = ctx.replace_dynamic_tools(thread_id, tools).await {
-        warn!("state db replace_dynamic_tools failed during {stage}: {err}");
+    if let Err(err) = ctx.persist_dynamic_tools(thread_id, tools).await {
+        warn!("state db persist_dynamic_tools failed during {stage}: {err}");
     }
 }
 
@@ -270,7 +270,7 @@ pub async fn reconcile_rollout(
         return;
     }
     if let Ok(meta_line) = crate::rollout::list::read_session_meta_line(rollout_path).await {
-        replace_dynamic_tools(
+        persist_dynamic_tools(
             Some(ctx),
             meta_line.meta.id,
             meta_line.meta.dynamic_tools.as_deref(),

--- a/codex-rs/core/src/state_db.rs
+++ b/codex-rs/core/src/state_db.rs
@@ -9,6 +9,7 @@ use chrono::Timelike;
 use chrono::Utc;
 use codex_otel::OtelManager;
 use codex_protocol::ThreadId;
+use codex_protocol::dynamic_tools::DynamicToolSpec;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::SessionSource;
 use codex_state::DB_METRIC_COMPARE_ERROR;
@@ -196,6 +197,37 @@ pub async fn find_rollout_path_by_id(
         })
 }
 
+/// Get dynamic tools for a thread id using SQLite.
+pub async fn get_dynamic_tools(
+    context: Option<&codex_state::StateRuntime>,
+    thread_id: ThreadId,
+    stage: &str,
+) -> Option<Vec<DynamicToolSpec>> {
+    let ctx = context?;
+    match ctx.get_dynamic_tools(thread_id).await {
+        Ok(tools) => tools,
+        Err(err) => {
+            warn!("state db get_dynamic_tools failed during {stage}: {err}");
+            None
+        }
+    }
+}
+
+/// Replace dynamic tools for a thread id using SQLite.
+pub async fn replace_dynamic_tools(
+    context: Option<&codex_state::StateRuntime>,
+    thread_id: ThreadId,
+    tools: Option<&[DynamicToolSpec]>,
+    stage: &str,
+) {
+    let Some(ctx) = context else {
+        return;
+    };
+    if let Err(err) = ctx.replace_dynamic_tools(thread_id, tools).await {
+        warn!("state db replace_dynamic_tools failed during {stage}: {err}");
+    }
+}
+
 /// Reconcile rollout items into SQLite, falling back to scanning the rollout file.
 pub async fn reconcile_rollout(
     context: Option<&codex_state::StateRuntime>,
@@ -233,6 +265,21 @@ pub async fn reconcile_rollout(
     if let Err(err) = ctx.upsert_thread(&outcome.metadata).await {
         warn!(
             "state db reconcile_rollout upsert failed {}: {err}",
+            rollout_path.display()
+        );
+        return;
+    }
+    if let Ok(meta_line) = crate::rollout::list::read_session_meta_line(rollout_path).await {
+        replace_dynamic_tools(
+            Some(ctx),
+            meta_line.meta.id,
+            meta_line.meta.dynamic_tools.as_deref(),
+            "reconcile_rollout",
+        )
+        .await;
+    } else {
+        warn!(
+            "state db reconcile_rollout missing session meta {}",
             rollout_path.display()
         );
     }

--- a/codex-rs/core/tests/suite/sqlite_state.rs
+++ b/codex-rs/core/tests/suite/sqlite_state.rs
@@ -177,10 +177,15 @@ async fn backfill_scans_existing_rollouts() -> Result<()> {
     assert_eq!(metadata.model_provider, default_provider);
     assert!(metadata.has_user_event);
 
-    let stored_tools = db
-        .get_dynamic_tools(thread_id)
-        .await?
-        .expect("dynamic tools should be stored");
+    let mut stored_tools = None;
+    for _ in 0..40 {
+        stored_tools = db.get_dynamic_tools(thread_id).await?;
+        if stored_tools.is_some() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    let stored_tools = stored_tools.expect("dynamic tools should be stored");
     assert_eq!(stored_tools, dynamic_tools);
 
     Ok(())

--- a/codex-rs/core/tests/suite/sqlite_state.rs
+++ b/codex-rs/core/tests/suite/sqlite_state.rs
@@ -1,6 +1,7 @@
 use anyhow::Result;
 use codex_core::features::Feature;
 use codex_protocol::ThreadId;
+use codex_protocol::dynamic_tools::DynamicToolSpec;
 use codex_protocol::protocol::EventMsg;
 use codex_protocol::protocol::RolloutItem;
 use codex_protocol::protocol::RolloutLine;
@@ -74,6 +75,28 @@ async fn backfill_scans_existing_rollouts() -> Result<()> {
     let rollout_rel_path = format!("sessions/2026/01/27/rollout-2026-01-27T12-00-00-{uuid}.jsonl");
     let rollout_rel_path_for_hook = rollout_rel_path.clone();
 
+    let dynamic_tools = vec![
+        DynamicToolSpec {
+            name: "geo_lookup".to_string(),
+            description: "lookup a city".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "required": ["city"],
+                "properties": { "city": { "type": "string" } }
+            }),
+        },
+        DynamicToolSpec {
+            name: "weather_lookup".to_string(),
+            description: "lookup weather".to_string(),
+            input_schema: json!({
+                "type": "object",
+                "required": ["zip"],
+                "properties": { "zip": { "type": "string" } }
+            }),
+        },
+    ];
+    let dynamic_tools_for_hook = dynamic_tools.clone();
+
     let mut builder = test_codex()
         .with_pre_build_hook(move |codex_home| {
             let rollout_path = codex_home.join(&rollout_rel_path_for_hook);
@@ -81,7 +104,6 @@ async fn backfill_scans_existing_rollouts() -> Result<()> {
                 .parent()
                 .expect("rollout path should have parent");
             fs::create_dir_all(parent).expect("should create rollout directory");
-
             let session_meta_line = SessionMetaLine {
                 meta: SessionMeta {
                     id: thread_id,
@@ -93,7 +115,7 @@ async fn backfill_scans_existing_rollouts() -> Result<()> {
                     source: SessionSource::default(),
                     model_provider: None,
                     base_instructions: None,
-                    dynamic_tools: None,
+                    dynamic_tools: Some(dynamic_tools_for_hook),
                 },
                 git: None,
             };
@@ -154,6 +176,12 @@ async fn backfill_scans_existing_rollouts() -> Result<()> {
     assert_eq!(metadata.rollout_path, rollout_path);
     assert_eq!(metadata.model_provider, default_provider);
     assert!(metadata.has_user_event);
+
+    let stored_tools = db
+        .get_dynamic_tools(thread_id)
+        .await?
+        .expect("dynamic tools should be stored");
+    assert_eq!(stored_tools, dynamic_tools);
 
     Ok(())
 }

--- a/codex-rs/state/migrations/0004_thread_dynamic_tools.sql
+++ b/codex-rs/state/migrations/0004_thread_dynamic_tools.sql
@@ -1,0 +1,11 @@
+CREATE TABLE thread_dynamic_tools (
+    thread_id TEXT NOT NULL,
+    position INTEGER NOT NULL,
+    name TEXT NOT NULL,
+    description TEXT NOT NULL,
+    input_schema TEXT NOT NULL,
+    PRIMARY KEY(thread_id, position),
+    FOREIGN KEY(thread_id) REFERENCES threads(id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_thread_dynamic_tools_thread ON thread_dynamic_tools(thread_id);

--- a/codex-rs/state/src/runtime.rs
+++ b/codex-rs/state/src/runtime.rs
@@ -16,8 +16,10 @@ use chrono::DateTime;
 use chrono::Utc;
 use codex_otel::OtelManager;
 use codex_protocol::ThreadId;
+use codex_protocol::dynamic_tools::DynamicToolSpec;
 use codex_protocol::protocol::RolloutItem;
 use log::LevelFilter;
+use serde_json::Value;
 use sqlx::ConnectOptions;
 use sqlx::QueryBuilder;
 use sqlx::Row;
@@ -115,6 +117,38 @@ WHERE id = ?
         .await?;
         row.map(|row| ThreadRow::try_from_row(&row).and_then(ThreadMetadata::try_from))
             .transpose()
+    }
+
+    /// Get dynamic tools for a thread, if present.
+    pub async fn get_dynamic_tools(
+        &self,
+        thread_id: ThreadId,
+    ) -> anyhow::Result<Option<Vec<DynamicToolSpec>>> {
+        let rows = sqlx::query(
+            r#"
+SELECT name, description, input_schema
+FROM thread_dynamic_tools
+WHERE thread_id = ?
+ORDER BY position ASC
+            "#,
+        )
+        .bind(thread_id.to_string())
+        .fetch_all(self.pool.as_ref())
+        .await?;
+        if rows.is_empty() {
+            return Ok(None);
+        }
+        let mut tools = Vec::with_capacity(rows.len());
+        for row in rows {
+            let input_schema: String = row.try_get("input_schema")?;
+            let input_schema = serde_json::from_str::<Value>(input_schema.as_str())?;
+            tools.push(DynamicToolSpec {
+                name: row.try_get("name")?,
+                description: row.try_get("description")?,
+                input_schema,
+            });
+        }
+        Ok(Some(tools))
     }
 
     /// Find a rollout path by thread id using the underlying database.
@@ -369,6 +403,46 @@ ON CONFLICT(id) DO UPDATE SET
         Ok(())
     }
 
+    /// Replace dynamic tools for a thread.
+    pub async fn replace_dynamic_tools(
+        &self,
+        thread_id: ThreadId,
+        tools: Option<&[DynamicToolSpec]>,
+    ) -> anyhow::Result<()> {
+        let mut tx = self.pool.begin().await?;
+        let thread_id = thread_id.to_string();
+        sqlx::query("DELETE FROM thread_dynamic_tools WHERE thread_id = ?")
+            .bind(thread_id.as_str())
+            .execute(&mut *tx)
+            .await?;
+        if let Some(tools) = tools {
+            for (idx, tool) in tools.iter().enumerate() {
+                let position = i64::try_from(idx).unwrap_or(i64::MAX);
+                let input_schema = serde_json::to_string(&tool.input_schema)?;
+                sqlx::query(
+                    r#"
+INSERT INTO thread_dynamic_tools (
+    thread_id,
+    position,
+    name,
+    description,
+    input_schema
+) VALUES (?, ?, ?, ?, ?)
+                    "#,
+                )
+                .bind(thread_id.as_str())
+                .bind(position)
+                .bind(tool.name.as_str())
+                .bind(tool.description.as_str())
+                .bind(input_schema)
+                .execute(&mut *tx)
+                .await?;
+            }
+        }
+        tx.commit().await?;
+        Ok(())
+    }
+
     /// Apply rollout items incrementally using the underlying database.
     pub async fn apply_rollout_items(
         &self,
@@ -390,9 +464,22 @@ ON CONFLICT(id) DO UPDATE SET
         if let Some(updated_at) = file_modified_time_utc(builder.rollout_path.as_path()).await {
             metadata.updated_at = updated_at;
         }
+        // Keep the thread upsert before dynamic tools to satisfy the foreign key constraint:
+        // thread_dynamic_tools.thread_id -> threads.id.
         if let Err(err) = self.upsert_thread(&metadata).await {
             if let Some(otel) = otel {
                 otel.counter(DB_ERROR_METRIC, 1, &[("stage", "apply_rollout_items")]);
+            }
+            return Err(err);
+        }
+        let dynamic_tools = extract_dynamic_tools(items);
+        if let Some(dynamic_tools) = dynamic_tools
+            && let Err(err) = self
+                .replace_dynamic_tools(builder.id, dynamic_tools.as_deref())
+                .await
+        {
+            if let Some(otel) = otel {
+                otel.counter(DB_ERROR_METRIC, 1, &[("stage", "replace_dynamic_tools")]);
             }
             return Err(err);
         }
@@ -505,6 +592,16 @@ fn push_like_filters<'a>(
             .push(" || '%'");
     }
     builder.push(")");
+}
+
+fn extract_dynamic_tools(items: &[RolloutItem]) -> Option<Option<Vec<DynamicToolSpec>>> {
+    items.iter().find_map(|item| match item {
+        RolloutItem::SessionMeta(meta_line) => Some(meta_line.meta.dynamic_tools.clone()),
+        RolloutItem::ResponseItem(_)
+        | RolloutItem::Compacted(_)
+        | RolloutItem::TurnContext(_)
+        | RolloutItem::EventMsg(_) => None,
+    })
 }
 
 async fn open_sqlite(path: &Path) -> anyhow::Result<SqlitePool> {


### PR DESCRIPTION
Persist thread_dynamic_tools in sqlite and read first from it. Fall back to rollout files if it's not found. Persist dynamic tools to both sqlite and rollout files.

Saw that new sessions get populated to db correctly & old sessions get backfilled correctly at startup:
```
celia@com-92114 codex-rs % sqlite3 ~/.codex/state.sqlite \      "select thread_id, position,name,description,input_schema from thread_dynamic_tools;"
019c0cad-ec0d-74b2-a787-e8b33a349117|0|geo_lookup|lookup a city|{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"}
....
019c10ca-aa4b-7620-ae40-c0919fbd7ea7|0|geo_lookup|lookup a city|{"properties":{"city":{"type":"string"}},"required":["city"],"type":"object"}
```