### PR TITLE
core: refresh developer instructions after compaction replacement history

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1768,11 +1768,10 @@ impl Session {
                 }
                 RolloutItem::Compacted(compacted) => {
                     if let Some(replacement) = &compacted.replacement_history {
-                        let initial_context = self.build_initial_context(turn_context).await;
-                        history.replace(compact::refresh_compacted_developer_instructions(
-                            replacement.clone(),
-                            &initial_context,
-                        ));
+                        history.replace(
+                            self.process_compacted_history(turn_context, replacement.clone())
+                                .await,
+                        );
                     } else {
                         let user_messages = collect_user_messages(history.raw_items());
                         let rebuilt = compact::build_compacted_history(
@@ -1790,6 +1789,15 @@ impl Session {
             }
         }
         history.raw_items().to_vec()
+    }
+
+    pub(crate) async fn process_compacted_history(
+        &self,
+        turn_context: &TurnContext,
+        compacted_history: Vec<ResponseItem>,
+    ) -> Vec<ResponseItem> {
+        let initial_context = self.build_initial_context(turn_context).await;
+        compact::process_compacted_history(compacted_history, &initial_context)
     }
 
     /// Append ResponseItems to the in-memory conversation history only.

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -264,7 +264,7 @@ pub(crate) fn is_summary_message(message: &str) -> bool {
     message.starts_with(format!("{SUMMARY_PREFIX}\n").as_str())
 }
 
-pub(crate) fn refresh_compacted_developer_instructions(
+pub(crate) fn process_compacted_history(
     mut compacted_history: Vec<ResponseItem>,
     initial_context: &[ResponseItem],
 ) -> Vec<ResponseItem> {
@@ -600,7 +600,7 @@ mod tests {
     }
 
     #[test]
-    fn refresh_compacted_developer_instructions_replaces_developer_messages() {
+    fn process_compacted_history_replaces_developer_messages() {
         let compacted_history = vec![
             ResponseItem::Message {
                 id: None,
@@ -660,8 +660,7 @@ mod tests {
             },
         ];
 
-        let refreshed =
-            refresh_compacted_developer_instructions(compacted_history, &initial_context);
+        let refreshed = process_compacted_history(compacted_history, &initial_context);
         let expected = vec![
             ResponseItem::Message {
                 id: None,

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -3,7 +3,6 @@ use std::sync::Arc;
 use crate::Prompt;
 use crate::codex::Session;
 use crate::codex::TurnContext;
-use crate::compact::refresh_compacted_developer_instructions;
 use crate::context_manager::ContextManager;
 use crate::context_manager::is_codex_generated_item;
 use crate::error::Result as CodexResult;
@@ -81,8 +80,9 @@ async fn run_remote_compact_task_inner_impl(
         .client
         .compact_conversation_history(&prompt)
         .await?;
-    let initial_context = sess.build_initial_context(turn_context).await;
-    new_history = refresh_compacted_developer_instructions(new_history, &initial_context);
+    new_history = sess
+        .process_compacted_history(turn_context, new_history)
+        .await;
 
     if !ghost_snapshots.is_empty() {
         new_history.extend(ghost_snapshots);

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::Prompt;
 use crate::codex::Session;
 use crate::codex::TurnContext;
+use crate::compact::refresh_compacted_developer_instructions;
 use crate::context_manager::ContextManager;
 use crate::context_manager::is_codex_generated_item;
 use crate::error::Result as CodexResult;
@@ -80,6 +81,8 @@ async fn run_remote_compact_task_inner_impl(
         .client
         .compact_conversation_history(&prompt)
         .await?;
+    let initial_context = sess.build_initial_context(turn_context).await;
+    new_history = refresh_compacted_developer_instructions(new_history, &initial_context);
 
     if !ghost_snapshots.is_empty() {
         new_history.extend(ghost_snapshots);

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -537,16 +537,222 @@ async fn remote_compact_persists_replacement_history_in_rollout() -> Result<()> 
         };
         if let RolloutItem::Compacted(compacted) = entry.item
             && compacted.message.is_empty()
-            && compacted.replacement_history.as_ref() == Some(&compacted_history)
+            && let Some(replacement_history) = compacted.replacement_history.as_ref()
         {
-            saw_compacted_history = true;
-            break;
+            let has_compacted_user_summary = replacement_history.iter().any(|item| {
+                matches!(
+                    item,
+                    ResponseItem::Message { role, content, .. }
+                        if role == "user"
+                            && content.iter().any(|part| matches!(
+                                part,
+                                ContentItem::InputText { text } if text == "COMPACTED_USER_SUMMARY"
+                            ))
+                )
+            });
+            let has_compaction_item = replacement_history.iter().any(|item| {
+                matches!(
+                    item,
+                    ResponseItem::Compaction { encrypted_content }
+                        if encrypted_content == "ENCRYPTED_COMPACTION_SUMMARY"
+                )
+            });
+            let has_compacted_assistant_note = replacement_history.iter().any(|item| {
+                matches!(
+                    item,
+                    ResponseItem::Message { role, content, .. }
+                        if role == "assistant"
+                            && content.iter().any(|part| matches!(
+                                part,
+                                ContentItem::OutputText { text } if text == "COMPACTED_ASSISTANT_NOTE"
+                            ))
+                )
+            });
+            let has_permissions_developer_message = replacement_history.iter().any(|item| {
+                matches!(
+                    item,
+                    ResponseItem::Message { role, content, .. }
+                        if role == "developer"
+                            && content.iter().any(|part| matches!(
+                                part,
+                                ContentItem::InputText { text }
+                                    if text.contains("<permissions instructions>")
+                            ))
+                )
+            });
+
+            if has_compacted_user_summary
+                && has_compaction_item
+                && has_compacted_assistant_note
+                && has_permissions_developer_message
+            {
+                saw_compacted_history = true;
+                break;
+            }
         }
     }
 
     assert!(
         saw_compacted_history,
         "expected rollout to persist remote compaction history"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn remote_compact_and_resume_refresh_stale_developer_instructions() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = wiremock::MockServer::start().await;
+    let stale_developer_message = "STALE_DEVELOPER_INSTRUCTIONS_SHOULD_BE_REMOVED";
+
+    let mut start_builder = test_codex()
+        .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+        .with_config(|config| {
+            config.features.enable(Feature::RemoteCompaction);
+        });
+    let initial = start_builder.build(&server).await?;
+    let home = initial.home.clone();
+    let rollout_path = initial
+        .session_configured
+        .rollout_path
+        .clone()
+        .expect("rollout path");
+
+    let responses_mock = responses::mount_sse_sequence(
+        &server,
+        vec![
+            responses::sse(vec![
+                responses::ev_assistant_message("m1", "BASELINE_REPLY"),
+                responses::ev_completed("resp-1"),
+            ]),
+            responses::sse(vec![
+                responses::ev_assistant_message("m2", "AFTER_COMPACT_REPLY"),
+                responses::ev_completed("resp-2"),
+            ]),
+            responses::sse(vec![
+                responses::ev_assistant_message("m3", "AFTER_RESUME_REPLY"),
+                responses::ev_completed("resp-3"),
+            ]),
+        ],
+    )
+    .await;
+
+    let compacted_history = vec![
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: "REMOTE_COMPACTED_SUMMARY".to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Message {
+            id: None,
+            role: "developer".to_string(),
+            content: vec![ContentItem::InputText {
+                text: stale_developer_message.to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        },
+        ResponseItem::Compaction {
+            encrypted_content: "ENCRYPTED_COMPACTION_SUMMARY".to_string(),
+        },
+    ];
+    let compact_mock = responses::mount_compact_json_once(
+        &server,
+        serde_json::json!({ "output": compacted_history }),
+    )
+    .await;
+
+    initial
+        .codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "start remote compact flow".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+        })
+        .await?;
+    wait_for_event(&initial.codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    initial.codex.submit(Op::Compact).await?;
+    wait_for_event(&initial.codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    initial
+        .codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "after compact in same session".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+        })
+        .await?;
+    wait_for_event(&initial.codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    initial.codex.submit(Op::Shutdown).await?;
+    wait_for_event(&initial.codex, |ev| {
+        matches!(ev, EventMsg::ShutdownComplete)
+    })
+    .await;
+
+    let mut resume_builder = test_codex()
+        .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+        .with_config(|config| {
+            config.features.enable(Feature::RemoteCompaction);
+        });
+    let resumed = resume_builder.resume(&server, home, rollout_path).await?;
+
+    resumed
+        .codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "after resume".into(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+        })
+        .await?;
+    wait_for_event(&resumed.codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    assert_eq!(compact_mock.requests().len(), 1);
+    let requests = responses_mock.requests();
+    assert_eq!(requests.len(), 3, "expected three model requests");
+
+    let after_compact_request = &requests[1];
+    let after_resume_request = &requests[2];
+
+    let after_compact_body = after_compact_request.body_json().to_string();
+    assert!(
+        !after_compact_body.contains(stale_developer_message),
+        "stale developer instructions should be removed immediately after compaction"
+    );
+    assert!(
+        after_compact_body.contains("<permissions instructions>"),
+        "fresh developer instructions should be present after compaction"
+    );
+    assert!(
+        after_compact_body.contains("REMOTE_COMPACTED_SUMMARY"),
+        "compacted summary should be present after compaction"
+    );
+
+    let after_resume_body = after_resume_request.body_json().to_string();
+    assert!(
+        !after_resume_body.contains(stale_developer_message),
+        "stale developer instructions should be removed after resume"
+    );
+    assert!(
+        after_resume_body.contains("<permissions instructions>"),
+        "fresh developer instructions should be present after resume"
+    );
+    assert!(
+        after_resume_body.contains("REMOTE_COMPACTED_SUMMARY"),
+        "compacted summary should persist after resume"
     );
 
     Ok(())


### PR DESCRIPTION
## Summary

When replaying compacted history (especially `replacement_history` from remote compaction), we should not keep stale developer messages from older session state. This PR trims developer-
role messages from compacted replacement history and reinjects fresh developer instructions derived from current turn/session state.

This aligns compaction replay behavior with the intended "fresh instructions after summary" model.

## Problem

Compaction replay had two paths:

- `Compacted { replacement_history: None }`: rebuilt with fresh initial context
- `Compacted { replacement_history: Some(...) }`: previously used raw replacement history as-is

The second path could carry stale developer instructions (permissions/personality/collab-mode guidance) across session changes.

## What Changed

### 1) Added helper to refresh compacted developer instructions

- **File:** `codex-rs/core/src/compact.rs`
- **Function:** `refresh_compacted_developer_instructions(...)`

Behavior:
- remove all `ResponseItem::Message { role: "developer", .. }` from compacted history
- append fresh developer messages from current `build_initial_context(...)`

### 2) Applied helper in remote compaction flow

- **File:** `codex-rs/core/src/compact_remote.rs`
- After receiving compact endpoint output, refresh developer instructions before replacing history and persisting `replacement_history`.

### 3) Applied helper while reconstructing history from rollout

- **File:** `codex-rs/core/src/codex.rs`
- In `reconstruct_history_from_rollout(...)`, when processing `Compacted` entries with `replacement_history`, refresh developer instructions instead of directly replacing with raw history.

## Non-Goals / Follow-up

This PR does **not** address the existing first-turn-after-resume double-injection behavior.
A follow-up PR will handle resume-time dedup/idempotence separately.

If you want, I can also give you a shorter “squash-merge friendly” version of the description.

## Codex author
`codex fork 019c25e6-706e-75d1-9198-688ec00a8256`