### PR TITLE
Defer rollout file creation

### DIFF
--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -71,6 +71,7 @@ use codex_app_server_protocol::TurnPlanUpdatedNotification;
 use codex_app_server_protocol::TurnStatus;
 use codex_app_server_protocol::build_turns_from_event_msgs;
 use codex_core::CodexThread;
+use codex_core::RolloutPersistenceStatus;
 use codex_core::parse_command::shlex_join;
 use codex_core::protocol::ApplyPatchApprovalRequestEvent;
 use codex_core::protocol::CodexErrorInfo as CoreCodexErrorInfo;
@@ -1062,14 +1063,28 @@ pub(crate) async fn apply_bespoke_event_handling(
             };
 
             if let Some(request_id) = pending {
-                let Some(rollout_path) = conversation.rollout_path() else {
-                    let error = JSONRPCErrorError {
-                        code: INVALID_REQUEST_ERROR_CODE,
-                        message: "thread has no persisted rollout".to_string(),
-                        data: None,
-                    };
-                    outgoing.send_error(request_id, error).await;
-                    return;
+                // Rollback responses are rebuilt from rollout-on-disk, and `thread/start`
+                // can defer rollout file creation, so force persistence before reading.
+                let rollout_path = match conversation.ensure_rollout_persisted().await {
+                    Ok(RolloutPersistenceStatus::Persisted(path)) => path,
+                    Ok(RolloutPersistenceStatus::Ephemeral) => {
+                        let error = JSONRPCErrorError {
+                            code: INVALID_REQUEST_ERROR_CODE,
+                            message: "thread has no persisted rollout".to_string(),
+                            data: None,
+                        };
+                        outgoing.send_error(request_id, error).await;
+                        return;
+                    }
+                    Err(err) => {
+                        let error = JSONRPCErrorError {
+                            code: INTERNAL_ERROR_CODE,
+                            message: format!("failed to persist rollout for rollback: {err}"),
+                            data: None,
+                        };
+                        outgoing.send_error(request_id, error).await;
+                        return;
+                    }
                 };
                 let response = match read_summary_from_rollout(
                     rollout_path.as_path(),

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -1740,15 +1740,13 @@ impl CodexMessageProcessor {
                 } = new_thread;
                 let rollout_path = match session_configured.rollout_path {
                     Some(path) => path,
-                    None => {
-                        let error = JSONRPCErrorError {
-                            code: INTERNAL_ERROR_CODE,
-                            message: "rollout path missing for v1 conversation".to_string(),
-                            data: None,
-                        };
-                        self.outgoing.send_error(request_id, error).await;
-                        return;
-                    }
+                    None => match self.resolve_rollout_path(thread_id).await {
+                        Ok(path) => path,
+                        Err(err) => {
+                            self.outgoing.send_error(request_id, err).await;
+                            return;
+                        }
+                    },
                 };
                 let response = NewConversationResponse {
                     conversation_id: thread_id,
@@ -1973,29 +1971,13 @@ impl CodexMessageProcessor {
             }
         };
 
-        let rollout_path =
-            match find_thread_path_by_id_str(&self.config.codex_home, &thread_id.to_string()).await
-            {
-                Ok(Some(p)) => p,
-                Ok(None) => {
-                    let error = JSONRPCErrorError {
-                        code: INVALID_REQUEST_ERROR_CODE,
-                        message: format!("no rollout found for thread id {thread_id}"),
-                        data: None,
-                    };
-                    self.outgoing.send_error(request_id, error).await;
-                    return;
-                }
-                Err(err) => {
-                    let error = JSONRPCErrorError {
-                        code: INVALID_REQUEST_ERROR_CODE,
-                        message: format!("failed to locate thread id {thread_id}: {err}"),
-                        data: None,
-                    };
-                    self.outgoing.send_error(request_id, error).await;
-                    return;
-                }
-            };
+        let rollout_path = match self.resolve_rollout_path(thread_id).await {
+            Ok(path) => path,
+            Err(err) => {
+                self.outgoing.send_error(request_id, err).await;
+                return;
+            }
+        };
 
         match self.archive_thread_common(thread_id, &rollout_path).await {
             Ok(()) => {
@@ -2587,27 +2569,10 @@ impl CodexMessageProcessor {
                 }
             };
 
-            let path = match find_thread_path_by_id_str(
-                &self.config.codex_home,
-                &existing_thread_id.to_string(),
-            )
-            .await
-            {
-                Ok(Some(p)) => p,
-                Ok(None) => {
-                    self.send_invalid_request_error(
-                        request_id,
-                        format!("no rollout found for thread id {existing_thread_id}"),
-                    )
-                    .await;
-                    return;
-                }
+            let path = match self.resolve_rollout_path(existing_thread_id).await {
+                Ok(path) => path,
                 Err(err) => {
-                    self.send_invalid_request_error(
-                        request_id,
-                        format!("failed to locate thread id {existing_thread_id}: {err}"),
-                    )
-                    .await;
+                    self.outgoing.send_error(request_id, err).await;
                     return;
                 }
             };
@@ -2773,30 +2738,14 @@ impl CodexMessageProcessor {
                 }
             };
 
-            match find_thread_path_by_id_str(
-                &self.config.codex_home,
-                &existing_thread_id.to_string(),
-            )
-            .await
-            {
-                Ok(Some(p)) => (p, Some(existing_thread_id)),
-                Ok(None) => {
-                    self.send_invalid_request_error(
-                        request_id,
-                        format!("no rollout found for thread id {existing_thread_id}"),
-                    )
-                    .await;
-                    return;
-                }
+            let rollout_path = match self.resolve_rollout_path(existing_thread_id).await {
+                Ok(path) => path,
                 Err(err) => {
-                    self.send_invalid_request_error(
-                        request_id,
-                        format!("failed to locate thread id {existing_thread_id}: {err}"),
-                    )
-                    .await;
+                    self.outgoing.send_error(request_id, err).await;
                     return;
                 }
-            }
+            };
+            (rollout_path, Some(existing_thread_id))
         };
 
         let history_cwd =
@@ -2969,21 +2918,9 @@ impl CodexMessageProcessor {
                 }
             }
             GetConversationSummaryParams::ThreadId { conversation_id } => {
-                match codex_core::find_thread_path_by_id_str(
-                    &self.config.codex_home,
-                    &conversation_id.to_string(),
-                )
-                .await
-                {
-                    Ok(Some(p)) => p,
-                    _ => {
-                        let error = JSONRPCErrorError {
-                            code: INVALID_REQUEST_ERROR_CODE,
-                            message: format!(
-                                "no rollout found for conversation id {conversation_id}"
-                            ),
-                            data: None,
-                        };
+                match self.resolve_rollout_path(conversation_id).await {
+                    Ok(path) => path,
+                    Err(error) => {
                         self.outgoing.send_error(request_id, error).await;
                         return;
                     }
@@ -3651,36 +3588,22 @@ impl CodexMessageProcessor {
                 }
             }
         } else if let Some(conversation_id) = conversation_id {
-            match find_thread_path_by_id_str(&self.config.codex_home, &conversation_id.to_string())
-                .await
-            {
-                Ok(Some(found_path)) => {
-                    match RolloutRecorder::get_rollout_history(&found_path).await {
-                        Ok(initial_history) => initial_history,
-                        Err(err) => {
-                            self.send_invalid_request_error(
-                                request_id,
-                                format!(
-                                    "failed to load rollout `{}` for conversation {conversation_id}: {err}",
-                                    found_path.display()
-                                ),
-                            ).await;
-                            return;
-                        }
-                    }
-                }
-                Ok(None) => {
-                    self.send_invalid_request_error(
-                        request_id,
-                        format!("no rollout found for conversation id {conversation_id}"),
-                    )
-                    .await;
+            let found_path = match self.resolve_rollout_path(conversation_id).await {
+                Ok(path) => path,
+                Err(err) => {
+                    self.outgoing.send_error(request_id, err).await;
                     return;
                 }
+            };
+            match RolloutRecorder::get_rollout_history(&found_path).await {
+                Ok(initial_history) => initial_history,
                 Err(err) => {
                     self.send_invalid_request_error(
                         request_id,
-                        format!("failed to locate conversation id {conversation_id}: {err}"),
+                        format!(
+                            "failed to load rollout `{}` for conversation {conversation_id}: {err}",
+                            found_path.display()
+                        ),
                     )
                     .await;
                     return;
@@ -3849,27 +3772,14 @@ impl CodexMessageProcessor {
         let (rollout_path, source_thread_id) = if let Some(path) = path {
             (path, None)
         } else if let Some(conversation_id) = conversation_id {
-            match find_thread_path_by_id_str(&self.config.codex_home, &conversation_id.to_string())
-                .await
-            {
-                Ok(Some(found_path)) => (found_path, Some(conversation_id)),
-                Ok(None) => {
-                    self.send_invalid_request_error(
-                        request_id,
-                        format!("no rollout found for conversation id {conversation_id}"),
-                    )
-                    .await;
-                    return;
-                }
+            let rollout_path = match self.resolve_rollout_path(conversation_id).await {
+                Ok(path) => path,
                 Err(err) => {
-                    self.send_invalid_request_error(
-                        request_id,
-                        format!("failed to locate conversation id {conversation_id}: {err}"),
-                    )
-                    .await;
+                    self.outgoing.send_error(request_id, err).await;
                     return;
                 }
-            }
+            };
+            (rollout_path, Some(conversation_id))
         } else {
             self.send_invalid_request_error(
                 request_id,
@@ -4767,19 +4677,7 @@ impl CodexMessageProcessor {
         review_request: ReviewRequest,
         display_text: &str,
     ) -> std::result::Result<(), JSONRPCErrorError> {
-        let rollout_path =
-            find_thread_path_by_id_str(&self.config.codex_home, &parent_thread_id.to_string())
-                .await
-                .map_err(|err| JSONRPCErrorError {
-                    code: INTERNAL_ERROR_CODE,
-                    message: format!("failed to locate thread id {parent_thread_id}: {err}"),
-                    data: None,
-                })?
-                .ok_or_else(|| JSONRPCErrorError {
-                    code: INVALID_REQUEST_ERROR_CODE,
-                    message: format!("no rollout found for thread id {parent_thread_id}"),
-                    data: None,
-                })?;
+        let rollout_path = self.resolve_rollout_path(parent_thread_id).await?;
 
         let mut config = self.config.as_ref().clone();
         if let Some(review_model) = &config.review_model {
@@ -4813,7 +4711,23 @@ impl CodexMessageProcessor {
         }
 
         let fallback_provider = self.config.model_provider_id.as_str();
-        if let Some(rollout_path) = review_thread.rollout_path() {
+        let review_rollout_path = if let Some(path) = session_configured.rollout_path.clone() {
+            Some(path)
+        } else {
+            match self.resolve_rollout_path(thread_id).await {
+                Ok(path) => Some(path),
+                Err(err) => {
+                    tracing::warn!(
+                        "review thread {} has no persisted rollout path: {}",
+                        session_configured.session_id,
+                        err.message
+                    );
+                    None
+                }
+            }
+        };
+
+        if let Some(rollout_path) = review_rollout_path {
             match read_summary_from_rollout(rollout_path.as_path(), fallback_provider).await {
                 Ok(summary) => {
                     let thread = summary_to_thread(summary);
@@ -4830,11 +4744,6 @@ impl CodexMessageProcessor {
                     );
                 }
             }
-        } else {
-            tracing::warn!(
-                "review thread {} has no rollout path",
-                session_configured.session_id
-            );
         }
 
         let turn_id = review_thread
@@ -5196,7 +5105,13 @@ impl CodexMessageProcessor {
 
         let validated_rollout_path = if include_logs {
             match conversation_id {
-                Some(conv_id) => self.resolve_rollout_path(conv_id).await,
+                Some(conv_id) => match self.resolve_rollout_path(conv_id).await {
+                    Ok(path) => Some(path),
+                    Err(err) => {
+                        self.outgoing.send_error(request_id, err).await;
+                        return;
+                    }
+                },
                 None => None,
             }
         } else {
@@ -5245,10 +5160,27 @@ impl CodexMessageProcessor {
         }
     }
 
-    async fn resolve_rollout_path(&self, conversation_id: ThreadId) -> Option<PathBuf> {
-        match self.thread_manager.get_thread(conversation_id).await {
-            Ok(conv) => conv.rollout_path(),
-            Err(_) => None,
+    async fn resolve_rollout_path(
+        &self,
+        thread_id: ThreadId,
+    ) -> Result<PathBuf, JSONRPCErrorError> {
+        match self.thread_manager.resolve_rollout_path(thread_id).await {
+            Ok(path) => Ok(path),
+            Err(CodexErr::ThreadNotFound(_)) => Err(JSONRPCErrorError {
+                code: INVALID_REQUEST_ERROR_CODE,
+                message: format!("no rollout found for thread id {thread_id}"),
+                data: None,
+            }),
+            Err(CodexErr::InvalidRequest(message)) => Err(JSONRPCErrorError {
+                code: INVALID_REQUEST_ERROR_CODE,
+                message,
+                data: None,
+            }),
+            Err(err) => Err(JSONRPCErrorError {
+                code: INTERNAL_ERROR_CODE,
+                message: err.to_string(),
+                data: None,
+            }),
         }
     }
 }

--- a/codex-rs/app-server/tests/suite/v2/thread_archive.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_archive.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use app_test_support::McpProcess;
+use app_test_support::create_mock_responses_server_repeating_assistant;
 use app_test_support::to_response;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::RequestId;
@@ -7,6 +8,8 @@ use codex_app_server_protocol::ThreadArchiveParams;
 use codex_app_server_protocol::ThreadArchiveResponse;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
+use codex_app_server_protocol::TurnStartParams;
+use codex_app_server_protocol::UserInput;
 use codex_core::ARCHIVED_SESSIONS_SUBDIR;
 use codex_core::find_thread_path_by_id_str;
 use std::path::Path;
@@ -18,7 +21,8 @@ const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 #[tokio::test]
 async fn thread_archive_moves_rollout_into_archived_directory() -> Result<()> {
     let codex_home = TempDir::new()?;
-    create_config_toml(codex_home.path())?;
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+    create_config_toml(codex_home.path(), &server.uri())?;
 
     let mut mcp = McpProcess::new(codex_home.path()).await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
@@ -37,6 +41,22 @@ async fn thread_archive_moves_rollout_into_archived_directory() -> Result<()> {
     .await??;
     let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(start_resp)?;
     assert!(!thread.id.is_empty());
+
+    let turn_id = mcp
+        .send_turn_start_request(TurnStartParams {
+            thread_id: thread.id.clone(),
+            input: vec![UserInput::Text {
+                text: "hello".to_string(),
+                text_elements: Vec::new(),
+            }],
+            ..Default::default()
+        })
+        .await?;
+    let _: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(turn_id)),
+    )
+    .await??;
 
     // Locate the rollout path recorded for this thread id.
     let rollout_path = find_thread_path_by_id_str(codex_home.path(), &thread.id)
@@ -80,14 +100,25 @@ async fn thread_archive_moves_rollout_into_archived_directory() -> Result<()> {
     Ok(())
 }
 
-fn create_config_toml(codex_home: &Path) -> std::io::Result<()> {
+fn create_config_toml(codex_home: &Path, server_uri: &str) -> std::io::Result<()> {
     let config_toml = codex_home.join("config.toml");
-    std::fs::write(config_toml, config_contents())
+    std::fs::write(config_toml, config_contents(server_uri))
 }
 
-fn config_contents() -> &'static str {
-    r#"model = "mock-model"
+fn config_contents(server_uri: &str) -> String {
+    format!(
+        r#"model = "mock-model"
 approval_policy = "never"
 sandbox_mode = "read-only"
+
+model_provider = "mock_provider"
+
+[model_providers.mock_provider]
+name = "Mock provider for test"
+base_url = "{server_uri}/v1"
+wire_api = "responses"
+request_max_retries = 0
+stream_max_retries = 0
 "#
+    )
 }

--- a/codex-rs/app-server/tests/suite/v2/thread_resume.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_resume.rs
@@ -57,6 +57,22 @@ async fn thread_resume_returns_original_thread() -> Result<()> {
     .await??;
     let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(start_resp)?;
 
+    let turn_id = mcp
+        .send_turn_start_request(TurnStartParams {
+            thread_id: thread.id.clone(),
+            input: vec![UserInput::Text {
+                text: "hello".to_string(),
+                text_elements: Vec::new(),
+            }],
+            ..Default::default()
+        })
+        .await?;
+    let _: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(turn_id)),
+    )
+    .await??;
+
     // Resume it via v2 API.
     let resume_id = mcp
         .send_thread_resume_request(ThreadResumeParams {

--- a/codex-rs/app-server/tests/suite/v2/thread_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_start.rs
@@ -9,7 +9,10 @@ use codex_app_server_protocol::RequestId;
 use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::ThreadStartedNotification;
+use codex_app_server_protocol::TurnStartParams;
+use codex_app_server_protocol::UserInput;
 use codex_core::config::set_project_trust_level;
+use codex_core::find_thread_path_by_id_str;
 use codex_protocol::config_types::TrustLevel;
 use codex_protocol::openai_models::ReasoningEffort;
 use std::path::Path;
@@ -59,6 +62,11 @@ async fn thread_start_creates_thread_and_emits_started() -> Result<()> {
         thread.created_at > 0,
         "created_at should be a positive UNIX timestamp"
     );
+    let rollout_path = find_thread_path_by_id_str(codex_home.path(), &thread.id).await?;
+    assert!(
+        rollout_path.is_none(),
+        "fresh threads should not create rollout files until first turn"
+    );
 
     // A corresponding thread/started notification should arrive.
     let notif: JSONRPCNotification = timeout(
@@ -69,6 +77,28 @@ async fn thread_start_creates_thread_and_emits_started() -> Result<()> {
     let started: ThreadStartedNotification =
         serde_json::from_value(notif.params.expect("params must be present"))?;
     assert_eq!(started.thread, thread);
+
+    // First turn should create the rollout file lazily.
+    let turn_id = mcp
+        .send_turn_start_request(TurnStartParams {
+            thread_id: thread.id.clone(),
+            input: vec![UserInput::Text {
+                text: "Hello".to_string(),
+                text_elements: Vec::new(),
+            }],
+            ..Default::default()
+        })
+        .await?;
+    let _: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(turn_id)),
+    )
+    .await??;
+    let rollout_path = find_thread_path_by_id_str(codex_home.path(), &thread.id).await?;
+    assert!(
+        rollout_path.is_some(),
+        "first turn should create rollout file"
+    );
 
     Ok(())
 }

--- a/codex-rs/app-server/tests/suite/v2/thread_unarchive.rs
+++ b/codex-rs/app-server/tests/suite/v2/thread_unarchive.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use app_test_support::McpProcess;
+use app_test_support::create_mock_responses_server_repeating_assistant;
 use app_test_support::to_response;
 use codex_app_server_protocol::JSONRPCResponse;
 use codex_app_server_protocol::RequestId;
@@ -9,6 +10,8 @@ use codex_app_server_protocol::ThreadStartParams;
 use codex_app_server_protocol::ThreadStartResponse;
 use codex_app_server_protocol::ThreadUnarchiveParams;
 use codex_app_server_protocol::ThreadUnarchiveResponse;
+use codex_app_server_protocol::TurnStartParams;
+use codex_app_server_protocol::UserInput;
 use codex_core::find_archived_thread_path_by_id_str;
 use codex_core::find_thread_path_by_id_str;
 use std::fs::FileTimes;
@@ -24,7 +27,8 @@ const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs
 #[tokio::test]
 async fn thread_unarchive_moves_rollout_back_into_sessions_directory() -> Result<()> {
     let codex_home = TempDir::new()?;
-    create_config_toml(codex_home.path())?;
+    let server = create_mock_responses_server_repeating_assistant("Done").await;
+    create_config_toml(codex_home.path(), &server.uri())?;
 
     let mut mcp = McpProcess::new(codex_home.path()).await?;
     timeout(DEFAULT_READ_TIMEOUT, mcp.initialize()).await??;
@@ -41,6 +45,22 @@ async fn thread_unarchive_moves_rollout_back_into_sessions_directory() -> Result
     )
     .await??;
     let ThreadStartResponse { thread, .. } = to_response::<ThreadStartResponse>(start_resp)?;
+
+    let turn_id = mcp
+        .send_turn_start_request(TurnStartParams {
+            thread_id: thread.id.clone(),
+            input: vec![UserInput::Text {
+                text: "hello".to_string(),
+                text_elements: Vec::new(),
+            }],
+            ..Default::default()
+        })
+        .await?;
+    let _: JSONRPCResponse = timeout(
+        DEFAULT_READ_TIMEOUT,
+        mcp.read_stream_until_response_message(RequestId::Integer(turn_id)),
+    )
+    .await??;
 
     let rollout_path = find_thread_path_by_id_str(codex_home.path(), &thread.id)
         .await?
@@ -108,14 +128,25 @@ async fn thread_unarchive_moves_rollout_back_into_sessions_directory() -> Result
     Ok(())
 }
 
-fn create_config_toml(codex_home: &Path) -> std::io::Result<()> {
+fn create_config_toml(codex_home: &Path, server_uri: &str) -> std::io::Result<()> {
     let config_toml = codex_home.join("config.toml");
-    std::fs::write(config_toml, config_contents())
+    std::fs::write(config_toml, config_contents(server_uri))
 }
 
-fn config_contents() -> &'static str {
-    r#"model = "mock-model"
+fn config_contents(server_uri: &str) -> String {
+    format!(
+        r#"model = "mock-model"
 approval_policy = "never"
 sandbox_mode = "read-only"
+
+model_provider = "mock_provider"
+
+[model_providers.mock_provider]
+name = "Mock provider for test"
+base_url = "{server_uri}/v1"
+wire_api = "responses"
+request_max_retries = 0
+stream_max_retries = 0
 "#
+    )
 }

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -28,6 +28,12 @@ pub struct ThreadConfigSnapshot {
     pub session_source: SessionSource,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum RolloutPersistenceStatus {
+    Persisted(PathBuf),
+    Ephemeral,
+}
+
 pub struct CodexThread {
     codex: Codex,
     rollout_path: Option<PathBuf>,
@@ -74,6 +80,11 @@ impl CodexThread {
 
     pub fn rollout_path(&self) -> Option<PathBuf> {
         self.rollout_path.clone()
+    }
+
+    /// Ensure this thread has a persisted rollout and return its status.
+    pub async fn ensure_rollout_persisted(&self) -> CodexResult<RolloutPersistenceStatus> {
+        self.codex.ensure_rollout_persisted().await
     }
 
     pub fn state_db(&self) -> Option<StateDbHandle> {

--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -17,6 +17,7 @@ pub use codex::SteerInputError;
 mod codex_thread;
 mod compact_remote;
 pub use codex_thread::CodexThread;
+pub use codex_thread::RolloutPersistenceStatus;
 pub use codex_thread::ThreadConfigSnapshot;
 mod agent;
 mod codex_delegate;

--- a/codex-rs/core/src/rollout/mod.rs
+++ b/codex-rs/core/src/rollout/mod.rs
@@ -22,6 +22,7 @@ pub use list::find_thread_path_by_id_str;
 #[deprecated(note = "use find_thread_path_by_id_str")]
 pub use list::find_thread_path_by_id_str as find_conversation_path_by_id_str;
 pub use list::rollout_date_parts;
+pub use recorder::RolloutCreateMode;
 pub use recorder::RolloutRecorder;
 pub use recorder::RolloutRecorderParams;
 pub use session_index::find_thread_name_by_id;

--- a/codex-rs/core/src/rollout/recorder.rs
+++ b/codex-rs/core/src/rollout/recorder.rs
@@ -1,4 +1,11 @@
-//! Persist Codex session rollouts (.jsonl) so sessions can be replayed or inspected later.
+//! Persist Codex session rollouts (.jsonl) via a single background writer task.
+//!
+//! All rollout writes are serialized through that task so item ordering is
+//! preserved and `flush` can wait for prior writes to commit.
+//!
+//! `CreateDeferred` starts without a file/path and buffers rollout items
+//! in-memory. `EnsurePersisted` materializes the file on demand, writes
+//! `SessionMeta` first, then drains buffered items in order.
 
 use std::fs::File;
 use std::fs::{self};

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -645,6 +645,26 @@ impl App {
         }
     }
 
+    async fn resolve_rollout_path_for_thread(
+        &mut self,
+        thread_id: ThreadId,
+    ) -> std::result::Result<PathBuf, String> {
+        let path = self
+            .server
+            .resolve_rollout_path(thread_id)
+            .await
+            .map_err(|err| err.to_string())?;
+        self.chat_widget.set_rollout_path(Some(path.clone()));
+        Ok(path)
+    }
+
+    async fn resolve_active_rollout_path(&mut self) -> std::result::Result<PathBuf, String> {
+        let Some(thread_id) = self.chat_widget.thread_id() else {
+            return Err("Current session is not ready yet.".to_string());
+        };
+        self.resolve_rollout_path_for_thread(thread_id).await
+    }
+
     async fn shutdown_current_thread(&mut self) {
         if let Some(thread_id) = self.chat_widget.thread_id() {
             // Clear any in-flight rollback guard when switching threads.
@@ -1444,49 +1464,66 @@ impl App {
                 );
                 self.chat_widget
                     .add_plain_history_lines(vec!["/fork".magenta().into()]);
-                if let Some(path) = self.chat_widget.rollout_path() {
-                    match self
-                        .server
-                        .fork_thread(usize::MAX, self.config.clone(), path.clone())
-                        .await
-                    {
-                        Ok(forked) => {
-                            self.shutdown_current_thread().await;
-                            let init = self.chatwidget_init_for_forked_or_resumed_thread(
-                                tui,
-                                self.config.clone(),
-                            );
-                            self.chat_widget = ChatWidget::new_from_existing(
-                                init,
-                                forked.thread,
-                                forked.session_configured,
-                            );
-                            self.reset_thread_event_state();
-                            if let Some(summary) = summary {
-                                let mut lines: Vec<Line<'static>> =
-                                    vec![summary.usage_line.clone().into()];
-                                if let Some(command) = summary.resume_command {
-                                    let spans = vec![
-                                        "To continue this session, run ".into(),
-                                        command.cyan(),
-                                    ];
-                                    lines.push(spans.into());
-                                }
-                                self.chat_widget.add_plain_history_lines(lines);
+                let path = match self.resolve_active_rollout_path().await {
+                    Ok(path) => path,
+                    Err(err) => {
+                        self.chat_widget
+                            .add_error_message(format!("Failed to fork current session: {err}"));
+                        tui.frame_requester().schedule_frame();
+                        return Ok(AppRunControl::Continue);
+                    }
+                };
+                match self
+                    .server
+                    .fork_thread(usize::MAX, self.config.clone(), path.clone())
+                    .await
+                {
+                    Ok(forked) => {
+                        self.shutdown_current_thread().await;
+                        let init = self
+                            .chatwidget_init_for_forked_or_resumed_thread(tui, self.config.clone());
+                        self.chat_widget = ChatWidget::new_from_existing(
+                            init,
+                            forked.thread,
+                            forked.session_configured,
+                        );
+                        self.reset_thread_event_state();
+                        if let Some(summary) = summary {
+                            let mut lines: Vec<Line<'static>> =
+                                vec![summary.usage_line.clone().into()];
+                            if let Some(command) = summary.resume_command {
+                                let spans =
+                                    vec!["To continue this session, run ".into(), command.cyan()];
+                                lines.push(spans.into());
                             }
-                        }
-                        Err(err) => {
-                            let path_display = path.display();
-                            self.chat_widget.add_error_message(format!(
-                                "Failed to fork current session from {path_display}: {err}"
-                            ));
+                            self.chat_widget.add_plain_history_lines(lines);
                         }
                     }
-                } else {
-                    self.chat_widget
-                        .add_error_message("Current session is not ready to fork yet.".to_string());
+                    Err(err) => {
+                        let path_display = path.display();
+                        self.chat_widget.add_error_message(format!(
+                            "Failed to fork current session from {path_display}: {err}"
+                        ));
+                    }
                 }
 
+                tui.frame_requester().schedule_frame();
+            }
+            AppEvent::ShowRolloutPath => {
+                match self.resolve_active_rollout_path().await {
+                    Ok(path) => {
+                        self.chat_widget.add_info_message(
+                            format!("Current rollout path: {}", path.display()),
+                            None,
+                        );
+                    }
+                    Err(err) => {
+                        self.chat_widget.add_info_message(
+                            format!("Rollout path is not available yet: {err}"),
+                            None,
+                        );
+                    }
+                }
                 tui.frame_requester().schedule_frame();
             }
             AppEvent::InsertHistoryCell(cell) => {

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -65,6 +65,9 @@ pub(crate) enum AppEvent {
     /// Fork the current session into a new thread.
     ForkCurrentSession,
 
+    /// Show the current session rollout path.
+    ShowRolloutPath,
+
     /// Request to exit the application.
     ///
     /// Use `ShutdownFirst` for user-initiated quits so core cleanup runs and the

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3319,14 +3319,7 @@ impl ChatWidget {
                 self.add_connectors_output();
             }
             SlashCommand::Rollout => {
-                if let Some(path) = self.rollout_path() {
-                    self.add_info_message(
-                        format!("Current rollout path: {}", path.display()),
-                        None,
-                    );
-                } else {
-                    self.add_info_message("Rollout path is not available yet.".to_string(), None);
-                }
+                self.app_event_tx.send(AppEvent::ShowRolloutPath);
             }
             SlashCommand::TestApproval => {
                 use codex_core::protocol::EventMsg;
@@ -6768,8 +6761,9 @@ impl ChatWidget {
     pub(crate) fn thread_name(&self) -> Option<String> {
         self.thread_name.clone()
     }
-    pub(crate) fn rollout_path(&self) -> Option<PathBuf> {
-        self.current_rollout_path.clone()
+
+    pub(crate) fn set_rollout_path(&mut self, rollout_path: Option<PathBuf>) {
+        self.current_rollout_path = rollout_path;
     }
 
     /// Returns a cache key describing the current in-flight active cell for the transcript overlay.

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -3131,39 +3131,21 @@ async fn slash_fork_requests_current_fork() {
 }
 
 #[tokio::test]
-async fn slash_rollout_displays_current_path() {
+async fn slash_rollout_requests_path_display() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
-    let rollout_path = PathBuf::from("/tmp/codex-test-rollout.jsonl");
-    chat.current_rollout_path = Some(rollout_path.clone());
 
     chat.dispatch_command(SlashCommand::Rollout);
 
-    let cells = drain_insert_history(&mut rx);
-    assert_eq!(cells.len(), 1, "expected info message for rollout path");
-    let rendered = lines_to_single_string(&cells[0]);
-    assert!(
-        rendered.contains(&rollout_path.display().to_string()),
-        "expected rollout path to be shown: {rendered}"
-    );
+    assert_matches!(rx.try_recv(), Ok(AppEvent::ShowRolloutPath));
 }
 
 #[tokio::test]
-async fn slash_rollout_handles_missing_path() {
+async fn slash_rollout_requests_path_display_when_missing_path() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
 
     chat.dispatch_command(SlashCommand::Rollout);
 
-    let cells = drain_insert_history(&mut rx);
-    assert_eq!(
-        cells.len(),
-        1,
-        "expected info message explaining missing path"
-    );
-    let rendered = lines_to_single_string(&cells[0]);
-    assert!(
-        rendered.contains("not available"),
-        "expected missing rollout path message: {rendered}"
-    );
+    assert_matches!(rx.try_recv(), Ok(AppEvent::ShowRolloutPath));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Change Summary

Defer rollout creation until needed

- Add core API to force rollout persistence for non-ephemeral threads:
- `RolloutRecorder` now owns deferred persistence mechanics:
- Centralize rollout path resolution in core thread manager:
- Route rollout-dependent app-server paths through centralized resolution:
  - `thread/archive`
  - `thread/resume` (thread-id path)
  - `thread/fork` (thread-id path)
  - `resumeConversation` (conversation_id path)
  - `forkConversation` (conversation_id path)
  - Thread summary lookup by thread id
  - Detached review parent-thread rollout resolution
  - Feedback `include_logs` rollout resolution
- Rollback handling now forces persistence before rebuilding response payloads from rollout on disk (avoids stale/missing-path assumptions under deferred creation).
- TUI rollout-dependent paths now resolve lazily through app-server instead of assuming a cached path:
  - `/fork` resolves active thread rollout path on demand.
  - `/rollout` dispatches to app-level async resolution (`ShowRolloutPath`).
  - `ChatWidget` keeps `set_rollout_path(...)` to cache newly resolved paths for later feedback flows.

## Tests Updated/Added

### Core
- `record_initial_history_new_seeds_initial_context_immediately`
- `lazy_rollout_creation_writes_session_meta_then_initial_context_then_turn_context`
- `ensure_rollout_persisted_is_idempotent`
- `ensure_rollout_persisted_returns_ephemeral_when_session_is_ephemeral`

### App-Server (v2)
- `thread_start`: asserts rollout is absent immediately after `thread/start`, then present after first completed turn.
- `thread_archive`: now drives a first turn before archive flow.
- `thread_unarchive`: now drives a first turn before archive/unarchive flow.
- `thread_resume`: now drives a first turn before resume-by-thread-id flow.

### TUI
- `/rollout` tests now assert event dispatch (`AppEvent::ShowRolloutPath`) rather than synchronous message rendering in `ChatWidget`.