### PR TITLE
Add more detail to 401 error

### DIFF
--- a/codex-rs/core/src/error.rs
+++ b/codex-rs/core/src/error.rs
@@ -286,13 +286,42 @@ pub struct UnexpectedResponseError {
     pub status: StatusCode,
     pub body: String,
     pub url: Option<String>,
+    pub cf_ray: Option<String>,
     pub request_id: Option<String>,
 }
 
 const CLOUDFLARE_BLOCKED_MESSAGE: &str =
     "Access blocked by Cloudflare. This usually happens when connecting from a restricted region";
+const UNEXPECTED_RESPONSE_BODY_MAX_BYTES: usize = 1000;
 
 impl UnexpectedResponseError {
+    fn display_body(&self) -> String {
+        if let Some(message) = self.extract_error_message() {
+            return message;
+        }
+
+        let trimmed_body = self.body.trim();
+        if trimmed_body.is_empty() {
+            return "Unknown error".to_string();
+        }
+
+        truncate_with_ellipsis(trimmed_body, UNEXPECTED_RESPONSE_BODY_MAX_BYTES)
+    }
+
+    fn extract_error_message(&self) -> Option<String> {
+        let json = serde_json::from_str::<serde_json::Value>(&self.body).ok()?;
+        let message = json
+            .get("error")
+            .and_then(|error| error.get("message"))
+            .and_then(serde_json::Value::as_str)?;
+        let message = message.trim();
+        if message.is_empty() {
+            None
+        } else {
+            Some(message.to_string())
+        }
+    }
+
     fn friendly_message(&self) -> Option<String> {
         if self.status != StatusCode::FORBIDDEN {
             return None;
@@ -306,6 +335,9 @@ impl UnexpectedResponseError {
         let mut message = format!("{CLOUDFLARE_BLOCKED_MESSAGE} (status {status})");
         if let Some(url) = &self.url {
             message.push_str(&format!(", url: {url}"));
+        }
+        if let Some(cf_ray) = &self.cf_ray {
+            message.push_str(&format!(", cf-ray: {cf_ray}"));
         }
         if let Some(id) = &self.request_id {
             message.push_str(&format!(", request id: {id}"));
@@ -321,10 +353,13 @@ impl std::fmt::Display for UnexpectedResponseError {
             write!(f, "{friendly}")
         } else {
             let status = self.status;
-            let body = &self.body;
+            let body = self.display_body();
             let mut message = format!("unexpected status {status}: {body}");
             if let Some(url) = &self.url {
                 message.push_str(&format!(", url: {url}"));
+            }
+            if let Some(cf_ray) = &self.cf_ray {
+                message.push_str(&format!(", cf-ray: {cf_ray}"));
             }
             if let Some(id) = &self.request_id {
                 message.push_str(&format!(", request id: {id}"));
@@ -335,6 +370,21 @@ impl std::fmt::Display for UnexpectedResponseError {
 }
 
 impl std::error::Error for UnexpectedResponseError {}
+
+fn truncate_with_ellipsis(text: &str, max_bytes: usize) -> String {
+    if text.len() <= max_bytes {
+        return text.to_string();
+    }
+
+    let mut cut = max_bytes;
+    while !text.is_char_boundary(cut) {
+        cut = cut.saturating_sub(1);
+    }
+    let mut truncated = text[..cut].to_string();
+    truncated.push_str("...");
+    truncated
+}
+
 #[derive(Debug)]
 pub struct RetryLimitReachedError {
     pub status: StatusCode,
@@ -952,15 +1002,14 @@ mod tests {
             body: "<html><body>Cloudflare error: Sorry, you have been blocked</body></html>"
                 .to_string(),
             url: Some("http://example.com/blocked".to_string()),
-            request_id: Some("ray-id".to_string()),
+            cf_ray: Some("ray-id".to_string()),
+            request_id: None,
         };
         let status = StatusCode::FORBIDDEN.to_string();
         let url = "http://example.com/blocked";
         assert_eq!(
             err.to_string(),
-            format!(
-                "{CLOUDFLARE_BLOCKED_MESSAGE} (status {status}), url: {url}, request id: ray-id"
-            )
+            format!("{CLOUDFLARE_BLOCKED_MESSAGE} (status {status}), url: {url}, cf-ray: ray-id")
         );
     }
 
@@ -970,6 +1019,7 @@ mod tests {
             status: StatusCode::FORBIDDEN,
             body: "plain text error".to_string(),
             url: Some("http://example.com/plain".to_string()),
+            cf_ray: None,
             request_id: None,
         };
         let status = StatusCode::FORBIDDEN.to_string();
@@ -977,6 +1027,63 @@ mod tests {
         assert_eq!(
             err.to_string(),
             format!("unexpected status {status}: plain text error, url: {url}")
+        );
+    }
+
+    #[test]
+    fn unexpected_status_prefers_error_message_when_present() {
+        let err = UnexpectedResponseError {
+            status: StatusCode::UNAUTHORIZED,
+            body: r#"{"error":{"message":"Workspace is not authorized in this region."},"status":401}"#
+                .to_string(),
+            url: Some("https://chatgpt.com/backend-api/codex/responses".to_string()),
+            cf_ray: None,
+            request_id: Some("req-123".to_string()),
+        };
+        let status = StatusCode::UNAUTHORIZED.to_string();
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "unexpected status {status}: Workspace is not authorized in this region., url: https://chatgpt.com/backend-api/codex/responses, request id: req-123"
+            )
+        );
+    }
+
+    #[test]
+    fn unexpected_status_truncates_long_body_with_ellipsis() {
+        let long_body = "x".repeat(UNEXPECTED_RESPONSE_BODY_MAX_BYTES + 10);
+        let err = UnexpectedResponseError {
+            status: StatusCode::BAD_GATEWAY,
+            body: long_body,
+            url: Some("http://example.com/long".to_string()),
+            cf_ray: None,
+            request_id: Some("req-long".to_string()),
+        };
+        let status = StatusCode::BAD_GATEWAY.to_string();
+        let expected_body = format!("{}...", "x".repeat(UNEXPECTED_RESPONSE_BODY_MAX_BYTES));
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "unexpected status {status}: {expected_body}, url: http://example.com/long, request id: req-long"
+            )
+        );
+    }
+
+    #[test]
+    fn unexpected_status_includes_cf_ray_and_request_id() {
+        let err = UnexpectedResponseError {
+            status: StatusCode::UNAUTHORIZED,
+            body: "plain text error".to_string(),
+            url: Some("https://chatgpt.com/backend-api/codex/responses".to_string()),
+            cf_ray: Some("9c81f9f18f2fa49d-LHR".to_string()),
+            request_id: Some("req-xyz".to_string()),
+        };
+        let status = StatusCode::UNAUTHORIZED.to_string();
+        assert_eq!(
+            err.to_string(),
+            format!(
+                "unexpected status {status}: plain text error, url: https://chatgpt.com/backend-api/codex/responses, cf-ray: 9c81f9f18f2fa49d-LHR, request id: req-xyz"
+            )
         );
     }
 


### PR DESCRIPTION
Add the error.message if it exists, the body otherwise. Truncate body to 1k characters. Print the cf-ray and the requestId.

**Before:**
<img width="860" height="305" alt="Screenshot 2026-02-03 at 13 15 28" src="https://github.com/user-attachments/assets/949d5a4d-2b51-488c-a723-c6deffde0353" />

**After:**
<img width="1523" height="373" alt="Screenshot 2026-02-03 at 13 15 38" src="https://github.com/user-attachments/assets/f96a747e-e596-4a7a-aae9-64210d805b26" />
