### PR TITLE
chore: split NPM packages

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -593,18 +593,20 @@ jobs:
           version="${{ needs.release.outputs.version }}"
           tag="${{ needs.release.outputs.tag }}"
           mkdir -p dist/npm
-          gh release download "$tag" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --pattern "codex-npm-${version}.tgz" \
-            --dir dist/npm
-          gh release download "$tag" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --pattern "codex-responses-api-proxy-npm-${version}.tgz" \
-            --dir dist/npm
-          gh release download "$tag" \
-            --repo "${GITHUB_REPOSITORY}" \
-            --pattern "codex-sdk-npm-${version}.tgz" \
-            --dir dist/npm
+          patterns=(
+            "codex-npm-${version}.tgz"
+            "codex-linux-*-npm-${version}.tgz"
+            "codex-darwin-*-npm-${version}.tgz"
+            "codex-win32-*-npm-${version}.tgz"
+            "codex-responses-api-proxy-npm-${version}.tgz"
+            "codex-sdk-npm-${version}.tgz"
+          )
+          for pattern in "${patterns[@]}"; do
+            gh release download "$tag" \
+              --repo "${GITHUB_REPOSITORY}" \
+              --pattern "$pattern" \
+              --dir dist/npm
+          done
 
       # No NODE_AUTH_TOKEN needed because we use OIDC.
       - name: Publish to npm
@@ -618,14 +620,15 @@ jobs:
             tag_args+=(--tag "${NPM_TAG}")
           fi
 
-          tarballs=(
-            "codex-npm-${VERSION}.tgz"
-            "codex-responses-api-proxy-npm-${VERSION}.tgz"
-            "codex-sdk-npm-${VERSION}.tgz"
-          )
+          shopt -s nullglob
+          tarballs=(dist/npm/*-npm-"${VERSION}".tgz)
+          if [[ ${#tarballs[@]} -eq 0 ]]; then
+            echo "No npm tarballs found in dist/npm for version ${VERSION}"
+            exit 1
+          fi
 
           for tarball in "${tarballs[@]}"; do
-            npm publish "${GITHUB_WORKSPACE}/dist/npm/${tarball}" "${tag_args[@]}"
+            npm publish "${GITHUB_WORKSPACE}/${tarball}" "${tag_args[@]}"
           done
 
   update-branch:

--- a/codex-cli/scripts/README.md
+++ b/codex-cli/scripts/README.md
@@ -14,6 +14,9 @@ example, to stage the CLI, responses proxy, and SDK packages for version `0.6.0`
 This downloads the native artifacts once, hydrates `vendor/` for each package, and writes
 tarballs to `dist/npm/`.
 
+When `--package codex` is provided, the staging helper builds the lightweight
+`@openai/codex` meta package plus all `@openai/codex-<platform>` native packages.
+
 If you need to invoke `build_npm_package.py` directly, run
 `codex-cli/scripts/install_native_deps.py` first and pass `--vendor-src` pointing to the
 directory that contains the populated `vendor/` tree.

--- a/scripts/stage_npm_packages.py
+++ b/scripts/stage_npm_packages.py
@@ -25,7 +25,7 @@ if _SPEC is None or _SPEC.loader is None:
 _BUILD_MODULE = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_BUILD_MODULE)
 PACKAGE_NATIVE_COMPONENTS = getattr(_BUILD_MODULE, "PACKAGE_NATIVE_COMPONENTS", {})
-WINDOWS_ONLY_COMPONENTS = getattr(_BUILD_MODULE, "WINDOWS_ONLY_COMPONENTS", {})
+PACKAGE_EXPANSIONS = getattr(_BUILD_MODULE, "PACKAGE_EXPANSIONS", {})
 
 
 def parse_args() -> argparse.Namespace:
@@ -64,8 +64,17 @@ def collect_native_components(packages: list[str]) -> set[str]:
     components: set[str] = set()
     for package in packages:
         components.update(PACKAGE_NATIVE_COMPONENTS.get(package, []))
-        components.update(WINDOWS_ONLY_COMPONENTS.get(package, []))
     return components
+
+
+def expand_packages(packages: list[str]) -> list[str]:
+    expanded: list[str] = []
+    for package in packages:
+        for expanded_package in PACKAGE_EXPANSIONS.get(package, [package]):
+            if expanded_package in expanded:
+                continue
+            expanded.append(expanded_package)
+    return expanded
 
 
 def resolve_release_workflow(version: str) -> dict:
@@ -128,14 +137,14 @@ def main() -> int:
 
     runner_temp = Path(os.environ.get("RUNNER_TEMP", tempfile.gettempdir()))
 
-    packages = list(args.packages)
+    packages = expand_packages(list(args.packages))
     native_components = collect_native_components(packages)
 
     vendor_temp_root: Path | None = None
     vendor_src: Path | None = None
     resolved_head_sha: str | None = None
 
-    final_messsages = []
+    final_messages = []
 
     try:
         if native_components:
@@ -174,12 +183,12 @@ def main() -> int:
                 if not args.keep_staging_dirs:
                     shutil.rmtree(staging_dir, ignore_errors=True)
 
-            final_messsages.append(f"Staged {package} at {pack_output}")
+            final_messages.append(f"Staged {package} at {pack_output}")
     finally:
         if vendor_temp_root is not None and not args.keep_staging_dirs:
             shutil.rmtree(vendor_temp_root, ignore_errors=True)
 
-    for msg in final_messsages:
+    for msg in final_messages:
         print(msg)
 
     return 0


### PR DESCRIPTION
## Summary

  This PR changes npm distribution for @openai/codex from one monolithic tarball to a split-package model:

  - @openai/codex becomes a small JS launcher package.
  - Native binaries move into per-platform packages (for example @openai/codex-darwin-arm64, @openai/codex-
    linux-x64-musl, etc.).
  - The root package uses optionalDependencies so npm installs only the matching platform package.

  ## Why

  Our current publish uploads a single large tarball (~206.5 MB, ~504.7 MB unpacked), which now fails in
  release CI with:

  - npm ERR! code E413
  - 413 Payload Too Large - PUT https://registry.npmjs.org/@openai%2fcodex

  Splitting by platform keeps each publish payload below registry limits and follows established native-CLI
  npm patterns.

  ## Behavior/Compatibility

  - npx @openai/codex and codex CLI UX stay the same.
  - No runtime binary download is required.
  - Unsupported platform/arch still returns a clear error.

  ## Release Workflow Changes

  - Build and pack platform-specific npm packages.
  - Publish root package + platform packages under the same version/tag (latest / alpha).
  - Keep trusted publishing/provenance flow unchanged.