### PR TITLE
feat(core): add network_proxy feature flag scaffold

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -221,6 +221,9 @@
             "include_apply_patch_tool": {
               "type": "boolean"
             },
+            "network_proxy": {
+              "type": "boolean"
+            },
             "memory_tool": {
               "type": "boolean"
             },
@@ -1259,6 +1262,9 @@
           "type": "boolean"
         },
         "include_apply_patch_tool": {
+          "type": "boolean"
+        },
+        "network_proxy": {
           "type": "boolean"
         },
         "memory_tool": {

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -91,6 +91,8 @@ pub enum Feature {
     UseLinuxSandboxBwrap,
     /// Allow the model to request approval and propose exec rules.
     RequestRule,
+    /// Gate experimental network proxy behavior, including approval integration.
+    NetworkProxy,
     /// Enable Windows sandbox (restricted token) on Windows.
     WindowsSandbox,
     /// Use the elevated Windows sandbox pipeline (setup + runner).
@@ -476,6 +478,12 @@ pub const FEATURES: &[FeatureSpec] = &[
         key: "request_rule",
         stage: Stage::Stable,
         default_enabled: true,
+    },
+    FeatureSpec {
+        id: Feature::NetworkProxy,
+        key: "network_proxy",
+        stage: Stage::UnderDevelopment,
+        default_enabled: false,
     },
     FeatureSpec {
         id: Feature::WindowsSandbox,


### PR DESCRIPTION
## Summary

- add a single `network_proxy` feature flag scaffold in core
- keep default disabled (`false`) and stage as `UnderDevelopment`
- update generated config schema for the new feature key

