### PR TITLE
fix: explicitly end Plan mode when switching to Code mode

### DIFF
--- a/codex-rs/core/templates/collaboration_mode/code.md
+++ b/codex-rs/core/templates/collaboration_mode/code.md
@@ -1,1 +1,2 @@
-you are now in code mode.
+Plan Mode is now ended. You are in Code mode.
+You may now execute commands, edit files, and perform mutating actions.


### PR DESCRIPTION
## Summary

Fixes #10185

When switching from Plan to Code mode, the Code mode template now explicitly ends Plan mode.

## Root Cause

The Plan mode template (`plan.md`) states:
> "You are in **Plan Mode** until a developer message explicitly ends it."

But the Code mode template (`code.md`) only said:
> "you are now in code mode."

This wasn't an explicit "end" to Plan mode, causing the model to continue following Plan mode instructions even after switching.

## Changes

Updated `code.md` to explicitly end Plan mode:

```markdown
Plan Mode is now ended. You are in Code mode.
You may now execute commands, edit files, and perform mutating actions.
```

## Testing

1. Start in Code mode
2. Switch to Plan mode (shift+tab)
3. Switch back to Code mode
4. Ask for execution → agent should now execute instead of refusing

Thread ID from issue: `019c0aed-2138-7b32-acf5-f3fb174f84f3`