### PR TITLE
Wire v2 thread/compact to Op::Compact

### DIFF
--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -152,6 +152,10 @@ client_request_definitions! {
         params: v2::ThreadReadParams,
         response: v2::ThreadReadResponse,
     },
+    ThreadCompact => "thread/compact" {
+        params: v2::ThreadCompactParams,
+        response: v2::TurnStartResponse,
+    },
     SkillsList => "skills/list" {
         params: v2::SkillsListParams,
         response: v2::SkillsListResponse,

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1452,6 +1452,13 @@ pub struct ThreadReadResponse {
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
 #[serde(rename_all = "camelCase")]
 #[ts(export_to = "v2/")]
+pub struct ThreadCompactParams {
+    pub thread_id: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]
+#[serde(rename_all = "camelCase")]
+#[ts(export_to = "v2/")]
 pub struct SkillsListParams {
     /// When empty, defaults to the current session working directory.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -81,6 +81,7 @@ Example (from OpenAI's official VSCode extension):
 - `thread/list` — page through stored rollouts; supports cursor-based pagination and optional `modelProviders` filtering.
 - `thread/loaded/list` — list the thread ids currently loaded in memory.
 - `thread/read` — read a stored thread by id without resuming it; optionally include turns via `includeTurns`.
+- `thread/compact` — trigger a context compaction run for a thread; returns a `TurnStartResponse`. No `turn/started` notification is emitted; clients should rely on the core event stream (`task_started`) and item notifications.
 - `thread/archive` — move a thread’s rollout file into the archived directory; returns `{}` on success.
 - `thread/name/set` — set or update a thread’s user-facing name; returns `{}` on success. Thread names are not required to be unique; name lookups resolve to the most recently updated thread.
 - `thread/unarchive` — move an archived rollout file back into the sessions directory; returns the restored `thread` on success.

--- a/codex-rs/app-server/tests/common/mcp_process.rs
+++ b/codex-rs/app-server/tests/common/mcp_process.rs
@@ -48,6 +48,7 @@ use codex_app_server_protocol::SendUserTurnParams;
 use codex_app_server_protocol::ServerRequest;
 use codex_app_server_protocol::SetDefaultModelParams;
 use codex_app_server_protocol::ThreadArchiveParams;
+use codex_app_server_protocol::ThreadCompactParams;
 use codex_app_server_protocol::ThreadForkParams;
 use codex_app_server_protocol::ThreadListParams;
 use codex_app_server_protocol::ThreadLoadedListParams;
@@ -425,6 +426,15 @@ impl McpProcess {
     ) -> anyhow::Result<i64> {
         let params = Some(serde_json::to_value(params)?);
         self.send_request("thread/read", params).await
+    }
+
+    /// Send a `thread/compact` JSON-RPC request.
+    pub async fn send_thread_compact_request(
+        &mut self,
+        params: ThreadCompactParams,
+    ) -> anyhow::Result<i64> {
+        let params = Some(serde_json::to_value(params)?);
+        self.send_request("thread/compact", params).await
     }
 
     /// Send a `model/list` JSON-RPC request.

--- a/codex-rs/app-server/tests/suite/v2/compaction.rs
+++ b/codex-rs/app-server/tests/suite/v2/compaction.rs
@@ -26,7 +26,6 @@ use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::TurnCompletedNotification;
 use codex_app_server_protocol::TurnStartParams;
 use codex_app_server_protocol::TurnStartResponse;
-use codex_app_server_protocol::TurnStartedNotification;
 use codex_app_server_protocol::TurnStatus;
 use codex_app_server_protocol::UserInput as V2UserInput;
 use codex_core::auth::AuthCredentialsStoreMode;
@@ -370,12 +369,9 @@ async fn wait_for_context_compaction_started_without_turn_started(
                 }
             }
             JSONRPCMessage::Notification(notification) if notification.method == "turn/started" => {
-                let started: TurnStartedNotification = serde_json::from_value(
-                    notification.params.clone().expect("turn/started params"),
-                )?;
-                if started.turn.id == forbidden_turn_id {
-                    anyhow::bail!("unexpected v2 turn/started notification for manual compaction");
-                }
+                anyhow::bail!(
+                    "unexpected v2 turn/started notification for manual compaction (turn_id={forbidden_turn_id})"
+                );
             }
             _ => {}
         }
@@ -400,12 +396,9 @@ async fn wait_for_context_compaction_completed_without_turn_started(
                 }
             }
             JSONRPCMessage::Notification(notification) if notification.method == "turn/started" => {
-                let started: TurnStartedNotification = serde_json::from_value(
-                    notification.params.clone().expect("turn/started params"),
-                )?;
-                if started.turn.id == forbidden_turn_id {
-                    anyhow::bail!("unexpected v2 turn/started notification for manual compaction");
-                }
+                anyhow::bail!(
+                    "unexpected v2 turn/started notification for manual compaction (turn_id={forbidden_turn_id})"
+                );
             }
             _ => {}
         }


### PR DESCRIPTION
- Add v2 "thread/compact" (returns "TurnStartResponse", no v2 "turn/started").
- Wire app-server handler to Op::Compact + add v2 E2E coverage and docs.