### PR TITLE
feat: mem v2 - PR4

### DIFF
--- a/codex-rs/core/src/memories/layout.rs
+++ b/codex-rs/core/src/memories/layout.rs
@@ -1,13 +1,12 @@
 use std::path::Path;
 use std::path::PathBuf;
 
-use super::scope::MEMORY_SCOPE_KEY_USER;
-
 pub(super) const ROLLOUT_SUMMARIES_SUBDIR: &str = "rollout_summaries";
 pub(super) const RAW_MEMORIES_FILENAME: &str = "raw_memories.md";
 pub(super) const MEMORY_REGISTRY_FILENAME: &str = "MEMORY.md";
 pub(super) const LEGACY_CONSOLIDATED_FILENAME: &str = "consolidated.md";
 pub(super) const SKILLS_SUBDIR: &str = "skills";
+const LEGACY_USER_SUBDIR: &str = "user";
 const LEGACY_MEMORY_SUBDIR: &str = "memory";
 
 /// Returns the shared on-disk memory root directory.
@@ -46,7 +45,7 @@ pub(super) async fn ensure_layout(root: &Path) -> std::io::Result<()> {
 fn legacy_user_memory_root(codex_home: &Path) -> PathBuf {
     codex_home
         .join("memories")
-        .join(MEMORY_SCOPE_KEY_USER)
+        .join(LEGACY_USER_SUBDIR)
         .join(LEGACY_MEMORY_SUBDIR)
 }
 

--- a/codex-rs/core/src/memories/mod.rs
+++ b/codex-rs/core/src/memories/mod.rs
@@ -2,12 +2,11 @@
 //!
 //! The startup memory pipeline is split into two phases:
 //! - Phase 1: select rollouts, extract stage-1 raw memories, persist stage-1 outputs, and enqueue consolidation.
-//! - Phase 2: claim scopes, materialize consolidation inputs, and dispatch consolidation agents.
+//! - Phase 2: claim a global consolidation lock, materialize consolidation inputs, and dispatch one consolidation agent.
 
 mod layout;
 mod prompts;
 mod rollout;
-mod scope;
 mod stage_one;
 mod startup;
 mod storage;
@@ -23,10 +22,8 @@ const MEMORY_CONSOLIDATION_SUBAGENT_LABEL: &str = "memory_consolidation";
 const MAX_ROLLOUTS_PER_STARTUP: usize = 64;
 /// Concurrency cap for startup memory extraction and consolidation scheduling.
 const PHASE_ONE_CONCURRENCY_LIMIT: usize = MAX_ROLLOUTS_PER_STARTUP;
-/// Concurrency cap for phase-2 consolidation dispatch.
-const PHASE_TWO_CONCURRENCY_LIMIT: usize = MAX_ROLLOUTS_PER_STARTUP;
-/// Maximum number of recent raw memories retained per scope.
-const MAX_RAW_MEMORIES_PER_SCOPE: usize = 64;
+/// Maximum number of recent raw memories retained for global consolidation.
+const MAX_RAW_MEMORIES_FOR_GLOBAL: usize = 64;
 /// Maximum rollout age considered for phase-1 extraction.
 const PHASE_ONE_MAX_ROLLOUT_AGE_DAYS: i64 = 30;
 /// Minimum rollout idle time required before phase-1 extraction.

--- a/codex-rs/core/src/memories/scope.rs
+++ b/codex-rs/core/src/memories/scope.rs
@@ -1,2 +1,0 @@
-pub(super) const MEMORY_SCOPE_KIND_USER: &str = "user";
-pub(super) const MEMORY_SCOPE_KEY_USER: &str = "user";

--- a/codex-rs/core/src/memories/startup/dispatch.rs
+++ b/codex-rs/core/src/memories/startup/dispatch.rs
@@ -1,5 +1,6 @@
 use crate::codex::Session;
 use crate::config::Config;
+use crate::memories::layout::memory_root;
 use codex_protocol::protocol::SessionSource;
 use codex_protocol::protocol::SubAgentSource;
 use codex_protocol::user_input::UserInput;
@@ -8,7 +9,7 @@ use tracing::debug;
 use tracing::info;
 use tracing::warn;
 
-use super::super::MAX_RAW_MEMORIES_PER_SCOPE;
+use super::super::MAX_RAW_MEMORIES_FOR_GLOBAL;
 use super::super::MEMORY_CONSOLIDATION_SUBAGENT_LABEL;
 use super::super::PHASE_TWO_JOB_LEASE_SECONDS;
 use super::super::PHASE_TWO_JOB_RETRY_DELAY_SECONDS;
@@ -16,38 +17,25 @@ use super::super::prompts::build_consolidation_prompt;
 use super::super::storage::rebuild_raw_memories_file_from_memories;
 use super::super::storage::sync_rollout_summaries_from_memories;
 use super::super::storage::wipe_consolidation_outputs;
-use super::MemoryScopeTarget;
 use super::watch::spawn_phase2_completion_task;
 
-pub(super) async fn run_memory_consolidation_for_scope(
-    session: Arc<Session>,
+pub(super) async fn run_global_memory_consolidation(
+    session: &Arc<Session>,
     config: Arc<Config>,
-    scope: MemoryScopeTarget,
-) {
+) -> bool {
     let Some(state_db) = session.services.state_db.as_deref() else {
-        warn!(
-            "state db unavailable for scope {}:{}; skipping consolidation",
-            scope.scope_kind, scope.scope_key
-        );
-        return;
+        warn!("state db unavailable; skipping global memory consolidation");
+        return false;
     };
 
     let claim = match state_db
-        .try_claim_phase2_job(
-            scope.scope_kind,
-            &scope.scope_key,
-            session.conversation_id,
-            PHASE_TWO_JOB_LEASE_SECONDS,
-        )
+        .try_claim_global_phase2_job(session.conversation_id, PHASE_TWO_JOB_LEASE_SECONDS)
         .await
     {
         Ok(claim) => claim,
         Err(err) => {
-            warn!(
-                "state db try_claim_phase2_job failed for scope {}:{}: {err}",
-                scope.scope_kind, scope.scope_key
-            );
-            return;
+            warn!("state db try_claim_global_phase2_job failed during memories startup: {err}");
+            return false;
         }
     };
     let (ownership_token, claimed_watermark) = match claim {
@@ -56,131 +44,90 @@ pub(super) async fn run_memory_consolidation_for_scope(
             input_watermark,
         } => (ownership_token, input_watermark),
         codex_state::Phase2JobClaimOutcome::SkippedNotDirty => {
-            debug!(
-                "memory phase-2 scope not pending (or already up to date); skipping consolidation: {}:{}",
-                scope.scope_kind, scope.scope_key
-            );
-            return;
+            debug!("memory phase-2 global lock is up-to-date; skipping consolidation");
+            return false;
         }
         codex_state::Phase2JobClaimOutcome::SkippedRunning => {
-            debug!(
-                "memory phase-2 job already running for scope {}:{}; skipping",
-                scope.scope_kind, scope.scope_key
-            );
-            return;
+            debug!("memory phase-2 global consolidation already running; skipping");
+            return false;
         }
     };
 
     let latest_memories = match state_db
-        .list_stage1_outputs_for_scope(
-            scope.scope_kind,
-            &scope.scope_key,
-            MAX_RAW_MEMORIES_PER_SCOPE,
-        )
+        .list_stage1_outputs_for_global(MAX_RAW_MEMORIES_FOR_GLOBAL)
         .await
     {
         Ok(memories) => memories,
         Err(err) => {
-            warn!(
-                "state db list_stage1_outputs_for_scope failed during consolidation for scope {}:{}: {err}",
-                scope.scope_kind, scope.scope_key
-            );
+            warn!("state db list_stage1_outputs_for_global failed during consolidation: {err}");
             let _ = state_db
-                .mark_phase2_job_failed(
-                    scope.scope_kind,
-                    &scope.scope_key,
+                .mark_global_phase2_job_failed(
                     &ownership_token,
-                    "failed to read scope stage-1 outputs before consolidation",
+                    "failed to read stage-1 outputs before global consolidation",
                     PHASE_TWO_JOB_RETRY_DELAY_SECONDS,
                 )
                 .await;
-            return;
+            return false;
         }
     };
     if latest_memories.is_empty() {
-        debug!(
-            "memory phase-2 scope has no stage-1 outputs; skipping consolidation: {}:{}",
-            scope.scope_kind, scope.scope_key
-        );
+        debug!("memory phase-2 has no stage-1 outputs; skipping global consolidation");
         let _ = state_db
-            .mark_phase2_job_succeeded(
-                scope.scope_kind,
-                &scope.scope_key,
-                &ownership_token,
-                claimed_watermark,
-            )
+            .mark_global_phase2_job_succeeded(&ownership_token, claimed_watermark)
             .await;
-        return;
+        return false;
     };
 
+    let root = memory_root(&config.codex_home);
     let materialized_watermark = latest_memories
         .iter()
         .map(|memory| memory.source_updated_at.timestamp())
         .max()
         .unwrap_or(claimed_watermark);
 
-    if let Err(err) =
-        sync_rollout_summaries_from_memories(&scope.memory_root, &latest_memories).await
-    {
-        warn!(
-            "failed syncing phase-1 rollout summaries for scope {}:{}: {err}",
-            scope.scope_kind, scope.scope_key
-        );
+    if let Err(err) = sync_rollout_summaries_from_memories(&root, &latest_memories).await {
+        warn!("failed syncing phase-1 rollout summaries for global consolidation: {err}");
         let _ = state_db
-            .mark_phase2_job_failed(
-                scope.scope_kind,
-                &scope.scope_key,
+            .mark_global_phase2_job_failed(
                 &ownership_token,
                 "failed syncing phase-1 rollout summaries",
                 PHASE_TWO_JOB_RETRY_DELAY_SECONDS,
             )
             .await;
-        return;
+        return false;
     }
 
-    if let Err(err) =
-        rebuild_raw_memories_file_from_memories(&scope.memory_root, &latest_memories).await
-    {
-        warn!(
-            "failed rebuilding raw memories aggregate for scope {}:{}: {err}",
-            scope.scope_kind, scope.scope_key
-        );
+    if let Err(err) = rebuild_raw_memories_file_from_memories(&root, &latest_memories).await {
+        warn!("failed rebuilding raw memories aggregate for global consolidation: {err}");
         let _ = state_db
-            .mark_phase2_job_failed(
-                scope.scope_kind,
-                &scope.scope_key,
+            .mark_global_phase2_job_failed(
                 &ownership_token,
                 "failed rebuilding raw memories aggregate",
                 PHASE_TWO_JOB_RETRY_DELAY_SECONDS,
             )
             .await;
-        return;
+        return false;
     }
 
-    if let Err(err) = wipe_consolidation_outputs(&scope.memory_root).await {
-        warn!(
-            "failed to wipe previous consolidation outputs for scope {}:{}: {err}",
-            scope.scope_kind, scope.scope_key
-        );
+    if let Err(err) = wipe_consolidation_outputs(&root).await {
+        warn!("failed to wipe previous global consolidation outputs: {err}");
         let _ = state_db
-            .mark_phase2_job_failed(
-                scope.scope_kind,
-                &scope.scope_key,
+            .mark_global_phase2_job_failed(
                 &ownership_token,
                 "failed to wipe previous consolidation outputs",
                 PHASE_TWO_JOB_RETRY_DELAY_SECONDS,
             )
             .await;
-        return;
+        return false;
     }
 
-    let prompt = build_consolidation_prompt(&scope.memory_root);
+    let prompt = build_consolidation_prompt(&root);
     let input = vec![UserInput::Text {
         text: prompt,
         text_elements: vec![],
     }];
     let mut consolidation_config = config.as_ref().clone();
-    consolidation_config.cwd = scope.memory_root.clone();
+    consolidation_config.cwd = root.clone();
     let source = SessionSource::SubAgent(SubAgentSource::Other(
         MEMORY_CONSOLIDATION_SUBAGENT_LABEL.to_string(),
     ));
@@ -193,31 +140,209 @@ pub(super) async fn run_memory_consolidation_for_scope(
     {
         Ok(consolidation_agent_id) => {
             info!(
-                "memory phase-2 consolidation agent started: scope={} scope_key={} agent_id={}",
-                scope.scope_kind, scope.scope_key, consolidation_agent_id
+                "memory phase-2 global consolidation agent started: agent_id={consolidation_agent_id}"
             );
             spawn_phase2_completion_task(
                 session.as_ref(),
-                scope,
                 ownership_token,
                 materialized_watermark,
                 consolidation_agent_id,
             );
+            true
         }
         Err(err) => {
-            warn!(
-                "failed to spawn memory consolidation agent for scope {}:{}: {err}",
-                scope.scope_kind, scope.scope_key
-            );
+            warn!("failed to spawn global memory consolidation agent: {err}");
             let _ = state_db
-                .mark_phase2_job_failed(
-                    scope.scope_kind,
-                    &scope.scope_key,
+                .mark_global_phase2_job_failed(
                     &ownership_token,
                     "failed to spawn consolidation agent",
                     PHASE_TWO_JOB_RETRY_DELAY_SECONDS,
                 )
                 .await;
+            false
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_global_memory_consolidation;
+    use crate::CodexAuth;
+    use crate::ThreadManager;
+    use crate::codex::Session;
+    use crate::codex::make_session_and_context;
+    use crate::config::Config;
+    use crate::config::test_config;
+    use chrono::Utc;
+    use codex_protocol::ThreadId;
+    use codex_protocol::protocol::Op;
+    use codex_protocol::protocol::SessionSource;
+    use codex_state::Phase2JobClaimOutcome;
+    use codex_state::ThreadMetadataBuilder;
+    use pretty_assertions::assert_eq;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    struct DispatchHarness {
+        _codex_home: TempDir,
+        config: Arc<Config>,
+        session: Arc<Session>,
+        manager: ThreadManager,
+        state_db: Arc<codex_state::StateRuntime>,
+    }
+
+    impl DispatchHarness {
+        async fn new() -> Self {
+            let codex_home = tempfile::tempdir().expect("create temp codex home");
+            let mut config = test_config();
+            config.codex_home = codex_home.path().to_path_buf();
+            config.cwd = config.codex_home.clone();
+            let config = Arc::new(config);
+
+            let state_db = Arc::new(
+                codex_state::StateRuntime::init(
+                    config.codex_home.clone(),
+                    config.model_provider_id.clone(),
+                    None,
+                )
+                .await
+                .expect("initialize state db"),
+            );
+
+            let manager = ThreadManager::with_models_provider_and_home(
+                CodexAuth::from_api_key("dummy"),
+                config.model_provider.clone(),
+                config.codex_home.clone(),
+            );
+            let (mut session, _turn_context) = make_session_and_context().await;
+            session.services.state_db = Some(Arc::clone(&state_db));
+            session.services.agent_control = manager.agent_control();
+
+            Self {
+                _codex_home: codex_home,
+                config,
+                session: Arc::new(session),
+                manager,
+                state_db,
+            }
+        }
+
+        async fn seed_stage1_output(&self, source_updated_at: i64) {
+            let thread_id = ThreadId::new();
+            let mut metadata_builder = ThreadMetadataBuilder::new(
+                thread_id,
+                self.config.codex_home.join(format!("rollout-{thread_id}.jsonl")),
+                Utc::now(),
+                SessionSource::Cli,
+            );
+            metadata_builder.cwd = self.config.cwd.clone();
+            metadata_builder.model_provider = Some(self.config.model_provider_id.clone());
+            let metadata = metadata_builder.build(&self.config.model_provider_id);
+
+            self.state_db
+                .upsert_thread(&metadata)
+                .await
+                .expect("upsert thread metadata");
+
+            let claim = self
+                .state_db
+                .try_claim_stage1_job(
+                    thread_id,
+                    self.session.conversation_id,
+                    source_updated_at,
+                    3_600,
+                    64,
+                )
+                .await
+                .expect("claim stage-1 job");
+            let ownership_token = match claim {
+                codex_state::Stage1JobClaimOutcome::Claimed { ownership_token } => ownership_token,
+                other => panic!("unexpected stage-1 claim outcome: {other:?}"),
+            };
+            assert!(
+                self.state_db
+                    .mark_stage1_job_succeeded(
+                        thread_id,
+                        &ownership_token,
+                        source_updated_at,
+                        "raw memory",
+                        "rollout summary",
+                    )
+                    .await
+                    .expect("mark stage-1 success"),
+                "stage-1 success should enqueue global consolidation"
+            );
+        }
+
+        async fn shutdown_threads(&self) {
+            self.manager
+                .remove_and_close_all_threads()
+                .await
+                .expect("shutdown spawned threads");
+        }
+    }
+
+    #[tokio::test]
+    async fn dispatch_reclaims_stale_global_lock_and_starts_consolidation() {
+        let harness = DispatchHarness::new().await;
+        harness.seed_stage1_output(100).await;
+
+        let stale_claim = harness
+            .state_db
+            .try_claim_global_phase2_job(ThreadId::new(), 0)
+            .await
+            .expect("claim stale global lock");
+        assert!(
+            matches!(stale_claim, Phase2JobClaimOutcome::Claimed { .. }),
+            "stale lock precondition should be claimed"
+        );
+
+        let scheduled =
+            run_global_memory_consolidation(&harness.session, Arc::clone(&harness.config)).await;
+        assert!(scheduled, "dispatch should reclaim stale lock and spawn one agent");
+
+        let running_claim = harness
+            .state_db
+            .try_claim_global_phase2_job(ThreadId::new(), 3_600)
+            .await
+            .expect("claim while running");
+        assert_eq!(running_claim, Phase2JobClaimOutcome::SkippedRunning);
+
+        let user_input_ops = harness
+            .manager
+            .captured_ops()
+            .into_iter()
+            .filter(|(_, op)| matches!(op, Op::UserInput { .. }))
+            .count();
+        assert_eq!(user_input_ops, 1);
+
+        harness.shutdown_threads().await;
+    }
+
+    #[tokio::test]
+    async fn dispatch_schedules_only_one_agent_while_lock_is_running() {
+        let harness = DispatchHarness::new().await;
+        harness.seed_stage1_output(200).await;
+
+        let first_run =
+            run_global_memory_consolidation(&harness.session, Arc::clone(&harness.config)).await;
+        let second_run =
+            run_global_memory_consolidation(&harness.session, Arc::clone(&harness.config)).await;
+
+        assert!(first_run, "first dispatch should schedule consolidation");
+        assert!(
+            !second_run,
+            "second dispatch should skip while the global lock is running"
+        );
+
+        let user_input_ops = harness
+            .manager
+            .captured_ops()
+            .into_iter()
+            .filter(|(_, op)| matches!(op, Op::UserInput { .. }))
+            .count();
+        assert_eq!(user_input_ops, 1);
+
+        harness.shutdown_threads().await;
     }
 }

--- a/codex-rs/core/src/memories/startup/dispatch.rs
+++ b/codex-rs/core/src/memories/startup/dispatch.rs
@@ -199,15 +199,13 @@ mod tests {
             config.cwd = config.codex_home.clone();
             let config = Arc::new(config);
 
-            let state_db = Arc::new(
-                codex_state::StateRuntime::init(
-                    config.codex_home.clone(),
-                    config.model_provider_id.clone(),
-                    None,
-                )
-                .await
-                .expect("initialize state db"),
-            );
+            let state_db = codex_state::StateRuntime::init(
+                config.codex_home.clone(),
+                config.model_provider_id.clone(),
+                None,
+            )
+            .await
+            .expect("initialize state db");
 
             let manager = ThreadManager::with_models_provider_and_home(
                 CodexAuth::from_api_key("dummy"),

--- a/codex-rs/core/src/memories/startup/dispatch.rs
+++ b/codex-rs/core/src/memories/startup/dispatch.rs
@@ -231,7 +231,9 @@ mod tests {
             let thread_id = ThreadId::new();
             let mut metadata_builder = ThreadMetadataBuilder::new(
                 thread_id,
-                self.config.codex_home.join(format!("rollout-{thread_id}.jsonl")),
+                self.config
+                    .codex_home
+                    .join(format!("rollout-{thread_id}.jsonl")),
                 Utc::now(),
                 SessionSource::Cli,
             );
@@ -299,7 +301,10 @@ mod tests {
 
         let scheduled =
             run_global_memory_consolidation(&harness.session, Arc::clone(&harness.config)).await;
-        assert!(scheduled, "dispatch should reclaim stale lock and spawn one agent");
+        assert!(
+            scheduled,
+            "dispatch should reclaim stale lock and spawn one agent"
+        );
 
         let running_claim = harness
             .state_db

--- a/codex-rs/core/src/memories/startup/mod.rs
+++ b/codex-rs/core/src/memories/startup/mod.rs
@@ -7,10 +7,7 @@ use crate::codex::TurnContext;
 use crate::config::Config;
 use crate::error::Result as CodexResult;
 use crate::features::Feature;
-use crate::memories::layout::memory_root;
 use crate::memories::layout::migrate_legacy_user_memory_root_if_needed;
-use crate::memories::scope::MEMORY_SCOPE_KEY_USER;
-use crate::memories::scope::MEMORY_SCOPE_KIND_USER;
 use crate::rollout::INTERACTIVE_SESSION_SOURCES;
 use codex_otel::OtelManager;
 use codex_protocol::config_types::ReasoningSummary as ReasoningSummaryConfig;
@@ -19,7 +16,6 @@ use codex_protocol::openai_models::ReasoningEffort as ReasoningEffortConfig;
 use codex_protocol::protocol::SessionSource;
 use futures::StreamExt;
 use serde_json::Value;
-use std::path::PathBuf;
 use std::sync::Arc;
 use tracing::info;
 use tracing::warn;
@@ -43,52 +39,6 @@ impl StageOneRequestContext {
             reasoning_effort: turn_context.reasoning_effort,
             reasoning_summary: turn_context.reasoning_summary,
             turn_metadata_header,
-        }
-    }
-}
-
-/// Canonical memory scope metadata used by both startup phases.
-#[derive(Clone, Debug, PartialEq, Eq)]
-pub(super) struct MemoryScopeTarget {
-    /// Scope family used for DB ownership and dirty-state tracking.
-    pub(super) scope_kind: &'static str,
-    /// Scope identifier used for DB keys.
-    pub(super) scope_key: String,
-    /// On-disk root where phase-1 artifacts and phase-2 outputs live.
-    pub(super) memory_root: PathBuf,
-}
-
-/// Converts a pending scope consolidation row into a concrete filesystem target for phase 2.
-///
-/// Unsupported scope kinds or malformed keys are ignored.
-pub(super) fn memory_scope_target_for_pending_scope(
-    config: &Config,
-    pending_scope: codex_state::PendingScopeConsolidation,
-) -> Option<MemoryScopeTarget> {
-    let scope_kind = pending_scope.scope_kind;
-    let scope_key = pending_scope.scope_key;
-
-    match scope_kind.as_str() {
-        MEMORY_SCOPE_KIND_USER => {
-            if scope_key != MEMORY_SCOPE_KEY_USER {
-                warn!(
-                    "skipping unsupported user memory scope key for phase-2: {}:{}",
-                    scope_kind, scope_key
-                );
-                return None;
-            }
-            Some(MemoryScopeTarget {
-                scope_kind: MEMORY_SCOPE_KIND_USER,
-                scope_key,
-                memory_root: memory_root(&config.codex_home),
-            })
-        }
-        _ => {
-            warn!(
-                "skipping unsupported memory scope for phase-2 consolidation: {}:{}",
-                scope_kind, scope_key
-            );
-            None
         }
     }
 }
@@ -125,7 +75,7 @@ pub(crate) fn start_memories_startup_task(
 /// Phase 1 selects rollout candidates, performs stage-1 extraction requests in
 /// parallel, persists stage-1 outputs, and enqueues consolidation work.
 ///
-/// Phase 2 claims pending scopes and spawns consolidation agents.
+/// Phase 2 claims a global consolidation lock and spawns one consolidation agent.
 pub(super) async fn run_memories_startup_pipeline(
     session: &Arc<Session>,
     config: Arc<Config>,
@@ -236,115 +186,15 @@ pub(super) async fn run_memories_startup_pipeline(
         claimed_count, succeeded_count
     );
 
-    let consolidation_scope_count = run_consolidation_dispatch(session, config).await;
+    let consolidation_job_count = run_consolidation_dispatch(session, config).await;
     info!(
-        "memory consolidation dispatch complete: {} scope(s) scheduled",
-        consolidation_scope_count
+        "memory consolidation dispatch complete: {} job(s) scheduled",
+        consolidation_job_count
     );
 
     Ok(())
 }
 
 async fn run_consolidation_dispatch(session: &Arc<Session>, config: Arc<Config>) -> usize {
-    let scopes = list_consolidation_scopes(
-        session.as_ref(),
-        config.as_ref(),
-        super::MAX_ROLLOUTS_PER_STARTUP,
-    )
-    .await;
-    let consolidation_scope_count = scopes.len();
-
-    futures::stream::iter(scopes.into_iter())
-        .map(|scope| {
-            let session = Arc::clone(session);
-            let config = Arc::clone(&config);
-            async move {
-                dispatch::run_memory_consolidation_for_scope(session, config, scope).await;
-            }
-        })
-        .buffer_unordered(super::PHASE_TWO_CONCURRENCY_LIMIT)
-        .collect::<Vec<_>>()
-        .await;
-
-    consolidation_scope_count
-}
-
-async fn list_consolidation_scopes(
-    session: &Session,
-    config: &Config,
-    limit: usize,
-) -> Vec<MemoryScopeTarget> {
-    if limit == 0 {
-        return Vec::new();
-    }
-
-    let Some(state_db) = session.services.state_db.as_deref() else {
-        return Vec::new();
-    };
-
-    let pending_scopes = match state_db.list_pending_scope_consolidations(limit).await {
-        Ok(scopes) => scopes,
-        Err(_) => return Vec::new(),
-    };
-
-    pending_scopes
-        .into_iter()
-        .filter_map(|scope| memory_scope_target_for_pending_scope(config, scope))
-        .collect()
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::config::test_config;
-
-    /// Verifies that phase-2 pending scope rows are translated only for supported scopes.
-    #[test]
-    fn pending_scope_mapping_accepts_supported_scopes_only() {
-        let mut config = test_config();
-        config.codex_home = "/tmp/memory-startup-test-home".into();
-
-        let user_target = memory_scope_target_for_pending_scope(
-            &config,
-            codex_state::PendingScopeConsolidation {
-                scope_kind: MEMORY_SCOPE_KIND_USER.to_string(),
-                scope_key: MEMORY_SCOPE_KEY_USER.to_string(),
-            },
-        )
-        .expect("valid user scope should map");
-        assert_eq!(user_target.scope_kind, MEMORY_SCOPE_KIND_USER);
-
-        assert!(
-            memory_scope_target_for_pending_scope(
-                &config,
-                codex_state::PendingScopeConsolidation {
-                    scope_kind: MEMORY_SCOPE_KIND_USER.to_string(),
-                    scope_key: "unexpected-user-key".to_string(),
-                },
-            )
-            .is_none()
-        );
-
-        assert!(
-            memory_scope_target_for_pending_scope(
-                &config,
-                codex_state::PendingScopeConsolidation {
-                    scope_kind: "cwd".to_string(),
-                    scope_key: "/tmp/project-a".to_string(),
-                },
-            )
-            .is_none()
-        );
-
-        assert!(
-            memory_scope_target_for_pending_scope(
-                &config,
-                codex_state::PendingScopeConsolidation {
-                    scope_kind: "unknown".to_string(),
-                    scope_key: "scope".to_string(),
-                },
-            )
-            .is_none()
-        );
-    }
+    usize::from(dispatch::run_global_memory_consolidation(session, config).await)
 }

--- a/codex-rs/core/src/memories/storage.rs
+++ b/codex-rs/core/src/memories/storage.rs
@@ -4,7 +4,7 @@ use std::fmt::Write as _;
 use std::path::Path;
 use tracing::warn;
 
-use super::MAX_RAW_MEMORIES_PER_SCOPE;
+use super::MAX_RAW_MEMORIES_FOR_GLOBAL;
 use super::text::compact_whitespace;
 use crate::memories::layout::LEGACY_CONSOLIDATED_FILENAME;
 use crate::memories::layout::MEMORY_REGISTRY_FILENAME;
@@ -31,7 +31,7 @@ pub(super) async fn sync_rollout_summaries_from_memories(
 
     let retained = memories
         .iter()
-        .take(MAX_RAW_MEMORIES_PER_SCOPE)
+        .take(MAX_RAW_MEMORIES_FOR_GLOBAL)
         .collect::<Vec<_>>();
     let keep = retained
         .iter()
@@ -77,7 +77,7 @@ pub(super) async fn wipe_consolidation_outputs(root: &Path) -> std::io::Result<(
 async fn rebuild_raw_memories_file(root: &Path, memories: &[Stage1Output]) -> std::io::Result<()> {
     let retained = memories
         .iter()
-        .take(MAX_RAW_MEMORIES_PER_SCOPE)
+        .take(MAX_RAW_MEMORIES_FOR_GLOBAL)
         .collect::<Vec<_>>();
     let mut body = String::from("# Raw Memories\n\n");
 

--- a/codex-rs/state/src/lib.rs
+++ b/codex-rs/state/src/lib.rs
@@ -31,7 +31,6 @@ pub use model::Stage1Output;
 pub use model::ThreadMetadata;
 pub use model::ThreadMetadataBuilder;
 pub use model::ThreadsPage;
-pub use runtime::PendingScopeConsolidation;
 pub use runtime::Phase2JobClaimOutcome;
 pub use runtime::STATE_DB_FILENAME;
 pub use runtime::STATE_DB_VERSION;


### PR DESCRIPTION
# Memories migration plan (simplified global workflow)

## Target behavior

- One shared memory root only: `~/.codex/memories/`.
- No per-cwd memory buckets, no cwd hash handling.
- Phase 1 candidate rules:
- Not currently being processed unless the job lease is stale.
- Rollout updated within the max-age window (currently 30 days).
- Rollout idle for at least 12 hours (new constant).
- Global cap: at most 64 stage-1 jobs in `running` state at any time (new invariant).
- Stage-1 model output shape (new):
- `rollout_slug` (accepted but ignored for now).
- `rollout_summary`.
- `raw_memory`.
- Phase-1 artifacts written under the shared root:
- `rollout_summaries/<thread_id>.md` for each rollout summary.
- `raw_memories.md` containing appended/merged raw memory paragraphs.
- Phase 2 runs one consolidation agent for the shared `memories/` directory.
- Phase-2 lock is DB-backed with 1 hour lease and heartbeat/expiry.

## Current code map

- Core startup pipeline: `core/src/memories/startup/mod.rs`.
- Stage-1 request+parse: `core/src/memories/startup/extract.rs`, `core/src/memories/stage_one.rs`, templates in `core/templates/memories/`.
- File materialization: `core/src/memories/storage.rs`, `core/src/memories/layout.rs`.
- Scope routing (cwd/user): `core/src/memories/scope.rs`, `core/src/memories/startup/mod.rs`.
- DB job lifecycle and scope queueing: `state/src/runtime/memory.rs`.

## PR plan

## PR 1: Correct phase-1 selection invariants (no behavior-breaking layout changes yet)

- Add `PHASE_ONE_MIN_ROLLOUT_IDLE_HOURS: i64 = 12` in `core/src/memories/mod.rs`.
- Thread this into `state::claim_stage1_jobs_for_startup(...)`.
- Enforce idle-time filter in DB selection logic (not only in-memory filtering after `scan_limit`) so eligible threads are not starved by very recent threads.
- Enforce global running cap of 64 at claim time in DB logic:
- Count fresh `memory_stage1` running jobs.
- Only allow new claims while count < cap.
- Keep stale-lease takeover behavior intact.
- Add/adjust tests in `state/src/runtime.rs`:
- Idle filter inclusion/exclusion around 12h boundary.
- Global running-cap guarantee.
- Existing stale/fresh ownership behavior still passes.

Acceptance criteria:
- Startup never creates more than 64 fresh `memory_stage1` running jobs.
- Threads updated <12h ago are skipped.
- Threads older than 30d are skipped.

## PR 2: Stage-1 output contract + storage artifacts (forward-compatible)

- Update parser/types to accept the new structured output while keeping backward compatibility:
- Add `rollout_slug` (optional for now).
- Add `rollout_summary`.
- Keep alias support for legacy `summary` and `rawMemory` until prompt swap completes.
- Update stage-1 schema generator in `core/src/memories/stage_one.rs` to include the new keys.
- Update prompt templates:
- `core/templates/memories/stage_one_system.md`.
- `core/templates/memories/stage_one_input.md`.
- Replace storage model in `core/src/memories/storage.rs`:
- Introduce `rollout_summaries/` directory writer (`<thread_id>.md` files).
- Introduce `raw_memories.md` aggregator writer from DB rows.
- Keep deterministic rebuild behavior from DB outputs so files can always be regenerated.
- Update consolidation prompt template to reference `rollout_summaries/` + `raw_memories.md` inputs.

Acceptance criteria:
- Stage-1 accepts both old and new output keys during migration.
- Phase-1 artifacts are generated in new format from DB state.
- No dependence on per-thread files in `raw_memories/`.

## PR 3: Remove per-cwd memories and move to one global memory root

- Simplify layout in `core/src/memories/layout.rs`:
- Single root: `codex_home/memories`.
- Remove cwd-hash bucket helpers and normalization logic used only for memory pathing.
- Remove scope branching from startup phase-2 dispatch path:
- No cwd/user mapping in `core/src/memories/startup/mod.rs`.
- One target root for consolidation.
- In `state/src/runtime/memory.rs`, stop enqueueing/handling cwd consolidation scope.
- Keep one logical consolidation scope/job key (global/user) to avoid a risky schema rewrite in same PR.
- Add one-time migration helper (core side) to preserve current shared memory output:
- If `~/.codex/memories/user/memory` exists and new root is empty, move/copy contents into `~/.codex/memories`.
- Leave old hashed cwd buckets untouched for now (safe/no-destructive migration).

Acceptance criteria:
- New runs only read/write `~/.codex/memories`.
- No new cwd-scoped consolidation jobs are enqueued.
- Existing user-shared memory content is preserved.

## PR 4: Phase-2 global lock simplification and cleanup

- Replace multi-scope dispatch with a single global consolidation claim path:
- Either reuse jobs table with one fixed key, or add a tiny dedicated lock helper; keep 1h lease.
- Ensure at most one consolidation agent can run at once.
- Keep heartbeat + stale lock recovery semantics in `core/src/memories/startup/watch.rs`.
- Remove dead scope code and legacy constants no longer used.
- Update tests:
- One-agent-at-a-time behavior.
- Lock expiry allows takeover after stale lease.

Acceptance criteria:
- Exactly one phase-2 consolidation agent can be active cluster-wide (per local DB).
- Stale lock recovers automatically.

## PR 5: Final cleanup and docs

- Remove legacy artifacts and references:
- `raw_memories/` and `memory_summary.md` assumptions from prompts/comments/tests.
- Scope constants for cwd memory pathing in core/state if fully unused.
- Update docs under `docs/` for memory workflow and directory layout.
- Add a brief operator note for rollout: compatibility window for old stage-1 JSON keys and when to remove aliases.

Acceptance criteria:
- Code and docs reflect only the simplified global workflow.
- No stale references to per-cwd memory buckets.

## Notes on sequencing

- PR 1 is safest first because it improves correctness without changing external artifact layout.
- PR 2 keeps parser compatibility so prompt deployment can happen independently.
- PR 3 and PR 4 split filesystem/scope simplification from locking simplification to reduce blast radius.
- PR 5 is intentionally cleanup-only.
