### PR TITLE
Add CODEX_SESSION_ID env var and inject into shell tool environments

### DIFF
--- a/codex-rs/core/src/exec_env.rs
+++ b/codex-rs/core/src/exec_env.rs
@@ -4,6 +4,8 @@ use crate::config::types::ShellEnvironmentPolicyInherit;
 use std::collections::HashMap;
 use std::collections::HashSet;
 
+pub const CODEX_SESSION_ID_ENV_VAR: &str = "CODEX_SESSION_ID";
+
 /// Construct an environment map based on the rules in the specified policy. The
 /// resulting map can be passed directly to `Command::envs()` after calling
 /// `env_clear()` to ensure no unintended variables are leaked to the spawned

--- a/codex-rs/core/src/tools/handlers/shell.rs
+++ b/codex-rs/core/src/tools/handlers/shell.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 
 use crate::codex::TurnContext;
 use crate::exec::ExecParams;
+use crate::exec_env::CODEX_SESSION_ID_ENV_VAR;
 use crate::exec_env::create_env;
 use crate::exec_policy::ExecApprovalRequest;
 use crate::function_tool::FunctionCallError;
@@ -238,6 +239,10 @@ impl ShellHandler {
         if !dependency_env.is_empty() {
             exec_params.env.extend(dependency_env);
         }
+        exec_params
+            .env
+            .entry(CODEX_SESSION_ID_ENV_VAR.to_string())
+            .or_insert_with(|| session.conversation_id.to_string());
 
         // Approval policy guard for explicit escalation in non-OnRequest modes.
         if exec_params


### PR DESCRIPTION
### Motivation
- Ensure processes launched by the CLI (shell tool calls) can discover their originating Codex session id via an environment variable for improved traceability and tooling integration.

### Description
- Define `CODEX_SESSION_ID_ENV_VAR` in `core/src/exec_env.rs` and inject the active `session.conversation_id` into shell tool invocation env maps in `core/src/tools/handlers/shell.rs` using `.entry(...).or_insert_with(...)` so existing values are preserved.

### Testing
- Ran `just fmt` in `codex-rs`, which completed successfully. 
- Ran `cargo test -p codex-core`; the test run executed and produced `857 passed, 10 failed` with failures appearing in `default_client::tests::test_create_client_sets_default_headers`, several `models_manager::manager` tests, some `shell_snapshot` tests, and a few `unified_exec` tests, which appear related to network/shell behavior in the test environment rather than this small env-var change.