### PR TITLE
plan mode: allow clarification turns without proposed_plan

### DIFF
--- a/codex-rs/core/templates/collaboration_mode/plan.md
+++ b/codex-rs/core/templates/collaboration_mode/plan.md
@@ -59,13 +59,17 @@ Do not ask questions that can be answered from the repo or system (for example, 
 
 Every assistant turn MUST be exactly one of:
 A) a `request_user_input` tool call (questions/options only), OR
-B) the final output: a titled, plan-only document.
+B) a direct answer or clarification in plain assistant text, OR
+C) the final output: a titled, plan-only document inside a `<proposed_plan>` block.
 
 Rules:
 
 * No questions in free text (only via `request_user_input`).
 * Never mix a `request_user_input` call with plan content.
-* Internal tool/repo exploration is allowed privately before A or B.
+* Turn type B must NOT include a `<proposed_plan>` block.
+* Turn type B should not look like a full plan.
+* If the user asks for clarification but you still need input to proceed, use `request_user_input` and include the brief explanation inside the question text (do not answer in plain text in that case).
+* Internal tool/repo exploration is allowed privately before A, B, or C.
 
 ## Ask a lot, but never ask trivia
 
@@ -96,6 +100,8 @@ Use the `request_user_input` tool only for decisions that materially change the 
 ## Finalization rule
 
 Only output the final plan when it is decision complete and leaves no decisions to the implementer.
+
+Use `<proposed_plan>` only for the official final plan, never for explanations or clarifications.
 
 When you present the official plan, wrap it in a `<proposed_plan>` block so the client can render it specially:
 


### PR DESCRIPTION
The failure mode was that Plan Mode forced every turn to be either a request_user_input tool call or a final plan, so when a user asked for a clarification (“can you explain the issue?”), the model often responded with a full plan (sometimes inside <proposed_plan>), which prematurely triggered the “Implement this plan?” UI. This change adds an explicit “clarification/answer” turn type and makes it clear that <proposed_plan> is only for the official final plan.