### PR TITLE
Show left/right arrows to navigate in tui request_user_input

### DIFF
--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_footer_wrap.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/src/bottom_pane/request_user_input/mod.rs
+assertion_line: 2600
 expression: "render_snapshot(&overlay, area)"
 ---
                                                     
@@ -11,4 +12,4 @@ expression: "render_snapshot(&overlay, area)"
     3. Option 3  Third choice.                      
                                                     
   tab to add notes | enter to submit answer         
-  ctrl + n next question | esc to interrupt
+  ←/→ to navigate questions | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_first.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_first.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/src/bottom_pane/request_user_input/mod.rs
+assertion_line: 2744
 expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
@@ -10,4 +11,4 @@ expression: "render_snapshot(&overlay, area)"
     2. Option 2  Second choice.                                                                                         
     3. Option 3  Third choice.                                                                                          
                                                                                                                         
-  tab to add notes | enter to submit answer | ctrl + n next question | esc to interrupt
+  tab to add notes | enter to submit answer | ←/→ to navigate questions | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_multi_question_last.snap
@@ -1,5 +1,6 @@
 ---
 source: tui/src/bottom_pane/request_user_input/mod.rs
+assertion_line: 2770
 expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
@@ -12,4 +13,4 @@ expression: "render_snapshot(&overlay, area)"
                                                                                                                         
                                                                                                                         
                                                                                                                         
-  enter to submit all | ctrl + n first question | esc to interrupt
+  enter to submit all | ctrl + p / ctrl + n change question | esc to interrupt


### PR DESCRIPTION
<img width="785" height="185" alt="Screenshot 2026-02-06 at 10 25 13 AM" src="https://github.com/user-attachments/assets/402a6e79-4626-4df9-b3da-bc2f28e64611" />

<img width="784" height="213" alt="Screenshot 2026-02-06 at 10 26 37 AM" src="https://github.com/user-attachments/assets/cf9614b2-aa1e-4c61-8579-1d2c7e1c7dc1" />

"left/right to navigate questions" in request_user_input footer