### PR TITLE
fix(tui): flush input buffer on init to prevent early exit on Windows

### DIFF
--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -214,6 +214,8 @@ pub fn init() -> Result<Terminal> {
     }
     set_modes()?;
 
+    flush_terminal_input_buffer();
+
     set_panic_hook();
 
     let backend = CrosstermBackend::new(stdout());


### PR DESCRIPTION
Fixes #10661.

### Problem
On Windows, the sign-in menu can exit immediately if the OS-level input buffer contains trailing characters (like the Enter key from running the command).

### Solution
**Flush Input Buffer on Init**: Use FlushConsoleInputBuffer on Windows (and 	cflush on Unix) in 	ui::init() to discard any input captured before the TUI was ready.

Verified by @CodebyAmbrose in #10661.