### PR TITLE
prompt: use markdown links for clickable file references

### DIFF
--- a/codex-rs/core/prompt_with_apply_patch_instructions.md
+++ b/codex-rs/core/prompt_with_apply_patch_instructions.md
@@ -212,7 +212,7 @@ You are producing plain text that will later be styled by the CLI. Follow these 
 
 **Monospace**
 
-- Wrap commands, env vars, and code identifiers in backticks.
+- Wrap commands, env vars, and code identifiers in backticks (`` `...` ``).
 - Apply to inline examples and to bullet keywords if the keyword itself is a literal file/command.
 - Never mix monospace and bold markers; choose one based on whether it’s a keyword (`**`) or inline code/path (`` ` ``).
 

--- a/codex-rs/core/prompt_with_apply_patch_instructions.md
+++ b/codex-rs/core/prompt_with_apply_patch_instructions.md
@@ -212,13 +212,13 @@ You are producing plain text that will later be styled by the CLI. Follow these 
 
 **Monospace**
 
-- Wrap all commands, file paths, env vars, and code identifiers in backticks (`` `...` ``).
+- Wrap commands, env vars, and code identifiers in backticks.
 - Apply to inline examples and to bullet keywords if the keyword itself is a literal file/command.
 - Never mix monospace and bold markers; choose one based on whether it’s a keyword (`**`) or inline code/path (`` ` ``).
 
 **File References**
 When referencing files in your response, make sure to include the relevant start line and always follow the below rules:
-  * Use inline code to make file paths clickable.
+  * Use markdown links (not inline code) for clickable file paths.
   * Each reference should have a stand alone path. Even if it's the same file.
   * Accepted: absolute, workspace‑relative, a/ or b/ diff prefixes, or bare filename/suffix.
   * Line/column (1‑based, optional): :line[:column] or #Lline[Ccolumn] (column defaults to 1).

--- a/codex-rs/protocol/src/prompts/base_instructions/default.md
+++ b/codex-rs/protocol/src/prompts/base_instructions/default.md
@@ -212,7 +212,7 @@ You are producing plain text that will later be styled by the CLI. Follow these 
 
 **Monospace**
 
-- Wrap commands, env vars, and code identifiers in backticks.
+- Wrap commands, env vars, and code identifiers in backticks (`` `...` ``).
 - Apply to inline examples and to bullet keywords if the keyword itself is a literal file/command.
 - Never mix monospace and bold markers; choose one based on whether it’s a keyword (`**`) or inline code/path (`` ` ``).
 

--- a/codex-rs/protocol/src/prompts/base_instructions/default.md
+++ b/codex-rs/protocol/src/prompts/base_instructions/default.md
@@ -212,13 +212,13 @@ You are producing plain text that will later be styled by the CLI. Follow these 
 
 **Monospace**
 
-- Wrap all commands, file paths, env vars, and code identifiers in backticks (`` `...` ``).
+- Wrap commands, env vars, and code identifiers in backticks.
 - Apply to inline examples and to bullet keywords if the keyword itself is a literal file/command.
 - Never mix monospace and bold markers; choose one based on whether it’s a keyword (`**`) or inline code/path (`` ` ``).
 
 **File References**
 When referencing files in your response, make sure to include the relevant start line and always follow the below rules:
-  * Use inline code to make file paths clickable.
+  * Use markdown links (not inline code) for clickable file paths.
   * Each reference should have a stand alone path. Even if it's the same file.
   * Accepted: absolute, workspace‑relative, a/ or b/ diff prefixes, or bare filename/suffix.
   * Line/column (1‑based, optional): :line[:column] or #Lline[Ccolumn] (column defaults to 1).


### PR DESCRIPTION
## Summary
- update file-reference guidance in core prompt instructions to require markdown links (not inline code) for clickable file paths
- apply the same wording in the protocol default base instructions so behavior is consistent across prompt sources
- keep the change minimal and token-cheap by only editing the two conflicting lines in each file

## Testing
- `cd /private/tmp/codex-prompt-markdown-file-links/codex-rs && cargo test -p codex-protocol`
- `cd /private/tmp/codex-prompt-markdown-file-links/codex-rs && cargo test -p codex-core --test responses_headers`

## Notes
- I did not run `cargo test --all-features`; happy to run it if you want.
