### PR TITLE
Fix npm README image link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="center"><code>npm i -g @openai/codex</code><br />or <code>brew install --cask codex</code></p>
 <p align="center"><strong>Codex CLI</strong> is a coding agent from OpenAI that runs locally on your computer.
 <p align="center">
-  <img src="./.github/codex-cli-splash.png" alt="Codex CLI splash" width="80%" />
+  <img src="https://github.com/openai/codex/blob/main/.github/codex-cli-splash.png" alt="Codex CLI splash" width="80%" />
 </p>
 </br>
 If you want Codex in your code editor (VS Code, Cursor, Windsurf), <a href="https://developers.openai.com/codex/ide">install in your IDE.</a>


### PR DESCRIPTION
### Motivation
- The image referenced in the package README was 404ing on the npm package page because it used a relative file path that doesn't resolve on npm, so the splash image needs a GitHub-hosted URL to render correctly.

### Description
- Update `README.md` to replace the relative image path `./.github/codex-cli-splash.png` with the GitHub-hosted URL `https://github.com/openai/codex/blob/main/.github/codex-cli-splash.png`.

### Testing
- No automated tests were run because this is a docs-only change and does not affect code or test behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_i_697e58dbce34832d87c7847779e8f4a5)