### PR TITLE
feat: add `--experimental` to `generate-ts`

### DIFF
--- a/codex-rs/app-server-protocol/src/bin/write_schema_fixtures.rs
+++ b/codex-rs/app-server-protocol/src/bin/write_schema_fixtures.rs
@@ -13,6 +13,10 @@ struct Args {
     /// Optional path to the Prettier executable to format generated TypeScript files.
     #[arg(short = 'p', long = "prettier", value_name = "PRETTIER_BIN")]
     prettier: Option<PathBuf>,
+
+    /// Include experimental API methods and fields in generated fixtures.
+    #[arg(long = "experimental")]
+    experimental: bool,
 }
 
 fn main() -> Result<()> {
@@ -22,11 +26,17 @@ fn main() -> Result<()> {
         .schema_root
         .unwrap_or_else(|| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("schema"));
 
-    codex_app_server_protocol::write_schema_fixtures(&schema_root, args.prettier.as_deref())
-        .with_context(|| {
-            format!(
-                "failed to regenerate schema fixtures under {}",
-                schema_root.display()
-            )
-        })
+    codex_app_server_protocol::write_schema_fixtures_with_options(
+        &schema_root,
+        args.prettier.as_deref(),
+        codex_app_server_protocol::SchemaFixtureOptions {
+            experimental_api: args.experimental,
+        },
+    )
+    .with_context(|| {
+        format!(
+            "failed to regenerate schema fixtures under {}",
+            schema_root.display()
+        )
+    })
 }

--- a/codex-rs/app-server-protocol/src/lib.rs
+++ b/codex-rs/app-server-protocol/src/lib.rs
@@ -16,5 +16,7 @@ pub use protocol::common::*;
 pub use protocol::thread_history::*;
 pub use protocol::v1::*;
 pub use protocol::v2::*;
+pub use schema_fixtures::SchemaFixtureOptions;
 pub use schema_fixtures::read_schema_fixture_tree;
 pub use schema_fixtures::write_schema_fixtures;
+pub use schema_fixtures::write_schema_fixtures_with_options;

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -788,6 +788,8 @@ At runtime, clients must send `initialize` with `capabilities.experimentalApi = 
 
    ```bash
    just write-app-server-schema
+   # Include experimental API fields/methods in fixtures.
+   just write-app-server-schema --experimental
    ```
     
 5. Verify the protocol crate:

--- a/justfile
+++ b/justfile
@@ -69,8 +69,8 @@ write-config-schema:
     cargo run -p codex-core --bin codex-write-config-schema
 
 # Regenerate vendored app-server protocol schema artifacts.
-write-app-server-schema:
-    cargo run -p codex-app-server-protocol --bin write_schema_fixtures
+write-app-server-schema *args:
+    cargo run -p codex-app-server-protocol --bin write_schema_fixtures -- "$@"
 
 # Tail logs from the state SQLite database
 log *args:


### PR DESCRIPTION
Adding a `--experimental` flag to the `generate-ts` fct in the app-sever.

It can be called through one of those 2 command
```
just write-app-server-schema --experimental
codex app-server generate-ts --experimental
```