### PR TITLE
Fixed sandbox mode inconsistency if untrusted is selected

### DIFF
--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -494,12 +494,9 @@ async fn run_ratatui_app(
                 exit_reason: ExitReason::UserRequested,
             });
         }
-        // if the user acknowledged windows or made an explicit decision ato trust the directory, reload the config accordingly
-        if onboarding_result
-            .directory_trust_decision
-            .map(|d| d == TrustDirectorySelection::Trust)
-            .unwrap_or(false)
-        {
+        // If the user made an explicit trust decision, reload config so current
+        // process state reflects what was persisted to config.toml.
+        if onboarding_result.directory_trust_decision.is_some() {
             load_config_or_exit(
                 cli_kv_overrides.clone(),
                 overrides.clone(),

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -114,7 +114,6 @@ mod wrapping;
 #[cfg(test)]
 pub mod test_backend;
 
-use crate::onboarding::TrustDirectorySelection;
 use crate::onboarding::onboarding_screen::OnboardingScreenArgs;
 use crate::onboarding::onboarding_screen::run_onboarding_app;
 use crate::tui::Tui;


### PR DESCRIPTION
This PR addresses #10395

When a user is asked to pick the trust level of a project, the code currently reloads the config if they select "trusted". It doesn't reload the config in the "untrusted" case but should. This causes the sandbox mode to be reported incorrectly in `/status` during the first run (it's displayed as `read-only` even though it acts as though it's `workspace-write`).
