### PR TITLE
core: preconnect Responses websocket for first turn

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -549,6 +549,10 @@ impl TurnContext {
             .clone()
     }
 
+    /// Resolves the per-turn metadata header under a shared timeout policy.
+    ///
+    /// This uses the same timeout helper as websocket startup preconnect so both turn execution
+    /// and background preconnect observe identical "timeout means best-effort fallback" behavior.
     pub async fn resolve_turn_metadata_header(&self) -> Option<String> {
         resolve_turn_metadata_header_with_timeout(
             self.build_turn_metadata_header(),
@@ -557,6 +561,10 @@ impl TurnContext {
         .await
     }
 
+    /// Starts best-effort background computation of turn metadata.
+    ///
+    /// This warms the cached value used by [`TurnContext::resolve_turn_metadata_header`] so turns
+    /// and websocket preconnect are less likely to pay metadata construction latency on demand.
     pub fn spawn_turn_metadata_header_task(self: &Arc<Self>) {
         let context = Arc::clone(self);
         tokio::spawn(async move {

--- a/codex-rs/core/src/turn_metadata.rs
+++ b/codex-rs/core/src/turn_metadata.rs
@@ -1,11 +1,15 @@
 use std::collections::BTreeMap;
 use std::path::Path;
+use std::time::Duration;
 
 use serde::Serialize;
 
 use crate::git_info::get_git_remote_urls_assume_git_repo;
 use crate::git_info::get_git_repo_root;
 use crate::git_info::get_head_commit_hash;
+
+/// Timeout used when resolving the optional turn-metadata header.
+pub(crate) const TURN_METADATA_HEADER_TIMEOUT: Duration = Duration::from_millis(250);
 
 #[derive(Serialize)]
 struct TurnMetadataWorkspace {

--- a/codex-rs/core/src/turn_metadata.rs
+++ b/codex-rs/core/src/turn_metadata.rs
@@ -1,8 +1,10 @@
 use std::collections::BTreeMap;
+use std::future::Future;
 use std::path::Path;
 use std::time::Duration;
 
 use serde::Serialize;
+use tracing::warn;
 
 use crate::git_info::get_git_remote_urls_assume_git_repo;
 use crate::git_info::get_git_repo_root;
@@ -10,6 +12,28 @@ use crate::git_info::get_head_commit_hash;
 
 /// Timeout used when resolving the optional turn-metadata header.
 pub(crate) const TURN_METADATA_HEADER_TIMEOUT: Duration = Duration::from_millis(250);
+
+/// Resolves turn metadata with a shared timeout policy.
+///
+/// On timeout, this logs a warning and returns the provided fallback header.
+pub(crate) async fn resolve_turn_metadata_header_with_timeout<F>(
+    build_header: F,
+    fallback_on_timeout: Option<String>,
+) -> Option<String>
+where
+    F: Future<Output = Option<String>>,
+{
+    match tokio::time::timeout(TURN_METADATA_HEADER_TIMEOUT, build_header).await {
+        Ok(header) => header,
+        Err(_) => {
+            warn!(
+                "timed out after {}ms while building turn metadata header",
+                TURN_METADATA_HEADER_TIMEOUT.as_millis()
+            );
+            fallback_on_timeout
+        }
+    }
+}
 
 #[derive(Serialize)]
 struct TurnMetadataWorkspace {

--- a/codex-rs/core/src/turn_metadata.rs
+++ b/codex-rs/core/src/turn_metadata.rs
@@ -1,3 +1,9 @@
+//! Helpers for computing and resolving optional per-turn metadata headers.
+//!
+//! This module owns both metadata construction and the shared timeout policy used by
+//! turn execution and startup websocket preconnect. Keeping timeout behavior centralized
+//! ensures both call sites treat timeout as the same best-effort fallback condition.
+
 use std::collections::BTreeMap;
 use std::future::Future;
 use std::path::Path;
@@ -16,6 +22,9 @@ pub(crate) const TURN_METADATA_HEADER_TIMEOUT: Duration = Duration::from_millis(
 /// Resolves turn metadata with a shared timeout policy.
 ///
 /// On timeout, this logs a warning and returns the provided fallback header.
+///
+/// Keeping this helper centralized avoids drift between turn-time metadata resolution and startup
+/// websocket preconnect, both of which need identical timeout semantics.
 pub(crate) async fn resolve_turn_metadata_header_with_timeout<F>(
     build_header: F,
     fallback_on_timeout: Option<String>,

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -299,6 +299,29 @@ impl WebSocketTestServer {
         self.handshakes.lock().unwrap().clone()
     }
 
+    /// Waits until at least `expected` websocket handshakes have been observed or timeout elapses.
+    ///
+    /// Uses a short bounded polling interval so tests can deterministically wait for background
+    /// preconnect activity without busy-spinning.
+    pub async fn wait_for_handshakes(&self, expected: usize, timeout: Duration) -> bool {
+        if self.handshakes.lock().unwrap().len() >= expected {
+            return true;
+        }
+
+        let deadline = tokio::time::Instant::now() + timeout;
+        let poll_interval = Duration::from_millis(10);
+        loop {
+            if self.handshakes.lock().unwrap().len() >= expected {
+                return true;
+            }
+            let now = tokio::time::Instant::now();
+            if now >= deadline {
+                return false;
+            }
+            let sleep_for = std::cmp::min(poll_interval, deadline.saturating_duration_since(now));
+            tokio::time::sleep(sleep_for).await;
+        }
+    }
     pub fn single_handshake(&self) -> WebSocketHandshake {
         let handshakes = self.handshakes.lock().unwrap();
         if handshakes.len() != 1 {

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -268,6 +268,11 @@ impl WebSocketHandshake {
 pub struct WebSocketConnectionConfig {
     pub requests: Vec<Vec<Value>>,
     pub response_headers: Vec<(String, String)>,
+    /// Optional delay inserted before accepting the websocket handshake.
+    ///
+    /// Tests use this to force startup preconnect into an in-flight state so first-turn adoption
+    /// paths can be exercised deterministically.
+    pub accept_delay: Option<Duration>,
 }
 
 pub struct WebSocketTestServer {
@@ -884,6 +889,7 @@ pub async fn start_websocket_server(connections: Vec<Vec<Vec<Value>>>) -> WebSoc
         .map(|requests| WebSocketConnectionConfig {
             requests,
             response_headers: Vec::new(),
+            accept_delay: None,
         })
         .collect();
     start_websocket_server_with_headers(connections).await
@@ -922,6 +928,10 @@ pub async fn start_websocket_server_with_headers(
             let Some(connection) = connection else {
                 continue;
             };
+
+            if let Some(delay) = connection.accept_delay {
+                tokio::time::sleep(delay).await;
+            }
 
             let response_headers = connection.response_headers.clone();
             let handshake_log = Arc::clone(&handshakes);

--- a/codex-rs/core/tests/suite/agent_websocket.rs
+++ b/codex-rs/core/tests/suite/agent_websocket.rs
@@ -9,6 +9,7 @@ use core_test_support::skip_if_no_network;
 use core_test_support::test_codex::test_codex;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
+use std::time::Duration;
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn websocket_test_codex_shell_chain() -> Result<()> {
@@ -63,6 +64,33 @@ async fn websocket_test_codex_shell_chain() -> Result<()> {
         output_item.get("call_id").and_then(Value::as_str),
         Some(call_id)
     );
+
+    server.shutdown().await;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn websocket_preconnect_happens_on_session_start() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_websocket_server(vec![vec![vec![
+        ev_response_created("resp-1"),
+        ev_completed("resp-1"),
+    ]]])
+    .await;
+
+    let mut builder = test_codex();
+    let test = builder.build_with_websocket_server(&server).await?;
+
+    assert!(
+        server.wait_for_handshakes(1, Duration::from_secs(2)).await,
+        "expected websocket preconnect handshake during session startup"
+    );
+
+    test.submit_turn("hello").await?;
+
+    assert_eq!(server.handshakes().len(), 1);
+    assert_eq!(server.single_connection().len(), 1);
 
     server.shutdown().await;
     Ok(())

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -86,6 +86,68 @@ async fn responses_websocket_streams_request() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn responses_websocket_preconnect_reuses_connection() {
+    skip_if_no_network!();
+
+    let server = start_websocket_server(vec![vec![vec![
+        ev_response_created("resp-1"),
+        ev_completed("resp-1"),
+    ]]])
+    .await;
+
+    let harness = websocket_harness(&server).await;
+    assert!(harness.client.preconnect(&harness.otel_manager, None).await);
+
+    let mut client_session = harness.client.new_session();
+    let prompt = prompt_with_input(vec![message_item("hello")]);
+    stream_until_complete(&mut client_session, &harness, &prompt).await;
+
+    assert_eq!(server.handshakes().len(), 1);
+    assert_eq!(server.single_connection().len(), 1);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn responses_websocket_preconnect_is_reused_even_with_header_changes() {
+    skip_if_no_network!();
+
+    let server = start_websocket_server(vec![vec![vec![
+        ev_response_created("resp-1"),
+        ev_completed("resp-1"),
+    ]]])
+    .await;
+
+    let harness = websocket_harness(&server).await;
+    assert!(harness.client.preconnect(&harness.otel_manager, None).await);
+
+    let mut client_session = harness.client.new_session();
+    let prompt = prompt_with_input(vec![message_item("hello")]);
+    let mut stream = client_session
+        .stream(
+            &prompt,
+            &harness.model_info,
+            &harness.otel_manager,
+            harness.effort,
+            harness.summary,
+            None,
+        )
+        .await
+        .expect("websocket stream failed");
+
+    while let Some(event) = stream.next().await {
+        if matches!(event, Ok(ResponseEvent::Completed { .. })) {
+            break;
+        }
+    }
+
+    assert_eq!(server.handshakes().len(), 1);
+    assert_eq!(server.single_connection().len(), 1);
+
+    server.shutdown().await;
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 #[traced_test]
 async fn responses_websocket_emits_websocket_telemetry_events() {
     skip_if_no_network!();

--- a/codex-rs/core/tests/suite/client_websockets.rs
+++ b/codex-rs/core/tests/suite/client_websockets.rs
@@ -252,6 +252,7 @@ async fn responses_websocket_emits_reasoning_included_event() {
     let server = start_websocket_server_with_headers(vec![WebSocketConnectionConfig {
         requests: vec![vec![ev_response_created("resp-1"), ev_completed("resp-1")]],
         response_headers: vec![("X-Reasoning-Included".to_string(), "true".to_string())],
+        accept_delay: None,
     }])
     .await;
 
@@ -322,6 +323,7 @@ async fn responses_websocket_emits_rate_limit_events() {
             ("X-Models-Etag".to_string(), "etag-123".to_string()),
             ("X-Reasoning-Included".to_string(), "true".to_string()),
         ],
+        accept_delay: None,
     }])
     .await;
 

--- a/codex-rs/core/tests/suite/turn_state.rs
+++ b/codex-rs/core/tests/suite/turn_state.rs
@@ -83,6 +83,7 @@ async fn websocket_turn_state_persists_within_turn_and_resets_after() -> Result<
                 ev_done(),
             ]],
             response_headers: vec![(TURN_STATE_HEADER.to_string(), "ts-1".to_string())],
+            accept_delay: None,
         },
         WebSocketConnectionConfig {
             requests: vec![vec![
@@ -91,6 +92,7 @@ async fn websocket_turn_state_persists_within_turn_and_resets_after() -> Result<
                 ev_completed("resp-2"),
             ]],
             response_headers: Vec::new(),
+            accept_delay: None,
         },
         WebSocketConnectionConfig {
             requests: vec![vec![
@@ -99,6 +101,7 @@ async fn websocket_turn_state_persists_within_turn_and_resets_after() -> Result<
                 ev_completed("resp-3"),
             ]],
             response_headers: Vec::new(),
+            accept_delay: None,
         },
     ])
     .await;

--- a/codex-rs/core/tests/suite/websocket_fallback.rs
+++ b/codex-rs/core/tests/suite/websocket_fallback.rs
@@ -46,7 +46,7 @@ async fn websocket_fallback_switches_to_http_after_retries_exhausted() -> Result
         .filter(|req| req.method == Method::POST && req.url.path().ends_with("/responses"))
         .count();
 
-    assert_eq!(websocket_attempts, 1);
+    assert!((1..=2).contains(&websocket_attempts));
     assert_eq!(http_attempts, 1);
     assert_eq!(response_mock.requests().len(), 1);
 
@@ -92,7 +92,7 @@ async fn websocket_fallback_is_sticky_across_turns() -> Result<()> {
         .filter(|req| req.method == Method::POST && req.url.path().ends_with("/responses"))
         .count();
 
-    assert_eq!(websocket_attempts, 1);
+    assert!((1..=2).contains(&websocket_attempts));
     assert_eq!(http_attempts, 2);
     assert_eq!(response_mock.requests().len(), 2);
 

--- a/codex-rs/core/tests/suite/websocket_fallback.rs
+++ b/codex-rs/core/tests/suite/websocket_fallback.rs
@@ -46,7 +46,9 @@ async fn websocket_fallback_switches_to_http_after_retries_exhausted() -> Result
         .filter(|req| req.method == Method::POST && req.url.path().ends_with("/responses"))
         .count();
 
-    assert!((1..=2).contains(&websocket_attempts));
+    // One websocket attempt comes from startup preconnect and one from the first turn's stream
+    // attempt before fallback activates; after fallback, transport is HTTP.
+    assert_eq!(websocket_attempts, 2);
     assert_eq!(http_attempts, 1);
     assert_eq!(response_mock.requests().len(), 1);
 
@@ -92,7 +94,9 @@ async fn websocket_fallback_is_sticky_across_turns() -> Result<()> {
         .filter(|req| req.method == Method::POST && req.url.path().ends_with("/responses"))
         .count();
 
-    assert!((1..=2).contains(&websocket_attempts));
+    // The first turn issues exactly two websocket attempts (startup preconnect + first stream
+    // attempt). After fallback becomes sticky, subsequent turns stay on HTTP.
+    assert_eq!(websocket_attempts, 2);
     assert_eq!(http_attempts, 2);
     assert_eq!(response_mock.requests().len(), 2);
 

--- a/codex-rs/core/tests/suite/websocket_fallback.rs
+++ b/codex-rs/core/tests/suite/websocket_fallback.rs
@@ -47,7 +47,8 @@ async fn websocket_fallback_switches_to_http_after_retries_exhausted() -> Result
         .count();
 
     // One websocket attempt comes from startup preconnect and one from the first turn's stream
-    // attempt before fallback activates; after fallback, transport is HTTP.
+    // attempt before fallback activates; after fallback, transport is HTTP. This matches the
+    // retry-budget tradeoff documented in [`codex_core::client`] module docs.
     assert_eq!(websocket_attempts, 2);
     assert_eq!(http_attempts, 1);
     assert_eq!(response_mock.requests().len(), 1);
@@ -95,7 +96,8 @@ async fn websocket_fallback_is_sticky_across_turns() -> Result<()> {
         .count();
 
     // The first turn issues exactly two websocket attempts (startup preconnect + first stream
-    // attempt). After fallback becomes sticky, subsequent turns stay on HTTP.
+    // attempt). After fallback becomes sticky, subsequent turns stay on HTTP. This mirrors the
+    // retry-budget tradeoff documented in [`codex_core::client`] module docs.
     assert_eq!(websocket_attempts, 2);
     assert_eq!(http_attempts, 2);
     assert_eq!(response_mock.requests().len(), 2);


### PR DESCRIPTION
## Problem
The first user turn can pay websocket handshake latency even when a session has already started. We want to reduce that initial delay while preserving turn semantics and avoiding any prompt send during startup.

Reviewer feedback also called out duplicated connect/setup paths and unnecessary preconnect state complexity.

## Mental model
`ModelClient` owns session-scoped transport state. During session startup, it can opportunistically warm one websocket handshake slot. A turn-scoped `ModelClientSession` adopts that slot once if available, restores captured sticky turn-state, and otherwise opens a websocket through the same shared connect path.

If startup preconnect is still in flight, first turn setup awaits that task and treats it as the first connection attempt for the turn.

Preconnect is handshake-only. The first `response.create` is still sent only when a turn starts.

## Non-goals
This change does not make preconnect required for correctness and does not change prompt/turn payload semantics. It also does not expand fallback behavior beyond clearing preconnect state when fallback activates.

## Tradeoffs
The implementation prioritizes simpler ownership and shared connection code over header-match gating for reuse. The single-slot cache keeps lifecycle straightforward but only benefits the immediate next turn.

Awaiting in-flight preconnect has the same app-level connect-timeout semantics as existing websocket connect behavior (no new timeout class introduced by this PR).

## Architecture
`core/src/client.rs`:
- Added session-level preconnect lifecycle state (`Idle` / `InFlight` / `Ready`) carrying one warmed websocket plus optional captured turn-state.
- Added `pre_establish_connection()` startup warmup and `preconnect()` handshake-only setup.
- Deduped auth/provider resolution into `current_client_setup()` and websocket handshake wiring into `connect_websocket()` / `build_websocket_headers()`.
- Updated turn websocket path to adopt preconnect first, await in-flight preconnect when present, then create a new websocket only when needed.
- Ensured fallback activation clears warmed preconnect state.
- Added documentation for lifecycle, ownership, sticky-routing invariants, and timeout semantics.

`core/src/codex.rs`:
- Session startup invokes `model_client.pre_establish_connection(...)`.
- Turn metadata resolution uses the shared timeout helper.

`core/src/turn_metadata.rs`:
- Centralized shared timeout helper used by both turn-time metadata resolution and startup preconnect metadata building.

`core/tests/common/responses.rs` + websocket test suites:
- Added deterministic handshake waiting helper (`wait_for_handshakes`) with bounded polling.
- Added startup preconnect and in-flight preconnect reuse coverage.
- Fallback expectations now assert exactly two websocket attempts in covered scenarios (startup preconnect + turn attempt before fallback sticks).

## Observability
Preconnect remains best-effort and non-fatal. Existing websocket/fallback telemetry remains in place, and debug logs now make preconnect-await behavior and preconnect failures easier to reason about.

## Tests
Validated with:
1. `just fmt`
2. `cargo test -p codex-core websocket_preconnect -- --nocapture`
3. `cargo test -p codex-core websocket_fallback -- --nocapture`
4. `cargo test -p codex-core websocket_first_turn_waits_for_inflight_preconnect -- --nocapture`
