### PR TITLE
fix(auth): isolate chatgptAuthTokens concept to auth manager and app-server

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1917,7 +1917,6 @@ version = "0.0.0"
 dependencies = [
  "chrono",
  "codex-api",
- "codex-app-server-protocol",
  "codex-protocol",
  "codex-utils-absolute-path",
  "codex-utils-string",

--- a/codex-rs/cli/src/login.rs
+++ b/codex-rs/cli/src/login.rs
@@ -1,7 +1,7 @@
-use codex_app_server_protocol::AuthMode;
 use codex_common::CliConfigOverrides;
 use codex_core::CodexAuth;
 use codex_core::auth::AuthCredentialsStoreMode;
+use codex_core::auth::AuthMode;
 use codex_core::auth::CLIENT_ID;
 use codex_core::auth::login_with_api_key;
 use codex_core::auth::logout;
@@ -225,7 +225,7 @@ pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {
     let config = load_config_or_exit(cli_config_overrides).await;
 
     match CodexAuth::from_auth_storage(&config.codex_home, config.cli_auth_credentials_store_mode) {
-        Ok(Some(auth)) => match auth.api_auth_mode() {
+        Ok(Some(auth)) => match auth.auth_mode() {
             AuthMode::ApiKey => match auth.get_token() {
                 Ok(api_key) => {
                     eprintln!("Logged in using an API key - {}", safe_format_key(&api_key));
@@ -238,10 +238,6 @@ pub async fn run_login_status(cli_config_overrides: CliConfigOverrides) -> ! {
             },
             AuthMode::Chatgpt => {
                 eprintln!("Logged in using ChatGPT");
-                std::process::exit(0);
-            }
-            AuthMode::ChatgptAuthTokens => {
-                eprintln!("Logged in using ChatGPT (external tokens)");
                 std::process::exit(0);
             }
         },

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -225,7 +225,7 @@ impl ModelClient {
         let api_provider = self
             .state
             .provider
-            .to_api_provider(auth.as_ref().map(CodexAuth::internal_auth_mode))?;
+            .to_api_provider(auth.as_ref().map(CodexAuth::auth_mode))?;
         let api_auth = auth_provider_from_auth(auth.clone(), &self.state.provider)?;
         let transport = ReqwestTransport::new(build_reqwest_client());
         let request_telemetry = Self::build_request_telemetry(otel_manager);
@@ -271,7 +271,7 @@ impl ModelClient {
         let api_provider = self
             .state
             .provider
-            .to_api_provider(auth.as_ref().map(CodexAuth::internal_auth_mode))?;
+            .to_api_provider(auth.as_ref().map(CodexAuth::auth_mode))?;
         let api_auth = auth_provider_from_auth(auth, &self.state.provider)?;
         let transport = ReqwestTransport::new(build_reqwest_client());
         let request_telemetry = Self::build_request_telemetry(otel_manager);
@@ -557,7 +557,7 @@ impl ModelClientSession {
                 .client
                 .state
                 .provider
-                .to_api_provider(auth.as_ref().map(CodexAuth::internal_auth_mode))?;
+                .to_api_provider(auth.as_ref().map(CodexAuth::auth_mode))?;
             let api_auth = auth_provider_from_auth(auth.clone(), &self.client.state.provider)?;
             let transport = ReqwestTransport::new(build_reqwest_client());
             let (request_telemetry, sse_telemetry) = Self::build_streaming_telemetry(otel_manager);
@@ -622,7 +622,7 @@ impl ModelClientSession {
                 .client
                 .state
                 .provider
-                .to_api_provider(auth.as_ref().map(CodexAuth::internal_auth_mode))?;
+                .to_api_provider(auth.as_ref().map(CodexAuth::auth_mode))?;
             let api_auth = auth_provider_from_auth(auth.clone(), &self.client.state.provider)?;
             let compression = self.responses_request_compression(auth.as_ref());
 

--- a/codex-rs/core/tests/responses_headers.rs
+++ b/codex-rs/core/tests/responses_headers.rs
@@ -1,7 +1,6 @@
 use std::process::Command;
 use std::sync::Arc;
 
-use codex_app_server_protocol::AuthMode;
 use codex_core::AuthManager;
 use codex_core::CodexAuth;
 use codex_core::ContentItem;
@@ -14,6 +13,7 @@ use codex_core::WEB_SEARCH_ELIGIBLE_HEADER;
 use codex_core::WireApi;
 use codex_core::models_manager::manager::ModelsManager;
 use codex_otel::OtelManager;
+use codex_otel::TelemetryAuthMode;
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::ReasoningSummary;
 use codex_protocol::config_types::WebSearchMode;
@@ -72,7 +72,7 @@ async fn responses_stream_includes_subagent_header_on_review() {
     let config = Arc::new(config);
 
     let conversation_id = ThreadId::new();
-    let auth_mode = AuthMode::Chatgpt;
+    let auth_mode = TelemetryAuthMode::Chatgpt;
     let session_source = SessionSource::SubAgent(SubAgentSource::Review);
     let model_info = ModelsManager::construct_model_info_offline(model.as_str(), &config);
     let otel_manager = OtelManager::new(
@@ -182,7 +182,7 @@ async fn responses_stream_includes_subagent_header_on_other() {
     let config = Arc::new(config);
 
     let conversation_id = ThreadId::new();
-    let auth_mode = AuthMode::Chatgpt;
+    let auth_mode = TelemetryAuthMode::Chatgpt;
     let session_source = SessionSource::SubAgent(SubAgentSource::Other("my-task".to_string()));
     let model_info = ModelsManager::construct_model_info_offline(model.as_str(), &config);
 
@@ -350,8 +350,9 @@ async fn responses_respects_model_info_overrides_from_config() {
     let config = Arc::new(config);
 
     let conversation_id = ThreadId::new();
-    let auth_mode =
-        AuthManager::from_auth_for_testing(CodexAuth::from_api_key("Test API Key")).get_auth_mode();
+    let auth_mode = AuthManager::from_auth_for_testing(CodexAuth::from_api_key("Test API Key"))
+        .auth_mode()
+        .map(TelemetryAuthMode::from);
     let session_source =
         SessionSource::SubAgent(SubAgentSource::Other("override-check".to_string()));
     let model_info = ModelsManager::construct_model_info_offline(model.as_str(), &config);

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -21,6 +21,7 @@ use codex_core::protocol::EventMsg;
 use codex_core::protocol::Op;
 use codex_core::protocol::SessionSource;
 use codex_otel::OtelManager;
+use codex_otel::TelemetryAuthMode;
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::CollaborationMode;
 use codex_protocol::config_types::ModeKind;
@@ -1257,7 +1258,7 @@ async fn azure_responses_request_includes_store_and_reasoning_ids() {
         model_info.slug.as_str(),
         None,
         Some("test@test.com".to_string()),
-        auth_manager.get_auth_mode(),
+        auth_manager.auth_mode().map(TelemetryAuthMode::from),
         false,
         "test".to_string(),
         SessionSource::Exec,

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -14,6 +14,7 @@ use codex_core::features::Feature;
 use codex_core::models_manager::manager::ModelsManager;
 use codex_core::protocol::SessionSource;
 use codex_otel::OtelManager;
+use codex_otel::TelemetryAuthMode;
 use codex_otel::metrics::MetricsClient;
 use codex_otel::metrics::MetricsConfig;
 use codex_protocol::ThreadId;
@@ -446,7 +447,7 @@ async fn websocket_harness_with_runtime_metrics(
         model_info.slug.as_str(),
         None,
         Some("test@test.com".to_string()),
-        auth_manager.get_auth_mode(),
+        auth_manager.auth_mode().map(TelemetryAuthMode::from),
         false,
         "test".to_string(),
         SessionSource::Exec,

--- a/codex-rs/otel/Cargo.toml
+++ b/codex-rs/otel/Cargo.toml
@@ -21,7 +21,6 @@ disable-default-metrics-exporter = []
 
 [dependencies]
 chrono = { workspace = true }
-codex-app-server-protocol = { workspace = true }
 codex-utils-absolute-path = { workspace = true }
 codex-utils-string = { workspace = true }
 codex-api = { workspace = true }

--- a/codex-rs/otel/src/lib.rs
+++ b/codex-rs/otel/src/lib.rs
@@ -31,6 +31,12 @@ pub enum ToolDecisionSource {
     User,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Display)]
+pub enum TelemetryAuthMode {
+    ApiKey,
+    Chatgpt,
+}
+
 #[derive(Debug, Clone)]
 pub struct OtelEventMetadata {
     pub(crate) conversation_id: ThreadId,

--- a/codex-rs/otel/src/lib.rs
+++ b/codex-rs/otel/src/lib.rs
@@ -31,6 +31,7 @@ pub enum ToolDecisionSource {
     User,
 }
 
+/// Maps to core AuthMode to avoid a circular dependency on codex-core.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Display)]
 pub enum TelemetryAuthMode {
     ApiKey,

--- a/codex-rs/otel/src/traces/otel_manager.rs
+++ b/codex-rs/otel/src/traces/otel_manager.rs
@@ -1,3 +1,4 @@
+use crate::TelemetryAuthMode;
 use crate::metrics::names::API_CALL_COUNT_METRIC;
 use crate::metrics::names::API_CALL_DURATION_METRIC;
 use crate::metrics::names::RESPONSES_API_INFERENCE_TIME_DURATION_METRIC;
@@ -15,7 +16,6 @@ use chrono::SecondsFormat;
 use chrono::Utc;
 use codex_api::ApiError;
 use codex_api::ResponseEvent;
-use codex_app_server_protocol::AuthMode;
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::ReasoningSummary;
 use codex_protocol::models::ResponseItem;
@@ -57,7 +57,7 @@ impl OtelManager {
         slug: &str,
         account_id: Option<String>,
         account_email: Option<String>,
-        auth_mode: Option<AuthMode>,
+        auth_mode: Option<TelemetryAuthMode>,
         log_user_prompts: bool,
         terminal_type: String,
         session_source: SessionSource,

--- a/codex-rs/otel/tests/suite/manager_metrics.rs
+++ b/codex-rs/otel/tests/suite/manager_metrics.rs
@@ -2,8 +2,8 @@ use crate::harness::attributes_to_map;
 use crate::harness::build_metrics_with_defaults;
 use crate::harness::find_metric;
 use crate::harness::latest_metrics;
-use codex_app_server_protocol::AuthMode;
 use codex_otel::OtelManager;
+use codex_otel::TelemetryAuthMode;
 use codex_otel::metrics::Result;
 use codex_protocol::ThreadId;
 use codex_protocol::protocol::SessionSource;
@@ -22,7 +22,7 @@ fn manager_attaches_metadata_tags_to_metrics() -> Result<()> {
         "gpt-5.1",
         Some("account-id".to_string()),
         None,
-        Some(AuthMode::ApiKey),
+        Some(TelemetryAuthMode::ApiKey),
         true,
         "tty".to_string(),
         SessionSource::Cli,
@@ -52,7 +52,10 @@ fn manager_attaches_metadata_tags_to_metrics() -> Result<()> {
             "app.version".to_string(),
             env!("CARGO_PKG_VERSION").to_string(),
         ),
-        ("auth_mode".to_string(), AuthMode::ApiKey.to_string()),
+        (
+            "auth_mode".to_string(),
+            TelemetryAuthMode::ApiKey.to_string(),
+        ),
         ("model".to_string(), "gpt-5.1".to_string()),
         ("service".to_string(), "codex-cli".to_string()),
         ("session_source".to_string(), "cli".to_string()),
@@ -73,7 +76,7 @@ fn manager_allows_disabling_metadata_tags() -> Result<()> {
         "gpt-4o",
         Some("account-id".to_string()),
         None,
-        Some(AuthMode::ApiKey),
+        Some(TelemetryAuthMode::ApiKey),
         true,
         "tty".to_string(),
         SessionSource::Cli,

--- a/codex-rs/otel/tests/suite/runtime_summary.rs
+++ b/codex-rs/otel/tests/suite/runtime_summary.rs
@@ -1,7 +1,7 @@
-use codex_app_server_protocol::AuthMode;
 use codex_otel::OtelManager;
 use codex_otel::RuntimeMetricTotals;
 use codex_otel::RuntimeMetricsSummary;
+use codex_otel::TelemetryAuthMode;
 use codex_otel::metrics::MetricsClient;
 use codex_otel::metrics::MetricsConfig;
 use codex_otel::metrics::Result;
@@ -26,7 +26,7 @@ fn runtime_metrics_summary_collects_tool_api_and_streaming_metrics() -> Result<(
         "gpt-5.1",
         Some("account-id".to_string()),
         None,
-        Some(AuthMode::ApiKey),
+        Some(TelemetryAuthMode::ApiKey),
         true,
         "tty".to_string(),
         SessionSource::Cli,

--- a/codex-rs/otel/tests/suite/snapshot.rs
+++ b/codex-rs/otel/tests/suite/snapshot.rs
@@ -1,7 +1,7 @@
 use crate::harness::attributes_to_map;
 use crate::harness::find_metric;
-use codex_app_server_protocol::AuthMode;
 use codex_otel::OtelManager;
+use codex_otel::TelemetryAuthMode;
 use codex_otel::metrics::MetricsClient;
 use codex_otel::metrics::MetricsConfig;
 use codex_otel::metrics::Result;
@@ -75,7 +75,7 @@ fn manager_snapshot_metrics_collects_without_shutdown() -> Result<()> {
         "gpt-5.1",
         Some("account-id".to_string()),
         None,
-        Some(AuthMode::ApiKey),
+        Some(TelemetryAuthMode::ApiKey),
         true,
         "tty".to_string(),
         SessionSource::Cli,
@@ -107,7 +107,10 @@ fn manager_snapshot_metrics_collects_without_shutdown() -> Result<()> {
             "app.version".to_string(),
             env!("CARGO_PKG_VERSION").to_string(),
         ),
-        ("auth_mode".to_string(), AuthMode::ApiKey.to_string()),
+        (
+            "auth_mode".to_string(),
+            TelemetryAuthMode::ApiKey.to_string(),
+        ),
         ("model".to_string(), "gpt-5.1".to_string()),
         ("service".to_string(), "codex-cli".to_string()),
         ("session_source".to_string(), "cli".to_string()),

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -60,6 +60,7 @@ use codex_core::protocol::TokenUsage;
 #[cfg(target_os = "windows")]
 use codex_core::windows_sandbox::WindowsSandboxLevelExt;
 use codex_otel::OtelManager;
+use codex_otel::TelemetryAuthMode;
 use codex_protocol::ThreadId;
 use codex_protocol::config_types::Personality;
 #[cfg(target_os = "windows")]
@@ -975,13 +976,16 @@ impl App {
         } else {
             FeedbackAudience::External
         };
+        let auth_mode = auth_ref
+            .map(CodexAuth::auth_mode)
+            .map(TelemetryAuthMode::from);
         let otel_manager = OtelManager::new(
             ThreadId::new(),
             model.as_str(),
             model.as_str(),
             auth_ref.and_then(CodexAuth::get_account_id),
             auth_ref.and_then(CodexAuth::get_account_email),
-            auth_ref.map(CodexAuth::api_auth_mode),
+            auth_mode,
             config.otel.log_user_prompt,
             codex_core::terminal::user_agent(),
             SessionSource::Cli,

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -7,7 +7,6 @@ use additional_dirs::add_dir_warning_message;
 use app::App;
 pub use app::AppExitInfo;
 pub use app::ExitReason;
-use codex_app_server_protocol::AuthMode;
 use codex_cloud_requirements::cloud_requirements_loader;
 use codex_common::oss::ensure_oss_provider_ready;
 use codex_common::oss::get_default_model_for_oss_provider;
@@ -16,6 +15,7 @@ use codex_core::CodexAuth;
 use codex_core::INTERACTIVE_SESSION_SOURCES;
 use codex_core::RolloutRecorder;
 use codex_core::ThreadSortKey;
+use codex_core::auth::AuthMode;
 use codex_core::auth::enforce_login_restrictions;
 use codex_core::config::Config;
 use codex_core::config::ConfigBuilder;
@@ -841,7 +841,7 @@ fn get_login_status(config: &Config) -> LoginStatus {
         // to refresh the token. Block on it.
         let codex_home = config.codex_home.clone();
         match CodexAuth::from_auth_storage(&codex_home, config.cli_auth_credentials_store_mode) {
-            Ok(Some(auth)) => LoginStatus::AuthMode(auth.api_auth_mode()),
+            Ok(Some(auth)) => LoginStatus::AuthMode(auth.auth_mode()),
             Ok(None) => LoginStatus::NotAuthenticated,
             Err(err) => {
                 error!("Failed to read auth.json: {err}");

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -30,7 +30,7 @@ use ratatui::widgets::Paragraph;
 use ratatui::widgets::WidgetRef;
 use ratatui::widgets::Wrap;
 
-use codex_app_server_protocol::AuthMode;
+use codex_core::auth::AuthMode;
 use codex_protocol::config_types::ForcedLoginMethod;
 use std::sync::RwLock;
 
@@ -661,10 +661,7 @@ impl AuthModeWidget {
     }
 
     fn handle_existing_chatgpt_login(&mut self) -> bool {
-        if matches!(
-            self.login_status,
-            LoginStatus::AuthMode(AuthMode::Chatgpt | AuthMode::ChatgptAuthTokens)
-        ) {
+        if matches!(self.login_status, LoginStatus::AuthMode(AuthMode::Chatgpt)) {
             *self.sign_in_state.write().unwrap() = SignInState::ChatGptSuccess;
             self.request_frame.schedule_frame();
             true

--- a/codex-rs/tui/src/status/helpers.rs
+++ b/codex-rs/tui/src/status/helpers.rs
@@ -3,7 +3,7 @@ use crate::text_formatting;
 use chrono::DateTime;
 use chrono::Local;
 use codex_core::AuthManager;
-use codex_core::CodexAuth;
+use codex_core::auth::AuthMode as CoreAuthMode;
 use codex_core::config::Config;
 use codex_core::project_doc::discover_project_doc_paths;
 use codex_protocol::account::PlanType;
@@ -90,15 +90,15 @@ pub(crate) fn compose_account_display(
 ) -> Option<StatusAccountDisplay> {
     let auth = auth_manager.auth_cached()?;
 
-    match auth {
-        CodexAuth::Chatgpt(_) | CodexAuth::ChatgptAuthTokens(_) => {
+    match auth.auth_mode() {
+        CoreAuthMode::ApiKey => Some(StatusAccountDisplay::ApiKey),
+        CoreAuthMode::Chatgpt => {
             let email = auth.get_account_email();
             let plan = plan
                 .map(|plan_type| title_case(format!("{plan_type:?}").as_str()))
                 .or_else(|| Some("Unknown".to_string()));
             Some(StatusAccountDisplay::ChatGpt { email, plan })
         }
-        CodexAuth::ApiKey(_) => Some(StatusAccountDisplay::ApiKey),
     }
 }
 


### PR DESCRIPTION
So that the rest of the codebase (like TUI) don't need to be concerned whether ChatGPT auth was handled by Codex itself or passed in via app-server's external auth mode.