### PR TITLE
Nicer highlighting of slash commands, /plan accepts prompt args and pasted images

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -2071,10 +2071,7 @@ impl ChatComposer {
             self.windows_degraded_sandbox_active,
         )?;
 
-        if !matches!(
-            cmd,
-            SlashCommand::Review | SlashCommand::Rename | SlashCommand::Plan
-        ) {
+        if !cmd.supports_inline_args() {
             return None;
         }
         if self.reject_slash_command_if_unavailable(cmd) {

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -2081,6 +2081,10 @@ impl ChatComposer {
             return Some(InputResult::None);
         }
 
+        // `/plan ...` is staged differently from other arg-taking commands:
+        // history recording + pending-paste expansion must happen only after
+        // ChatWidget confirms Plan mode actually activated. If Plan mode is
+        // unavailable, we keep the raw draft intact instead of consuming it.
         if cmd == SlashCommand::Plan {
             let mut args_elements = Self::slash_command_args_elements(
                 rest,

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -404,6 +404,7 @@ impl BottomPane {
     ) {
         self.composer
             .set_text_content(text, text_elements, local_image_paths);
+        self.composer.move_cursor_to_end();
         self.request_redraw();
     }
 

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -218,7 +218,7 @@ impl BottomPane {
         self.composer.take_mention_paths()
     }
 
-    /// Clear pending attachments and mention paths when a command doesn't submit text.
+    /// Clear pending attachments and mention paths e.g. when a slash command doesn't submit text.
     pub(crate) fn drain_pending_submission_state(&mut self) {
         let _ = self.take_recent_submission_images_with_placeholders();
         let _ = self.take_mention_paths();

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -794,6 +794,10 @@ impl BottomPane {
             .take_recent_submission_images_with_placeholders()
     }
 
+    pub(crate) fn prepare_plan_args_submission(&mut self) -> Option<(String, Vec<TextElement>)> {
+        self.composer.prepare_plan_args_submission()
+    }
+
     fn as_renderable(&'_ self) -> RenderableItem<'_> {
         if let Some(view) = self.active_view() {
             RenderableItem::Borrowed(view)

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -218,6 +218,12 @@ impl BottomPane {
         self.composer.take_mention_paths()
     }
 
+    /// Clear pending attachments and mention paths when a command doesn't submit text.
+    pub(crate) fn drain_pending_submission_state(&mut self) {
+        let _ = self.take_recent_submission_images_with_placeholders();
+        let _ = self.take_mention_paths();
+    }
+
     pub fn set_steer_enabled(&mut self, enabled: bool) {
         self.composer.set_steer_enabled(enabled);
     }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -794,8 +794,11 @@ impl BottomPane {
             .take_recent_submission_images_with_placeholders()
     }
 
-    pub(crate) fn prepare_plan_args_submission(&mut self) -> Option<(String, Vec<TextElement>)> {
-        self.composer.prepare_plan_args_submission()
+    pub(crate) fn prepare_inline_args_submission(
+        &mut self,
+        record_history: bool,
+    ) -> Option<(String, Vec<TextElement>)> {
+        self.composer.prepare_inline_args_submission(record_history)
     }
 
     fn as_renderable(&'_ self) -> RenderableItem<'_> {

--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -872,6 +872,18 @@ impl TextArea {
         self.elements.sort_by_key(|e| e.range.start);
     }
 
+    pub fn remove_element_range(&mut self, range: Range<usize>) -> bool {
+        let start = self.clamp_pos_to_char_boundary(range.start.min(self.text.len()));
+        let end = self.clamp_pos_to_char_boundary(range.end.min(self.text.len()));
+        if start >= end {
+            return false;
+        }
+        let len_before = self.elements.len();
+        self.elements
+            .retain(|elem| elem.range.start != start || elem.range.end != end);
+        len_before != self.elements.len()
+    }
+
     fn add_element(&mut self, range: Range<usize>) {
         let elem = TextElement { range };
         self.elements.push(elem);

--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -844,6 +844,34 @@ impl TextArea {
         self.set_cursor(end);
     }
 
+    /// Mark an existing text range as an atomic element without changing the text.
+    ///
+    /// This is used to convert already-typed tokens (like `/plan`) into elements
+    /// so they render and edit atomically. Overlapping or duplicate ranges are ignored.
+    pub fn add_element_range(&mut self, range: Range<usize>) {
+        let start = self.clamp_pos_to_char_boundary(range.start.min(self.text.len()));
+        let end = self.clamp_pos_to_char_boundary(range.end.min(self.text.len()));
+        if start >= end {
+            return;
+        }
+        if self
+            .elements
+            .iter()
+            .any(|e| e.range.start == start && e.range.end == end)
+        {
+            return;
+        }
+        if self
+            .elements
+            .iter()
+            .any(|e| start < e.range.end && end > e.range.start)
+        {
+            return;
+        }
+        self.elements.push(TextElement { range: start..end });
+        self.elements.sort_by_key(|e| e.range.start);
+    }
+
     fn add_element(&mut self, range: Range<usize>) {
         let elem = TextElement { range };
         self.elements.push(elem);

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3024,7 +3024,7 @@ impl ChatWidget {
         &mut self,
         cmd: SlashCommand,
         args: String,
-        text_elements: Vec<TextElement>,
+        _text_elements: Vec<TextElement>,
     ) {
         if !cmd.available_during_task() && self.bottom_pane.is_task_running() {
             let message = format!(
@@ -3054,15 +3054,19 @@ impl ChatWidget {
             SlashCommand::Plan if !trimmed.is_empty() => {
                 self.dispatch_command(cmd);
                 if self.active_mode_kind() != ModeKind::Plan {
-                    self.bottom_pane.drain_pending_submission_state();
                     return;
                 }
+                let Some((prepared_args, prepared_elements)) =
+                    self.bottom_pane.prepare_plan_args_submission()
+                else {
+                    return;
+                };
                 let user_message = UserMessage {
-                    text: args,
+                    text: prepared_args,
                     local_images: self
                         .bottom_pane
                         .take_recent_submission_images_with_placeholders(),
-                    text_elements,
+                    text_elements: prepared_elements,
                     mention_paths: self.bottom_pane.take_mention_paths(),
                 };
                 if self.is_session_configured() {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2783,10 +2783,7 @@ impl ChatWidget {
                 cmd.command()
             );
             self.add_to_history(history_cell::new_error_event(message));
-            let _ = self
-                .bottom_pane
-                .take_recent_submission_images_with_placeholders();
-            let _ = self.bottom_pane.take_mention_paths();
+            self.bottom_pane.drain_pending_submission_state();
             self.request_redraw();
             return;
         }
@@ -3035,10 +3032,7 @@ impl ChatWidget {
                 cmd.command()
             );
             self.add_to_history(history_cell::new_error_event(message));
-            let _ = self
-                .bottom_pane
-                .take_recent_submission_images_with_placeholders();
-            let _ = self.bottom_pane.take_mention_paths();
+            self.bottom_pane.drain_pending_submission_state();
             self.request_redraw();
             return;
         }
@@ -3055,18 +3049,12 @@ impl ChatWidget {
                 self.request_redraw();
                 self.app_event_tx
                     .send(AppEvent::CodexOp(Op::SetThreadName { name }));
-                let _ = self
-                    .bottom_pane
-                    .take_recent_submission_images_with_placeholders();
-                let _ = self.bottom_pane.take_mention_paths();
+                self.bottom_pane.drain_pending_submission_state();
             }
             SlashCommand::Plan if !trimmed.is_empty() => {
                 self.dispatch_command(cmd);
                 if self.active_mode_kind() != ModeKind::Plan {
-                    let _ = self
-                        .bottom_pane
-                        .take_recent_submission_images_with_placeholders();
-                    let _ = self.bottom_pane.take_mention_paths();
+                    self.bottom_pane.drain_pending_submission_state();
                     return;
                 }
                 let user_message = UserMessage {
@@ -3095,10 +3083,7 @@ impl ChatWidget {
                         user_facing_hint: None,
                     },
                 });
-                let _ = self
-                    .bottom_pane
-                    .take_recent_submission_images_with_placeholders();
-                let _ = self.bottom_pane.take_mention_paths();
+                self.bottom_pane.drain_pending_submission_state();
             }
             _ => self.dispatch_command(cmd),
         }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3026,6 +3026,10 @@ impl ChatWidget {
         args: String,
         _text_elements: Vec<TextElement>,
     ) {
+        if !cmd.supports_inline_args() {
+            self.dispatch_command(cmd);
+            return;
+        }
         if !cmd.available_during_task() && self.bottom_pane.is_task_running() {
             let message = format!(
                 "'/{}' is disabled while a task is in progress.",

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3090,7 +3090,7 @@ impl ChatWidget {
                 self.submit_op(Op::Review {
                     review_request: ReviewRequest {
                         target: ReviewTarget::Custom {
-                            instructions: trimmed.clone(),
+                            instructions: trimmed,
                         },
                         user_facing_hint: None,
                     },

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -87,6 +87,14 @@ impl SlashCommand {
         self.into()
     }
 
+    /// Whether this command supports inline args (for example `/review ...`).
+    pub fn supports_inline_args(self) -> bool {
+        matches!(
+            self,
+            SlashCommand::Review | SlashCommand::Rename | SlashCommand::Plan
+        )
+    }
+
     /// Whether this command can be run while a task is in progress.
     pub fn available_during_task(self) -> bool {
         match self {

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -103,6 +103,7 @@ impl SlashCommand {
             | SlashCommand::ElevateSandbox
             | SlashCommand::Experimental
             | SlashCommand::Review
+            | SlashCommand::Plan
             | SlashCommand::Logout => false,
             SlashCommand::Diff
             | SlashCommand::Rename
@@ -117,7 +118,6 @@ impl SlashCommand {
             | SlashCommand::Exit => true,
             SlashCommand::Rollout => true,
             SlashCommand::TestApproval => true,
-            SlashCommand::Plan => true,
             SlashCommand::Collab => true,
             SlashCommand::Agent => true,
         }

--- a/docs/tui-chat-composer.md
+++ b/docs/tui-chat-composer.md
@@ -48,6 +48,8 @@ The solution is to detect paste-like _bursts_ and buffer them into a single expl
   history navigation, etc).
 - After handling the key, `sync_popups()` runs so popup visibility/filters stay consistent with the
   latest text + cursor.
+- When a slash command name is completed and the user types a space, the `/command` token is
+  promoted into a text element so it renders distinctly and edits atomically.
 
 ### History navigation (↑/↓)
 
@@ -104,6 +106,9 @@ There are multiple submission paths, but they share the same core rules:
 4. Prunes attachments so only placeholders that survive expansion are sent.
 5. Clears pending pastes on success and suppresses submission if the final text is empty and there
    are no attachments.
+
+The same preparation path is reused for slash commands with arguments (for example `/plan` and
+`/review`) so pasted content and text elements are preserved when extracting args.
 
 ### Numeric auto-submit path
 


### PR DESCRIPTION
## Summary
- Make typed slash commands become text elements when the user hits space, including paste‑burst spaces.
- Enable `/plan` to accept inline args and submit them in plan mode, mirroring `/review` behavior and blocking submission while a task is
running.
- Preserve text elements/attachments for slash commands that take args.

<img width="1510" height="500" alt="image" src="https://github.com/user-attachments/assets/446024df-b69a-4249-85db-1a85110e07f1" />

## Changes
- Add safe helper to insert element ranges in the textarea.
- Extend command‑with‑args pipeline to carry text elements and reuse submission prep.
- Update `/plan` dispatch to switch to plan mode then submit prompt + elements.
- Document new composer behavior and add tests.

## Notes
- `/plan` is blocked during active tasks (same as `/review`).
- Slash‑command elementization recognizes built‑ins and `/prompts:` custom commands only.

## Codex author
`codex fork 019c16d3-4520-7bb0-9b9d-48720d40a8ab`