### PR TITLE
chore:  Improve diagnostics for residency-related 401s

### DIFF
--- a/codex-rs/core/src/default_client.rs
+++ b/codex-rs/core/src/default_client.rs
@@ -84,6 +84,13 @@ pub fn set_default_client_residency_requirement(enforce_residency: Option<Reside
         tracing::warn!("Failed to acquire requirements residency lock");
         return;
     };
+    if *guard != enforce_residency {
+        tracing::info!(
+            previous = ?*guard,
+            updated = ?enforce_residency,
+            "Updated Codex residency requirement"
+        );
+    }
     *guard = enforce_residency;
 }
 
@@ -188,6 +195,11 @@ pub fn build_reqwest_client() -> reqwest::Client {
         let value = match requirement {
             ResidencyRequirement::Us => HeaderValue::from_static("us"),
         };
+        tracing::debug!(
+            header_name = RESIDENCY_HEADER_NAME,
+            header_value = ?value,
+            "Applying residency header to default HTTP client"
+        );
         headers.insert(RESIDENCY_HEADER_NAME, value);
     }
     let ua = get_codex_user_agent();


### PR DESCRIPTION
- Adds a targeted log on 401s for /codex/responses that reports whether the residency header was present and its value.
- Logs residency requirement changes when they occur (low-frequency signal).