### PR TITLE
Fix minor typos in comments and documentation

### DIFF
--- a/.github/codex/labels/codex-rust-review.md
+++ b/.github/codex/labels/codex-rust-review.md
@@ -15,10 +15,10 @@ Things to look out for when doing the review:
 
 ## Code Organization
 
-- Each create in the Cargo workspace in `codex-rs` has a specific purpose: make a note if you believe new code is not introduced in the correct crate.
+- Each crate in the Cargo workspace in `codex-rs` has a specific purpose: make a note if you believe new code is not introduced in the correct crate.
 - When possible, try to keep the `core` crate as small as possible. Non-core but shared logic is often a good candidate for `codex-rs/common`.
 - Be wary of large files and offer suggestions for how to break things into more reasonably-sized files.
-- Rust files should generally be organized such that the public parts of the API appear near the top of the file and helper functions go below. This is analagous to the "inverted pyramid" structure that is favored in journalism.
+- Rust files should generally be organized such that the public parts of the API appear near the top of the file and helper functions go below. This is analogous to the "inverted pyramid" structure that is favored in journalism.
 
 ## Assertions in Tests
 

--- a/codex-rs/apply-patch/src/standalone_executable.rs
+++ b/codex-rs/apply-patch/src/standalone_executable.rs
@@ -27,7 +27,7 @@ pub fn run_main() -> i32 {
             match std::io::stdin().read_to_string(&mut buf) {
                 Ok(_) => {
                     if buf.is_empty() {
-                        eprintln!("Usage: apply_patch 'PATCH'\n       echo 'PATCH' | apply-patch");
+                        eprintln!("Usage: apply_patch 'PATCH'\n       echo 'PATCH' | apply_patch");
                         return 2;
                     }
                     buf

--- a/codex-rs/cloud-requirements/src/lib.rs
+++ b/codex-rs/cloud-requirements/src/lib.rs
@@ -20,7 +20,7 @@ use std::time::Duration;
 use std::time::Instant;
 use tokio::time::timeout;
 
-/// This blocks codecs startup, so must be short.
+/// This blocks codex startup, so must be short.
 const CLOUD_REQUIREMENTS_TIMEOUT: Duration = Duration::from_secs(5);
 
 #[async_trait]

--- a/codex-rs/tui/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/command_popup.rs
@@ -80,7 +80,7 @@ impl CommandPopup {
 
     /// Update the filter string based on the current composer text. The text
     /// passed in is expected to start with a leading '/'. Everything after the
-    /// *first* '/" on the *first* line becomes the active filter that is used
+    /// *first* '/' on the *first* line becomes the active filter that is used
     /// to narrow down the list of available commands.
     pub(crate) fn on_composer_text_change(&mut self, text: String) {
         let first_line = text.lines().next().unwrap_or("");

--- a/sdk/typescript/src/thread.ts
+++ b/sdk/typescript/src/thread.ts
@@ -37,7 +37,7 @@ export type UserInput =
 
 export type Input = string | UserInput[];
 
-/** Respesent a thread of conversation with the agent. One thread can have multiple consecutive turns. */
+/** Represent a thread of conversation with the agent. One thread can have multiple consecutive turns. */
 export class Thread {
   private _exec: CodexExec;
   private _options: CodexOptions;


### PR DESCRIPTION
## Summary

I have read the contribution guidelines.  
All changes in this PR are limited to text corrections and do not modify any business logic, runtime behavior, or user-facing functionality.

## Details

This PR fixes several minor typos, including:

- `create` -> `crate`
- `analagous` -> `analogous`
- `apply-patch` -> `apply_patch`
- `codecs` -> `codex`
- ` '/" ` -> ` '/' `
- `Respesent` -> `Represent`