### PR TITLE
Do not poll for usage when using API Key auth

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -4492,12 +4492,7 @@ impl ChatWidget {
     fn prefetch_rate_limits(&mut self) {
         self.stop_rate_limit_poller();
 
-        if !self
-            .auth_manager
-            .auth_cached()
-            .as_ref()
-            .is_some_and(CodexAuth::is_chatgpt_auth)
-        {
+        if !self.should_prefetch_rate_limits() {
             return;
         }
 
@@ -4520,6 +4515,17 @@ impl ChatWidget {
         });
 
         self.rate_limit_poller = Some(handle);
+    }
+
+    fn should_prefetch_rate_limits(&self) -> bool {
+        if !self.config.model_provider.requires_openai_auth {
+            return false;
+        }
+
+        self.auth_manager
+            .auth_cached()
+            .as_ref()
+            .is_some_and(CodexAuth::is_chatgpt_auth)
     }
 
     fn lower_cost_preset(&self) -> Option<ModelPreset> {

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1139,6 +1139,22 @@ fn set_chatgpt_auth(chat: &mut ChatWidget) {
 }
 
 #[tokio::test]
+async fn prefetch_rate_limits_is_gated_on_chatgpt_auth_provider() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
+
+    assert!(!chat.should_prefetch_rate_limits());
+
+    set_chatgpt_auth(&mut chat);
+    assert!(chat.should_prefetch_rate_limits());
+
+    chat.config.model_provider.requires_openai_auth = false;
+    assert!(!chat.should_prefetch_rate_limits());
+
+    chat.prefetch_rate_limits();
+    assert!(chat.rate_limit_poller.is_none());
+}
+
+#[tokio::test]
 async fn worked_elapsed_from_resets_when_timer_restarts() {
     let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
     assert_eq!(chat.worked_elapsed_from(5), 5);


### PR DESCRIPTION
Fixes #10869

- Gate TUI rate-limit polling on ChatGPT-auth providers only.
- `prefetch_rate_limits()` now checks `should_prefetch_rate_limits()`.
- New gate requires:
  - `config.model_provider.requires_openai_auth`
  - cached auth is ChatGPT (`CodexAuth::is_chatgpt_auth`)
- Prevents `/wham/usage` polling in API/custom-endpoint profiles.
