### PR TITLE
Personality setting is no longer available in experimental menu

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -4572,9 +4572,7 @@ impl ChatWidget {
 
         let mut header = ColumnRenderable::new();
         header.push(Line::from("Select Personality".bold()));
-        header.push(Line::from(
-            "Choose a communication style for Codex. Disable in /experimental.".dim(),
-        ));
+        header.push(Line::from("Choose a communication style for Codex.".dim()));
 
         self.bottom_pane.show_selection_view(SelectionViewParams {
             header: Box::new(header),

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__personality_selection_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__personality_selection_popup.snap
@@ -3,7 +3,7 @@ source: tui/src/chatwidget/tests.rs
 expression: popup
 ---
   Select Personality
-  Choose a communication style for Codex. Disable in /experimental.
+  Choose a communication style for Codex.
 
   1. Friendly             Warm, collaborative, and helpful.
 › 2. Pragmatic (current)  Concise, task-focused, and direct.


### PR DESCRIPTION
This PR removes the inaccurate "Disable in /experimental." statement now that the "personality" feature flag is no longer experimental.

This addresses #10850
