### PR TITLE
Updated bug and feature templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/2-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug-report.yml
@@ -19,7 +19,7 @@ body:
     id: version
     attributes:
       label: What version of Codex is running?
-      description: Copy the output of `codex --version`
+      description: (App) look in "About Codex" dialog; (CLI) use `codex --version`; (IDE Extension) look in extensions panel.
     validations:
       required: true
   - type: input

--- a/.github/ISSUE_TEMPLATE/4-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/4-feature-request.yml
@@ -12,6 +12,13 @@ body:
         1. Search existing issues for similar features. If you find one, 👍 it rather than opening a new one.
         2. The Codex team will try to balance the varying needs of the community when prioritizing or rejecting new features. Not all features will be accepted. See [Contributing](https://github.com/openai/codex#contributing) for more details.
 
+  - type: input
+    id: variant
+    attributes:
+      label: What variant of Codex are you using?
+      description: (e.g., CLI, App, IDE Extension, Web)
+    validations:
+      required: true
   - type: textarea
     id: feature
     attributes:


### PR DESCRIPTION
The current bug template uses CLI-specific instructions for getting the version.

The current feature template doesn't ask the user to provide the Codex variant (surface) they are using.

This PR addresses these problems.