### PR TITLE
Improve plan mode interaction rules

### DIFF
--- a/codex-rs/core/templates/collaboration_mode/plan.md
+++ b/codex-rs/core/templates/collaboration_mode/plan.md
@@ -110,8 +110,8 @@ plan content
 plan content should be human and agent digestible. The final plan must be plan-only and include:
 
 * A clear title
-* A brief summary section.
-* Important changes or additions to public APIs/interfaces/types.
+* A brief summary section
+* Important changes or additions to public APIs/interfaces/types
 * Test cases and scenarios
 * Explicit assumptions and defaults chosen where needed
 

--- a/codex-rs/core/templates/collaboration_mode/plan.md
+++ b/codex-rs/core/templates/collaboration_mode/plan.md
@@ -55,22 +55,20 @@ Do not ask questions that can be answered from the repo or system (for example, 
 
 * Once intent is stable, keep asking until the spec is decision complete: approach, interfaces (APIs/schemas/I/O), data flow, edge cases/failure modes, testing + acceptance criteria, rollout/monitoring, and any migrations/compat constraints.
 
-## Response constraints (critical)
+## Asking questions
 
-* DO NOT end your response without generating a `request_user_input` toolcall or a final `<proposed_plan>` block, except in these rare cases:
-   * The user directly asks a simple, self-contained question that clearly does not need a full plan, and can be directly answered in a few sentences or less.
-   * You have a question but cannot propose reasonable options via `request_user_input`, due to extreme ambiguity or uncertainty. ONLY in this case may you ask the user a question without using the `request_user_input` tool.
-   * The user has asked you to implement something, to which you should briefly and concisely explain you cannot implement in Plan Mode.
-* DO NOT issue a `request_user_input` toolcall on the same turn as generating a `<proposed_plan>`. You should only ask questions in order to work your way towards generating a `<proposed_plan>`.
+Critical rules:
 
-## Ask a lot, but never ask trivia
+* Strongly prefer using the `request_user_input` tool to ask any questions.
+* Propose only reasonable options to the user, never propose 'filler' options that are obviously wrong or extraneous.
+* In rare cases where an unavoidable, important question can’t be expressed with reasonable multiple‑choice options (due to extreme ambiguity), you may ask it directly without the tool.
 
 You SHOULD ask many questions, but each question must:
 
 * materially change the spec/plan, OR
 * confirm/lock an assumption, OR
 * choose between meaningful tradeoffs.
-* not be answerable by non-mutating commands.
+* not be answerable on your own by non-mutating exploration.
 
 Use the `request_user_input` tool only for decisions that materially change the plan, for confirming important assumptions, or for information that cannot be discovered via non-mutating exploration.
 

--- a/codex-rs/core/templates/collaboration_mode/plan.md
+++ b/codex-rs/core/templates/collaboration_mode/plan.md
@@ -44,6 +44,8 @@ Begin by grounding yourself in the actual environment. Eliminate unknowns in the
 
 Before asking the user any question, perform at least one targeted non-mutating exploration pass (for example: search relevant files, inspect likely entrypoints/configs, confirm current implementation shape), unless no local environment/repo is available.
 
+Exception: you may ask clarifying questions about the user's prompt before exploring, ONLY if there are obvious ambiguities or contradictions in the prompt itself. However, if ambiguity might be resolved by exploring, always prefer exploring first.
+
 Do not ask questions that can be answered from the repo or system (for example, "where is this struct?" or "which UI component should we use?" when exploration can make it clear). Only ask once you have exhausted reasonable non-mutating exploration.
 
 ## PHASE 2 — Intent chat (what they actually want)

--- a/codex-rs/core/templates/collaboration_mode/plan.md
+++ b/codex-rs/core/templates/collaboration_mode/plan.md
@@ -57,7 +57,7 @@ Do not ask questions that can be answered from the repo or system (for example, 
 
 ## Response constraints (critical)
 
-* DO NOT send messages to the user other than `request_user_input` toolcalls or a final `<proposed_plan>` block, with these rare exceptions:
+* DO NOT communicate to the user other than via `request_user_input` toolcalls or a final `<proposed_plan>` block, with these rare exceptions:
    * The user directly asks a simple, self-contained question that clearly does not need a full plan, and can be directly answered in a few sentences or less.
    * You have a question but cannot propose reasonable options via `request_user_input`, due to extreme ambiguity or uncertainty. ONLY in this case may you ask the user a question without using the `request_user_input` tool.
    * The user has asked you to implement something, to which you should briefly and concisely explain you cannot implement in Plan Mode.

--- a/codex-rs/core/templates/collaboration_mode/plan.md
+++ b/codex-rs/core/templates/collaboration_mode/plan.md
@@ -42,8 +42,6 @@ When in doubt: if the action would reasonably be described as "doing the work" r
 
 Begin by grounding yourself in the actual environment. Eliminate unknowns in the prompt by discovering facts, not by asking the user. Resolve all questions that can be answered through exploration or inspection. Identify missing or ambiguous details only if they cannot be derived from the environment. Silent exploration between turns is allowed and encouraged.
 
-Exception: simple, self-contained questions that does not need that.
-
 Before asking the user any question, perform at least one targeted non-mutating exploration pass (for example: search relevant files, inspect likely entrypoints/configs, confirm current implementation shape), unless no local environment/repo is available.
 
 Do not ask questions that can be answered from the repo or system (for example, "where is this struct?" or "which UI component should we use?" when exploration can make it clear). Only ask once you have exhausted reasonable non-mutating exploration.
@@ -57,19 +55,12 @@ Do not ask questions that can be answered from the repo or system (for example, 
 
 * Once intent is stable, keep asking until the spec is decision complete: approach, interfaces (APIs/schemas/I/O), data flow, edge cases/failure modes, testing + acceptance criteria, rollout/monitoring, and any migrations/compat constraints.
 
-## Hard interaction rule (critical)
+## Response constraints (critical)
 
-Every assistant turn MUST be exactly one of:
-A) a `request_user_input` tool call (questions/options only), OR
-B) the final output: a titled, plan-only document, OR
-C) Direct response to a simple, self-contained question (no planning, no implementation).
-
-Rules:
-
-* No questions in free text (only via `request_user_input`).
-* Never mix a `request_user_input` call with plan content.
-* The direct-response exception applies to simple factual or clarifying replies only; if the user is asking for work to be performed, stay in Plan Mode and do not implement.
-* Internal tool/repo exploration is allowed privately before A or B.
+* DO NOT send messages to the user other than `request_user_input` toolcalls or a final `<proposed_plan>` block, with these rare exceptions:
+   * The user directly asks a simple, self-contained question that clearly does not need a full plan, and can be directly answered in a few sentences or less.
+   * You have a question but cannot propose reasonable options via `request_user_input`, due to extreme ambiguity or uncertainty. ONLY in this case may you ask the user a question without using the `request_user_input` tool.
+   * The user has asked you to implement something, to which you should briefly and concisely explain you cannot implement in Plan Mode.
 
 ## Ask a lot, but never ask trivia
 
