### PR TITLE
feat: add SkillPolicy to skill metadata and support allow_implicit_invocation

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -298,6 +298,19 @@ impl Codex {
             loaded_skills.allowed_skills_for_implicit_invocation();
         let user_instructions =
             get_user_instructions(&config, Some(&allowed_skills_for_implicit_invocation)).await;
+        let allowed_skill_names: Vec<&str> = allowed_skills_for_implicit_invocation
+            .iter()
+            .map(|skill| skill.name.as_str())
+            .collect();
+        info!(
+            allowed_skills = ?allowed_skill_names,
+            "allowed skills for implicit invocation"
+        );
+        if let Some(instructions) = user_instructions.as_deref() {
+            info!(%instructions, "user instructions");
+        } else {
+            info!("user instructions: <none>");
+        }
 
         let exec_policy = ExecPolicyManager::load(&config.config_layer_stack)
             .await

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -293,8 +293,10 @@ impl Codex {
             config.features.disable(Feature::Collab);
         }
 
-        let enabled_skills = loaded_skills.enabled_skills();
-        let user_instructions = get_user_instructions(&config, Some(&enabled_skills)).await;
+        let allowed_skills_for_implicit_invocation =
+            loaded_skills.allowed_skills_for_implicit_invocation();
+        let user_instructions =
+            get_user_instructions(&config, Some(&allowed_skills_for_implicit_invocation)).await;
 
         let exec_policy = ExecPolicyManager::load(&config.config_layer_stack)
             .await

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -298,19 +298,6 @@ impl Codex {
             loaded_skills.allowed_skills_for_implicit_invocation();
         let user_instructions =
             get_user_instructions(&config, Some(&allowed_skills_for_implicit_invocation)).await;
-        let allowed_skill_names: Vec<&str> = allowed_skills_for_implicit_invocation
-            .iter()
-            .map(|skill| skill.name.as_str())
-            .collect();
-        info!(
-            allowed_skills = ?allowed_skill_names,
-            "allowed skills for implicit invocation"
-        );
-        if let Some(instructions) = user_instructions.as_deref() {
-            info!(%instructions, "user instructions");
-        } else {
-            info!("user instructions: <none>");
-        }
 
         let exec_policy = ExecPolicyManager::load(&config.config_layer_stack)
             .await

--- a/codex-rs/core/src/mcp/skill_dependencies.rs
+++ b/codex-rs/core/src/mcp/skill_dependencies.rs
@@ -25,6 +25,7 @@ use crate::default_client::is_first_party_originator;
 use crate::default_client::originator;
 use crate::features::Feature;
 use crate::skills::SkillMetadata;
+use crate::skills::SkillPolicy;
 use crate::skills::model::SkillToolDependency;
 
 const SKILL_MCP_DEPENDENCY_PROMPT_ID: &str = "skill_mcp_dependency_install";
@@ -431,6 +432,9 @@ mod tests {
             short_description: None,
             interface: None,
             dependencies: Some(SkillDependencies { tools }),
+            policy: SkillPolicy {
+                allow_implicit_invocation: true,
+            },
             path: PathBuf::from("skill"),
             scope: SkillScope::User,
         }

--- a/codex-rs/core/src/mcp/skill_dependencies.rs
+++ b/codex-rs/core/src/mcp/skill_dependencies.rs
@@ -25,7 +25,6 @@ use crate::default_client::is_first_party_originator;
 use crate::default_client::originator;
 use crate::features::Feature;
 use crate::skills::SkillMetadata;
-use crate::skills::SkillPolicy;
 use crate::skills::model::SkillToolDependency;
 
 const SKILL_MCP_DEPENDENCY_PROMPT_ID: &str = "skill_mcp_dependency_install";
@@ -420,6 +419,7 @@ fn mcp_dependency_to_server_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::skills::SkillPolicy;
     use crate::skills::model::SkillDependencies;
     use codex_protocol::protocol::SkillScope;
     use pretty_assertions::assert_eq;

--- a/codex-rs/core/src/mcp/skill_dependencies.rs
+++ b/codex-rs/core/src/mcp/skill_dependencies.rs
@@ -419,7 +419,6 @@ fn mcp_dependency_to_server_config(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::skills::SkillPolicy;
     use crate::skills::model::SkillDependencies;
     use codex_protocol::protocol::SkillScope;
     use pretty_assertions::assert_eq;
@@ -432,9 +431,7 @@ mod tests {
             short_description: None,
             interface: None,
             dependencies: Some(SkillDependencies { tools }),
-            policy: SkillPolicy {
-                allow_implicit_invocation: true,
-            },
+            policy: None,
             path: PathBuf::from("skill"),
             scope: SkillScope::User,
         }

--- a/codex-rs/core/src/skills/assets/samples/skill-creator/references/openai_yaml.md
+++ b/codex-rs/core/src/skills/assets/samples/skill-creator/references/openai_yaml.md
@@ -46,3 +46,4 @@ Top-level constraints:
 - `dependencies.tools[].url`: MCP server URL when `type` is `mcp`.
 - `policy.allow_implicit_invocation`: When false, the skill is not injected into
   the model context by default, but can still be invoked explicitly via `$skill`.
+  Defaults to true.

--- a/codex-rs/core/src/skills/assets/samples/skill-creator/references/openai_yaml.md
+++ b/codex-rs/core/src/skills/assets/samples/skill-creator/references/openai_yaml.md
@@ -20,6 +20,9 @@ dependencies:
       description: "GitHub MCP server"
       transport: "streamable_http"
       url: "https://api.githubcopilot.com/mcp/"
+
+policy:
+  allow_implicit_invocation: true
 ```
 
 ## Field descriptions and constraints
@@ -41,3 +44,5 @@ Top-level constraints:
 - `dependencies.tools[].description`: Human-readable explanation of the dependency.
 - `dependencies.tools[].transport`: Connection type when `type` is `mcp`.
 - `dependencies.tools[].url`: MCP server URL when `type` is `mcp`.
+- `policy.allow_implicit_invocation`: When false, the skill is not injected into
+  the model context by default, but can still be invoked explicitly via `$skill`.

--- a/codex-rs/core/src/skills/injection.rs
+++ b/codex-rs/core/src/skills/injection.rs
@@ -462,7 +462,6 @@ fn is_mention_name_char(byte: u8) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::skills::SkillPolicy;
     use pretty_assertions::assert_eq;
     use std::collections::HashMap;
     use std::collections::HashSet;
@@ -474,9 +473,7 @@ mod tests {
             short_description: None,
             interface: None,
             dependencies: None,
-            policy: SkillPolicy {
-                allow_implicit_invocation: true,
-            },
+            policy: None,
             path: PathBuf::from(path),
             scope: codex_protocol::protocol::SkillScope::User,
         }

--- a/codex-rs/core/src/skills/injection.rs
+++ b/codex-rs/core/src/skills/injection.rs
@@ -7,6 +7,7 @@ use crate::analytics_client::SkillInvocation;
 use crate::analytics_client::TrackEventsContext;
 use crate::instructions::SkillInstructions;
 use crate::skills::SkillMetadata;
+use crate::skills::SkillPolicy;
 use codex_otel::OtelManager;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::user_input::UserInput;
@@ -473,6 +474,9 @@ mod tests {
             short_description: None,
             interface: None,
             dependencies: None,
+            policy: SkillPolicy {
+                allow_implicit_invocation: true,
+            },
             path: PathBuf::from(path),
             scope: codex_protocol::protocol::SkillScope::User,
         }

--- a/codex-rs/core/src/skills/injection.rs
+++ b/codex-rs/core/src/skills/injection.rs
@@ -7,7 +7,6 @@ use crate::analytics_client::SkillInvocation;
 use crate::analytics_client::TrackEventsContext;
 use crate::instructions::SkillInstructions;
 use crate::skills::SkillMetadata;
-use crate::skills::SkillPolicy;
 use codex_otel::OtelManager;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::user_input::UserInput;
@@ -463,6 +462,7 @@ fn is_mention_name_char(byte: u8) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::skills::SkillPolicy;
     use pretty_assertions::assert_eq;
     use std::collections::HashMap;
     use std::collections::HashSet;

--- a/codex-rs/core/src/skills/loader.rs
+++ b/codex-rs/core/src/skills/loader.rs
@@ -70,20 +70,8 @@ struct Dependencies {
 
 #[derive(Debug, Deserialize)]
 struct Policy {
-    #[serde(default = "default_allow_implicit_invocation")]
-    allow_implicit_invocation: bool,
-}
-
-impl Default for Policy {
-    fn default() -> Self {
-        Self {
-            allow_implicit_invocation: true,
-        }
-    }
-}
-
-fn default_allow_implicit_invocation() -> bool {
-    true
+    #[serde(default)]
+    allow_implicit_invocation: Option<bool>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -1267,7 +1255,7 @@ policy:
         assert_eq!(
             outcome.skills[0].policy,
             Some(SkillPolicy {
-                allow_implicit_invocation: false,
+                allow_implicit_invocation: Some(false),
             })
         );
         assert!(outcome.allowed_skills_for_implicit_invocation().is_empty());
@@ -1298,8 +1286,12 @@ policy: {}
         assert_eq!(
             outcome.skills[0].policy,
             Some(SkillPolicy {
-                allow_implicit_invocation: true,
+                allow_implicit_invocation: None,
             })
+        );
+        assert_eq!(
+            outcome.allowed_skills_for_implicit_invocation(),
+            outcome.skills.clone()
         );
     }
 

--- a/codex-rs/core/src/skills/loader.rs
+++ b/codex-rs/core/src/skills/loader.rs
@@ -49,7 +49,7 @@ struct SkillMetadataFile {
     #[serde(default)]
     dependencies: Option<Dependencies>,
     #[serde(default)]
-    policy: SkillPolicyFile,
+    policy: Policy,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -69,12 +69,12 @@ struct Dependencies {
 }
 
 #[derive(Debug, Deserialize)]
-struct SkillPolicyFile {
+struct Policy {
     #[serde(default)]
     allow_implicit_invocation: bool,
 }
 
-impl Default for SkillPolicyFile {
+impl Default for Policy {
     fn default() -> Self {
         Self {
             allow_implicit_invocation: true,

--- a/codex-rs/core/src/skills/loader.rs
+++ b/codex-rs/core/src/skills/loader.rs
@@ -49,7 +49,7 @@ struct SkillMetadataFile {
     #[serde(default)]
     dependencies: Option<Dependencies>,
     #[serde(default)]
-    policy: Policy,
+    policy: Option<Policy>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -575,14 +575,11 @@ fn load_skill_metadata(
         dependencies,
         policy,
     } = parsed;
-    let policy = SkillPolicy {
-        allow_implicit_invocation: policy.allow_implicit_invocation,
-    };
 
     (
         resolve_interface(interface, skill_dir),
         resolve_dependencies(dependencies),
-        policy,
+        resolve_policy(policy),
     )
 }
 
@@ -628,6 +625,13 @@ fn resolve_dependencies(dependencies: Option<Dependencies>) -> Option<SkillDepen
         None
     } else {
         Some(SkillDependencies { tools })
+    }
+}
+
+fn resolve_policy(policy: Option<Policy>) -> SkillPolicy {
+    let policy = policy.unwrap_or_default();
+    SkillPolicy {
+        allow_implicit_invocation: policy.allow_implicit_invocation,
     }
 }
 

--- a/codex-rs/core/src/skills/loader.rs
+++ b/codex-rs/core/src/skills/loader.rs
@@ -1291,7 +1291,7 @@ policy: {}
         );
         assert_eq!(
             outcome.allowed_skills_for_implicit_invocation(),
-            outcome.skills.clone()
+            outcome.skills
         );
     }
 

--- a/codex-rs/core/src/skills/mod.rs
+++ b/codex-rs/core/src/skills/mod.rs
@@ -17,4 +17,5 @@ pub use manager::SkillsManager;
 pub use model::SkillError;
 pub use model::SkillLoadOutcome;
 pub use model::SkillMetadata;
+pub use model::SkillPolicy;
 pub use render::render_skills_section;

--- a/codex-rs/core/src/skills/model.rs
+++ b/codex-rs/core/src/skills/model.rs
@@ -71,10 +71,14 @@ impl SkillLoadOutcome {
         !self.disabled_paths.contains(&skill.path)
     }
 
+    pub fn is_skill_enabled_for_implicit_use(&self, skill: &SkillMetadata) -> bool {
+        self.is_skill_enabled(skill) && skill.policy.allow_implicit_invocation
+    }
+
     pub fn enabled_skills(&self) -> Vec<SkillMetadata> {
         self.skills
             .iter()
-            .filter(|skill| self.is_skill_enabled(skill) && skill.policy.allow_implicit_invocation)
+            .filter(|skill| self.is_skill_enabled_for_implicit_use(skill))
             .cloned()
             .collect()
     }

--- a/codex-rs/core/src/skills/model.rs
+++ b/codex-rs/core/src/skills/model.rs
@@ -19,19 +19,20 @@ impl SkillMetadata {
     fn allow_implicit_invocation(&self) -> bool {
         self.policy
             .as_ref()
-            .map_or(true, |policy| policy.allow_implicit_invocation)
+            .and_then(|policy| policy.allow_implicit_invocation)
+            .unwrap_or(true)
     }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct SkillPolicy {
-    pub allow_implicit_invocation: bool,
+    pub allow_implicit_invocation: Option<bool>,
 }
 
 impl Default for SkillPolicy {
     fn default() -> Self {
         Self {
-            allow_implicit_invocation: true,
+            allow_implicit_invocation: None,
         }
     }
 }

--- a/codex-rs/core/src/skills/model.rs
+++ b/codex-rs/core/src/skills/model.rs
@@ -10,8 +10,22 @@ pub struct SkillMetadata {
     pub short_description: Option<String>,
     pub interface: Option<SkillInterface>,
     pub dependencies: Option<SkillDependencies>,
+    pub policy: SkillPolicy,
     pub path: PathBuf,
     pub scope: SkillScope,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SkillPolicy {
+    pub allow_implicit_invocation: bool,
+}
+
+impl Default for SkillPolicy {
+    fn default() -> Self {
+        Self {
+            allow_implicit_invocation: true,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -60,7 +74,7 @@ impl SkillLoadOutcome {
     pub fn enabled_skills(&self) -> Vec<SkillMetadata> {
         self.skills
             .iter()
-            .filter(|skill| self.is_skill_enabled(skill))
+            .filter(|skill| self.is_skill_enabled(skill) && skill.policy.allow_implicit_invocation)
             .cloned()
             .collect()
     }

--- a/codex-rs/core/src/skills/model.rs
+++ b/codex-rs/core/src/skills/model.rs
@@ -24,17 +24,9 @@ impl SkillMetadata {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct SkillPolicy {
     pub allow_implicit_invocation: Option<bool>,
-}
-
-impl Default for SkillPolicy {
-    fn default() -> Self {
-        Self {
-            allow_implicit_invocation: None,
-        }
-    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/codex-rs/core/src/skills/model.rs
+++ b/codex-rs/core/src/skills/model.rs
@@ -10,9 +10,17 @@ pub struct SkillMetadata {
     pub short_description: Option<String>,
     pub interface: Option<SkillInterface>,
     pub dependencies: Option<SkillDependencies>,
-    pub policy: SkillPolicy,
+    pub policy: Option<SkillPolicy>,
     pub path: PathBuf,
     pub scope: SkillScope,
+}
+
+impl SkillMetadata {
+    fn allow_implicit_invocation(&self) -> bool {
+        self.policy
+            .as_ref()
+            .map_or(true, |policy| policy.allow_implicit_invocation)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -71,14 +79,14 @@ impl SkillLoadOutcome {
         !self.disabled_paths.contains(&skill.path)
     }
 
-    pub fn is_skill_enabled_for_implicit_use(&self, skill: &SkillMetadata) -> bool {
-        self.is_skill_enabled(skill) && skill.policy.allow_implicit_invocation
+    pub fn is_skill_allowed_for_implicit_invocation(&self, skill: &SkillMetadata) -> bool {
+        self.is_skill_enabled(skill) && skill.allow_implicit_invocation()
     }
 
-    pub fn enabled_skills(&self) -> Vec<SkillMetadata> {
+    pub fn allowed_skills_for_implicit_invocation(&self) -> Vec<SkillMetadata> {
         self.skills
             .iter()
-            .filter(|skill| self.is_skill_enabled_for_implicit_use(skill))
+            .filter(|skill| self.is_skill_allowed_for_implicit_invocation(skill))
             .cloned()
             .collect()
     }

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -28,6 +28,7 @@ use crate::tui::FrameRequester;
 use bottom_pane_view::BottomPaneView;
 use codex_core::features::Features;
 use codex_core::skills::model::SkillMetadata;
+use codex_core::skills::model::SkillPolicy;
 use codex_file_search::FileMatch;
 use codex_protocol::request_user_input::RequestUserInputEvent;
 use codex_protocol::user_input::TextElement;
@@ -1332,6 +1333,9 @@ mod tests {
                 short_description: None,
                 interface: None,
                 dependencies: None,
+                policy: SkillPolicy {
+                    allow_implicit_invocation: true,
+                },
                 path: PathBuf::from("test-skill"),
                 scope: SkillScope::User,
             }]),

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -956,7 +956,6 @@ mod tests {
     use super::*;
     use crate::app_event::AppEvent;
     use codex_core::protocol::Op;
-    use codex_core::skills::model::SkillPolicy;
     use codex_protocol::protocol::SkillScope;
     use crossterm::event::KeyModifiers;
     use insta::assert_snapshot;
@@ -1333,9 +1332,7 @@ mod tests {
                 short_description: None,
                 interface: None,
                 dependencies: None,
-                policy: SkillPolicy {
-                    allow_implicit_invocation: true,
-                },
+                policy: None,
                 path: PathBuf::from("test-skill"),
                 scope: SkillScope::User,
             }]),

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -28,7 +28,6 @@ use crate::tui::FrameRequester;
 use bottom_pane_view::BottomPaneView;
 use codex_core::features::Features;
 use codex_core::skills::model::SkillMetadata;
-use codex_core::skills::model::SkillPolicy;
 use codex_file_search::FileMatch;
 use codex_protocol::request_user_input::RequestUserInputEvent;
 use codex_protocol::user_input::TextElement;
@@ -957,6 +956,7 @@ mod tests {
     use super::*;
     use crate::app_event::AppEvent;
     use codex_core::protocol::Op;
+    use codex_core::skills::model::SkillPolicy;
     use codex_protocol::protocol::SkillScope;
     use crossterm::event::KeyModifiers;
     use insta::assert_snapshot;

--- a/codex-rs/tui/src/chatwidget/skills.rs
+++ b/codex-rs/tui/src/chatwidget/skills.rs
@@ -20,7 +20,6 @@ use codex_core::protocol::SkillsListEntry;
 use codex_core::skills::model::SkillDependencies;
 use codex_core::skills::model::SkillInterface;
 use codex_core::skills::model::SkillMetadata;
-use codex_core::skills::model::SkillPolicy;
 use codex_core::skills::model::SkillToolDependency;
 
 impl ChatWidget {
@@ -190,9 +189,7 @@ fn protocol_skill_to_core(skill: &ProtocolSkillMetadata) -> SkillMetadata {
                     })
                     .collect(),
             }),
-        policy: SkillPolicy {
-            allow_implicit_invocation: true,
-        },
+        policy: None,
         path: skill.path.clone(),
         scope: skill.scope,
     }

--- a/codex-rs/tui/src/chatwidget/skills.rs
+++ b/codex-rs/tui/src/chatwidget/skills.rs
@@ -20,6 +20,7 @@ use codex_core::protocol::SkillsListEntry;
 use codex_core::skills::model::SkillDependencies;
 use codex_core::skills::model::SkillInterface;
 use codex_core::skills::model::SkillMetadata;
+use codex_core::skills::model::SkillPolicy;
 use codex_core::skills::model::SkillToolDependency;
 
 impl ChatWidget {
@@ -189,6 +190,9 @@ fn protocol_skill_to_core(skill: &ProtocolSkillMetadata) -> SkillMetadata {
                     })
                     .collect(),
             }),
+        policy: SkillPolicy {
+            allow_implicit_invocation: true,
+        },
         path: skill.path.clone(),
         scope: skill.scope,
     }

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -64,7 +64,6 @@ use codex_core::protocol::UndoStartedEvent;
 use codex_core::protocol::ViewImageToolCallEvent;
 use codex_core::protocol::WarningEvent;
 use codex_core::skills::model::SkillMetadata;
-use codex_core::skills::model::SkillPolicy;
 use codex_otel::OtelManager;
 use codex_otel::RuntimeMetricsSummary;
 use codex_protocol::ThreadId;
@@ -435,9 +434,7 @@ async fn submission_prefers_selected_duplicate_skill_path() {
             short_description: None,
             interface: None,
             dependencies: None,
-            policy: SkillPolicy {
-                allow_implicit_invocation: true,
-            },
+            policy: None,
             path: repo_skill_path,
             scope: SkillScope::Repo,
         },
@@ -447,9 +444,7 @@ async fn submission_prefers_selected_duplicate_skill_path() {
             short_description: None,
             interface: None,
             dependencies: None,
-            policy: SkillPolicy {
-                allow_implicit_invocation: true,
-            },
+            policy: None,
             path: user_skill_path.clone(),
             scope: SkillScope::User,
         },

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -64,6 +64,7 @@ use codex_core::protocol::UndoStartedEvent;
 use codex_core::protocol::ViewImageToolCallEvent;
 use codex_core::protocol::WarningEvent;
 use codex_core::skills::model::SkillMetadata;
+use codex_core::skills::model::SkillPolicy;
 use codex_otel::OtelManager;
 use codex_otel::RuntimeMetricsSummary;
 use codex_protocol::ThreadId;
@@ -434,6 +435,9 @@ async fn submission_prefers_selected_duplicate_skill_path() {
             short_description: None,
             interface: None,
             dependencies: None,
+            policy: SkillPolicy {
+                allow_implicit_invocation: true,
+            },
             path: repo_skill_path,
             scope: SkillScope::Repo,
         },
@@ -443,6 +447,9 @@ async fn submission_prefers_selected_duplicate_skill_path() {
             short_description: None,
             interface: None,
             dependencies: None,
+            policy: SkillPolicy {
+                allow_implicit_invocation: true,
+            },
             path: user_skill_path.clone(),
             scope: SkillScope::User,
         },

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,3 +1,7 @@
 # Skills
 
 For information about skills, refer to [this documentation](https://developers.openai.com/codex/skills).
+
+Local skills can opt out of implicit prompt injection by setting
+`policy.allow_implicit_invocation = false` in `agents/openai.yaml`, while still
+supporting explicit `$skill` mentions.

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,7 +1,3 @@
 # Skills
 
 For information about skills, refer to [this documentation](https://developers.openai.com/codex/skills).
-
-Local skills can opt out of implicit prompt injection by setting
-`policy.allow_implicit_invocation = false` in `agents/openai.yaml`, while still
-supporting explicit `$skill` mentions.


### PR DESCRIPTION
Tested by setting the policy in agents/openai.yaml to true, false, and leaving it unset (default).
```
policy:
  allow_implicit_invocation: false
```
<img width="847" height="289" alt="Screenshot 2026-02-09 at 3 42 41 PM" src="https://github.com/user-attachments/assets/d3476264-3355-47cf-894a-4ffba53e3481" />
