### PR TITLE
Add plan implementation option to start in new thread

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -59,6 +59,12 @@ pub(crate) enum AppEvent {
     /// Start a new session.
     NewSession,
 
+    /// Start a new session and immediately submit an initial message.
+    NewSessionWithInitialMessage {
+        text: String,
+        model: String,
+    },
+
     /// Open the resume picker inside the running TUI session.
     OpenResumePicker,
 

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup.snap
@@ -4,7 +4,9 @@ expression: popup
 ---
   Implement this plan?
 
-› 1. Yes, implement this plan  Switch to Default and start coding.
-  2. No, stay in Plan mode     Continue planning with the model.
+› 1. Yes, implement this plan      Switch to Default and start coding.
+  2. Yes, implement in new thread  Start a fresh thread and begin
+                                   implementation with the plan.
+  3. No, stay in Plan mode         Continue planning with the model.
 
   Press enter to confirm or esc to go back

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup_no_selected.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__plan_implementation_popup_no_selected.snap
@@ -4,7 +4,9 @@ expression: popup
 ---
   Implement this plan?
 
-  1. Yes, implement this plan  Switch to Default and start coding.
-› 2. No, stay in Plan mode     Continue planning with the model.
+  1. Yes, implement this plan      Switch to Default and start coding.
+  2. Yes, implement in new thread  Start a fresh thread and begin
+                                   implementation with the plan.
+› 3. No, stay in Plan mode         Continue planning with the model.
 
   Press enter to confirm or esc to go back


### PR DESCRIPTION
- Summary: Add a new "Implement in new thread" option after Plan mode completes.
- Related: Partially addresses #10948 (CLI/TUI only; no thinking-level picker).
- Root cause: Implementing immediately in the same thread can keep a lot of planning context around.
- Fix: Capture the proposed plan text, start a fresh session in Default mode, and auto-submit an initial message containing the plan.
- Tests: `cargo test -p codex-tui`
