### PR TITLE
Treat first rollout session_meta as canonical thread identity

### DIFF
--- a/codex-rs/core/src/rollout/list.rs
+++ b/codex-rs/core/src/rollout/list.rs
@@ -1015,25 +1015,27 @@ async fn read_head_summary(path: &Path, head_limit: usize) -> io::Result<HeadTai
 
         match rollout_line.item {
             RolloutItem::SessionMeta(session_meta_line) => {
-                summary.source = Some(session_meta_line.meta.source.clone());
-                summary.model_provider = session_meta_line.meta.model_provider.clone();
-                summary.thread_id = Some(session_meta_line.meta.id);
-                summary.cwd = Some(session_meta_line.meta.cwd.clone());
-                summary.git_branch = session_meta_line
-                    .git
-                    .as_ref()
-                    .and_then(|git| git.branch.clone());
-                summary.git_sha = session_meta_line
-                    .git
-                    .as_ref()
-                    .and_then(|git| git.commit_hash.clone());
-                summary.git_origin_url = session_meta_line
-                    .git
-                    .as_ref()
-                    .and_then(|git| git.repository_url.clone());
-                summary.cli_version = Some(session_meta_line.meta.cli_version);
-                summary.created_at = Some(session_meta_line.meta.timestamp.clone());
-                summary.saw_session_meta = true;
+                if !summary.saw_session_meta {
+                    summary.source = Some(session_meta_line.meta.source.clone());
+                    summary.model_provider = session_meta_line.meta.model_provider.clone();
+                    summary.thread_id = Some(session_meta_line.meta.id);
+                    summary.cwd = Some(session_meta_line.meta.cwd.clone());
+                    summary.git_branch = session_meta_line
+                        .git
+                        .as_ref()
+                        .and_then(|git| git.branch.clone());
+                    summary.git_sha = session_meta_line
+                        .git
+                        .as_ref()
+                        .and_then(|git| git.commit_hash.clone());
+                    summary.git_origin_url = session_meta_line
+                        .git
+                        .as_ref()
+                        .and_then(|git| git.repository_url.clone());
+                    summary.cli_version = Some(session_meta_line.meta.cli_version);
+                    summary.created_at = Some(session_meta_line.meta.timestamp.clone());
+                    summary.saw_session_meta = true;
+                }
             }
             RolloutItem::ResponseItem(_) => {
                 summary.created_at = summary

--- a/codex-rs/core/src/rollout/tests.rs
+++ b/codex-rs/core/src/rollout/tests.rs
@@ -881,6 +881,7 @@ async fn test_list_threads_scans_past_head_for_user_event() {
     .unwrap();
 
     assert_eq!(page.items.len(), 1);
+    assert_eq!(page.items[0].thread_id, Some(thread_id_from_uuid(uuid)));
 }
 
 #[tokio::test]


### PR DESCRIPTION
During thread/fork, the new rollout includes the fork’s own session_meta plus copied history that can contain older session_meta entries from the source thread. thread/list was overwriting metadata on later session_meta lines, so a fork could be reported with the source thread’s thread_id. This fix only uses the first session_meta, so the fork keeps its own ID.