### PR TITLE
Fail agent loop eagerly on auto compaction failure

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3908,8 +3908,7 @@ async fn run_auto_compact(
     if should_use_remote_compact_task(&turn_context.provider) {
         run_remote_compaction(Arc::clone(sess), Arc::clone(turn_context)).await
     } else {
-        run_inline_auto_compact_task(Arc::clone(sess), Arc::clone(turn_context)).await;
-        Ok(())
+        run_inline_auto_compact_task(Arc::clone(sess), Arc::clone(turn_context)).await
     }
 }
 

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -85,7 +85,7 @@ pub(crate) async fn run_remote_compaction(
         )
         .await?;
     new_history = sess
-        .process_compacted_history(turn_context, new_history)
+        .process_compacted_history(turn_context.as_ref(), new_history)
         .await;
 
     if !ghost_snapshots.is_empty() {

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -38,7 +38,7 @@ impl SessionTask for CompactTask {
                 1,
                 &[("type", "local")],
             );
-            crate::compact::run_compact_task(session, ctx, input).await
+            crate::compact::run_user_requested_local_compact_task(session, ctx, input).await
         }
 
         None

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -31,7 +31,7 @@ impl SessionTask for CompactTask {
                 1,
                 &[("type", "remote")],
             );
-            crate::compact_remote::run_remote_compact_task(session, ctx).await
+            crate::compact_remote::run_user_requested_remote_compact_task(session, ctx).await
         } else {
             let _ = session.services.otel_manager.counter(
                 "codex.task.compact",

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -788,6 +788,19 @@ pub async fn mount_compact_json_once(server: &MockServer, body: serde_json::Valu
     response_mock
 }
 
+pub async fn mount_compact_response(
+    server: &MockServer,
+    response: ResponseTemplate,
+    max_times: u64,
+) -> ResponseMock {
+    let (mock, response_mock) = compact_mock();
+    mock.respond_with(response)
+        .up_to_n_times(max_times)
+        .mount(server)
+        .await;
+    response_mock
+}
+
 pub async fn mount_models_once(server: &MockServer, body: ModelsResponse) -> ModelsMock {
     let (mock, models_mock) = models_mock();
     mock.respond_with(


### PR DESCRIPTION
Previously we just emitted a UI error event; this may be an artifact of the `/compact` days where users could run `/compact` and keep going if it failed