### PR TITLE
Make plan highlight use popup grey background

### DIFF
--- a/codex-rs/tui/src/style.rs
+++ b/codex-rs/tui/src/style.rs
@@ -40,10 +40,5 @@ pub fn user_message_bg(terminal_bg: (u8, u8, u8)) -> Color {
 
 #[allow(clippy::disallowed_methods)]
 pub fn proposed_plan_bg(terminal_bg: (u8, u8, u8)) -> Color {
-    let (top, alpha) = if is_light(terminal_bg) {
-        ((0, 110, 150), 0.08)
-    } else {
-        ((80, 170, 220), 0.2)
-    };
-    best_color(blend(top, terminal_bg, alpha))
+    user_message_bg(terminal_bg)
 }


### PR DESCRIPTION
## Summary
- align proposed plan background with popup surface color by reusing `user_message_bg`
- remove the custom blue-tinted plan background

<img width="1572" height="1568" alt="image" src="https://github.com/user-attachments/assets/63a5341e-4342-4c07-b6b0-c4350c3b2639" />
