### PR TITLE
refactor(network-proxy): flatten network config under [network]

### DIFF
--- a/codex-rs/network-proxy/README.md
+++ b/codex-rs/network-proxy/README.md
@@ -17,7 +17,7 @@ It enforces an allow/deny policy and a "limited" mode intended for read-only net
 Example config:
 
 ```toml
-[network_proxy]
+[network]
 enabled = true
 proxy_url = "http://127.0.0.1:3128"
 admin_url = "http://127.0.0.1:8080"
@@ -35,7 +35,6 @@ dangerously_allow_non_loopback_proxy = false
 dangerously_allow_non_loopback_admin = false
 mode = "full" # default when unset; use "limited" for read-only mode
 
-[network_proxy.policy]
 # Hosts must match the allowlist (unless denied).
 # If `allowed_domains` is empty, the proxy blocks requests until an allowlist is configured.
 allowed_domains = ["*.openai.com"]

--- a/codex-rs/network-proxy/src/http_proxy.rs
+++ b/codex-rs/network-proxy/src/http_proxy.rs
@@ -688,7 +688,7 @@ mod tests {
     use super::*;
 
     use crate::config::NetworkMode;
-    use crate::config::NetworkPolicy;
+    use crate::config::NetworkProxySettings;
     use crate::runtime::network_proxy_state_for_policy;
     use pretty_assertions::assert_eq;
     use rama_http::Method;
@@ -697,7 +697,7 @@ mod tests {
 
     #[tokio::test]
     async fn http_connect_accept_blocks_in_limited_mode() {
-        let policy = NetworkPolicy {
+        let policy = NetworkProxySettings {
             allowed_domains: vec!["example.com".to_string()],
             ..Default::default()
         };

--- a/codex-rs/network-proxy/src/network_policy.rs
+++ b/codex-rs/network-proxy/src/network_policy.rs
@@ -217,7 +217,7 @@ fn map_decider_decision(decision: NetworkDecision) -> NetworkDecision {
 mod tests {
     use super::*;
 
-    use crate::config::NetworkPolicy;
+    use crate::config::NetworkProxySettings;
     use crate::reasons::REASON_DENIED;
     use crate::reasons::REASON_NOT_ALLOWED_LOCAL;
     use crate::state::network_proxy_state_for_policy;
@@ -228,7 +228,7 @@ mod tests {
 
     #[tokio::test]
     async fn evaluate_host_policy_invokes_decider_for_not_allowed() {
-        let state = network_proxy_state_for_policy(NetworkPolicy::default());
+        let state = network_proxy_state_for_policy(NetworkProxySettings::default());
         let calls = Arc::new(AtomicUsize::new(0));
         let decider: Arc<dyn NetworkPolicyDecider> = Arc::new({
             let calls = calls.clone();
@@ -259,10 +259,10 @@ mod tests {
 
     #[tokio::test]
     async fn evaluate_host_policy_skips_decider_for_denied() {
-        let state = network_proxy_state_for_policy(NetworkPolicy {
+        let state = network_proxy_state_for_policy(NetworkProxySettings {
             allowed_domains: vec!["example.com".to_string()],
             denied_domains: vec!["blocked.com".to_string()],
-            ..NetworkPolicy::default()
+            ..NetworkProxySettings::default()
         });
         let calls = Arc::new(AtomicUsize::new(0));
         let decider: Arc<dyn NetworkPolicyDecider> = Arc::new({
@@ -299,10 +299,10 @@ mod tests {
 
     #[tokio::test]
     async fn evaluate_host_policy_skips_decider_for_not_allowed_local() {
-        let state = network_proxy_state_for_policy(NetworkPolicy {
+        let state = network_proxy_state_for_policy(NetworkProxySettings {
             allowed_domains: vec!["example.com".to_string()],
             allow_local_binding: false,
-            ..NetworkPolicy::default()
+            ..NetworkProxySettings::default()
         });
         let calls = Arc::new(AtomicUsize::new(0));
         let decider: Arc<dyn NetworkPolicyDecider> = Arc::new({

--- a/codex-rs/network-proxy/src/proxy.rs
+++ b/codex-rs/network-proxy/src/proxy.rs
@@ -66,7 +66,7 @@ impl NetworkProxyBuilder {
             self.http_addr.unwrap_or(runtime.http_addr),
             runtime.socks_addr,
             self.admin_addr.unwrap_or(runtime.admin_addr),
-            &current_cfg.network_proxy,
+            &current_cfg.network,
         );
 
         Ok(NetworkProxy {
@@ -95,8 +95,8 @@ impl NetworkProxy {
 
     pub async fn run(&self) -> Result<NetworkProxyHandle> {
         let current_cfg = self.state.current_cfg().await?;
-        if !current_cfg.network_proxy.enabled {
-            warn!("network_proxy.enabled is false; skipping proxy listeners");
+        if !current_cfg.network.enabled {
+            warn!("network.enabled is false; skipping proxy listeners");
             return Ok(NetworkProxyHandle::noop());
         }
 
@@ -109,12 +109,12 @@ impl NetworkProxy {
             self.http_addr,
             self.policy_decider.clone(),
         ));
-        let socks_task = if current_cfg.network_proxy.enable_socks5 {
+        let socks_task = if current_cfg.network.enable_socks5 {
             Some(tokio::spawn(socks5::run_socks5(
                 self.state.clone(),
                 self.socks_addr,
                 self.policy_decider.clone(),
-                current_cfg.network_proxy.enable_socks5_udp,
+                current_cfg.network.enable_socks5_udp,
             )))
         } else {
             None

--- a/codex-rs/network-proxy/src/state.rs
+++ b/codex-rs/network-proxy/src/state.rs
@@ -56,8 +56,8 @@ pub(crate) async fn build_config_state() -> Result<ConfigState> {
     let constraints = enforce_trusted_constraints(&config_layer_stack, &config)?;
 
     let layer_mtimes = collect_layer_mtimes(&config_layer_stack);
-    let deny_set = compile_globset(&config.network_proxy.policy.denied_domains)?;
-    let allow_set = compile_globset(&config.network_proxy.policy.allowed_domains)?;
+    let deny_set = compile_globset(&config.network.denied_domains)?;
+    let allow_set = compile_globset(&config.network.allowed_domains)?;
     Ok(ConfigState {
         config,
         allow_set,
@@ -94,22 +94,16 @@ fn collect_layer_mtimes(stack: &ConfigLayerStack) -> Vec<LayerMtime> {
 #[derive(Debug, Default, Deserialize)]
 struct PartialConfig {
     #[serde(default)]
-    network_proxy: PartialNetworkProxyConfig,
+    network: PartialNetworkConfig,
 }
 
 #[derive(Debug, Default, Deserialize)]
-struct PartialNetworkProxyConfig {
+struct PartialNetworkConfig {
     enabled: Option<bool>,
     mode: Option<NetworkMode>,
     allow_upstream_proxy: Option<bool>,
     dangerously_allow_non_loopback_proxy: Option<bool>,
     dangerously_allow_non_loopback_admin: Option<bool>,
-    #[serde(default)]
-    policy: PartialNetworkPolicy,
-}
-
-#[derive(Debug, Default, Deserialize)]
-struct PartialNetworkPolicy {
     #[serde(default)]
     allowed_domains: Option<Vec<String>>,
     #[serde(default)]
@@ -137,13 +131,13 @@ fn enforce_trusted_constraints(
     layers: &codex_core::config_loader::ConfigLayerStack,
     config: &NetworkProxyConfig,
 ) -> Result<NetworkProxyConstraints> {
-    let constraints = network_proxy_constraints_from_trusted_layers(layers)?;
+    let constraints = network_constraints_from_trusted_layers(layers)?;
     validate_policy_against_constraints(config, &constraints)
         .context("network proxy constraints")?;
     Ok(constraints)
 }
 
-fn network_proxy_constraints_from_trusted_layers(
+fn network_constraints_from_trusted_layers(
     layers: &codex_core::config_loader::ConfigLayerStack,
 ) -> Result<NetworkProxyConstraints> {
     let mut constraints = NetworkProxyConstraints::default();
@@ -163,38 +157,38 @@ fn network_proxy_constraints_from_trusted_layers(
             .try_into()
             .context("failed to deserialize trusted config layer")?;
 
-        if let Some(enabled) = partial.network_proxy.enabled {
+        if let Some(enabled) = partial.network.enabled {
             constraints.enabled = Some(enabled);
         }
-        if let Some(mode) = partial.network_proxy.mode {
+        if let Some(mode) = partial.network.mode {
             constraints.mode = Some(mode);
         }
-        if let Some(allow_upstream_proxy) = partial.network_proxy.allow_upstream_proxy {
+        if let Some(allow_upstream_proxy) = partial.network.allow_upstream_proxy {
             constraints.allow_upstream_proxy = Some(allow_upstream_proxy);
         }
         if let Some(dangerously_allow_non_loopback_proxy) =
-            partial.network_proxy.dangerously_allow_non_loopback_proxy
+            partial.network.dangerously_allow_non_loopback_proxy
         {
             constraints.dangerously_allow_non_loopback_proxy =
                 Some(dangerously_allow_non_loopback_proxy);
         }
         if let Some(dangerously_allow_non_loopback_admin) =
-            partial.network_proxy.dangerously_allow_non_loopback_admin
+            partial.network.dangerously_allow_non_loopback_admin
         {
             constraints.dangerously_allow_non_loopback_admin =
                 Some(dangerously_allow_non_loopback_admin);
         }
 
-        if let Some(allowed_domains) = partial.network_proxy.policy.allowed_domains {
+        if let Some(allowed_domains) = partial.network.allowed_domains {
             constraints.allowed_domains = Some(allowed_domains);
         }
-        if let Some(denied_domains) = partial.network_proxy.policy.denied_domains {
+        if let Some(denied_domains) = partial.network.denied_domains {
             constraints.denied_domains = Some(denied_domains);
         }
-        if let Some(allow_unix_sockets) = partial.network_proxy.policy.allow_unix_sockets {
+        if let Some(allow_unix_sockets) = partial.network.allow_unix_sockets {
             constraints.allow_unix_sockets = Some(allow_unix_sockets);
         }
-        if let Some(allow_local_binding) = partial.network_proxy.policy.allow_local_binding {
+        if let Some(allow_local_binding) = partial.network.allow_local_binding {
             constraints.allow_local_binding = Some(allow_local_binding);
         }
     }
@@ -227,12 +221,12 @@ pub(crate) fn validate_policy_against_constraints(
         }
     }
 
-    let enabled = config.network_proxy.enabled;
+    let enabled = config.network.enabled;
     if let Some(max_enabled) = constraints.enabled {
         let _ = Constrained::new(enabled, move |candidate| {
             if *candidate && !max_enabled {
                 Err(invalid_value(
-                    "network_proxy.enabled",
+                    "network.enabled",
                     "true",
                     "false (disabled by managed config)",
                 ))
@@ -243,10 +237,10 @@ pub(crate) fn validate_policy_against_constraints(
     }
 
     if let Some(max_mode) = constraints.mode {
-        let _ = Constrained::new(config.network_proxy.mode, move |candidate| {
+        let _ = Constrained::new(config.network.mode, move |candidate| {
             if network_mode_rank(*candidate) > network_mode_rank(max_mode) {
                 Err(invalid_value(
-                    "network_proxy.mode",
+                    "network.mode",
                     format!("{candidate:?}"),
                     format!("{max_mode:?} or more restrictive"),
                 ))
@@ -257,14 +251,13 @@ pub(crate) fn validate_policy_against_constraints(
     }
 
     let allow_upstream_proxy = constraints.allow_upstream_proxy;
-    let _ = Constrained::new(
-        config.network_proxy.allow_upstream_proxy,
-        move |candidate| match allow_upstream_proxy {
+    let _ = Constrained::new(config.network.allow_upstream_proxy, move |candidate| {
+        match allow_upstream_proxy {
             Some(true) | None => Ok(()),
             Some(false) => {
                 if *candidate {
                     Err(invalid_value(
-                        "network_proxy.allow_upstream_proxy",
+                        "network.allow_upstream_proxy",
                         "true",
                         "false (disabled by managed config)",
                     ))
@@ -272,18 +265,18 @@ pub(crate) fn validate_policy_against_constraints(
                     Ok(())
                 }
             }
-        },
-    )?;
+        }
+    })?;
 
     let allow_non_loopback_admin = constraints.dangerously_allow_non_loopback_admin;
     let _ = Constrained::new(
-        config.network_proxy.dangerously_allow_non_loopback_admin,
+        config.network.dangerously_allow_non_loopback_admin,
         move |candidate| match allow_non_loopback_admin {
             Some(true) | None => Ok(()),
             Some(false) => {
                 if *candidate {
                     Err(invalid_value(
-                        "network_proxy.dangerously_allow_non_loopback_admin",
+                        "network.dangerously_allow_non_loopback_admin",
                         "true",
                         "false (disabled by managed config)",
                     ))
@@ -296,13 +289,13 @@ pub(crate) fn validate_policy_against_constraints(
 
     let allow_non_loopback_proxy = constraints.dangerously_allow_non_loopback_proxy;
     let _ = Constrained::new(
-        config.network_proxy.dangerously_allow_non_loopback_proxy,
+        config.network.dangerously_allow_non_loopback_proxy,
         move |candidate| match allow_non_loopback_proxy {
             Some(true) | None => Ok(()),
             Some(false) => {
                 if *candidate {
                     Err(invalid_value(
-                        "network_proxy.dangerously_allow_non_loopback_proxy",
+                        "network.dangerously_allow_non_loopback_proxy",
                         "true",
                         "false (disabled by managed config)",
                     ))
@@ -314,20 +307,17 @@ pub(crate) fn validate_policy_against_constraints(
     )?;
 
     if let Some(allow_local_binding) = constraints.allow_local_binding {
-        let _ = Constrained::new(
-            config.network_proxy.policy.allow_local_binding,
-            move |candidate| {
-                if *candidate && !allow_local_binding {
-                    Err(invalid_value(
-                        "network_proxy.policy.allow_local_binding",
-                        "true",
-                        "false (disabled by managed config)",
-                    ))
-                } else {
-                    Ok(())
-                }
-            },
-        )?;
+        let _ = Constrained::new(config.network.allow_local_binding, move |candidate| {
+            if *candidate && !allow_local_binding {
+                Err(invalid_value(
+                    "network.allow_local_binding",
+                    "true",
+                    "false (disabled by managed config)",
+                ))
+            } else {
+                Ok(())
+            }
+        })?;
     }
 
     if let Some(allowed_domains) = &constraints.allowed_domains {
@@ -335,30 +325,27 @@ pub(crate) fn validate_policy_against_constraints(
             .iter()
             .map(|entry| DomainPattern::parse_for_constraints(entry))
             .collect();
-        let _ = Constrained::new(
-            config.network_proxy.policy.allowed_domains.clone(),
-            move |candidate| {
-                let mut invalid = Vec::new();
-                for entry in candidate {
-                    let candidate_pattern = DomainPattern::parse_for_constraints(entry);
-                    if !managed_patterns
-                        .iter()
-                        .any(|managed| managed.allows(&candidate_pattern))
-                    {
-                        invalid.push(entry.clone());
-                    }
+        let _ = Constrained::new(config.network.allowed_domains.clone(), move |candidate| {
+            let mut invalid = Vec::new();
+            for entry in candidate {
+                let candidate_pattern = DomainPattern::parse_for_constraints(entry);
+                if !managed_patterns
+                    .iter()
+                    .any(|managed| managed.allows(&candidate_pattern))
+                {
+                    invalid.push(entry.clone());
                 }
-                if invalid.is_empty() {
-                    Ok(())
-                } else {
-                    Err(invalid_value(
-                        "network_proxy.policy.allowed_domains",
-                        format!("{invalid:?}"),
-                        "subset of managed allowed_domains",
-                    ))
-                }
-            },
-        )?;
+            }
+            if invalid.is_empty() {
+                Ok(())
+            } else {
+                Err(invalid_value(
+                    "network.allowed_domains",
+                    format!("{invalid:?}"),
+                    "subset of managed allowed_domains",
+                ))
+            }
+        })?;
     }
 
     if let Some(denied_domains) = &constraints.denied_domains {
@@ -366,27 +353,24 @@ pub(crate) fn validate_policy_against_constraints(
             .iter()
             .map(|s| s.to_ascii_lowercase())
             .collect();
-        let _ = Constrained::new(
-            config.network_proxy.policy.denied_domains.clone(),
-            move |candidate| {
-                let candidate_set: HashSet<String> =
-                    candidate.iter().map(|s| s.to_ascii_lowercase()).collect();
-                let missing: Vec<String> = required_set
-                    .iter()
-                    .filter(|entry| !candidate_set.contains(*entry))
-                    .cloned()
-                    .collect();
-                if missing.is_empty() {
-                    Ok(())
-                } else {
-                    Err(invalid_value(
-                        "network_proxy.policy.denied_domains",
-                        "missing managed denied_domains entries",
-                        format!("{missing:?}"),
-                    ))
-                }
-            },
-        )?;
+        let _ = Constrained::new(config.network.denied_domains.clone(), move |candidate| {
+            let candidate_set: HashSet<String> =
+                candidate.iter().map(|s| s.to_ascii_lowercase()).collect();
+            let missing: Vec<String> = required_set
+                .iter()
+                .filter(|entry| !candidate_set.contains(*entry))
+                .cloned()
+                .collect();
+            if missing.is_empty() {
+                Ok(())
+            } else {
+                Err(invalid_value(
+                    "network.denied_domains",
+                    "missing managed denied_domains entries",
+                    format!("{missing:?}"),
+                ))
+            }
+        })?;
     }
 
     if let Some(allow_unix_sockets) = &constraints.allow_unix_sockets {
@@ -395,7 +379,7 @@ pub(crate) fn validate_policy_against_constraints(
             .map(|s| s.to_ascii_lowercase())
             .collect();
         let _ = Constrained::new(
-            config.network_proxy.policy.allow_unix_sockets.clone(),
+            config.network.allow_unix_sockets.clone(),
             move |candidate| {
                 let mut invalid = Vec::new();
                 for entry in candidate {
@@ -407,7 +391,7 @@ pub(crate) fn validate_policy_against_constraints(
                     Ok(())
                 } else {
                     Err(invalid_value(
-                        "network_proxy.policy.allow_unix_sockets",
+                        "network.allow_unix_sockets",
                         format!("{invalid:?}"),
                         "subset of managed allow_unix_sockets",
                     ))


### PR DESCRIPTION
Summary:
- Rename config table from network_proxy to network.
- Flatten allowed_domains, denied_domains, allow_unix_sockets, and allow_local_binding onto NetworkProxySettings.
- Update runtime, state constraints, tests, and README to the new config shape.