### PR TITLE
Increase timeout for flake

### DIFF
--- a/codex-rs/core/tests/suite/shell_command.rs
+++ b/codex-rs/core/tests/suite/shell_command.rs
@@ -50,7 +50,7 @@ fn shell_responses_with_timeout(
 }
 
 fn shell_responses(call_id: &str, command: &str, login: Option<bool>) -> Vec<String> {
-    shell_responses_with_timeout(call_id, command, login, 2_000)
+    shell_responses_with_timeout(call_id, command, login, MEDIUM_TIMEOUT.as_millis() as i64)
 }
 
 async fn shell_command_harness_with(


### PR DESCRIPTION
Saw:

```
stdout ───

    running 1 test
    test suite::shell_command::shell_command_works ... FAILED

    failures:

    failures:
        suite::shell_command::shell_command_works

    test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 513 filtered out; finished in 7.73s
    
  stderr ───

    thread 'suite::shell_command::shell_command_works' (13004) panicked at core\tests\common\lib.rs:27:28:
    regex "(?s)^Exit code: 0\\nWall time: [0-9]+(?:\\.[0-9]+)? seconds\\nOutput:\\nhello, world\\n?$" did not match "Exit code: 124\nWall time: 2 seconds\nOutput:\ncommand timed out after 2005 milliseconds\nhello, world"
```

So using MEDIUM_TIMEOUT:

```rust
/// Use this timeout if, empirically, a test seems to need more time than the
/// default.
const MEDIUM_TIMEOUT: Duration = Duration::from_secs(5);
```