### PR TITLE
feat: mem v2 - PR3

### DIFF
--- a/codex-rs/core/src/memories/layout.rs
+++ b/codex-rs/core/src/memories/layout.rs
@@ -1,35 +1,18 @@
-use crate::path_utils::normalize_for_path_comparison;
-use sha2::Digest;
-use sha2::Sha256;
 use std::path::Path;
 use std::path::PathBuf;
 
 use super::scope::MEMORY_SCOPE_KEY_USER;
 
-pub(super) const MEMORY_SUBDIR: &str = "memory";
 pub(super) const ROLLOUT_SUMMARIES_SUBDIR: &str = "rollout_summaries";
 pub(super) const RAW_MEMORIES_FILENAME: &str = "raw_memories.md";
 pub(super) const MEMORY_REGISTRY_FILENAME: &str = "MEMORY.md";
 pub(super) const LEGACY_CONSOLIDATED_FILENAME: &str = "consolidated.md";
 pub(super) const SKILLS_SUBDIR: &str = "skills";
+const LEGACY_MEMORY_SUBDIR: &str = "memory";
 
-const CWD_MEMORY_BUCKET_HEX_LEN: usize = 16;
-
-/// Returns the on-disk memory root directory for a given working directory.
-///
-/// The cwd is normalized and hashed into a deterministic bucket under
-/// `<codex_home>/memories/<hash>/memory`.
-pub(super) fn memory_root_for_cwd(codex_home: &Path, cwd: &Path) -> PathBuf {
-    let bucket = memory_bucket_for_cwd(cwd);
-    codex_home.join("memories").join(bucket).join(MEMORY_SUBDIR)
-}
-
-/// Returns the on-disk user-shared memory root directory.
-pub(super) fn memory_root_for_user(codex_home: &Path) -> PathBuf {
-    codex_home
-        .join("memories")
-        .join(MEMORY_SCOPE_KEY_USER)
-        .join(MEMORY_SUBDIR)
+/// Returns the shared on-disk memory root directory.
+pub(super) fn memory_root(codex_home: &Path) -> PathBuf {
+    codex_home.join("memories")
 }
 
 pub(super) fn rollout_summaries_dir(root: &Path) -> PathBuf {
@@ -40,20 +23,62 @@ pub(super) fn raw_memories_file(root: &Path) -> PathBuf {
     root.join(RAW_MEMORIES_FILENAME)
 }
 
+/// Migrates legacy user memory contents into the shared root when no shared-root
+/// phase artifacts exist yet.
+pub(super) async fn migrate_legacy_user_memory_root_if_needed(
+    codex_home: &Path,
+) -> std::io::Result<()> {
+    let root = memory_root(codex_home);
+    let legacy = legacy_user_memory_root(codex_home);
+
+    if !tokio::fs::try_exists(&legacy).await? || global_root_has_phase_artifacts(&root).await? {
+        return Ok(());
+    }
+
+    copy_dir_contents_if_missing(&legacy, &root).await
+}
+
 /// Ensures the phase-1 memory directory layout exists for the given root.
 pub(super) async fn ensure_layout(root: &Path) -> std::io::Result<()> {
     tokio::fs::create_dir_all(rollout_summaries_dir(root)).await
 }
 
-fn memory_bucket_for_cwd(cwd: &Path) -> String {
-    let normalized = normalize_cwd_for_memory(cwd);
-    let normalized = normalized.to_string_lossy();
-    let mut hasher = Sha256::new();
-    hasher.update(normalized.as_bytes());
-    let full_hash = format!("{:x}", hasher.finalize());
-    full_hash[..CWD_MEMORY_BUCKET_HEX_LEN].to_string()
+fn legacy_user_memory_root(codex_home: &Path) -> PathBuf {
+    codex_home
+        .join("memories")
+        .join(MEMORY_SCOPE_KEY_USER)
+        .join(LEGACY_MEMORY_SUBDIR)
 }
 
-fn normalize_cwd_for_memory(cwd: &Path) -> PathBuf {
-    normalize_for_path_comparison(cwd).unwrap_or_else(|_| cwd.to_path_buf())
+async fn global_root_has_phase_artifacts(root: &Path) -> std::io::Result<bool> {
+    if tokio::fs::try_exists(&rollout_summaries_dir(root)).await?
+        || tokio::fs::try_exists(&raw_memories_file(root)).await?
+        || tokio::fs::try_exists(&root.join(MEMORY_REGISTRY_FILENAME)).await?
+        || tokio::fs::try_exists(&root.join(LEGACY_CONSOLIDATED_FILENAME)).await?
+        || tokio::fs::try_exists(&root.join(SKILLS_SUBDIR)).await?
+    {
+        return Ok(true);
+    }
+    Ok(false)
+}
+
+fn copy_dir_contents_if_missing<'a>(
+    src_dir: &'a Path,
+    dst_dir: &'a Path,
+) -> futures::future::BoxFuture<'a, std::io::Result<()>> {
+    Box::pin(async move {
+        tokio::fs::create_dir_all(dst_dir).await?;
+        let mut dir = tokio::fs::read_dir(src_dir).await?;
+        while let Some(entry) = dir.next_entry().await? {
+            let src_path = entry.path();
+            let dst_path = dst_dir.join(entry.file_name());
+            let metadata = entry.metadata().await?;
+            if metadata.is_dir() {
+                copy_dir_contents_if_missing(&src_path, &dst_path).await?;
+            } else if metadata.is_file() && !tokio::fs::try_exists(&dst_path).await? {
+                tokio::fs::copy(&src_path, &dst_path).await?;
+            }
+        }
+        Ok(())
+    })
 }

--- a/codex-rs/core/src/memories/scope.rs
+++ b/codex-rs/core/src/memories/scope.rs
@@ -1,3 +1,2 @@
-pub(super) const MEMORY_SCOPE_KIND_CWD: &str = "cwd";
 pub(super) const MEMORY_SCOPE_KIND_USER: &str = "user";
 pub(super) const MEMORY_SCOPE_KEY_USER: &str = "user";


### PR DESCRIPTION
# Memories migration plan (simplified global workflow)

## Target behavior

- One shared memory root only: `~/.codex/memories/`.
- No per-cwd memory buckets, no cwd hash handling.
- Phase 1 candidate rules:
- Not currently being processed unless the job lease is stale.
- Rollout updated within the max-age window (currently 30 days).
- Rollout idle for at least 12 hours (new constant).
- Global cap: at most 64 stage-1 jobs in `running` state at any time (new invariant).
- Stage-1 model output shape (new):
- `rollout_slug` (accepted but ignored for now).
- `rollout_summary`.
- `raw_memory`.
- Phase-1 artifacts written under the shared root:
- `rollout_summaries/<thread_id>.md` for each rollout summary.
- `raw_memories.md` containing appended/merged raw memory paragraphs.
- Phase 2 runs one consolidation agent for the shared `memories/` directory.
- Phase-2 lock is DB-backed with 1 hour lease and heartbeat/expiry.

## Current code map

- Core startup pipeline: `core/src/memories/startup/mod.rs`.
- Stage-1 request+parse: `core/src/memories/startup/extract.rs`, `core/src/memories/stage_one.rs`, templates in `core/templates/memories/`.
- File materialization: `core/src/memories/storage.rs`, `core/src/memories/layout.rs`.
- Scope routing (cwd/user): `core/src/memories/scope.rs`, `core/src/memories/startup/mod.rs`.
- DB job lifecycle and scope queueing: `state/src/runtime/memory.rs`.

## PR plan

## PR 1: Correct phase-1 selection invariants (no behavior-breaking layout changes yet)

- Add `PHASE_ONE_MIN_ROLLOUT_IDLE_HOURS: i64 = 12` in `core/src/memories/mod.rs`.
- Thread this into `state::claim_stage1_jobs_for_startup(...)`.
- Enforce idle-time filter in DB selection logic (not only in-memory filtering after `scan_limit`) so eligible threads are not starved by very recent threads.
- Enforce global running cap of 64 at claim time in DB logic:
- Count fresh `memory_stage1` running jobs.
- Only allow new claims while count < cap.
- Keep stale-lease takeover behavior intact.
- Add/adjust tests in `state/src/runtime.rs`:
- Idle filter inclusion/exclusion around 12h boundary.
- Global running-cap guarantee.
- Existing stale/fresh ownership behavior still passes.

Acceptance criteria:
- Startup never creates more than 64 fresh `memory_stage1` running jobs.
- Threads updated <12h ago are skipped.
- Threads older than 30d are skipped.

## PR 2: Stage-1 output contract + storage artifacts (forward-compatible)

- Update parser/types to accept the new structured output while keeping backward compatibility:
- Add `rollout_slug` (optional for now).
- Add `rollout_summary`.
- Keep alias support for legacy `summary` and `rawMemory` until prompt swap completes.
- Update stage-1 schema generator in `core/src/memories/stage_one.rs` to include the new keys.
- Update prompt templates:
- `core/templates/memories/stage_one_system.md`.
- `core/templates/memories/stage_one_input.md`.
- Replace storage model in `core/src/memories/storage.rs`:
- Introduce `rollout_summaries/` directory writer (`<thread_id>.md` files).
- Introduce `raw_memories.md` aggregator writer from DB rows.
- Keep deterministic rebuild behavior from DB outputs so files can always be regenerated.
- Update consolidation prompt template to reference `rollout_summaries/` + `raw_memories.md` inputs.

Acceptance criteria:
- Stage-1 accepts both old and new output keys during migration.
- Phase-1 artifacts are generated in new format from DB state.
- No dependence on per-thread files in `raw_memories/`.

## PR 3: Remove per-cwd memories and move to one global memory root

- Simplify layout in `core/src/memories/layout.rs`:
- Single root: `codex_home/memories`.
- Remove cwd-hash bucket helpers and normalization logic used only for memory pathing.
- Remove scope branching from startup phase-2 dispatch path:
- No cwd/user mapping in `core/src/memories/startup/mod.rs`.
- One target root for consolidation.
- In `state/src/runtime/memory.rs`, stop enqueueing/handling cwd consolidation scope.
- Keep one logical consolidation scope/job key (global/user) to avoid a risky schema rewrite in same PR.
- Add one-time migration helper (core side) to preserve current shared memory output:
- If `~/.codex/memories/user/memory` exists and new root is empty, move/copy contents into `~/.codex/memories`.
- Leave old hashed cwd buckets untouched for now (safe/no-destructive migration).

Acceptance criteria:
- New runs only read/write `~/.codex/memories`.
- No new cwd-scoped consolidation jobs are enqueued.
- Existing user-shared memory content is preserved.

## PR 4: Phase-2 global lock simplification and cleanup

- Replace multi-scope dispatch with a single global consolidation claim path:
- Either reuse jobs table with one fixed key, or add a tiny dedicated lock helper; keep 1h lease.
- Ensure at most one consolidation agent can run at once.
- Keep heartbeat + stale lock recovery semantics in `core/src/memories/startup/watch.rs`.
- Remove dead scope code and legacy constants no longer used.
- Update tests:
- One-agent-at-a-time behavior.
- Lock expiry allows takeover after stale lease.

Acceptance criteria:
- Exactly one phase-2 consolidation agent can be active cluster-wide (per local DB).
- Stale lock recovers automatically.

## PR 5: Final cleanup and docs

- Remove legacy artifacts and references:
- `raw_memories/` and `memory_summary.md` assumptions from prompts/comments/tests.
- Scope constants for cwd memory pathing in core/state if fully unused.
- Update docs under `docs/` for memory workflow and directory layout.
- Add a brief operator note for rollout: compatibility window for old stage-1 JSON keys and when to remove aliases.

Acceptance criteria:
- Code and docs reflect only the simplified global workflow.
- No stale references to per-cwd memory buckets.

## Notes on sequencing

- PR 1 is safest first because it improves correctness without changing external artifact layout.
- PR 2 keeps parser compatibility so prompt deployment can happen independently.
- PR 3 and PR 4 split filesystem/scope simplification from locking simplification to reduce blast radius.
- PR 5 is intentionally cleanup-only.
