### PR TITLE
Handle MCP image blocks for non-multimodal models

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3921,7 +3921,9 @@ pub(crate) async fn run_turn(
                 error_or_panic(
                     "Invalid image detected; sanitizing tool output to prevent poisoning",
                 );
-                if state.history.replace_last_turn_images("Invalid image") {
+                if state.history.replace_last_turn_images(
+                    "[there was an image here but it was removed for non-multimodal models]",
+                ) {
                     continue;
                 }
                 let event = EventMsg::Error(ErrorEvent {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3937,10 +3937,7 @@ pub(crate) async fn run_turn(
                 error_or_panic(
                     "Invalid image detected; sanitizing tool output to prevent poisoning",
                 );
-                if state
-                    .history
-                    .replace_last_turn_images(NON_MULTIMODAL_IMAGE_PLACEHOLDER)
-                {
+                if state.history.replace_last_turn_images("Invalid image") {
                     continue;
                 }
                 let event = EventMsg::Error(ErrorEvent {

--- a/codex-rs/core/src/context_manager/history_tests.rs
+++ b/codex-rs/core/src/context_manager/history_tests.rs
@@ -354,7 +354,9 @@ fn replace_last_turn_images_replaces_tool_output_images() {
     ];
     let mut history = create_history_with_items(items);
 
-    assert!(history.replace_last_turn_images("Invalid image"));
+    assert!(history.replace_last_turn_images(
+        "[there was an image here but it was removed for non-multimodal models]"
+    ));
 
     assert_eq!(
         history.raw_items(),
@@ -365,7 +367,9 @@ fn replace_last_turn_images_replaces_tool_output_images() {
                 output: FunctionCallOutputPayload {
                     body: FunctionCallOutputBody::ContentItems(vec![
                         FunctionCallOutputContentItem::InputText {
-                            text: "Invalid image".to_string(),
+                            text:
+                                "[there was an image here but it was removed for non-multimodal models]"
+                                    .to_string(),
                         },
                     ]),
                     success: Some(true),
@@ -388,7 +392,9 @@ fn replace_last_turn_images_does_not_touch_user_images() {
     }];
     let mut history = create_history_with_items(items.clone());
 
-    assert!(!history.replace_last_turn_images("Invalid image"));
+    assert!(!history.replace_last_turn_images(
+        "[there was an image here but it was removed for non-multimodal models]"
+    ));
     assert_eq!(history.raw_items(), items);
 }
 

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -597,9 +597,7 @@ async fn replaces_invalid_local_image_after_bad_request() -> anyhow::Result<()> 
         "second request should replace the invalid image"
     );
     let user_texts = second_request.message_input_texts("user");
-    assert!(user_texts.iter().any(|text| {
-        text == "[there was an image here but it was removed for non-multimodal models]"
-    }));
+    assert!(user_texts.iter().any(|text| text == "Invalid image"));
 
     Ok(())
 }

--- a/codex-rs/core/tests/suite/view_image.rs
+++ b/codex-rs/core/tests/suite/view_image.rs
@@ -597,7 +597,9 @@ async fn replaces_invalid_local_image_after_bad_request() -> anyhow::Result<()> 
         "second request should replace the invalid image"
     );
     let user_texts = second_request.message_input_texts("user");
-    assert!(user_texts.iter().any(|text| text == "Invalid image"));
+    assert!(user_texts.iter().any(|text| {
+        text == "[there was an image here but it was removed for non-multimodal models]"
+    }));
 
     Ok(())
 }


### PR DESCRIPTION
- replace MCP image blocks with placeholder text blocks for non-multimodal models