### PR TITLE
Fix plan implementation prompt reappearing after /agent thread switch

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1070,6 +1070,9 @@ impl ChatWidget {
         if !from_replay && self.queued_user_messages.is_empty() {
             self.maybe_prompt_plan_implementation();
         }
+        // `saw_plan_item_this_turn` is only meaningful while a turn is active; clearing it here
+        // avoids replay/live duplicate TurnComplete events re-triggering the plan prompt.
+        self.saw_plan_item_this_turn = false;
         // If there is a queued user message, send exactly one now to begin the next turn.
         self.maybe_send_next_queued_input();
         // Emit a notification when the turn completes (suppressed if focused).

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1070,9 +1070,11 @@ impl ChatWidget {
         if !from_replay && self.queued_user_messages.is_empty() {
             self.maybe_prompt_plan_implementation();
         }
-        // `saw_plan_item_this_turn` is only meaningful while a turn is active; clearing it here
-        // avoids replay/live duplicate TurnComplete events re-triggering the plan prompt.
-        self.saw_plan_item_this_turn = false;
+        // Keep this flag for replayed completion events so a subsequent live TurnComplete can
+        // still show the prompt once after thread switch replay.
+        if !from_replay {
+            self.saw_plan_item_this_turn = false;
+        }
         // If there is a queued user message, send exactly one now to begin the next turn.
         self.maybe_send_next_queued_input();
         // Emit a notification when the turn completes (suppressed if focused).

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1261,6 +1261,36 @@ async fn plan_implementation_popup_skips_replayed_turn_complete() {
 }
 
 #[tokio::test]
+async fn plan_implementation_popup_skips_duplicate_live_turn_complete_after_replay() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5")).await;
+    chat.set_feature_enabled(Feature::CollaborationModes, true);
+    let plan_mask =
+        collaboration_modes::mask_for_kind(chat.models_manager.as_ref(), ModeKind::Plan)
+            .expect("expected plan collaboration mask");
+    chat.set_collaboration_mask(plan_mask);
+
+    chat.on_task_started();
+    chat.on_plan_delta("- Step 1\n- Step 2\n".to_string());
+    chat.on_plan_item_completed("- Step 1\n- Step 2\n".to_string());
+
+    chat.replay_initial_messages(vec![EventMsg::TurnComplete(TurnCompleteEvent {
+        last_agent_message: Some("Plan details".to_string()),
+    })]);
+    chat.handle_codex_event(Event {
+        id: "duplicate-turn-complete".to_string(),
+        msg: EventMsg::TurnComplete(TurnCompleteEvent {
+            last_agent_message: Some("Plan details".to_string()),
+        }),
+    });
+
+    let popup = render_bottom_popup(&chat, 80);
+    assert!(
+        !popup.contains(PLAN_IMPLEMENTATION_TITLE),
+        "expected no plan popup for duplicate turn completion, got {popup:?}"
+    );
+}
+
+#[tokio::test]
 async fn plan_implementation_popup_skips_when_messages_queued() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5")).await;
     chat.set_feature_enabled(Feature::CollaborationModes, true);

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1261,7 +1261,7 @@ async fn plan_implementation_popup_skips_replayed_turn_complete() {
 }
 
 #[tokio::test]
-async fn plan_implementation_popup_skips_duplicate_live_turn_complete_after_replay() {
+async fn plan_implementation_popup_shows_once_when_replay_precedes_live_turn_complete() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(Some("gpt-5")).await;
     chat.set_feature_enabled(Feature::CollaborationModes, true);
     let plan_mask =
@@ -1276,8 +1276,14 @@ async fn plan_implementation_popup_skips_duplicate_live_turn_complete_after_repl
     chat.replay_initial_messages(vec![EventMsg::TurnComplete(TurnCompleteEvent {
         last_agent_message: Some("Plan details".to_string()),
     })]);
+    let replay_popup = render_bottom_popup(&chat, 80);
+    assert!(
+        !replay_popup.contains(PLAN_IMPLEMENTATION_TITLE),
+        "expected no prompt for replayed turn completion, got {replay_popup:?}"
+    );
+
     chat.handle_codex_event(Event {
-        id: "duplicate-turn-complete".to_string(),
+        id: "live-turn-complete-1".to_string(),
         msg: EventMsg::TurnComplete(TurnCompleteEvent {
             last_agent_message: Some("Plan details".to_string()),
         }),
@@ -1285,8 +1291,27 @@ async fn plan_implementation_popup_skips_duplicate_live_turn_complete_after_repl
 
     let popup = render_bottom_popup(&chat, 80);
     assert!(
-        !popup.contains(PLAN_IMPLEMENTATION_TITLE),
-        "expected no plan popup for duplicate turn completion, got {popup:?}"
+        popup.contains(PLAN_IMPLEMENTATION_TITLE),
+        "expected prompt for first live turn completion after replay, got {popup:?}"
+    );
+
+    chat.handle_key_event(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE));
+    let dismissed_popup = render_bottom_popup(&chat, 80);
+    assert!(
+        !dismissed_popup.contains(PLAN_IMPLEMENTATION_TITLE),
+        "expected prompt to dismiss on Esc, got {dismissed_popup:?}"
+    );
+
+    chat.handle_codex_event(Event {
+        id: "live-turn-complete-2".to_string(),
+        msg: EventMsg::TurnComplete(TurnCompleteEvent {
+            last_agent_message: Some("Plan details".to_string()),
+        }),
+    });
+    let duplicate_popup = render_bottom_popup(&chat, 80);
+    assert!(
+        !duplicate_popup.contains(PLAN_IMPLEMENTATION_TITLE),
+        "expected no prompt for duplicate live completion, got {duplicate_popup:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

This fixes a UX bug (https://github.com/openai/codex/issues/10442) where the **"Implement this plan?"** prompt could reappear after switching agents with `/agent` and then switching back to the original agent during plan execution.

## Root Cause

On thread switch, the TUI rebuilds `ChatWidget`, replays buffered thread events, then drains any queued live events.

In this flow, a `TurnComplete` can be handled twice for the same logical turn:
1. replayed (`from_replay = true`)
2. then live (`from_replay = false`)

`ChatWidget` used `saw_plan_item_this_turn` to decide whether to show the plan implementation prompt, but that flag was only reset on `TurnStarted`.
If duplicate completion events occurred, stale `saw_plan_item_this_turn = true` could cause the prompt to re-trigger unexpectedly.

## Fix

- Clear `saw_plan_item_this_turn` at the end of `on_task_complete`, after prompt gating runs.
- This keeps the flag truly turn-scoped and prevents duplicate `TurnComplete` handling from reopening the prompt.