### PR TITLE
feat(tui): add Alt+C and /copy to copy last agent response as markdown

### DIFF
--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -3136,10 +3136,28 @@ mod tests {
             id: "session".to_string(),
             msg: EventMsg::SessionConfigured(make_session_configured_event(thread_id)),
         });
+        app.chat_widget.handle_codex_event_replay(Event {
+            id: "user-1".to_string(),
+            msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                message: "first".to_string(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
+            }),
+        });
         app.chat_widget.handle_codex_event(Event {
             id: "agent-1".to_string(),
             msg: EventMsg::AgentMessage(codex_core::protocol::AgentMessageEvent {
                 message: "answer first".to_string(),
+            }),
+        });
+        app.chat_widget.handle_codex_event_replay(Event {
+            id: "user-2".to_string(),
+            msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                message: "second".to_string(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
             }),
         });
         app.chat_widget.handle_codex_event(Event {
@@ -3196,6 +3214,15 @@ mod tests {
             id: "session".to_string(),
             msg: EventMsg::SessionConfigured(make_session_configured_event(thread_id)),
         });
+        app.chat_widget.handle_codex_event_replay(Event {
+            id: "user-1".to_string(),
+            msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                message: "first".to_string(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
+            }),
+        });
 
         app.chat_widget.handle_codex_event(Event {
             id: "turn-1-started".to_string(),
@@ -3214,6 +3241,15 @@ mod tests {
             id: "turn-1-complete".to_string(),
             msg: EventMsg::TurnComplete(codex_core::protocol::TurnCompleteEvent {
                 last_agent_message: Some("answer first".to_string()),
+            }),
+        });
+        app.chat_widget.handle_codex_event_replay(Event {
+            id: "user-2".to_string(),
+            msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                message: "second".to_string(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
             }),
         });
 
@@ -3275,6 +3311,15 @@ mod tests {
             id: "session".to_string(),
             msg: EventMsg::SessionConfigured(make_session_configured_event(thread_id)),
         });
