### PR TITLE
Update explorer role default model

### DIFF
--- a/codex-rs/core/src/agent/role.rs
+++ b/codex-rs/core/src/agent/role.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 const ORCHESTRATOR_PROMPT: &str = include_str!("../../templates/agents/orchestrator.md");
 /// Default model override used.
 // TODO(jif) update when we have something smarter.
-const EXPLORER_MODEL: &str = "gpt-5.2-codex";
+const EXPLORER_MODEL: &str = "gpt-5.1-codex-mini";
 
 /// Enumerated list of all supported agent roles.
 const ALL_ROLES: [AgentRole; 3] = [


### PR DESCRIPTION
Summary
- switch the explorer role in core agent configuration to use `gpt-5.1-codex-mini` as the default model override
- leave other role defaults untouched

Testing
- Not run (not requested)