### PR TITLE
fix(release): include codex.exe in windows bundle zip

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -377,6 +377,7 @@ jobs:
                 setup_src="$dest/codex-windows-sandbox-setup-${{ matrix.target }}.exe"
                 if [[ -f "$runner_src" && -f "$setup_src" ]]; then
                   cp "$dest/$base" "$bundle_dir/$base"
+                  cp "$dest/$base" "$bundle_dir/codex.exe"
                   cp "$runner_src" "$bundle_dir/codex-command-runner.exe"
                   cp "$setup_src" "$bundle_dir/codex-windows-sandbox-setup.exe"
                   # Use an absolute path so bundle zips land in the real dist


### PR DESCRIPTION
Fixes #11283

## What
Update Windows release bundling in `.github/workflows/rust-release.yml` to include `codex.exe` in the main bundled zip path.

## Why
WinGet users can end up with a target-suffixed executable name (for example `codex-x86_64-pc-windows-msvc.exe`) which leads to manual rename/shim steps. Including `codex.exe` in the bundle improves install ergonomics.

## How
In the Windows bundle branch for `codex-${{ matrix.target }}.exe`, copy the same binary twice into the bundle directory:
- existing: `codex-${{ matrix.target }}.exe`
- new: `codex.exe`

Keep existing helper binaries unchanged:
- `codex-command-runner.exe`
- `codex-windows-sandbox-setup.exe`

## Impact
- Backward-compatible: existing target-suffixed artifact remains unchanged.
- Improves WinGet installation experience by providing `codex.exe` directly in the bundle.