### PR TITLE
Deflake mixed parallel tools timing test

### DIFF
--- a/codex-rs/core/tests/suite/tool_parallelism.rs
+++ b/codex-rs/core/tests/suite/tool_parallelism.rs
@@ -187,6 +187,8 @@ async fn mixed_parallel_tools_run_in_parallel() -> anyhow::Result<()> {
     .to_string();
     let shell_args = serde_json::to_string(&json!({
         "command": "sleep 0.3",
+        // Avoid user-specific shell startup cost in timing assertions.
+        "login": false,
         "timeout_ms": 1_000,
     }))?;
 


### PR DESCRIPTION
```
        FAIL [   1.903s] (1926/3311) codex-core::all suite::tool_parallelism::mixed_parallel_tools_run_in_parallel
  stdout ───

    running 1 test
    test suite::tool_parallelism::mixed_parallel_tools_run_in_parallel ... FAILED

    failures:

    failures:
        suite::tool_parallelism::mixed_parallel_tools_run_in_parallel

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 684 filtered out; finished in 1.86s
    
  stderr ───

    thread 'suite::tool_parallelism::mixed_parallel_tools_run_in_parallel' (205083) panicked at core/tests/suite/tool_parallelism.rs:74:5:
    expected parallel execution to finish quickly, got 1.406255993s
    stack backtrace:
       0: __rustc::rust_begin_unwind
                 at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/std/src/panicking.rs:689:5
       1: core::panicking::panic_fmt
                 at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/core/src/panicking.rs:80:14
       2: all::suite::tool_parallelism::assert_parallel_duration
                 at ./tests/suite/tool_parallelism.rs:74:5
       3: all::suite::tool_parallelism::mixed_parallel_tools_run_in_parallel::{{closure}}
                 at ./tests/suite/tool_parallelism.rs:206:5
       4: <core::pin::Pin<P> as core::future::future::Future>::poll
                 at /home/runner/.rustup/toolchains/1.93.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/future/future.rs:133:9
       5: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
                 at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/park.rs:284:71
       6: tokio::task::coop::with_budget
                 at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/task/coop/mod.rs:167:5
       7: tokio::task::coop::budget
                 at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/task/coop/mod.rs:133:5
       8: tokio::runtime::park::CachedParkThread::block_on
                 at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/park.rs:284:31
       9: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
                 at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/context/blocking.rs:66:14
      10: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
                 at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/scheduler/multi_thread/mod.rs:89:22
      11: tokio::runtime::context::runtime::enter_runtime
                 at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/context/runtime.rs:65:16
      12: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
                 at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/scheduler/multi_thread/mod.rs:88:9
      13: tokio::runtime::runtime::Runtime::block_on_inner
                 at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/runtime.rs:370:50
      14: tokio::runtime::runtime::Runtime::block_on
                 at /home/runner/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.49.0/src/runtime/runtime.rs:342:18
      15: all::suite::tool_parallelism::mixed_parallel_tools_run_in_parallel
                 at ./tests/suite/tool_parallelism.rs:208:7
      16: all::suite::tool_parallelism::mixed_parallel_tools_run_in_parallel::{{closure}}
                 at ./tests/suite/tool_parallelism.rs:178:52
      17: core::ops::function::FnOnce::call_once
                 at /home/runner/.rustup/toolchains/1.93.0-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
      18: core::ops::function::FnOnce::call_once
                 at /rustc/254b59607d4417e9dffbc307138ae5c86280fe4c/library/core/src/ops/function.rs:250:5
    note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```