### PR TITLE
fix(core) Stop duplicating dev messages from OverrideTurnContext

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/thread_resume.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_resume.rs
@@ -437,6 +437,14 @@ async fn thread_resume_accepts_personality_override() -> Result<()> {
 
     let request = response_mock.single_request();
     let developer_texts = request.message_input_texts("developer");
+    let personality_update_count = developer_texts
+        .iter()
+        .filter(|text| text.contains("<personality_spec>"))
+        .count();
+    assert_eq!(
+        personality_update_count, 1,
+        "expected exactly one personality update message in developer input, got {developer_texts:?}"
+    );
     assert!(
         developer_texts
             .iter()

--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -474,6 +474,14 @@ async fn turn_start_accepts_personality_override_v2() -> Result<()> {
         eprintln!("request body: {}", request.body_json());
     }
 
+    let personality_update_count = developer_texts
+        .iter()
+        .filter(|text| text.contains("<personality_spec>"))
+        .count();
+    assert_eq!(
+        personality_update_count, 1,
+        "expected exactly one personality update message in developer input, got {developer_texts:?}"
+    );
     assert!(
         developer_texts
             .iter()
@@ -585,6 +593,14 @@ async fn turn_start_change_personality_mid_thread_v2() -> Result<()> {
     );
 
     let second_developer_texts = requests[1].message_input_texts("developer");
+    let personality_update_count = second_developer_texts
+        .iter()
+        .filter(|text| text.contains("<personality_spec>"))
+        .count();
+    assert_eq!(
+        personality_update_count, 1,
+        "expected exactly one personality update message in second request, got {second_developer_texts:?}"
+    );
     assert!(
         second_developer_texts
             .iter()

--- a/codex-rs/core/tests/suite/personality.rs
+++ b/codex-rs/core/tests/suite/personality.rs
@@ -255,6 +255,14 @@ async fn user_turn_personality_some_adds_update_message() -> anyhow::Result<()> 
         .expect("expected personality update request");
 
     let developer_texts = request.message_input_texts("developer");
+    let personality_update_count = developer_texts
+        .iter()
+        .filter(|text| text.contains("<personality_spec>"))
+        .count();
+    assert_eq!(
+        personality_update_count, 1,
+        "expected exactly one personality update message in developer input, got {developer_texts:?}"
+    );
     let personality_text = developer_texts
         .iter()
         .find(|text| text.contains("<personality_spec>"))
@@ -738,6 +746,14 @@ async fn user_turn_personality_remote_model_template_includes_update_message() -
         .last()
         .expect("expected personality update request");
     let developer_texts = request.message_input_texts("developer");
+    let personality_update_count = developer_texts
+        .iter()
+        .filter(|text| text.contains("<personality_spec>"))
+        .count();
+    assert_eq!(
+        personality_update_count, 1,
+        "expected exactly one personality update message in developer input, got {developer_texts:?}"
+    );
     let personality_text = developer_texts
         .iter()
         .find(|text| text.contains("<personality_spec>"))

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -388,17 +388,14 @@ async fn overrides_turn_context_but_keeps_cached_prefix_and_key_constant() -> an
     });
     let expected_permissions_msg = body1["input"][0].clone();
     let body1_input = body1["input"].as_array().expect("input array");
-    // After overriding the turn context, emit two updated permissions messages.
+    // After overriding the turn context, emit one updated permissions message.
     let expected_permissions_msg_2 = body2["input"][body1_input.len()].clone();
-    let expected_permissions_msg_3 = body2["input"][body1_input.len() + 1].clone();
     assert_ne!(
         expected_permissions_msg_2, expected_permissions_msg,
         "expected updated permissions message after override"
     );
-    assert_eq!(expected_permissions_msg_2, expected_permissions_msg_3);
     let mut expected_body2 = body1_input.to_vec();
     expected_body2.push(expected_permissions_msg_2);
-    expected_body2.push(expected_permissions_msg_3);
     expected_body2.push(expected_user_message_2);
     assert_eq!(body2["input"], serde_json::Value::Array(expected_body2));
 


### PR DESCRIPTION
## Summary
We are adding personality update messages twice -  the root cause is stale previous_context. OverrideTurnContext recorded one personality update immediately, then the next user turn diffed against old context and emitted another.

## Testing
- [x] Added stronger integration assertions to catch this exact bug by requiring exactly one <personality_spec> developer message
