### PR TITLE
Stop auto-compact follow-up loop on compaction failure

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3654,8 +3654,8 @@ pub(crate) async fn run_turn(
         collaboration_mode_kind: turn_context.collaboration_mode.mode,
     });
     sess.send_event(&turn_context, event).await;
-    if total_usage_tokens >= auto_compact_limit {
-        run_auto_compact(&sess, &turn_context).await;
+    if total_usage_tokens >= auto_compact_limit && !run_auto_compact(&sess, &turn_context).await {
+        return None;
     }
 
     let skills_outcome = Some(
@@ -3837,7 +3837,9 @@ pub(crate) async fn run_turn(
 
                 // as long as compaction works well in getting us way below the token limit, we shouldn't worry about being in an infinite loop.
                 if token_limit_reached && needs_follow_up {
-                    run_auto_compact(&sess, &turn_context).await;
+                    if !run_auto_compact(&sess, &turn_context).await {
+                        break;
+                    }
                     continue;
                 }
 
@@ -3895,11 +3897,11 @@ pub(crate) async fn run_turn(
     last_agent_message
 }
 
-async fn run_auto_compact(sess: &Arc<Session>, turn_context: &Arc<TurnContext>) {
+async fn run_auto_compact(sess: &Arc<Session>, turn_context: &Arc<TurnContext>) -> bool {
     if should_use_remote_compact_task(&turn_context.provider) {
-        run_inline_remote_auto_compact_task(Arc::clone(sess), Arc::clone(turn_context)).await;
+        run_inline_remote_auto_compact_task(Arc::clone(sess), Arc::clone(turn_context)).await
     } else {
-        run_inline_auto_compact_task(Arc::clone(sess), Arc::clone(turn_context)).await;
+        run_inline_auto_compact_task(Arc::clone(sess), Arc::clone(turn_context)).await
     }
 }
 

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -19,8 +19,8 @@ use tracing::info;
 pub(crate) async fn run_inline_remote_auto_compact_task(
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
-) {
-    run_remote_compact_task_inner(&sess, &turn_context).await;
+) -> bool {
+    run_remote_compact_task_inner(&sess, &turn_context).await
 }
 
 pub(crate) async fn run_remote_compact_task(sess: Arc<Session>, turn_context: Arc<TurnContext>) {
@@ -30,16 +30,21 @@ pub(crate) async fn run_remote_compact_task(sess: Arc<Session>, turn_context: Ar
     });
     sess.send_event(&turn_context, start_event).await;
 
-    run_remote_compact_task_inner(&sess, &turn_context).await;
+    let _ = run_remote_compact_task_inner(&sess, &turn_context).await;
 }
 
-async fn run_remote_compact_task_inner(sess: &Arc<Session>, turn_context: &Arc<TurnContext>) {
+async fn run_remote_compact_task_inner(
+    sess: &Arc<Session>,
+    turn_context: &Arc<TurnContext>,
+) -> bool {
     if let Err(err) = run_remote_compact_task_inner_impl(sess, turn_context).await {
         let event = EventMsg::Error(
             err.to_error_event(Some("Error running remote compact task".to_string())),
         );
         sess.send_event(turn_context, event).await;
+        return false;
     }
+    true
 }
 
 async fn run_remote_compact_task_inner_impl(

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -2279,8 +2279,12 @@ async fn auto_compact_failure_stops_follow_up_sampling_loop() {
     })
     .await;
     assert!(
-        error_message.contains("Error running remote compact task"),
-        "expected remote auto compact failure message, got: {error_message}"
+        !error_message.contains("Error running remote compact task"),
+        "expected propagated compact error instead of wrapper message, got: {error_message}"
+    );
+    assert!(
+        !error_message.is_empty(),
+        "expected non-empty compact error message"
     );
     wait_for_event(&codex, |msg| matches!(msg, EventMsg::TurnComplete(_))).await;
 

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -245,6 +245,7 @@ async fn remote_compact_trims_function_call_history_to_fit_context_window() -> R
             .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
             .with_config(|config| {
                 config.model_context_window = Some(2_000);
+                config.model_auto_compact_token_limit = Some(i64::MAX);
             }),
     )
     .await?;


### PR DESCRIPTION
- Stop continuing the turn loop when auto-compaction fails (including follow-up sampling).
- Add regression coverage to ensure compact errors terminate the loop instead of retrying sampling.