### PR TITLE
[apps] Gateway MCP should be blocking.

### DIFF
--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -453,16 +453,8 @@ impl McpConnectionManager {
     #[instrument(level = "trace", skip_all)]
     pub async fn list_all_tools(&self) -> HashMap<String, ToolInfo> {
         let mut tools = HashMap::new();
-        for (server_name, managed_client) in &self.clients {
-            let client = if server_name == CODEX_APPS_MCP_SERVER_NAME {
-                // Avoid blocking on codex_apps_mcp startup; use tools only when ready.
-                match managed_client.client.clone().now_or_never() {
-                    Some(Ok(client)) => Some(client),
-                    _ => None,
-                }
-            } else {
-                managed_client.client().await.ok()
-            };
+        for managed_client in self.clients.values() {
+            let client = managed_client.client().await.ok();
             if let Some(client) = client {
                 tools.extend(qualify_tools(filter_tools(
                     client.tools,


### PR DESCRIPTION
Make Apps Gateway MCP blocking since otherwise app mentions may not work when apps are not loaded. Messages sent before apps become available will be queued.

This only affects when `apps` feature is enabled.