### PR TITLE
fix: ensure resume args precede image args

### DIFF
--- a/sdk/typescript/src/exec.ts
+++ b/sdk/typescript/src/exec.ts
@@ -115,14 +115,14 @@ export class CodexExec {
       commandArgs.push("--config", `approval_policy="${args.approvalPolicy}"`);
     }
 
+    if (args.threadId) {
+      commandArgs.push("resume", args.threadId);
+    }
+
     if (args.images?.length) {
       for (const image of args.images) {
         commandArgs.push("--image", image);
       }
-    }
-
-    if (args.threadId) {
-      commandArgs.push("resume", args.threadId);
     }
 
     const env: Record<string, string> = {};


### PR DESCRIPTION
## Summary
Fixes argument ordering when `resumeThread()` is used with `local_image`. The SDK previously emitted CLI args with `--image` before `resume <threadId>`, which caused the Codex CLI to treat `resume`/UUID as image paths and start a new session. This PR moves `resume <threadId>` before any `--image` flags and adds a regression test.

## Bug Report / Links
- OpenAI issue: https://github.com/openai/codex/issues/10708
- Repro repo: https://github.com/cryptonerdcn/codex-resume-local-image-repro
- Repro issue (repo): https://github.com/cryptonerdcn/codex-resume-local-image-repro/issues/1

## Repro (pre-fix)
1. Build SDK from source
2. Run resume + local_image
3. Args order: `--image <path> resume <id>`
4. Result: new session created (thread id changes)

## Fix
Move `resume <threadId>` before `--image` in `CodexExec.run` and add a regression test to assert ordering.

## Tests
- `cd sdk/typescript && npm test`
  - **Failed**: `codex-rs/target/debug/codex` missing (ENOENT)

## Notes
- I can rerun tests in an environment with `codex-rs` built and report results.
