### PR TITLE
fix(nix): update flake for newer Rust toolchain requirements

### DIFF
--- a/codex-rs/default.nix
+++ b/codex-rs/default.nix
@@ -22,6 +22,11 @@ rustPlatform.buildRustPackage (_: {
   cargoLock.outputHashes = {
     "ratatui-0.29.0" = "sha256-HBvT5c8GsiCxMffNjJGLmHnvG77A6cqEL+1ARurBXho=";
     "crossterm-0.28.1" = "sha256-6qCtfSMuXACKFb9ATID39XyFDIEMFDmbx6SSmNe+728=";
+    "nucleo-0.5.0" = "sha256-Hm4SxtTSBrcWpXrtSqeO0TACbUxq3gizg1zD/6Yw/sI=";
+    "nucleo-matcher-0.3.1" = "sha256-Hm4SxtTSBrcWpXrtSqeO0TACbUxq3gizg1zD/6Yw/sI=";
+    "runfiles-0.1.0" = "sha256-uJpVLcQh8wWZA3GPv9D8Nt43EOirajfDJ7eq/FB+tek=";
+    "tokio-tungstenite-0.28.0" = "sha256-vJZ3S41gHtRt4UAODsjAoSCaTksgzCALiBmbWgyDCi8=";
+    "tungstenite-0.28.0" = "sha256-CyXZp58zGlUhEor7WItjQoS499IoSP55uWqr++ia+0A=";
   };
 
   meta = with lib; {

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758427187,
-        "narHash": "sha256-pHpxZ/IyCwoTQPtFIAG2QaxuSm8jWzrzBGjwQZIttJc=",
+        "lastModified": 1769461804,
+        "narHash": "sha256-msG8SU5WsBUfVVa/9RPLaymvi5bI8edTavbIq3vRlhI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "554be6495561ff07b6c724047bdd7e0716aa7b46",
+        "rev": "bfc1b8a4574108ceef22f02bafcf6611380c100d",
         "type": "github"
       },
       "original": {
@@ -18,7 +18,28 @@
     },
     "root": {
       "inputs": {
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "rust-overlay": "rust-overlay"
+      }
+    },
+    "rust-overlay": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769828398,
+        "narHash": "sha256-zmnvRUm15QrlKH0V1BZoiT3U+Q+tr+P5Osi8qgtL9fY=",
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "rev": "a1d32c90c8a4ea43e9586b7e5894c179d5747425",
+        "type": "github"
+      },
+      "original": {
+        "owner": "oxalica",
+        "repo": "rust-overlay",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -1,9 +1,15 @@
 {
   description = "Development Nix flake for OpenAI Codex CLI";
 
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    rust-overlay = {
+      url = "github:oxalica/rust-overlay";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
 
-  outputs = { nixpkgs, ... }:
+  outputs = { nixpkgs, rust-overlay, ... }:
     let
       systems = [
         "x86_64-linux"
@@ -16,12 +22,51 @@
     {
       packages = forAllSystems (system:
         let
-          pkgs = nixpkgs.legacyPackages.${system};
-          codex-rs = pkgs.callPackage ./codex-rs { };
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ rust-overlay.overlays.default ];
+          };
+          codex-rs = pkgs.callPackage ./codex-rs {
+            rustPlatform = pkgs.makeRustPlatform {
+              cargo = pkgs.rust-bin.stable.latest.minimal;
+              rustc = pkgs.rust-bin.stable.latest.minimal;
+            };
+          };
         in
         {
           codex-rs = codex-rs;
           default = codex-rs;
+        }
+      );
+
+      devShells = forAllSystems (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            overlays = [ rust-overlay.overlays.default ];
+          };
+          rust = pkgs.rust-bin.stable.latest.default.override {
+            extensions = [ "rust-src" "rust-analyzer" ];
+          };
+        in
+        {
+          default = pkgs.mkShell {
+            buildInputs = [
+              rust
+              pkgs.pkg-config
+              pkgs.openssl
+              pkgs.cmake
+              pkgs.llvmPackages.clang
+              pkgs.llvmPackages.libclang.lib
+            ];
+            PKG_CONFIG_PATH = "${pkgs.openssl.dev}/lib/pkgconfig";
+            LIBCLANG_PATH = "${pkgs.llvmPackages.libclang.lib}/lib";
+            # Use clang for BoringSSL compilation (avoids GCC 15 warnings-as-errors)
+            shellHook = ''
+              export CC=clang
+              export CXX=clang++
+            '';
+          };
         }
       );
     };


### PR DESCRIPTION
## Summary

- Add rust-overlay input to provide newer Rust versions (rama crates require rustc 1.91.0+)
- Add devShells output with complete development environment
- Add missing git dependency hashes to codex-rs/default.nix

## Changes

**flake.nix:**
- Added `rust-overlay` input to get newer Rust toolchains
- Updated `packages` output to use `rust-bin.stable.latest.minimal` for builds
- Added `devShells` output with:
  - Rust with `rust-src` and `rust-analyzer` extensions for IDE support
  - Required build dependencies: `pkg-config`, `openssl`, `cmake`, `libclang`
  - Environment variables: `PKG_CONFIG_PATH`, `LIBCLANG_PATH`

**codex-rs/default.nix:**
- Added missing `outputHashes` for git dependencies:
  - `nucleo-0.5.0`, `nucleo-matcher-0.3.1`
  - `runfiles-0.1.0`
  - `tokio-tungstenite-0.28.0`, `tungstenite-0.28.0`

## Test Plan

- [x] `nix develop` enters shell successfully
- [x] `nix develop -c rustc --version` shows 1.93.0
- [x] `nix develop -c cargo build` completes successfully