### PR TITLE
Add support for folder mentions in Codex TUI

### DIFF
--- a/codex-rs/file-search/src/lib.rs
+++ b/codex-rs/file-search/src/lib.rs
@@ -53,6 +53,7 @@ pub struct FileMatch {
     pub score: u32,
     pub path: PathBuf,
     pub root: PathBuf,
+    pub is_dir: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub indices: Option<Vec<u32>>, // Sorted & deduplicated when present
 }
@@ -93,6 +94,7 @@ pub struct FileSearchOptions {
     pub threads: NonZero<usize>,
     pub compute_indices: bool,
     pub respect_gitignore: bool,
+    pub include_dirs: bool,
 }
 
 impl Default for FileSearchOptions {
@@ -105,6 +107,7 @@ impl Default for FileSearchOptions {
             threads: NonZero::new(2).unwrap(),
             compute_indices: false,
             respect_gitignore: true,
+            include_dirs: false,
         }
     }
 }
@@ -163,6 +166,7 @@ fn create_session_inner(
         threads,
         compute_indices,
         respect_gitignore,
+        include_dirs,
     } = options;
 
     let Some(primary_search_directory) = search_directories.first() else {
@@ -191,6 +195,7 @@ fn create_session_inner(
         threads: threads.get(),
         compute_indices,
         respect_gitignore,
+        include_dirs,
         cancelled: cancelled.clone(),
         shutdown: Arc::new(AtomicBool::new(false)),
         reporter,
@@ -266,6 +271,7 @@ pub async fn run_main<T: Reporter>(
             threads,
             compute_indices,
             respect_gitignore: true,
+            include_dirs: false,
         },
         None,
     )?;
@@ -344,6 +350,7 @@ struct SessionInner {
     threads: usize,
     compute_indices: bool,
     respect_gitignore: bool,
+    include_dirs: bool,
     cancelled: Arc<AtomicBool>,
     shutdown: Arc<AtomicBool>,
     reporter: Arc<dyn SessionReporter>,
@@ -432,6 +439,7 @@ fn walker_worker(
         const CHECK_INTERVAL: usize = 1024;
         let mut n = 0;
         let search_directories = inner.search_directories.clone();
+        let include_dirs = inner.include_dirs;
         let injector = injector.clone();
         let cancelled = inner.cancelled.clone();
         let shutdown = inner.shutdown.clone();
@@ -441,7 +449,8 @@ fn walker_worker(
                 Ok(entry) => entry,
                 Err(_) => return ignore::WalkState::Continue,
             };
-            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+            let is_dir = entry.file_type().is_some_and(|ft| ft.is_dir());
+            if is_dir && !include_dirs {
                 return ignore::WalkState::Continue;
             }
             let path = entry.path();
@@ -449,8 +458,15 @@ fn walker_worker(
                 return ignore::WalkState::Continue;
             };
             if let Some((_, relative_path)) = get_file_path(path, &search_directories) {
+                if relative_path.is_empty() {
+                    return ignore::WalkState::Continue;
+                }
                 injector.push(Arc::from(full_path), |_, cols| {
-                    cols[0] = Utf32String::from(relative_path);
+                    cols[0] = if is_dir {
+                        Utf32String::from(format!("{relative_path}/"))
+                    } else {
+                        Utf32String::from(relative_path)
+                    };
                 });
             }
             n += 1;
@@ -549,6 +565,7 @@ fn matcher_worker(
                                 score: match_.score,
                                 path: PathBuf::from(relative_path),
                                 root: inner.search_directories[root_idx].clone(),
+                                is_dir: Path::new(full_path).is_dir(),
                                 indices,
                             })
                         })
@@ -895,6 +912,7 @@ mod tests {
             threads: NonZero::new(2).unwrap(),
             compute_indices: false,
             respect_gitignore: true,
+            include_dirs: false,
         };
         let results =
             run("file-000", vec![dir.path().to_path_buf()], options, None).expect("run ok");

--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -1347,53 +1347,58 @@ impl ChatComposer {
                     return (InputResult::None, true);
                 };
 
