### PR TITLE
fix(tui): wrap feedback thread link in backticks

### DIFF
--- a/codex-rs/tui/src/bottom_pane/feedback_view.rs
+++ b/codex-rs/tui/src/bottom_pane/feedback_view.rs
@@ -129,7 +129,7 @@ impl FeedbackNoteView {
                             Line::from("  Share this and add some info about your problem:"),
                             Line::from(vec![
                                 "    ".into(),
-                                format!("go/codex-feedback/{thread_id}").bold(),
+                                format!("`go/codex-feedback/{thread_id}`").bold(),
                             ]),
                         ]);
                     }


### PR DESCRIPTION
Wrap the [go/codex-feedback](https://www.golinks.io/codex-feedback?trackSource=github)/<thread_id> snippet in backticks in the employee
feedback-upload success message so it's ready to paste into Slack as inline code.

Tests:
- cargo test -p codex-tui
