### PR TITLE
feat: show runtime metrics in console

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -208,6 +208,9 @@
             "responses_websockets": {
               "type": "boolean"
             },
+            "runtime_metrics": {
+              "type": "boolean"
+            },
             "shell_snapshot": {
               "type": "boolean"
             },
@@ -1231,6 +1234,9 @@
           "type": "boolean"
         },
         "responses_websockets": {
+          "type": "boolean"
+        },
+        "runtime_metrics": {
           "type": "boolean"
         },
         "shell_snapshot": {

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -101,6 +101,8 @@ pub enum Feature {
     RemoteModels,
     /// Experimental shell snapshotting.
     ShellSnapshot,
+    /// Enable runtime metrics snapshots via a manual reader.
+    RuntimeMetrics,
     /// Persist rollout metadata to a local SQLite database.
     Sqlite,
     /// Append additional AGENTS.md guidance to user instructions.
@@ -435,6 +437,12 @@ pub const FEATURES: &[FeatureSpec] = &[
             menu_description: "Snapshot your shell environment to avoid re-running login scripts for every command.",
             announcement: "NEW! Try shell snapshotting to make your Codex faster. Enable in /experimental!",
         },
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::RuntimeMetrics,
+        key: "runtime_metrics",
+        stage: Stage::UnderDevelopment,
         default_enabled: false,
     },
     FeatureSpec {

--- a/codex-rs/core/src/otel_init.rs
+++ b/codex-rs/core/src/otel_init.rs
@@ -2,6 +2,7 @@ use crate::config::Config;
 use crate::config::types::OtelExporterKind as Kind;
 use crate::config::types::OtelHttpProtocol as Protocol;
 use crate::default_client::originator;
+use crate::features::Feature;
 use codex_otel::config::OtelExporter;
 use codex_otel::config::OtelHttpProtocol;
 use codex_otel::config::OtelSettings;
@@ -77,6 +78,7 @@ pub fn build_provider(
 
     let originator = originator();
     let service_name = service_name_override.unwrap_or(originator.value.as_str());
+    let runtime_metrics = config.features.enabled(Feature::RuntimeMetrics);
 
     OtelProvider::from(&OtelSettings {
         service_name: service_name.to_string(),
@@ -86,6 +88,7 @@ pub fn build_provider(
         exporter,
         trace_exporter,
         metrics_exporter,
+        runtime_metrics,
     })
 }
 

--- a/codex-rs/otel/Cargo.toml
+++ b/codex-rs/otel/Cargo.toml
@@ -41,7 +41,14 @@ opentelemetry-otlp = { workspace = true, features = [
     "tls-roots",
 ]}
 opentelemetry-semantic-conventions = { workspace = true }
-opentelemetry_sdk = { workspace = true, features = ["logs", "metrics", "rt-tokio", "testing", "trace"] }
+opentelemetry_sdk = { workspace = true, features = [
+    "experimental_metrics_custom_reader",
+    "logs",
+    "metrics",
+    "rt-tokio",
+    "testing",
+    "trace",
+] }
 http = { workspace = true }
 reqwest = { workspace = true, features = ["blocking", "rustls-tls"] }
 serde = { workspace = true, features = ["derive"] }
@@ -54,5 +61,8 @@ tracing-opentelemetry = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 [dev-dependencies]
-opentelemetry_sdk = { workspace = true, features = ["testing"] }
+opentelemetry_sdk = { workspace = true, features = [
+    "experimental_metrics_custom_reader",
+    "testing",
+] }
 pretty_assertions = { workspace = true }

--- a/codex-rs/otel/src/config.rs
+++ b/codex-rs/otel/src/config.rs
@@ -37,6 +37,7 @@ pub struct OtelSettings {
     pub exporter: OtelExporter,
     pub trace_exporter: OtelExporter,
     pub metrics_exporter: OtelExporter,
+    pub runtime_metrics: bool,
 }
 
 #[derive(Clone, Debug)]

--- a/codex-rs/otel/src/metrics/config.rs
+++ b/codex-rs/otel/src/metrics/config.rs
@@ -19,6 +19,7 @@ pub struct MetricsConfig {
     pub(crate) service_version: String,
     pub(crate) exporter: MetricsExporter,
     pub(crate) export_interval: Option<Duration>,
+    pub(crate) runtime_reader: bool,
     pub(crate) default_tags: BTreeMap<String, String>,
 }
 
@@ -35,6 +36,7 @@ impl MetricsConfig {
             service_version: service_version.into(),
             exporter: MetricsExporter::Otlp(exporter),
             export_interval: None,
+            runtime_reader: false,
             default_tags: BTreeMap::new(),
         }
     }
@@ -52,6 +54,7 @@ impl MetricsConfig {
             service_version: service_version.into(),
             exporter: MetricsExporter::InMemory(exporter),
             export_interval: None,
+            runtime_reader: false,
             default_tags: BTreeMap::new(),
         }
     }
@@ -59,6 +62,12 @@ impl MetricsConfig {
     /// Override the interval between periodic metric exports.
     pub fn with_export_interval(mut self, interval: Duration) -> Self {
         self.export_interval = Some(interval);
+        self
+    }
+
+    /// Enable a manual reader for on-demand runtime snapshots.
+    pub fn with_runtime_reader(mut self) -> Self {
+        self.runtime_reader = true;
         self
     }
 

--- a/codex-rs/otel/src/metrics/error.rs
+++ b/codex-rs/otel/src/metrics/error.rs
@@ -34,4 +34,13 @@ pub enum MetricsError {
         #[source]
         source: opentelemetry_sdk::error::OTelSdkError,
     },
+
+    #[error("runtime metrics snapshot reader is not enabled")]
+    RuntimeSnapshotUnavailable,
+
+    #[error("failed to collect runtime metrics snapshot from metrics reader")]
+    RuntimeSnapshotCollect {
+        #[source]
+        source: opentelemetry_sdk::error::OTelSdkError,
+    },
 }

--- a/codex-rs/otel/src/metrics/mod.rs
+++ b/codex-rs/otel/src/metrics/mod.rs
@@ -1,6 +1,8 @@
 mod client;
 mod config;
 mod error;
+pub(crate) mod names;
+pub(crate) mod runtime_metrics;
 pub(crate) mod timer;
 pub(crate) mod validation;
 

--- a/codex-rs/otel/src/metrics/names.rs
+++ b/codex-rs/otel/src/metrics/names.rs
@@ -1,0 +1,6 @@
+pub(crate) const TOOL_CALL_COUNT_METRIC: &str = "codex.tool.call";
+pub(crate) const TOOL_CALL_DURATION_METRIC: &str = "codex.tool.call.duration_ms";
+pub(crate) const API_CALL_COUNT_METRIC: &str = "codex.api_request";
+pub(crate) const API_CALL_DURATION_METRIC: &str = "codex.api_request.duration_ms";
+pub(crate) const SSE_EVENT_COUNT_METRIC: &str = "codex.sse_event";
+pub(crate) const SSE_EVENT_DURATION_METRIC: &str = "codex.sse_event.duration_ms";

--- a/codex-rs/otel/src/metrics/runtime_metrics.rs
+++ b/codex-rs/otel/src/metrics/runtime_metrics.rs
@@ -1,0 +1,101 @@
+use crate::metrics::names::API_CALL_COUNT_METRIC;
+use crate::metrics::names::API_CALL_DURATION_METRIC;
+use crate::metrics::names::SSE_EVENT_COUNT_METRIC;
+use crate::metrics::names::SSE_EVENT_DURATION_METRIC;
+use crate::metrics::names::TOOL_CALL_COUNT_METRIC;
+use crate::metrics::names::TOOL_CALL_DURATION_METRIC;
+use opentelemetry_sdk::metrics::data::AggregatedMetrics;
+use opentelemetry_sdk::metrics::data::Metric;
+use opentelemetry_sdk::metrics::data::MetricData;
+use opentelemetry_sdk::metrics::data::ResourceMetrics;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RuntimeMetricTotals {
+    pub count: u64,
+    pub duration_ms: u64,
+}
+
+impl RuntimeMetricTotals {
+    pub fn is_empty(self) -> bool {
+        self.count == 0 && self.duration_ms == 0
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct RuntimeMetricsSummary {
+    pub tool_calls: RuntimeMetricTotals,
+    pub api_calls: RuntimeMetricTotals,
+    pub streaming_events: RuntimeMetricTotals,
+}
+
+impl RuntimeMetricsSummary {
+    pub fn is_empty(self) -> bool {
+        self.tool_calls.is_empty() && self.api_calls.is_empty() && self.streaming_events.is_empty()
+    }
+
+    pub(crate) fn from_snapshot(snapshot: &ResourceMetrics) -> Self {
+        let tool_calls = RuntimeMetricTotals {
+            count: sum_counter(snapshot, TOOL_CALL_COUNT_METRIC),
+            duration_ms: sum_histogram_ms(snapshot, TOOL_CALL_DURATION_METRIC),
+        };
+        let api_calls = RuntimeMetricTotals {
+            count: sum_counter(snapshot, API_CALL_COUNT_METRIC),
+            duration_ms: sum_histogram_ms(snapshot, API_CALL_DURATION_METRIC),
+        };
+        let streaming_events = RuntimeMetricTotals {
+            count: sum_counter(snapshot, SSE_EVENT_COUNT_METRIC),
+            duration_ms: sum_histogram_ms(snapshot, SSE_EVENT_DURATION_METRIC),
+        };
+        Self {
+            tool_calls,
+            api_calls,
+            streaming_events,
+        }
+    }
+}
+
+fn sum_counter(snapshot: &ResourceMetrics, name: &str) -> u64 {
+    snapshot
+        .scope_metrics()
+        .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+        .filter(|metric| metric.name() == name)
+        .map(sum_counter_metric)
+        .sum()
+}
+
+fn sum_counter_metric(metric: &Metric) -> u64 {
+    match metric.data() {
+        AggregatedMetrics::U64(MetricData::Sum(sum)) => sum
+            .data_points()
+            .map(opentelemetry_sdk::metrics::data::SumDataPoint::value)
+            .sum(),
+        _ => 0,
+    }
+}
+
+fn sum_histogram_ms(snapshot: &ResourceMetrics, name: &str) -> u64 {
+    snapshot
+        .scope_metrics()
+        .flat_map(opentelemetry_sdk::metrics::data::ScopeMetrics::metrics)
+        .filter(|metric| metric.name() == name)
+        .map(sum_histogram_metric_ms)
+        .sum()
+}
+
+fn sum_histogram_metric_ms(metric: &Metric) -> u64 {
+    match metric.data() {
+        AggregatedMetrics::F64(MetricData::Histogram(histogram)) => histogram
+            .data_points()
+            .map(|point| f64_to_u64(point.sum()))
+            .sum(),
+        _ => 0,
+    }
+}
+
+fn f64_to_u64(value: f64) -> u64 {
+    if !value.is_finite() || value <= 0.0 {
+        return 0;
+    }
+    let clamped = value.min(u64::MAX as f64);
+    clamped.round() as u64
+}

--- a/codex-rs/otel/src/otel_provider.rs
+++ b/codex-rs/otel/src/otel_provider.rs
@@ -75,12 +75,16 @@ impl OtelProvider {
         let metrics = if matches!(metric_exporter, OtelExporter::None) {
             None
         } else {
-            Some(MetricsClient::new(MetricsConfig::otlp(
+            let mut config = MetricsConfig::otlp(
                 settings.environment.clone(),
                 settings.service_name.clone(),
                 settings.service_version.clone(),
                 metric_exporter,
-            ))?)
+            );
+            if settings.runtime_metrics {
+                config = config.with_runtime_reader();
+            }
+            Some(MetricsClient::new(config)?)
         };
 
         if let Some(metrics) = metrics.as_ref() {

--- a/codex-rs/otel/tests/suite/mod.rs
+++ b/codex-rs/otel/tests/suite/mod.rs
@@ -1,5 +1,7 @@
 mod manager_metrics;
 mod otlp_http_loopback;
+mod runtime_summary;
 mod send;
+mod snapshot;
 mod timing;
 mod validation;

--- a/codex-rs/otel/tests/suite/runtime_summary.rs
+++ b/codex-rs/otel/tests/suite/runtime_summary.rs
@@ -1,0 +1,77 @@
+use codex_app_server_protocol::AuthMode;
+use codex_otel::OtelManager;
+use codex_otel::RuntimeMetricTotals;
+use codex_otel::RuntimeMetricsSummary;
+use codex_otel::metrics::MetricsClient;
+use codex_otel::metrics::MetricsConfig;
+use codex_otel::metrics::Result;
+use codex_protocol::ThreadId;
+use codex_protocol::protocol::SessionSource;
+use eventsource_stream::Event as StreamEvent;
+use opentelemetry_sdk::metrics::InMemoryMetricExporter;
+use pretty_assertions::assert_eq;
+use std::time::Duration;
+
+#[test]
+fn runtime_metrics_summary_collects_tool_api_and_streaming_metrics() -> Result<()> {
+    let exporter = InMemoryMetricExporter::default();
+    let metrics = MetricsClient::new(
+        MetricsConfig::in_memory("test", "codex-cli", env!("CARGO_PKG_VERSION"), exporter)
+            .with_runtime_reader(),
+    )?;
+    let manager = OtelManager::new(
+        ThreadId::new(),
+        "gpt-5.1",
+        "gpt-5.1",
+        Some("account-id".to_string()),
+        None,
+        Some(AuthMode::ApiKey),
+        true,
+        "tty".to_string(),
+        SessionSource::Cli,
+    )
+    .with_metrics(metrics);
+
+    manager.reset_runtime_metrics();
+
+    manager.tool_result(
+        "shell",
+        "call-1",
+        "{\"cmd\":\"echo\"}",
+        Duration::from_millis(250),
+        true,
+        "ok",
+    );
+    manager.record_api_request(1, Some(200), None, Duration::from_millis(300));
+    let sse_response: std::result::Result<
+        Option<std::result::Result<StreamEvent, eventsource_stream::EventStreamError<&str>>>,
+        tokio::time::error::Elapsed,
+    > = Ok(Some(Ok(StreamEvent {
+        event: "response.created".to_string(),
+        data: "{}".to_string(),
+        id: String::new(),
+        retry: None,
+    })));
+    manager.log_sse_event(&sse_response, Duration::from_millis(120));
+
+    let summary = manager
+        .runtime_metrics_summary()
+        .expect("runtime metrics summary should be available");
+    let expected = RuntimeMetricsSummary {
+        tool_calls: RuntimeMetricTotals {
+            count: 1,
+            duration_ms: 250,
+        },
+        api_calls: RuntimeMetricTotals {
+            count: 1,
+            duration_ms: 300,
+        },
+        streaming_events: RuntimeMetricTotals {
+            count: 1,
+            duration_ms: 120,
+        },
+    };
+    assert_eq!(summary, expected);
+
+    Ok(())
+}

--- a/codex-rs/otel/tests/suite/snapshot.rs
+++ b/codex-rs/otel/tests/suite/snapshot.rs
@@ -1,0 +1,120 @@
+use crate::harness::attributes_to_map;
+use crate::harness::find_metric;
+use codex_app_server_protocol::AuthMode;
+use codex_otel::OtelManager;
+use codex_otel::metrics::MetricsClient;
+use codex_otel::metrics::MetricsConfig;
+use codex_otel::metrics::Result;
+use codex_protocol::ThreadId;
+use codex_protocol::protocol::SessionSource;
+use opentelemetry_sdk::metrics::InMemoryMetricExporter;
+use opentelemetry_sdk::metrics::data::AggregatedMetrics;
+use opentelemetry_sdk::metrics::data::MetricData;
+use pretty_assertions::assert_eq;
+use std::collections::BTreeMap;
+
+#[test]
+fn snapshot_collects_metrics_without_shutdown() -> Result<()> {
+    let exporter = InMemoryMetricExporter::default();
+    let config = MetricsConfig::in_memory(
+        "test",
+        "codex-cli",
+        env!("CARGO_PKG_VERSION"),
+        exporter.clone(),
+    )
+    .with_tag("service", "codex-cli")?
+    .with_runtime_reader();
+    let metrics = MetricsClient::new(config)?;
+
+    metrics.counter(
+        "codex.tool.call",
+        1,
+        &[("tool", "shell"), ("success", "true")],
+    )?;
+
+    let snapshot = metrics.snapshot()?;
+
+    let metric = find_metric(&snapshot, "codex.tool.call").expect("counter metric missing");
+    let attrs = match metric.data() {
+        AggregatedMetrics::U64(data) => match data {
+            MetricData::Sum(sum) => {
+                let points: Vec<_> = sum.data_points().collect();
+                assert_eq!(points.len(), 1);
+                attributes_to_map(points[0].attributes())
+            }
+            _ => panic!("unexpected counter aggregation"),
+        },
+        _ => panic!("unexpected counter data type"),
+    };
+
+    let expected = BTreeMap::from([
+        ("service".to_string(), "codex-cli".to_string()),
+        ("success".to_string(), "true".to_string()),
+        ("tool".to_string(), "shell".to_string()),
+    ]);
+    assert_eq!(attrs, expected);
+
+    let finished = exporter
+        .get_finished_metrics()
+        .expect("finished metrics should be readable");
+    assert!(finished.is_empty(), "expected no periodic exports yet");
+
+    Ok(())
+}
+
+#[test]
+fn manager_snapshot_metrics_collects_without_shutdown() -> Result<()> {
+    let exporter = InMemoryMetricExporter::default();
+    let config = MetricsConfig::in_memory("test", "codex-cli", env!("CARGO_PKG_VERSION"), exporter)
+        .with_tag("service", "codex-cli")?
+        .with_runtime_reader();
+    let metrics = MetricsClient::new(config)?;
+    let manager = OtelManager::new(
+        ThreadId::new(),
+        "gpt-5.1",
+        "gpt-5.1",
+        Some("account-id".to_string()),
+        None,
+        Some(AuthMode::ApiKey),
+        true,
+        "tty".to_string(),
+        SessionSource::Cli,
+    )
+    .with_metrics(metrics);
+
+    manager.counter(
+        "codex.tool.call",
+        1,
+        &[("tool", "shell"), ("success", "true")],
+    );
+
+    let snapshot = manager.snapshot_metrics()?;
+    let metric = find_metric(&snapshot, "codex.tool.call").expect("counter metric missing");
+    let attrs = match metric.data() {
+        AggregatedMetrics::U64(data) => match data {
+            MetricData::Sum(sum) => {
+                let points: Vec<_> = sum.data_points().collect();
+                assert_eq!(points.len(), 1);
+                attributes_to_map(points[0].attributes())
+            }
+            _ => panic!("unexpected counter aggregation"),
+        },
+        _ => panic!("unexpected counter data type"),
+    };
+
+    let expected = BTreeMap::from([
+        (
+            "app.version".to_string(),
+            env!("CARGO_PKG_VERSION").to_string(),
+        ),
+        ("auth_mode".to_string(), AuthMode::ApiKey.to_string()),
+        ("model".to_string(), "gpt-5.1".to_string()),
+        ("service".to_string(), "codex-cli".to_string()),
+        ("session_source".to_string(), "cli".to_string()),
+        ("success".to_string(), "true".to_string()),
+        ("tool".to_string(), "shell".to_string()),
+    ]);
+    assert_eq!(attrs, expected);
+
+    Ok(())
+}

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -45,6 +45,7 @@ use codex_core::protocol::McpAuthStatus;
 use codex_core::protocol::McpInvocation;
 use codex_core::protocol::SessionConfiguredEvent;
 use codex_core::web_search::web_search_detail;
+use codex_otel::RuntimeMetricsSummary;
 use codex_protocol::models::WebSearchAction;
 use codex_protocol::openai_models::ReasoningEffort as ReasoningEffortConfig;
 use codex_protocol::plan_tool::PlanItemArg;
@@ -1966,32 +1967,94 @@ pub(crate) fn new_reasoning_summary_block(full_reasoning_buffer: String) -> Box<
 /// divider.
 pub struct FinalMessageSeparator {
     elapsed_seconds: Option<u64>,
+    runtime_metrics: Option<RuntimeMetricsSummary>,
 }
 impl FinalMessageSeparator {
     /// Creates a separator; `elapsed_seconds` typically comes from the status indicator timer.
-    pub(crate) fn new(elapsed_seconds: Option<u64>) -> Self {
-        Self { elapsed_seconds }
+    pub(crate) fn new(
+        elapsed_seconds: Option<u64>,
+        runtime_metrics: Option<RuntimeMetricsSummary>,
+    ) -> Self {
+        Self {
+            elapsed_seconds,
+            runtime_metrics,
+        }
     }
 }
 impl HistoryCell for FinalMessageSeparator {
     fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
-        let elapsed_seconds = self
+        let mut label_parts = Vec::new();
+        if let Some(elapsed_seconds) = self
             .elapsed_seconds
-            .map(super::status_indicator_widget::fmt_elapsed_compact);
-        if let Some(elapsed_seconds) = elapsed_seconds {
-            let worked_for = format!("─ Worked for {elapsed_seconds} ─");
-            let worked_for_width = worked_for.width();
-            vec![
-                Line::from_iter([
-                    worked_for,
-                    "─".repeat((width as usize).saturating_sub(worked_for_width)),
-                ])
-                .dim(),
-            ]
-        } else {
-            vec![Line::from_iter(["─".repeat(width as usize).dim()])]
+            .map(super::status_indicator_widget::fmt_elapsed_compact)
+        {
+            label_parts.push(format!("Worked for {elapsed_seconds}"));
         }
+        if let Some(metrics_label) = self.runtime_metrics.and_then(runtime_metrics_label) {
+            label_parts.push(metrics_label);
+        }
+
+        if label_parts.is_empty() {
+            return vec![Line::from_iter(["─".repeat(width as usize).dim()])];
+        }
+
+        let label = format!("─ {} ─", label_parts.join(" • "));
+        let (label, _suffix, label_width) = take_prefix_by_width(&label, width as usize);
+        vec![
+            Line::from_iter([
+                label,
+                "─".repeat((width as usize).saturating_sub(label_width)),
+            ])
+            .dim(),
+        ]
     }
+}
+
+fn runtime_metrics_label(summary: RuntimeMetricsSummary) -> Option<String> {
+    let mut parts = Vec::new();
+    if summary.tool_calls.count > 0 {
+        let duration = format_duration_ms(summary.tool_calls.duration_ms);
+        let calls = pluralize(summary.tool_calls.count, "call", "calls");
+        parts.push(format!(
+            "Local tools: {} {calls} ({duration})",
+            summary.tool_calls.count
+        ));
+    }
+    if summary.api_calls.count > 0 {
+        let duration = format_duration_ms(summary.api_calls.duration_ms);
+        let calls = pluralize(summary.api_calls.count, "call", "calls");
+        parts.push(format!(
+            "Inference: {} {calls} ({duration})",
+            summary.api_calls.count
+        ));
+    }
+    if summary.streaming_events.count > 0 {
+        let duration = format_duration_ms(summary.streaming_events.duration_ms);
+        let stream_label = pluralize(summary.streaming_events.count, "Stream", "Streams");
+        let events = pluralize(summary.streaming_events.count, "event", "events");
+        parts.push(format!(
+            "{stream_label}: {} {events} ({duration})",
+            summary.streaming_events.count
+        ));
+    }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join(" • "))
+    }
+}
+
+fn format_duration_ms(duration_ms: u64) -> String {
+    if duration_ms >= 1_000 {
+        let seconds = duration_ms as f64 / 1_000.0;
+        format!("{seconds:.1}s")
+    } else {
+        format!("{duration_ms}ms")
+    }
+}
+
+fn pluralize(count: u64, singular: &'static str, plural: &'static str) -> &'static str {
+    if count == 1 { singular } else { plural }
 }
 
 fn format_mcp_invocation<'a>(invocation: McpInvocation) -> Line<'a> {
@@ -2026,6 +2089,8 @@ mod tests {
     use codex_core::config::types::McpServerConfig;
     use codex_core::config::types::McpServerTransportConfig;
     use codex_core::protocol::McpAuthStatus;
+    use codex_otel::RuntimeMetricTotals;
+    use codex_otel::RuntimeMetricsSummary;
     use codex_protocol::models::WebSearchAction;
     use codex_protocol::parse_command::ParsedCommand;
     use dirs::home_dir;
@@ -2099,6 +2164,32 @@ mod tests {
             lines,
             vec!["↳ Interacted with background terminal", "  └ (waited)"],
         );
+    }
+
+    #[test]
+    fn final_message_separator_includes_runtime_metrics() {
+        let summary = RuntimeMetricsSummary {
+            tool_calls: RuntimeMetricTotals {
+                count: 3,
+                duration_ms: 2_450,
+            },
+            api_calls: RuntimeMetricTotals {
+                count: 2,
+                duration_ms: 1_200,
+            },
+            streaming_events: RuntimeMetricTotals {
+                count: 6,
+                duration_ms: 900,
+            },
+        };
+        let cell = FinalMessageSeparator::new(Some(12), Some(summary));
+        let rendered = render_lines(&cell.display_lines(120));
+
+        assert_eq!(rendered.len(), 1);
+        assert!(rendered[0].contains("Worked for 12s"));
+        assert!(rendered[0].contains("Local tools: 3 calls (2.5s)"));
+        assert!(rendered[0].contains("Inference: 2 calls (1.2s)"));
+        assert!(rendered[0].contains("Streams: 6 events (900ms)"));
     }
 
     #[test]


### PR DESCRIPTION
Summary of changes:

- Adds a new feature flag: runtime_metrics
  - Declared in core/src/features.rs
  - Added to core/config.schema.json
  - Wired into OTEL init in core/src/otel_init.rs

- Enables on-demand runtime metric snapshots in OTEL
  - Adds runtime_metrics: bool to otel/src/config.rs
  - Enables experimental custom reader features in otel/Cargo.toml
  - Adds snapshot/reset/summary APIs in:
    - otel/src/lib.rs
    - otel/src/metrics/client.rs
    - otel/src/metrics/config.rs
    - otel/src/metrics/error.rs

- Defines metric names and a runtime summary builder
  - New files:
    - otel/src/metrics/names.rs
    - otel/src/metrics/runtime_metrics.rs
  - Summarizes totals for:
    - Tool calls
    - API requests
    - SSE/streaming events

- Instruments metrics collection in OTEL manager
  - otel/src/traces/otel_manager.rs now records:
    - API call counts + durations
    - SSE event counts + durations (success/failure)
    - Tool call metrics now use shared constants

- Surfaces runtime metrics in the TUI
  - Resets runtime metrics at turn start in tui/src/chatwidget.rs
  - Displays metrics in the final separator line in tui/src/history_cell.rs

- Adds tests
  - New OTEL tests:
    - otel/tests/suite/snapshot.rs
    - otel/tests/suite/runtime_summary.rs
  - New TUI test:
    - final_message_separator_includes_runtime_metrics in tui/src/history_cell.rs

Scope:
- 19 files changed
- ~652 insertions, 38 deletions


<img width="922" height="169" alt="Screenshot 2026-01-30 at 4 11 34 PM" src="https://github.com/user-attachments/assets/1efd754d-a16d-4564-83a5-f4442fd2f998" />