-                let sel_path = sel.to_string_lossy().to_string();
-                // If selected path looks like an image (png/jpeg), attach as image instead of inserting text.
-                let is_image = Self::is_image_path(&sel_path);
-                if is_image {
-                    // Determine dimensions; if that fails fall back to normal path insertion.
-                    let path_buf = PathBuf::from(&sel_path);
-                    match image::image_dimensions(&path_buf) {
-                        Ok((width, height)) => {
-                            tracing::debug!("selected image dimensions={}x{}", width, height);
-                            // Remove the current @token (mirror logic from insert_selected_path without inserting text)
-                            // using the flat text and byte-offset cursor API.
-                            let cursor_offset = self.textarea.cursor();
-                            let text = self.textarea.text();
-                            // Clamp to a valid char boundary to avoid panics when slicing.
-                            let safe_cursor = Self::clamp_to_char_boundary(text, cursor_offset);
-                            let before_cursor = &text[..safe_cursor];
-                            let after_cursor = &text[safe_cursor..];
+                let sel_path = sel.path.to_string_lossy().to_string();
 
-                            // Determine token boundaries in the full text.
-                            let start_idx = before_cursor
-                                .char_indices()
-                                .rfind(|(_, c)| c.is_whitespace())
-                                .map(|(idx, c)| idx + c.len_utf8())
-                                .unwrap_or(0);
-                            let end_rel_idx = after_cursor
-                                .char_indices()
-                                .find(|(_, c)| c.is_whitespace())
-                                .map(|(idx, _)| idx)
-                                .unwrap_or(after_cursor.len());
-                            let end_idx = safe_cursor + end_rel_idx;
-
-                            self.textarea.replace_range(start_idx..end_idx, "");
-                            self.textarea.set_cursor(start_idx);
-
-                            self.attach_image(path_buf);
-                            // Add a trailing space to keep typing fluid.
-                            self.textarea.insert_str(" ");
-                        }
-                        Err(err) => {
-                            tracing::trace!("image dimensions lookup failed: {err}");
-                            // Fallback to plain path insertion if metadata read fails.
-                            self.insert_selected_path(&sel_path);
-                        }
-                    }
+                if sel.is_dir {
+                    self.insert_selected_dir_mention(&sel_path);
                 } else {
-                    // Non-image: inserting file path.
-                    self.insert_selected_path(&sel_path);
+                    // If selected path looks like an image (png/jpeg), attach as image instead of inserting text.
+                    let is_image = Self::is_image_path(&sel_path);
+                    if is_image {
+                        // Determine dimensions; if that fails fall back to normal path insertion.
+                        let path_buf = PathBuf::from(&sel_path);
+                        match image::image_dimensions(&path_buf) {
+                            Ok((width, height)) => {
+                                tracing::debug!("selected image dimensions={}x{}", width, height);
+                                // Remove the current @token (mirror logic from insert_selected_path without inserting text)
+                                // using the flat text and byte-offset cursor API.
+                                let cursor_offset = self.textarea.cursor();
+                                let text = self.textarea.text();
+                                // Clamp to a valid char boundary to avoid panics when slicing.
+                                let safe_cursor = Self::clamp_to_char_boundary(text, cursor_offset);
+                                let before_cursor = &text[..safe_cursor];
+                                let after_cursor = &text[safe_cursor..];
+
+                                // Determine token boundaries in the full text.
+                                let start_idx = before_cursor
+                                    .char_indices()
+                                    .rfind(|(_, c)| c.is_whitespace())
+                                    .map(|(idx, c)| idx + c.len_utf8())
+                                    .unwrap_or(0);
+                                let end_rel_idx = after_cursor
+                                    .char_indices()
+                                    .find(|(_, c)| c.is_whitespace())
+                                    .map(|(idx, _)| idx)
+                                    .unwrap_or(after_cursor.len());
+                                let end_idx = safe_cursor + end_rel_idx;
+
+                                self.textarea.replace_range(start_idx..end_idx, "");
+                                self.textarea.set_cursor(start_idx);
+
+                                self.attach_image(path_buf);
+                                // Add a trailing space to keep typing fluid.
+                                self.textarea.insert_str(" ");
+                            }
+                            Err(err) => {
+                                tracing::trace!("image dimensions lookup failed: {err}");
+                                // Fallback to plain path insertion if metadata read fails.
+                                self.insert_selected_path(&sel_path);
+                            }
+                        }
+                    } else {
+                        // Non-image: inserting file path.
+                        self.insert_selected_path(&sel_path);
+                    }
                 }
                 // No selection: treat Enter as closing the popup/session.
                 self.active_popup = ActivePopup::None;
@@ -1471,7 +1476,7 @@ impl ChatComposer {
                 if let Some(path) = path.as_deref() {
                     self.record_mention_path(&insert_text, path);
                 }
-                self.insert_selected_mention(&insert_text);
+                self.insert_selected_file_mention(&insert_text);
             }
             self.active_popup = ActivePopup::None;
         }
