### PR TITLE
fix: remove config.schema.json from tag check

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -45,15 +45,6 @@ jobs:
           echo "✅  Tag and Cargo.toml agree (${tag_ver})"
           echo "::endgroup::"
 
-      - name: Verify config schema fixture
-        shell: bash
-        working-directory: codex-rs
-        run: |
-          set -euo pipefail
-          echo "If this fails, run: just write-config-schema to overwrite fixture with intentional changes."
-          cargo run -p codex-core --bin codex-write-config-schema
-          git diff --exit-code core/config.schema.json
-
   build:
     needs: tag-check
     name: Build - ${{ matrix.runner }} - ${{ matrix.target }}


### PR DESCRIPTION
Given that we have https://github.com/openai/codex/pull/10977, the existing "Verify config schema fixture" step seems unnecessary. Further, because it happens as part of the `tag-check` job (which is meant to be fast), it slows down the entire build process because it delays the more expensive steps from starting. 