### PR TITLE
Warn when server serves different model than requested

### DIFF
--- a/codex-rs/codex-api/src/common.rs
+++ b/codex-rs/codex-api/src/common.rs
@@ -53,7 +53,13 @@ pub struct MemorySummarizeOutput {
 
 #[derive(Debug)]
 pub enum ResponseEvent {
-    Created,
+    /// The server accepted the request and created a response object.
+    ///
+    /// Note: some test fixtures omit these fields; treat them as best-effort.
+    Created {
+        response_id: Option<String>,
+        model: Option<String>,
+    },
     OutputItemDone(ResponseItem),
     OutputItemAdded(ResponseItem),
     /// Emitted when `X-Reasoning-Included: true` is present on the response,

--- a/codex-rs/codex-api/src/endpoint/aggregate.rs
+++ b/codex-rs/codex-api/src/endpoint/aggregate.rs
@@ -113,7 +113,7 @@ impl Stream for AggregatedStream {
                         token_usage,
                     })));
                 }
-                Poll::Ready(Some(Ok(ResponseEvent::Created))) => continue,
+                Poll::Ready(Some(Ok(ResponseEvent::Created { .. }))) => continue,
                 Poll::Ready(Some(Ok(ResponseEvent::OutputTextDelta(delta)))) => {
                     this.cumulative.push_str(&delta);
                     continue;

--- a/codex-rs/codex-api/src/sse/responses.rs
+++ b/codex-rs/codex-api/src/sse/responses.rs
@@ -218,8 +218,16 @@ pub fn process_responses_event(
             }
         }
         "response.created" => {
-            if event.response.is_some() {
-                return Ok(Some(ResponseEvent::Created {}));
+            if let Some(resp_val) = event.response {
+                let response_id = resp_val
+                    .get("id")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                let model = resp_val
+                    .get("model")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string());
+                return Ok(Some(ResponseEvent::Created { response_id, model }));
             }
         }
         "response.failed" => {
@@ -773,7 +781,7 @@ mod tests {
         }
 
         fn is_created(ev: &ResponseEvent) -> bool {
-            matches!(ev, ResponseEvent::Created)
+            matches!(ev, ResponseEvent::Created { .. })
         }
         fn is_output(ev: &ResponseEvent) -> bool {
             matches!(ev, ResponseEvent::OutputItemDone(_))

--- a/codex-rs/otel/src/traces/otel_manager.rs
+++ b/codex-rs/otel/src/traces/otel_manager.rs
@@ -738,7 +738,7 @@ impl OtelManager {
 
     fn responses_type(event: &ResponseEvent) -> String {
         match event {
-            ResponseEvent::Created => "created".into(),
+            ResponseEvent::Created { .. } => "created".into(),
             ResponseEvent::OutputItemDone(item) => OtelManager::responses_item_type(item),
             ResponseEvent::OutputItemAdded(item) => OtelManager::responses_item_type(item),
             ResponseEvent::Completed { .. } => "completed".into(),


### PR DESCRIPTION
When using ChatGPT subscription auth, the backend may silently route/fallback to a different model than requested (e.g. requesting gpt-5.3-codex but response.created.response.model reports gpt-5.2-2025-12-11).

This PR carries response.created model+id through ResponseEvent::Created and emits a user-visible Warning when served != requested.

Helps debugging and reproducibility for #11189.