### PR TITLE
Process-group cleanup for stdio MCP servers to prevent orphan process storms

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2001,6 +2001,7 @@ dependencies = [
  "codex-protocol",
  "codex-utils-cargo-bin",
  "codex-utils-home-dir",
+ "codex-utils-pty",
  "futures",
  "keyring",
  "oauth2",

--- a/codex-rs/rmcp-client/Cargo.toml
+++ b/codex-rs/rmcp-client/Cargo.toml
@@ -15,6 +15,7 @@ axum = { workspace = true, default-features = false, features = [
 ] }
 codex-keyring-store = { workspace = true }
 codex-protocol = { workspace = true }
+codex-utils-pty = { workspace = true }
 codex-utils-home-dir = { workspace = true }
 futures = { workspace = true, default-features = false, features = ["std"] }
 keyring = { workspace = true, features = ["crypto-rust"] }

--- a/codex-rs/rmcp-client/src/rmcp_client.rs
+++ b/codex-rs/rmcp-client/src/rmcp_client.rs
@@ -107,31 +107,38 @@ impl ProcessGroupGuard {
             Self
         }
     }
+
+    #[cfg(unix)]
+    fn maybe_terminate_process_group(&self) {
+        let process_group_id = self.process_group_id;
+        let should_escalate =
+            match codex_utils_pty::process_group::terminate_process_group(process_group_id) {
+                Ok(exists) => exists,
+                Err(error) => {
+                    warn!("Failed to terminate MCP process group {process_group_id}: {error}");
+                    false
+                }
+            };
+        if should_escalate {
+            std::thread::spawn(move || {
+                std::thread::sleep(PROCESS_GROUP_TERM_GRACE_PERIOD);
+                if let Err(error) =
+                    codex_utils_pty::process_group::kill_process_group(process_group_id)
+                {
+                    warn!("Failed to kill MCP process group {process_group_id}: {error}");
+                }
+            });
+        }
+    }
+
+    #[cfg(not(unix))]
+    fn maybe_terminate_process_group(&self) {}
 }
 
 impl Drop for ProcessGroupGuard {
     fn drop(&mut self) {
-        #[cfg(unix)]
-        {
-            let process_group_id = self.process_group_id;
-            let should_escalate =
-                match codex_utils_pty::process_group::terminate_process_group(process_group_id) {
-                    Ok(exists) => exists,
-                    Err(error) => {
-                        warn!("Failed to terminate MCP process group {process_group_id}: {error}");
-                        false
-                    }
-                };
-            if should_escalate {
-                std::thread::spawn(move || {
-                    std::thread::sleep(PROCESS_GROUP_TERM_GRACE_PERIOD);
-                    if let Err(error) =
-                        codex_utils_pty::process_group::kill_process_group(process_group_id)
-                    {
-                        warn!("Failed to kill MCP process group {process_group_id}: {error}");
-                    }
-                });
-            }
+        if cfg!(unix) {
+            self.maybe_terminate_process_group();
         }
     }
 }

--- a/codex-rs/rmcp-client/src/rmcp_client.rs
+++ b/codex-rs/rmcp-client/src/rmcp_client.rs
@@ -84,15 +84,28 @@ enum ClientState {
     },
 }
 
+#[cfg(unix)]
 const PROCESS_GROUP_TERM_GRACE_PERIOD: Duration = Duration::from_secs(2);
 
+#[cfg(unix)]
 struct ProcessGroupGuard {
     process_group_id: u32,
 }
 
+#[cfg(not(unix))]
+struct ProcessGroupGuard;
+
 impl ProcessGroupGuard {
     fn new(process_group_id: u32) -> Self {
-        Self { process_group_id }
+        #[cfg(unix)]
+        {
+            Self { process_group_id }
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = process_group_id;
+            Self
+        }
     }
 }
 

--- a/codex-rs/rmcp-client/src/rmcp_client.rs
+++ b/codex-rs/rmcp-client/src/rmcp_client.rs
@@ -114,20 +114,24 @@ impl Drop for ProcessGroupGuard {
         #[cfg(unix)]
         {
             let process_group_id = self.process_group_id;
-            if let Err(error) =
-                codex_utils_pty::process_group::terminate_process_group(process_group_id)
-            {
-                warn!("Failed to terminate MCP process group {process_group_id}: {error}");
+            let should_escalate =
+                match codex_utils_pty::process_group::terminate_process_group(process_group_id) {
+                    Ok(exists) => exists,
+                    Err(error) => {
+                        warn!("Failed to terminate MCP process group {process_group_id}: {error}");
+                        false
+                    }
+                };
+            if should_escalate {
+                std::thread::spawn(move || {
+                    std::thread::sleep(PROCESS_GROUP_TERM_GRACE_PERIOD);
+                    if let Err(error) =
+                        codex_utils_pty::process_group::kill_process_group(process_group_id)
+                    {
+                        warn!("Failed to kill MCP process group {process_group_id}: {error}");
+                    }
+                });
             }
-
-            std::thread::spawn(move || {
-                std::thread::sleep(PROCESS_GROUP_TERM_GRACE_PERIOD);
-                if let Err(error) =
-                    codex_utils_pty::process_group::kill_process_group(process_group_id)
-                {
-                    warn!("Failed to kill MCP process group {process_group_id}: {error}");
-                }
-            });
         }
     }
 }

