### PR TITLE
feat: mem v2 - PR1

### DIFF
--- a/codex-rs/core/src/memories/mod.rs
+++ b/codex-rs/core/src/memories/mod.rs
@@ -29,6 +29,8 @@ const PHASE_TWO_CONCURRENCY_LIMIT: usize = MAX_ROLLOUTS_PER_STARTUP;
 const MAX_RAW_MEMORIES_PER_SCOPE: usize = 64;
 /// Maximum rollout age considered for phase-1 extraction.
 const PHASE_ONE_MAX_ROLLOUT_AGE_DAYS: i64 = 30;
+/// Minimum rollout idle time required before phase-1 extraction.
+const PHASE_ONE_MIN_ROLLOUT_IDLE_HOURS: i64 = 12;
 /// Lease duration (seconds) for phase-1 job ownership.
 const PHASE_ONE_JOB_LEASE_SECONDS: i64 = 3_600;
 /// Backoff delay (seconds) before retrying a failed stage-1 extraction job.

--- a/codex-rs/core/src/memories/startup/mod.rs
+++ b/codex-rs/core/src/memories/startup/mod.rs
@@ -156,11 +156,14 @@ pub(super) async fn run_memories_startup_pipeline(
     let claimed_candidates = match state_db
         .claim_stage1_jobs_for_startup(
             session.conversation_id,
-            PHASE_ONE_THREAD_SCAN_LIMIT,
-            super::MAX_ROLLOUTS_PER_STARTUP,
-            super::PHASE_ONE_MAX_ROLLOUT_AGE_DAYS,
-            allowed_sources.as_slice(),
-            super::PHASE_ONE_JOB_LEASE_SECONDS,
+            codex_state::Stage1StartupClaimParams {
+                scan_limit: PHASE_ONE_THREAD_SCAN_LIMIT,
+                max_claimed: super::MAX_ROLLOUTS_PER_STARTUP,
+                max_age_days: super::PHASE_ONE_MAX_ROLLOUT_AGE_DAYS,
+                min_rollout_idle_hours: super::PHASE_ONE_MIN_ROLLOUT_IDLE_HOURS,
+                allowed_sources: allowed_sources.as_slice(),
+                lease_seconds: super::PHASE_ONE_JOB_LEASE_SECONDS,
+            },
         )
         .await
     {

--- a/codex-rs/state/src/lib.rs
+++ b/codex-rs/state/src/lib.rs
@@ -37,6 +37,7 @@ pub use runtime::STATE_DB_FILENAME;
 pub use runtime::STATE_DB_VERSION;
 pub use runtime::Stage1JobClaim;
 pub use runtime::Stage1JobClaimOutcome;
+pub use runtime::Stage1StartupClaimParams;
 pub use runtime::state_db_filename;
 pub use runtime::state_db_path;
 


### PR DESCRIPTION
# Memories migration plan (simplified global workflow)

## Target behavior

- One shared memory root only: `~/.codex/memories/`.
- No per-cwd memory buckets, no cwd hash handling.
- Phase 1 candidate rules:
- Not currently being processed unless the job lease is stale.
- Rollout updated within the max-age window (currently 30 days).
- Rollout idle for at least 12 hours (new constant).
- Global cap: at most 64 stage-1 jobs in `running` state at any time (new invariant).
- Stage-1 model output shape (new):
- `rollout_slug` (accepted but ignored for now).
- `rollout_summary`.
- `raw_memory`.
- Phase-1 artifacts written under the shared root:
- `rollout_summaries/<thread_id>.md` for each rollout summary.
- `raw_memories.md` containing appended/merged raw memory paragraphs.
- Phase 2 runs one consolidation agent for the shared `memories/` directory.
- Phase-2 lock is DB-backed with 1 hour lease and heartbeat/expiry.

## Current code map

- Core startup pipeline: `core/src/memories/startup/mod.rs`.
- Stage-1 request+parse: `core/src/memories/startup/extract.rs`, `core/src/memories/stage_one.rs`, templates in `core/templates/memories/`.
- File materialization: `core/src/memories/storage.rs`, `core/src/memories/layout.rs`.
- Scope routing (cwd/user): `core/src/memories/scope.rs`, `core/src/memories/startup/mod.rs`.
- DB job lifecycle and scope queueing: `state/src/runtime/memory.rs`.

## PR plan

## PR 1: Correct phase-1 selection invariants (no behavior-breaking layout changes yet)

- Add `PHASE_ONE_MIN_ROLLOUT_IDLE_HOURS: i64 = 12` in `core/src/memories/mod.rs`.
- Thread this into `state::claim_stage1_jobs_for_startup(...)`.
- Enforce idle-time filter in DB selection logic (not only in-memory filtering after `scan_limit`) so eligible threads are not starved by very recent threads.
- Enforce global running cap of 64 at claim time in DB logic:
- Count fresh `memory_stage1` running jobs.
- Only allow new claims while count < cap.
- Keep stale-lease takeover behavior intact.
- Add/adjust tests in `state/src/runtime.rs`:
- Idle filter inclusion/exclusion around 12h boundary.
- Global running-cap guarantee.
- Existing stale/fresh ownership behavior still passes.

Acceptance criteria:
- Startup never creates more than 64 fresh `memory_stage1` running jobs.
- Threads updated <12h ago are skipped.
- Threads older than 30d are skipped.

## PR 2: Stage-1 output contract + storage artifacts (forward-compatible)

- Update parser/types to accept the new structured output while keeping backward compatibility:
- Add `rollout_slug` (optional for now).
- Add `rollout_summary`.
- Keep alias support for legacy `summary` and `rawMemory` until prompt swap completes.
- Update stage-1 schema generator in `core/src/memories/stage_one.rs` to include the new keys.
- Update prompt templates:
- `core/templates/memories/stage_one_system.md`.
- `core/templates/memories/stage_one_input.md`.
- Replace storage model in `core/src/memories/storage.rs`:
- Introduce `rollout_summaries/` directory writer (`<thread_id>.md` files).
- Introduce `raw_memories.md` aggregator writer from DB rows.
- Keep deterministic rebuild behavior from DB outputs so files can always be regenerated.
- Update consolidation prompt template to reference `rollout_summaries/` + `raw_memories.md` inputs.

Acceptance criteria:
- Stage-1 accepts both old and new output keys during migration.
- Phase-1 artifacts are generated in new format from DB state.
- No dependence on per-thread files in `raw_memories/`.

## PR 3: Remove per-cwd memories and move to one global memory root

- Simplify layout in `core/src/memories/layout.rs`:
- Single root: `codex_home/memories`.
- Remove cwd-hash bucket helpers and normalization logic used only for memory pathing.
- Remove scope branching from startup phase-2 dispatch path:
- No cwd/user mapping in `core/src/memories/startup/mod.rs`.
- One target root for consolidation.
- In `state/src/runtime/memory.rs`, stop enqueueing/handling cwd consolidation scope.
- Keep one logical consolidation scope/job key (global/user) to avoid a risky schema rewrite in same PR.
- Add one-time migration helper (core side) to preserve current shared memory output:
- If `~/.codex/memories/user/memory` exists and new root is empty, move/copy contents into `~/.codex/memories`.
- Leave old hashed cwd buckets untouched for now (safe/no-destructive migration).

Acceptance criteria:
- New runs only read/write `~/.codex/memories`.
- No new cwd-scoped consolidation jobs are enqueued.
- Existing user-shared memory content is preserved.

## PR 4: Phase-2 global lock simplification and cleanup

- Replace multi-scope dispatch with a single global consolidation claim path:
- Either reuse jobs table with one fixed key, or add a tiny dedicated lock helper; keep 1h lease.
- Ensure at most one consolidation agent can run at once.
- Keep heartbeat + stale lock recovery semantics in `core/src/memories/startup/watch.rs`.
- Remove dead scope code and legacy constants no longer used.
- Update tests:
- One-agent-at-a-time behavior.
- Lock expiry allows takeover after stale lease.

Acceptance criteria:
- Exactly one phase-2 consolidation agent can be active cluster-wide (per local DB).
- Stale lock recovers automatically.

## PR 5: Final cleanup and docs

- Remove legacy artifacts and references:
- `raw_memories/` and `memory_summary.md` assumptions from prompts/comments/tests.
- Scope constants for cwd memory pathing in core/state if fully unused.
- Update docs under `docs/` for memory workflow and directory layout.
- Add a brief operator note for rollout: compatibility window for old stage-1 JSON keys and when to remove aliases.

Acceptance criteria:
- Code and docs reflect only the simplified global workflow.
- No stale references to per-cwd memory buckets.

## Notes on sequencing

- PR 1 is safest first because it improves correctness without changing external artifact layout.
- PR 2 keeps parser compatibility so prompt deployment can happen independently.
- PR 3 and PR 4 split filesystem/scope simplification from locking simplification to reduce blast radius.
- PR 5 is intentionally cleanup-only.
