### PR TITLE
Persist pending input user events

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3496,6 +3496,7 @@ pub(crate) async fn run_turn(
         if !pending_response_items.is_empty() {
             for response_item in pending_response_items {
                 if let Some(TurnItem::UserMessage(user_message)) = parse_turn_item(&response_item) {
+                    // todo(aibrahim): move pending input to be UserInput only to keep TextElements. context: https://github.com/openai/codex/pull/10656#discussion_r2765522480
                     sess.record_user_prompt_and_emit_turn_item(
                         turn_context.as_ref(),
                         &user_message.content,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3496,15 +3496,6 @@ pub(crate) async fn run_turn(
         if !pending_response_items.is_empty() {
             sess.record_conversation_items(&turn_context, &pending_response_items)
                 .await;
-            for item in &pending_response_items {
-                if let Some(turn_item) = parse_turn_item(item)
-                    && matches!(turn_item, TurnItem::UserMessage(_))
-                {
-                    sess.emit_turn_item_started(&turn_context, &turn_item).await;
-                    sess.emit_turn_item_completed(&turn_context, turn_item)
-                        .await;
-                }
-            }
         }
 
         // Construct the input that we will send to the model.

--- a/codex-rs/core/tests/suite/pending_input.rs
+++ b/codex-rs/core/tests/suite/pending_input.rs
@@ -125,6 +125,11 @@ async fn injected_user_input_triggers_follow_up_request_with_deltas() {
 
     let _ = gate_completed_tx.send(());
 
+    let _ = wait_for_event(&codex, |event| {
+        matches!(event, EventMsg::UserMessage(message) if message.message == "second prompt")
+    })
+    .await;
+
     wait_for_event(&codex, |event| matches!(event, EventMsg::TurnComplete(_))).await;
 
     let requests = server.requests().await;


### PR DESCRIPTION
- Persist user-message events for mid-turn injected input by emitting user message turn items when pending input is recorded.