### PR TITLE
Fix pending input test waiting logic

### DIFF
--- a/codex-rs/core/tests/suite/pending_input.rs
+++ b/codex-rs/core/tests/suite/pending_input.rs
@@ -125,11 +125,6 @@ async fn injected_user_input_triggers_follow_up_request_with_deltas() {
 
     let _ = gate_completed_tx.send(());
 
-    let _ = wait_for_event(&codex, |event| {
-        matches!(event, EventMsg::UserMessage(message) if message.message == "second prompt")
-    })
-    .await;
-
     wait_for_event(&codex, |event| matches!(event, EventMsg::TurnComplete(_))).await;
 
     let requests = server.requests().await;


### PR DESCRIPTION
## Summary
- remove redundant user message wait that could time out and cause flakiness
- rely on the existing turn-complete wait to ensure the follow-up request is observed

## Testing
- Not run (not requested)