### PR TITLE
Preserve websocket v2 state/connection across turns

### DIFF
--- a/codex-rs/core/tests/suite/turn_state.rs
+++ b/codex-rs/core/tests/suite/turn_state.rs
@@ -221,9 +221,14 @@ async fn websocket_v2_reconnect_after_turn_boundary_does_not_replay_turn_state()
         .first()
         .expect("second websocket connection should have a request")
         .body_json();
-    assert_eq!(
-        second_request["previous_response_id"].as_str(),
-        Some("resp-1")
+    assert_eq!(second_request.get("previous_response_id"), None);
+    let second_input_len = second_request["input"]
+        .as_array()
+        .map(Vec::len)
+        .unwrap_or(0);
+    assert!(
+        second_input_len > 1,
+        "reconnect should send full input items, got {second_input_len}"
     );
 
     server.shutdown().await;


### PR DESCRIPTION
**Summary**
- add shared session state for v2 websocket connections so turns can reuse the socket and prior response chain
- clear or reuse shared chain data at the right turn boundaries and keep diagnostics updated accordingly
- extend websocket suite with scenarios covering reuse and reconnection behavior



**Test Plan**
added tests + 

```
cargo build -p codex-cli && RUST_LOG='codex_api::endpoint::responses_websocket=trace,codex_core::client=debug,codex_core::codex=debug' \
  ./target/debug/codex \
    --enable responses_websockets_v2 \
    --profile localapi \
    --full-auto
```