### PR TITLE
fix: flaky test

### DIFF
--- a/codex-rs/state/src/runtime.rs
+++ b/codex-rs/state/src/runtime.rs
@@ -1272,7 +1272,6 @@ WHERE id = 1
     }
 
     #[tokio::test]
-    #[ignore = "TODO(jif): flaky"]
     async fn stage1_concurrent_claims_respect_running_cap() {
         let codex_home = unique_temp_dir();
         let runtime = StateRuntime::init(codex_home.clone(), "test-provider".to_string(), None)

--- a/codex-rs/state/src/runtime/memories.rs
+++ b/codex-rs/state/src/runtime/memories.rs
@@ -174,7 +174,7 @@ LIMIT ?
         let thread_id = thread_id.to_string();
         let worker_id = worker_id.to_string();
 
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
 
         let existing_output = sqlx::query(
             r#"
@@ -424,7 +424,7 @@ WHERE kind = ? AND job_key = ?
         let ownership_token = Uuid::new_v4().to_string();
         let worker_id = worker_id.to_string();
 
-        let mut tx = self.pool.begin().await?;
+        let mut tx = self.pool.begin_with("BEGIN IMMEDIATE").await?;
 
         let existing_job = sqlx::query(
             r#"


### PR DESCRIPTION
stage1_concurrent_claims_respect_running_cap was flaky due to SQLite lock contention, not cap logic correctness. The claim flow used deferred  transactions (BEGIN) with read-then-write behavior, which can fail under concurrency with SQLITE_BUSY_SNAPSHOT/database is locked when upgrading a read transaction to a write transaction. We fixed this by using BEGIN IMMEDIATE for stage1 and phase2 claim paths, so lock acquisition happens up front and contenders serialize cleanly instead of failing during upgrade. After the change, codex-state tests pass and stress reruns of the flaky path no longer reproduced the failure.