### PR TITLE
feat: raw memories as yaml

### DIFF
--- a/codex-rs/core/src/memories/mod.rs
+++ b/codex-rs/core/src/memories/mod.rs
@@ -21,7 +21,7 @@ use std::path::PathBuf;
 /// Subagent source label used to identify consolidation tasks.
 const MEMORY_CONSOLIDATION_SUBAGENT_LABEL: &str = "memory_consolidation";
 const ROLLOUT_SUMMARIES_SUBDIR: &str = "rollout_summaries";
-const RAW_MEMORIES_FILENAME: &str = "raw_memories.md";
+const RAW_MEMORIES_FILENAME: &str = "raw_memories.yaml";
 /// Maximum number of rollout candidates processed per startup pass.
 const MAX_ROLLOUTS_PER_STARTUP: usize = 64;
 /// Concurrency cap for startup memory extraction and consolidation scheduling.

--- a/codex-rs/core/src/memories/tests.rs
+++ b/codex-rs/core/src/memories/tests.rs
@@ -17,6 +17,7 @@ use codex_protocol::protocol::CompactedItem;
 use codex_protocol::protocol::RolloutItem;
 use codex_state::Stage1Output;
 use pretty_assertions::assert_eq;
+use serde::Deserialize;
 use tempfile::tempdir;
 
 #[test]
@@ -195,6 +196,19 @@ async fn sync_rollout_summaries_and_raw_memories_file_keeps_latest_memories_only
     let raw_memories = tokio::fs::read_to_string(raw_memories_file(&root))
         .await
         .expect("read raw memories");
-    assert!(raw_memories.contains("raw memory"));
-    assert!(raw_memories.contains(&keep_id));
+    let parsed: Vec<RawMemoryYamlEntry> =
+        serde_yaml::from_str(&raw_memories).expect("parse raw memories yaml");
+    assert_eq!(
+        parsed,
+        vec![RawMemoryYamlEntry {
+            file_path: keep_path.display().to_string(),
+            raw_memory: "raw memory".to_string(),
+        }]
+    );
+}
+
+#[derive(Debug, PartialEq, Eq, Deserialize)]
+struct RawMemoryYamlEntry {
+    file_path: String,
+    raw_memory: String,
 }

--- a/codex-rs/core/templates/memories/consolidation.md
+++ b/codex-rs/core/templates/memories/consolidation.md
@@ -6,7 +6,7 @@ Integrate Phase 1 artifacts into a stable, retrieval-friendly memory hierarchy w
 
 Primary inputs in this directory:
 - `rollout_summaries/` (per-thread summaries from Phase 1)
-- `raw_memories.md` (merged Stage 1 raw memories; latest first)
+- `raw_memories.yaml` (array of Stage 1 raw memories with `file_path` and `raw_memory`)
 - Existing outputs if present:
   - `MEMORY.md`
   - `memory_summary.md`
@@ -40,7 +40,7 @@ Expected outputs (create/update only these):
 
 Workflow (order matters):
 1. Determine mode (`INIT` vs `INCREMENTAL`) from artifact availability/content.
-2. Read `rollout_summaries/` first for routing, then validate details in `raw_memories.md`.
+2. Read `rollout_summaries/` first for routing, then validate details in `raw_memories.yaml`.
 3. Read existing `MEMORY.md`, `memory_summary.md`, and `skills/` for continuity.
 4. Update `skills/` only for reliable, repeatable procedures with clear verification.
 5. Update `MEMORY.md` as the durable registry; add clear related-skill pointers in note bodies when useful.


### PR DESCRIPTION
Store `raw_memories` as a YAML file instead of a `.md`