### PR TITLE
fix(release): include codex.exe in windows bundle zip

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -377,6 +377,7 @@ jobs:
                 setup_src="$dest/codex-windows-sandbox-setup-${{ matrix.target }}.exe"
                 if [[ -f "$runner_src" && -f "$setup_src" ]]; then
                   cp "$dest/$base" "$bundle_dir/$base"
+                  cp "$dest/$base" "$bundle_dir/codex.exe"
                   cp "$runner_src" "$bundle_dir/codex-command-runner.exe"
                   cp "$setup_src" "$bundle_dir/codex-windows-sandbox-setup.exe"
                   # Use an absolute path so bundle zips land in the real dist


### PR DESCRIPTION
## Summary
  Add `codex.exe` into the Windows bundled zip generated in release workflow when packaging
  `codex-${{ matrix.target }}.exe`.

## Why
  WinGet installs currently expose the target-suffixed executable name, which leads users to manually rename files to
  `codex.exe`. Including `codex.exe` in the bundle makes installed usage consistent.

## Change
  - In `.github/workflows/rust-release.yml`, during Windows main bundle creation, copy:
    - `codex-${{ matrix.target }}.exe` (existing)
    - `codex.exe` (new alias copy)
    - `codex-command-runner.exe` (existing)
    - `codex-windows-sandbox-setup.exe` (existing)

## Impact
  - Backward-compatible: existing artifact naming remains.
  - Improves WinGet install ergonomics by providing `codex.exe` directly.