### PR TITLE
core: improve remote compaction failure observability

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -114,6 +114,7 @@ use crate::config::resolve_web_search_mode_for_turn;
 use crate::config::types::McpServerConfig;
 use crate::config::types::ShellEnvironmentPolicy;
 use crate::context_manager::ContextManager;
+use crate::context_manager::TotalTokenUsageBreakdown;
 use crate::environment_context::EnvironmentContext;
 use crate::error::CodexErr;
 use crate::error::Result as CodexResult;
@@ -1214,12 +1215,20 @@ impl Session {
         format!("auto-compact-{id}")
     }
 
-    async fn get_total_token_usage(&self) -> i64 {
+    pub(crate) async fn get_total_token_usage(&self) -> i64 {
         let state = self.state.lock().await;
         state.get_total_token_usage(state.server_reasoning_included())
     }
 
-    async fn get_estimated_token_count(&self, turn_context: &TurnContext) -> Option<i64> {
+    pub(crate) async fn get_total_token_usage_breakdown(&self) -> TotalTokenUsageBreakdown {
+        let state = self.state.lock().await;
+        state.get_total_token_usage_breakdown()
+    }
+
+    pub(crate) async fn get_estimated_token_count(
+        &self,
+        turn_context: &TurnContext,
+    ) -> Option<i64> {
         let state = self.state.lock().await;
         state.history.estimate_token_count(turn_context)
     }

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -4,6 +4,7 @@ use crate::instructions::SkillInstructions;
 use crate::instructions::UserInstructions;
 use crate::session_prefix::is_session_prefix;
 use crate::truncate::TruncationPolicy;
+use crate::truncate::approx_bytes_for_tokens;
 use crate::truncate::approx_token_count;
 use crate::truncate::approx_tokens_from_byte_count;
 use crate::truncate::truncate_function_output_items_with_policy;
@@ -25,6 +26,14 @@ pub(crate) struct ContextManager {
     /// The oldest items are at the beginning of the vector.
     items: Vec<ResponseItem>,
     token_info: Option<TokenUsageInfo>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct TotalTokenUsageBreakdown {
+    pub last_api_response_total_tokens: i64,
+    pub last_api_response_total_bytes_estimate: usize,
+    pub estimated_tokens_of_items_added_since_last_successful_api_response: i64,
+    pub estimated_bytes_of_items_added_since_last_successful_api_response: usize,
 }
 
 impl ContextManager {
@@ -247,6 +256,21 @@ impl ContextManager {
         total
     }
 
+    fn get_trailing_codex_generated_items_bytes(&self) -> usize {
+        let mut total = 0usize;
+        for item in self.items.iter().rev() {
+            if !is_codex_generated_item(item) {
+                break;
+            }
+            total = total.saturating_add(
+                serde_json::to_vec(item)
+                    .map(|bytes| bytes.len())
+                    .unwrap_or_default(),
+            );
+        }
+        total
+    }
+
     /// When true, the server already accounted for past reasoning tokens and
     /// the client should not re-estimate them.
     pub(crate) fn get_total_token_usage(&self, server_reasoning_included: bool) -> i64 {
@@ -262,6 +286,29 @@ impl ContextManager {
             last_tokens
                 .saturating_add(self.get_non_last_reasoning_items_tokens())
                 .saturating_add(trailing_codex_generated_tokens)
+        }
+    }
+
+    pub(crate) fn get_total_token_usage_breakdown(&self) -> TotalTokenUsageBreakdown {
+        let last_usage = self
+            .token_info
+            .as_ref()
+            .map(|info| info.last_token_usage.clone())
+            .unwrap_or_default();
+
+        TotalTokenUsageBreakdown {
+            last_api_response_total_tokens: last_usage.total_tokens,
+            last_api_response_total_bytes_estimate: if last_usage.total_tokens <= 0 {
+                0
+            } else {
+                usize::try_from(last_usage.total_tokens)
+                    .map(approx_bytes_for_tokens)
+                    .unwrap_or(usize::MAX)
+            },
+            estimated_tokens_of_items_added_since_last_successful_api_response: self
+                .get_trailing_codex_generated_items_tokens(),
+            estimated_bytes_of_items_added_since_last_successful_api_response: self
+                .get_trailing_codex_generated_items_bytes(),
         }
     }
 

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -247,12 +247,13 @@ impl ContextManager {
 
     // These are local items added after the most recent model-emitted item.
     // They are not reflected in `last_token_usage.total_tokens`.
+    // If no model item has been emitted yet, treat the delta as empty.
     fn items_after_last_model_generated_item(&self) -> &[ResponseItem] {
         let start = self
             .items
             .iter()
             .rposition(is_model_generated_item)
-            .map_or(0, |index| index.saturating_add(1));
+            .map_or(self.items.len(), |index| index.saturating_add(1));
         &self.items[start..]
     }
 

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -247,7 +247,6 @@ impl ContextManager {
 
     // These are local items added after the most recent model-emitted item.
     // They are not reflected in `last_token_usage.total_tokens`.
-    // If no model item has been emitted yet, treat the delta as empty.
     fn items_after_last_model_generated_item(&self) -> &[ResponseItem] {
         let start = self
             .items

--- a/codex-rs/core/src/context_manager/history_tests.rs
+++ b/codex-rs/core/src/context_manager/history_tests.rs
@@ -250,6 +250,31 @@ fn usage_breakdown_counts_no_items_after_last_model_generated_item() {
 }
 
 #[test]
+fn usage_breakdown_is_zero_without_model_generated_items() {
+    let mut history = create_history_with_items(vec![user_msg("no model output yet")]);
+    history.update_token_info(
+        &TokenUsage {
+            total_tokens: 100,
+            ..Default::default()
+        },
+        None,
+    );
+
+    assert_eq!(
+        history
+            .get_total_token_usage_breakdown()
+            .estimated_tokens_of_items_added_since_last_successful_api_response,
+        0
+    );
+    assert_eq!(
+        history
+            .get_total_token_usage_breakdown()
+            .estimated_bytes_of_items_added_since_last_successful_api_response,
+        0
+    );
+}
+
+#[test]
 fn total_token_usage_includes_all_items_after_last_model_generated_item() {
     let mut history = create_history_with_items(vec![assistant_msg("already counted by API")]);
     history.update_token_info(

--- a/codex-rs/core/src/context_manager/history_tests.rs
+++ b/codex-rs/core/src/context_manager/history_tests.rs
@@ -182,7 +182,7 @@ fn non_last_reasoning_tokens_ignore_entries_after_last_user() {
 }
 
 #[test]
-fn usage_breakdown_counts_all_items_added_since_last_usage() {
+fn usage_breakdown_counts_all_items_after_last_model_generated_item() {
     let mut history = create_history_with_items(vec![assistant_msg("already counted by API")]);
     history.update_token_info(
         &TokenUsage {
@@ -225,7 +225,7 @@ fn usage_breakdown_counts_all_items_added_since_last_usage() {
 }
 
 #[test]
-fn usage_breakdown_counts_no_added_items_when_nothing_changed_since_last_usage() {
+fn usage_breakdown_counts_no_items_after_last_model_generated_item() {
     let mut history = create_history_with_items(vec![assistant_msg("already counted by API")]);
     history.update_token_info(
         &TokenUsage {
@@ -250,7 +250,7 @@ fn usage_breakdown_counts_no_added_items_when_nothing_changed_since_last_usage()
 }
 
 #[test]
-fn total_token_usage_includes_all_items_added_since_last_usage() {
+fn total_token_usage_includes_all_items_after_last_model_generated_item() {
     let mut history = create_history_with_items(vec![assistant_msg("already counted by API")]);
     history.update_token_info(
         &TokenUsage {

--- a/codex-rs/core/src/context_manager/history_tests.rs
+++ b/codex-rs/core/src/context_manager/history_tests.rs
@@ -62,13 +62,6 @@ fn user_input_text_msg(text: &str) -> ResponseItem {
     }
 }
 
-fn function_call_output(call_id: &str, content: &str) -> ResponseItem {
-    ResponseItem::FunctionCallOutput {
-        call_id: call_id.to_string(),
-        output: FunctionCallOutputPayload::from_text(content.to_string()),
-    }
-}
-
 fn custom_tool_call_output(call_id: &str, output: &str) -> ResponseItem {
     ResponseItem::CustomToolCallOutput {
         call_id: call_id.to_string(),
@@ -189,48 +182,51 @@ fn non_last_reasoning_tokens_ignore_entries_after_last_user() {
 }
 
 #[test]
-fn trailing_codex_generated_tokens_stop_at_first_non_generated_item() {
-    let earlier_output = function_call_output("call-earlier", "earlier output");
-    let trailing_function_output = function_call_output("call-tail-1", "tail function output");
-    let trailing_custom_output = custom_tool_call_output("call-tail-2", "tail custom output");
-    let history = create_history_with_items(vec![
-        earlier_output,
-        user_msg("boundary item"),
-        trailing_function_output.clone(),
-        trailing_custom_output.clone(),
-    ]);
-    let expected_tokens = estimate_item_token_count(&trailing_function_output)
-        .saturating_add(estimate_item_token_count(&trailing_custom_output));
+fn usage_breakdown_counts_all_items_added_since_last_usage() {
+    let mut history = create_history_with_items(vec![assistant_msg("already counted by API")]);
+    history.update_token_info(
+        &TokenUsage {
+            total_tokens: 100,
+            ..Default::default()
+        },
+        None,
+    );
+
+    let added_user = user_msg("new user message");
+    let added_tool_output = custom_tool_call_output("call-tail", "new tool output");
+    history.record_items(
+        [&added_user, &added_tool_output],
+        TruncationPolicy::Tokens(10_000),
+    );
+
+    let expected_tokens = estimate_item_token_count(&added_user)
+        .saturating_add(estimate_item_token_count(&added_tool_output));
+    let expected_bytes = serde_json::to_vec(&added_user)
+        .map(|bytes| bytes.len())
+        .unwrap_or_default()
+        .saturating_add(
+            serde_json::to_vec(&added_tool_output)
+                .map(|bytes| bytes.len())
+                .unwrap_or_default(),
+        );
 
     assert_eq!(
-        history.get_trailing_codex_generated_items_tokens(),
+        history
+            .get_total_token_usage_breakdown()
+            .estimated_tokens_of_items_added_since_last_successful_api_response,
         expected_tokens
+    );
+    assert_eq!(
+        history
+            .get_total_token_usage_breakdown()
+            .estimated_bytes_of_items_added_since_last_successful_api_response,
+        expected_bytes
     );
 }
 
 #[test]
-fn trailing_codex_generated_tokens_exclude_function_call_tail() {
-    let history = create_history_with_items(vec![ResponseItem::FunctionCall {
-        id: None,
-        name: "not-generated".to_string(),
-        arguments: "{}".to_string(),
-        call_id: "call-tail".to_string(),
-    }]);
-
-    assert_eq!(history.get_trailing_codex_generated_items_tokens(), 0);
-}
-
-#[test]
-fn total_token_usage_includes_only_trailing_codex_generated_items() {
-    let non_trailing_output = function_call_output("call-before-message", "not trailing");
-    let trailing_assistant = assistant_msg("assistant boundary");
-    let trailing_output = custom_tool_call_output("tool-tail", "trailing output");
-    let mut history = create_history_with_items(vec![
-        non_trailing_output,
-        user_msg("boundary"),
-        trailing_assistant,
-        trailing_output.clone(),
-    ]);
+fn usage_breakdown_counts_no_added_items_when_nothing_changed_since_last_usage() {
+    let mut history = create_history_with_items(vec![assistant_msg("already counted by API")]);
     history.update_token_info(
         &TokenUsage {
             total_tokens: 100,
@@ -240,8 +236,40 @@ fn total_token_usage_includes_only_trailing_codex_generated_items() {
     );
 
     assert_eq!(
+        history
+            .get_total_token_usage_breakdown()
+            .estimated_tokens_of_items_added_since_last_successful_api_response,
+        0
+    );
+    assert_eq!(
+        history
+            .get_total_token_usage_breakdown()
+            .estimated_bytes_of_items_added_since_last_successful_api_response,
+        0
+    );
+}
+
+#[test]
+fn total_token_usage_includes_all_items_added_since_last_usage() {
+    let mut history = create_history_with_items(vec![assistant_msg("already counted by API")]);
+    history.update_token_info(
+        &TokenUsage {
+            total_tokens: 100,
+            ..Default::default()
+        },
+        None,
+    );
+    let added_user = user_msg("new user message");
+    let added_tool_output = custom_tool_call_output("tool-tail", "new tool output");
+    history.record_items(
+        [&added_user, &added_tool_output],
+        TruncationPolicy::Tokens(10_000),
+    );
+
+    assert_eq!(
         history.get_total_token_usage(true),
-        100 + estimate_item_token_count(&trailing_output)
+        100 + estimate_item_token_count(&added_user)
+            + estimate_item_token_count(&added_tool_output)
     );
 }
 

--- a/codex-rs/core/src/context_manager/mod.rs
+++ b/codex-rs/core/src/context_manager/mod.rs
@@ -2,5 +2,6 @@ mod history;
 mod normalize;
 
 pub(crate) use history::ContextManager;
+pub(crate) use history::TotalTokenUsageBreakdown;
 pub(crate) use history::is_codex_generated_item;
 pub(crate) use history::is_user_turn_boundary;

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 
 use crate::codex::SessionConfiguration;
 use crate::context_manager::ContextManager;
+use crate::context_manager::TotalTokenUsageBreakdown;
 use crate::protocol::RateLimitSnapshot;
 use crate::protocol::TokenUsage;
 use crate::protocol::TokenUsageInfo;
@@ -98,6 +99,10 @@ impl SessionState {
     pub(crate) fn get_total_token_usage(&self, server_reasoning_included: bool) -> i64 {
         self.history
             .get_total_token_usage(server_reasoning_included)
+    }
+
+    pub(crate) fn get_total_token_usage_breakdown(&self) -> TotalTokenUsageBreakdown {
+        self.history.get_total_token_usage_breakdown()
     }
 
     pub(crate) fn set_server_reasoning_included(&mut self, included: bool) {


### PR DESCRIPTION
## Summary
- capture and log the full remote compaction request payload before returning a compaction error
- log explicit diagnostics in the same failure path: status code, last API-reported total tokens/bytes estimate, and estimated tokens/bytes for items that are not yet reflected in the last API usage snapshot
- expose a narrow `TotalTokenUsageBreakdown` from session/context manager so compaction failure logging reports stable, specific fields
- estimate the post-usage delta with a non-stateful boundary: scan backward to the most recent model-generated history item, then count all items after it (user/developer/tool outputs/etc.)
- if no model-generated item exists yet, treat that delta as empty (prevents premature auto-compaction before first model output)

## Test Fixes Included
- fix `suite::compact` regressions caused by the new boundary behavior
- remove stale `Feature::RemoteCompaction` toggles from `suite/compact_remote.rs` (feature no longer exists), so the `all` integration target compiles

## Why
When compaction fails with `context_length_exceeded`, we need both:
1. the exact failing request payload, and
2. a delta estimate that better matches local history growth after model output.

The previous trailing-codex-generated approach could miss non-codex items appended after model output. The new boundary includes all appended items after the latest model-generated item while staying simple and readable.

## Validation
- `just fmt`
- `cargo test -p codex-core --lib history::tests::`
- `cargo test -p codex-core --test all suite::compact::auto_compact_ -- --nocapture`
- relying on CI for full suite
