### PR TITLE
Add configurable MCP OAuth callback URL for MCP login

### DIFF
--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -4014,6 +4014,7 @@ impl CodexMessageProcessor {
             scopes.as_deref().unwrap_or_default(),
             timeout_secs,
             config.mcp_oauth_callback_port,
+            config.mcp_oauth_callback_url.as_deref(),
         )
         .await
         {

--- a/codex-rs/cli/src/mcp_cmd.rs
+++ b/codex-rs/cli/src/mcp_cmd.rs
@@ -273,6 +273,7 @@ async fn run_add(config_overrides: &CliConfigOverrides, add_args: AddArgs) -> Re
                 oauth_config.env_http_headers,
                 &Vec::new(),
                 config.mcp_oauth_callback_port,
+                config.mcp_oauth_callback_url.as_deref(),
             )
             .await?;
             println!("Successfully logged in.");
@@ -356,6 +357,7 @@ async fn run_login(config_overrides: &CliConfigOverrides, login_args: LoginArgs)
         env_http_headers,
         &scopes,
         config.mcp_oauth_callback_port,
+        config.mcp_oauth_callback_url.as_deref(),
     )
     .await?;
     println!("Successfully logged in to MCP server '{name}'.");

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -1554,6 +1554,10 @@
       "minimum": 0.0,
       "type": "integer"
     },
+    "mcp_oauth_callback_url": {
+      "description": "Optional redirect URI to use during MCP OAuth login. When set, this URI is used in the OAuth authorization request instead of the local listener address. The local callback listener still binds to 127.0.0.1 (using `mcp_oauth_callback_port` when provided).",
+      "type": "string"
+    },
     "mcp_oauth_credentials_store": {
       "allOf": [
         {

--- a/codex-rs/core/src/mcp/skill_dependencies.rs
+++ b/codex-rs/core/src/mcp/skill_dependencies.rs
@@ -242,6 +242,7 @@ pub(crate) async fn maybe_install_mcp_dependencies(
             oauth_config.env_http_headers,
             &[],
             config.mcp_oauth_callback_port,
+            config.mcp_oauth_callback_url.as_deref(),
         )
         .await
         {

--- a/codex-rs/core/tests/suite/shell_snapshot.rs
+++ b/codex-rs/core/tests/suite/shell_snapshot.rs
@@ -541,7 +541,10 @@ async fn shell_command_snapshot_still_intercepts_apply_patch() -> Result<()> {
 
     wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
 
-    assert_eq!(wait_for_file_contents(&target).await?, "hello from snapshot\n");
+    assert_eq!(
+        wait_for_file_contents(&target).await?,
+        "hello from snapshot\n"
+    );
 
     Ok(())
 }

--- a/codex-rs/core/tests/suite/shell_snapshot.rs
+++ b/codex-rs/core/tests/suite/shell_snapshot.rs
@@ -535,16 +535,13 @@ async fn shell_command_snapshot_still_intercepts_apply_patch() -> Result<()> {
         })
         .await?;
 
-    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
-
-    assert_eq!(
-        wait_for_file_contents(&target).await?,
-        "hello from snapshot\n"
-    );
-
     let snapshot_path = wait_for_snapshot(&codex_home).await?;
     let snapshot_content = fs::read_to_string(&snapshot_path).await?;
     assert_posix_snapshot_sections(&snapshot_content);
+
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    assert_eq!(wait_for_file_contents(&target).await?, "hello from snapshot\n");
 
     Ok(())
 }

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -114,8 +114,9 @@ fn spawn_callback_server(
             let path = request.url().to_string();
             match parse_oauth_callback(&path, &expected_callback_path) {
                 CallbackOutcome::Success(OauthCallbackResult { code, state }) => {
-                    let response =
-                        Response::from_string("Authentication complete. You may close this window.");
+                    let response = Response::from_string(
+                        "Authentication complete. You may close this window.",
+                    );
                     if let Err(err) = request.respond(response) {
                         eprintln!("Failed to respond to OAuth callback: {err}");
                     }

--- a/codex-rs/rmcp-client/src/perform_oauth_login.rs
+++ b/codex-rs/rmcp-client/src/perform_oauth_login.rs
@@ -39,6 +39,7 @@ impl Drop for CallbackServerGuard {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn perform_oauth_login(
     server_name: &str,
     server_url: &str,


### PR DESCRIPTION
## Summary

Implements a configurable MCP OAuth callback URL override for `codex mcp login` and app-server OAuth login flows, including support for non-local callback endpoints (for example, devbox ingress URLs).

## What changed

- Added new config key: `mcp_oauth_callback_url` in `~/.codex/config.toml`.
- OAuth authorization now uses `mcp_oauth_callback_url` as `redirect_uri` when set.
- Callback handling validates the callback path against the configured redirect URI path.
- Listener bind behavior is now host-aware:
  - local callback URL hosts (`localhost`, `127.0.0.1`, `::1`) bind to `127.0.0.1`
  - non-local callback URL hosts bind to `0.0.0.0`
- `mcp_oauth_callback_port` remains supported and is used for the listener port.
- Wired through:
  - CLI MCP login flow
  - App-server MCP OAuth login flow
  - Skill dependency OAuth login flow
- Updated config schema and config tests.

## Why

Some environments need OAuth callbacks to land on a specific reachable URL (for example ingress in remote devboxes), not loopback. This change allows that while preserving local defaults for existing users.

## Backward compatibility

- No behavior change when `mcp_oauth_callback_url` is unset.
- Existing `mcp_oauth_callback_port` behavior remains intact.
- Local callback flows continue binding to loopback by default.

## Testing

- `cargo test -p codex-rmcp-client callback -- --nocapture`
- `cargo test -p codex-core --lib mcp_oauth_callback -- --nocapture`
- `cargo check -p codex-cli -p codex-app-server -p codex-rmcp-client`

## Example config

```toml
mcp_oauth_callback_port = 5555
mcp_oauth_callback_url = "https://<devbox>-<namespace>.gateway.<cluster>.internal.api.openai.org/callback"
