### PR TITLE
Fix jitter in TUI apps/connectors picker 

### DIFF
--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -65,6 +65,7 @@ mod skill_popup;
 mod skills_toggle_view;
 mod slash_commands;
 pub(crate) use footer::CollaborationModeIndicator;
+pub(crate) use list_selection_view::ColumnWidthMode;
 pub(crate) use list_selection_view::SelectionViewParams;
 mod feedback_view;
 pub(crate) use feedback_view::FeedbackAudience;

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__list_selection_view__tests__list_selection_col_width_mode_auto_all_rows_scroll.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__list_selection_view__tests__list_selection_col_width_mode_auto_all_rows_scroll.snap
@@ -1,0 +1,31 @@
+---
+source: tui/src/bottom_pane/list_selection_view.rs
+assertion_line: 1054
+expression: "render_before_after_scroll_snapshot(ColumnWidthMode::AutoAllRows, 96)"
+---
+before scroll:
+                                                                                                
+  Debug                                                                                         
+                                                                                                
+› 1. Item 1                                         desc 1                                      
+  2. Item 2                                         desc 2                                      
+  3. Item 3                                         desc 3                                      
+  4. Item 4                                         desc 4                                      
+  5. Item 5                                         desc 5                                      
+  6. Item 6                                         desc 6                                      
+  7. Item 7                                         desc 7                                      
+  8. Item 8                                         desc 8                                      
+                                                                                                
+
+after scroll:
+                                                                                                
+  Debug                                                                                         
+                                                                                                
+  2. Item 2                                         desc 2                                      
+  3. Item 3                                         desc 3                                      
+  4. Item 4                                         desc 4                                      
+  5. Item 5                                         desc 5                                      
+  6. Item 6                                         desc 6                                      
+  7. Item 7                                         desc 7                                      
+  8. Item 8                                         desc 8                                      
+› 9. Item 9 with an intentionally much longer name  desc 9

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__list_selection_view__tests__list_selection_col_width_mode_auto_visible_scroll.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__list_selection_view__tests__list_selection_col_width_mode_auto_visible_scroll.snap
@@ -1,0 +1,31 @@
+---
+source: tui/src/bottom_pane/list_selection_view.rs
+assertion_line: 1046
+expression: "render_before_after_scroll_snapshot(ColumnWidthMode::AutoVisible, 96)"
+---
+before scroll:
+                                                                                                
+  Debug                                                                                         
+                                                                                                
+› 1. Item 1  desc 1                                                                             
+  2. Item 2  desc 2                                                                             
+  3. Item 3  desc 3                                                                             
+  4. Item 4  desc 4                                                                             
+  5. Item 5  desc 5                                                                             
+  6. Item 6  desc 6                                                                             
+  7. Item 7  desc 7                                                                             
+  8. Item 8  desc 8                                                                             
+                                                                                                
+
+after scroll:
+                                                                                                
+  Debug                                                                                         
+                                                                                                
+  2. Item 2                                         desc 2                                      
+  3. Item 3                                         desc 3                                      
+  4. Item 4                                         desc 4                                      
+  5. Item 5                                         desc 5                                      
+  6. Item 6                                         desc 6                                      
+  7. Item 7                                         desc 7                                      
+  8. Item 8                                         desc 8                                      
+› 9. Item 9 with an intentionally much longer name  desc 9

--- a/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__list_selection_view__tests__list_selection_col_width_mode_fixed_scroll.snap
+++ b/codex-rs/tui/src/bottom_pane/snapshots/codex_tui__bottom_pane__list_selection_view__tests__list_selection_col_width_mode_fixed_scroll.snap
@@ -1,0 +1,31 @@
+---
+source: tui/src/bottom_pane/list_selection_view.rs
+assertion_line: 1062
+expression: "render_before_after_scroll_snapshot(ColumnWidthMode::Fixed, 96)"
+---
+before scroll:
+                                                                                                
+  Debug                                                                                         
+                                                                                                
+› 1. Item 1                 desc 1                                                              
+  2. Item 2                 desc 2                                                              
+  3. Item 3                 desc 3                                                              
+  4. Item 4                 desc 4                                                              
+  5. Item 5                 desc 5                                                              
+  6. Item 6                 desc 6                                                              
+  7. Item 7                 desc 7                                                              
+  8. Item 8                 desc 8                                                              
+                                                                                                
+
+after scroll:
+                                                                                                
+  Debug                                                                                         
+                                                                                                
+  2. Item 2                 desc 2                                                              
+  3. Item 3                 desc 3                                                              
+  4. Item 4                 desc 4                                                              
+  5. Item 5                 desc 5                                                              
+  6. Item 6                 desc 6                                                              
+  7. Item 7                 desc 7                                                              
+  8. Item 8                 desc 8                                                              
+› 9. Item 9 with an intent… desc 9

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -5742,7 +5742,7 @@ impl ChatWidget {
             items,
             is_searchable: true,
             search_placeholder: Some("Type to search apps".to_string()),
-            stable_desc_col: true,
+            stable_col_widths: true,
             ..Default::default()
         });
     }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -5742,6 +5742,7 @@ impl ChatWidget {
             items,
             is_searchable: true,
             search_placeholder: Some("Type to search apps".to_string()),
+            stable_desc_col: true,
             ..Default::default()
         });
     }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -144,6 +144,7 @@ use crate::bottom_pane::BottomPane;
 use crate::bottom_pane::BottomPaneParams;
 use crate::bottom_pane::CancellationEvent;
 use crate::bottom_pane::CollaborationModeIndicator;
+use crate::bottom_pane::ColumnWidthMode;
 use crate::bottom_pane::DOUBLE_PRESS_QUIT_SHORTCUT_ENABLED;
 use crate::bottom_pane::ExperimentalFeatureItem;
 use crate::bottom_pane::ExperimentalFeaturesView;
@@ -5742,7 +5743,7 @@ impl ChatWidget {
             items,
             is_searchable: true,
             search_placeholder: Some("Type to search apps".to_string()),
-            stable_col_widths: true,
+            col_width_mode: ColumnWidthMode::AutoAllRows,
             ..Default::default()
         });
     }


### PR DESCRIPTION
This PR fixes jitter in the TUI apps menu by making the description column stable during rendering and height measurement.
Added a `stable_desc_col` option to `SelectionViewParams`/`ListSelectionView`, introduced stable variants of the shared row render/measure helpers in `selection_popup_common`, and enabled the stable mode for the apps/connectors picker in `chatwidget`. With these changes, only the apps/connectors picker uses this new option, though it could be used elsewhere in the future.

Why: previously, the description column was computed from only currently visible rows, so as you scrolled or filtered, the column could shift and cause wrapping/height changes that looked jumpy. Computing it from all rows in this popup keeps alignment and layout consistent as users scroll through avaialble apps.



**Before:**
https://github.com/user-attachments/assets/3856cb72-5465-4b90-a993-65a2ffb09113





**After:**
https://github.com/user-attachments/assets/37b9d626-0b21-4c0f-8bb8-244c9ef971ff


