### PR TITLE
Add feedback_enabled option to requirements

### DIFF
--- a/codex-rs/app-server/src/config_api.rs
+++ b/codex-rs/app-server/src/config_api.rs
@@ -157,6 +157,7 @@ mod tests {
             mcp_servers: None,
             rules: None,
             enforce_residency: Some(CoreResidencyRequirement::Us),
+            feedback_enabled: None,
         };
 
         let mapped = map_requirements_toml_to_api(requirements);

--- a/codex-rs/cloud-requirements/src/lib.rs
+++ b/codex-rs/cloud-requirements/src/lib.rs
@@ -384,6 +384,7 @@ mod tests {
                 mcp_servers: None,
                 rules: None,
                 enforce_residency: None,
+                feedback_enabled: None,
             })
         );
     }
@@ -424,6 +425,7 @@ mod tests {
                 mcp_servers: None,
                 rules: None,
                 enforce_residency: None,
+                feedback_enabled: None,
             })
         );
     }
@@ -467,6 +469,7 @@ mod tests {
                 mcp_servers: None,
                 rules: None,
                 enforce_residency: None,
+                feedback_enabled: None,
             })
         );
         assert_eq!(fetcher.request_count.load(Ordering::SeqCst), 2);

--- a/codex-rs/core/src/config_loader/tests.rs
+++ b/codex-rs/core/src/config_loader/tests.rs
@@ -539,6 +539,7 @@ allowed_approval_policies = ["on-request"]
                 mcp_servers: None,
                 rules: None,
                 enforce_residency: None,
+                feedback_enabled: None,
             })
         }),
     )
@@ -585,6 +586,7 @@ allowed_approval_policies = ["on-request"]
             mcp_servers: None,
             rules: None,
             enforce_residency: None,
+            feedback_enabled: None,
         },
     );
     load_requirements_toml(&mut config_requirements_toml, &requirements_file).await?;
@@ -620,6 +622,7 @@ async fn load_config_layers_includes_cloud_requirements() -> anyhow::Result<()> 
         mcp_servers: None,
         rules: None,
         enforce_residency: None,
+        feedback_enabled: None,
     };
     let expected = requirements.clone();
     let cloud_requirements = CloudRequirementsLoader::new(async move { Some(requirements) });

--- a/codex-rs/tui/src/debug_config.rs
+++ b/codex-rs/tui/src/debug_config.rs
@@ -99,6 +99,14 @@ fn render_debug_config_lines(stack: &ConfigLayerStack) -> Vec<Line<'static>> {
         ));
     }
 
+    if let Some(feedback_enabled) = requirements_toml.feedback_enabled {
+        requirement_lines.push(requirement_line(
+            "feedback_enabled",
+            feedback_enabled.to_string(),
+            requirements.feedback_enabled.source.as_ref(),
+        ));
+    }
+
     if requirement_lines.is_empty() {
         lines.push("  <none>".dim().into());
     } else {
@@ -287,6 +295,10 @@ mod tests {
             Constrained::allow_any(Some(ResidencyRequirement::Us)),
             Some(RequirementSource::CloudRequirements),
         );
+        requirements.feedback_enabled = ConstrainedWithSource::new(
+            Constrained::allow_any(false),
+            Some(RequirementSource::CloudRequirements),
+        );
 
         let requirements_toml = ConfigRequirementsToml {
             allowed_approval_policies: Some(vec![AskForApproval::OnRequest]),
@@ -301,6 +313,7 @@ mod tests {
             )])),
             rules: None,
             enforce_residency: Some(ResidencyRequirement::Us),
+            feedback_enabled: Some(false),
         };
 
         let user_file = if cfg!(windows) {
@@ -333,6 +346,7 @@ mod tests {
         );
         assert!(rendered.contains("mcp_servers: docs (source: MDM managed_config.toml (legacy))"));
         assert!(rendered.contains("enforce_residency: us (source: cloud requirements)"));
+        assert!(rendered.contains("feedback_enabled: false (source: cloud requirements)"));
         assert!(!rendered.contains("  - rules:"));
     }
 }


### PR DESCRIPTION
We can set this in config already, but it should probably have a corresponding entry in requirements.toml