### PR TITLE
TUI: fix request_user_input wrapping for long option labels

### DIFF
--- a/codex-rs/tui/src/bottom_pane/list_selection_view.rs
+++ b/codex-rs/tui/src/bottom_pane/list_selection_view.rs
@@ -631,7 +631,7 @@ impl Renderable for ListSelectionView {
                     "no matches",
                     ColumnWidthMode::Fixed,
                 ),
-            }
+            };
         }
 
         if footer_area.height > 0 {

--- a/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/mod.rs
@@ -1408,6 +1408,37 @@ mod tests {
         }
     }
 
+    fn question_with_long_scroll_options(id: &str, header: &str) -> RequestUserInputQuestion {
+        RequestUserInputQuestion {
+            id: id.to_string(),
+            header: header.to_string(),
+            question:
+                "Choose one option; each hint is intentionally very long to test wrapped scrolling."
+                    .to_string(),
+            is_other: false,
+            is_secret: false,
+            options: Some(vec![
+                RequestUserInputQuestionOption {
+                    label: "Use Detailed Hint A (Recommended)".to_string(),
+                    description: "Select this if you want a deliberately overextended explanatory hint that reads like a miniature specification, including context, rationale, expected behavior, and an explicit statement that this choice is mainly for testing how gracefully the interface wraps, truncates, and preserves readability under unusually verbose helper text conditions.".to_string(),
+                },
+                RequestUserInputQuestionOption {
+                    label: "Use Detailed Hint B".to_string(),
+                    description: "Select this if you want an equally verbose but differently phrased guidance block that emphasizes user-facing clarity, spacing tolerance, multiline wrapping, visual hierarchy interactions, and whether long descriptive metadata remains understandable when scanned quickly in a constrained layout where cognitive load is already high.".to_string(),
+                },
+                RequestUserInputQuestionOption {
+                    label: "Use Detailed Hint C".to_string(),
+                    description: "Select this when you specifically want to verify that navigating downward will keep the currently highlighted option visible, even when previous options consume many wrapped lines and would otherwise push the selection out of the viewport.".to_string(),
+                },
+                RequestUserInputQuestionOption {
+                    label: "None of the above".to_string(),
+                    description:
+                        "Use this only if the previous long-form options do not apply.".to_string(),
+                },
+            ]),
+        }
+    }
+
     fn question_without_options(id: &str, header: &str) -> RequestUserInputQuestion {
         RequestUserInputQuestion {
             id: id.to_string(),
@@ -2618,6 +2649,29 @@ mod tests {
         insta::assert_snapshot!(
             "request_user_input_long_option_text",
             render_snapshot(&overlay, area)
+        );
+    }
+
+    #[test]
+    fn selected_long_wrapped_option_stays_visible() {
+        let (tx, _rx) = test_sender();
+        let mut overlay = RequestUserInputOverlay::new(
+            request_event(
+                "turn-1",
+                vec![question_with_long_scroll_options("q1", "Scroll")],
+            ),
+            tx,
+            true,
+            false,
+            false,
+        );
+        let answer = overlay.current_answer_mut().expect("answer missing");
+        answer.options_state.selected_idx = Some(2);
+
+        let rendered = render_snapshot(&overlay, Rect::new(0, 0, 80, 20));
+        assert!(
+            rendered.contains("› 3. Use Detailed Hint C"),
+            "expected selected option to be visible in viewport\n{rendered}"
         );
     }
 

--- a/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
@@ -306,6 +306,9 @@ impl RequestUserInputOverlay {
 
         // Build rows with selection markers for the shared selection renderer.
         let option_rows = self.option_rows();
+        let options_hidden = self.has_options()
+            && sections.options_area.height > 0
+            && self.options_required_height(content_area.width) > sections.options_area.height;
 
         if self.has_options() {
             let mut options_state = self
@@ -316,7 +319,7 @@ impl RequestUserInputOverlay {
                 // Ensure the selected option is visible in the scroll window.
                 options_state
                     .ensure_visible(option_rows.len(), sections.options_area.height as usize);
-                render_rows(
+                render_rows_bottom_aligned(
                     sections.options_area,
                     buf,
                     &option_rows,
@@ -344,9 +347,6 @@ impl RequestUserInputOverlay {
         if footer_area.height == 0 {
             return;
         }
-        let options_hidden = self.has_options()
-            && sections.options_area.height > 0
-            && self.options_required_height(content_area.width) > sections.options_area.height;
         let option_tip = if options_hidden {
             let selected = self.selected_option_index().unwrap_or(0).saturating_add(1);
             let total = self.options_len();
@@ -429,6 +429,48 @@ fn line_width(line: &Line<'_>) -> usize {
     line.iter()
         .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
         .sum()
+}
+
+/// Render rows into `area`, bottom-aligning the visible rows when fewer than
+/// `area.height` lines are produced.
+///
+/// This keeps footer spacing stable by anchoring the options block to the
+/// bottom of its allocated region.
+fn render_rows_bottom_aligned(
+    area: Rect,
+    buf: &mut Buffer,
+    rows: &[crate::bottom_pane::selection_popup_common::GenericDisplayRow],
+    state: &ScrollState,
+    max_results: usize,
+    empty_message: &str,
+) {
+    if area.width == 0 || area.height == 0 {
+        return;
+    }
+
+    let scratch_area = Rect::new(0, 0, area.width, area.height);
+    let mut scratch = Buffer::empty(scratch_area);
+    for y in 0..area.height {
+        for x in 0..area.width {
+            scratch[(x, y)] = buf[(area.x + x, area.y + y)].clone();
+        }
+    }
+    let rendered_height = render_rows(
+        scratch_area,
+        &mut scratch,
+        rows,
+        state,
+        max_results,
+        empty_message,
+    );
+
+    let visible_height = rendered_height.min(area.height);
+    let y_offset = area.height.saturating_sub(visible_height);
+    for y in 0..visible_height {
+        for x in 0..area.width {
+            buf[(area.x + x, area.y + y_offset + y)] = scratch[(x, y)].clone();
+        }
+    }
 }
 
 /// Truncate a styled line to `max_width`, preferring a word boundary, and append an ellipsis.

--- a/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/render.rs
@@ -306,9 +306,6 @@ impl RequestUserInputOverlay {
 
         // Build rows with selection markers for the shared selection renderer.
         let option_rows = self.option_rows();
-        let options_hidden = self.has_options()
-            && sections.options_area.height > 0
-            && self.options_required_height(content_area.width) > sections.options_area.height;
 
         if self.has_options() {
             let mut options_state = self
@@ -347,6 +344,9 @@ impl RequestUserInputOverlay {
         if footer_area.height == 0 {
             return;
         }
+        let options_hidden = self.has_options()
+            && sections.options_area.height > 0
+            && self.options_required_height(content_area.width) > sections.options_area.height;
         let option_tip = if options_hidden {
             let selected = self.selected_option_index().unwrap_or(0).saturating_add(1);
             let total = self.options_len();

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_long_option_text.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_long_option_text.snap
@@ -1,16 +1,17 @@
 ---
 source: tui/src/bottom_pane/request_user_input/mod.rs
-assertion_line: 2618
 expression: "render_snapshot(&overlay, area)"
 ---
                                                                                                                         
   Question 1/1 (1 unanswered)                                                                                           
   Choose one option.                                                                                                    
                                                                                                                         
-  › 1. Job: running/completed/failed/expired; Run/          Keep async job statuses for progress tracking and include   
-       Experiment: succeeded/failed/unknown (Recommended    enough context for debugging retries, stale workers, and    
-       when triaging long-running background work and       unexpected expiration paths.                                
-       status transitions)                                                                                              
-    2. Add a short status model                             Simpler labels with less detail for quick rollouts.         
+  › 1. Job: running/completed/failed/expired; Run/Experiment: succeeded/failed/    Keep async job statuses for          
+       unknown (Recommended when triaging long-running background work and status  progress tracking and include        
+       transitions)                                                                enough context for debugging         
+                                                                                   retries, stale workers, and          
+                                                                                   unexpected expiration paths.         
+    2. Add a short status model                                                    Simpler labels with less detail for  
+                                                                                   quick rollouts.                      
                                                                                                                         
   tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_long_option_text.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_long_option_text.snap
@@ -1,0 +1,16 @@
+---
+source: tui/src/bottom_pane/request_user_input/mod.rs
+assertion_line: 2618
+expression: "render_snapshot(&overlay, area)"
+---
+                                                                                                                        
+  Question 1/1 (1 unanswered)                                                                                           
+  Choose one option.                                                                                                    
+                                                                                                                        
+  › 1. Job: running/completed/failed/expired; Run/Experiment: succeeded/failed/unknown (Recommended when triaging       
+       long-running background work and status transitions)  Keep async job statuses for progress tracking and include  
+       enough context for debugging retries, stale workers, and unexpected expiration paths.                            
+    2. Add a short status model                                                    Simpler labels with less detail for  
+       quick rollouts.                                                                                                  
+                                                                                                                        
+  tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_long_option_text.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_long_option_text.snap
@@ -7,10 +7,12 @@ expression: "render_snapshot(&overlay, area)"
   Question 1/1 (1 unanswered)                                                                                           
   Choose one option.                                                                                                    
                                                                                                                         
-  › 1. Job: running/completed/failed/expired; Run/Experiment: succeeded/failed/unknown (Recommended when triaging       
-       long-running background work and status transitions)  Keep async job statuses for progress tracking and include  
-       enough context for debugging retries, stale workers, and unexpected expiration paths.                            
+  › 1. Job: running/completed/failed/expired; Run/Experiment: succeeded/failed/    Keep async job statuses for          
+       unknown (Recommended when triaging long-running background work and status  progress tracking and include        
+       transitions)                                                                enough context for debugging         
+                                                                                   retries, stale workers, and          
+                                                                                   unexpected expiration paths.         
     2. Add a short status model                                                    Simpler labels with less detail for  
-       quick rollouts.                                                                                                  
+                                                                                   quick rollouts.                      
                                                                                                                         
   tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_long_option_text.snap
+++ b/codex-rs/tui/src/bottom_pane/request_user_input/snapshots/codex_tui__bottom_pane__request_user_input__tests__request_user_input_long_option_text.snap
@@ -7,12 +7,10 @@ expression: "render_snapshot(&overlay, area)"
   Question 1/1 (1 unanswered)                                                                                           
   Choose one option.                                                                                                    
                                                                                                                         
-  › 1. Job: running/completed/failed/expired; Run/Experiment: succeeded/failed/    Keep async job statuses for          
-       unknown (Recommended when triaging long-running background work and status  progress tracking and include        
-       transitions)                                                                enough context for debugging         
-                                                                                   retries, stale workers, and          
-                                                                                   unexpected expiration paths.         
-    2. Add a short status model                                                    Simpler labels with less detail for  
-                                                                                   quick rollouts.                      
+  › 1. Job: running/completed/failed/expired; Run/          Keep async job statuses for progress tracking and include   
+       Experiment: succeeded/failed/unknown (Recommended    enough context for debugging retries, stale workers, and    
+       when triaging long-running background work and       unexpected expiration paths.                                
+       status transitions)                                                                                              
+    2. Add a short status model                             Simpler labels with less detail for quick rollouts.         
                                                                                                                         
   tab to add notes | enter to submit answer | esc to interrupt

--- a/codex-rs/tui/src/bottom_pane/selection_popup_common.rs
+++ b/codex-rs/tui/src/bottom_pane/selection_popup_common.rs
@@ -163,7 +163,7 @@ fn wrap_row_two_columns(row: &GenericDisplayRow, width: u16) -> Vec<Line<'static
     let row_count = label_lines.len().max(desc_lines.len()).max(1);
     let mut lines = Vec::with_capacity(row_count);
     for idx in 0..row_count {
-        let mut spans = Vec::new();
+        let mut spans: Vec<Span<'static>> = Vec::new();
         if let Some(label_line) = label_lines.get(idx) {
             spans.push(label_line.to_string().into());
         }

--- a/codex-rs/tui/src/bottom_pane/selection_popup_common.rs
+++ b/codex-rs/tui/src/bottom_pane/selection_popup_common.rs
@@ -9,6 +9,7 @@ use ratatui::text::Line;
 use ratatui::text::Span;
 use ratatui::widgets::Block;
 use ratatui::widgets::Widget;
+use std::borrow::Cow;
 use unicode_width::UnicodeWidthChar;
 use unicode_width::UnicodeWidthStr;
 
@@ -52,15 +53,19 @@ pub(crate) enum ColumnWidthMode {
     Fixed,
 }
 
-// Default fixed split used by general selection popups: left column gets 30%
-// for the row label, right column gets 70% for description text.
+// Fraction for fixed mode's left (name) column width: 3/10 = 30%.
 const FIXED_LEFT_COLUMN_NUMERATOR: usize = 3;
 const FIXED_LEFT_COLUMN_DENOMINATOR: usize = 10;
 
-// For rows that opt into wrapped labels (`wrap_indent`), use an even split so
-// label and description each have predictable space while wrapping.
-const WRAPPED_LABEL_DESC_COL_NUMERATOR: usize = 1;
-const WRAPPED_LABEL_DESC_COL_DENOMINATOR: usize = 2;
+// Upper bound fraction for auto modes' left (name) column width: 7/10 = 70%.
+// This keeps at least 30% available for the right (description) column.
+const AUTO_LEFT_COLUMN_MAX_NUMERATOR: usize = 7;
+const AUTO_LEFT_COLUMN_MAX_DENOMINATOR: usize = 10;
+
+// For oversized wrapped labels, use a balanced split so left/right columns
+// each get half of the row width.
+const WRAPPED_BALANCED_COL_NUMERATOR: usize = 1;
+const WRAPPED_BALANCED_COL_DENOMINATOR: usize = 2;
 
 const MENU_SURFACE_INSET_V: u16 = 1;
 const MENU_SURFACE_INSET_H: u16 = 2;
@@ -114,76 +119,19 @@ fn line_width(line: &Line<'_>) -> usize {
         .sum()
 }
 
-fn combined_description(row: &GenericDisplayRow) -> Option<String> {
-    match (&row.description, &row.disabled_reason) {
-        (Some(desc), Some(reason)) => Some(format!("{desc} (disabled: {reason})")),
-        (Some(desc), None) => Some(desc.clone()),
-        (None, Some(reason)) => Some(format!("disabled: {reason}")),
-        (None, None) => None,
+fn line_to_owned(line: Line<'_>) -> Line<'static> {
+    Line {
+        style: line.style,
+        alignment: line.alignment,
+        spans: line
+            .spans
+            .into_iter()
+            .map(|span| Span {
+                style: span.style,
+                content: Cow::Owned(span.content.into_owned()),
+            })
+            .collect(),
     }
-}
-
-fn should_wrap_label_in_left_column(row: &GenericDisplayRow) -> bool {
-    row.wrap_indent.is_some()
-        && row.description.is_some()
-        && row.match_indices.is_none()
-        && row.display_shortcut.is_none()
-        && row.category_tag.is_none()
-}
-
-fn wrapped_label_desc_col(width: u16) -> usize {
-    let width = width.max(1);
-    let max_desc_col = width.saturating_sub(1) as usize;
-    ((width as usize * WRAPPED_LABEL_DESC_COL_NUMERATOR) / WRAPPED_LABEL_DESC_COL_DENOMINATOR)
-        .clamp(1, max_desc_col)
-}
-
-fn wrap_row_two_columns(row: &GenericDisplayRow, width: u16) -> Vec<Line<'static>> {
-    let Some(desc) = combined_description(row) else {
-        return Vec::new();
-    };
-
-    let desc_col = wrapped_label_desc_col(width);
-    let left_width = desc_col.saturating_sub(2).max(1);
-    let right_width = (width as usize).saturating_sub(desc_col).max(1);
-    let label_indent = row
-        .wrap_indent
-        .unwrap_or(0)
-        .min(left_width.saturating_sub(1));
-
-    let label_subsequent_indent = " ".repeat(label_indent);
-    let label_wrap_options = textwrap::Options::new(left_width)
-        .initial_indent("")
-        .subsequent_indent(label_subsequent_indent.as_str());
-    let label_lines = textwrap::wrap(row.name.as_str(), label_wrap_options);
-
-    let desc_wrap_options = textwrap::Options::new(right_width).initial_indent("");
-    let desc_lines = textwrap::wrap(desc.as_str(), desc_wrap_options);
-
-    let row_count = label_lines.len().max(desc_lines.len()).max(1);
-    let mut lines = Vec::with_capacity(row_count);
-    for idx in 0..row_count {
-        let mut spans: Vec<Span<'static>> = Vec::new();
-        if let Some(label_line) = label_lines.get(idx) {
-            spans.push(label_line.to_string().into());
-        }
-        if let Some(desc_line) = desc_lines.get(idx) {
-            let left_used = spans
-                .first()
-                .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
-                .unwrap_or(0);
-            let gap = if left_used == 0 {
-                desc_col
-            } else {
-                desc_col.saturating_sub(left_used).max(2)
-            };
-            spans.push(" ".repeat(gap).into());
-            spans.push(desc_line.to_string().dim());
-        }
-        lines.push(Line::from(spans));
-    }
-
-    lines
 }
 
 pub(crate) fn truncate_line_to_width(line: Line<'static>, max_width: usize) -> Line<'static> {
@@ -288,6 +236,14 @@ fn compute_desc_col(
     }
 
     let max_desc_col = content_width.saturating_sub(1) as usize;
+    // In auto modes, keep at least ~30% of width available for descriptions so
+    // very long names do not push wrapped descriptions into a near-vertical
+    // right-edge column.
+    let max_auto_desc_col = max_desc_col.min(
+        ((content_width as usize * AUTO_LEFT_COLUMN_MAX_NUMERATOR)
+            / AUTO_LEFT_COLUMN_MAX_DENOMINATOR)
+            .max(1),
+    );
     match col_width_mode {
         ColumnWidthMode::Fixed => ((content_width as usize * FIXED_LEFT_COLUMN_NUMERATOR)
             / FIXED_LEFT_COLUMN_DENOMINATOR)
@@ -322,7 +278,7 @@ fn compute_desc_col(
                 ColumnWidthMode::Fixed => 0,
             };
 
-            max_name_width.saturating_add(2).min(max_desc_col)
+            max_name_width.saturating_add(2).min(max_auto_desc_col)
         }
     }
 }
@@ -340,19 +296,16 @@ fn wrap_indent(row: &GenericDisplayRow, desc_col: usize, max_width: u16) -> usiz
     indent.min(max_indent)
 }
 
-/// Build the full display line for a row with the description padded to start
-/// at `desc_col`. Applies fuzzy-match bolding when indices are present and
-/// dims the description.
-fn build_full_line(row: &GenericDisplayRow, desc_col: usize) -> Line<'static> {
-    let combined_description = combined_description(row);
+fn combined_description_text(row: &GenericDisplayRow) -> Option<String> {
+    match (&row.description, &row.disabled_reason) {
+        (Some(desc), Some(reason)) => Some(format!("{desc} (disabled: {reason})")),
+        (Some(desc), None) => Some(desc.clone()),
+        (None, Some(reason)) => Some(format!("disabled: {reason}")),
+        (None, None) => None,
+    }
+}
 
-    // Enforce single-line name: allow at most desc_col - 2 cells for name,
-    // reserving two spaces before the description column.
-    let name_limit = combined_description
-        .as_ref()
-        .map(|_| desc_col.saturating_sub(2))
-        .unwrap_or(usize::MAX);
-
+fn build_name_spans(row: &GenericDisplayRow, name_limit: usize) -> Vec<Span<'static>> {
     let mut name_spans: Vec<Span> = Vec::with_capacity(row.name.len());
     let mut used_width = 0usize;
     let mut truncated = false;
@@ -398,6 +351,35 @@ fn build_full_line(row: &GenericDisplayRow, desc_col: usize) -> Line<'static> {
         name_spans.push(" (disabled)".dim());
     }
 
+    name_spans
+}
+
+fn build_name_line(row: &GenericDisplayRow, name_limit: usize) -> Line<'static> {
+    let mut name_spans = build_name_spans(row, name_limit);
+    if let Some(display_shortcut) = row.display_shortcut {
+        name_spans.push(" (".into());
+        name_spans.push(display_shortcut.into());
+        name_spans.push(")".into());
+    }
+    Line::from(name_spans)
+}
+
+/// Build the full display line for a row with the description padded to start
+/// at `desc_col`. Applies fuzzy-match bolding when indices are present and
+/// dims the description.
+fn build_full_line(row: &GenericDisplayRow, desc_col: usize) -> Line<'static> {
+    let combined_description = combined_description_text(row);
+
+    // Enforce single-line names only when no explicit wrap indent is set.
+    // Callers that set `wrap_indent` can opt into wrapped names even when a
+    // description is present.
+    let name_limit = if combined_description.is_some() && row.wrap_indent.is_none() {
+        desc_col.saturating_sub(2)
+    } else {
+        usize::MAX
+    };
+
+    let name_spans = build_name_spans(row, name_limit);
     let this_name_width = Line::from(name_spans.clone()).width();
     let mut full_spans: Vec<Span> = name_spans;
     if let Some(display_shortcut) = row.display_shortcut {
@@ -406,7 +388,11 @@ fn build_full_line(row: &GenericDisplayRow, desc_col: usize) -> Line<'static> {
         full_spans.push(")".into());
     }
     if let Some(desc) = combined_description.as_ref() {
-        let gap = desc_col.saturating_sub(this_name_width);
+        let gap = if row.wrap_indent.is_some() {
+            desc_col.saturating_sub(this_name_width).max(2)
+        } else {
+            desc_col.saturating_sub(this_name_width)
+        };
         if gap > 0 {
             full_spans.push(" ".repeat(gap).into());
         }
@@ -417,6 +403,123 @@ fn build_full_line(row: &GenericDisplayRow, desc_col: usize) -> Line<'static> {
         full_spans.push(tag.to_string().dim());
     }
     Line::from(full_spans)
+}
+
+fn should_wrap_name_in_column(row: &GenericDisplayRow) -> bool {
+    row.wrap_indent.is_some()
+        && (row.description.is_some() || row.disabled_reason.is_some())
+        && row.category_tag.is_none()
+}
+
+fn wrap_two_column_row(row: &GenericDisplayRow, desc_col: usize, width: u16) -> Vec<Line<'static>> {
+    use crate::wrapping::RtOptions;
+    use crate::wrapping::word_wrap_line;
+
+    let Some(combined_desc) = combined_description_text(row) else {
+        return Vec::new();
+    };
+
+    let width = width.max(1);
+    let max_desc_col = width.saturating_sub(1) as usize;
+    let balanced_desc_col = ((width as usize * WRAPPED_BALANCED_COL_NUMERATOR)
+        / WRAPPED_BALANCED_COL_DENOMINATOR)
+        .clamp(1, max_desc_col);
+    let desc_col = desc_col.clamp(1, max_desc_col).min(balanced_desc_col);
+    let left_width = desc_col.saturating_sub(2).max(1);
+    let right_width = width.saturating_sub(desc_col as u16).max(1) as usize;
+    let name_wrap_indent = row
+        .wrap_indent
+        .unwrap_or(0)
+        .min(left_width.saturating_sub(1));
+    let name_line = build_name_line(row, usize::MAX);
+
+    let name_lines = word_wrap_line(
+        &name_line,
+        RtOptions::new(left_width)
+            .initial_indent(Line::from(""))
+            .subsequent_indent(Line::from(" ".repeat(name_wrap_indent))),
+    )
+    .into_iter()
+    .map(line_to_owned)
+    .collect::<Vec<_>>();
+
+    let desc_line = Line::from(combined_desc.dim());
+    let desc_lines = word_wrap_line(
+        &desc_line,
+        RtOptions::new(right_width)
+            .initial_indent(Line::from(""))
+            .subsequent_indent(Line::from("")),
+    )
+    .into_iter()
+    .map(line_to_owned)
+    .collect::<Vec<_>>();
+
+    let rows = name_lines.len().max(desc_lines.len()).max(1);
+    let mut out = Vec::with_capacity(rows);
+    for idx in 0..rows {
+        let mut spans = Vec::new();
+        if let Some(name) = name_lines.get(idx) {
+            spans.extend(name.spans.clone());
+        }
+
+        if let Some(desc) = desc_lines.get(idx) {
+            let left_used = spans
+                .iter()
+                .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
+                .sum::<usize>();
+            let gap = if left_used == 0 {
+                desc_col
+            } else {
+                desc_col.saturating_sub(left_used).max(2)
+            };
+            if gap > 0 {
+                spans.push(" ".repeat(gap).into());
+            }
+            spans.extend(desc.spans.clone());
+        }
+
+        out.push(Line::from(spans));
+    }
+    out
+}
+
+fn wrap_row_lines(row: &GenericDisplayRow, desc_col: usize, width: u16) -> Vec<Line<'static>> {
+    use crate::wrapping::RtOptions;
+    use crate::wrapping::word_wrap_line;
+
+    if should_wrap_name_in_column(row) {
+        let wrapped = wrap_two_column_row(row, desc_col, width);
+        if !wrapped.is_empty() {
+            return wrapped;
+        }
+    }
+
+    let full_line = build_full_line(row, desc_col);
+    let continuation_indent = wrap_indent(row, desc_col, width);
+    let options = RtOptions::new(width.max(1) as usize)
+        .initial_indent(Line::from(""))
+        .subsequent_indent(Line::from(" ".repeat(continuation_indent)));
+    word_wrap_line(&full_line, options)
+        .into_iter()
+        .map(line_to_owned)
+        .collect()
+}
+
+fn apply_row_state_style(lines: &mut [Line<'static>], selected: bool, is_disabled: bool) {
+    if selected {
+        for line in lines.iter_mut() {
+            line.spans.iter_mut().for_each(|span| {
+                span.style = Style::default().fg(Color::Cyan).bold();
+            });
+        }
+    }
+    if is_disabled {
+        for line in lines.iter_mut() {
+            line.spans.iter_mut().for_each(|span| {
+                span.style = span.style.dim();
+            });
+        }
+    }
 }
 
 /// Render a list of rows using the provided ScrollState, with shared styling
@@ -476,67 +579,12 @@ fn render_rows_inner(
             break;
         }
 
-        // Special-case long labels that opt-in via wrap_indent: keep two
-        // independent columns (label left, description right) and wrap each
-        // column separately.
-        if should_wrap_label_in_left_column(row) {
-            let mut wrapped = wrap_row_two_columns(row, area.width);
-            if Some(i) == state.selected_idx && !row.is_disabled {
-                wrapped.iter_mut().for_each(|line| {
-                    line.spans.iter_mut().for_each(|span| {
-                        span.style = Style::default().fg(Color::Cyan).bold();
-                    });
-                });
-            }
-            if row.is_disabled {
-                wrapped.iter_mut().for_each(|line| {
-                    line.spans.iter_mut().for_each(|span| {
-                        span.style = span.style.dim();
-                    });
-                });
-            }
-
-            // Render the wrapped lines.
-            for line in wrapped {
-                if cur_y >= area.y + area.height {
-                    break;
-                }
-                line.render(
-                    Rect {
-                        x: area.x,
-                        y: cur_y,
-                        width: area.width,
-                        height: 1,
-                    },
-                    buf,
-                );
-                cur_y = cur_y.saturating_add(1);
-            }
-            continue;
-        }
-
-        let mut full_line = build_full_line(row, desc_col);
-        if Some(i) == state.selected_idx && !row.is_disabled {
-            // Match previous behavior: cyan + bold for the selected row.
-            // Reset the style first to avoid inheriting dim from keyboard shortcuts.
-            full_line.spans.iter_mut().for_each(|span| {
-                span.style = Style::default().fg(Color::Cyan).bold();
-            });
-        }
-        if row.is_disabled {
-            full_line.spans.iter_mut().for_each(|span| {
-                span.style = span.style.dim();
-            });
-        }
-
-        // Wrap with subsequent indent aligned to the description column.
-        use crate::wrapping::RtOptions;
-        use crate::wrapping::word_wrap_line;
-        let continuation_indent = wrap_indent(row, desc_col, area.width);
-        let options = RtOptions::new(area.width as usize)
-            .initial_indent(Line::from(""))
-            .subsequent_indent(Line::from(" ".repeat(continuation_indent)));
-        let wrapped = word_wrap_line(&full_line, options);
+        let mut wrapped = wrap_row_lines(row, desc_col, area.width);
+        apply_row_state_style(
+            &mut wrapped,
+            Some(i) == state.selected_idx && !row.is_disabled,
+            row.is_disabled,
+        );
 
         // Render the wrapped lines.
         for line in wrapped {
@@ -803,8 +851,6 @@ fn measure_rows_height_inner(
         col_width_mode,
     );
 
-    use crate::wrapping::RtOptions;
-    use crate::wrapping::word_wrap_line;
     let mut total: u16 = 0;
     for row in rows_all
         .iter()
@@ -813,16 +859,7 @@ fn measure_rows_height_inner(
         .take(visible_items)
         .map(|(_, r)| r)
     {
-        let wrapped_lines = if should_wrap_label_in_left_column(row) {
-            wrap_row_two_columns(row, content_width).len()
-        } else {
-            let full_line = build_full_line(row, desc_col);
-            let continuation_indent = wrap_indent(row, desc_col, content_width);
-            let opts = RtOptions::new(content_width as usize)
-                .initial_indent(Line::from(""))
-                .subsequent_indent(Line::from(" ".repeat(continuation_indent)));
-            word_wrap_line(&full_line, opts).len()
-        };
+        let wrapped_lines = wrap_row_lines(row, desc_col, content_width).len();
         total = total.saturating_add(wrapped_lines as u16);
     }
     total.max(1)

--- a/codex-rs/tui/src/bottom_pane/selection_popup_common.rs
+++ b/codex-rs/tui/src/bottom_pane/selection_popup_common.rs
@@ -9,7 +9,6 @@ use ratatui::text::Line;
 use ratatui::text::Span;
 use ratatui::widgets::Block;
 use ratatui::widgets::Widget;
-use std::borrow::Cow;
 use unicode_width::UnicodeWidthChar;
 use unicode_width::UnicodeWidthStr;
 
@@ -53,14 +52,15 @@ pub(crate) enum ColumnWidthMode {
     Fixed,
 }
 
-// Fraction for fixed mode's left (name) column width: 3/10 = 30%.
+// Default fixed split used by general selection popups: left column gets 30%
+// for the row label, right column gets 70% for description text.
 const FIXED_LEFT_COLUMN_NUMERATOR: usize = 3;
 const FIXED_LEFT_COLUMN_DENOMINATOR: usize = 10;
 
-// Upper bound fraction for auto modes' left (name) column width: 7/10 = 70%.
-// This keeps at least 30% available for the right (description) column.
-const AUTO_LEFT_COLUMN_MAX_NUMERATOR: usize = 7;
-const AUTO_LEFT_COLUMN_MAX_DENOMINATOR: usize = 10;
+// For rows that opt into wrapped labels (`wrap_indent`), use an even split so
+// label and description each have predictable space while wrapping.
+const WRAPPED_LABEL_DESC_COL_NUMERATOR: usize = 1;
+const WRAPPED_LABEL_DESC_COL_DENOMINATOR: usize = 2;
 
 const MENU_SURFACE_INSET_V: u16 = 1;
 const MENU_SURFACE_INSET_H: u16 = 2;
@@ -114,19 +114,76 @@ fn line_width(line: &Line<'_>) -> usize {
         .sum()
 }
 
-fn line_to_owned(line: Line<'_>) -> Line<'static> {
-    Line {
-        style: line.style,
-        alignment: line.alignment,
-        spans: line
-            .spans
-            .into_iter()
-            .map(|span| Span {
-                style: span.style,
-                content: Cow::Owned(span.content.into_owned()),
-            })
-            .collect(),
+fn combined_description(row: &GenericDisplayRow) -> Option<String> {
+    match (&row.description, &row.disabled_reason) {
+        (Some(desc), Some(reason)) => Some(format!("{desc} (disabled: {reason})")),
+        (Some(desc), None) => Some(desc.clone()),
+        (None, Some(reason)) => Some(format!("disabled: {reason}")),
+        (None, None) => None,
     }
+}
+
+fn should_wrap_label_in_left_column(row: &GenericDisplayRow) -> bool {
+    row.wrap_indent.is_some()
+        && row.description.is_some()
+        && row.match_indices.is_none()
+        && row.display_shortcut.is_none()
+        && row.category_tag.is_none()
+}
+
+fn wrapped_label_desc_col(width: u16) -> usize {
+    let width = width.max(1);
+    let max_desc_col = width.saturating_sub(1) as usize;
+    ((width as usize * WRAPPED_LABEL_DESC_COL_NUMERATOR) / WRAPPED_LABEL_DESC_COL_DENOMINATOR)
+        .clamp(1, max_desc_col)
+}
+
+fn wrap_row_two_columns(row: &GenericDisplayRow, width: u16) -> Vec<Line<'static>> {
+    let Some(desc) = combined_description(row) else {
+        return Vec::new();
+    };
+
+    let desc_col = wrapped_label_desc_col(width);
+    let left_width = desc_col.saturating_sub(2).max(1);
+    let right_width = (width as usize).saturating_sub(desc_col).max(1);
+    let label_indent = row
+        .wrap_indent
+        .unwrap_or(0)
+        .min(left_width.saturating_sub(1));
+
+    let label_subsequent_indent = " ".repeat(label_indent);
+    let label_wrap_options = textwrap::Options::new(left_width)
+        .initial_indent("")
+        .subsequent_indent(label_subsequent_indent.as_str());
+    let label_lines = textwrap::wrap(row.name.as_str(), label_wrap_options);
+
+    let desc_wrap_options = textwrap::Options::new(right_width).initial_indent("");
+    let desc_lines = textwrap::wrap(desc.as_str(), desc_wrap_options);
+
+    let row_count = label_lines.len().max(desc_lines.len()).max(1);
+    let mut lines = Vec::with_capacity(row_count);
+    for idx in 0..row_count {
+        let mut spans = Vec::new();
+        if let Some(label_line) = label_lines.get(idx) {
+            spans.push(label_line.to_string().into());
+        }
+        if let Some(desc_line) = desc_lines.get(idx) {
+            let left_used = spans
+                .first()
+                .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
+                .unwrap_or(0);
+            let gap = if left_used == 0 {
+                desc_col
+            } else {
+                desc_col.saturating_sub(left_used).max(2)
+            };
+            spans.push(" ".repeat(gap).into());
+            spans.push(desc_line.to_string().dim());
+        }
+        lines.push(Line::from(spans));
+    }
+
+    lines
 }
 
 pub(crate) fn truncate_line_to_width(line: Line<'static>, max_width: usize) -> Line<'static> {
@@ -231,14 +288,6 @@ fn compute_desc_col(
     }
 
     let max_desc_col = content_width.saturating_sub(1) as usize;
-    // In auto modes, keep at least ~30% of width available for descriptions so
-    // very long names do not push wrapped descriptions into a near-vertical
-    // right-edge column.
-    let max_auto_desc_col = max_desc_col.min(
-        ((content_width as usize * AUTO_LEFT_COLUMN_MAX_NUMERATOR)
-            / AUTO_LEFT_COLUMN_MAX_DENOMINATOR)
-            .max(1),
-    );
     match col_width_mode {
         ColumnWidthMode::Fixed => ((content_width as usize * FIXED_LEFT_COLUMN_NUMERATOR)
             / FIXED_LEFT_COLUMN_DENOMINATOR)
@@ -273,7 +322,7 @@ fn compute_desc_col(
                 ColumnWidthMode::Fixed => 0,
             };
 
-            max_name_width.saturating_add(2).min(max_auto_desc_col)
+            max_name_width.saturating_add(2).min(max_desc_col)
         }
     }
 }
@@ -291,16 +340,19 @@ fn wrap_indent(row: &GenericDisplayRow, desc_col: usize, max_width: u16) -> usiz
     indent.min(max_indent)
 }
 
-fn combined_description_text(row: &GenericDisplayRow) -> Option<String> {
-    match (&row.description, &row.disabled_reason) {
-        (Some(desc), Some(reason)) => Some(format!("{desc} (disabled: {reason})")),
-        (Some(desc), None) => Some(desc.clone()),
-        (None, Some(reason)) => Some(format!("disabled: {reason}")),
-        (None, None) => None,
-    }
-}
+/// Build the full display line for a row with the description padded to start
+/// at `desc_col`. Applies fuzzy-match bolding when indices are present and
+/// dims the description.
+fn build_full_line(row: &GenericDisplayRow, desc_col: usize) -> Line<'static> {
+    let combined_description = combined_description(row);
 
-fn build_name_spans(row: &GenericDisplayRow, name_limit: usize) -> Vec<Span<'static>> {
+    // Enforce single-line name: allow at most desc_col - 2 cells for name,
+    // reserving two spaces before the description column.
+    let name_limit = combined_description
+        .as_ref()
+        .map(|_| desc_col.saturating_sub(2))
+        .unwrap_or(usize::MAX);
+
     let mut name_spans: Vec<Span> = Vec::with_capacity(row.name.len());
     let mut used_width = 0usize;
     let mut truncated = false;
@@ -346,35 +398,6 @@ fn build_name_spans(row: &GenericDisplayRow, name_limit: usize) -> Vec<Span<'sta
         name_spans.push(" (disabled)".dim());
     }
 
-    name_spans
-}
-
-fn build_name_line(row: &GenericDisplayRow, name_limit: usize) -> Line<'static> {
-    let mut name_spans = build_name_spans(row, name_limit);
-    if let Some(display_shortcut) = row.display_shortcut {
-        name_spans.push(" (".into());
-        name_spans.push(display_shortcut.into());
-        name_spans.push(")".into());
-    }
-    Line::from(name_spans)
-}
-
-/// Build the full display line for a row with the description padded to start
-/// at `desc_col`. Applies fuzzy-match bolding when indices are present and
-/// dims the description.
-fn build_full_line(row: &GenericDisplayRow, desc_col: usize) -> Line<'static> {
-    let combined_description = combined_description_text(row);
-
-    // Enforce single-line names only when no explicit wrap indent is set.
-    // Callers that set `wrap_indent` can opt into wrapped names even when a
-    // description is present.
-    let name_limit = if combined_description.is_some() && row.wrap_indent.is_none() {
-        desc_col.saturating_sub(2)
-    } else {
-        usize::MAX
-    };
-
-    let name_spans = build_name_spans(row, name_limit);
     let this_name_width = Line::from(name_spans.clone()).width();
     let mut full_spans: Vec<Span> = name_spans;
     if let Some(display_shortcut) = row.display_shortcut {
@@ -383,11 +406,7 @@ fn build_full_line(row: &GenericDisplayRow, desc_col: usize) -> Line<'static> {
         full_spans.push(")".into());
     }
     if let Some(desc) = combined_description.as_ref() {
-        let gap = if row.wrap_indent.is_some() {
-            desc_col.saturating_sub(this_name_width).max(2)
-        } else {
-            desc_col.saturating_sub(this_name_width)
-        };
+        let gap = desc_col.saturating_sub(this_name_width);
         if gap > 0 {
             full_spans.push(" ".repeat(gap).into());
         }
@@ -398,118 +417,6 @@ fn build_full_line(row: &GenericDisplayRow, desc_col: usize) -> Line<'static> {
         full_spans.push(tag.to_string().dim());
     }
     Line::from(full_spans)
-}
-
-fn should_wrap_name_in_column(row: &GenericDisplayRow) -> bool {
-    row.wrap_indent.is_some()
-        && (row.description.is_some() || row.disabled_reason.is_some())
-        && row.category_tag.is_none()
-}
-
-fn wrap_two_column_row(row: &GenericDisplayRow, desc_col: usize, width: u16) -> Vec<Line<'static>> {
-    use crate::wrapping::RtOptions;
-    use crate::wrapping::word_wrap_line;
-
-    let Some(combined_desc) = combined_description_text(row) else {
-        return Vec::new();
-    };
-
-    let width = width.max(1);
-    let left_width = desc_col.saturating_sub(2).max(1);
-    let right_width = width.saturating_sub(desc_col as u16).max(1) as usize;
-    let name_wrap_indent = row
-        .wrap_indent
-        .unwrap_or(0)
-        .min(left_width.saturating_sub(1));
-
-    let name_line = build_name_line(row, usize::MAX);
-    let name_lines = word_wrap_line(
-        &name_line,
-        RtOptions::new(left_width)
-            .initial_indent(Line::from(""))
-            .subsequent_indent(Line::from(" ".repeat(name_wrap_indent))),
-    )
-    .into_iter()
-    .map(line_to_owned)
-    .collect::<Vec<_>>();
-
-    let desc_line = Line::from(combined_desc.dim());
-    let desc_lines = word_wrap_line(
-        &desc_line,
-        RtOptions::new(right_width)
-            .initial_indent(Line::from(""))
-            .subsequent_indent(Line::from("")),
-    )
-    .into_iter()
-    .map(line_to_owned)
-    .collect::<Vec<_>>();
-
-    let rows = name_lines.len().max(desc_lines.len()).max(1);
-    let mut out = Vec::with_capacity(rows);
-    for idx in 0..rows {
-        let mut spans = Vec::new();
-        if let Some(name) = name_lines.get(idx) {
-            spans.extend(name.spans.clone());
-        }
-
-        if let Some(desc) = desc_lines.get(idx) {
-            let left_used = spans
-                .iter()
-                .map(|span| UnicodeWidthStr::width(span.content.as_ref()))
-                .sum::<usize>();
-            let gap = if left_used == 0 {
-                desc_col
-            } else {
-                desc_col.saturating_sub(left_used).max(2)
-            };
-            if gap > 0 {
-                spans.push(" ".repeat(gap).into());
-            }
-            spans.extend(desc.spans.clone());
-        }
-
-        out.push(Line::from(spans));
-    }
-    out
-}
-
-fn wrap_row_lines(row: &GenericDisplayRow, desc_col: usize, width: u16) -> Vec<Line<'static>> {
-    use crate::wrapping::RtOptions;
-    use crate::wrapping::word_wrap_line;
-
-    if should_wrap_name_in_column(row) {
-        let wrapped = wrap_two_column_row(row, desc_col, width);
-        if !wrapped.is_empty() {
-            return wrapped;
-        }
-    }
-
-    let full_line = build_full_line(row, desc_col);
-    let continuation_indent = wrap_indent(row, desc_col, width);
-    let options = RtOptions::new(width.max(1) as usize)
-        .initial_indent(Line::from(""))
-        .subsequent_indent(Line::from(" ".repeat(continuation_indent)));
-    word_wrap_line(&full_line, options)
-        .into_iter()
-        .map(line_to_owned)
-        .collect()
-}
-
-fn apply_row_state_style(lines: &mut [Line<'static>], selected: bool, is_disabled: bool) {
-    if selected {
-        for line in lines.iter_mut() {
-            line.spans.iter_mut().for_each(|span| {
-                span.style = Style::default().fg(Color::Cyan).bold();
-            });
-        }
-    }
-    if is_disabled {
-        for line in lines.iter_mut() {
-            line.spans.iter_mut().for_each(|span| {
-                span.style = span.style.dim();
-            });
-        }
-    }
 }
 
 /// Render a list of rows using the provided ScrollState, with shared styling
@@ -569,12 +476,67 @@ fn render_rows_inner(
             break;
         }
 
-        let mut wrapped = wrap_row_lines(row, desc_col, area.width);
-        apply_row_state_style(
-            &mut wrapped,
-            Some(i) == state.selected_idx && !row.is_disabled,
-            row.is_disabled,
-        );
+        // Special-case long labels that opt-in via wrap_indent: keep two
+        // independent columns (label left, description right) and wrap each
+        // column separately.
+        if should_wrap_label_in_left_column(row) {
+            let mut wrapped = wrap_row_two_columns(row, area.width);
+            if Some(i) == state.selected_idx && !row.is_disabled {
+                wrapped.iter_mut().for_each(|line| {
+                    line.spans.iter_mut().for_each(|span| {
+                        span.style = Style::default().fg(Color::Cyan).bold();
+                    });
+                });
+            }
+            if row.is_disabled {
+                wrapped.iter_mut().for_each(|line| {
+                    line.spans.iter_mut().for_each(|span| {
+                        span.style = span.style.dim();
+                    });
+                });
+            }
+
+            // Render the wrapped lines.
+            for line in wrapped {
+                if cur_y >= area.y + area.height {
+                    break;
+                }
+                line.render(
+                    Rect {
+                        x: area.x,
+                        y: cur_y,
+                        width: area.width,
+                        height: 1,
+                    },
+                    buf,
+                );
+                cur_y = cur_y.saturating_add(1);
+            }
+            continue;
+        }
+
+        let mut full_line = build_full_line(row, desc_col);
+        if Some(i) == state.selected_idx && !row.is_disabled {
+            // Match previous behavior: cyan + bold for the selected row.
+            // Reset the style first to avoid inheriting dim from keyboard shortcuts.
+            full_line.spans.iter_mut().for_each(|span| {
+                span.style = Style::default().fg(Color::Cyan).bold();
+            });
+        }
+        if row.is_disabled {
+            full_line.spans.iter_mut().for_each(|span| {
+                span.style = span.style.dim();
+            });
+        }
+
+        // Wrap with subsequent indent aligned to the description column.
+        use crate::wrapping::RtOptions;
+        use crate::wrapping::word_wrap_line;
+        let continuation_indent = wrap_indent(row, desc_col, area.width);
+        let options = RtOptions::new(area.width as usize)
+            .initial_indent(Line::from(""))
+            .subsequent_indent(Line::from(" ".repeat(continuation_indent)));
+        let wrapped = word_wrap_line(&full_line, options);
 
         // Render the wrapped lines.
         for line in wrapped {
@@ -841,6 +803,8 @@ fn measure_rows_height_inner(
         col_width_mode,
     );
 
+    use crate::wrapping::RtOptions;
+    use crate::wrapping::word_wrap_line;
     let mut total: u16 = 0;
     for row in rows_all
         .iter()
@@ -849,7 +813,16 @@ fn measure_rows_height_inner(
         .take(visible_items)
         .map(|(_, r)| r)
     {
-        let wrapped_lines = wrap_row_lines(row, desc_col, content_width).len();
+        let wrapped_lines = if should_wrap_label_in_left_column(row) {
+            wrap_row_two_columns(row, content_width).len()
+        } else {
+            let full_line = build_full_line(row, desc_col);
+            let continuation_indent = wrap_indent(row, desc_col, content_width);
+            let opts = RtOptions::new(content_width as usize)
+                .initial_indent(Line::from(""))
+                .subsequent_indent(Line::from(" ".repeat(continuation_indent)));
+            word_wrap_line(&full_line, opts).len()
+        };
         total = total.saturating_add(wrapped_lines as u16);
     }
     total.max(1)


### PR DESCRIPTION
## Summary

This PR fixes long-text rendering in the `request_user_input` TUI overlay while preserving a clear two-column option layout. (Issue https://github.com/openai/codex/issues/11093)

Before:
- very long option labels could push description text into a narrow right-edge strip
- option labels were effectively single-line when descriptions were present, causing truncation/poor readability
- label and description wrapping interacted in one combined wrapped line

<img width="504" height="409" alt="Screenshot 2026-02-08 at 2 27 25 PM" src="https://github.com/user-attachments/assets/a9afd108-d792-4522-bce1-e43b3cce882b" />

After:
- option labels wrap inside the left column
- descriptions wrap independently inside the right column
- row measurement and row rendering use the same wrapping path, so layout stays stable

<img width="582" height="211" alt="Screenshot 2026-02-09 at 10 28 02 AM" src="https://github.com/user-attachments/assets/47885a1c-07e5-4b0f-b992-032b149f1b0d" />

## Problem

`request_user_input` needs to handle verbose prompts/options. With oversized labels:
- descriptions could collapse into a thin, hard-to-read column
- important label context was lost

## Root Cause

In shared row rendering (`selection_popup_common`):
- rows were wrapped as a single combined line
- auto column sizing could still place `desc_col` too far right for long labels
- `request_user_input` rows did not provide wrap metadata to align continuation lines after the option prefix

## What Changed

### 1) `request_user_input` rows opt into wrapped labels
File: `codex-rs/tui/src/bottom_pane/request_user_input/mod.rs`

- In `option_rows()`, compute the rendered option prefix (`› 1. ` / `  2. `) and set `wrap_indent` from its display width.
- Apply the same behavior to the synthetic “None of the above” row.
- Add long-text snapshot test coverage (`question_with_very_long_option_text` + `request_user_input_long_option_text_snapshot`).

### 2) Shared renderer now has an opt-in two-column wrapping path
File: `codex-rs/tui/src/bottom_pane/selection_popup_common.rs`

- Add focused helpers:
  - `should_wrap_name_in_column`
  - `wrap_two_column_row`
  - `wrap_standard_row`
  - `wrap_row_lines`
  - `apply_row_state_style`
- For opted-in rows (plain option rows with `wrap_indent` + description), wrap label and description independently in their own columns.
- Keep the legacy standard wrapping path for non-opted rows.
- Use the same `wrap_row_lines` function in both rendering and height measurement to keep them in sync.

### 3) Keep column sizing simple and derived from existing fixed split constants
File: `codex-rs/tui/src/bottom_pane/selection_popup_common.rs`

- Keep fixed mode at `3/10` left column (`30/70` split).
- In auto modes, cap label width using those same fixed constants (max 70% label, min 30% description), instead of extra special-case
constants/branches.
- Add/keep narrow-width safety guard in `wrap_two_column_row` so extremely small widths do not panic.

### 4) Snapshot coverage
File: `codex-rs/tui/src/bottom_pane/request_user_input/snapshots/
codex_tui__bottom_pane__request_user_input__tests__request_user_input_long_option_text.snap`

- Add snapshot for long-label/long-description two-column rendering behavior.