### PR TITLE
emit a separate metric when the user cancels UAT during elevated setup

### DIFF
--- a/codex-rs/core/src/windows_sandbox.rs
+++ b/codex-rs/core/src/windows_sandbox.rs
@@ -66,6 +66,25 @@ pub fn elevated_setup_failure_details(_err: &anyhow::Error) -> Option<(String, S
 }
 
 #[cfg(target_os = "windows")]
+pub fn elevated_setup_failure_metric_name(err: &anyhow::Error) -> &'static str {
+    if codex_windows_sandbox::extract_setup_failure(err).is_some_and(|failure| {
+        matches!(
+            failure.code,
+            codex_windows_sandbox::SetupErrorCode::OrchestratorHelperLaunchCanceled
+        )
+    }) {
+        "codex.windows_sandbox.elevated_setup_canceled"
+    } else {
+        "codex.windows_sandbox.elevated_setup_failure"
+    }
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn elevated_setup_failure_metric_name(_err: &anyhow::Error) -> &'static str {
+    panic!("elevated_setup_failure_metric_name is only supported on Windows")
+}
+
+#[cfg(target_os = "windows")]
 pub fn run_elevated_setup(
     policy: &SandboxPolicy,
     policy_cwd: &Path,

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1700,7 +1700,9 @@ impl App {
                                     tags.push(("message", message));
                                 }
                                 otel_manager.counter(
-                                    "codex.windows_sandbox.elevated_setup_failure",
+                                    codex_core::windows_sandbox::elevated_setup_failure_metric_name(
+                                        &err,
+                                    ),
                                     1,
                                     &tags,
                                 );

--- a/codex-rs/windows-sandbox-rs/src/setup_error.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_error.rs
@@ -22,6 +22,8 @@ pub enum SetupErrorCode {
     OrchestratorPayloadSerializeFailed,
     /// Failed to launch the setup helper process (spawn or ShellExecuteExW).
     OrchestratorHelperLaunchFailed,
+    /// User canceled the UAC prompt while launching the helper.
+    OrchestratorHelperLaunchCanceled,
     /// Helper exited non-zero and no structured report was available.
     OrchestratorHelperExitNonzero,
     /// Helper exited non-zero and reading `setup_error.json` failed.
@@ -72,6 +74,7 @@ impl SetupErrorCode {
             Self::OrchestratorElevationCheckFailed => "orchestrator_elevation_check_failed",
             Self::OrchestratorPayloadSerializeFailed => "orchestrator_payload_serialize_failed",
             Self::OrchestratorHelperLaunchFailed => "orchestrator_helper_launch_failed",
+            Self::OrchestratorHelperLaunchCanceled => "orchestrator_helper_launch_canceled",
             Self::OrchestratorHelperExitNonzero => "orchestrator_helper_exit_nonzero",
             Self::OrchestratorHelperReportReadFailed => "orchestrator_helper_report_read_failed",
             Self::HelperRequestArgsFailed => "helper_request_args_failed",


### PR DESCRIPTION
Currently this shows up as elevated setup failure, which isn't quite accurate.