### PR TITLE
feat(tui): show thread names in codex resume picker

### DIFF
--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -119,6 +119,7 @@ pub use rollout::list::ThreadsPage;
 pub use rollout::list::parse_cursor;
 pub use rollout::list::read_head_for_summary;
 pub use rollout::list::read_session_meta_line;
+pub use rollout::read_thread_names_by_id;
 pub use rollout::rollout_date_parts;
 pub use transport_manager::TransportManager;
 mod function_tool;

--- a/codex-rs/core/src/rollout/mod.rs
+++ b/codex-rs/core/src/rollout/mod.rs
@@ -25,6 +25,7 @@ pub use list::rollout_date_parts;
 pub use recorder::RolloutRecorder;
 pub use recorder::RolloutRecorderParams;
 pub use session_index::find_thread_path_by_name_str;
+pub use session_index::read_thread_names_by_id;
 
 #[cfg(test)]
 pub mod tests;

--- a/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_table.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_table.snap
@@ -2,7 +2,7 @@
 source: tui/src/resume_picker.rs
 expression: snapshot
 ---
-  Updated         Branch  CWD  Conversation
-  42 seconds ago  -       -    Fix resume picker timestamps
-> 35 minutes ago  -       -    Investigate lazy pagination cap
-  2 hours ago     -       -    Explain the codebase
+  Updated         Name           Branch  CWD  Conversation
+  42 seconds ago  resume-picker  -       -    Fix resume picker timestamps
+> 35 minutes ago  -              -       -    Investigate lazy pagination cap
+  2 hours ago     -              -       -    Explain the codebase


### PR DESCRIPTION
This PR improves the `codex resume` picker by surfacing thread names (set via `/rename`) and by including thread names in the picker's search/filter.

Changes:
- Add `codex_core::read_thread_names_by_id` to read `session_index.jsonl` once and build a `{ThreadId -> latest thread name}` map (last entry wins).
- Show a “Name” column in the resume picker when at least one listed thread has a non-empty name.
- Extend picker filtering to match queries against both the conversation preview and the thread name.

Refs: #10315

Testing:
- `cd codex-rs && just fmt`
- `XDG_CONFIG_HOME=/tmp/codex-xdg-empty CARGO_NET_GIT_FETCH_WITH_CLI=true cargo test -p codex-tui`
