### PR TITLE
# Use `@openai/codex` dist-tags for platform binaries instead of separate package names

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -595,9 +595,9 @@ jobs:
           mkdir -p dist/npm
           patterns=(
             "codex-npm-${version}.tgz"
-            "codex-linux-*-npm-${version}.tgz"
-            "codex-darwin-*-npm-${version}.tgz"
-            "codex-win32-*-npm-${version}.tgz"
+            "codex-npm-linux-*-${version}.tgz"
+            "codex-npm-darwin-*-${version}.tgz"
+            "codex-npm-win32-*-${version}.tgz"
             "codex-responses-api-proxy-npm-${version}.tgz"
             "codex-sdk-npm-${version}.tgz"
           )
@@ -615,20 +615,44 @@ jobs:
           NPM_TAG: ${{ needs.release.outputs.npm_tag }}
         run: |
           set -euo pipefail
-          tag_args=()
+          prefix=""
           if [[ -n "${NPM_TAG}" ]]; then
-            tag_args+=(--tag "${NPM_TAG}")
+            prefix="${NPM_TAG}-"
           fi
 
           shopt -s nullglob
-          tarballs=(dist/npm/*-npm-"${VERSION}".tgz)
+          tarballs=(dist/npm/*-"${VERSION}".tgz)
           if [[ ${#tarballs[@]} -eq 0 ]]; then
             echo "No npm tarballs found in dist/npm for version ${VERSION}"
             exit 1
           fi
 
           for tarball in "${tarballs[@]}"; do
-            npm publish "${GITHUB_WORKSPACE}/${tarball}" "${tag_args[@]}"
+            filename="$(basename "${tarball}")"
+            tag=""
+
+            case "${filename}" in
+              codex-npm-linux-*-"${VERSION}".tgz|codex-npm-darwin-*-"${VERSION}".tgz|codex-npm-win32-*-"${VERSION}".tgz)
+                platform="${filename#codex-npm-}"
+                platform="${platform%-${VERSION}.tgz}"
+                tag="${prefix}${platform}"
+                ;;
+              codex-npm-"${VERSION}".tgz|codex-responses-api-proxy-npm-"${VERSION}".tgz|codex-sdk-npm-"${VERSION}".tgz)
+                tag="${NPM_TAG}"
+                ;;
+              *)
+                echo "Unexpected npm tarball: ${filename}"
+                exit 1
+                ;;
+            esac
+
+            publish_cmd=(npm publish "${GITHUB_WORKSPACE}/${tarball}")
+            if [[ -n "${tag}" ]]; then
+              publish_cmd+=(--tag "${tag}")
+            fi
+
+            echo "+ ${publish_cmd[*]}"
+            "${publish_cmd[@]}"
           done
 
   update-branch:

--- a/codex-cli/scripts/README.md
+++ b/codex-cli/scripts/README.md
@@ -15,7 +15,8 @@ This downloads the native artifacts once, hydrates `vendor/` for each package, a
 tarballs to `dist/npm/`.
 
 When `--package codex` is provided, the staging helper builds the lightweight
-`@openai/codex` meta package plus all `@openai/codex-<platform>` native packages.
+`@openai/codex` meta package plus all platform-native `@openai/codex` variants
+that are later published under platform-specific dist-tags.
 
 If you need to invoke `build_npm_package.py` directly, run
 `codex-cli/scripts/install_native_deps.py` first and pass `--vendor-src` pointing to the

--- a/scripts/stage_npm_packages.py
+++ b/scripts/stage_npm_packages.py
@@ -26,6 +26,7 @@ _BUILD_MODULE = importlib.util.module_from_spec(_SPEC)
 _SPEC.loader.exec_module(_BUILD_MODULE)
 PACKAGE_NATIVE_COMPONENTS = getattr(_BUILD_MODULE, "PACKAGE_NATIVE_COMPONENTS", {})
 PACKAGE_EXPANSIONS = getattr(_BUILD_MODULE, "PACKAGE_EXPANSIONS", {})
+CODEX_PLATFORM_PACKAGES = getattr(_BUILD_MODULE, "CODEX_PLATFORM_PACKAGES", {})
 
 
 def parse_args() -> argparse.Namespace:
@@ -129,6 +130,13 @@ def run_command(cmd: list[str]) -> None:
     subprocess.run(cmd, cwd=REPO_ROOT, check=True)
 
 
+def tarball_name_for_package(package: str, version: str) -> str:
+    if package in CODEX_PLATFORM_PACKAGES:
+        platform = package.removeprefix("codex-")
+        return f"codex-npm-{platform}-{version}.tgz"
+    return f"{package}-npm-{version}.tgz"
+
+
 def main() -> int:
     args = parse_args()
 
@@ -160,7 +168,7 @@ def main() -> int:
 
         for package in packages:
             staging_dir = Path(tempfile.mkdtemp(prefix=f"npm-stage-{package}-", dir=runner_temp))
-            pack_output = output_dir / f"{package}-npm-{args.release_version}.tgz"
+            pack_output = output_dir / tarball_name_for_package(package, args.release_version)
 
             cmd = [
                 str(BUILD_SCRIPT),


### PR DESCRIPTION
https://github.com/openai/codex/pull/11318 introduced logic to publish platform artifacts as separate npm packages (for example, `@openai/codex-darwin-arm64`, `@openai/codex-linux-x64`, etc.). That requires provisioning and maintaining multiple package entries in npm, which we want to avoid.

We still need to keep the package-size mitigation (platform-specific payloads), but we want that layout to live under a single npm package namespace (`@openai/codex`) using dist-tags.

We also need to preserve pre-release workflows where users install `@openai/codex@alpha` and get platform-appropriate binaries.

Additionally, we want GitHub Release assets to group Codex npm tarballs together, so platform tarballs should follow the same `codex-npm-*` filename prefix as the main Codex tarball.

## Release Strategy (New Scheme)

We publish **one npm package name for Codex binaries** (`@openai/codex`) and use **dist-tags** to select platform-specific payloads. This avoids creating separate platform package names while keeping the package size split by platform.

### What gets published

#### Mainline release (`x.y.z`)

- `@openai/codex@latest` (meta package)
- `@openai/codex@darwin-arm64`
- `@openai/codex@darwin-x64`
- `@openai/codex@linux-arm64`
- `@openai/codex@linux-x64`
- `@openai/codex@win32-arm64`
- `@openai/codex@win32-x64`
- `@openai/codex-responses-api-proxy@latest`
- `@openai/codex-sdk@latest`

#### Alpha release (`x.y.z-alpha.N`)

- `@openai/codex@alpha` (meta package)
- `@openai/codex@alpha-darwin-arm64`
- `@openai/codex@alpha-darwin-x64`
- `@openai/codex@alpha-linux-arm64`
- `@openai/codex@alpha-linux-x64`
- `@openai/codex@alpha-win32-arm64`
- `@openai/codex@alpha-win32-x64`
- `@openai/codex-responses-api-proxy@alpha`
- `@openai/codex-sdk@alpha`

As an example, the `package.json` for `@openai/codex@alpha` (using `0.99.0-alpha.17` as the `version`) would be:

```
{
  "name": "@openai/codex",
  "version": "0.99.0-alpha.17",
  "license": "Apache-2.0",
  "bin": {
    "codex": "bin/codex.js"
  },
  "type": "module",
  "engines": {
    "node": ">=16"
  },
  "files": [
    "bin"
  ],
  "repository": {
    "type": "git",
    "url": "git+https://github.com/openai/codex.git",
    "directory": "codex-cli"
  },
  "packageManager": "pnpm@10.28.2+sha512.41872f037ad22f7348e3b1debbaf7e867cfd448f2726d9cf74c08f19507c31d2c8e7a11525b983febc2df640b5438dee6023ebb1f84ed43cc2d654d2bc326264",
  "optionalDependencies": {
    "@openai/codex-linux-x64": "npm:@openai/codex@0.99.0-alpha.17-linux-x64",
    "@openai/codex-linux-arm64": "npm:@openai/codex@0.99.0-alpha.17-linux-arm64",
    "@openai/codex-darwin-x64": "npm:@openai/codex@0.99.0-alpha.17-darwin-x64",
    "@openai/codex-darwin-arm64": "npm:@openai/codex@0.99.0-alpha.17-darwin-arm64",
    "@openai/codex-win32-x64": "npm:@openai/codex@0.99.0-alpha.17-win32-x64",
    "@openai/codex-win32-arm64": "npm:@openai/codex@0.99.0-alpha.17-win32-arm64"
  }
}
```

Note that the keys in `optionalDependencies` have "clean" names, but the values have the tag embedded.

### Important note

**Note:** Because we never created the new platform package names on npm (for example,
`@openai/codex-darwin-arm64`) since #11318 landed, there are no extra npm packages to clean up.

## What changed

### 1. Stage platform tarballs as `@openai/codex` with platform-specific versions

File: `codex-cli/scripts/build_npm_package.py`

- Added `CODEX_NPM_NAME = "@openai/codex"` and platform metadata `npm_tag` values:
  - `darwin-arm64`, `darwin-x64`, `linux-arm64`, `linux-x64`, `win32-arm64`, `win32-x64`
- For platform package staging (`codex-<platform>` inputs), switched generated `package.json` from:
  - `name = @openai/codex-<platform>`
  to:
  - `name = @openai/codex`
- Added `compute_platform_package_version(version, platform_tag)` so platform tarballs have unique
  versions (`<release-version>-<platform-tag>`), which is required because npm forbids re-publishing
  the same `name@version`.

### 2. Point meta package optional dependencies at dist-tags on `@openai/codex`

File: `codex-cli/scripts/build_npm_package.py`

- Updated `optionalDependencies` generation for the main `codex` package to use npm alias syntax:
  - key remains alias package name (for example, `@openai/codex-darwin-arm64`) so runtime lookup behavior is unchanged
  - value now resolves to `@openai/codex` by dist-tag
- Stable releases emit tags like `npm:@openai/codex@darwin-arm64`.
- Alpha releases (`x.y.z-alpha.N`) emit tags like `npm:@openai/codex@alpha-darwin-arm64`.

### 3. Publish with per-tarball dist-tags in release CI

File: `.github/workflows/rust-release.yml`

- Reworked npm publish logic to derive the publish tag per tarball filename:
  - platform tarballs publish with `<platform>` tags for stable releases
  - platform tarballs publish with `alpha-<platform>` tags for alpha releases
  - top-level tarballs (`codex`, `codex-responses-api-proxy`, `codex-sdk`) continue using
    the existing channel tag policy (`latest` implicit for stable, `alpha` for alpha)
- Added fail-fast behavior for unexpected tarball names to avoid silent mispublishes.

### 4. Normalize Codex platform tarball filenames for GitHub Release grouping

Files: `scripts/stage_npm_packages.py`, `.github/workflows/rust-release.yml`

- Renamed staged platform tarball filenames from:
  - `codex-linux-<arch>-npm-<version>.tgz`
  - `codex-darwin-<arch>-npm-<version>.tgz`
  - `codex-win32-<arch>-npm-<version>.tgz`
- To:
  - `codex-npm-linux-<arch>-<version>.tgz`
  - `codex-npm-darwin-<arch>-<version>.tgz`
  - `codex-npm-win32-<arch>-<version>.tgz`

This keeps all Codex npm artifacts grouped under a common `codex-npm-` prefix in GitHub Releases.

### 5. Documentation update

File: `codex-cli/scripts/README.md`

- Updated staging docs to clarify that platform-native variants are published as dist-tagged
  `@openai/codex` artifacts rather than separate npm package names.

## Resulting behavior

- Mainline release:
  - `@openai/codex@latest` resolves the meta package
  - meta package optional dependencies resolve `@openai/codex@<platform-tag>`
- Alpha release:
  - users can continue installing `@openai/codex@alpha`
  - alpha meta package optional dependencies resolve `@openai/codex@alpha-<platform-tag>`
- Release assets:
  - Codex npm tarballs share `codex-npm-` prefix for cleaner grouping in GitHub Releases

This preserves platform-specific payload distribution while avoiding separate npm package names and
improves release-asset discoverability.

## Validation notes

- Verified staged `package.json` output for stable and alpha meta packages includes expected alias targets.
- Verified staged platform package manifests are `name=@openai/codex` with unique platform-suffixed versions.
- Verified publish tag derivation maps renamed platform tarballs to expected stable and alpha dist-tags.
