### PR TITLE
go back to auto-enabling web_search for azure

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -719,7 +719,6 @@ impl Session {
         per_turn_config.personality = session_configuration.personality;
         per_turn_config.web_search_mode = Some(resolve_web_search_mode_for_turn(
             per_turn_config.web_search_mode,
-            session_configuration.provider.is_azure_responses_endpoint(),
             session_configuration.sandbox_policy.get(),
         ));
         per_turn_config.features = config.features.clone();

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -1288,14 +1288,10 @@ fn resolve_web_search_mode(
 
 pub(crate) fn resolve_web_search_mode_for_turn(
     explicit_mode: Option<WebSearchMode>,
-    is_azure_responses_endpoint: bool,
     sandbox_policy: &SandboxPolicy,
 ) -> WebSearchMode {
     if let Some(mode) = explicit_mode {
         return mode;
-    }
-    if is_azure_responses_endpoint {
-        return WebSearchMode::Disabled;
     }
     if matches!(sandbox_policy, SandboxPolicy::DangerFullAccess) {
         WebSearchMode::Live
@@ -2413,14 +2409,14 @@ trust_level = "trusted"
 
     #[test]
     fn web_search_mode_for_turn_defaults_to_cached_when_unset() {
-        let mode = resolve_web_search_mode_for_turn(None, false, &SandboxPolicy::ReadOnly);
+        let mode = resolve_web_search_mode_for_turn(None, &SandboxPolicy::ReadOnly);
 
         assert_eq!(mode, WebSearchMode::Cached);
     }
 
     #[test]
     fn web_search_mode_for_turn_defaults_to_live_for_danger_full_access() {
-        let mode = resolve_web_search_mode_for_turn(None, false, &SandboxPolicy::DangerFullAccess);
+        let mode = resolve_web_search_mode_for_turn(None, &SandboxPolicy::DangerFullAccess);
 
         assert_eq!(mode, WebSearchMode::Live);
     }
@@ -2429,18 +2425,10 @@ trust_level = "trusted"
     fn web_search_mode_for_turn_prefers_explicit_value() {
         let mode = resolve_web_search_mode_for_turn(
             Some(WebSearchMode::Cached),
-            false,
             &SandboxPolicy::DangerFullAccess,
         );
 
         assert_eq!(mode, WebSearchMode::Cached);
-    }
-
-    #[test]
-    fn web_search_mode_for_turn_disables_for_azure_responses_endpoint() {
-        let mode = resolve_web_search_mode_for_turn(None, true, &SandboxPolicy::DangerFullAccess);
-
-        assert_eq!(mode, WebSearchMode::Disabled);
     }
 
     #[test]

--- a/codex-rs/core/src/model_provider_info.rs
+++ b/codex-rs/core/src/model_provider_info.rs
@@ -8,7 +8,6 @@
 use crate::auth::AuthMode;
 use crate::error::EnvVarError;
 use codex_api::Provider as ApiProvider;
-use codex_api::is_azure_responses_wire_base_url;
 use codex_api::provider::RetryConfig as ApiRetryConfig;
 use http::HeaderMap;
 use http::header::HeaderName;
@@ -172,10 +171,6 @@ impl ModelProviderInfo {
             retry,
             stream_idle_timeout: self.stream_idle_timeout(),
         })
-    }
-
-    pub(crate) fn is_azure_responses_endpoint(&self) -> bool {
-        is_azure_responses_wire_base_url(&self.name, self.base_url.as_deref())
     }
 
     /// If `env_key` is Some, returns the API key for this provider if present

--- a/codex-rs/core/tests/suite/web_search.rs
+++ b/codex-rs/core/tests/suite/web_search.rs
@@ -1,7 +1,5 @@
 #![allow(clippy::unwrap_used)]
 
-use codex_core::WireApi;
-use codex_core::built_in_model_providers;
 use codex_core::features::Feature;
 use codex_core::protocol::SandboxPolicy;
 use codex_protocol::config_types::WebSearchMode;
@@ -20,15 +18,6 @@ fn find_web_search_tool(body: &Value) -> &Value {
         .iter()
         .find(|tool| tool.get("type").and_then(Value::as_str) == Some("web_search"))
         .expect("tools should include a web_search tool")
-}
-
-#[allow(clippy::expect_used)]
-fn has_web_search_tool(body: &Value) -> bool {
-    body["tools"]
-        .as_array()
-        .expect("request body should include tools array")
-        .iter()
-        .any(|tool| tool.get("type").and_then(Value::as_str) == Some("web_search"))
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -196,50 +185,5 @@ async fn web_search_mode_updates_between_turns_with_sandbox_policy() {
             .and_then(Value::as_bool),
         Some(true),
         "danger-full-access policy should default web_search to live"
-    );
-}
-
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn web_search_mode_defaults_to_disabled_for_azure_responses() {
-    skip_if_no_network!();
-
-    let server = start_mock_server().await;
-    let sse = responses::sse(vec![
-        responses::ev_response_created("resp-1"),
-        responses::ev_completed("resp-1"),
-    ]);
-    let resp_mock = responses::mount_sse_once(&server, sse).await;
-
-    let mut builder = test_codex()
-        .with_model("gpt-5-codex")
-        .with_config(|config| {
-            let base_url = config.model_provider.base_url.clone();
-            let mut provider = built_in_model_providers()["openai"].clone();
-            provider.name = "Azure".to_string();
-            provider.base_url = base_url;
-            provider.wire_api = WireApi::Responses;
-            config.model_provider_id = provider.name.clone();
-            config.model_provider = provider;
-            config.web_search_mode = None;
-            config.features.disable(Feature::WebSearchCached);
-            config.features.disable(Feature::WebSearchRequest);
-        });
-    let test = builder
-        .build(&server)
-        .await
-        .expect("create test Codex conversation");
-
-    test.submit_turn_with_policy(
-        "hello azure default web search",
-        SandboxPolicy::DangerFullAccess,
-    )
-    .await
-    .expect("submit turn");
-
-    let body = resp_mock.single_request().body_json();
-    assert_eq!(
-        has_web_search_tool(&body),
-        false,
-        "azure responses requests should disable web_search by default"
     );
 }


### PR DESCRIPTION
###### What
Remove special-casing that prevented auto-enabling `web_search` for Azure model provider users. Addresses #10071, #10257.

###### Why
Azure fixed their responsesapi implementation; `web_search` is now supported on models it wasn't before (like `gpt-5.1-codex-max`).

This request now works:
```
curl "$AZURE_API_ENDPOINT" -H "Content-Type: application/json" -H "Authorization: Bearer $AZURE_API_KEY" -d '{
  "model": "gpt-5.1-codex-max",
  "tools": [
    { "type": "web_search" }
  ],
  "tool_choice": "auto",
  "input": "Find the sunrise time in Paris today and cite the source."
}'
```

###### Tests
Tested with above curl, removed Azure-specific tests.