### PR TITLE
Use longest remote model prefix matching

### DIFF
--- a/codex-rs/core/src/models_manager/manager.rs
+++ b/codex-rs/core/src/models_manager/manager.rs
@@ -152,22 +152,21 @@ impl ModelsManager {
         model: &str,
         config: &Config,
     ) -> Option<ModelInfo> {
-        self.get_remote_models(config)
-            .await
-            .into_iter()
-            .fold(None, |best, candidate| {
-                if model.starts_with(&candidate.slug) {
-                    let is_better_match = if let Some(current) = best.as_ref() {
-                        candidate.slug.len() > current.slug.len()
-                    } else {
-                        true
-                    };
-                    if is_better_match {
-                        return Some(candidate);
-                    }
-                }
-                best
-            })
+        let mut best = None;
+        for candidate in self.get_remote_models(config).await {
+            if !model.starts_with(&candidate.slug) {
+                continue;
+            }
+            let is_better_match = if let Some(current) = best.as_ref() {
+                candidate.slug.len() > current.slug.len()
+            } else {
+                true
+            };
+            if is_better_match {
+                best = Some(candidate);
+            }
+        }
+        best
     }
 
     /// Refresh models if the provided ETag differs from the cached ETag.

--- a/codex-rs/core/src/models_manager/manager.rs
+++ b/codex-rs/core/src/models_manager/manager.rs
@@ -137,16 +137,37 @@ impl ModelsManager {
     /// Look up model metadata, applying remote overrides and config adjustments.
     pub async fn get_model_info(&self, model: &str, config: &Config) -> ModelInfo {
         let remote = self
-            .get_remote_models(config)
-            .await
-            .into_iter()
-            .find(|m| m.slug == model);
+            .find_remote_model_by_longest_prefix(model, config)
+            .await;
         let model = if let Some(remote) = remote {
             remote
         } else {
             model_info::find_model_info_for_slug(model)
         };
         model_info::with_config_overrides(model, config)
+    }
+
+    async fn find_remote_model_by_longest_prefix(
+        &self,
+        model: &str,
+        config: &Config,
+    ) -> Option<ModelInfo> {
+        self.get_remote_models(config)
+            .await
+            .into_iter()
+            .fold(None, |best, candidate| {
+                if model.starts_with(&candidate.slug) {
+                    let is_better_match = if let Some(current) = best.as_ref() {
+                        candidate.slug.len() > current.slug.len()
+                    } else {
+                        true
+                    };
+                    if is_better_match {
+                        return Some(candidate);
+                    }
+                }
+                best
+            })
     }
 
     /// Refresh models if the provided ETag differs from the cached ETag.

--- a/codex-rs/core/src/models_manager/manager.rs
+++ b/codex-rs/core/src/models_manager/manager.rs
@@ -152,7 +152,7 @@ impl ModelsManager {
         model: &str,
         config: &Config,
     ) -> Option<ModelInfo> {
-        let mut best = None;
+        let mut best: Option<ModelInfo> = None;
         for candidate in self.get_remote_models(config).await {
             if !model.starts_with(&candidate.slug) {
                 continue;


### PR DESCRIPTION
Match model metadata by longest matching remote slug prefix before local fallback.

- Update `get_model_info` to prefer the most specific remote slug prefix for the requested model.
- Add an integration test to assert `gpt-5.3-codex-test` resolves to `gpt-5.3-codex` over `gpt-5.3`.