### PR TITLE
Stop client from being state carrier

### DIFF
--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -153,61 +153,6 @@ impl ModelClient {
 }
 
 impl ModelClient {
-    pub fn get_model_context_window(&self) -> Option<i64> {
-        let model_info = &self.state.model_info;
-        let effective_context_window_percent = model_info.effective_context_window_percent;
-        model_info.context_window.map(|context_window| {
-            context_window.saturating_mul(effective_context_window_percent) / 100
-        })
-    }
-
-    pub fn config(&self) -> Arc<Config> {
-        Arc::clone(&self.state.config)
-    }
-
-    pub fn provider(&self) -> &ModelProviderInfo {
-        &self.state.provider
-    }
-
-    pub fn get_provider(&self) -> ModelProviderInfo {
-        self.state.provider.clone()
-    }
-
-    pub fn get_otel_manager(&self) -> OtelManager {
-        self.state.otel_manager.clone()
-    }
-
-    pub fn get_session_source(&self) -> SessionSource {
-        self.state.session_source.clone()
-    }
-
-    pub(crate) fn transport_manager(&self) -> TransportManager {
-        self.state.transport_manager.clone()
-    }
-
-    /// Returns the currently configured model slug.
-    pub fn get_model(&self) -> String {
-        self.state.model_info.slug.clone()
-    }
-
-    pub fn get_model_info(&self) -> ModelInfo {
-        self.state.model_info.clone()
-    }
-
-    /// Returns the current reasoning effort setting.
-    pub fn get_reasoning_effort(&self) -> Option<ReasoningEffortConfig> {
-        self.state.effort
-    }
-
-    /// Returns the current reasoning summary setting.
-    pub fn get_reasoning_summary(&self) -> ReasoningSummaryConfig {
-        self.state.summary
-    }
-
-    pub fn get_auth_manager(&self) -> Option<Arc<AuthManager>> {
-        self.state.auth_manager.clone()
-    }
-
     /// Compacts the current conversation history using the Compact endpoint.
     ///
     /// This is a unary call (no streaming) that returns a new list of

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -60,7 +60,7 @@ pub(crate) async fn run_compact_task(
     input: Vec<UserInput>,
 ) {
     let start_event = EventMsg::TurnStarted(TurnStartedEvent {
-        model_context_window: turn_context.client.get_model_context_window(),
+        model_context_window: turn_context.model_context_window(),
         collaboration_mode_kind: turn_context.collaboration_mode.mode,
     });
     sess.send_event(&turn_context, start_event).await;
@@ -85,7 +85,7 @@ async fn run_compact_task_inner(
 
     let mut truncated_count = 0usize;
 
-    let max_retries = turn_context.client.get_provider().stream_max_retries();
+    let max_retries = turn_context.provider.stream_max_retries();
     let mut retries = 0;
 
     // TODO: If we need to guarantee the persisted mode always matches the prompt used for this
@@ -97,11 +97,11 @@ async fn run_compact_task_inner(
         cwd: turn_context.cwd.clone(),
         approval_policy: turn_context.approval_policy,
         sandbox_policy: turn_context.sandbox_policy.clone(),
-        model: turn_context.client.get_model(),
+        model: turn_context.model_info.slug.clone(),
         personality: turn_context.personality,
         collaboration_mode: Some(collaboration_mode),
-        effort: turn_context.client.get_reasoning_effort(),
-        summary: turn_context.client.get_reasoning_summary(),
+        effort: turn_context.reasoning_effort,
+        summary: turn_context.reasoning_summary,
         user_instructions: turn_context.user_instructions.clone(),
         developer_instructions: turn_context.developer_instructions.clone(),
         final_output_json_schema: turn_context.final_output_json_schema.clone(),

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -24,7 +24,7 @@ pub(crate) async fn run_inline_remote_auto_compact_task(
 
 pub(crate) async fn run_remote_compact_task(sess: Arc<Session>, turn_context: Arc<TurnContext>) {
     let start_event = EventMsg::TurnStarted(TurnStartedEvent {
-        model_context_window: turn_context.client.get_model_context_window(),
+        model_context_window: turn_context.model_context_window(),
         collaboration_mode_kind: turn_context.collaboration_mode.mode,
     });
     sess.send_event(&turn_context, start_event).await;
@@ -104,7 +104,7 @@ fn trim_function_call_history_to_fit_context_window(
     turn_context: &TurnContext,
 ) -> usize {
     let mut deleted_items = 0usize;
-    let Some(context_window) = turn_context.client.get_model_context_window() else {
+    let Some(context_window) = turn_context.model_context_window() else {
         return deleted_items;
     };
 

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -85,10 +85,8 @@ impl ContextManager {
     // Estimate token usage using byte-based heuristics from the truncation helpers.
     // This is a coarse lower bound, not a tokenizer-accurate count.
     pub(crate) fn estimate_token_count(&self, turn_context: &TurnContext) -> Option<i64> {
-        let model_info = turn_context.client.get_model_info();
-        let personality = turn_context
-            .personality
-            .or(turn_context.client.config().personality);
+        let model_info = &turn_context.model_info;
+        let personality = turn_context.personality.or(turn_context.config.personality);
         let base_instructions = model_info.get_model_instructions(personality);
         let base_tokens = i64::try_from(approx_token_count(&base_instructions)).unwrap_or(i64::MAX);
 

--- a/codex-rs/core/src/mcp/skill_dependencies.rs
+++ b/codex-rs/core/src/mcp/skill_dependencies.rs
@@ -144,7 +144,7 @@ pub(crate) async fn maybe_prompt_and_install_mcp_dependencies(
         return;
     }
 
-    let config = turn_context.client.config();
+    let config = turn_context.config.clone();
     if mentioned_skills.is_empty() || !config.features.enabled(Feature::SkillMcpDependencyInstall) {
         return;
     }

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -120,8 +120,7 @@ pub(crate) async fn handle_mcp_tool_call(
 
         let status = if result.is_ok() { "ok" } else { "error" };
         turn_context
-            .client
-            .get_otel_manager()
+            .otel_manager
             .counter("codex.mcp.call", 1, &[("status", status)]);
 
         return ResponseInputItem::McpToolCallOutput { call_id, result };
@@ -153,8 +152,7 @@ pub(crate) async fn handle_mcp_tool_call(
 
     let status = if result.is_ok() { "ok" } else { "error" };
     turn_context
-        .client
-        .get_otel_manager()
+        .otel_manager
         .counter("codex.mcp.call", 1, &[("status", status)]);
 
     ResponseInputItem::McpToolCallOutput { call_id, result }

--- a/codex-rs/core/src/stream_events_utils.rs
+++ b/codex-rs/core/src/stream_events_utils.rs
@@ -100,8 +100,7 @@ pub(crate) async fn handle_output_item_done(
         Err(FunctionCallError::MissingLocalShellCallId) => {
             let msg = "LocalShellCall without call_id or id";
             ctx.turn_context
-                .client
-                .get_otel_manager()
+                .otel_manager
                 .log_tool_failed("local_shell", msg);
             tracing::error!(msg);
 

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -25,10 +25,7 @@ impl SessionTask for CompactTask {
         _cancellation_token: CancellationToken,
     ) -> Option<String> {
         let session = session.clone_session();
-        if crate::compact::should_use_remote_compact_task(
-            session.as_ref(),
-            &ctx.client.get_provider(),
-        ) {
+        if crate::compact::should_use_remote_compact_task(session.as_ref(), &ctx.provider) {
             let _ = session.services.otel_manager.counter(
                 "codex.task.compact",
                 1,

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -158,8 +158,7 @@ impl Session {
         };
 
         let timer = turn_context
-            .client
-            .get_otel_manager()
+            .otel_manager
             .start_timer("codex.turn.e2e_duration_ms", &[])
             .ok();
 

--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -82,7 +82,7 @@ async fn start_review_conversation(
     input: Vec<UserInput>,
     cancellation_token: CancellationToken,
 ) -> Option<async_channel::Receiver<Event>> {
-    let config = ctx.client.config();
+    let config = ctx.config.clone();
     let mut sub_agent_config = config.as_ref().clone();
     // Carry over review-only feature restrictions so the delegate cannot
     // re-enable blocked tools (web search, view image).
@@ -94,7 +94,7 @@ async fn start_review_conversation(
     let model = config
         .review_model
         .clone()
-        .unwrap_or_else(|| ctx.client.get_model());
+        .unwrap_or_else(|| ctx.model_info.slug.clone());
     sub_agent_config.model = Some(model);
     (run_codex_thread_one_shot(
         sub_agent_config,

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -66,7 +66,7 @@ impl SessionTask for UserShellCommandTask {
             .counter("codex.task.user_shell", 1, &[]);
 
         let event = EventMsg::TurnStarted(TurnStartedEvent {
-            model_context_window: turn_context.client.get_model_context_window(),
+            model_context_window: turn_context.model_context_window(),
             collaboration_mode_kind: turn_context.collaboration_mode.mode,
         });
         let session = session.clone_session();

--- a/codex-rs/core/src/tools/handlers/collab.rs
+++ b/codex-rs/core/src/tools/handlers/collab.rs
@@ -114,7 +114,7 @@ mod spawn {
                 "Empty message can't be sent to an agent".to_string(),
             ));
         }
-        let session_source = turn.client.get_session_source();
+        let session_source = turn.session_source.clone();
         let child_depth = next_thread_spawn_depth(&session_source);
         if exceeds_thread_spawn_depth_limit(child_depth) {
             return Err(FunctionCallError::RespondToModel(
@@ -593,13 +593,13 @@ fn build_agent_spawn_config(
     turn: &TurnContext,
     child_depth: i32,
 ) -> Result<Config, FunctionCallError> {
-    let base_config = turn.client.config();
+    let base_config = turn.config.clone();
     let mut config = (*base_config).clone();
     config.base_instructions = Some(base_instructions.text.clone());
-    config.model = Some(turn.client.get_model());
-    config.model_provider = turn.client.get_provider();
-    config.model_reasoning_effort = turn.client.get_reasoning_effort();
-    config.model_reasoning_summary = turn.client.get_reasoning_summary();
+    config.model = Some(turn.model_info.slug.clone());
+    config.model_provider = turn.provider.clone();
+    config.model_reasoning_effort = turn.reasoning_effort;
+    config.model_reasoning_summary = turn.reasoning_summary;
     config.developer_instructions = turn.developer_instructions.clone();
     config.compact_prompt = turn.compact_prompt.clone();
     config.shell_environment_policy = turn.shell_environment_policy.clone();
@@ -633,7 +633,6 @@ mod tests {
     use crate::ThreadManager;
     use crate::agent::MAX_THREAD_SPAWN_DEPTH;
     use crate::built_in_model_providers;
-    use crate::client::ModelClient;
     use crate::codex::make_session_and_context;
     use crate::config::types::ShellEnvironmentPolicy;
     use crate::function_tool::FunctionCallError;
@@ -767,22 +766,10 @@ mod tests {
         let manager = thread_manager();
         session.services.agent_control = manager.agent_control();
 
-        let session_source = SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
+        turn.session_source = SessionSource::SubAgent(SubAgentSource::ThreadSpawn {
             parent_thread_id: session.conversation_id,
             depth: MAX_THREAD_SPAWN_DEPTH,
         });
-        turn.client = ModelClient::new(
-            turn.client.config(),
-            Some(session.services.auth_manager.clone()),
-            turn.client.get_model_info(),
-            turn.client.get_otel_manager(),
-            turn.client.get_provider(),
-            turn.client.get_reasoning_effort(),
-            turn.client.get_reasoning_summary(),
-            session.conversation_id,
-            session_source,
-            session.services.transport_manager.clone(),
-        );
 
         let invocation = invocation(
             Arc::new(session),
@@ -865,7 +852,7 @@ mod tests {
         let (mut session, turn) = make_session_and_context().await;
         let manager = thread_manager();
         session.services.agent_control = manager.agent_control();
-        let config = turn.client.config().as_ref().clone();
+        let config = turn.config.as_ref().clone();
         let thread = manager.start_thread(config).await.expect("start thread");
         let agent_id = thread.thread_id;
         let invocation = invocation(
@@ -1008,7 +995,7 @@ mod tests {
         let (mut session, turn) = make_session_and_context().await;
         let manager = thread_manager();
         session.services.agent_control = manager.agent_control();
-        let config = turn.client.config().as_ref().clone();
+        let config = turn.config.as_ref().clone();
         let thread = manager.start_thread(config).await.expect("start thread");
         let agent_id = thread.thread_id;
         let invocation = invocation(
@@ -1053,7 +1040,7 @@ mod tests {
         let (mut session, turn) = make_session_and_context().await;
         let manager = thread_manager();
         session.services.agent_control = manager.agent_control();
-        let config = turn.client.config().as_ref().clone();
+        let config = turn.config.as_ref().clone();
         let thread = manager.start_thread(config).await.expect("start thread");
         let agent_id = thread.thread_id;
         let invocation = invocation(
@@ -1084,7 +1071,7 @@ mod tests {
         let (mut session, turn) = make_session_and_context().await;
         let manager = thread_manager();
         session.services.agent_control = manager.agent_control();
-        let config = turn.client.config().as_ref().clone();
+        let config = turn.config.as_ref().clone();
         let thread = manager.start_thread(config).await.expect("start thread");
         let agent_id = thread.thread_id;
         let mut status_rx = manager
@@ -1138,7 +1125,7 @@ mod tests {
         let (mut session, turn) = make_session_and_context().await;
         let manager = thread_manager();
         session.services.agent_control = manager.agent_control();
-        let config = turn.client.config().as_ref().clone();
+        let config = turn.config.as_ref().clone();
         let thread = manager.start_thread(config).await.expect("start thread");
         let agent_id = thread.thread_id;
         let status_before = manager.agent_control().get_status(agent_id).await;
@@ -1193,12 +1180,12 @@ mod tests {
         turn.sandbox_policy = SandboxPolicy::DangerFullAccess;
 
         let config = build_agent_spawn_config(&base_instructions, &turn, 0).expect("spawn config");
-        let mut expected = (*turn.client.config()).clone();
+        let mut expected = (*turn.config).clone();
         expected.base_instructions = Some(base_instructions.text);
-        expected.model = Some(turn.client.get_model());
-        expected.model_provider = turn.client.get_provider();
-        expected.model_reasoning_effort = turn.client.get_reasoning_effort();
-        expected.model_reasoning_summary = turn.client.get_reasoning_summary();
+        expected.model = Some(turn.model_info.slug.clone());
+        expected.model_provider = turn.provider.clone();
+        expected.model_reasoning_effort = turn.reasoning_effort;
+        expected.model_reasoning_summary = turn.reasoning_summary;
         expected.developer_instructions = turn.developer_instructions.clone();
         expected.compact_prompt = turn.compact_prompt.clone();
         expected.shell_environment_policy = turn.shell_environment_policy.clone();
@@ -1217,24 +1204,11 @@ mod tests {
 
     #[tokio::test]
     async fn build_agent_spawn_config_preserves_base_user_instructions() {
-        let (session, mut turn) = make_session_and_context().await;
-        let session_source = turn.client.get_session_source();
-        let mut base_config = (*turn.client.config()).clone();
+        let (_session, mut turn) = make_session_and_context().await;
+        let mut base_config = (*turn.config).clone();
         base_config.user_instructions = Some("base-user".to_string());
         turn.user_instructions = Some("resolved-user".to_string());
-        let transport_manager = turn.client.transport_manager();
-        turn.client = ModelClient::new(
-            Arc::new(base_config.clone()),
-            Some(session.services.auth_manager.clone()),
-            turn.client.get_model_info(),
-            turn.client.get_otel_manager(),
-            turn.client.get_provider(),
-            turn.client.get_reasoning_effort(),
-            turn.client.get_reasoning_summary(),
-            session.conversation_id,
-            session_source,
-            transport_manager,
-        );
+        turn.config = Arc::new(base_config.clone());
         let base_instructions = BaseInstructions {
             text: "base".to_string(),
         };

--- a/codex-rs/core/src/tools/orchestrator.rs
+++ b/codex-rs/core/src/tools/orchestrator.rs
@@ -43,7 +43,7 @@ impl ToolOrchestrator {
     where
         T: ToolRuntime<Rq, Out>,
     {
-        let otel = turn_ctx.client.get_otel_manager();
+        let otel = turn_ctx.otel_manager.clone();
         let otel_tn = &tool_ctx.tool_name;
         let otel_ci = &tool_ctx.call_id;
         let otel_user = ToolDecisionSource::User;

--- a/codex-rs/core/src/tools/registry.rs
+++ b/codex-rs/core/src/tools/registry.rs
@@ -70,7 +70,7 @@ impl ToolRegistry {
     ) -> Result<ResponseInputItem, FunctionCallError> {
         let tool_name = invocation.tool_name.clone();
         let call_id_owned = invocation.call_id.clone();
-        let otel = invocation.turn.client.get_otel_manager();
+        let otel = invocation.turn.otel_manager.clone();
         let payload_for_response = invocation.payload.clone();
         let log_payload = payload_for_response.log_payload();
 


### PR DESCRIPTION
I'd like to make client session wide. This requires shedding all random state it has to carry.
