### PR TITLE
Fix test flake

### DIFF
--- a/codex-rs/core/tests/suite/apply_patch_cli.rs
+++ b/codex-rs/core/tests/suite/apply_patch_cli.rs
@@ -23,6 +23,7 @@ use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
 use core_test_support::responses::ev_function_call;
 use core_test_support::responses::ev_response_created;
+use core_test_support::responses::ev_shell_command_call_with_args;
 use core_test_support::responses::mount_sse_sequence;
 use core_test_support::responses::sse;
 use core_test_support::skip_if_no_network;
@@ -783,9 +784,13 @@ async fn apply_patch_cli_can_use_shell_command_output_as_patch_input() -> Result
                     } else {
                         "cat source.txt"
                     };
+                    let args = json!({
+                        "command": command,
+                        "login": false,
+                    });
                     let body = sse(vec![
                         ev_response_created("resp-1"),
-                        ev_shell_command_call(&self.read_call_id, command),
+                        ev_shell_command_call_with_args(&self.read_call_id, &args),
                         ev_completed("resp-1"),
                     ]);
                     ResponseTemplate::new(200)


### PR DESCRIPTION
Flaking with

```
   Nextest run ID 6b7ff5f7-57f6-4c9c-8026-67f08fa2f81f with nextest profile: default
      Starting 3282 tests across 118 binaries (21 tests skipped)
          FAIL [  14.548s] (1367/3282) codex-core::all suite::apply_patch_cli::apply_patch_cli_can_use_shell_command_output_as_patch_input
    stdout ───

      running 1 test
      test suite::apply_patch_cli::apply_patch_cli_can_use_shell_command_output_as_patch_input ... FAILED

      failures:

      failures:
          suite::apply_patch_cli::apply_patch_cli_can_use_shell_command_output_as_patch_input

      test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 522 filtered out; finished in 14.41s

    stderr ───

      thread 'suite::apply_patch_cli::apply_patch_cli_can_use_shell_command_output_as_patch_input' (15632) panicked at C:\a\codex\codex\codex-rs\core\tests\common\lib.rs:186:14:
      timeout waiting for event: Elapsed(())
      stack backtrace:
      read_output:
      Exit code: 0
      Wall time: 8.5 seconds
      Output:
      line1
      naïve café
      line3

      stdout:
      line1
      naïve café
      line3
      patch:
      *** Begin Patch
      *** Add File: target.txt
      +line1
      +naïve café
      +line3
      *** End Patch
      note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```