### PR TITLE
tui: make Esc clear request_user_input notes while notes are shown

### DIFF
--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_options_notes_visible.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/src/bottom_pane/request_user_input/mod.rs
+assertion_line: 2321
 expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
@@ -16,4 +17,4 @@ expression: "render_snapshot(&overlay, area)"
                                                                                                                         
                                                                                                                         
                                                                                                                         
-  tab to clear notes | enter to submit answer | esc to interrupt
+  tab or esc to clear notes | enter to submit answer

--- a/docs/tui-request-user-input.md
+++ b/docs/tui-request-user-input.md
@@ -30,7 +30,9 @@ friction for freeform input.
 - Enter advances to the next question.
 - Enter on the last question submits all answers.
 - PageUp/PageDown navigate across questions (when multiple are present).
-- Esc interrupts the run.
+- Esc interrupts the run in option selection mode.
+- When notes are open for an option question, Tab or Esc clears notes and returns
+  to option selection.
 
 ## Layout priorities
 


### PR DESCRIPTION
## Summary

This PR updates the `request_user_input` TUI overlay so `Esc` is context-aware:

- When notes are visible for an option question, `Esc` now clears notes and exits notes mode.
- When notes are not visible (normal option selection UI), `Esc` still interrupts as before.

It also updates footer guidance text to match behavior.

## Changes

- Added a shared notes-clear path for option questions:
  - `Tab` and `Esc` now both clear notes and return focus to options when notes are visible.
- Updated footer hint text in notes-visible state:
  - from: `tab to clear notes | ... | esc to interrupt`
  - to: `tab or esc to clear notes | ...`
- Hid `esc to interrupt` hint while notes are visible for option questions.
- Kept `esc to interrupt` visible and functional in normal option-selection mode.
- Updated tests to assert the new `Esc` behavior in notes mode.
- Updated snapshot output for the notes-visible footer row.
- Updated docs in `docs/tui-request-user-input.md` to reflect mode-specific `Esc` behavior.