### PR TITLE
feat(process-hardening): add config-gated pre-main hardening opt-out

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1950,8 +1950,12 @@ dependencies = [
 name = "codex-process-hardening"
 version = "0.0.0"
 dependencies = [
+ "codex-utils-home-dir",
  "libc",
  "pretty_assertions",
+ "serde",
+ "tempfile",
+ "toml 0.9.11+spec-1.1.0",
 ]
 
 [[package]]

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -923,6 +923,17 @@
       },
       "type": "object"
     },
+    "SecurityConfigToml": {
+      "additionalProperties": false,
+      "description": "Security settings loaded from config.toml. Fields are optional so we can apply defaults.",
+      "properties": {
+        "process_hardening_disable": {
+          "description": "When `true`, disables process hardening (e.g enables ptrace attach).",
+          "type": "boolean"
+        }
+      },
+      "type": "object"
+    },
     "ShellEnvironmentPolicyInherit": {
       "oneOf": [
         {
@@ -1560,6 +1571,15 @@
         }
       ],
       "description": "Sandbox configuration to apply if `sandbox` is `WorkspaceWrite`."
+    },
+    "security": {
+      "allOf": [
+        {
+          "$ref": "#/definitions/SecurityConfigToml"
+        }
+      ],
+      "default": null,
+      "description": "Security settings."
     },
     "shell_environment_policy": {
       "allOf": [

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -14,6 +14,7 @@ use crate::config::types::OtelConfig;
 use crate::config::types::OtelConfigToml;
 use crate::config::types::OtelExporterKind;
 use crate::config::types::SandboxWorkspaceWrite;
+use crate::config::types::SecurityConfigToml;
 use crate::config::types::ShellEnvironmentPolicy;
 use crate::config::types::ShellEnvironmentPolicyToml;
 use crate::config::types::SkillsConfig;
@@ -864,6 +865,10 @@ pub struct ConfigToml {
 
     /// Sandbox configuration to apply if `sandbox` is `WorkspaceWrite`.
     pub sandbox_workspace_write: Option<SandboxWorkspaceWrite>,
+
+    /// Security settings.
+    #[serde(default)]
+    pub security: Option<SecurityConfigToml>,
 
     /// Optional external command to spawn for end-user notifications.
     #[serde(default)]

--- a/codex-rs/core/src/config/types.rs
+++ b/codex-rs/core/src/config/types.rs
@@ -323,6 +323,16 @@ pub enum HistoryPersistence {
     None,
 }
 
+// ===== Security configuration =====
+
+/// Security settings loaded from config.toml. Fields are optional so we can apply defaults.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default, JsonSchema)]
+#[schemars(deny_unknown_fields)]
+pub struct SecurityConfigToml {
+    /// When `true`, disables process hardening for this installation.
+    pub process_hardening_disable: Option<bool>,
+}
+
 // ===== Analytics configuration =====
 
 /// Analytics settings loaded from config.toml. Fields are optional so we can apply defaults.

--- a/codex-rs/process-hardening/Cargo.toml
+++ b/codex-rs/process-hardening/Cargo.toml
@@ -12,7 +12,11 @@ path = "src/lib.rs"
 workspace = true
 
 [dependencies]
+codex-utils-home-dir = { workspace = true }
 libc = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+toml = { workspace = true }
 
 [dev-dependencies]
 pretty_assertions = { workspace = true }
+tempfile = { workspace = true }

--- a/codex-rs/process-hardening/README.md
+++ b/codex-rs/process-hardening/README.md
@@ -5,3 +5,11 @@ This crate provides `pre_main_hardening()`, which is designed to be called pre-`
 - disabling core dumps
 - disabling ptrace attach on Linux and macOS
 - removing dangerous environment variables such as `LD_PRELOAD` and `DYLD_*`
+
+To opt out in dev or test environments, set the following in your
+`~/.codex/config.toml`:
+
+```toml
+[security]
+process_hardening_disable = true
+```

--- a/docs/config.md
+++ b/docs/config.md
@@ -24,6 +24,16 @@ Codex can run a notification hook when the agent finishes a turn. See the config
 
 - https://developers.openai.com/codex/config-reference
 
+## Process hardening
+
+Codex applies process hardening by default. To disable it in dev or test
+environments, add the following to `~/.codex/config.toml`:
+
+```toml
+[security]
+process_hardening_disable = true
+```
+
 ## JSON Schema
 
 The generated JSON Schema for `config.toml` lives at `codex-rs/core/config.schema.json`.


### PR DESCRIPTION
## What

Adds a config-gated opt-out for pre-main process hardening:

- Add `[security].process_hardening_disable` in config types/schema/docs.
- Update `codex-process-hardening` to read this flag before applying hardening.
- Keep secure default behavior: hardening remains enabled unless explicitly disabled.
- Add unit tests for missing/invalid/true/false config handling.
- Read only `${CODEX_HOME}/config.toml` (home-level), not repo/project config layers, to avoid untrusted-repo config injection. This preserves safe defaults while allowing explicit opt-out.

## Why

Dev/test workflows (debugger attach, ASan/LSan) currently conflict with hardening defaults.

## How

- Added `security.process_hardening_disable` to config model and schema.
- Implemented fail-closed pre-main check in `codex-process-hardening`:
  - missing/invalid config => **hardening stays enabled.**
  - explicit `true` => hardening disabled.
- Added tests for config parsing behavior and env-key filtering behavior.

## Issue

- Issue: https://github.com/openai/codex/issues/10998

## Validation

Run locally:

- `cd codex-rs`
- `just fmt`
- `just fix -p codex-process-hardening`
- `cargo test -p codex-process-hardening`
- `cargo test -p codex-core`

## Risk / Security Notes

- Default remains secure (hardening enabled).
- Opt-out is explicit and user-local only (`CODEX_HOME` / `~/.codex/config.toml`), not repo-injected.

## Alternatives

Use environment variables to gate hardening.