### PR TITLE
docs: add macOS network sandbox troubleshooting to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,34 @@ Run `codex` and select **Sign in with ChatGPT**. We recommend signing into your 
 
 You can also use Codex with an API key, but this requires [additional setup](https://developers.openai.com/codex/auth#sign-in-with-an-api-key).
 
+## Troubleshooting
+
+<details>
+<summary><strong>macOS: Network calls fail even with <code>network_access = true</code></strong></summary>
+
+On macOS, the seatbelt sandbox unconditionally blocks outbound network access regardless of your `config.toml` settings. Commands that require network (cloud CLIs, curl, API clients, package managers) will fail with connection timeouts.
+
+**Symptoms:**
+- `CODEX_SANDBOX_NETWORK_DISABLED=1` is set in the sandbox environment
+- `network_access = true` under `[sandbox_workspace_write]` in `~/.codex/config.toml` has no effect
+- Network commands time out or report host unreachable
+
+**Workaround — use the CLI flag:**
+
+```shell
+codex --sandbox danger-full-access "your prompt"
+```
+
+Or add a persistent alias to your shell profile (`~/.zshrc` / `~/.bashrc`):
+
+```shell
+alias codex='CODEX_SANDBOX_NETWORK_DISABLED=0 codex --sandbox danger-full-access'
+```
+
+> **Note:** `--sandbox danger-full-access` disables all sandbox restrictions. Only use this in environments you trust. See [#10390](https://github.com/openai/codex/issues/10390) for details and a proposed fix.
+
+</details>
+
 ## Docs
 
 - [**Codex Documentation**](https://developers.openai.com/codex)


### PR DESCRIPTION
## Summary

- Adds a **Troubleshooting** section to the README documenting the macOS seatbelt sandbox silently ignoring `network_access = true` from `config.toml`
- Includes a confirmed workaround (`--sandbox danger-full-access` CLI flag and shell alias)
- References #10390 for full context and a proposed code fix

## Context

On macOS, the seatbelt sandbox unconditionally sets `CODEX_SANDBOX_NETWORK_DISABLED=1`, causing all outbound network calls to fail — even when the user has explicitly set `network_access = true` in `~/.codex/config.toml`. This affects cloud CLIs (OCI, AWS, GCP), curl, package managers, and any workflow requiring network from within a Codex session.

Multiple closed issues reference this problem (#8714, #5041, #3454, #5090) but none document the workaround in an easily discoverable place. This small README addition helps users find the fix without digging through issue threads.