### PR TITLE
deflake linux-sandbox NoNewPrivs timeout

### DIFF
--- a/codex-rs/linux-sandbox/tests/suite/landlock.rs
+++ b/codex-rs/linux-sandbox/tests/suite/landlock.rs
@@ -199,7 +199,9 @@ async fn test_no_new_privs_is_enabled() {
     let output = run_cmd_output(
         &["bash", "-lc", "grep '^NoNewPrivs:' /proc/self/status"],
         &[],
-        SHORT_TIMEOUT_MS,
+        // We have seen timeouts when running this test in CI on GitHub,
+        // so we are using a generous timeout until we can diagnose further.
+        LONG_TIMEOUT_MS,
     )
     .await;
     let line = output


### PR DESCRIPTION
Deflake `codex-linux-sandbox::all suite::landlock::test_no_new_privs_is_enabled`.

CI has intermittently failed with `Sandbox(Timeout)` (exit 124) because the sandboxed
`grep '^NoNewPrivs:' /proc/self/status` can run close to the short timeout budget.

This updates only this test to use `LONG_TIMEOUT_MS`, which removes the near-threshold timeout
behavior while keeping the rest of the suite unchanged.

Refs (previous failures):
- PR: https://github.com/openai/codex/actions/runs/21836764823/job/63009902779
- PR: https://github.com/openai/codex/actions/runs/21837427251/job/63012470353
- main: https://github.com/openai/codex/actions/runs/21830746538/job/62988079964

Validation:
- Local: `cd codex-rs && cargo test -p codex-linux-sandbox` (non-Linux runs 0 tests)
