### PR TITLE
fix: System skills marker includes nested folders recursively

### DIFF
--- a/codex-rs/core/Cargo.toml
+++ b/codex-rs/core/Cargo.toml
@@ -3,6 +3,7 @@ edition.workspace = true
 license.workspace = true
 name = "codex-core"
 version.workspace = true
+build = "build.rs"
 
 [lib]
 doctest = false

--- a/codex-rs/core/build.rs
+++ b/codex-rs/core/build.rs
@@ -1,0 +1,27 @@
+use std::fs;
+use std::path::Path;
+
+fn main() {
+    let samples_dir = Path::new("src/skills/assets/samples");
+    if !samples_dir.exists() {
+        return;
+    }
+
+    println!("cargo:rerun-if-changed={}", samples_dir.display());
+    visit_dir(samples_dir);
+}
+
+fn visit_dir(dir: &Path) {
+    let entries = match fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        println!("cargo:rerun-if-changed={}", path.display());
+        if path.is_dir() {
+            visit_dir(&path);
+        }
+    }
+}


### PR DESCRIPTION
Updated system skills bundled with Codex were not correctly replacing the user's skills in their .system folder.

- Fix `.codex-system-skills.marker` not updating by hashing embedded system skills recursively (nested dirs + file contents), so updates trigger a reinstall.
- Added a build Cargo hook to rerun if there are changes in `src/skills/assets/samples/*`, ensuring embedded skill updates rebuild correctly under caching.
- Add a small unit test to ensure nested entries are included in the fingerprint.