### PR TITLE
Print warning when config does not meet requirements

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -946,6 +946,14 @@ impl Session {
                 }),
             });
         }
+        for message in &config.startup_warnings {
+            post_session_configured_events.push(Event {
+                id: "".to_owned(),
+                msg: EventMsg::Warning(WarningEvent {
+                    message: message.clone(),
+                }),
+            });
+        }
         maybe_push_unstable_features_warning(&config, &mut post_session_configured_events);
 
         let auth = auth.as_ref();


### PR DESCRIPTION
<img width="1019" height="284" alt="Screenshot 2026-02-05 at 23 34 08" src="https://github.com/user-attachments/assets/19ec3ce1-3c3b-40f5-b251-a31d964bf3bb" />

Currently, if a config value is set that fails the requirements, we exit Codex.

Now, instead of this, we print a warning and default to a requirements-permitting value.