### PR TITLE
Bootstrap shell commands via user shell snapshot

### DIFF
--- a/codex-rs/core/src/tools/runtimes/mod.rs
+++ b/codex-rs/core/src/tools/runtimes/mod.rs
@@ -47,7 +47,7 @@ pub(crate) fn build_command_spec(
 /// the original script:
 ///
 ///   shell -lc "<script>"
-///   => user_shell -c ". SNAPSHOT (best effort); exec shell -lc <script>"
+///   => user_shell -c ". SNAPSHOT (best effort); exec shell -c <script>"
 ///
 /// This wrapper script uses POSIX constructs (`if`, `.`, `exec`) so it can
 /// be run by Bash/Zsh/sh. On non-matching commands this is a no-op.
@@ -78,7 +78,7 @@ pub(crate) fn maybe_wrap_shell_lc_with_snapshot(
     let original_script = shell_single_quote(&command[2]);
     let snapshot_path = shell_single_quote(snapshot_path.as_ref());
     let rewritten_script = format!(
-        "if . '{snapshot_path}' >/dev/null 2>&1; then :; fi; exec '{original_shell}' -lc '{original_script}'"
+        "if . '{snapshot_path}' >/dev/null 2>&1; then :; fi; exec '{original_shell}' -c '{original_script}'"
     );
 
     vec![shell_path.to_string(), "-c".to_string(), rewritten_script]
@@ -131,7 +131,7 @@ mod tests {
         assert_eq!(rewritten[0], "/bin/zsh");
         assert_eq!(rewritten[1], "-c");
         assert!(rewritten[2].contains("if . '"));
-        assert!(rewritten[2].contains("exec '/bin/bash' -lc 'echo hello'"));
+        assert!(rewritten[2].contains("exec '/bin/bash' -c 'echo hello'"));
     }
 
     #[test]
@@ -148,7 +148,7 @@ mod tests {
 
         let rewritten = maybe_wrap_shell_lc_with_snapshot(&command, &session_shell);
 
-        assert!(rewritten[2].contains(r#"exec '/bin/bash' -lc 'echo '"'"'hello'"'"''"#));
+        assert!(rewritten[2].contains(r#"exec '/bin/bash' -c 'echo '"'"'hello'"'"''"#));
     }
 
     #[test]
@@ -168,7 +168,7 @@ mod tests {
         assert_eq!(rewritten[0], "/bin/bash");
         assert_eq!(rewritten[1], "-c");
         assert!(rewritten[2].contains("if . '"));
-        assert!(rewritten[2].contains("exec '/bin/zsh' -lc 'echo hello'"));
+        assert!(rewritten[2].contains("exec '/bin/zsh' -c 'echo hello'"));
     }
 
     #[test]
@@ -188,6 +188,6 @@ mod tests {
         assert_eq!(rewritten[0], "/bin/sh");
         assert_eq!(rewritten[1], "-c");
         assert!(rewritten[2].contains("if . '"));
-        assert!(rewritten[2].contains("exec '/bin/bash' -lc 'echo hello'"));
+        assert!(rewritten[2].contains("exec '/bin/bash' -c 'echo hello'"));
     }
 }

--- a/codex-rs/core/src/tools/runtimes/mod.rs
+++ b/codex-rs/core/src/tools/runtimes/mod.rs
@@ -47,9 +47,10 @@ pub(crate) fn build_command_spec(
 /// the original script:
 ///
 ///   shell -lc "<script>"
-///   => shell -c ". SNAPSHOT && <script>"
+///   => user_shell -c ". SNAPSHOT (best effort); exec shell -lc <script>"
 ///
-/// On non-POSIX shells or non-matching commands this is a no-op.
+/// This wrapper script uses POSIX constructs (`if`, `.`, `exec`) so it can
+/// be run by Bash/Zsh/sh. On non-matching commands this is a no-op.
 pub(crate) fn maybe_wrap_shell_lc_with_snapshot(
     command: &[String],
     session_shell: &Shell,
@@ -72,10 +73,121 @@ pub(crate) fn maybe_wrap_shell_lc_with_snapshot(
     }
 
     let snapshot_path = snapshot.path.to_string_lossy();
-    let rewritten_script = format!(". \"{snapshot_path}\" && {}", command[2]);
+    let shell_path = session_shell.shell_path.to_string_lossy();
+    let original_shell = shell_single_quote(&command[0]);
+    let original_script = shell_single_quote(&command[2]);
+    let snapshot_path = shell_single_quote(snapshot_path.as_ref());
+    let rewritten_script = format!(
+        "if . '{snapshot_path}' >/dev/null 2>&1; then :; fi; exec '{original_shell}' -lc '{original_script}'"
+    );
 
-    let mut rewritten = command.to_vec();
-    rewritten[1] = "-c".to_string();
-    rewritten[2] = rewritten_script;
-    rewritten
+    vec![shell_path.to_string(), "-c".to_string(), rewritten_script]
+}
+
+fn shell_single_quote(input: &str) -> String {
+    input.replace('\'', r#"'"'"'"#)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::shell::ShellType;
+    use crate::shell_snapshot::ShellSnapshot;
+    use pretty_assertions::assert_eq;
+    use std::path::PathBuf;
+    use std::sync::Arc;
+    use tempfile::tempdir;
+    use tokio::sync::watch;
+
+    fn shell_with_snapshot(
+        shell_type: ShellType,
+        shell_path: &str,
+        snapshot_path: PathBuf,
+    ) -> Shell {
+        let (_tx, shell_snapshot) = watch::channel(Some(Arc::new(ShellSnapshot {
+            path: snapshot_path,
+        })));
+        Shell {
+            shell_type,
+            shell_path: PathBuf::from(shell_path),
+            shell_snapshot,
+        }
+    }
+
+    #[test]
+    fn maybe_wrap_shell_lc_with_snapshot_bootstraps_in_user_shell() {
+        let dir = tempdir().expect("create temp dir");
+        let snapshot_path = dir.path().join("snapshot.sh");
+        std::fs::write(&snapshot_path, "# Snapshot file\n").expect("write snapshot");
+        let session_shell = shell_with_snapshot(ShellType::Zsh, "/bin/zsh", snapshot_path);
+        let command = vec![
+            "/bin/bash".to_string(),
+            "-lc".to_string(),
+            "echo hello".to_string(),
+        ];
+
+        let rewritten = maybe_wrap_shell_lc_with_snapshot(&command, &session_shell);
+
+        assert_eq!(rewritten[0], "/bin/zsh");
+        assert_eq!(rewritten[1], "-c");
+        assert!(rewritten[2].contains("if . '"));
+        assert!(rewritten[2].contains("exec '/bin/bash' -lc 'echo hello'"));
+    }
+
+    #[test]
+    fn maybe_wrap_shell_lc_with_snapshot_escapes_single_quotes() {
+        let dir = tempdir().expect("create temp dir");
+        let snapshot_path = dir.path().join("snapshot.sh");
+        std::fs::write(&snapshot_path, "# Snapshot file\n").expect("write snapshot");
+        let session_shell = shell_with_snapshot(ShellType::Zsh, "/bin/zsh", snapshot_path);
+        let command = vec![
+            "/bin/bash".to_string(),
+            "-lc".to_string(),
+            "echo 'hello'".to_string(),
+        ];
+
+        let rewritten = maybe_wrap_shell_lc_with_snapshot(&command, &session_shell);
+
+        assert!(rewritten[2].contains(r#"exec '/bin/bash' -lc 'echo '"'"'hello'"'"''"#));
+    }
+
+    #[test]
+    fn maybe_wrap_shell_lc_with_snapshot_uses_bash_bootstrap_shell() {
+        let dir = tempdir().expect("create temp dir");
+        let snapshot_path = dir.path().join("snapshot.sh");
+        std::fs::write(&snapshot_path, "# Snapshot file\n").expect("write snapshot");
+        let session_shell = shell_with_snapshot(ShellType::Bash, "/bin/bash", snapshot_path);
+        let command = vec![
+            "/bin/zsh".to_string(),
+            "-lc".to_string(),
+            "echo hello".to_string(),
+        ];
+
+        let rewritten = maybe_wrap_shell_lc_with_snapshot(&command, &session_shell);
+
+        assert_eq!(rewritten[0], "/bin/bash");
+        assert_eq!(rewritten[1], "-c");
+        assert!(rewritten[2].contains("if . '"));
+        assert!(rewritten[2].contains("exec '/bin/zsh' -lc 'echo hello'"));
+    }
+
+    #[test]
+    fn maybe_wrap_shell_lc_with_snapshot_uses_sh_bootstrap_shell() {
+        let dir = tempdir().expect("create temp dir");
+        let snapshot_path = dir.path().join("snapshot.sh");
+        std::fs::write(&snapshot_path, "# Snapshot file\n").expect("write snapshot");
+        let session_shell = shell_with_snapshot(ShellType::Sh, "/bin/sh", snapshot_path);
+        let command = vec![
+            "/bin/bash".to_string(),
+            "-lc".to_string(),
+            "echo hello".to_string(),
+        ];
+
+        let rewritten = maybe_wrap_shell_lc_with_snapshot(&command, &session_shell);
+
+        assert_eq!(rewritten[0], "/bin/sh");
+        assert_eq!(rewritten[1], "-c");
+        assert!(rewritten[2].contains("if . '"));
+        assert!(rewritten[2].contains("exec '/bin/bash' -lc 'echo hello'"));
+    }
 }


### PR DESCRIPTION
Summary
- wrap `shell -lc` executions that use a snapshot with the session shell so the saved environment is sourced before delegating to the original shell
- escape single quotes in the generated wrapper and add tests covering Bash/Zsh/sh session bootstrapping

Testing
- Not run (not requested)