### PR TITLE
Fix Ctrl+C startup deadlocks in review and MCP init paths

### DIFF
--- a/codex-rs/core/src/codex_delegate.rs
+++ b/codex-rs/core/src/codex_delegate.rs
@@ -60,7 +60,8 @@ pub(crate) async fn run_codex_thread_interactive(
         parent_session.services.agent_control.clone(),
         Vec::new(),
     )
-    .await?;
+    .or_cancel(&cancel_token)
+    .await??;
     let codex = Arc::new(codex);
 
     // Use a child token so parent cancel cascades but we can scope it to this task

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -324,7 +324,7 @@ impl AsyncManagedClient {
     }
 
     async fn notify_sandbox_state_change(&self, sandbox_state: &SandboxState) -> Result<()> {
-        let managed = self.client().await?;
+        let managed = self.client_with_startup_timeout().await?;
         managed.notify_sandbox_state_change(sandbox_state).await
     }
 }
@@ -392,7 +392,7 @@ impl McpConnectionManager {
             let auth_entry = auth_entries.get(&server_name).cloned();
             let sandbox_state = initial_sandbox_state.clone();
             join_set.spawn(async move {
-                let outcome = async_managed_client.client().await;
+                let outcome = async_managed_client.client_with_startup_timeout().await;
                 if cancel_token.is_cancelled() {
                     return (server_name, Err(StartupOutcomeError::Cancelled));
                 }


### PR DESCRIPTION
## Summary
- make thread startup interruptible in TUI bootstrap so queued `Op::Shutdown` can terminate immediately even if `start_thread` is still pending
- bound MCP client startup waits in remaining startup-sensitive paths (`initialize` startup join task and sandbox-state notification) to avoid indefinite waits on unresolved client futures
- add a shutdown fallback in app exit handling so repeated `ShutdownFirst` requests escalate to immediate exit when shutdown completion is stalled
- make review/sub-agent startup cancellation-aware by racing `Codex::spawn(...)` with cancellation (`or_cancel`)
- add regression coverage for shutdown escalation behavior

Closes #11267.

## Testing Done
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p codex-core required_startup_failures_times_out_pending_server`
- `cargo test -p codex-core list_all_tools_skips_pending_server_after_timeout`
- `cargo test -p codex-tui shutdown_first_exit_escalates_on_second_request`
- `cargo test -p codex-tui ctrl_c_shutdown_works_with_caps_lock`
- `cargo test -p codex-tui`
- `cargo test` *(fails on pre-existing environment-sensitive tests unrelated to this change: `shell::tests::detects_bash`, `seatbelt::tests::create_seatbelt_args_with_read_only_git_pointer_file`, `seatbelt::tests::create_seatbelt_args_with_read_only_git_and_codex_subpaths`)*
