### PR TITLE
feat(config): support codex.toml as configuration file

### DIFF
--- a/codex-rs/core/src/config/edit.rs
+++ b/codex-rs/core/src/config/edit.rs
@@ -1,3 +1,4 @@
+use crate::config::CODEX_TOML_FILE;
 use crate::config::CONFIG_TOML_FILE;
 use crate::config::types::McpServerConfig;
 use crate::config::types::Notice;
@@ -637,7 +638,13 @@ pub fn apply_blocking(
         return Ok(());
     }
 
-    let config_path = codex_home.join(CONFIG_TOML_FILE);
+    let mut config_path = codex_home.join(CODEX_TOML_FILE);
+    if !config_path.exists() {
+        let legacy_path = codex_home.join(CONFIG_TOML_FILE);
+        if legacy_path.exists() {
+            config_path = legacy_path;
+        }
+    }
     let write_paths = resolve_symlink_write_paths(&config_path)?;
     let serialized = match write_paths.read_path {
         Some(path) => match std::fs::read_to_string(&path) {

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -97,6 +97,8 @@ pub(crate) const PROJECT_DOC_MAX_BYTES: usize = 32 * 1024; // 32 KiB
 pub(crate) const DEFAULT_AGENT_MAX_THREADS: Option<usize> = Some(6);
 
 pub const CONFIG_TOML_FILE: &str = "config.toml";
+pub const CODEX_TOML_FILE: &str = "codex.toml";
+pub const CONFIG_FILENAMES: &[&str] = &[CODEX_TOML_FILE, CONFIG_TOML_FILE];
 
 #[cfg(test)]
 pub(crate) fn test_config() -> Config {


### PR DESCRIPTION
Closes #11301. Adds support for codex.toml, prioritizing it over config.toml for configuration loading.