### PR TITLE
Azure OpenAI deployment doesn't support /personality feature

### DIFF
--- a/.codex-insights/proposals/issue-10759.md
+++ b/.codex-insights/proposals/issue-10759.md
@@ -1,0 +1,16 @@
+# Proposal issue-10759
+
+Title: Azure OpenAI deployment doesn't support /personality feature
+Area: CLI
+Status: Proposed
+
+Summary
+### What version of Codex CLI is running? v0.97.0 ### What subscription do you have? Azure OpenAI API ### Which model were you using? gpt-5.2 ### What platform is your computer? Windows11+WSL2 ### What terminal emulator 
+
+Rationale
+Derived from GitHub issue evidence.
+
+Evidence
+https://github.com/openai/codex/issues/10759
+
+Generated: 2026-02-05T21:40:45.719Z


### PR DESCRIPTION
Summary
- Proposal: Azure OpenAI deployment doesn't support /personality feature
- Area: CLI

Evidence
- https://github.com/openai/codex/issues/10759

Notes
- This PR was generated by the Codex Insights agent.
- Please review and confirm before merging.