### PR TITLE
fix(skills): improve symlink handling in skill loader

### DIFF
--- a/codex-rs/core/src/skills/loader.rs
+++ b/codex-rs/core/src/skills/loader.rs
@@ -26,6 +26,7 @@ use std::path::Path;
 use std::path::PathBuf;
 use toml::Value as TomlValue;
 use tracing::error;
+use tracing::warn;
 
 #[derive(Debug, Deserialize)]
 struct SkillFrontmatter {
@@ -265,6 +266,13 @@ fn repo_agents_skill_roots(config_layer_stack: &ConfigLayerStack, cwd: &Path) ->
                 path: agents_skills,
                 scope: SkillScope::Repo,
             });
+        } else if let Ok(metadata) = fs::symlink_metadata(&agents_skills) {
+            if metadata.is_symlink() {
+                tracing::warn!(
+                    "ignoring invalid skills path (symlink to non-directory or broken): {}",
+                    agents_skills.display()
+                );
+            }
         }
     }
     roots


### PR DESCRIPTION
Closes #11314. Adds explicit logging for broken/invalid symlinks encountered when loading skills from project or user directories. This helps diagnose issues where skills fail to load due to symlink configuration errors.