+        app.chat_widget.handle_codex_event_replay(Event {
+            id: "user-1".to_string(),
+            msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                message: "first".to_string(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
+            }),
+        });
         app.chat_widget.handle_codex_event(Event {
             id: "turn-1-started".to_string(),
             msg: EventMsg::TurnStarted(codex_core::protocol::TurnStartedEvent {
@@ -3294,6 +3339,15 @@ mod tests {
                 last_agent_message: Some("answer first".to_string()),
             }),
         });
+        app.chat_widget.handle_codex_event_replay(Event {
+            id: "user-2".to_string(),
+            msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                message: "second".to_string(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
+            }),
+        });
         app.chat_widget.handle_codex_event(Event {
             id: "turn-2-started".to_string(),
             msg: EventMsg::TurnStarted(codex_core::protocol::TurnStartedEvent {
@@ -3309,6 +3363,15 @@ mod tests {
             id: "turn-2-complete".to_string(),
             msg: EventMsg::TurnComplete(codex_core::protocol::TurnCompleteEvent {
                 last_agent_message: None,
+            }),
+        });
+        app.chat_widget.handle_codex_event_replay(Event {
+            id: "user-3".to_string(),
+            msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                message: "third".to_string(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
             }),
         });
         app.chat_widget.handle_codex_event(Event {
@@ -3387,6 +3450,15 @@ mod tests {
 
         let mut transcript_cells: Vec<Arc<dyn HistoryCell>> = Vec::new();
         for turn in 1..=300 {
+            app.chat_widget.handle_codex_event_replay(Event {
+                id: format!("user-{turn}"),
+                msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                    message: format!("user {turn}"),
+                    images: None,
+                    text_elements: Vec::new(),
+                    local_images: Vec::new(),
+                }),
+            });
             app.chat_widget.handle_codex_event(Event {
                 id: format!("agent-{turn}"),
                 msg: EventMsg::AgentMessage(codex_core::protocol::AgentMessageEvent {
@@ -3433,6 +3505,15 @@ mod tests {
 
         let mut transcript_cells: Vec<Arc<dyn HistoryCell>> = Vec::new();
         for turn in 1..=300 {
+            app.chat_widget.handle_codex_event_replay(Event {
+                id: format!("user-{turn}"),
+                msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                    message: format!("user {turn}"),
+                    images: None,
+                    text_elements: Vec::new(),
+                    local_images: Vec::new(),
+                }),
+            });
             app.chat_widget.handle_codex_event(Event {
                 id: format!("agent-{turn}"),
                 msg: EventMsg::AgentMessage(codex_core::protocol::AgentMessageEvent {
@@ -3476,6 +3557,15 @@ mod tests {
             id: "session".to_string(),
             msg: EventMsg::SessionConfigured(make_session_configured_event(thread_id)),
         });
+        app.chat_widget.handle_codex_event_replay(Event {
+            id: "user-1".to_string(),
+            msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                message: "first".to_string(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
+            }),
+        });
         app.chat_widget.handle_codex_event(Event {
             id: "turn-1-started".to_string(),
             msg: EventMsg::TurnStarted(codex_core::protocol::TurnStartedEvent {
@@ -3495,6 +3585,15 @@ mod tests {
                 last_agent_message: Some("Context compacted".to_string()),
             }),
         });
+        app.chat_widget.handle_codex_event_replay(Event {
+            id: "user-2".to_string(),
+            msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                message: "second".to_string(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
+            }),
+        });
         app.chat_widget.handle_codex_event(Event {
             id: "turn-2-started".to_string(),
             msg: EventMsg::TurnStarted(codex_core::protocol::TurnStartedEvent {
@@ -3510,6 +3609,15 @@ mod tests {
             id: "turn-2-complete".to_string(),
             msg: EventMsg::TurnComplete(codex_core::protocol::TurnCompleteEvent {
                 last_agent_message: None,
+            }),
+        });
+        app.chat_widget.handle_codex_event_replay(Event {
+            id: "user-3".to_string(),
+            msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                message: "third".to_string(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
             }),
         });
         app.chat_widget.handle_codex_event(Event {
@@ -3576,6 +3684,167 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rollback_can_drop_surviving_turn_complete_only_copy_source_after_non_user_task() {
+        let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
+
+        let thread_id = ThreadId::new();
+        app.chat_widget.handle_codex_event(Event {
+            id: "session".to_string(),
+            msg: EventMsg::SessionConfigured(make_session_configured_event(thread_id)),
+        });
+
+        app.chat_widget.handle_codex_event_replay(Event {
+            id: "user-1".to_string(),
+            msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                message: "first".to_string(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
+            }),
+        });
+
+        // User turn 1: normal agent message.
+        app.chat_widget.handle_codex_event(Event {
+            id: "turn-1-started".to_string(),
+            msg: EventMsg::TurnStarted(codex_core::protocol::TurnStartedEvent {
+                model_context_window: None,
+                collaboration_mode_kind: codex_protocol::config_types::ModeKind::Default,
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "agent-1".to_string(),
+            msg: EventMsg::AgentMessage(codex_core::protocol::AgentMessageEvent {
+                message: "answer first".to_string(),
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "turn-1-complete".to_string(),
+            msg: EventMsg::TurnComplete(codex_core::protocol::TurnCompleteEvent {
+                last_agent_message: Some("answer first".to_string()),
+            }),
+        });
+
+        // Non-user task completion (e.g. /compact) should not shift user-turn ordinals.
+        app.chat_widget.handle_codex_event(Event {
+            id: "non-user-started".to_string(),
+            msg: EventMsg::TurnStarted(codex_core::protocol::TurnStartedEvent {
+                model_context_window: None,
+                collaboration_mode_kind: codex_protocol::config_types::ModeKind::Default,
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "non-user-complete".to_string(),
+            msg: EventMsg::TurnComplete(codex_core::protocol::TurnCompleteEvent {
+                last_agent_message: Some("compact summary".to_string()),
+            }),
+        });
+
+        app.chat_widget.handle_codex_event_replay(Event {
+            id: "user-2".to_string(),
+            msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                message: "second".to_string(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
+            }),
+        });
+
+        // User turn 2: copy source comes only from TurnComplete.last_agent_message.
+        app.chat_widget.handle_codex_event(Event {
+            id: "turn-2-started".to_string(),
+            msg: EventMsg::TurnStarted(codex_core::protocol::TurnStartedEvent {
+                model_context_window: None,
+                collaboration_mode_kind: codex_protocol::config_types::ModeKind::Default,
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "turn-2-complete".to_string(),
+            msg: EventMsg::TurnComplete(codex_core::protocol::TurnCompleteEvent {
+                last_agent_message: Some("plan-only answer".to_string()),
+            }),
+        });
+
+        app.chat_widget.handle_codex_event_replay(Event {
+            id: "user-3".to_string(),
+            msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                message: "third".to_string(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
+            }),
+        });
+
+        // User turn 3: normal response to be rolled back.
+        app.chat_widget.handle_codex_event(Event {
+            id: "turn-3-started".to_string(),
+            msg: EventMsg::TurnStarted(codex_core::protocol::TurnStartedEvent {
+                model_context_window: None,
+                collaboration_mode_kind: codex_protocol::config_types::ModeKind::Default,
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "agent-3".to_string(),
+            msg: EventMsg::AgentMessage(codex_core::protocol::AgentMessageEvent {
+                message: "answer third".to_string(),
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "turn-3-complete".to_string(),
+            msg: EventMsg::TurnComplete(codex_core::protocol::TurnCompleteEvent {
+                last_agent_message: Some("answer third".to_string()),
+            }),
+        });
+
+        app.transcript_cells = vec![
+            Arc::new(UserHistoryCell {
+                message: "first".to_string(),
+                text_elements: Vec::new(),
+                local_image_paths: Vec::new(),
+            }) as Arc<dyn HistoryCell>,
+            Arc::new(AgentMessageCell::new(
+                vec![Line::from("answer first".to_string())],
+                true,
+            )) as Arc<dyn HistoryCell>,
+            Arc::new(UserHistoryCell {
+                message: "second".to_string(),
+                text_elements: Vec::new(),
+                local_image_paths: Vec::new(),
+            }) as Arc<dyn HistoryCell>,
+            Arc::new(new_info_event("plan details".to_string(), None)) as Arc<dyn HistoryCell>,
+            Arc::new(UserHistoryCell {
+                message: "third".to_string(),
+                text_elements: Vec::new(),
+                local_image_paths: Vec::new(),
+            }) as Arc<dyn HistoryCell>,
+            Arc::new(AgentMessageCell::new(
+                vec![Line::from("answer third".to_string())],
+                true,
+            )) as Arc<dyn HistoryCell>,
+        ];
+
+        assert_eq!(
+            app.chat_widget.last_agent_markdown_text(),
+            Some("answer third"),
+        );
+
+        // Roll back the third user turn, preserving the first two user turns.
+        app.apply_backtrack_rollback(crate::app_backtrack::BacktrackSelection {
+            nth_user_message: 2,
+            prefill: String::new(),
+            text_elements: Vec::new(),
+            local_image_paths: Vec::new(),
+        });
+        app.handle_backtrack_event(&EventMsg::ThreadRolledBack(
+            codex_core::protocol::ThreadRolledBackEvent { num_turns: 1 },
+        ));
+
+        assert_eq!(
+            app.chat_widget.last_agent_markdown_text(),
+            Some("plan-only answer"),
+        );
+    }
+
+    #[tokio::test]
     async fn rollback_to_first_user_clears_copy_source() {
         let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
 
@@ -3627,6 +3896,18 @@ mod tests {
             msg: EventMsg::SessionConfigured(make_session_configured_event(thread_id)),
         });
 
+        app.chat_widget.handle_codex_event_replay(Event {
+            id: "user-main".to_string(),
+            msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                message:
+                    "Can you create a new worktree and branch from upstream/main and apply only the Alt+C hotkey feature?"
+                        .to_string(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
+            }),
+        });
+
         // Simulate resumed history where a single user turn contains multiple agent updates.
         let first_turn_updates = [
             "I'll do this in three steps: inspect commits on your current branch to isolate the Alt+C hotkey change, create a new worktree/branch from `upstream/main`, and then apply only that feature there. I'm starting by checking remotes, branch state, and recent commits.",
@@ -3642,6 +3923,16 @@ mod tests {
                 }),
             });
         }
+
+        app.chat_widget.handle_codex_event_replay(Event {
+            id: "user-hi".to_string(),
+            msg: EventMsg::UserMessage(codex_core::protocol::UserMessageEvent {
+                message: "hi".to_string(),
+                images: None,
+                text_elements: Vec::new(),
+                local_images: Vec::new(),
+            }),
+        });
 
         app.chat_widget.handle_codex_event(Event {
             id: "agent-hi".to_string(),

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -2844,6 +2844,25 @@ mod tests {
         codex_core::models_manager::model_presets::all_model_presets().clone()
     }
 
+    fn make_session_configured_event(thread_id: ThreadId) -> SessionConfiguredEvent {
+        SessionConfiguredEvent {
+            session_id: thread_id,
+            forked_from_id: None,
+            thread_name: None,
+            model: "gpt-test".to_string(),
+            model_provider_id: "test-provider".to_string(),
+            approval_policy: AskForApproval::Never,
+            sandbox_policy: SandboxPolicy::ReadOnly,
+            cwd: PathBuf::from("/home/user/project"),
+            reasoning_effort: None,
+            history_log_id: 0,
+            history_entry_count: 0,
+            initial_messages: None,
+            network_proxy: None,
+            rollout_path: Some(PathBuf::new()),
+        }
+    }
+
     fn model_migration_copy_to_plain_text(
         copy: &crate::model_migration::ModelMigrationCopy,
     ) -> String {
@@ -3041,22 +3060,7 @@ mod tests {
         };
 
         let make_header = |is_first| {
-            let event = SessionConfiguredEvent {
-                session_id: ThreadId::new(),
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                approval_policy: AskForApproval::Never,
-                sandbox_policy: SandboxPolicy::ReadOnly,
-                cwd: PathBuf::from("/home/user/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            };
+            let event = make_session_configured_event(ThreadId::new());
             Arc::new(new_session_info(
                 app.chat_widget.config_ref(),
                 app.chat_widget.current_model(),
@@ -3096,22 +3100,7 @@ mod tests {
         let base_id = ThreadId::new();
         app.chat_widget.handle_codex_event(Event {
             id: String::new(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: base_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                approval_policy: AskForApproval::Never,
-                sandbox_policy: SandboxPolicy::ReadOnly,
-                cwd: PathBuf::from("/home/user/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                network_proxy: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
+            msg: EventMsg::SessionConfigured(make_session_configured_event(base_id)),
         });
 
         app.backtrack.base_id = Some(base_id);
@@ -3145,21 +3134,7 @@ mod tests {
         let thread_id = ThreadId::new();
         app.chat_widget.handle_codex_event(Event {
             id: "session".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                approval_policy: AskForApproval::Never,
-                sandbox_policy: SandboxPolicy::ReadOnly,
-                cwd: PathBuf::from("/home/user/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
+            msg: EventMsg::SessionConfigured(make_session_configured_event(thread_id)),
         });
         app.chat_widget.handle_codex_event(Event {
             id: "agent-1".to_string(),
@@ -3219,21 +3194,7 @@ mod tests {
         let thread_id = ThreadId::new();
         app.chat_widget.handle_codex_event(Event {
             id: "session".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                approval_policy: AskForApproval::Never,
-                sandbox_policy: SandboxPolicy::ReadOnly,
-                cwd: PathBuf::from("/home/user/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
+            msg: EventMsg::SessionConfigured(make_session_configured_event(thread_id)),
         });
 
         app.chat_widget.handle_codex_event(Event {
@@ -3312,21 +3273,7 @@ mod tests {
         let thread_id = ThreadId::new();
         app.chat_widget.handle_codex_event(Event {
             id: "session".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                approval_policy: AskForApproval::Never,
-                sandbox_policy: SandboxPolicy::ReadOnly,
-                cwd: PathBuf::from("/home/user/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
+            msg: EventMsg::SessionConfigured(make_session_configured_event(thread_id)),
         });
         app.chat_widget.handle_codex_event(Event {
             id: "turn-1-started".to_string(),
@@ -3435,21 +3382,7 @@ mod tests {
         let thread_id = ThreadId::new();
         app.chat_widget.handle_codex_event(Event {
             id: "session".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                approval_policy: AskForApproval::Never,
-                sandbox_policy: SandboxPolicy::ReadOnly,
-                cwd: PathBuf::from("/home/user/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
+            msg: EventMsg::SessionConfigured(make_session_configured_event(thread_id)),
         });
 
         let mut transcript_cells: Vec<Arc<dyn HistoryCell>> = Vec::new();
@@ -3495,21 +3428,7 @@ mod tests {
         let thread_id = ThreadId::new();
         app.chat_widget.handle_codex_event(Event {
             id: "session".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                approval_policy: AskForApproval::Never,
-                sandbox_policy: SandboxPolicy::ReadOnly,
-                cwd: PathBuf::from("/home/user/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
+            msg: EventMsg::SessionConfigured(make_session_configured_event(thread_id)),
         });
 
         let mut transcript_cells: Vec<Arc<dyn HistoryCell>> = Vec::new();
@@ -3555,21 +3474,7 @@ mod tests {
         let thread_id = ThreadId::new();
         app.chat_widget.handle_codex_event(Event {
             id: "session".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                approval_policy: AskForApproval::Never,
-                sandbox_policy: SandboxPolicy::ReadOnly,
-                cwd: PathBuf::from("/home/user/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
+            msg: EventMsg::SessionConfigured(make_session_configured_event(thread_id)),
         });
         app.chat_widget.handle_codex_event(Event {
             id: "turn-1-started".to_string(),
@@ -3677,21 +3582,7 @@ mod tests {
         let thread_id = ThreadId::new();
         app.chat_widget.handle_codex_event(Event {
             id: "session".to_string(),
-            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
-                session_id: thread_id,
-                forked_from_id: None,
-                thread_name: None,
-                model: "gpt-test".to_string(),
-                model_provider_id: "test-provider".to_string(),
-                approval_policy: AskForApproval::Never,
-                sandbox_policy: SandboxPolicy::ReadOnly,
-                cwd: PathBuf::from("/home/user/project"),
-                reasoning_effort: None,
-                history_log_id: 0,
-                history_entry_count: 0,
-                initial_messages: None,
-                rollout_path: Some(PathBuf::new()),
-            }),
+            msg: EventMsg::SessionConfigured(make_session_configured_event(thread_id)),
         });
         app.chat_widget.handle_codex_event(Event {
             id: "agent-1".to_string(),
@@ -3731,22 +3622,7 @@ mod tests {
         let (mut app, mut app_event_rx, mut op_rx) = make_test_app_with_channels().await;
 
         let thread_id = ThreadId::new();
-        let event = SessionConfiguredEvent {
-            session_id: thread_id,
-            forked_from_id: None,
-            thread_name: None,
-            model: "gpt-test".to_string(),
-            model_provider_id: "test-provider".to_string(),
-            approval_policy: AskForApproval::Never,
-            sandbox_policy: SandboxPolicy::ReadOnly,
-            cwd: PathBuf::from("/home/user/project"),
-            reasoning_effort: None,
-            history_log_id: 0,
-            history_entry_count: 0,
-            initial_messages: None,
-            network_proxy: None,
-            rollout_path: Some(PathBuf::new()),
-        };
+        let event = make_session_configured_event(thread_id);
 
         app.chat_widget.handle_codex_event(Event {
             id: String::new(),

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -3628,7 +3628,7 @@ mod tests {
         });
 
         // Simulate resumed history where a single user turn contains multiple agent updates.
-        let first_turn_updates = vec![
+        let first_turn_updates = [
             "I'll do this in three steps: inspect commits on your current branch to isolate the Alt+C hotkey change, create a new worktree/branch from `upstream/main`, and then apply only that feature there. I'm starting by checking remotes, branch state, and recent commits.",
             "I found local uncommitted edits in two TUI files, so I'll avoid touching them and work from committed history. Next I'm fetching upstream/main and identifying exactly which commit(s) represent the Alt+C hotkey feature.",
             "I committed the extracted Alt+C-only implementation on the new branch after formatting and full codex-tui test validation. I'm now collecting the exact worktree path, branch, and commit hash for you.",

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -3138,6 +3138,136 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rollback_recomputes_copy_source_to_remaining_agent_message() {
+        let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
+
+        let thread_id = ThreadId::new();
+        app.chat_widget.handle_codex_event(Event {
+            id: "session".to_string(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                approval_policy: AskForApproval::Never,
+                sandbox_policy: SandboxPolicy::ReadOnly,
+                cwd: PathBuf::from("/home/user/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                rollout_path: Some(PathBuf::new()),
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "agent-1".to_string(),
+            msg: EventMsg::AgentMessage(codex_core::protocol::AgentMessageEvent {
+                message: "answer first".to_string(),
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "agent-2".to_string(),
+            msg: EventMsg::AgentMessage(codex_core::protocol::AgentMessageEvent {
+                message: "answer second".to_string(),
+            }),
+        });
+
+        app.transcript_cells = vec![
+            Arc::new(UserHistoryCell {
+                message: "first".to_string(),
+                text_elements: Vec::new(),
+                local_image_paths: Vec::new(),
+            }) as Arc<dyn HistoryCell>,
+            Arc::new(AgentMessageCell::new(
+                vec![Line::from("answer first".to_string())],
+                true,
+            )) as Arc<dyn HistoryCell>,
+            Arc::new(UserHistoryCell {
+                message: "second".to_string(),
+                text_elements: Vec::new(),
+                local_image_paths: Vec::new(),
+            }) as Arc<dyn HistoryCell>,
+            Arc::new(AgentMessageCell::new(
+                vec![Line::from("answer second".to_string())],
+                true,
+            )) as Arc<dyn HistoryCell>,
+        ];
+
+        app.apply_backtrack_rollback(crate::app_backtrack::BacktrackSelection {
+            nth_user_message: 1,
+            prefill: String::new(),
+            text_elements: Vec::new(),
+            local_image_paths: Vec::new(),
+        });
+        app.handle_backtrack_event(&EventMsg::ThreadRolledBack(
+            codex_core::protocol::ThreadRolledBackEvent { num_turns: 1 },
+        ));
+
+        assert_eq!(app.chat_widget.agent_turn_markdown_count(), 1);
+        assert_eq!(
+            app.chat_widget.last_agent_markdown_text(),
+            Some("answer first"),
+        );
+    }
+
+    #[tokio::test]
+    async fn rollback_to_first_user_clears_copy_source() {
+        let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
+
+        let thread_id = ThreadId::new();
+        app.chat_widget.handle_codex_event(Event {
+            id: "session".to_string(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                approval_policy: AskForApproval::Never,
+                sandbox_policy: SandboxPolicy::ReadOnly,
+                cwd: PathBuf::from("/home/user/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                rollout_path: Some(PathBuf::new()),
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "agent-1".to_string(),
+            msg: EventMsg::AgentMessage(codex_core::protocol::AgentMessageEvent {
+                message: "answer first".to_string(),
+            }),
+        });
+
+        app.transcript_cells = vec![
+            Arc::new(UserHistoryCell {
+                message: "first".to_string(),
+                text_elements: Vec::new(),
+                local_image_paths: Vec::new(),
+            }) as Arc<dyn HistoryCell>,
+            Arc::new(AgentMessageCell::new(
+                vec![Line::from("answer first".to_string())],
+                true,
+            )) as Arc<dyn HistoryCell>,
+        ];
+
+        app.apply_backtrack_rollback(crate::app_backtrack::BacktrackSelection {
+            nth_user_message: 0,
+            prefill: String::new(),
+            text_elements: Vec::new(),
+            local_image_paths: Vec::new(),
+        });
+        app.handle_backtrack_event(&EventMsg::ThreadRolledBack(
+            codex_core::protocol::ThreadRolledBackEvent { num_turns: 1 },
+        ));
+
+        assert_eq!(app.chat_widget.agent_turn_markdown_count(), 0);
+        assert_eq!(app.chat_widget.last_agent_markdown_text(), None);
+    }
+
+    #[tokio::test]
     async fn new_session_requests_shutdown_for_previous_conversation() {
         let (mut app, mut app_event_rx, mut op_rx) = make_test_app_with_channels().await;
 

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -2619,6 +2619,7 @@ mod tests {
     use crate::history_cell::AgentMessageCell;
     use crate::history_cell::HistoryCell;
     use crate::history_cell::UserHistoryCell;
+    use crate::history_cell::new_info_event;
     use crate::history_cell::new_session_info;
     use codex_core::AuthManager;
     use codex_core::CodexAuth;
@@ -3266,10 +3267,7 @@ mod tests {
                 text_elements: Vec::new(),
                 local_image_paths: Vec::new(),
             }) as Arc<dyn HistoryCell>,
-            Arc::new(AgentMessageCell::new(
-                vec![Line::from("Context compacted".to_string())],
-                true,
-            )) as Arc<dyn HistoryCell>,
+            Arc::new(new_info_event("Context compacted".to_string(), None)) as Arc<dyn HistoryCell>,
             Arc::new(UserHistoryCell {
                 message: "third".to_string(),
                 text_elements: Vec::new(),
@@ -3295,6 +3293,149 @@ mod tests {
         assert_eq!(
             app.chat_widget.last_agent_markdown_text(),
             Some("answer first"),
+        );
+    }
+
+    #[tokio::test]
+    async fn rollback_after_long_session_updates_copy_source_with_bounded_history() {
+        let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
+
+        let thread_id = ThreadId::new();
+        app.chat_widget.handle_codex_event(Event {
+            id: "session".to_string(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                approval_policy: AskForApproval::Never,
+                sandbox_policy: SandboxPolicy::ReadOnly,
+                cwd: PathBuf::from("/home/user/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                rollout_path: Some(PathBuf::new()),
+            }),
+        });
+
+        let mut transcript_cells: Vec<Arc<dyn HistoryCell>> = Vec::new();
+        for turn in 1..=300 {
+            app.chat_widget.handle_codex_event(Event {
+                id: format!("agent-{turn}"),
+                msg: EventMsg::AgentMessage(codex_core::protocol::AgentMessageEvent {
+                    message: format!("answer {turn}"),
+                }),
+            });
+            transcript_cells.push(Arc::new(UserHistoryCell {
+                message: format!("user {turn}"),
+                text_elements: Vec::new(),
+                local_image_paths: Vec::new(),
+            }) as Arc<dyn HistoryCell>);
+            transcript_cells.push(Arc::new(AgentMessageCell::new(
+                vec![Line::from(format!("answer {turn}"))],
+                true,
+            )) as Arc<dyn HistoryCell>);
+        }
+        app.transcript_cells = transcript_cells;
+
+        app.apply_backtrack_rollback(crate::app_backtrack::BacktrackSelection {
+            nth_user_message: 299,
+            prefill: String::new(),
+            text_elements: Vec::new(),
+            local_image_paths: Vec::new(),
+        });
+        app.handle_backtrack_event(&EventMsg::ThreadRolledBack(
+            codex_core::protocol::ThreadRolledBackEvent { num_turns: 1 },
+        ));
+
+        assert_eq!(
+            app.chat_widget.last_agent_markdown_text(),
+            Some("answer 299"),
+        );
+    }
+
+    #[tokio::test]
+    async fn rollback_preserves_real_context_compacted_reply() {
+        let (mut app, _app_event_rx, _op_rx) = make_test_app_with_channels().await;
+
+        let thread_id = ThreadId::new();
+        app.chat_widget.handle_codex_event(Event {
+            id: "session".to_string(),
+            msg: EventMsg::SessionConfigured(SessionConfiguredEvent {
+                session_id: thread_id,
+                forked_from_id: None,
+                thread_name: None,
+                model: "gpt-test".to_string(),
+                model_provider_id: "test-provider".to_string(),
+                approval_policy: AskForApproval::Never,
+                sandbox_policy: SandboxPolicy::ReadOnly,
+                cwd: PathBuf::from("/home/user/project"),
+                reasoning_effort: None,
+                history_log_id: 0,
+                history_entry_count: 0,
+                initial_messages: None,
+                rollout_path: Some(PathBuf::new()),
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "agent-real".to_string(),
+            msg: EventMsg::AgentMessage(codex_core::protocol::AgentMessageEvent {
+                message: "Context compacted".to_string(),
+            }),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "compacted".to_string(),
+            msg: EventMsg::ContextCompacted(codex_core::protocol::ContextCompactedEvent),
+        });
+        app.chat_widget.handle_codex_event(Event {
+            id: "agent-new".to_string(),
+            msg: EventMsg::AgentMessage(codex_core::protocol::AgentMessageEvent {
+                message: "answer second".to_string(),
+            }),
+        });
+
+        app.transcript_cells = vec![
+            Arc::new(UserHistoryCell {
+                message: "first".to_string(),
+                text_elements: Vec::new(),
+                local_image_paths: Vec::new(),
+            }) as Arc<dyn HistoryCell>,
+            Arc::new(AgentMessageCell::new(
+                vec![Line::from("Context compacted".to_string())],
+                true,
+            )) as Arc<dyn HistoryCell>,
+            Arc::new(UserHistoryCell {
+                message: "second".to_string(),
+                text_elements: Vec::new(),
+                local_image_paths: Vec::new(),
+            }) as Arc<dyn HistoryCell>,
+            Arc::new(new_info_event("Context compacted".to_string(), None)) as Arc<dyn HistoryCell>,
+            Arc::new(UserHistoryCell {
+                message: "third".to_string(),
+                text_elements: Vec::new(),
+                local_image_paths: Vec::new(),
+            }) as Arc<dyn HistoryCell>,
+            Arc::new(AgentMessageCell::new(
+                vec![Line::from("answer second".to_string())],
+                true,
+            )) as Arc<dyn HistoryCell>,
+        ];
+
+        app.apply_backtrack_rollback(crate::app_backtrack::BacktrackSelection {
+            nth_user_message: 2,
+            prefill: String::new(),
+            text_elements: Vec::new(),
+            local_image_paths: Vec::new(),
+        });
+        app.handle_backtrack_event(&EventMsg::ThreadRolledBack(
+            codex_core::protocol::ThreadRolledBackEvent { num_turns: 1 },
+        ));
+
+        assert_eq!(
+            app.chat_widget.last_agent_markdown_text(),
+            Some("Context compacted"),
         );
     }
 

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -28,8 +28,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use crate::app::App;
-#[cfg(test)]
 use crate::history_cell::AgentMessageCell;
+use crate::history_cell::HistoryCell;
 use crate::history_cell::SessionInfoCell;
 use crate::history_cell::UserHistoryCell;
 use crate::pager_overlay::Overlay;
@@ -514,8 +514,9 @@ impl App {
     fn trim_transcript_for_backtrack(&mut self, nth_user_message: usize) {
         trim_transcript_cells_to_nth_user(&mut self.transcript_cells, nth_user_message);
         let remaining_turns = user_count(&self.transcript_cells);
+        let fallback_markdown = last_agent_markdown_from_transcript(&self.transcript_cells);
         self.chat_widget
-            .truncate_agent_turn_markdowns_to_turn_count(remaining_turns);
+            .truncate_agent_turn_markdowns_to_turn_count(remaining_turns, fallback_markdown);
     }
 }
 
@@ -562,6 +563,41 @@ fn user_positions_iter(
         .enumerate()
         .skip(start)
         .filter_map(move |(idx, cell)| (type_of(cell) == user_type).then_some(idx))
+}
+
+fn last_agent_markdown_from_transcript(
+    cells: &[Arc<dyn crate::history_cell::HistoryCell>],
+) -> Option<String> {
+    let session_start_type = TypeId::of::<SessionInfoCell>();
+    let type_of = |cell: &Arc<dyn crate::history_cell::HistoryCell>| cell.as_any().type_id();
+
+    let start = cells
+        .iter()
+        .rposition(|cell| type_of(cell) == session_start_type)
+        .map_or(0, |idx| idx + 1);
+    let visible_cells = &cells[start..];
+
+    let group_start = visible_cells.iter().rposition(|cell| {
+        cell.as_any().downcast_ref::<AgentMessageCell>().is_some() && !cell.is_stream_continuation()
+    })?;
+
+    let mut blocks: Vec<String> = Vec::new();
+    for (offset, cell) in visible_cells[group_start..].iter().enumerate() {
+        let Some(agent_cell) = cell.as_any().downcast_ref::<AgentMessageCell>() else {
+            break;
+        };
+        if offset > 0 && !agent_cell.is_stream_continuation() {
+            break;
+        }
+        blocks.push(agent_cell.plain_text());
+    }
+
+    let merged = blocks
+        .into_iter()
+        .filter(|block| !block.is_empty())
+        .collect::<Vec<String>>()
+        .join("\n");
+    (!merged.is_empty()).then_some(merged)
 }
 
 #[cfg(test)]

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -45,6 +45,8 @@ use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyEventKind;
 
+const CONTEXT_COMPACTED_MARKER: &str = "Context compacted";
+
 /// Aggregates all backtrack-related state used by the App.
 #[derive(Default)]
 pub(crate) struct BacktrackState {
@@ -583,8 +585,29 @@ fn agent_group_positions_iter(
         .skip(start)
         .filter_map(move |(idx, cell)| {
             let is_agent = cell.as_any().downcast_ref::<AgentMessageCell>().is_some();
-            (is_agent && !cell.is_stream_continuation()).then_some(idx)
+            let is_copy_source_group =
+                is_agent && !cell.is_stream_continuation() && !is_compaction_marker_cell(cell);
+            is_copy_source_group.then_some(idx)
         })
+}
+
+fn is_compaction_marker_cell(cell: &Arc<dyn crate::history_cell::HistoryCell>) -> bool {
+    let Some(agent_cell) = cell.as_any().downcast_ref::<AgentMessageCell>() else {
+        return false;
+    };
+    let rendered_lines = crate::history_cell::HistoryCell::display_lines(agent_cell, u16::MAX);
+    let Some(first_line) = rendered_lines.first() else {
+        return false;
+    };
+
+    line_text(first_line).trim_start_matches(['•', ' ']).trim() == CONTEXT_COMPACTED_MARKER
+}
+
+fn line_text(line: &ratatui::text::Line<'_>) -> String {
+    line.spans
+        .iter()
+        .map(|span| span.content.as_ref())
+        .collect()
 }
 
 #[cfg(test)]
@@ -707,6 +730,22 @@ mod tests {
                 text_elements: Vec::new(),
                 local_image_paths: Vec::new(),
             }) as Arc<dyn HistoryCell>,
+            Arc::new(AgentMessageCell::new(vec![Line::from("second")], true))
+                as Arc<dyn HistoryCell>,
+        ];
+
+        assert_eq!(agent_group_count(&cells), 2);
+    }
+
+    #[test]
+    fn agent_group_count_ignores_context_compacted_marker() {
+        let cells: Vec<Arc<dyn HistoryCell>> = vec![
+            Arc::new(AgentMessageCell::new(vec![Line::from("first")], true))
+                as Arc<dyn HistoryCell>,
+            Arc::new(AgentMessageCell::new(
+                vec![Line::from("Context compacted")],
+                true,
+            )) as Arc<dyn HistoryCell>,
             Arc::new(AgentMessageCell::new(vec![Line::from("second")], true))
                 as Arc<dyn HistoryCell>,
         ];

--- a/codex-rs/tui/src/app_backtrack.rs
+++ b/codex-rs/tui/src/app_backtrack.rs
@@ -742,13 +742,15 @@ mod tests {
                 as Arc<dyn HistoryCell>,
             Arc::new(AgentMessageCell::new(vec![Line::from("first-b")], false))
                 as Arc<dyn HistoryCell>,
-            Arc::new(AgentMessageCell::new(vec![Line::from("second")], true))
+            Arc::new(AgentMessageCell::new(vec![Line::from("second-a")], true))
+                as Arc<dyn HistoryCell>,
+            Arc::new(AgentMessageCell::new(vec![Line::from("second-b")], false))
                 as Arc<dyn HistoryCell>,
         ];
 
         assert_eq!(
             last_agent_markdown_from_transcript(&cells),
-            Some("second".to_string())
+            Some("second-a\nsecond-b".to_string())
         );
     }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -153,6 +153,7 @@ const PLAN_IMPLEMENTATION_YES: &str = "Yes, implement this plan";
 const PLAN_IMPLEMENTATION_NO: &str = "No, stay in Plan mode";
 const PLAN_IMPLEMENTATION_CODING_MESSAGE: &str = "Implement the plan.";
 const CONNECTORS_SELECTION_VIEW_ID: &str = "connectors-selection";
+const MAX_AGENT_COPY_HISTORY: usize = 256;
 
 use crate::app_event::AppEvent;
 use crate::app_event::ConnectorsSnapshot;
@@ -1026,9 +1027,12 @@ impl ChatWidget {
         if message.is_empty() {
             return;
         }
-        let markdown = message.to_string();
-        self.last_agent_markdown = Some(markdown.clone());
-        self.agent_turn_markdowns.push(markdown);
+        self.agent_turn_markdowns.push(message.to_string());
+        if self.agent_turn_markdowns.len() > MAX_AGENT_COPY_HISTORY {
+            let overflow = self.agent_turn_markdowns.len() - MAX_AGENT_COPY_HISTORY;
+            self.agent_turn_markdowns.drain(0..overflow);
+        }
+        self.last_agent_markdown = self.agent_turn_markdowns.last().cloned();
         self.saw_agent_message_this_turn = true;
     }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1298,7 +1298,6 @@ impl ChatWidget {
 
     fn on_task_started(&mut self) {
         self.agent_turn_running = true;
-        self.last_agent_markdown = None;
         self.saw_plan_update_this_turn = false;
         self.saw_plan_item_this_turn = false;
         self.plan_delta_buffer.clear();

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -4237,6 +4237,8 @@ impl ChatWidget {
     fn on_exited_review_mode(&mut self, review: ExitedReviewModeEvent) {
         // Leave review mode; if output is present, flush pending stream + show results.
         if let Some(output) = review.review_output {
+            let review_markdown = codex_core::review_format::render_review_output_text(&output);
+            self.record_agent_markdown(&review_markdown);
             self.flush_answer_stream_with_separator();
             self.flush_interrupt_queue();
             self.flush_active_cell();

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1326,6 +1326,9 @@ impl ChatWidget {
         } else {
             text
         };
+        if !plan_text.trim().is_empty() {
+            self.record_agent_markdown(&plan_text);
+        }
         // Plan commit ticks can hide the status row; remember whether we streamed plan output so
         // completion can restore it once stream queues are idle.
         let should_restore_after_stream = self.plan_stream_controller.is_some();

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1216,6 +1216,16 @@ impl ChatWidget {
         self.request_redraw();
     }
 
+    fn on_context_compacted(&mut self) {
+        self.flush_answer_stream_with_separator();
+        self.handle_stream_finished();
+        self.add_to_history(history_cell::new_info_event(
+            "Context compacted".to_owned(),
+            None,
+        ));
+        self.request_redraw();
+    }
+
     fn on_agent_message_delta(&mut self, delta: String) {
         self.handle_streaming_delta(delta);
     }
@@ -4093,7 +4103,7 @@ impl ChatWidget {
                 self.on_entered_review_mode(review_request, from_replay)
             }
             EventMsg::ExitedReviewMode(review) => self.on_exited_review_mode(review),
-            EventMsg::ContextCompacted(_) => self.on_agent_message("Context compacted".to_owned()),
+            EventMsg::ContextCompacted(_) => self.on_context_compacted(),
             EventMsg::CollabAgentSpawnBegin(_) => {}
             EventMsg::CollabAgentSpawnEnd(ev) => self.on_collab_event(collab::spawn_end(ev)),
             EventMsg::CollabAgentInteractionBegin(_) => {}
@@ -4300,8 +4310,9 @@ impl ChatWidget {
         self.request_redraw();
     }
 
-    pub(crate) fn truncate_agent_turn_markdowns(&mut self, len: usize) {
-        self.agent_turn_markdowns.truncate(len);
+    pub(crate) fn drop_recent_agent_turn_markdowns(&mut self, count: usize) {
+        let keep_len = self.agent_turn_markdowns.len().saturating_sub(count);
+        self.agent_turn_markdowns.truncate(keep_len);
         self.last_agent_markdown = self.agent_turn_markdowns.last().cloned();
     }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -4354,6 +4354,7 @@ impl ChatWidget {
     pub(crate) fn truncate_agent_turn_markdowns_to_turn_count(
         &mut self,
         remaining_turn_count: usize,
+        transcript_fallback: Option<String>,
     ) {
         while self
             .agent_turn_markdown_turn_ordinals
@@ -4363,6 +4364,15 @@ impl ChatWidget {
         {
             self.agent_turn_markdown_turn_ordinals.pop();
             self.agent_turn_markdowns.pop();
+        }
+        if self.agent_turn_markdowns.is_empty()
+            && let Some(fallback) = transcript_fallback
+                .map(|fallback| fallback.trim().to_string())
+                .filter(|fallback| !fallback.is_empty())
+        {
+            self.agent_turn_markdowns.push(fallback);
+            self.agent_turn_markdown_turn_ordinals
+                .push(remaining_turn_count);
         }
         self.completed_turn_count = self.completed_turn_count.min(remaining_turn_count);
         self.last_agent_markdown = self.agent_turn_markdowns.last().cloned();

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -4361,15 +4361,19 @@ impl ChatWidget {
         {
             self.agent_turn_markdowns.pop();
         }
-        if self.agent_turn_markdowns.is_empty()
-            && let Some(fallback) = transcript_fallback
-                .map(|fallback| fallback.trim().to_string())
-                .filter(|fallback| !fallback.is_empty())
+        if let Some(fallback) = transcript_fallback
+            .map(|fallback| fallback.trim().to_string())
+            .filter(|fallback| !fallback.is_empty())
         {
-            self.agent_turn_markdowns.push(AgentTurnMarkdown {
-                ordinal: remaining_turn_count,
-                markdown: fallback,
-            });
+            if let Some(last) = self.agent_turn_markdowns.last_mut() {
+                last.ordinal = remaining_turn_count;
+                last.markdown = fallback;
+            } else {
+                self.agent_turn_markdowns.push(AgentTurnMarkdown {
+                    ordinal: remaining_turn_count,
+                    markdown: fallback,
+                });
+            }
         }
         self.completed_turn_count = self.completed_turn_count.min(remaining_turn_count);
         self.last_agent_markdown = self

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3067,6 +3067,9 @@ impl ChatWidget {
                 kind: KeyEventKind::Press,
                 ..
             } => {
+                self.bottom_pane.clear_quit_shortcut_hint();
+                self.quit_shortcut_expires_at = None;
+                self.quit_shortcut_key = None;
                 self.copy_last_agent_markdown();
                 return;
             }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -631,6 +631,10 @@ pub(crate) struct ChatWidget {
     last_agent_markdown: Option<String>,
     /// Raw markdown for each completed agent response in this session timeline.
     agent_turn_markdowns: Vec<String>,
+    /// Turn ordinal for each entry in `agent_turn_markdowns`.
+    agent_turn_markdown_turn_ordinals: Vec<usize>,
+    /// Number of completed turns observed in this session timeline.
+    completed_turn_count: usize,
     /// Whether this turn already emitted a full `AgentMessage`.
     ///
     /// Some models only provide `TurnComplete.last_agent_message`. This flag lets us use
@@ -1027,11 +1031,30 @@ impl ChatWidget {
         if message.is_empty() {
             return;
         }
-        self.agent_turn_markdowns.push(message.to_string());
+        let turn_ordinal = self.completed_turn_count.saturating_add(1);
+        let message = message.to_string();
+        if self
+            .agent_turn_markdown_turn_ordinals
+            .last()
+            .copied()
+            .is_some_and(|ordinal| ordinal == turn_ordinal)
+        {
+            if let Some(last) = self.agent_turn_markdowns.last_mut() {
+                *last = message;
+            }
+        } else {
+            self.agent_turn_markdowns.push(message);
+            self.agent_turn_markdown_turn_ordinals.push(turn_ordinal);
+        }
         if self.agent_turn_markdowns.len() > MAX_AGENT_COPY_HISTORY {
             let overflow = self.agent_turn_markdowns.len() - MAX_AGENT_COPY_HISTORY;
             self.agent_turn_markdowns.drain(0..overflow);
+            self.agent_turn_markdown_turn_ordinals.drain(0..overflow);
         }
+        debug_assert_eq!(
+            self.agent_turn_markdowns.len(),
+            self.agent_turn_markdown_turn_ordinals.len()
+        );
         self.last_agent_markdown = self.agent_turn_markdowns.last().cloned();
         self.saw_agent_message_this_turn = true;
     }
@@ -1040,6 +1063,8 @@ impl ChatWidget {
     fn on_session_configured(&mut self, event: codex_core::protocol::SessionConfiguredEvent) {
         self.last_agent_markdown = None;
         self.agent_turn_markdowns.clear();
+        self.agent_turn_markdown_turn_ordinals.clear();
+        self.completed_turn_count = 0;
         self.saw_agent_message_this_turn = false;
         self.bottom_pane
             .set_history_metadata(event.history_log_id, event.history_entry_count);
@@ -1357,6 +1382,7 @@ impl ChatWidget {
     }
 
     fn on_task_complete(&mut self, last_agent_message: Option<String>, from_replay: bool) {
+        let turn_was_running = self.agent_turn_running;
         // If a stream is currently active, finalize it.
         self.flush_answer_stream_with_separator();
         if let Some(mut controller) = self.plan_stream_controller.take()
@@ -1404,6 +1430,11 @@ impl ChatWidget {
             && !self.saw_agent_message_this_turn
         {
             self.record_agent_markdown(message);
+        }
+        let should_advance_completed_turn_count =
+            turn_was_running || !self.saw_agent_message_this_turn;
+        if should_advance_completed_turn_count {
+            self.completed_turn_count = self.completed_turn_count.saturating_add(1);
         }
         self.saw_agent_message_this_turn = false;
 
@@ -2712,6 +2743,8 @@ impl ChatWidget {
             external_editor_state: ExternalEditorState::Closed,
             last_agent_markdown: None,
             agent_turn_markdowns: Vec::new(),
+            agent_turn_markdown_turn_ordinals: Vec::new(),
+            completed_turn_count: 0,
             saw_agent_message_this_turn: false,
         };
 
@@ -2880,6 +2913,8 @@ impl ChatWidget {
             external_editor_state: ExternalEditorState::Closed,
             last_agent_markdown: None,
             agent_turn_markdowns: Vec::new(),
+            agent_turn_markdown_turn_ordinals: Vec::new(),
+            completed_turn_count: 0,
             saw_agent_message_this_turn: false,
         };
 
@@ -3037,6 +3072,8 @@ impl ChatWidget {
             external_editor_state: ExternalEditorState::Closed,
             last_agent_markdown: None,
             agent_turn_markdowns: Vec::new(),
+            agent_turn_markdown_turn_ordinals: Vec::new(),
+            completed_turn_count: 0,
             saw_agent_message_this_turn: false,
         };
 
@@ -3986,7 +4023,11 @@ impl ChatWidget {
             EventMsg::SessionConfigured(e) => self.on_session_configured(e),
             EventMsg::ThreadNameUpdated(e) => self.on_thread_name_updated(e),
             EventMsg::AgentMessage(AgentMessageEvent { message }) => {
+                let count_as_completed_turn = !self.agent_turn_running && !message.is_empty();
                 self.record_agent_markdown(&message);
+                if count_as_completed_turn {
+                    self.completed_turn_count = self.completed_turn_count.saturating_add(1);
+                }
                 self.on_agent_message(message)
             }
             EventMsg::AgentMessageDelta(AgentMessageDeltaEvent { delta }) => {
@@ -4310,9 +4351,20 @@ impl ChatWidget {
         self.request_redraw();
     }
 
-    pub(crate) fn drop_recent_agent_turn_markdowns(&mut self, count: usize) {
-        let keep_len = self.agent_turn_markdowns.len().saturating_sub(count);
-        self.agent_turn_markdowns.truncate(keep_len);
+    pub(crate) fn truncate_agent_turn_markdowns_to_turn_count(
+        &mut self,
+        remaining_turn_count: usize,
+    ) {
+        while self
+            .agent_turn_markdown_turn_ordinals
+            .last()
+            .copied()
+            .is_some_and(|ordinal| ordinal > remaining_turn_count)
+        {
+            self.agent_turn_markdown_turn_ordinals.pop();
+            self.agent_turn_markdowns.pop();
+        }
+        self.completed_turn_count = self.completed_turn_count.min(remaining_turn_count);
         self.last_agent_markdown = self.agent_turn_markdowns.last().cloned();
     }
 

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -225,6 +225,7 @@ async fn resumed_initial_messages_set_last_agent_markdown_for_copy() {
                 message: "assistant reply".to_string(),
             }),
         ]),
+        network_proxy: None,
         rollout_path: Some(rollout_file.path().to_path_buf()),
     };
 
@@ -239,7 +240,10 @@ async fn resumed_initial_messages_set_last_agent_markdown_for_copy() {
         "expected replayed assistant message to seed copy state",
     );
     assert_eq!(
-        chat.agent_turn_markdowns,
+        chat.agent_turn_markdowns
+            .iter()
+            .map(|entry| entry.markdown.clone())
+            .collect::<Vec<String>>(),
         vec!["assistant reply".to_string()],
         "expected replayed assistant message to seed agent markdown timeline",
     );
@@ -318,7 +322,10 @@ async fn turn_complete_with_last_agent_message_seeds_copy_when_agent_message_is_
         Some("assistant fallback")
     );
     assert_eq!(
-        chat.agent_turn_markdowns,
+        chat.agent_turn_markdowns
+            .iter()
+            .map(|entry| entry.markdown.clone())
+            .collect::<Vec<String>>(),
         vec!["assistant fallback".to_string()]
     );
 }
@@ -349,7 +356,7 @@ async fn turn_complete_does_not_duplicate_when_agent_message_already_recorded() 
 
     assert_eq!(chat.last_agent_markdown.as_deref(), Some("assistant reply"));
     assert_eq!(chat.agent_turn_markdowns.len(), 1);
-    assert_eq!(chat.agent_turn_markdowns[0], "assistant reply");
+    assert_eq!(chat.agent_turn_markdowns[0].markdown, "assistant reply");
 }
 
 #[tokio::test]
@@ -406,6 +413,7 @@ async fn session_configured_resets_copy_state_before_replay() {
         history_log_id: 0,
         history_entry_count: 0,
         initial_messages: None,
+        network_proxy: None,
         rollout_path: None,
     };
 
@@ -437,7 +445,9 @@ async fn copy_history_is_bounded_to_recent_agent_messages() {
     let expected_last = format!("reply {}", total_messages - 1);
     assert_eq!(chat.agent_turn_markdowns.len(), MAX_AGENT_COPY_HISTORY);
     assert_eq!(
-        chat.agent_turn_markdowns.first().map(String::as_str),
+        chat.agent_turn_markdowns
+            .first()
+            .map(|entry| entry.markdown.as_str()),
         Some(expected_first.as_str())
     );
     assert_eq!(
@@ -1372,7 +1382,6 @@ async fn make_chatwidget_manual(
         external_editor_state: ExternalEditorState::Closed,
         last_agent_markdown: None,
         agent_turn_markdowns: Vec::new(),
-        agent_turn_markdown_turn_ordinals: Vec::new(),
         completed_turn_count: 0,
         saw_agent_message_this_turn: false,
     };

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1487,7 +1487,7 @@ async fn make_chatwidget_manual(
         last_agent_markdown: None,
         agent_turn_markdowns: Vec::new(),
         completed_turn_count: 0,
-        saw_agent_message_this_turn: false,
+        saw_copy_source_this_turn: false,
     };
     widget.set_model(&resolved_model);
     (widget, rx, op_rx)

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1372,6 +1372,8 @@ async fn make_chatwidget_manual(
         external_editor_state: ExternalEditorState::Closed,
         last_agent_markdown: None,
         agent_turn_markdowns: Vec::new(),
+        agent_turn_markdown_turn_ordinals: Vec::new(),
+        completed_turn_count: 0,
         saw_agent_message_this_turn: false,
     };
     widget.set_model(&resolved_model);

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -291,6 +291,33 @@ async fn turn_complete_without_last_agent_message_preserves_previous_copy_source
 }
 
 #[tokio::test]
+async fn turn_started_preserves_previous_copy_source() {
+    let (mut chat, _rx, _ops) = make_chatwidget_manual(None).await;
+
+    chat.handle_codex_event(Event {
+        id: "assistant".into(),
+        msg: EventMsg::AgentMessage(AgentMessageEvent {
+            message: "assistant reply".to_string(),
+        }),
+    });
+    assert_eq!(chat.last_agent_markdown.as_deref(), Some("assistant reply"));
+
+    chat.handle_codex_event(Event {
+        id: "turn-started".into(),
+        msg: EventMsg::TurnStarted(TurnStartedEvent {
+            model_context_window: None,
+            collaboration_mode_kind: ModeKind::Default,
+        }),
+    });
+
+    assert_eq!(
+        chat.last_agent_markdown.as_deref(),
+        Some("assistant reply"),
+        "starting a new turn should keep the previous copy source until a newer assistant message arrives",
+    );
+}
+
+#[tokio::test]
 async fn replayed_user_message_preserves_text_elements_and_local_images() {
     let (mut chat, mut rx, _ops) = make_chatwidget_manual(None).await;
 

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1119,6 +1119,7 @@ async fn make_chatwidget_manual(
         status_line_branch_pending: false,
         status_line_branch_lookup_complete: false,
         external_editor_state: ExternalEditorState::Closed,
+        last_agent_markdown: None,
     };
     widget.set_model(&resolved_model);
     (widget, rx, op_rx)

--- a/codex-rs/tui/src/clipboard_copy.rs
+++ b/codex-rs/tui/src/clipboard_copy.rs
@@ -1,0 +1,116 @@
+use base64::Engine;
+use std::io::Write;
+
+/// Copy text to the system clipboard.
+///
+/// Over SSH, prefers OSC 52 so the text reaches the *local* terminal emulator's
+/// clipboard rather than a remote X11/Wayland clipboard that the user cannot
+/// access. On a local session, tries `arboard` (native clipboard) first and
+/// falls back to OSC 52 if that fails.
+///
+/// OSC 52 is supported by kitty, WezTerm, iTerm2, Ghostty, and others.
+pub(crate) fn copy_to_clipboard(text: &str) -> Result<(), String> {
+    if is_ssh_session() {
+        // Over SSH the native clipboard writes to the remote machine which is
+        // useless. Prefer OSC 52 which travels through the SSH tunnel to the
+        // local terminal emulator.
+        _ = osc52_copy(text).map_err(|osc_err| {
+            tracing::warn!("OSC 52 clipboard copy failed: {osc_err}");
+        });
+    }
+
+    match arboard_copy(text) {
+        Ok(()) => Ok(()),
+        Err(native_err) => {
+            tracing::warn!("native clipboard copy failed: {native_err}, falling back to OSC 52");
+            osc52_copy(text).map_err(|osc_err| {
+                format!("native clipboard: {native_err}; OSC 52 fallback: {osc_err}")
+            })
+        }
+    }
+}
+
+/// Detect whether the current process is running inside an SSH session.
+fn is_ssh_session() -> bool {
+    std::env::var_os("SSH_TTY").is_some() || std::env::var_os("SSH_CONNECTION").is_some()
+}
+
+/// Run arboard with stderr suppressed.
+///
+/// On macOS, `arboard::Clipboard::new()` initializes `NSPasteboard` which
+/// triggers `os_log` / `NSLog` output on stderr. Because the TUI owns the
+/// terminal, that stray output corrupts the display. We temporarily redirect
+/// fd 2 to `/dev/null` around the call to keep the screen clean.
+fn arboard_copy(text: &str) -> Result<(), String> {
+    let _guard = SuppressStderr::new();
+    let mut clipboard =
+        arboard::Clipboard::new().map_err(|e| format!("clipboard unavailable: {e}"))?;
+    clipboard
+        .set_text(text)
+        .map_err(|e| format!("failed to set clipboard text: {e}"))
+}
+
+/// RAII guard that redirects stderr (fd 2) to `/dev/null` on creation and
+/// restores the original fd on drop.
+struct SuppressStderr {
+    saved_fd: Option<libc::c_int>,
+}
+
+impl SuppressStderr {
+    fn new() -> Self {
+        unsafe {
+            // Save the current stderr fd.
+            let saved = libc::dup(2);
+            if saved < 0 {
+                return Self { saved_fd: None };
+            }
+            // Open /dev/null and point fd 2 at it.
+            let devnull = libc::open(b"/dev/null\0".as_ptr().cast(), libc::O_WRONLY);
+            if devnull >= 0 {
+                libc::dup2(devnull, 2);
+                libc::close(devnull);
+            }
+            Self {
+                saved_fd: Some(saved),
+            }
+        }
+    }
+}
+
+impl Drop for SuppressStderr {
+    fn drop(&mut self) {
+        if let Some(saved) = self.saved_fd {
+            unsafe {
+                libc::dup2(saved, 2);
+                libc::close(saved);
+            }
+        }
+    }
+}
+
+/// Write text to the clipboard via the OSC 52 terminal escape sequence.
+fn osc52_copy(text: &str) -> Result<(), String> {
+    let encoded = base64::engine::general_purpose::STANDARD.encode(text.as_bytes());
+    let sequence = format!("\x1b]52;c;{encoded}\x07");
+    let mut stdout = std::io::stdout().lock();
+    stdout
+        .write_all(sequence.as_bytes())
+        .map_err(|e| format!("failed to write OSC 52: {e}"))?;
+    stdout
+        .flush()
+        .map_err(|e| format!("failed to flush OSC 52: {e}"))
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn osc52_encoding_roundtrips() {
+        use base64::Engine;
+        let text = "# Hello\n\n```rust\nfn main() {}\n```\n";
+        let encoded = base64::engine::general_purpose::STANDARD.encode(text.as_bytes());
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(&encoded)
+            .unwrap();
+        assert_eq!(decoded, text.as_bytes());
+    }
+}

--- a/codex-rs/tui/src/clipboard_copy.rs
+++ b/codex-rs/tui/src/clipboard_copy.rs
@@ -75,7 +75,7 @@ impl SuppressStderr {
                 return Self { saved_fd: None };
             }
             // Open /dev/null and point fd 2 at it.
-            let devnull = libc::open(b"/dev/null\0".as_ptr().cast(), libc::O_WRONLY);
+            let devnull = libc::open(c"/dev/null".as_ptr(), libc::O_WRONLY);
             if devnull >= 0 {
                 libc::dup2(devnull, 2);
                 libc::close(devnull);

--- a/codex-rs/tui/src/clipboard_copy.rs
+++ b/codex-rs/tui/src/clipboard_copy.rs
@@ -94,10 +94,16 @@ impl SuppressStderr {
             }
             // Open /dev/null and point fd 2 at it.
             let devnull = libc::open(c"/dev/null".as_ptr(), libc::O_WRONLY);
-            if devnull >= 0 {
-                libc::dup2(devnull, 2);
-                libc::close(devnull);
+            if devnull < 0 {
+                libc::close(saved);
+                return Self { saved_fd: None };
             }
+            if libc::dup2(devnull, 2) < 0 {
+                libc::close(saved);
+                libc::close(devnull);
+                return Self { saved_fd: None };
+            }
+            libc::close(devnull);
             Self {
                 saved_fd: Some(saved),
             }

--- a/codex-rs/tui/src/clipboard_copy.rs
+++ b/codex-rs/tui/src/clipboard_copy.rs
@@ -3,27 +3,37 @@ use std::io::Write;
 
 /// Copy text to the system clipboard.
 ///
-/// Over SSH, prefers OSC 52 so the text reaches the *local* terminal emulator's
+/// Over SSH, uses OSC 52 so the text reaches the *local* terminal emulator's
 /// clipboard rather than a remote X11/Wayland clipboard that the user cannot
 /// access. On a local session, tries `arboard` (native clipboard) first and
 /// falls back to OSC 52 if that fails.
 ///
 /// OSC 52 is supported by kitty, WezTerm, iTerm2, Ghostty, and others.
 pub(crate) fn copy_to_clipboard(text: &str) -> Result<(), String> {
-    if is_ssh_session() {
+    copy_to_clipboard_with(text, is_ssh_session(), osc52_copy, arboard_copy)
+}
+
+fn copy_to_clipboard_with(
+    text: &str,
+    ssh_session: bool,
+    osc52_copy_fn: impl Fn(&str) -> Result<(), String>,
+    arboard_copy_fn: impl Fn(&str) -> Result<(), String>,
+) -> Result<(), String> {
+    if ssh_session {
         // Over SSH the native clipboard writes to the remote machine which is
-        // useless. Prefer OSC 52 which travels through the SSH tunnel to the
+        // useless. Use OSC 52, which travels through the SSH tunnel to the
         // local terminal emulator.
-        _ = osc52_copy(text).map_err(|osc_err| {
-            tracing::warn!("OSC 52 clipboard copy failed: {osc_err}");
+        return osc52_copy_fn(text).map_err(|osc_err| {
+            tracing::warn!("OSC 52 clipboard copy failed over SSH: {osc_err}");
+            format!("OSC 52 clipboard copy failed over SSH: {osc_err}")
         });
     }
 
-    match arboard_copy(text) {
+    match arboard_copy_fn(text) {
         Ok(()) => Ok(()),
         Err(native_err) => {
             tracing::warn!("native clipboard copy failed: {native_err}, falling back to OSC 52");
-            osc52_copy(text).map_err(|osc_err| {
+            osc52_copy_fn(text).map_err(|osc_err| {
                 format!("native clipboard: {native_err}; OSC 52 fallback: {osc_err}")
             })
         }
@@ -103,6 +113,11 @@ fn osc52_copy(text: &str) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
+    use pretty_assertions::assert_eq;
+    use std::cell::Cell;
+
+    use super::copy_to_clipboard_with;
+
     #[test]
     fn osc52_encoding_roundtrips() {
         use base64::Engine;
@@ -112,5 +127,121 @@ mod tests {
             .decode(&encoded)
             .unwrap();
         assert_eq!(decoded, text.as_bytes());
+    }
+
+    #[test]
+    fn ssh_uses_osc52_and_skips_native_on_success() {
+        let osc_calls = Cell::new(0_u8);
+        let native_calls = Cell::new(0_u8);
+        let result = copy_to_clipboard_with(
+            "hello",
+            true,
+            |_| {
+                osc_calls.set(osc_calls.get() + 1);
+                Ok(())
+            },
+            |_| {
+                native_calls.set(native_calls.get() + 1);
+                Ok(())
+            },
+        );
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(osc_calls.get(), 1);
+        assert_eq!(native_calls.get(), 0);
+    }
+
+    #[test]
+    fn ssh_returns_osc52_error_and_skips_native() {
+        let osc_calls = Cell::new(0_u8);
+        let native_calls = Cell::new(0_u8);
+        let result = copy_to_clipboard_with(
+            "hello",
+            true,
+            |_| {
+                osc_calls.set(osc_calls.get() + 1);
+                Err("blocked".into())
+            },
+            |_| {
+                native_calls.set(native_calls.get() + 1);
+                Ok(())
+            },
+        );
+
+        assert_eq!(
+            result,
+            Err("OSC 52 clipboard copy failed over SSH: blocked".into())
+        );
+        assert_eq!(osc_calls.get(), 1);
+        assert_eq!(native_calls.get(), 0);
+    }
+
+    #[test]
+    fn local_uses_native_clipboard_first() {
+        let osc_calls = Cell::new(0_u8);
+        let native_calls = Cell::new(0_u8);
+        let result = copy_to_clipboard_with(
+            "hello",
+            false,
+            |_| {
+                osc_calls.set(osc_calls.get() + 1);
+                Ok(())
+            },
+            |_| {
+                native_calls.set(native_calls.get() + 1);
+                Ok(())
+            },
+        );
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(osc_calls.get(), 0);
+        assert_eq!(native_calls.get(), 1);
+    }
+
+    #[test]
+    fn local_falls_back_to_osc52_when_native_fails() {
+        let osc_calls = Cell::new(0_u8);
+        let native_calls = Cell::new(0_u8);
+        let result = copy_to_clipboard_with(
+            "hello",
+            false,
+            |_| {
+                osc_calls.set(osc_calls.get() + 1);
+                Ok(())
+            },
+            |_| {
+                native_calls.set(native_calls.get() + 1);
+                Err("native unavailable".into())
+            },
+        );
+
+        assert_eq!(result, Ok(()));
+        assert_eq!(osc_calls.get(), 1);
+        assert_eq!(native_calls.get(), 1);
+    }
+
+    #[test]
+    fn local_reports_both_errors_when_native_and_osc52_fail() {
+        let osc_calls = Cell::new(0_u8);
+        let native_calls = Cell::new(0_u8);
+        let result = copy_to_clipboard_with(
+            "hello",
+            false,
+            |_| {
+                osc_calls.set(osc_calls.get() + 1);
+                Err("osc blocked".into())
+            },
+            |_| {
+                native_calls.set(native_calls.get() + 1);
+                Err("native unavailable".into())
+            },
+        );
+
+        assert_eq!(
+            result,
+            Err("native clipboard: native unavailable; OSC 52 fallback: osc blocked".into())
+        );
+        assert_eq!(osc_calls.get(), 1);
+        assert_eq!(native_calls.get(), 1);
     }
 }

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -361,6 +361,19 @@ impl AgentMessageCell {
             is_first_line,
         }
     }
+
+    pub(crate) fn plain_text(&self) -> String {
+        self.lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.as_ref())
+                    .collect::<String>()
+            })
+            .collect::<Vec<String>>()
+            .join("\n")
+    }
 }
 
 impl HistoryCell for AgentMessageCell {

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -362,6 +362,12 @@ impl AgentMessageCell {
         }
     }
 
+    /// Flatten the rendered lines back to plain text (no ANSI styles).
+    ///
+    /// Used by the rollback fallback path to reconstruct copy-source markdown
+    /// when the bounded copy-history has already evicted the original entry.
+    /// The result is lossy — markdown syntax consumed during rendering is not
+    /// recovered.
     pub(crate) fn plain_text(&self) -> String {
         self.lines
             .iter()

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -61,6 +61,7 @@ mod ascii_animation;
 mod bottom_pane;
 mod chatwidget;
 mod cli;
+mod clipboard_copy;
 mod clipboard_paste;
 mod collab;
 mod collaboration_modes;

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -30,6 +30,7 @@ pub enum SlashCommand {
     Collab,
     Agent,
     // Undo,
+    Copy,
     Diff,
     Mention,
     Status,
@@ -62,6 +63,7 @@ impl SlashCommand {
             SlashCommand::Fork => "fork the current chat",
             // SlashCommand::Undo => "ask Codex to undo a turn",
             SlashCommand::Quit | SlashCommand::Exit => "exit Codex",
+            SlashCommand::Copy => "copy last response as markdown",
             SlashCommand::Diff => "show git diff (including untracked files)",
             SlashCommand::Mention => "mention a file",
             SlashCommand::Skills => "use skills to improve how Codex performs specific tasks",
@@ -119,7 +121,8 @@ impl SlashCommand {
             | SlashCommand::Review
             | SlashCommand::Plan
             | SlashCommand::Logout => false,
-            SlashCommand::Diff
+            SlashCommand::Copy
+            | SlashCommand::Diff
             | SlashCommand::Rename
             | SlashCommand::Mention
             | SlashCommand::Skills


### PR DESCRIPTION
## Problem

Users want to quickly copy the last agent response as markdown — for pasting into docs, issues, or chat. The TUI had no clipboard integration, and over SSH even if it did the clipboard would write to the _remote_ machine.

## Mental model

The copy feature maintains a **parallel timeline** of agent response markdown alongside the existing transcript cells. The transcript's `history` stores rendered `Line`/`Span` objects for display — the original markdown syntax (`#` headings, `**bold**`, code fences) is lost after rendering. Copying needs the raw markdown, so we keep it separately rather than modifying the shared display model that the rest of the TUI relies on for rendering, scrolling, and rollback.

Alternatives considered:

- **Store `raw_markdown` on `AgentMessageCell`** — couples copy logic to the display model, bloats every cell with an `Option<String>` even though only the last one matters, and rollback has to walk the history vec instead of a simple `Vec::pop`.
- **Query the backend transcript on demand** — `ChatWidget` only receives events; it has no direct access to the backend transcript. Plumbing an async query path or shared reference would be a bigger architectural change for a single feature.
- **Store just the turn ordinal, reconstruct from `plain_text()` on copy** — eliminates string duplication but makes _every_ copy lossy (not just the deep-rollback edge case), defeating the purpose of raw markdown.
- **Store only markdown, render lazily in `display_lines()`** — the most principled approach (markdown as single source of truth), but the streaming pipeline currently renders deltas incrementally into pre-rendered `Line`/`Span` cells, and a single agent response is split across multiple `AgentMessageCell` instances (one per stream chunk). This would require restructuring streaming to accumulate raw markdown, merging cells into one per response, and re-rendering on every draw (or caching, which is back to storing both). Valid long-term direction but too large a refactor for a copy-feature PR.

The current approach (parallel bounded vec) is the simplest that gives lossless copy in the common case without coupling to either the display model or the backend.

Two data structures track this:

- `last_agent_markdown` — the single string that Alt+C / `/copy` will send to the clipboard.
- `agent_turn_markdowns: Vec<AgentTurnMarkdown>` — a bounded (256-entry) vec with drain-on-overflow of `(ordinal, markdown)` pairs so that transcript rollbacks can truncate the timeline and recover the correct copy source.

The timeline is fed from four event sources (last writer wins within a turn):

1. `AgentMessage` — primary source; records commentary or full response text.
2. `PlanItemCompleted` — overwrites commentary with the completed plan text, so Alt+C copies the plan the user actually sees rather than a brief preamble.
3. `ExitedReviewMode` — records the rendered review output (explanation and/or findings) so Alt+C copies the review result.
4. `TurnComplete.last_agent_message` — fallback for providers that don't emit `AgentMessage`.

A `saw_copy_source_this_turn` flag prevents `TurnComplete` from recording a duplicate entry when any copy source (`AgentMessage`, plan item, or review output) was already recorded during the turn.

Clipboard writes use a two-tier strategy:

1. SSH detected → OSC 52 only (reaches local terminal).
2. Local → arboard (native) first, OSC 52 fallback.

> **What is OSC 52?** OSC 52 is a terminal escape sequence (Operating System
> Command #52) that asks the terminal emulator to write to the host's system
> clipboard. This is critical for SSH sessions: the TUI runs on the remote
> machine and has no access to the local clipboard, but the user's terminal
> emulator on the local machine interprets OSC 52 and writes to the local
> clipboard on their behalf. Most modern terminals (iTerm2, WezTerm, kitty,
> Windows Terminal, ghostty) support it.

OSC 52 is written to `/dev/tty` to bypass ratatui's alternate-screen buffer on stdout.

## Non-goals

- Copying tool-call output or reasoning traces. Note: commentary (`AgentMessage`) is recorded and copyable while the turn is still running; once a plan item or review output completes, it overwrites the commentary.

## Tradeoffs

| Decision                                    | Why                                                                                                                                                                                                                                                                        |
| ------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| Bounded 256-entry history                   | Keeps memory bounded in long sessions; deep rollbacks past the boundary use a lossy transcript-cell reconstruction.                                                                                                                                                        |
| `plain_text()` fallback is lossy            | The rendered `Line`/`Span` cells lose original markdown syntax. Acceptable because it only triggers on deep rollbacks past the 256-entry window.                                                                                                                           |
| Transcript fallback only when history is empty | After a rollback, the transcript-derived fallback is only inserted when copy history is empty after truncation. If surviving entries remain, they are used as-is.                                                                                                       |
| OSC 52 payload limit of 100 kB              | Most terminals silently truncate larger payloads; we reject early with a clear error.                                                                                                                                                                                      |
| Alt+C instead of Cmd+C / Ctrl+C             | Cmd+C is not available to terminal apps — the terminal emulator intercepts it before it reaches the TUI. Ctrl+C is already wired to SIGINT. Alt+C is the conventional modifier for terminal apps that need a copy binding (e.g. tmux, Midnight Commander).                 |
| macOS `SuppressStderr` guard around arboard | `arboard::Clipboard::new()` initializes `NSPasteboard`, which triggers `os_log`/`NSLog` output on stderr. In raw-mode TUI this corrupts the display. RAII guard redirects fd 2 to `/dev/null` around the call, serialized by a process-wide mutex. No-op on Linux/Windows. |
| Plan text unconditionally overwrites commentary copy source | In plan mode, the model often emits brief commentary ("I'll create a plan") before the plan itself. The plan is what the user sees and wants to copy — not the preamble. |

## Architecture

```
Alt+C / /copy
│
▼
ChatWidget::copy_last_agent_markdown()
│ reads self.last_agent_markdown
▼
clipboard_copy::copy_to_clipboard()
│
├─ SSH? ──► osc52_copy() ──► /dev/tty or stdout
│
└─ Local? ─► arboard_copy() ──► [fail] ──► osc52_copy()
```

Copy-state lifecycle:
```
SessionConfigured    → clear all copy state
AgentMessage         → record_agent_markdown (primary source)
PlanItemCompleted    → record_agent_markdown (overwrites commentary with plan text)
ExitedReviewMode     → record_agent_markdown (captures rendered review output)
TurnComplete         → record_agent_markdown (fallback, only if no copy source recorded this turn)
TurnStarted          → reset saw_copy_source_this_turn
ContextCompacted     → no-op on copy state (display-only info event)
Rollback             → truncate_agent_turn_markdowns_to_turn_count + transcript fallback
```

Copy source priority within a turn:
```
AgentMessage (commentary) → PlanItemCompleted (plan text overwrites) → ExitedReviewMode (review output overwrites) → TurnComplete (fallback, only if no source recorded yet)
```

## Observability

- `tracing::warn` on native clipboard failure before OSC 52 fallback.
- `tracing::debug` on `/dev/tty` open failure before stdout fallback.
- Visible history-cell feedback: "Copied last message to clipboard" / "Copy failed: ..." / "No agent response to copy".

## Tests

~28 new tests covering:

- Rollback recomputes copy source to surviving agent message
- Rollback past bounded history uses transcript fallback
- Deep rollback (300 turns → rollback to turn 20) recovers correct source
- Context-compacted marker does not replace copy source
- TurnComplete fallback seeds copy when AgentMessage is missing
- TurnComplete does not duplicate when AgentMessage already recorded
- Plan item completion overwrites commentary as copy source
- Review output (explanation-only) updates copy source on ExitedReviewMode
- Review output (with findings) updates copy source on ExitedReviewMode
- Session reset clears copy state before replay
- Bounded history evicts oldest entries
- Alt+C clears armed quit-shortcut state
- `/copy` available during running task
- Clipboard strategy: SSH/local, native/OSC52, both-fail error aggregation
- OSC 52 encoding roundtrip, payload size rejection, writer passthrough
- Transcript fallback joins stream-continuation groups
- Transcript fallback ignores info-event markers

Manual testing performed on:

- macOS (local, native clipboard via arboard)
- Linux (local)
- Windows (local)
- macOS → macOS over SSH (OSC 52 to local terminal)