### PR TITLE
Hebrew text showing up in reverse in reasoning traces

### DIFF
--- a/.codex-insights/proposals/issue-10777.md
+++ b/.codex-insights/proposals/issue-10777.md
@@ -1,0 +1,1 @@
+# Proposal issue-10777\n\nTitle: Hebrew text showing up in reverse in reasoning traces\nArea: TUI\nStatus: Proposed\n\nSummary\nHebrew text showing up in reverse in reasoning traces\n\nRationale\nDerived from GitHub issue evidence.\n\nEvidence\nhttps://github.com/openai/codex/issues/10777\n\nGenerated: 2026-02-05T21:09:48.127Z


### PR DESCRIPTION
Summary\n- Proposal: Hebrew text showing up in reverse in reasoning traces\n- Area: TUI\n\nEvidence\n- https://github.com/openai/codex/issues/10777\n\nNotes\n- This PR was generated by the Codex Insights agent.\n- Please review and confirm before merging.