### PR TITLE
feat(tui): add sortable resume picker with created/updated timestamp toggle

### DIFF
--- a/codex-rs/tui/src/resume_picker.rs
+++ b/codex-rs/tui/src/resume_picker.rs
@@ -1161,10 +1161,9 @@ fn format_updated_label(row: &Row) -> String {
 }
 
 fn format_created_label(row: &Row) -> String {
-    match (row.created_at, row.updated_at) {
-        (Some(created), _) => human_time_ago(created),
-        (None, Some(updated)) => human_time_ago(updated),
-        (None, None) => "-".to_string(),
+    match row.created_at {
+        Some(created) => human_time_ago(created),
+        None => "-".to_string(),
     }
 }
 

--- a/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_screen.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_screen.snap
@@ -2,9 +2,9 @@
 source: tui/src/resume_picker.rs
 expression: snapshot
 ---
-Resume a previous session  Sort: Creation
+Resume a previous session  Sort: Created at
 Type to search
-  Updated  Branch  CWD  Conversation
+  Created at  Updated at  Branch  CWD  Conversation
 No sessions yet
 
 

--- a/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_screen.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_screen.snap
@@ -1,9 +1,8 @@
 ---
 source: tui/src/resume_picker.rs
-assertion_line: 1438
 expression: snapshot
 ---
-Resume a previous session
+Resume a previous session  Sort: Creation
 Type to search
   Updated  Branch  CWD  Conversation
 No sessions yet
@@ -11,4 +10,4 @@ No sessions yet
 
 
 
-enter to resume     esc to start new     ctrl + c to quit
+enter to resume     esc to start new     ctrl + c to quit     tab to toggle sort

--- a/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_table.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_table.snap
@@ -2,7 +2,7 @@
 source: tui/src/resume_picker.rs
 expression: snapshot
 ---
-  Updated         Branch  CWD  Conversation
-  42 seconds ago  -       -    Fix resume picker timestamps
-> 35 minutes ago  -       -    Investigate lazy pagination cap
-  2 hours ago     -       -    Explain the codebase
+  Created at      Updated at      Branch  CWD  Conversation
+  16 minutes ago  42 seconds ago  -       -    Fix resume picker timestamps
+> 1 hour ago      35 minutes ago  -       -    Investigate lazy pagination cap
+  2 hours ago     2 hours ago     -       -    Explain the codebase

--- a/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_thread_names.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_thread_names.snap
@@ -3,5 +3,5 @@ source: tui/src/resume_picker.rs
 expression: snapshot
 ---
   Created at  Updated at  Branch  CWD  Conversation
-> 2 days ago  2 days ago  -       -    Keep this for now
-  3 days ago  3 days ago  -       -    Named thread
+> -           2 days ago  -       -    Keep this for now
+  -           3 days ago  -       -    Named thread

--- a/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_thread_names.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__resume_picker__tests__resume_picker_thread_names.snap
@@ -1,8 +1,7 @@
 ---
 source: tui/src/resume_picker.rs
-assertion_line: 1683
 expression: snapshot
 ---
-  Updated     Branch  CWD  Conversation
-> 2 days ago  -       -    Keep this for now
-  3 days ago  -       -    Named thread
+  Created at  Updated at  Branch  CWD  Conversation
+> 2 days ago  2 days ago  -       -    Keep this for now
+  3 days ago  3 days ago  -       -    Named thread


### PR DESCRIPTION
## Summary

- Add sorting support to the resume session picker with Tab key toggle
- Sessions can now be sorted by either creation time or last updated time
- Display the current sort mode in the picker header
- Default to sorting by creation time (most recent first)

## Changes

- Add `sort_key` field to `PickerState` to track current sort order
- Pass sort key to `RolloutRecorder::list_threads()` for proper backend sorting
- Add Tab key handler to toggle between `CreatedAt` and `UpdatedAt` sorting
- Show current sort mode ("Created at" / "Updated at") in header
- Add "Tab to toggle sort" keyboard hint
- Intelligently hide secondary date column when terminal is narrow
- Reload session list when sort order changes

## Test plan

- [x] Unit tests for sort key toggle functionality
- [x] Snapshot tests updated for new header format
- [x] Test that Tab key triggers reload with new sort key
- [x] Test column visibility adapts to narrow terminals