### PR TITLE
tui: avoid no-op status-line redraws

### DIFF
--- a/codex-rs/tui/src/bottom_pane/chat_composer.rs
+++ b/codex-rs/tui/src/bottom_pane/chat_composer.rs
@@ -3141,12 +3141,20 @@ impl ChatComposer {
         }
     }
 
-    pub(crate) fn set_status_line(&mut self, status_line: Option<Line<'static>>) {
+    pub(crate) fn set_status_line(&mut self, status_line: Option<Line<'static>>) -> bool {
+        if self.status_line_value == status_line {
+            return false;
+        }
         self.status_line_value = status_line;
+        true
     }
 
-    pub(crate) fn set_status_line_enabled(&mut self, enabled: bool) {
+    pub(crate) fn set_status_line_enabled(&mut self, enabled: bool) -> bool {
+        if self.status_line_enabled == enabled {
+            return false;
+        }
         self.status_line_enabled = enabled;
+        true
     }
 }
 

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -905,13 +905,15 @@ impl BottomPane {
     }
 
     pub(crate) fn set_status_line(&mut self, status_line: Option<Line<'static>>) {
-        self.composer.set_status_line(status_line);
-        self.request_redraw();
+        if self.composer.set_status_line(status_line) {
+            self.request_redraw();
+        }
     }
 
     pub(crate) fn set_status_line_enabled(&mut self, enabled: bool) {
-        self.composer.set_status_line_enabled(enabled);
-        self.request_redraw();
+        if self.composer.set_status_line_enabled(enabled) {
+            self.request_redraw();
+        }
     }
 }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -865,10 +865,9 @@ impl ChatWidget {
         self.set_status(header, None);
     }
 
-    /// Sets the currently rendered footer status-line value and schedules a redraw.
+    /// Sets the currently rendered footer status-line value.
     pub(crate) fn set_status_line(&mut self, status_line: Option<Line<'static>>) {
         self.bottom_pane.set_status_line(status_line);
-        self.request_redraw();
     }
 
     /// Recomputes footer status-line content from config and current runtime state.


### PR DESCRIPTION
Rate-limit snapshots are polled every 60s, which causes unconditional redraws.
This causes spurious "tab changed" indicators in terminal apps.

# External (non-OpenAI) Pull Request Requirements

Before opening this Pull Request, please read the dedicated "Contributing" markdown file or your PR may be closed:
https://github.com/openai/codex/blob/main/docs/contributing.md

If your PR conforms to our contribution guidelines, replace this text with a detailed and high quality description of your changes.

Include a link to a bug report or enhancement request.
