### PR TITLE
chore(app-server) migrate TurnStart to Op::UserTurn

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -651,7 +651,9 @@ impl SessionConfiguration {
             approval_policy: self.approval_policy.value(),
             sandbox_policy: self.sandbox_policy.get().clone(),
             cwd: self.cwd.clone(),
+            collaboration_mode: self.collaboration_mode.clone(),
             reasoning_effort: self.collaboration_mode.reasoning_effort(),
+            reasoning_summary: self.model_reasoning_summary,
             personality: self.personality,
             session_source: self.session_source.clone(),
         }

--- a/codex-rs/core/src/codex_thread.rs
+++ b/codex-rs/core/src/codex_thread.rs
@@ -5,7 +5,9 @@ use crate::error::Result as CodexResult;
 use crate::protocol::Event;
 use crate::protocol::Op;
 use crate::protocol::Submission;
+use codex_protocol::config_types::CollaborationMode;
 use codex_protocol::config_types::Personality;
+use codex_protocol::config_types::ReasoningSummary;
 use codex_protocol::openai_models::ReasoningEffort;
 use codex_protocol::protocol::AskForApproval;
 use codex_protocol::protocol::SandboxPolicy;
@@ -23,7 +25,9 @@ pub struct ThreadConfigSnapshot {
     pub approval_policy: AskForApproval,
     pub sandbox_policy: SandboxPolicy,
     pub cwd: PathBuf,
+    pub collaboration_mode: CollaborationMode,
     pub reasoning_effort: Option<ReasoningEffort>,
+    pub reasoning_summary: ReasoningSummary,
     pub personality: Option<Personality>,
     pub session_source: SessionSource,
 }


### PR DESCRIPTION
## Summary
Deprecate usage of OverrideTurnContext + UserInput in app-server

## Testing
- [ ] integration test coverage