### PR TITLE
Adjust shell command timeouts for Windows

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/turn_start.rs
+++ b/codex-rs/app-server/tests/suite/v2/turn_start.rs
@@ -53,6 +53,9 @@ use std::path::Path;
 use tempfile::TempDir;
 use tokio::time::timeout;
 
+#[cfg(windows)]
+const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+#[cfg(not(windows))]
 const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 const TEST_ORIGINATOR: &str = "codex_vscode";
 const LOCAL_PRAGMATIC_TEMPLATE: &str = "You are a deeply pragmatic, effective software engineer.";

--- a/codex-rs/core/tests/suite/shell_command.rs
+++ b/codex-rs/core/tests/suite/shell_command.rs
@@ -17,8 +17,14 @@ use core_test_support::test_codex::test_codex;
 use serde_json::json;
 use test_case::test_case;
 
-/// Use this timeout if, empirically, a test seems to need more time than the
-/// default.
+#[cfg(windows)]
+const DEFAULT_SHELL_TIMEOUT_MS: i64 = 7_000;
+#[cfg(not(windows))]
+const DEFAULT_SHELL_TIMEOUT_MS: i64 = 2_000;
+
+#[cfg(windows)]
+const MEDIUM_TIMEOUT: Duration = Duration::from_secs(10);
+#[cfg(not(windows))]
 const MEDIUM_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn shell_responses_with_timeout(
@@ -50,7 +56,7 @@ fn shell_responses_with_timeout(
 }
 
 fn shell_responses(call_id: &str, command: &str, login: Option<bool>) -> Vec<String> {
-    shell_responses_with_timeout(call_id, command, login, 2_000)
+    shell_responses_with_timeout(call_id, command, login, DEFAULT_SHELL_TIMEOUT_MS)
 }
 
 async fn shell_command_harness_with(


### PR DESCRIPTION
Summary
- add platform-aware defaults for shell command timeouts so Windows tests get longer waits
- keep medium timeout longer on Windows to ensure flakiness is reduced

Testing
- Not run (not requested)