### PR TITLE
Use thin LTO for alpha Rust release builds

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -58,6 +58,7 @@ jobs:
         working-directory: codex-rs
     env:
       CODEX_BWRAP_ENABLE_FFI: ${{ contains(matrix.target, 'unknown-linux') && '1' || '0' }}
+      CARGO_PROFILE_RELEASE_LTO: ${{ contains(github.ref_name, '-alpha') && 'thin' || 'fat' }}
 
     strategy:
       fail-fast: false

--- a/.github/workflows/shell-tool-mcp.yml
+++ b/.github/workflows/shell-tool-mcp.yml
@@ -72,6 +72,8 @@ jobs:
     needs: metadata
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 30
+    env:
+      CARGO_PROFILE_RELEASE_LTO: ${{ contains(needs.metadata.outputs.version, '-alpha') && 'thin' || 'fat' }}
     defaults:
       run:
         working-directory: codex-rs


### PR DESCRIPTION
We are looking to speed up build times for alpha releases, but we do not want to completely compromise on runtime performance by shipping debug builds. This PR changes our CI so that alpha releases build with `lto="thin"` instead of `lto="fat"`.

Specifically, this change keeps `[profile.release] lto = "fat"` as the default in `Cargo.toml`, but overrides LTO in CI using `CARGO_PROFILE_RELEASE_LTO`:
- `rust-release.yml`: use `thin` for `-alpha` tags, otherwise `fat`
- `shell-tool-mcp.yml`: use `thin` for `-alpha` versions, otherwise `fat`

Tradeoffs:
- Alpha binaries may be somewhat larger and/or slightly slower than fat-LTO builds
- LTO policy now lives in workflow logic for two pipelines, so consistency must be maintained across both files

Note `CARGO_PROFILE_<name>_LTO` is documented on https://doc.rust-lang.org/cargo/reference/environment-variables.html#configuration-environment-variables.