### PR TITLE
Replay rollout history for v2 thread surfaces

### DIFF
--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -3,8 +3,8 @@ use crate::codex_message_processor::PendingInterrupts;
 use crate::codex_message_processor::PendingRollbacks;
 use crate::codex_message_processor::TurnSummary;
 use crate::codex_message_processor::TurnSummaryStore;
-use crate::codex_message_processor::read_event_msgs_from_rollout;
 use crate::codex_message_processor::read_summary_from_rollout;
+use crate::codex_message_processor::read_turns_from_rollout;
 use crate::codex_message_processor::summary_to_thread;
 use crate::error_code::INTERNAL_ERROR_CODE;
 use crate::error_code::INVALID_REQUEST_ERROR_CODE;
@@ -69,7 +69,6 @@ use codex_app_server_protocol::TurnInterruptResponse;
 use codex_app_server_protocol::TurnPlanStep;
 use codex_app_server_protocol::TurnPlanUpdatedNotification;
 use codex_app_server_protocol::TurnStatus;
-use codex_app_server_protocol::build_turns_from_event_msgs;
 use codex_core::CodexThread;
 use codex_core::parse_command::shlex_join;
 use codex_core::protocol::ApplyPatchApprovalRequestEvent;
@@ -1077,9 +1076,9 @@ pub(crate) async fn apply_bespoke_event_handling(
                 {
                     Ok(summary) => {
                         let mut thread = summary_to_thread(summary);
-                        match read_event_msgs_from_rollout(rollout_path.as_path()).await {
-                            Ok(events) => {
-                                thread.turns = build_turns_from_event_msgs(&events);
+                        match read_turns_from_rollout(rollout_path.as_path()).await {
+                            Ok(turns) => {
+                                thread.turns = turns;
                                 ThreadRollbackResponse { thread }
                             }
                             Err(err) => {

--- a/codex-rs/app-server/tests/suite/v2/thread_read.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_read.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use app_test_support::McpProcess;
 use app_test_support::create_fake_rollout_with_text_elements;
 use app_test_support::create_mock_responses_server_repeating_assistant;
+use app_test_support::rollout_path;
 use app_test_support::to_response;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::RequestId;
@@ -11,6 +12,15 @@ use codex_app_server_protocol::ThreadReadParams;
 use codex_app_server_protocol::ThreadReadResponse;
 use codex_app_server_protocol::TurnStatus;
 use codex_app_server_protocol::UserInput;
+use codex_protocol::ThreadId;
+use codex_protocol::models::ContentItem;
+use codex_protocol::models::ResponseItem;
+use codex_protocol::protocol::CompactedItem;
+use codex_protocol::protocol::RolloutItem;
+use codex_protocol::protocol::RolloutLine;
+use codex_protocol::protocol::SessionMeta;
+use codex_protocol::protocol::SessionMetaLine;
+use codex_protocol::protocol::SessionSource as CoreSessionSource;
 use codex_protocol::user_input::ByteRange;
 use codex_protocol::user_input::TextElement;
 use pretty_assertions::assert_eq;
@@ -132,6 +142,156 @@ async fn thread_read_can_include_turns() -> Result<()> {
     }
 
     Ok(())
+}
+
+#[tokio::test]
+async fn thread_read_include_turns_replays_compaction_replacement_history() -> Result<()> {
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+    let codex_home = TempDir::new()?;
+    create_config_toml(codex_home.path(), &server.uri())?;
+    let conversation_id = create_rollout_with_compaction_replacement(
+        codex_home.path(),
+        "2025-01-06T12-00-00",
+        "2025-01-06T12:00:00Z",
+    )?;
+
+    let mut mcp = McpProcess::new(codex_home.path()).await?;
+    timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
+
+    let read_id = mcp
+        .send_thread_read_request(ThreadReadParams {
+            thread_id: conversation_id,
+            include_turns: true,
+        })
+        .await?;
+    let read_resp: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(read_id)),
+    )
+    .await??;
+    let ThreadReadResponse { thread } = to_response::<ThreadReadResponse>(read_resp)?;
+
+    assert_eq!(thread.turns.len(), 2);
+    assert_eq!(
+        thread.turns[0].items,
+        vec![ThreadItem::UserMessage {
+            id: "item-1".to_string(),
+            content: vec![UserInput::Text {
+                text: "compacted summary".to_string(),
+                text_elements: Vec::new(),
+            }],
+        }]
+    );
+    assert_eq!(
+        thread.turns[1].items,
+        vec![
+            ThreadItem::UserMessage {
+                id: "item-2".to_string(),
+                content: vec![UserInput::Text {
+                    text: "latest user".to_string(),
+                    text_elements: Vec::new(),
+                }],
+            },
+            ThreadItem::AgentMessage {
+                id: "item-3".to_string(),
+                text: "latest assistant".to_string(),
+            },
+        ]
+    );
+
+    Ok(())
+}
+
+fn create_rollout_with_compaction_replacement(
+    codex_home: &Path,
+    filename_ts: &str,
+    meta_rfc3339: &str,
+) -> Result<String> {
+    let uuid = uuid::Uuid::new_v4();
+    let thread_id = ThreadId::from_string(&uuid.to_string())?;
+    let path = rollout_path(codex_home, filename_ts, &uuid.to_string());
+    let parent = path
+        .parent()
+        .ok_or_else(|| anyhow::anyhow!("rollout path missing parent: {}", path.display()))?;
+    std::fs::create_dir_all(parent)?;
+
+    let session_meta = SessionMeta {
+        id: thread_id,
+        forked_from_id: None,
+        timestamp: meta_rfc3339.to_string(),
+        cwd: PathBuf::from("/"),
+        originator: "codex".to_string(),
+        cli_version: "0.0.0".to_string(),
+        source: CoreSessionSource::Cli,
+        model_provider: Some("mock_provider".to_string()),
+        base_instructions: None,
+        dynamic_tools: None,
+    };
+
+    let lines = [
+        RolloutLine {
+            timestamp: meta_rfc3339.to_string(),
+            item: RolloutItem::SessionMeta(SessionMetaLine {
+                meta: session_meta,
+                git: None,
+            }),
+        },
+        RolloutLine {
+            timestamp: meta_rfc3339.to_string(),
+            item: RolloutItem::ResponseItem(user_msg("old user")),
+        },
+        RolloutLine {
+            timestamp: meta_rfc3339.to_string(),
+            item: RolloutItem::ResponseItem(assistant_msg("old assistant")),
+        },
+        RolloutLine {
+            timestamp: meta_rfc3339.to_string(),
+            item: RolloutItem::Compacted(CompactedItem {
+                message: "summary".to_string(),
+                replacement_history: Some(vec![user_msg("compacted summary")]),
+            }),
+        },
+        RolloutLine {
+            timestamp: meta_rfc3339.to_string(),
+            item: RolloutItem::ResponseItem(user_msg("latest user")),
+        },
+        RolloutLine {
+            timestamp: meta_rfc3339.to_string(),
+            item: RolloutItem::ResponseItem(assistant_msg("latest assistant")),
+        },
+    ];
+
+    let content = lines
+        .iter()
+        .map(serde_json::to_string)
+        .collect::<Result<Vec<_>, _>>()?
+        .join("\n");
+    std::fs::write(path, format!("{content}\n"))?;
+    Ok(uuid.to_string())
+}
+
+fn user_msg(text: &str) -> ResponseItem {
+    ResponseItem::Message {
+        id: None,
+        role: "user".to_string(),
+        content: vec![ContentItem::InputText {
+            text: text.to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    }
+}
+
+fn assistant_msg(text: &str) -> ResponseItem {
+    ResponseItem::Message {
+        id: None,
+        role: "assistant".to_string(),
+        content: vec![ContentItem::OutputText {
+            text: text.to_string(),
+        }],
+        end_turn: None,
+        phase: None,
+    }
 }
 
 // Helper to create a config.toml pointing at the mock model server.

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -118,6 +118,8 @@ pub use rollout::list::ThreadsPage;
 pub use rollout::list::parse_cursor;
 pub use rollout::list::read_head_for_summary;
 pub use rollout::list::read_session_meta_line;
+pub use rollout::replay_rollout_response_items;
+pub use rollout::replay_rollout_response_items_with_initial_context;
 pub use rollout::rollout_date_parts;
 pub use rollout::session_index::find_thread_names_by_ids;
 pub use transport_manager::TransportManager;

--- a/codex-rs/core/src/rollout/mod.rs
+++ b/codex-rs/core/src/rollout/mod.rs
@@ -12,6 +12,7 @@ pub mod list;
 pub(crate) mod metadata;
 pub(crate) mod policy;
 pub mod recorder;
+pub mod replay;
 pub(crate) mod session_index;
 pub(crate) mod truncation;
 
@@ -24,6 +25,8 @@ pub use list::find_thread_path_by_id_str as find_conversation_path_by_id_str;
 pub use list::rollout_date_parts;
 pub use recorder::RolloutRecorder;
 pub use recorder::RolloutRecorderParams;
+pub use replay::replay_rollout_response_items;
+pub use replay::replay_rollout_response_items_with_initial_context;
 pub use session_index::find_thread_path_by_name_str;
 
 #[cfg(test)]

--- a/codex-rs/core/src/rollout/replay.rs
+++ b/codex-rs/core/src/rollout/replay.rs
@@ -1,0 +1,214 @@
+use crate::compact;
+use crate::compact::collect_user_messages;
+use crate::context_manager::is_user_turn_boundary;
+use codex_protocol::models::ResponseItem;
+use codex_protocol::protocol::EventMsg;
+use codex_protocol::protocol::RolloutItem;
+
+/// Replays rollout items into effective response history.
+///
+/// This applies compaction and rollback markers so callers can reconstruct
+/// the post-replay thread state instead of the raw persisted stream.
+pub fn replay_rollout_response_items(rollout_items: &[RolloutItem]) -> Vec<ResponseItem> {
+    replay_rollout_response_items_with_initial_context(rollout_items, infer_initial_context)
+}
+
+/// Replays rollout items into effective response history, with a custom initial-context provider
+/// used when rebuilding compaction entries that do not have replacement history.
+pub fn replay_rollout_response_items_with_initial_context<F>(
+    rollout_items: &[RolloutItem],
+    mut initial_context: F,
+) -> Vec<ResponseItem>
+where
+    F: FnMut(&[ResponseItem]) -> Vec<ResponseItem>,
+{
+    let mut history = Vec::new();
+    for item in rollout_items {
+        match item {
+            RolloutItem::ResponseItem(response_item) => {
+                history.push(response_item.clone());
+            }
+            RolloutItem::Compacted(compacted) => {
+                if let Some(replacement) = &compacted.replacement_history {
+                    history = replacement.clone();
+                } else {
+                    let initial_context = initial_context(&history);
+                    let user_messages = collect_user_messages(&history);
+                    history = compact::build_compacted_history(
+                        initial_context,
+                        &user_messages,
+                        &compacted.message,
+                    );
+                }
+            }
+            RolloutItem::EventMsg(EventMsg::ThreadRolledBack(rollback)) => {
+                drop_last_n_user_turns(&mut history, rollback.num_turns);
+            }
+            _ => {}
+        }
+    }
+    history
+}
+
+fn infer_initial_context(history: &[ResponseItem]) -> Vec<ResponseItem> {
+    match history.iter().position(is_user_turn_boundary) {
+        Some(first_user_idx) => history[..first_user_idx].to_vec(),
+        None => history.to_vec(),
+    }
+}
+
+fn drop_last_n_user_turns(history: &mut Vec<ResponseItem>, num_turns: u32) {
+    if num_turns == 0 {
+        return;
+    }
+
+    let user_positions = user_message_positions(history);
+    let Some(&first_user_idx) = user_positions.first() else {
+        return;
+    };
+
+    let n_from_end = usize::try_from(num_turns).unwrap_or(usize::MAX);
+    let cut_idx = if n_from_end >= user_positions.len() {
+        first_user_idx
+    } else {
+        user_positions[user_positions.len() - n_from_end]
+    };
+    history.truncate(cut_idx);
+}
+
+fn user_message_positions(items: &[ResponseItem]) -> Vec<usize> {
+    let mut positions = Vec::new();
+    for (idx, item) in items.iter().enumerate() {
+        if is_user_turn_boundary(item) {
+            positions.push(idx);
+        }
+    }
+    positions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_protocol::models::ContentItem;
+    use codex_protocol::protocol::CompactedItem;
+    use codex_protocol::protocol::ThreadRolledBackEvent;
+    use pretty_assertions::assert_eq;
+
+    fn user_msg(text: &str) -> ResponseItem {
+        ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: text.to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        }
+    }
+
+    fn assistant_msg(text: &str) -> ResponseItem {
+        ResponseItem::Message {
+            id: None,
+            role: "assistant".to_string(),
+            content: vec![ContentItem::OutputText {
+                text: text.to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        }
+    }
+
+    fn system_msg(text: &str) -> ResponseItem {
+        ResponseItem::Message {
+            id: None,
+            role: "system".to_string(),
+            content: vec![ContentItem::OutputText {
+                text: text.to_string(),
+            }],
+            end_turn: None,
+            phase: None,
+        }
+    }
+
+    #[test]
+    fn compaction_replay_uses_replacement_history_when_present() {
+        let replacement = vec![user_msg("replacement summary")];
+        let rollout = vec![
+            RolloutItem::ResponseItem(user_msg("before")),
+            RolloutItem::ResponseItem(assistant_msg("assistant before")),
+            RolloutItem::Compacted(CompactedItem {
+                message: "summary".to_string(),
+                replacement_history: Some(replacement.clone()),
+            }),
+            RolloutItem::ResponseItem(assistant_msg("after")),
+        ];
+
+        let replayed = replay_rollout_response_items(&rollout);
+        let expected = vec![replacement[0].clone(), assistant_msg("after")];
+        assert_eq!(replayed, expected);
+    }
+
+    #[test]
+    fn compaction_replay_rebuilds_when_replacement_history_absent() {
+        let rollout = vec![
+            RolloutItem::ResponseItem(system_msg("prefix")),
+            RolloutItem::ResponseItem(user_msg("first user")),
+            RolloutItem::ResponseItem(assistant_msg("assistant reply")),
+            RolloutItem::Compacted(CompactedItem {
+                message: "summary".to_string(),
+                replacement_history: None,
+            }),
+        ];
+
+        let replayed = replay_rollout_response_items(&rollout);
+        let expected = vec![
+            system_msg("prefix"),
+            user_msg("first user"),
+            user_msg("summary"),
+        ];
+        assert_eq!(replayed, expected);
+    }
+
+    #[test]
+    fn rollback_marker_applies_after_compaction_replay() {
+        let rollout = vec![
+            RolloutItem::ResponseItem(user_msg("before")),
+            RolloutItem::ResponseItem(assistant_msg("assistant before")),
+            RolloutItem::Compacted(CompactedItem {
+                message: "summary".to_string(),
+                replacement_history: Some(vec![user_msg("summary")]),
+            }),
+            RolloutItem::ResponseItem(user_msg("latest")),
+            RolloutItem::ResponseItem(assistant_msg("assistant latest")),
+            RolloutItem::EventMsg(EventMsg::ThreadRolledBack(ThreadRolledBackEvent {
+                num_turns: 1,
+            })),
+        ];
+
+        let replayed = replay_rollout_response_items(&rollout);
+        assert_eq!(replayed, vec![user_msg("summary")]);
+    }
+
+    #[test]
+    fn multiple_rollback_markers_apply_in_sequence() {
+        let rollout = vec![
+            RolloutItem::ResponseItem(system_msg("prefix")),
+            RolloutItem::ResponseItem(user_msg("u1")),
+            RolloutItem::ResponseItem(assistant_msg("a1")),
+            RolloutItem::ResponseItem(user_msg("u2")),
+            RolloutItem::ResponseItem(assistant_msg("a2")),
+            RolloutItem::EventMsg(EventMsg::ThreadRolledBack(ThreadRolledBackEvent {
+                num_turns: 1,
+            })),
+            RolloutItem::EventMsg(EventMsg::ThreadRolledBack(ThreadRolledBackEvent {
+                num_turns: 1,
+            })),
+            RolloutItem::EventMsg(EventMsg::ThreadRolledBack(ThreadRolledBackEvent {
+                num_turns: 1,
+            })),
+        ];
+
+        let replayed = replay_rollout_response_items(&rollout);
+        assert_eq!(replayed, vec![system_msg("prefix")]);
+    }
+}


### PR DESCRIPTION
- Reconstruct v2 thread turns from a shared rollout replay path across thread/read, thread/resume, thread/fork, and rollback responses so compaction and rollback markers are applied consistently.\n- Add a reusable codex-core replay helper plus core/app-server tests covering compaction replay, rollback replay, and user text_elements preservation.