### PR TITLE
fix: normalize line endings when reading file on Windows

### DIFF
--- a/codex-rs/core/src/config/schema.rs
+++ b/codex-rs/core/src/config/schema.rs
@@ -138,6 +138,9 @@ Run `just write-config-schema` to overwrite with your changes.\n\n{diff}"
         write_config_schema(&tmp_path).expect("write config schema to temp path");
         let tmp_contents =
             std::fs::read_to_string(&tmp_path).expect("read back config schema from temp path");
+        #[cfg(windows)]
+        let fixture = fixture.replace("\r\n", "\n");
+
         assert_eq!(
             fixture, tmp_contents,
             "fixture should match exactly with generated schema"


### PR DESCRIPTION
I did not wait for CI on https://github.com/openai/codex/pull/10980 because it was blocking an alpha release, but apparently it broken the Windows build.