### PR TITLE
core: add focused diagnostics for remote compaction overflows

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1238,7 +1238,7 @@ impl Session {
 
     pub(crate) async fn get_total_token_usage_breakdown(&self) -> TotalTokenUsageBreakdown {
         let state = self.state.lock().await;
-        state.get_total_token_usage_breakdown()
+        state.history.get_total_token_usage_breakdown()
     }
 
     pub(crate) async fn get_estimated_token_count(

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -114,6 +114,7 @@ use crate::config::resolve_web_search_mode_for_turn;
 use crate::config::types::McpServerConfig;
 use crate::config::types::ShellEnvironmentPolicy;
 use crate::context_manager::ContextManager;
+use crate::context_manager::TotalTokenUsageBreakdown;
 use crate::environment_context::EnvironmentContext;
 use crate::error::CodexErr;
 use crate::error::Result as CodexResult;
@@ -1230,12 +1231,20 @@ impl Session {
         format!("auto-compact-{id}")
     }
 
-    async fn get_total_token_usage(&self) -> i64 {
+    pub(crate) async fn get_total_token_usage(&self) -> i64 {
         let state = self.state.lock().await;
         state.get_total_token_usage(state.server_reasoning_included())
     }
 
-    async fn get_estimated_token_count(&self, turn_context: &TurnContext) -> Option<i64> {
+    pub(crate) async fn get_total_token_usage_breakdown(&self) -> TotalTokenUsageBreakdown {
+        let state = self.state.lock().await;
+        state.get_total_token_usage_breakdown()
+    }
+
+    pub(crate) async fn get_estimated_token_count(
+        &self,
+        turn_context: &TurnContext,
+    ) -> Option<i64> {
         let state = self.state.lock().await;
         state.history.estimate_token_count(turn_context)
     }

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -159,9 +159,17 @@ fn build_compact_request_metrics(
         input,
         instructions,
     };
-    let failing_compaction_request_body_json = serde_json::to_string(&payload)
-        .unwrap_or_else(|err| format!("{{\"compact_request_serialization_error\":\"{err}\"}}"));
-    let failing_compaction_request_body_bytes = failing_compaction_request_body_json.len();
+    let (failing_compaction_request_body_json, failing_compaction_request_body_bytes) =
+        match serde_json::to_vec(&payload) {
+            Ok(payload_bytes) => (
+                String::from_utf8_lossy(&payload_bytes).into_owned(),
+                payload_bytes.len(),
+            ),
+            Err(err) => (
+                format!("{{\"compact_request_serialization_error\":\"{err}\"}}"),
+                0,
+            ),
+        };
 
     CompactRequestMetrics {
         failing_compaction_request_body_json,

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -201,6 +201,7 @@ fn log_remote_compact_failure(
         turn_id = %turn_context.sub_id,
         compact_error_status = ?compact_error_status_code(err),
         last_api_response_total_tokens = total_usage_breakdown.last_api_response_total_tokens,
+        all_history_items_model_visible_bytes = total_usage_breakdown.all_history_items_model_visible_bytes,
         estimated_tokens_of_items_added_since_last_successful_api_response = total_usage_breakdown.estimated_tokens_of_items_added_since_last_successful_api_response,
         estimated_bytes_of_items_added_since_last_successful_api_response = total_usage_breakdown.estimated_bytes_of_items_added_since_last_successful_api_response,
         model_context_window_tokens = ?turn_context.model_context_window(),

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -19,6 +19,7 @@ use codex_protocol::models::BaseInstructions;
 use codex_protocol::models::ResponseItem;
 use tracing::error;
 use tracing::info;
+use tracing::trace;
 
 pub(crate) async fn run_inline_remote_auto_compact_task(
     sess: Arc<Session>,
@@ -192,7 +193,7 @@ fn log_remote_compact_failure(
     total_usage_breakdown: TotalTokenUsageBreakdown,
     err: &CodexErr,
 ) {
-    error!(
+    trace!(
         turn_id = %turn_context.sub_id,
         failing_compaction_request_body_json = %metrics.failing_compaction_request_body_json,
         "remote compaction request payload before failure"

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -157,15 +157,6 @@ fn build_compact_request_log_data(
     }
 }
 
-fn compact_error_status_code(err: &CodexErr) -> Option<u16> {
-    match err {
-        CodexErr::InvalidRequest(_) => Some(400),
-        CodexErr::UnexpectedStatus(status) => Some(status.status.as_u16()),
-        CodexErr::ContextWindowExceeded => Some(400),
-        _ => None,
-    }
-}
-
 fn log_remote_compact_failure(
     turn_context: &TurnContext,
     log_data: &CompactRequestLogData,
@@ -174,7 +165,12 @@ fn log_remote_compact_failure(
 ) {
     error!(
         turn_id = %turn_context.sub_id,
-        compact_error_status = ?compact_error_status_code(err),
+        compact_error_status = ?match err {
+            CodexErr::InvalidRequest(_) => Some(400),
+            CodexErr::UnexpectedStatus(status) => Some(status.status.as_u16()),
+            CodexErr::ContextWindowExceeded => Some(400),
+            _ => None,
+        },
         last_api_response_total_tokens = total_usage_breakdown.last_api_response_total_tokens,
         all_history_items_model_visible_bytes = total_usage_breakdown.all_history_items_model_visible_bytes,
         estimated_tokens_of_items_added_since_last_successful_api_response = total_usage_breakdown.estimated_tokens_of_items_added_since_last_successful_api_response,

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -193,7 +193,6 @@ fn log_remote_compact_failure(
         turn_id = %turn_context.sub_id,
         compact_error_status = ?compact_error_status_code(err),
         last_api_response_total_tokens = total_usage_breakdown.last_api_response_total_tokens,
-        last_api_response_total_bytes_estimate = total_usage_breakdown.last_api_response_total_bytes_estimate,
         estimated_tokens_of_items_added_since_last_successful_api_response = total_usage_breakdown.estimated_tokens_of_items_added_since_last_successful_api_response,
         estimated_bytes_of_items_added_since_last_successful_api_response = total_usage_breakdown.estimated_bytes_of_items_added_since_last_successful_api_response,
         model_context_window_tokens = ?turn_context.model_context_window(),

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -140,17 +140,20 @@ async fn run_remote_compact_task_inner_impl(
 
 #[derive(Debug)]
 struct CompactRequestLogData {
-    failing_compaction_request_model_visible_bytes: usize,
+    failing_compaction_request_model_visible_bytes: i64,
 }
 
 fn build_compact_request_log_data(
     input: &[ResponseItem],
     instructions: &str,
 ) -> CompactRequestLogData {
-    let failing_compaction_request_model_visible_bytes =
-        input.iter().fold(instructions.len(), |acc, item| {
-            acc.saturating_add(estimate_response_item_model_visible_bytes(item))
-        });
+    let failing_compaction_request_model_visible_bytes = input
+        .iter()
+        .map(estimate_response_item_model_visible_bytes)
+        .fold(
+            i64::try_from(instructions.len()).unwrap_or(i64::MAX),
+            i64::saturating_add,
+        );
 
     CompactRequestLogData {
         failing_compaction_request_model_visible_bytes,

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -168,12 +168,6 @@ fn log_remote_compact_failure(
 ) {
     error!(
         turn_id = %turn_context.sub_id,
-        compact_error_status = ?match err {
-            CodexErr::InvalidRequest(_) => Some(400),
-            CodexErr::UnexpectedStatus(status) => Some(status.status.as_u16()),
-            CodexErr::ContextWindowExceeded => Some(400),
-            _ => None,
-        },
         last_api_response_total_tokens = total_usage_breakdown.last_api_response_total_tokens,
         all_history_items_model_visible_bytes = total_usage_breakdown.all_history_items_model_visible_bytes,
         estimated_tokens_of_items_added_since_last_successful_api_response = total_usage_breakdown.estimated_tokens_of_items_added_since_last_successful_api_response,

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -266,7 +266,7 @@ impl ContextManager {
         self.items_after_last_model_generated_item()
             .iter()
             .fold(0usize, |acc, item| {
-                acc.saturating_add(estimate_item_token_approximation_bytes(item))
+                acc.saturating_add(estimate_item_model_visible_bytes(item))
             })
     }
 
@@ -389,12 +389,12 @@ fn estimate_reasoning_length(encoded_len: usize) -> usize {
 
 fn estimate_item_token_count(item: &ResponseItem) -> i64 {
     i64::try_from(approx_tokens_from_byte_count(
-        estimate_item_token_approximation_bytes(item),
+        estimate_item_model_visible_bytes(item),
     ))
     .unwrap_or(i64::MAX)
 }
 
-fn estimate_item_token_approximation_bytes(item: &ResponseItem) -> usize {
+fn estimate_item_model_visible_bytes(item: &ResponseItem) -> usize {
     match item {
         ResponseItem::GhostSnapshot { .. } => 0,
         ResponseItem::Reasoning {

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -30,9 +30,9 @@ pub(crate) struct ContextManager {
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct TotalTokenUsageBreakdown {
     pub last_api_response_total_tokens: i64,
-    pub all_history_items_model_visible_bytes: usize,
+    pub all_history_items_model_visible_bytes: i64,
     pub estimated_tokens_of_items_added_since_last_successful_api_response: i64,
-    pub estimated_bytes_of_items_added_since_last_successful_api_response: usize,
+    pub estimated_bytes_of_items_added_since_last_successful_api_response: i64,
 }
 
 impl ContextManager {
@@ -292,7 +292,8 @@ impl ContextManager {
                 .items
                 .iter()
                 .map(estimate_response_item_model_visible_bytes)
-                .fold(0usize, usize::saturating_add),
+                .map(|bytes| i64::try_from(bytes).unwrap_or(i64::MAX))
+                .fold(0i64, i64::saturating_add),
             estimated_tokens_of_items_added_since_last_successful_api_response:
                 items_after_last_model_generated
                     .iter()
@@ -302,7 +303,8 @@ impl ContextManager {
                 items_after_last_model_generated
                     .iter()
                     .map(estimate_response_item_model_visible_bytes)
-                    .fold(0usize, usize::saturating_add),
+                    .map(|bytes| i64::try_from(bytes).unwrap_or(i64::MAX))
+                    .fold(0i64, i64::saturating_add),
         }
     }
 

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -30,6 +30,7 @@ pub(crate) struct ContextManager {
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct TotalTokenUsageBreakdown {
     pub last_api_response_total_tokens: i64,
+    pub all_history_items_model_visible_bytes: usize,
     pub estimated_tokens_of_items_added_since_last_successful_api_response: i64,
     pub estimated_bytes_of_items_added_since_last_successful_api_response: usize,
 }
@@ -270,6 +271,12 @@ impl ContextManager {
             })
     }
 
+    fn get_all_items_model_visible_bytes(&self) -> usize {
+        self.items.iter().fold(0usize, |acc, item| {
+            acc.saturating_add(estimate_response_item_model_visible_bytes(item))
+        })
+    }
+
     /// When true, the server already accounted for past reasoning tokens and
     /// the client should not re-estimate them.
     pub(crate) fn get_total_token_usage(&self, server_reasoning_included: bool) -> i64 {
@@ -298,6 +305,7 @@ impl ContextManager {
 
         TotalTokenUsageBreakdown {
             last_api_response_total_tokens: last_usage.total_tokens,
+            all_history_items_model_visible_bytes: self.get_all_items_model_visible_bytes(),
             estimated_tokens_of_items_added_since_last_successful_api_response: self
                 .get_items_after_last_model_generated_tokens(),
             estimated_bytes_of_items_added_since_last_successful_api_response: self

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -110,9 +110,11 @@ impl ContextManager {
         let base_tokens =
             i64::try_from(approx_token_count(&base_instructions.text)).unwrap_or(i64::MAX);
 
-        let items_tokens = self.items.iter().fold(0i64, |acc, item| {
-            acc.saturating_add(estimate_item_token_count(item))
-        });
+        let items_tokens = self
+            .items
+            .iter()
+            .map(estimate_item_token_count)
+            .fold(0i64, i64::saturating_add);
 
         Some(base_tokens.saturating_add(items_tokens))
     }
@@ -239,9 +241,8 @@ impl ContextManager {
                     }
                 )
             })
-            .fold(0i64, |acc, item| {
-                acc.saturating_add(estimate_item_token_count(item))
-            })
+            .map(estimate_item_token_count)
+            .fold(0i64, i64::saturating_add)
     }
 
     // These are local items added after the most recent model-emitted item.
@@ -266,9 +267,8 @@ impl ContextManager {
         let items_after_last_model_generated_tokens = self
             .items_after_last_model_generated_item()
             .iter()
-            .fold(0i64, |acc, item| {
-                acc.saturating_add(estimate_item_token_count(item))
-            });
+            .map(estimate_item_token_count)
+            .fold(0i64, i64::saturating_add);
         if server_reasoning_included {
             last_tokens.saturating_add(items_after_last_model_generated_tokens)
         } else {
@@ -298,9 +298,8 @@ impl ContextManager {
             estimated_tokens_of_items_added_since_last_successful_api_response:
                 items_after_last_model_generated
                     .iter()
-                    .fold(0i64, |acc, item| {
-                        acc.saturating_add(estimate_item_token_count(item))
-                    }),
+                    .map(estimate_item_token_count)
+                    .fold(0i64, i64::saturating_add),
             estimated_bytes_of_items_added_since_last_successful_api_response:
                 items_after_last_model_generated
                     .iter()

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -266,15 +266,15 @@ impl ContextManager {
     fn get_items_after_last_model_generated_bytes(&self) -> usize {
         self.items_after_last_model_generated_item()
             .iter()
-            .fold(0usize, |acc, item| {
-                acc.saturating_add(estimate_response_item_model_visible_bytes(item))
-            })
+            .map(estimate_response_item_model_visible_bytes)
+            .fold(0usize, usize::saturating_add)
     }
 
     fn get_all_items_model_visible_bytes(&self) -> usize {
-        self.items.iter().fold(0usize, |acc, item| {
-            acc.saturating_add(estimate_response_item_model_visible_bytes(item))
-        })
+        self.items
+            .iter()
+            .map(estimate_response_item_model_visible_bytes)
+            .fold(0usize, usize::saturating_add)
     }
 
     /// When true, the server already accounted for past reasoning tokens and

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -4,6 +4,7 @@ use crate::instructions::SkillInstructions;
 use crate::instructions::UserInstructions;
 use crate::session_prefix::is_session_prefix;
 use crate::truncate::TruncationPolicy;
+use crate::truncate::approx_bytes_for_tokens;
 use crate::truncate::approx_token_count;
 use crate::truncate::approx_tokens_from_byte_count;
 use crate::truncate::truncate_function_output_items_with_policy;
@@ -25,6 +26,14 @@ pub(crate) struct ContextManager {
     /// The oldest items are at the beginning of the vector.
     items: Vec<ResponseItem>,
     token_info: Option<TokenUsageInfo>,
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct TotalTokenUsageBreakdown {
+    pub last_api_response_total_tokens: i64,
+    pub last_api_response_total_bytes_estimate: usize,
+    pub estimated_tokens_of_items_added_since_last_successful_api_response: i64,
+    pub estimated_bytes_of_items_added_since_last_successful_api_response: usize,
 }
 
 impl ContextManager {
@@ -255,6 +264,21 @@ impl ContextManager {
             })
     }
 
+    fn get_trailing_codex_generated_items_bytes(&self) -> usize {
+        let mut total = 0usize;
+        for item in self.items.iter().rev() {
+            if !is_codex_generated_item(item) {
+                break;
+            }
+            total = total.saturating_add(
+                serde_json::to_vec(item)
+                    .map(|bytes| bytes.len())
+                    .unwrap_or_default(),
+            );
+        }
+        total
+    }
+
     /// When true, the server already accounted for past reasoning tokens and
     /// the client should not re-estimate them.
     pub(crate) fn get_total_token_usage(&self, server_reasoning_included: bool) -> i64 {
@@ -271,6 +295,29 @@ impl ContextManager {
             last_tokens
                 .saturating_add(self.get_non_last_reasoning_items_tokens())
                 .saturating_add(items_after_last_model_generated_tokens)
+        }
+    }
+
+    pub(crate) fn get_total_token_usage_breakdown(&self) -> TotalTokenUsageBreakdown {
+        let last_usage = self
+            .token_info
+            .as_ref()
+            .map(|info| info.last_token_usage.clone())
+            .unwrap_or_default();
+
+        TotalTokenUsageBreakdown {
+            last_api_response_total_tokens: last_usage.total_tokens,
+            last_api_response_total_bytes_estimate: if last_usage.total_tokens <= 0 {
+                0
+            } else {
+                usize::try_from(last_usage.total_tokens)
+                    .map(approx_bytes_for_tokens)
+                    .unwrap_or(usize::MAX)
+            },
+            estimated_tokens_of_items_added_since_last_successful_api_response: self
+                .get_trailing_codex_generated_items_tokens(),
+            estimated_bytes_of_items_added_since_last_successful_api_response: self
+                .get_trailing_codex_generated_items_bytes(),
         }
     }
 

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -292,9 +292,8 @@ impl ContextManager {
                 .items
                 .iter()
                 .map(estimate_response_item_model_visible_bytes)
-                .fold(0i64, |acc, bytes| {
-                    acc.saturating_add(i64::try_from(bytes).unwrap_or(i64::MAX))
-                }),
+                .map(|bytes| i64::try_from(bytes).unwrap_or(i64::MAX))
+                .fold(0i64, i64::saturating_add),
             estimated_tokens_of_items_added_since_last_successful_api_response:
                 items_after_last_model_generated
                     .iter()
@@ -304,9 +303,8 @@ impl ContextManager {
                 items_after_last_model_generated
                     .iter()
                     .map(estimate_response_item_model_visible_bytes)
-                    .fold(0i64, |acc, bytes| {
-                        acc.saturating_add(i64::try_from(bytes).unwrap_or(i64::MAX))
-                    }),
+                    .map(|bytes| i64::try_from(bytes).unwrap_or(i64::MAX))
+                    .fold(0i64, i64::saturating_add),
         }
     }
 

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -270,13 +270,6 @@ impl ContextManager {
             .fold(0usize, usize::saturating_add)
     }
 
-    fn get_all_items_model_visible_bytes(&self) -> usize {
-        self.items
-            .iter()
-            .map(estimate_response_item_model_visible_bytes)
-            .fold(0usize, usize::saturating_add)
-    }
-
     /// When true, the server already accounted for past reasoning tokens and
     /// the client should not re-estimate them.
     pub(crate) fn get_total_token_usage(&self, server_reasoning_included: bool) -> i64 {
@@ -305,10 +298,13 @@ impl ContextManager {
 
         TotalTokenUsageBreakdown {
             last_api_response_total_tokens: last_usage.total_tokens,
-            all_history_items_model_visible_bytes: i64::try_from(
-                self.get_all_items_model_visible_bytes(),
-            )
-            .unwrap_or(i64::MAX),
+            all_history_items_model_visible_bytes: self
+                .items
+                .iter()
+                .map(estimate_response_item_model_visible_bytes)
+                .fold(0i64, |acc, bytes| {
+                    acc.saturating_add(i64::try_from(bytes).unwrap_or(i64::MAX))
+                }),
             estimated_tokens_of_items_added_since_last_successful_api_response: self
                 .get_items_after_last_model_generated_tokens(),
             estimated_bytes_of_items_added_since_last_successful_api_response: i64::try_from(

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -5,7 +5,7 @@ use crate::instructions::UserInstructions;
 use crate::session_prefix::is_session_prefix;
 use crate::truncate::TruncationPolicy;
 use crate::truncate::approx_token_count;
-use crate::truncate::approx_tokens_from_byte_count;
+use crate::truncate::approx_tokens_from_byte_count_i64;
 use crate::truncate::truncate_function_output_items_with_policy;
 use crate::truncate::truncate_text;
 use crate::user_shell_command::is_user_shell_command_text;
@@ -390,11 +390,7 @@ fn estimate_reasoning_length(encoded_len: usize) -> usize {
 
 fn estimate_item_token_count(item: &ResponseItem) -> i64 {
     let model_visible_bytes = estimate_response_item_model_visible_bytes(item);
-    if model_visible_bytes <= 0 {
-        return 0;
-    }
-    let model_visible_bytes = usize::try_from(model_visible_bytes).unwrap_or(usize::MAX);
-    i64::try_from(approx_tokens_from_byte_count(model_visible_bytes)).unwrap_or(i64::MAX)
+    approx_tokens_from_byte_count_i64(model_visible_bytes)
 }
 
 pub(crate) fn estimate_response_item_model_visible_bytes(item: &ResponseItem) -> i64 {

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -30,9 +30,9 @@ pub(crate) struct ContextManager {
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct TotalTokenUsageBreakdown {
     pub last_api_response_total_tokens: i64,
-    pub all_history_items_model_visible_bytes: i64,
+    pub all_history_items_model_visible_bytes: usize,
     pub estimated_tokens_of_items_added_since_last_successful_api_response: i64,
-    pub estimated_bytes_of_items_added_since_last_successful_api_response: i64,
+    pub estimated_bytes_of_items_added_since_last_successful_api_response: usize,
 }
 
 impl ContextManager {
@@ -292,8 +292,7 @@ impl ContextManager {
                 .items
                 .iter()
                 .map(estimate_response_item_model_visible_bytes)
-                .map(|bytes| i64::try_from(bytes).unwrap_or(i64::MAX))
-                .fold(0i64, i64::saturating_add),
+                .fold(0usize, usize::saturating_add),
             estimated_tokens_of_items_added_since_last_successful_api_response:
                 items_after_last_model_generated
                     .iter()
@@ -303,8 +302,7 @@ impl ContextManager {
                 items_after_last_model_generated
                     .iter()
                     .map(estimate_response_item_model_visible_bytes)
-                    .map(|bytes| i64::try_from(bytes).unwrap_or(i64::MAX))
-                    .fold(0i64, i64::saturating_add),
+                    .fold(0usize, usize::saturating_add),
         }
     }
 

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -4,7 +4,6 @@ use crate::instructions::SkillInstructions;
 use crate::instructions::UserInstructions;
 use crate::session_prefix::is_session_prefix;
 use crate::truncate::TruncationPolicy;
-use crate::truncate::approx_bytes_for_tokens;
 use crate::truncate::approx_token_count;
 use crate::truncate::approx_tokens_from_byte_count;
 use crate::truncate::truncate_function_output_items_with_policy;
@@ -31,7 +30,6 @@ pub(crate) struct ContextManager {
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct TotalTokenUsageBreakdown {
     pub last_api_response_total_tokens: i64,
-    pub last_api_response_total_bytes_estimate: usize,
     pub estimated_tokens_of_items_added_since_last_successful_api_response: i64,
     pub estimated_bytes_of_items_added_since_last_successful_api_response: usize,
 }
@@ -264,19 +262,16 @@ impl ContextManager {
             })
     }
 
-    fn get_trailing_codex_generated_items_bytes(&self) -> usize {
-        let mut total = 0usize;
-        for item in self.items.iter().rev() {
-            if !is_codex_generated_item(item) {
-                break;
-            }
-            total = total.saturating_add(
-                serde_json::to_vec(item)
-                    .map(|bytes| bytes.len())
-                    .unwrap_or_default(),
-            );
-        }
-        total
+    fn get_items_after_last_model_generated_bytes(&self) -> usize {
+        self.items_after_last_model_generated_item()
+            .iter()
+            .fold(0usize, |acc, item| {
+                acc.saturating_add(
+                    serde_json::to_vec(item)
+                        .map(|bytes| bytes.len())
+                        .unwrap_or_default(),
+                )
+            })
     }
 
     /// When true, the server already accounted for past reasoning tokens and
@@ -307,17 +302,10 @@ impl ContextManager {
 
         TotalTokenUsageBreakdown {
             last_api_response_total_tokens: last_usage.total_tokens,
-            last_api_response_total_bytes_estimate: if last_usage.total_tokens <= 0 {
-                0
-            } else {
-                usize::try_from(last_usage.total_tokens)
-                    .map(approx_bytes_for_tokens)
-                    .unwrap_or(usize::MAX)
-            },
             estimated_tokens_of_items_added_since_last_successful_api_response: self
-                .get_trailing_codex_generated_items_tokens(),
+                .get_items_after_last_model_generated_tokens(),
             estimated_bytes_of_items_added_since_last_successful_api_response: self
-                .get_trailing_codex_generated_items_bytes(),
+                .get_items_after_last_model_generated_bytes(),
         }
     }
 

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -266,11 +266,7 @@ impl ContextManager {
         self.items_after_last_model_generated_item()
             .iter()
             .fold(0usize, |acc, item| {
-                acc.saturating_add(
-                    serde_json::to_vec(item)
-                        .map(|bytes| bytes.len())
-                        .unwrap_or_default(),
-                )
+                acc.saturating_add(estimate_item_token_approximation_bytes(item))
             })
     }
 
@@ -392,6 +388,13 @@ fn estimate_reasoning_length(encoded_len: usize) -> usize {
 }
 
 fn estimate_item_token_count(item: &ResponseItem) -> i64 {
+    i64::try_from(approx_tokens_from_byte_count(
+        estimate_item_token_approximation_bytes(item),
+    ))
+    .unwrap_or(i64::MAX)
+}
+
+fn estimate_item_token_approximation_bytes(item: &ResponseItem) -> usize {
     match item {
         ResponseItem::GhostSnapshot { .. } => 0,
         ResponseItem::Reasoning {
@@ -400,14 +403,10 @@ fn estimate_item_token_count(item: &ResponseItem) -> i64 {
         }
         | ResponseItem::Compaction {
             encrypted_content: content,
-        } => {
-            let reasoning_bytes = estimate_reasoning_length(content.len());
-            i64::try_from(approx_tokens_from_byte_count(reasoning_bytes)).unwrap_or(i64::MAX)
-        }
-        item => {
-            let serialized = serde_json::to_string(item).unwrap_or_default();
-            i64::try_from(approx_token_count(&serialized)).unwrap_or(i64::MAX)
-        }
+        } => estimate_reasoning_length(content.len()),
+        item => serde_json::to_string(item)
+            .map(|serialized| serialized.len())
+            .unwrap_or_default(),
     }
 }
 

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -30,9 +30,9 @@ pub(crate) struct ContextManager {
 #[derive(Debug, Clone, Copy, Default)]
 pub(crate) struct TotalTokenUsageBreakdown {
     pub last_api_response_total_tokens: i64,
-    pub all_history_items_model_visible_bytes: usize,
+    pub all_history_items_model_visible_bytes: i64,
     pub estimated_tokens_of_items_added_since_last_successful_api_response: i64,
-    pub estimated_bytes_of_items_added_since_last_successful_api_response: usize,
+    pub estimated_bytes_of_items_added_since_last_successful_api_response: i64,
 }
 
 impl ContextManager {
@@ -305,11 +305,16 @@ impl ContextManager {
 
         TotalTokenUsageBreakdown {
             last_api_response_total_tokens: last_usage.total_tokens,
-            all_history_items_model_visible_bytes: self.get_all_items_model_visible_bytes(),
+            all_history_items_model_visible_bytes: i64::try_from(
+                self.get_all_items_model_visible_bytes(),
+            )
+            .unwrap_or(i64::MAX),
             estimated_tokens_of_items_added_since_last_successful_api_response: self
                 .get_items_after_last_model_generated_tokens(),
-            estimated_bytes_of_items_added_since_last_successful_api_response: self
-                .get_items_after_last_model_generated_bytes(),
+            estimated_bytes_of_items_added_since_last_successful_api_response: i64::try_from(
+                self.get_items_after_last_model_generated_bytes(),
+            )
+            .unwrap_or(i64::MAX),
         }
     }
 

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -255,21 +255,6 @@ impl ContextManager {
         &self.items[start..]
     }
 
-    fn get_items_after_last_model_generated_tokens(&self) -> i64 {
-        self.items_after_last_model_generated_item()
-            .iter()
-            .fold(0i64, |acc, item| {
-                acc.saturating_add(estimate_item_token_count(item))
-            })
-    }
-
-    fn get_items_after_last_model_generated_bytes(&self) -> usize {
-        self.items_after_last_model_generated_item()
-            .iter()
-            .map(estimate_response_item_model_visible_bytes)
-            .fold(0usize, usize::saturating_add)
-    }
-
     /// When true, the server already accounted for past reasoning tokens and
     /// the client should not re-estimate them.
     pub(crate) fn get_total_token_usage(&self, server_reasoning_included: bool) -> i64 {
@@ -278,8 +263,12 @@ impl ContextManager {
             .as_ref()
             .map(|info| info.last_token_usage.total_tokens)
             .unwrap_or(0);
-        let items_after_last_model_generated_tokens =
-            self.get_items_after_last_model_generated_tokens();
+        let items_after_last_model_generated_tokens = self
+            .items_after_last_model_generated_item()
+            .iter()
+            .fold(0i64, |acc, item| {
+                acc.saturating_add(estimate_item_token_count(item))
+            });
         if server_reasoning_included {
             last_tokens.saturating_add(items_after_last_model_generated_tokens)
         } else {
@@ -295,6 +284,7 @@ impl ContextManager {
             .as_ref()
             .map(|info| info.last_token_usage.clone())
             .unwrap_or_default();
+        let items_after_last_model_generated = self.items_after_last_model_generated_item();
 
         TotalTokenUsageBreakdown {
             last_api_response_total_tokens: last_usage.total_tokens,
@@ -305,12 +295,19 @@ impl ContextManager {
                 .fold(0i64, |acc, bytes| {
                     acc.saturating_add(i64::try_from(bytes).unwrap_or(i64::MAX))
                 }),
-            estimated_tokens_of_items_added_since_last_successful_api_response: self
-                .get_items_after_last_model_generated_tokens(),
-            estimated_bytes_of_items_added_since_last_successful_api_response: i64::try_from(
-                self.get_items_after_last_model_generated_bytes(),
-            )
-            .unwrap_or(i64::MAX),
+            estimated_tokens_of_items_added_since_last_successful_api_response:
+                items_after_last_model_generated
+                    .iter()
+                    .fold(0i64, |acc, item| {
+                        acc.saturating_add(estimate_item_token_count(item))
+                    }),
+            estimated_bytes_of_items_added_since_last_successful_api_response:
+                items_after_last_model_generated
+                    .iter()
+                    .map(estimate_response_item_model_visible_bytes)
+                    .fold(0i64, |acc, bytes| {
+                        acc.saturating_add(i64::try_from(bytes).unwrap_or(i64::MAX))
+                    }),
         }
     }
 

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -266,7 +266,7 @@ impl ContextManager {
         self.items_after_last_model_generated_item()
             .iter()
             .fold(0usize, |acc, item| {
-                acc.saturating_add(estimate_item_model_visible_bytes(item))
+                acc.saturating_add(estimate_response_item_model_visible_bytes(item))
             })
     }
 
@@ -389,12 +389,12 @@ fn estimate_reasoning_length(encoded_len: usize) -> usize {
 
 fn estimate_item_token_count(item: &ResponseItem) -> i64 {
     i64::try_from(approx_tokens_from_byte_count(
-        estimate_item_model_visible_bytes(item),
+        estimate_response_item_model_visible_bytes(item),
     ))
     .unwrap_or(i64::MAX)
 }
 
-fn estimate_item_model_visible_bytes(item: &ResponseItem) -> usize {
+pub(crate) fn estimate_response_item_model_visible_bytes(item: &ResponseItem) -> usize {
     match item {
         ResponseItem::GhostSnapshot { .. } => 0,
         ResponseItem::Reasoning {

--- a/codex-rs/core/src/context_manager/history_tests.rs
+++ b/codex-rs/core/src/context_manager/history_tests.rs
@@ -193,7 +193,11 @@ fn items_after_last_model_generated_tokens_include_user_and_tool_output() {
     );
 
     assert_eq!(
-        history.get_items_after_last_model_generated_tokens(),
+        history
+            .items_after_last_model_generated_item()
+            .iter()
+            .map(estimate_item_token_count)
+            .fold(0i64, i64::saturating_add),
         expected_tokens
     );
 }
@@ -202,7 +206,14 @@ fn items_after_last_model_generated_tokens_include_user_and_tool_output() {
 fn items_after_last_model_generated_tokens_are_zero_without_model_generated_items() {
     let history = create_history_with_items(vec![user_msg("no model output yet")]);
 
-    assert_eq!(history.get_items_after_last_model_generated_tokens(), 0);
+    assert_eq!(
+        history
+            .items_after_last_model_generated_item()
+            .iter()
+            .map(estimate_item_token_count)
+            .fold(0i64, i64::saturating_add),
+        0
+    );
 }
 
 #[test]

--- a/codex-rs/core/src/context_manager/mod.rs
+++ b/codex-rs/core/src/context_manager/mod.rs
@@ -2,5 +2,6 @@ mod history;
 mod normalize;
 
 pub(crate) use history::ContextManager;
+pub(crate) use history::TotalTokenUsageBreakdown;
 pub(crate) use history::is_codex_generated_item;
 pub(crate) use history::is_user_turn_boundary;

--- a/codex-rs/core/src/context_manager/mod.rs
+++ b/codex-rs/core/src/context_manager/mod.rs
@@ -3,5 +3,6 @@ mod normalize;
 
 pub(crate) use history::ContextManager;
 pub(crate) use history::TotalTokenUsageBreakdown;
+pub(crate) use history::estimate_response_item_model_visible_bytes;
 pub(crate) use history::is_codex_generated_item;
 pub(crate) use history::is_user_turn_boundary;

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -6,6 +6,7 @@ use std::collections::HashSet;
 
 use crate::codex::SessionConfiguration;
 use crate::context_manager::ContextManager;
+use crate::context_manager::TotalTokenUsageBreakdown;
 use crate::protocol::RateLimitSnapshot;
 use crate::protocol::TokenUsage;
 use crate::protocol::TokenUsageInfo;
@@ -98,6 +99,10 @@ impl SessionState {
     pub(crate) fn get_total_token_usage(&self, server_reasoning_included: bool) -> i64 {
         self.history
             .get_total_token_usage(server_reasoning_included)
+    }
+
+    pub(crate) fn get_total_token_usage_breakdown(&self) -> TotalTokenUsageBreakdown {
+        self.history.get_total_token_usage_breakdown()
     }
 
     pub(crate) fn set_server_reasoning_included(&mut self, included: bool) {

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -101,10 +101,6 @@ impl SessionState {
             .get_total_token_usage(server_reasoning_included)
     }
 
-    pub(crate) fn get_total_token_usage_breakdown(&self) -> TotalTokenUsageBreakdown {
-        self.history.get_total_token_usage_breakdown()
-    }
-
     pub(crate) fn set_server_reasoning_included(&mut self, included: bool) {
         self.server_reasoning_included = included;
     }

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -6,7 +6,6 @@ use std::collections::HashSet;
 
 use crate::codex::SessionConfiguration;
 use crate::context_manager::ContextManager;
-use crate::context_manager::TotalTokenUsageBreakdown;
 use crate::protocol::RateLimitSnapshot;
 use crate::protocol::TokenUsage;
 use crate::protocol::TokenUsageInfo;

--- a/codex-rs/core/src/truncate.rs
+++ b/codex-rs/core/src/truncate.rs
@@ -304,6 +304,14 @@ pub(crate) fn approx_tokens_from_byte_count(bytes: usize) -> u64 {
         / (APPROX_BYTES_PER_TOKEN as u64)
 }
 
+pub(crate) fn approx_tokens_from_byte_count_i64(bytes: i64) -> i64 {
+    if bytes <= 0 {
+        return 0;
+    }
+    let bytes = usize::try_from(bytes).unwrap_or(usize::MAX);
+    i64::try_from(approx_tokens_from_byte_count(bytes)).unwrap_or(i64::MAX)
+}
+
 #[cfg(test)]
 mod tests {
 


### PR DESCRIPTION
## Summary
- add targeted remote-compaction failure diagnostics in compact_remote logging
- log the specific values needed to explain overflow timing:
  - last_api_response_total_tokens
  - estimated_tokens_of_items_added_since_last_successful_api_response
  - estimated_bytes_of_items_added_since_last_successful_api_response
  - failing_compaction_request_body_bytes
- simplify breakdown naming and remove last_api_response_total_bytes_estimate (it was an approximation and not useful for debugging)

## Why
When compaction fails with context_length_exceeded, we need concrete, low-ambiguity numbers that map directly to:
1) what the API most recently reported, and
2) what local history added since then.

This keeps the failure logs actionable without adding broad, noisy metrics.

## Testing
- just fmt
- cargo test -p codex-core