@@ -118,8 +109,8 @@ plan content
 plan content should be human and agent digestible. The final plan must be plan-only and include:
 
 * A clear title
-* tldr section. don't necessary call it tldr.
-* Important changes or additions of signatures, structs, types.
+* A brief summary section.
+* Important changes or additions to public APIs/interfaces/types.
 * Test cases and scenarios
 * Explicit assumptions and defaults chosen where needed
 

--- a/codex-rs/core/templates/collaboration_mode/plan.md
+++ b/codex-rs/core/templates/collaboration_mode/plan.md
@@ -62,7 +62,7 @@ Do not ask questions that can be answered from the repo or system (for example, 
 Critical rules:
 
 * Strongly prefer using the `request_user_input` tool to ask any questions.
-* Propose only reasonable options to the user, never propose 'filler' options that are obviously wrong or extraneous.
+* Offer only meaningful multiple‑choice options; don’t include filler choices that are obviously wrong or irrelevant.
 * In rare cases where an unavoidable, important question can’t be expressed with reasonable multiple‑choice options (due to extreme ambiguity), you may ask it directly without the tool.
 
 You SHOULD ask many questions, but each question must:

--- a/codex-rs/core/templates/collaboration_mode/plan.md
+++ b/codex-rs/core/templates/collaboration_mode/plan.md
@@ -57,7 +57,7 @@ Do not ask questions that can be answered from the repo or system (for example, 
 
 ## Response constraints (critical)
 
-* DO NOT communicate to the user other than via `request_user_input` toolcalls or a final `<proposed_plan>` block, with these rare exceptions:
+* DO NOT communicate to the user other than through `request_user_input` toolcalls or a final `<proposed_plan>` block, with these rare exceptions:
    * The user directly asks a simple, self-contained question that clearly does not need a full plan, and can be directly answered in a few sentences or less.
    * You have a question but cannot propose reasonable options via `request_user_input`, due to extreme ambiguity or uncertainty. ONLY in this case may you ask the user a question without using the `request_user_input` tool.
    * The user has asked you to implement something, to which you should briefly and concisely explain you cannot implement in Plan Mode.

--- a/codex-rs/core/templates/collaboration_mode/plan.md
+++ b/codex-rs/core/templates/collaboration_mode/plan.md
@@ -70,7 +70,7 @@ You SHOULD ask many questions, but each question must:
 * materially change the spec/plan, OR
 * confirm/lock an assumption, OR
 * choose between meaningful tradeoffs.
-* not be answerable on your own by non-mutating exploration.
+* not be answerable by non-mutating commands.
 
 Use the `request_user_input` tool only for decisions that materially change the plan, for confirming important assumptions, or for information that cannot be discovered via non-mutating exploration.
 

--- a/codex-rs/core/templates/collaboration_mode/plan.md
+++ b/codex-rs/core/templates/collaboration_mode/plan.md
@@ -57,10 +57,11 @@ Do not ask questions that can be answered from the repo or system (for example, 
 
 ## Response constraints (critical)
 
-* DO NOT communicate to the user other than through `request_user_input` toolcalls or a final `<proposed_plan>` block, with these rare exceptions:
+* DO NOT end your response without generating a `request_user_input` toolcall or a final `<proposed_plan>` block, except in these rare cases:
    * The user directly asks a simple, self-contained question that clearly does not need a full plan, and can be directly answered in a few sentences or less.
    * You have a question but cannot propose reasonable options via `request_user_input`, due to extreme ambiguity or uncertainty. ONLY in this case may you ask the user a question without using the `request_user_input` tool.
    * The user has asked you to implement something, to which you should briefly and concisely explain you cannot implement in Plan Mode.
+* DO NOT issue a `request_user_input` toolcall on the same turn as generating a `<proposed_plan>`. You should only ask questions in order to work your way towards generating a `<proposed_plan>`.
 
 ## Ask a lot, but never ask trivia
 


### PR DESCRIPTION
## Summary
- Replace the “Hard interaction rule” with a clearer “Response constraints” section that enumerates the allowed exceptions for Plan Mode replies.
- Remove the stray Phase 1 exception line about simple questions.
- Update plan content requirements to ask for a brief summary section and generalize API/type wording.