@@ -1764,21 +1769,18 @@ impl ChatComposer {
             path.to_string()
         };
 
-        // Replace the slice `[start_idx, end_idx)` with the chosen path and a trailing space.
-        let mut new_text =
-            String::with_capacity(text.len() - (end_idx - start_idx) + inserted.len() + 1);
-        new_text.push_str(&text[..start_idx]);
-        new_text.push_str(&inserted);
-        new_text.push(' ');
-        new_text.push_str(&text[end_idx..]);
-
-        // Path replacement is plain text; rebuild without carrying elements.
-        self.textarea.set_text_clearing_elements(&new_text);
-        let new_cursor = start_idx.saturating_add(inserted.len()).saturating_add(1);
+        // Preserve existing elements (e.g. prior mentions) outside the replaced token.
+        let mut replacement = String::with_capacity(inserted.len() + 1);
+        replacement.push_str(&inserted);
+        replacement.push(' ');
+        self.textarea
+            .replace_range(start_idx..end_idx, &replacement);
+        let new_cursor = start_idx.saturating_add(replacement.len());
         self.textarea.set_cursor(new_cursor);
     }
 
-    fn insert_selected_mention(&mut self, insert_text: &str) {
+    // Inserts the selected file mention's insert_text at the current @token position.
+    fn insert_selected_file_mention(&mut self, insert_text: &str) {
         let cursor_offset = self.textarea.cursor();
         let text = self.textarea.text();
         let safe_cursor = Self::clamp_to_char_boundary(text, cursor_offset);
@@ -1799,19 +1801,47 @@ impl ChatComposer {
             .unwrap_or(after_cursor.len());
         let end_idx = safe_cursor + end_rel_idx;
 
-        let inserted = insert_text.to_string();
-
-        let mut new_text =
-            String::with_capacity(text.len() - (end_idx - start_idx) + inserted.len() + 1);
-        new_text.push_str(&text[..start_idx]);
-        new_text.push_str(&inserted);
-        new_text.push(' ');
-        new_text.push_str(&text[end_idx..]);
-
-        // Mention insertion rebuilds plain text, so drop existing elements.
-        self.textarea.set_text_clearing_elements(&new_text);
-        let new_cursor = start_idx.saturating_add(inserted.len()).saturating_add(1);
+        // Preserve existing elements (e.g. prior folder mentions) outside the replaced token.
+        let mut replacement = String::with_capacity(insert_text.len() + 1);
+        replacement.push_str(insert_text);
+        replacement.push(' ');
+        self.textarea
+            .replace_range(start_idx..end_idx, &replacement);
+        let new_cursor = start_idx.saturating_add(replacement.len());
         self.textarea.set_cursor(new_cursor);
+    }
+
+    // Inserts the selected directory mention's insert_text at the current @token position.
+    fn insert_selected_dir_mention(&mut self, path: &str) {
+        let cursor_offset = self.textarea.cursor();
+        let text = self.textarea.text();
+        let safe_cursor = Self::clamp_to_char_boundary(text, cursor_offset);
+
+        let before_cursor = &text[..safe_cursor];
+        let after_cursor = &text[safe_cursor..];
+
+        let start_idx = before_cursor
+            .char_indices()
+            .rfind(|(_, c)| c.is_whitespace())
+            .map(|(idx, c)| idx + c.len_utf8())
+            .unwrap_or(0);
+
+        let end_rel_idx = after_cursor
+            .char_indices()
+            .find(|(_, c)| c.is_whitespace())
+            .map(|(idx, _)| idx)
+            .unwrap_or(after_cursor.len());
+        let end_idx = safe_cursor + end_rel_idx;
+
+        self.textarea.replace_range(start_idx..end_idx, "");
+        self.textarea.set_cursor(start_idx);
+
+        let mut dir_path = path.to_string();
+        if !dir_path.ends_with('/') {
+            dir_path.push('/');
+        }
+        self.textarea.insert_element(&dir_path);
+        self.textarea.insert_str(" ");
     }
 
     fn record_mention_path(&mut self, insert_text: &str, path: &str) {
@@ -5061,7 +5091,7 @@ mod tests {
     }
 
     #[test]
-    fn slash_plan_args_preserve_text_elements() {
+    fn selecting_file_after_folder_preserves_folder_text_element() {
         use crossterm::event::KeyCode;
         use crossterm::event::KeyEvent;
         use crossterm::event::KeyModifiers;
@@ -5075,27 +5105,48 @@ mod tests {
             "Ask Codex to do anything".to_string(),
             false,
         );
-        composer.set_collaboration_modes_enabled(true);
 
-        type_chars_humanlike(&mut composer, &['/', 'p', 'l', 'a', 'n', ' ']);
-        let placeholder = local_image_label_text(1);
-        composer.attach_image(PathBuf::from("/tmp/plan.png"));
+        composer.insert_str("@doc");
+        composer.on_file_search_result(
+            "doc".to_string(),
+            vec![FileMatch {
+                score: 100,
+                path: PathBuf::from("docs"),
+                root: PathBuf::from("/repo"),
+                is_dir: true,
+                indices: None,
+            }],
+        );
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
 
-        let (result, _needs_redraw) =
-            composer.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+        let elements_after_dir = composer.text_elements();
+        assert_eq!(composer.textarea.text(), "docs/ ");
+        assert_eq!(elements_after_dir.len(), 1);
+        assert_eq!(
+            elements_after_dir[0].placeholder(composer.textarea.text()),
+            Some("docs/")
+        );
 
-        match result {
-            InputResult::CommandWithArgs(cmd, args, text_elements) => {
-                assert_eq!(cmd.command(), "plan");
-                assert_eq!(args, placeholder);
-                assert_eq!(text_elements.len(), 1);
-                assert_eq!(
-                    text_elements[0].placeholder(&args),
-                    Some(placeholder.as_str())
-                );
-            }
-            _ => panic!("expected CommandWithArgs for /plan with args"),
-        }
+        composer.insert_str("@main");
+        composer.on_file_search_result(
+            "main".to_string(),
+            vec![FileMatch {
+                score: 99,
+                path: PathBuf::from("main.rs"),
+                root: PathBuf::from("/repo"),
+                is_dir: false,
+                indices: None,
+            }],
+        );
+        let _ = composer.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+        let elements_after_file = composer.text_elements();
+        assert_eq!(composer.textarea.text(), "docs/ main.rs ");
+        assert_eq!(elements_after_file.len(), 1);
+        assert_eq!(
+            elements_after_file[0].placeholder(composer.textarea.text()),
+            Some("docs/"),
+        );
     }
 
     /// Behavior: multiple paste operations can coexist; placeholders should be expanded to their

--- a/codex-rs/tui/src/bottom_pane/file_search_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/file_search_popup.rs
@@ -1,5 +1,3 @@
-use std::path::PathBuf;
-
 use codex_file_search::FileMatch;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -91,11 +89,10 @@ impl FileSearchPopup {
         self.state.ensure_visible(len, len.min(MAX_POPUP_ROWS));
     }
 
-    pub(crate) fn selected_match(&self) -> Option<&PathBuf> {
+    pub(crate) fn selected_match(&self) -> Option<&FileMatch> {
         self.state
             .selected_idx
             .and_then(|idx| self.matches.get(idx))
-            .map(|file_match| &file_match.path)
     }
 
     pub(crate) fn calculate_required_height(&self) -> u16 {
@@ -118,7 +115,11 @@ impl WidgetRef for &FileSearchPopup {
             self.matches
                 .iter()
                 .map(|m| GenericDisplayRow {
-                    name: m.path.to_string_lossy().to_string(),
+                    name: if m.is_dir {
+                        format!("{}/", m.path.to_string_lossy())
+                    } else {
+                        m.path.to_string_lossy().to_string()
+                    },
                     match_indices: m
                         .indices
                         .as_ref()

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -369,6 +369,83 @@ async fn blocked_image_restore_preserves_mention_paths() {
 }
 
 #[tokio::test]
+async fn submission_expands_directory_mentions() {
+    let (mut chat, mut rx, mut op_rx) = make_chatwidget_manual(None).await;
+
+    let project_root = tempdir().unwrap();
+    std::fs::create_dir_all(project_root.path().join("docs")).unwrap();
+
+    let conversation_id = ThreadId::new();
+    let rollout_file = NamedTempFile::new().unwrap();
+    let configured = codex_core::protocol::SessionConfiguredEvent {
+        session_id: conversation_id,
+        forked_from_id: None,
+        thread_name: None,
+        model: "test-model".to_string(),
+        model_provider_id: "test-provider".to_string(),
+        approval_policy: AskForApproval::Never,
+        sandbox_policy: SandboxPolicy::ReadOnly,
+        cwd: project_root.path().to_path_buf(),
+        reasoning_effort: Some(ReasoningEffortConfig::default()),
+        history_log_id: 0,
+        history_entry_count: 0,
+        initial_messages: None,
+        rollout_path: Some(rollout_file.path().to_path_buf()),
+    };
+    chat.handle_codex_event(Event {
+        id: "initial".into(),
+        msg: EventMsg::SessionConfigured(configured),
+    });
+    drain_insert_history(&mut rx);
+    chat.config.cwd = project_root.path().to_path_buf();
+
+    let text = "docs/ review".to_string();
+    let text_elements = vec![TextElement::new(
+        (0.."docs/".len()).into(),
+        Some("docs/".into()),
+    )];
+    chat.bottom_pane
+        .set_composer_text(text.clone(), text_elements.clone(), Vec::new());
+    chat.handle_key_event(KeyEvent::new(KeyCode::Enter, KeyModifiers::NONE));
+
+    let items = match next_submit_op(&mut op_rx) {
+        Op::UserTurn { items, .. } => items,
+        other => panic!("expected Op::UserTurn, got {other:?}"),
+    };
+
+    let abs_docs = format!(
+        "{}/",
+        project_root
+            .path()
+            .join("docs")
+            .to_string_lossy()
+            .replace('\\', "/")
+    );
+    assert_eq!(
+        items,
+        vec![UserInput::Text {
+            text: format!("[docs/]({abs_docs}) review"),
+            text_elements: Vec::new(),
+        }],
+    );
+
+    let mut user_cell = None;
+    while let Ok(ev) = rx.try_recv() {
+        if let AppEvent::InsertHistoryCell(cell) = ev
+            && let Some(cell) = cell.as_any().downcast_ref::<UserHistoryCell>()
+        {
+            user_cell = Some((cell.message.clone(), cell.text_elements.clone()));
+            break;
+        }
+    }
+
+    let (stored_message, stored_elements) =
+        user_cell.expect("expected submitted user history cell");
+    assert_eq!(stored_message, text);
+    assert_eq!(stored_elements, text_elements);
+}
+
+#[tokio::test]
 async fn interrupted_turn_restores_queued_messages_with_images_and_elements() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
 

--- a/codex-rs/tui/src/file_search.rs
+++ b/codex-rs/tui/src/file_search.rs
@@ -84,6 +84,7 @@ impl FileSearchManager {
             &self.search_dir,
             file_search::FileSearchOptions {
                 compute_indices: true,
+                include_dirs: true,
                 ..Default::default()
             },
             reporter,

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -60,7 +60,7 @@ impl SlashCommand {
             // SlashCommand::Undo => "ask Codex to undo a turn",
             SlashCommand::Quit | SlashCommand::Exit => "exit Codex",
             SlashCommand::Diff => "show git diff (including untracked files)",
-            SlashCommand::Mention => "mention a file",
+            SlashCommand::Mention => "mention a file or folder",
             SlashCommand::Skills => "use skills to improve how Codex performs specific tasks",
             SlashCommand::Status => "show current session configuration and token usage",
             SlashCommand::Ps => "list background terminals",


### PR DESCRIPTION
This PR adds folder mentions to the TUI mention flow (@...), alongside existing file mentions. Users can now mention directories in the same picker used for files. Directory mentions are rendered naturally in the composer (e.g., docs/) and expanded into an unambiguous absolute path hint at send time.

**How to test**
- Type @ in the composer.
- Search/select either:
  - a file (existing behavior), or
  - a folder (new behavior).
- Folder appears in composer as folder_name/.
- On submit, model input includes a normalized absolute path hint for that folder.

<img width="2764" height="570" alt="image" src="https://github.com/user-attachments/assets/5bc25d08-2784-4943-a49a-75d1c08edc0a" />
