### PR TITLE
Fix flaky windows CI test

### DIFF
--- a/codex-rs/mcp-server/tests/suite/codex_tool.rs
+++ b/codex-rs/mcp-server/tests/suite/codex_tool.rs
@@ -505,6 +505,9 @@ base_url = "{server_uri}/v1"
 wire_api = "responses"
 request_max_retries = 0
 stream_max_retries = 0
+
+[features]
+remote_models = false
 "#
         ),
     )


### PR DESCRIPTION
Hardens PTY Python REPL test and make MCP test startup deterministic

**Summary**
- `utils/pty/src/tests.rs`
  - Added a REPL readiness handshake (`wait_for_python_repl_ready`) that repeatedly sends a marker and waits for it in PTY output before sending test commands.
  - Updated `pty_python_repl_emits_output_and_exits` to:
    - wait for readiness first,
    - preserve startup output,
    - append output collected through process exit.
  - Reduces Windows/ConPTY flakiness from early stdin writes racing REPL startup.

- `mcp-server/tests/suite/codex_tool.rs`
  - Avoid remote model refresh during MCP test startup, reducing timeout-prone nondeterminism.
