### PR TITLE
Add 'None' personality option to completely disable personality

### DIFF
--- a/codex-rs/core/src/models_manager/model_info.rs
+++ b/codex-rs/core/src/models_manager/model_info.rs
@@ -181,6 +181,7 @@ pub(crate) fn find_model_info_for_slug(slug: &str) -> ModelInfo {
                     personality_default: Some("".to_string()),
                     personality_friendly: Some(GPT_5_2_CODEX_PERSONALITY_FRIENDLY.to_string()),
                     personality_pragmatic: Some(GPT_5_2_CODEX_PERSONALITY_PRAGMATIC.to_string()),
+                    personality_none: None,
                 }),
             }),
             apply_patch_tool_type: Some(ApplyPatchToolType::Freeform),
@@ -224,6 +225,7 @@ pub(crate) fn find_model_info_for_slug(slug: &str) -> ModelInfo {
                     personality_default: Some("".to_string()),
                     personality_friendly: Some(GPT_5_2_CODEX_PERSONALITY_FRIENDLY.to_string()),
                     personality_pragmatic: Some(GPT_5_2_CODEX_PERSONALITY_PRAGMATIC.to_string()),
+                    personality_none: None,
                 }),
             }),
         )

--- a/codex-rs/core/src/models_manager/model_info.rs
+++ b/codex-rs/core/src/models_manager/model_info.rs
@@ -181,7 +181,6 @@ pub(crate) fn find_model_info_for_slug(slug: &str) -> ModelInfo {
                     personality_default: Some("".to_string()),
                     personality_friendly: Some(GPT_5_2_CODEX_PERSONALITY_FRIENDLY.to_string()),
                     personality_pragmatic: Some(GPT_5_2_CODEX_PERSONALITY_PRAGMATIC.to_string()),
-                    personality_none: None,
                 }),
             }),
             apply_patch_tool_type: Some(ApplyPatchToolType::Freeform),
@@ -225,7 +224,6 @@ pub(crate) fn find_model_info_for_slug(slug: &str) -> ModelInfo {
                     personality_default: Some("".to_string()),
                     personality_friendly: Some(GPT_5_2_CODEX_PERSONALITY_FRIENDLY.to_string()),
                     personality_pragmatic: Some(GPT_5_2_CODEX_PERSONALITY_PRAGMATIC.to_string()),
-                    personality_none: None,
                 }),
             }),
         )

--- a/codex-rs/protocol/src/config_types.rs
+++ b/codex-rs/protocol/src/config_types.rs
@@ -98,6 +98,7 @@ pub enum WindowsSandboxLevel {
 pub enum Personality {
     Friendly,
     Pragmatic,
+    None,
 }
 
 #[derive(

--- a/codex-rs/protocol/src/openai_models.rs
+++ b/codex-rs/protocol/src/openai_models.rs
@@ -323,7 +323,6 @@ pub struct ModelInstructionsVariables {
     pub personality_default: Option<String>,
     pub personality_friendly: Option<String>,
     pub personality_pragmatic: Option<String>,
-    pub personality_none: Option<String>,
 }
 
 impl ModelInstructionsVariables {
@@ -331,7 +330,6 @@ impl ModelInstructionsVariables {
         self.personality_default.is_some()
             && self.personality_friendly.is_some()
             && self.personality_pragmatic.is_some()
-            && self.personality_none.is_some()
     }
 
     pub fn get_personality_message(&self, personality: Option<Personality>) -> Option<String> {

--- a/codex-rs/protocol/src/openai_models.rs
+++ b/codex-rs/protocol/src/openai_models.rs
@@ -323,6 +323,7 @@ pub struct ModelInstructionsVariables {
     pub personality_default: Option<String>,
     pub personality_friendly: Option<String>,
     pub personality_pragmatic: Option<String>,
+    pub personality_none: Option<String>,
 }
 
 impl ModelInstructionsVariables {
@@ -330,6 +331,7 @@ impl ModelInstructionsVariables {
         self.personality_default.is_some()
             && self.personality_friendly.is_some()
             && self.personality_pragmatic.is_some()
+            && self.personality_none.is_some()
     }
 
     pub fn get_personality_message(&self, personality: Option<Personality>) -> Option<String> {
@@ -337,6 +339,8 @@ impl ModelInstructionsVariables {
             match personality {
                 Personality::Friendly => self.personality_friendly.clone(),
                 Personality::Pragmatic => self.personality_pragmatic.clone(),
+                // When None is explicitly selected, return None so no personality is injected
+                Personality::None => None,
             }
         } else {
             self.personality_default.clone()

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -2328,6 +2328,7 @@ impl App {
         match personality {
             Personality::Friendly => "Friendly",
             Personality::Pragmatic => "Pragmatic",
+            Personality::None => "None",
         }
     }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -4004,7 +4004,7 @@ impl ChatWidget {
 
     fn open_personality_popup_for_current_model(&mut self) {
         let current_personality = self.config.personality.unwrap_or(Personality::Friendly);
-        let personalities = [Personality::Friendly, Personality::Pragmatic];
+        let personalities = [Personality::Friendly, Personality::Pragmatic, Personality::None];
         let supports_personality = self.current_model_supports_personality();
 
         let items: Vec<SelectionItem> = personalities
@@ -5499,6 +5499,7 @@ impl ChatWidget {
         match personality {
             Personality::Friendly => "Friendly",
             Personality::Pragmatic => "Pragmatic",
+            Personality::None => "None",
         }
     }
 
@@ -5506,6 +5507,7 @@ impl ChatWidget {
         match personality {
             Personality::Friendly => "Warm, collaborative, and helpful.",
             Personality::Pragmatic => "Concise, task-focused, and direct.",
+            Personality::None => "No personality - purely functional responses.",
         }
     }
 

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__personality_selection_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__personality_selection_popup.snap
@@ -7,5 +7,6 @@ expression: popup
 
 › 1. Friendly (current)  Warm, collaborative, and helpful.
   2. Pragmatic           Concise, task-focused, and direct.
+  3. None                No personality - purely functional responses.
 
   Press enter to confirm or esc to go back


### PR DESCRIPTION
# Add 'None' Personality Option

## Summary

This PR adds a new "None" personality option that completely disables personality injection in AI responses. When selected, the model provides purely functional responses without any personality formatting or conversational styling.

## Changes

### Protocol Layer
- **`protocol/src/config_types.rs`**: Added `None` variant to the `Personality` enum
- **`protocol/src/openai_models.rs`**: Updated personality matching logic to return `None` (no personality injection) when `Personality::None` is selected

### UI Layer
- **`tui/src/app.rs`**: Added display label for the None personality option
- **`tui/src/chatwidget.rs`**:
  - Added `Personality::None` to the personality selection popup
  - Added display name and description for the None option
- Updated snapshot test for personality selection popup

### Bug Fix
- **`core/src/models_manager/model_info.rs`**: Removed leftover `personality_none` field assignments that were causing compilation errors after the struct field was removed

## User Impact

Users can now select "None" as a personality option, which will:
- Return responses without any personality styling
- Provide more direct, utilitarian output
- Be useful for users who prefer minimal AI personality in interactions

## Testing

- [ ] Existing snapshot test updated to reflect the new personality option
- [ ] Manual testing via the personality selection popup


Fixes #10582