### PR TITLE
Fixed a flaky test

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/review.rs
+++ b/codex-rs/app-server/tests/suite/v2/review.rs
@@ -407,6 +407,9 @@ sandbox_mode = "read-only"
 
 model_provider = "mock_provider"
 
+[features]
+remote_models = false
+
 [model_providers.mock_provider]
 name = "Mock provider"
 base_url = "{server_uri}/v1"


### PR DESCRIPTION
## Summary

Stabilize v2 review integration tests by making them hermetic with respect to model discovery.

`app-server` review tests were intermittently timing out in CI (especially on Windows runners) because their test config allowed remote model refresh. During `thread/start`, the test process could issue live `/v1/models` requests, introducing external network latency and nondeterministic timing before review flow assertions.

This change disables remote model fetching in the review test config helper used by these tests.