--- a/codex-rs/rmcp-client/tests/process_group_cleanup.rs
+++ b/codex-rs/rmcp-client/tests/process_group_cleanup.rs
@@ -1,0 +1,88 @@
+#![cfg(unix)]
+
+use std::collections::HashMap;
+use std::ffi::OsString;
+use std::fs;
+use std::path::Path;
+use std::time::Duration;
+
+use anyhow::Context;
+use anyhow::Result;
+use codex_rmcp_client::RmcpClient;
+
+fn process_exists(pid: u32) -> bool {
+    std::process::Command::new("kill")
+        .arg("-0")
+        .arg(pid.to_string())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .map(|status| status.success())
+        .unwrap_or(false)
+}
+
+async fn wait_for_pid_file(path: &Path) -> Result<u32> {
+    for _ in 0..50 {
+        match fs::read_to_string(path) {
+            Ok(content) => {
+                let pid = content
+                    .trim()
+                    .parse::<u32>()
+                    .with_context(|| format!("failed to parse pid from {}", path.display()))?;
+                return Ok(pid);
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+            }
+            Err(error) => {
+                return Err(error).with_context(|| format!("failed to read {}", path.display()));
+            }
+        }
+    }
+
+    anyhow::bail!("timed out waiting for child pid file at {}", path.display());
+}
+
+async fn wait_for_process_exit(pid: u32) -> Result<()> {
+    for _ in 0..50 {
+        if !process_exists(pid) {
+            return Ok(());
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    anyhow::bail!("process {pid} still running after timeout");
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 1)]
+async fn drop_kills_wrapper_process_group() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let child_pid_file = temp_dir.path().join("child.pid");
+    let child_pid_file_str = child_pid_file.to_string_lossy().into_owned();
+
+    let client = RmcpClient::new_stdio_client(
+        OsString::from("/bin/sh"),
+        vec![
+            OsString::from("-c"),
+            OsString::from(
+                "sleep 300 & child_pid=$!; echo \"$child_pid\" > \"$CHILD_PID_FILE\"; cat >/dev/null",
+            ),
+        ],
+        Some(HashMap::from([(
+            "CHILD_PID_FILE".to_string(),
+            child_pid_file_str,
+        )])),
+        &[],
+        None,
+    )
+    .await?;
+
+    let grandchild_pid = wait_for_pid_file(&child_pid_file).await?;
+    assert!(
+        process_exists(grandchild_pid),
+        "expected grandchild process {grandchild_pid} to be running before dropping client"
+    );
+
+    drop(client);
+
+    wait_for_process_exit(grandchild_pid).await
+}

--- a/codex-rs/utils/pty/src/process_group.rs
+++ b/codex-rs/utils/pty/src/process_group.rs
@@ -119,25 +119,29 @@ pub fn kill_process_group_by_pid(_pid: u32) -> io::Result<()> {
 
 #[cfg(unix)]
 /// Send SIGTERM to a specific process group ID (best-effort).
-pub fn terminate_process_group(process_group_id: u32) -> io::Result<()> {
+///
+/// Returns `Ok(true)` when SIGTERM was delivered to an existing group and
+/// `Ok(false)` when the group no longer exists.
+pub fn terminate_process_group(process_group_id: u32) -> io::Result<bool> {
     use std::io::ErrorKind;
 
     let pgid = process_group_id as libc::pid_t;
     let result = unsafe { libc::killpg(pgid, libc::SIGTERM) };
     if result == -1 {
         let err = io::Error::last_os_error();
-        if err.kind() != ErrorKind::NotFound {
-            return Err(err);
+        if err.kind() == ErrorKind::NotFound {
+            return Ok(false);
         }
+        return Err(err);
     }
 
-    Ok(())
+    Ok(true)
 }
 
 #[cfg(not(unix))]
 /// No-op on non-Unix platforms.
-pub fn terminate_process_group(_process_group_id: u32) -> io::Result<()> {
-    Ok(())
+pub fn terminate_process_group(_process_group_id: u32) -> io::Result<bool> {
+    Ok(false)
 }
 
 #[cfg(unix)]

--- a/codex-rs/utils/pty/src/process_group.rs
+++ b/codex-rs/utils/pty/src/process_group.rs
@@ -118,6 +118,29 @@ pub fn kill_process_group_by_pid(_pid: u32) -> io::Result<()> {
 }
 
 #[cfg(unix)]
+/// Send SIGTERM to a specific process group ID (best-effort).
+pub fn terminate_process_group(process_group_id: u32) -> io::Result<()> {
+    use std::io::ErrorKind;
+
+    let pgid = process_group_id as libc::pid_t;
+    let result = unsafe { libc::killpg(pgid, libc::SIGTERM) };
+    if result == -1 {
+        let err = io::Error::last_os_error();
+        if err.kind() != ErrorKind::NotFound {
+            return Err(err);
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(not(unix))]
+/// No-op on non-Unix platforms.
+pub fn terminate_process_group(_process_group_id: u32) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(unix)]
 /// Kill a specific process group ID (best-effort).
 pub fn kill_process_group(process_group_id: u32) -> io::Result<()> {
     use std::io::ErrorKind;


### PR DESCRIPTION
This PR changes stdio MCP child processes to run in their own process group
* Add guarded teardown in codex-rmcp-client: send SIGTERM to the group first, then SIGKILL after a short grace period.
* Add terminate_process_group helper in process_group.rs.
* Add Unix regression test in process_group_cleanup.rs to verify wrapper + grandchild are reaped on client drop.

Addresses reported MCP process/thread storm: #10581
