### PR TITLE
app-server: thread resume subscriptions

### DIFF
--- a/codex-rs/app-server/src/bespoke_event_handling.rs
+++ b/codex-rs/app-server/src/bespoke_event_handling.rs
@@ -4,9 +4,7 @@ use crate::codex_message_processor::read_summary_from_rollout;
 use crate::codex_message_processor::summary_to_thread;
 use crate::error_code::INTERNAL_ERROR_CODE;
 use crate::error_code::INVALID_REQUEST_ERROR_CODE;
-use crate::outgoing_message::ConnectionId;
-use crate::outgoing_message::ConnectionRequestId;
-use crate::outgoing_message::OutgoingMessageSender;
+use crate::outgoing_message::ThreadScopedOutgoingMessageSender;
 use crate::thread_state::ThreadState;
 use crate::thread_state::TurnSummary;
 use codex_app_server_protocol::AccountRateLimitsUpdatedNotification;
@@ -104,64 +102,16 @@ use tracing::error;
 
 type JsonValue = serde_json::Value;
 
-#[derive(Clone)]
-struct TargetedOutgoing {
-    outgoing: Arc<OutgoingMessageSender>,
-    connection_ids: Arc<Vec<ConnectionId>>,
-}
-
-impl TargetedOutgoing {
-    fn new(outgoing: Arc<OutgoingMessageSender>, connection_ids: Vec<ConnectionId>) -> Self {
-        Self {
-            outgoing,
-            connection_ids: Arc::new(connection_ids),
-        }
-    }
-
-    async fn send_request(&self, payload: ServerRequestPayload) -> oneshot::Receiver<JsonValue> {
-        if self.connection_ids.is_empty() {
-            let (_tx, rx) = oneshot::channel();
-            return rx;
-        }
-        self.outgoing
-            .send_request_to_connections(self.connection_ids.as_slice(), payload)
-            .await
-    }
-
-    async fn send_server_notification(&self, notification: ServerNotification) {
-        if self.connection_ids.is_empty() {
-            return;
-        }
-        self.outgoing
-            .send_server_notification_to_connections(self.connection_ids.as_slice(), notification)
-            .await;
-    }
-
-    async fn send_response<T: serde::Serialize>(
-        &self,
-        request_id: ConnectionRequestId,
-        response: T,
-    ) {
-        self.outgoing.send_response(request_id, response).await;
-    }
-
-    async fn send_error(&self, request_id: ConnectionRequestId, error: JSONRPCErrorError) {
-        self.outgoing.send_error(request_id, error).await;
-    }
-}
-
 #[allow(clippy::too_many_arguments)]
 pub(crate) async fn apply_bespoke_event_handling(
     event: Event,
     conversation_id: ThreadId,
     conversation: Arc<CodexThread>,
-    outgoing: Arc<OutgoingMessageSender>,
+    outgoing: ThreadScopedOutgoingMessageSender,
     thread_state: Arc<tokio::sync::Mutex<ThreadState>>,
-    target_connection_ids: Vec<ConnectionId>,
     api_version: ApiVersion,
     fallback_model_provider: String,
 ) {
-    let outgoing = TargetedOutgoing::new(outgoing, target_connection_ids);
     let Event {
         id: event_turn_id,
         msg,
@@ -1216,7 +1166,7 @@ async fn handle_turn_diff(
     event_turn_id: &str,
     turn_diff_event: TurnDiffEvent,
     api_version: ApiVersion,
-    outgoing: &TargetedOutgoing,
+    outgoing: &ThreadScopedOutgoingMessageSender,
 ) {
     if let ApiVersion::V2 = api_version {
         let notification = TurnDiffUpdatedNotification {
@@ -1235,7 +1185,7 @@ async fn handle_turn_plan_update(
     event_turn_id: &str,
     plan_update_event: UpdatePlanArgs,
     api_version: ApiVersion,
-    outgoing: &TargetedOutgoing,
+    outgoing: &ThreadScopedOutgoingMessageSender,
 ) {
     // `update_plan` is a todo/checklist tool; it is not related to plan-mode updates
     if let ApiVersion::V2 = api_version {
@@ -1260,7 +1210,7 @@ async fn emit_turn_completed_with_status(
     event_turn_id: String,
     status: TurnStatus,
     error: Option<TurnError>,
-    outgoing: &TargetedOutgoing,
+    outgoing: &ThreadScopedOutgoingMessageSender,
 ) {
     let notification = TurnCompletedNotification {
         thread_id: conversation_id.to_string(),
@@ -1282,7 +1232,7 @@ async fn complete_file_change_item(
     changes: Vec<FileUpdateChange>,
     status: PatchApplyStatus,
     turn_id: String,
-    outgoing: &TargetedOutgoing,
+    outgoing: &ThreadScopedOutgoingMessageSender,
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
     let mut state = thread_state.lock().await;
@@ -1314,7 +1264,7 @@ async fn complete_command_execution_item(
     process_id: Option<String>,
     command_actions: Vec<V2ParsedCommand>,
     status: CommandExecutionStatus,
-    outgoing: &TargetedOutgoing,
+    outgoing: &ThreadScopedOutgoingMessageSender,
 ) {
     let item = ThreadItem::CommandExecution {
         id: item_id,
@@ -1342,7 +1292,7 @@ async fn maybe_emit_raw_response_item_completed(
     conversation_id: ThreadId,
     turn_id: &str,
     item: codex_protocol::models::ResponseItem,
-    outgoing: &TargetedOutgoing,
+    outgoing: &ThreadScopedOutgoingMessageSender,
 ) {
     let ApiVersion::V2 = api_version else {
         return;
@@ -1369,7 +1319,7 @@ async fn find_and_remove_turn_summary(
 async fn handle_turn_complete(
     conversation_id: ThreadId,
     event_turn_id: String,
-    outgoing: &TargetedOutgoing,
+    outgoing: &ThreadScopedOutgoingMessageSender,
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
     let turn_summary = find_and_remove_turn_summary(conversation_id, thread_state).await;
@@ -1385,7 +1335,7 @@ async fn handle_turn_complete(
 async fn handle_turn_interrupted(
     conversation_id: ThreadId,
     event_turn_id: String,
-    outgoing: &TargetedOutgoing,
+    outgoing: &ThreadScopedOutgoingMessageSender,
     thread_state: &Arc<Mutex<ThreadState>>,
 ) {
     find_and_remove_turn_summary(conversation_id, thread_state).await;
@@ -1404,7 +1354,7 @@ async fn handle_thread_rollback_failed(
     _conversation_id: ThreadId,
     message: String,
     thread_state: &Arc<Mutex<ThreadState>>,
-    outgoing: &TargetedOutgoing,
+    outgoing: &ThreadScopedOutgoingMessageSender,
 ) {
     let pending_rollback = thread_state.lock().await.pending_rollbacks.take();
 
@@ -1426,7 +1376,7 @@ async fn handle_token_count_event(
     conversation_id: ThreadId,
     turn_id: String,
     token_count_event: TokenCountEvent,
-    outgoing: &TargetedOutgoing,
+    outgoing: &ThreadScopedOutgoingMessageSender,
 ) {
     let TokenCountEvent { info, rate_limits } = token_count_event;
     if let Some(token_usage) = info.map(ThreadTokenUsage::from) {
@@ -1683,7 +1633,7 @@ async fn on_file_change_request_approval_response(
     changes: Vec<FileUpdateChange>,
     receiver: oneshot::Receiver<JsonValue>,
     codex: Arc<CodexThread>,
-    outgoing: TargetedOutgoing,
+    outgoing: ThreadScopedOutgoingMessageSender,
     thread_state: Arc<Mutex<ThreadState>>,
 ) {
     let response = receiver.await;
@@ -1743,7 +1693,7 @@ async fn on_command_execution_request_approval_response(
     command_actions: Vec<V2ParsedCommand>,
     receiver: oneshot::Receiver<JsonValue>,
     conversation: Arc<CodexThread>,
-    outgoing: TargetedOutgoing,
+    outgoing: ThreadScopedOutgoingMessageSender,
 ) {
     let response = receiver.await;
     let (decision, completion_status) = match response {
@@ -2060,13 +2010,13 @@ mod tests {
         let event_turn_id = "complete1".to_string();
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(tx));
-        let targeted_outgoing = TargetedOutgoing::new(outgoing, vec![ConnectionId(1)]);
+        let outgoing = ThreadScopedOutgoingMessageSender::new(outgoing, vec![ConnectionId(1)]);
         let thread_state = new_thread_state();
 
         handle_turn_complete(
             conversation_id,
             event_turn_id.clone(),
-            &targeted_outgoing,
+            &outgoing,
             &thread_state,
         )
         .await;
@@ -2101,12 +2051,12 @@ mod tests {
         .await;
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(tx));
-        let targeted_outgoing = TargetedOutgoing::new(outgoing, vec![ConnectionId(1)]);
+        let outgoing = ThreadScopedOutgoingMessageSender::new(outgoing, vec![ConnectionId(1)]);
 
         handle_turn_interrupted(
             conversation_id,
             event_turn_id.clone(),
-            &targeted_outgoing,
+            &outgoing,
             &thread_state,
         )
         .await;
@@ -2141,12 +2091,12 @@ mod tests {
         .await;
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(tx));
-        let targeted_outgoing = TargetedOutgoing::new(outgoing, vec![ConnectionId(1)]);
+        let outgoing = ThreadScopedOutgoingMessageSender::new(outgoing, vec![ConnectionId(1)]);
 
         handle_turn_complete(
             conversation_id,
             event_turn_id.clone(),
-            &targeted_outgoing,
+            &outgoing,
             &thread_state,
         )
         .await;
@@ -2175,7 +2125,7 @@ mod tests {
     async fn test_handle_turn_plan_update_emits_notification_for_v2() -> Result<()> {
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(tx));
-        let targeted_outgoing = TargetedOutgoing::new(outgoing, vec![ConnectionId(1)]);
+        let outgoing = ThreadScopedOutgoingMessageSender::new(outgoing, vec![ConnectionId(1)]);
         let update = UpdatePlanArgs {
             explanation: Some("need plan".to_string()),
             plan: vec![
@@ -2197,7 +2147,7 @@ mod tests {
             "turn-123",
             update,
             ApiVersion::V2,
-            &targeted_outgoing,
+            &outgoing,
         )
         .await;
 
@@ -2225,7 +2175,7 @@ mod tests {
         let turn_id = "turn-123".to_string();
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(tx));
-        let targeted_outgoing = TargetedOutgoing::new(outgoing, vec![ConnectionId(1)]);
+        let outgoing = ThreadScopedOutgoingMessageSender::new(outgoing, vec![ConnectionId(1)]);
 
         let info = TokenUsageInfo {
             total_token_usage: TokenUsage {
@@ -2268,7 +2218,7 @@ mod tests {
                 info: Some(info),
                 rate_limits: Some(rate_limits),
             },
-            &targeted_outgoing,
+            &outgoing,
         )
         .await;
 
@@ -2309,7 +2259,7 @@ mod tests {
         let turn_id = "turn-456".to_string();
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(tx));
-        let targeted_outgoing = TargetedOutgoing::new(outgoing, vec![ConnectionId(1)]);
+        let outgoing = ThreadScopedOutgoingMessageSender::new(outgoing, vec![ConnectionId(1)]);
 
         handle_token_count_event(
             conversation_id,
@@ -2318,7 +2268,7 @@ mod tests {
                 info: None,
                 rate_limits: None,
             },
-            &targeted_outgoing,
+            &outgoing,
         )
         .await;
 
@@ -2376,7 +2326,7 @@ mod tests {
 
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(tx));
-        let targeted_outgoing = TargetedOutgoing::new(outgoing, vec![ConnectionId(1)]);
+        let outgoing = ThreadScopedOutgoingMessageSender::new(outgoing, vec![ConnectionId(1)]);
 
         // Turn 1 on conversation A
         let a_turn1 = "a_turn1".to_string();
@@ -2390,13 +2340,7 @@ mod tests {
             &thread_state,
         )
         .await;
-        handle_turn_complete(
-            conversation_a,
-            a_turn1.clone(),
-            &targeted_outgoing,
-            &thread_state,
-        )
-        .await;
+        handle_turn_complete(conversation_a, a_turn1.clone(), &outgoing, &thread_state).await;
 
         // Turn 1 on conversation B
         let b_turn1 = "b_turn1".to_string();
@@ -2410,23 +2354,11 @@ mod tests {
             &thread_state,
         )
         .await;
-        handle_turn_complete(
-            conversation_b,
-            b_turn1.clone(),
-            &targeted_outgoing,
-            &thread_state,
-        )
-        .await;
+        handle_turn_complete(conversation_b, b_turn1.clone(), &outgoing, &thread_state).await;
 
         // Turn 2 on conversation A
         let a_turn2 = "a_turn2".to_string();
-        handle_turn_complete(
-            conversation_a,
-            a_turn2.clone(),
-            &targeted_outgoing,
-            &thread_state,
-        )
-        .await;
+        handle_turn_complete(conversation_a, a_turn2.clone(), &outgoing, &thread_state).await;
 
         // Verify: A turn 1
         let msg = recv_broadcast_message(&mut rx).await?;
@@ -2617,7 +2549,7 @@ mod tests {
     async fn test_handle_turn_diff_emits_v2_notification() -> Result<()> {
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(tx));
-        let targeted_outgoing = TargetedOutgoing::new(outgoing, vec![ConnectionId(1)]);
+        let outgoing = ThreadScopedOutgoingMessageSender::new(outgoing, vec![ConnectionId(1)]);
         let unified_diff = "--- a\n+++ b\n".to_string();
         let conversation_id = ThreadId::new();
 
@@ -2628,7 +2560,7 @@ mod tests {
                 unified_diff: unified_diff.clone(),
             },
             ApiVersion::V2,
-            &targeted_outgoing,
+            &outgoing,
         )
         .await;
 
@@ -2651,7 +2583,7 @@ mod tests {
     async fn test_handle_turn_diff_is_noop_for_v1() -> Result<()> {
         let (tx, mut rx) = mpsc::channel(CHANNEL_CAPACITY);
         let outgoing = Arc::new(OutgoingMessageSender::new(tx));
-        let targeted_outgoing = TargetedOutgoing::new(outgoing, vec![ConnectionId(1)]);
+        let outgoing = ThreadScopedOutgoingMessageSender::new(outgoing, vec![ConnectionId(1)]);
         let conversation_id = ThreadId::new();
 
         handle_turn_diff(
@@ -2661,7 +2593,7 @@ mod tests {
                 unified_diff: "diff".to_string(),
             },
             ApiVersion::V1,
-            &targeted_outgoing,
+            &outgoing,
         )
         .await;
 

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -7,6 +7,7 @@ use crate::outgoing_message::ConnectionId;
 use crate::outgoing_message::ConnectionRequestId;
 use crate::outgoing_message::OutgoingMessageSender;
 use crate::outgoing_message::OutgoingNotification;
+use crate::outgoing_message::ThreadScopedOutgoingMessageSender;
 use chrono::DateTime;
 use chrono::SecondsFormat;
 use chrono::Utc;
@@ -5480,13 +5481,16 @@ impl CodexMessageProcessor {
                             )
                             .await;
 
+                        let thread_outgoing = ThreadScopedOutgoingMessageSender::new(
+                            outgoing_for_task.clone(),
+                            subscribed_connection_ids,
+                        );
                         apply_bespoke_event_handling(
                             event.clone(),
                             conversation_id,
                             conversation.clone(),
-                            outgoing_for_task.clone(),
+                            thread_outgoing,
                             thread_state.clone(),
-                            subscribed_connection_ids,
                             api_version,
                             fallback_model_provider.clone(),
                         )

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -2637,11 +2637,7 @@ impl CodexMessageProcessor {
     }
 
     /// Best-effort: attach a listener for thread_id if missing.
-    pub(crate) async fn try_attach_thread_listener(&mut self, thread_id: ThreadId) {
-        if self.thread_state_manager.has_listener_for_thread(thread_id) {
-            return;
-        }
-    }
+    pub(crate) async fn try_attach_thread_listener(&mut self, _thread_id: ThreadId) {}
 
     async fn thread_resume(&mut self, request_id: ConnectionRequestId, params: ThreadResumeParams) {
         let ThreadResumeParams {

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -490,6 +490,7 @@ pub async fn run_main_with_transport(
                                 {
                                     break;
                                 }
+                                processor.connection_closed(connection_id).await;
                                 connections.remove(&connection_id);
                                 if shutdown_when_no_connections && connections.is_empty() {
                                     break;

--- a/codex-rs/app-server/src/lib.rs
+++ b/codex-rs/app-server/src/lib.rs
@@ -27,7 +27,6 @@ use crate::transport::CHANNEL_CAPACITY;
 use crate::transport::ConnectionState;
 use crate::transport::OutboundConnectionState;
 use crate::transport::TransportEvent;
-use crate::transport::has_initialized_connections;
 use crate::transport::route_outgoing_envelope;
 use crate::transport::start_stdio_connection;
 use crate::transport::start_websocket_acceptor;
@@ -545,8 +544,19 @@ pub async fn run_main_with_transport(
                     created = thread_created_rx.recv(), if listen_for_threads => {
                         match created {
                             Ok(thread_id) => {
-                                if has_initialized_connections(&connections) {
-                                    processor.try_attach_thread_listener(thread_id).await;
+                                let initialized_connection_ids: Vec<ConnectionId> = connections
+                                    .iter()
+                                    .filter_map(|(connection_id, connection_state)| {
+                                        connection_state.session.initialized.then_some(*connection_id)
+                                    })
+                                    .collect();
+                                if !initialized_connection_ids.is_empty() {
+                                    processor
+                                        .try_attach_thread_listener(
+                                            thread_id,
+                                            initialized_connection_ids,
+                                        )
+                                        .await;
                                 }
                             }
                             Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -396,9 +396,13 @@ impl MessageProcessor {
         }
     }
 
-    pub(crate) async fn try_attach_thread_listener(&mut self, thread_id: ThreadId) {
+    pub(crate) async fn try_attach_thread_listener(
+        &mut self,
+        thread_id: ThreadId,
+        connection_ids: Vec<ConnectionId>,
+    ) {
         self.codex_message_processor
-            .try_attach_thread_listener(thread_id)
+            .try_attach_thread_listener(thread_id, connection_ids)
             .await;
     }
 

--- a/codex-rs/app-server/src/message_processor.rs
+++ b/codex-rs/app-server/src/message_processor.rs
@@ -402,6 +402,12 @@ impl MessageProcessor {
             .await;
     }
 
+    pub(crate) async fn connection_closed(&mut self, connection_id: ConnectionId) {
+        self.codex_message_processor
+            .connection_closed(connection_id)
+            .await;
+    }
+
     /// Handle a standalone JSON-RPC response originating from the peer.
     pub(crate) async fn process_response(&mut self, response: JSONRPCResponse) {
         tracing::info!("<- response: {:?}", response);

--- a/codex-rs/app-server/src/outgoing_message.rs
+++ b/codex-rs/app-server/src/outgoing_message.rs
@@ -57,16 +57,27 @@ impl OutgoingMessageSender {
         }
     }
 
-    pub(crate) async fn send_request(
+    pub(crate) async fn send_request_to_connections(
         &self,
+        connection_ids: &[ConnectionId],
         request: ServerRequestPayload,
     ) -> oneshot::Receiver<Result> {
-        let (_id, rx) = self.send_request_with_id(request).await;
+        let (_id, rx) = self
+            .send_request_with_id_to_connections(connection_ids, request)
+            .await;
         rx
     }
 
     pub(crate) async fn send_request_with_id(
         &self,
+        request: ServerRequestPayload,
+    ) -> (RequestId, oneshot::Receiver<Result>) {
+        self.send_request_with_id_to_connections(&[], request).await
+    }
+
+    async fn send_request_with_id_to_connections(
+        &self,
+        connection_ids: &[ConnectionId],
         request: ServerRequestPayload,
     ) -> (RequestId, oneshot::Receiver<Result>) {
         let id = RequestId::Integer(self.next_server_request_id.fetch_add(1, Ordering::Relaxed));
@@ -79,13 +90,34 @@ impl OutgoingMessageSender {
 
         let outgoing_message =
             OutgoingMessage::Request(request.request_with_id(outgoing_message_id.clone()));
-        if let Err(err) = self
-            .sender
-            .send(OutgoingEnvelope::Broadcast {
-                message: outgoing_message,
-            })
-            .await
-        {
+        let send_result = if connection_ids.is_empty() {
+            self.sender
+                .send(OutgoingEnvelope::Broadcast {
+                    message: outgoing_message,
+                })
+                .await
+        } else {
+            let mut send_error = None;
+            for connection_id in connection_ids {
+                if let Err(err) = self
+                    .sender
+                    .send(OutgoingEnvelope::ToConnection {
+                        connection_id: *connection_id,
+                        message: outgoing_message.clone(),
+                    })
+                    .await
+                {
+                    send_error = Some(err);
+                    break;
+                }
+            }
+            match send_error {
+                Some(err) => Err(err),
+                None => Ok(()),
+            }
+        };
+
+        if let Err(err) = send_result {
             warn!("failed to send request {outgoing_message_id:?} to client: {err:?}");
             let mut request_id_to_callback = self.request_id_to_callback.lock().await;
             request_id_to_callback.remove(&outgoing_message_id);
@@ -172,29 +204,71 @@ impl OutgoingMessageSender {
     }
 
     pub(crate) async fn send_server_notification(&self, notification: ServerNotification) {
-        if let Err(err) = self
-            .sender
-            .send(OutgoingEnvelope::Broadcast {
-                message: OutgoingMessage::AppServerNotification(notification),
-            })
-            .await
-        {
-            warn!("failed to send server notification to client: {err:?}");
+        self.send_server_notification_to_connections(&[], notification)
+            .await;
+    }
+
+    pub(crate) async fn send_server_notification_to_connections(
+        &self,
+        connection_ids: &[ConnectionId],
+        notification: ServerNotification,
+    ) {
+        let outgoing_message = OutgoingMessage::AppServerNotification(notification);
+        if connection_ids.is_empty() {
+            if let Err(err) = self
+                .sender
+                .send(OutgoingEnvelope::Broadcast {
+                    message: outgoing_message,
+                })
+                .await
+            {
+                warn!("failed to send server notification to client: {err:?}");
+            }
+            return;
+        }
+        for connection_id in connection_ids {
+            if let Err(err) = self
+                .sender
+                .send(OutgoingEnvelope::ToConnection {
+                    connection_id: *connection_id,
+                    message: outgoing_message.clone(),
+                })
+                .await
+            {
+                warn!("failed to send server notification to client: {err:?}");
+            }
         }
     }
 
-    /// All notifications should be migrated to [`ServerNotification`] and
-    /// [`OutgoingMessage::Notification`] should be removed.
-    pub(crate) async fn send_notification(&self, notification: OutgoingNotification) {
+    pub(crate) async fn send_notification_to_connections(
+        &self,
+        connection_ids: &[ConnectionId],
+        notification: OutgoingNotification,
+    ) {
         let outgoing_message = OutgoingMessage::Notification(notification);
-        if let Err(err) = self
-            .sender
-            .send(OutgoingEnvelope::Broadcast {
-                message: outgoing_message,
-            })
-            .await
-        {
-            warn!("failed to send notification to client: {err:?}");
+        if connection_ids.is_empty() {
+            if let Err(err) = self
+                .sender
+                .send(OutgoingEnvelope::Broadcast {
+                    message: outgoing_message,
+                })
+                .await
+            {
+                warn!("failed to send notification to client: {err:?}");
+            }
+            return;
+        }
+        for connection_id in connection_ids {
+            if let Err(err) = self
+                .sender
+                .send(OutgoingEnvelope::ToConnection {
+                    connection_id: *connection_id,
+                    message: outgoing_message.clone(),
+                })
+                .await
+            {
+                warn!("failed to send notification to client: {err:?}");
+            }
         }
     }
 

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -1,9 +1,12 @@
+use crate::outgoing_message::ConnectionId;
 use crate::outgoing_message::ConnectionRequestId;
 use codex_app_server_protocol::TurnError;
+use codex_core::CodexThread;
 use codex_protocol::ThreadId;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::sync::Weak;
 use tokio::sync::Mutex;
 use tokio::sync::oneshot;
 use uuid::Uuid;
@@ -25,26 +28,47 @@ pub(crate) struct ThreadState {
     pub(crate) pending_interrupts: PendingInterruptQueue,
     pub(crate) pending_rollbacks: Option<ConnectionRequestId>,
     pub(crate) turn_summary: TurnSummary,
-    pub(crate) listener_cancel_txs: HashMap<Uuid, oneshot::Sender<()>>,
+    pub(crate) cancel_tx: Option<oneshot::Sender<()>>,
+    listener_thread: Option<Weak<CodexThread>>,
+    subscribed_connections: HashSet<ConnectionId>,
 }
 
 impl ThreadState {
-    fn set_listener(&mut self, subscription_id: Uuid, cancel_tx: oneshot::Sender<()>) {
-        if let Some(previous) = self.listener_cancel_txs.insert(subscription_id, cancel_tx) {
+    pub(crate) fn listener_matches(&self, conversation: &Arc<CodexThread>) -> bool {
+        self.listener_thread
+            .as_ref()
+            .and_then(Weak::upgrade)
+            .is_some_and(|existing| Arc::ptr_eq(&existing, conversation))
+    }
+
+    pub(crate) fn set_listener(
+        &mut self,
+        cancel_tx: oneshot::Sender<()>,
+        conversation: &Arc<CodexThread>,
+    ) {
+        if let Some(previous) = self.cancel_tx.replace(cancel_tx) {
             let _ = previous.send(());
         }
+        self.listener_thread = Some(Arc::downgrade(conversation));
     }
 
-    fn clear_listener(&mut self, subscription_id: Uuid) {
-        if let Some(cancel_tx) = self.listener_cancel_txs.remove(&subscription_id) {
+    pub(crate) fn clear_listener(&mut self) {
+        if let Some(cancel_tx) = self.cancel_tx.take() {
             let _ = cancel_tx.send(());
         }
+        self.listener_thread = None;
     }
 
-    fn clear_listeners(&mut self) {
-        for (_, cancel_tx) in self.listener_cancel_txs.drain() {
-            let _ = cancel_tx.send(());
-        }
+    pub(crate) fn add_connection(&mut self, connection_id: ConnectionId) {
+        self.subscribed_connections.insert(connection_id);
+    }
+
+    pub(crate) fn remove_connection(&mut self, connection_id: ConnectionId) {
+        self.subscribed_connections.remove(&connection_id);
+    }
+
+    pub(crate) fn subscribed_connection_ids(&self) -> Vec<ConnectionId> {
+        self.subscribed_connections.iter().copied().collect()
     }
 }
 
@@ -52,6 +76,7 @@ impl ThreadState {
 pub(crate) struct ThreadStateManager {
     thread_states: HashMap<ThreadId, Arc<Mutex<ThreadState>>>,
     thread_id_by_subscription: HashMap<Uuid, ThreadId>,
+    thread_ids_by_connection: HashMap<ConnectionId, HashSet<ThreadId>>,
 }
 
 impl ThreadStateManager {
@@ -75,32 +100,66 @@ impl ThreadStateManager {
     pub(crate) async fn remove_listener(&mut self, subscription_id: Uuid) -> Option<ThreadId> {
         let thread_id = self.thread_id_by_subscription.remove(&subscription_id)?;
         if let Some(thread_state) = self.thread_states.get(&thread_id) {
-            thread_state.lock().await.clear_listener(subscription_id);
+            let mut state = thread_state.lock().await;
+            // Back-compat: removing any subscription clears the active listener task for the
+            // thread, but we intentionally do not delete other subscription IDs here.
+            // TODO: Revisit once v1 listener lifecycle semantics are cleaned up.
+            state.clear_listener();
         }
         Some(thread_id)
     }
 
     pub(crate) async fn remove_thread_state(&mut self, thread_id: ThreadId) {
         if let Some(thread_state) = self.thread_states.remove(&thread_id) {
-            thread_state.lock().await.clear_listeners();
+            thread_state.lock().await.clear_listener();
         }
         self.thread_id_by_subscription
             .retain(|_, existing_thread_id| *existing_thread_id != thread_id);
+        self.thread_ids_by_connection.retain(|_, thread_ids| {
+            thread_ids.remove(&thread_id);
+            !thread_ids.is_empty()
+        });
     }
 
     pub(crate) async fn set_listener(
         &mut self,
         subscription_id: Uuid,
         thread_id: ThreadId,
-        cancel_tx: oneshot::Sender<()>,
+        connection_id: ConnectionId,
     ) -> Arc<Mutex<ThreadState>> {
         self.thread_id_by_subscription
             .insert(subscription_id, thread_id);
+        self.thread_ids_by_connection
+            .entry(connection_id)
+            .or_default()
+            .insert(thread_id);
         let thread_state = self.thread_state(thread_id);
+        thread_state.lock().await.add_connection(connection_id);
         thread_state
-            .lock()
-            .await
-            .set_listener(subscription_id, cancel_tx);
+    }
+
+    pub(crate) async fn ensure_connection_subscribed(
+        &mut self,
+        thread_id: ThreadId,
+        connection_id: ConnectionId,
+    ) -> Arc<Mutex<ThreadState>> {
+        self.thread_ids_by_connection
+            .entry(connection_id)
+            .or_default()
+            .insert(thread_id);
+        let thread_state = self.thread_state(thread_id);
+        thread_state.lock().await.add_connection(connection_id);
         thread_state
+    }
+
+    pub(crate) async fn remove_connection(&mut self, connection_id: ConnectionId) {
+        let Some(thread_ids) = self.thread_ids_by_connection.remove(&connection_id) else {
+            return;
+        };
+        for thread_id in thread_ids {
+            if let Some(thread_state) = self.thread_states.get(&thread_id) {
+                thread_state.lock().await.remove_connection(connection_id);
+            }
+        }
     }
 }

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -132,13 +132,9 @@ impl ThreadStateManager {
             }
         }
 
-        let has_remaining_subscriptions = self
-            .subscription_state_by_id
-            .values()
-            .any(|state| state.thread_id == thread_id);
         if let Some(thread_state) = self.thread_states.get(&thread_id) {
             let mut thread_state = thread_state.lock().await;
-            if !has_remaining_subscriptions {
+            if thread_state.subscribed_connection_ids().is_empty() {
                 thread_state.clear_listener();
             }
         }
@@ -214,13 +210,9 @@ impl ThreadStateManager {
 
         for thread_id in thread_ids {
             if let Some(thread_state) = self.thread_states.get(&thread_id) {
-                let has_remaining_subscriptions = self
-                    .subscription_state_by_id
-                    .values()
-                    .any(|state| state.thread_id == thread_id);
                 let mut thread_state = thread_state.lock().await;
                 thread_state.remove_connection(connection_id);
-                if !has_remaining_subscriptions {
+                if thread_state.subscribed_connection_ids().is_empty() {
                     thread_state.clear_listener();
                 }
             }

--- a/codex-rs/app-server/src/thread_state.rs
+++ b/codex-rs/app-server/src/thread_state.rs
@@ -84,12 +84,6 @@ impl ThreadStateManager {
         Self::default()
     }
 
-    pub(crate) fn has_listener_for_thread(&self, thread_id: ThreadId) -> bool {
-        self.thread_id_by_subscription
-            .values()
-            .any(|existing| *existing == thread_id)
-    }
-
     pub(crate) fn thread_state(&mut self, thread_id: ThreadId) -> Arc<Mutex<ThreadState>> {
         self.thread_states
             .entry(thread_id)


### PR DESCRIPTION
This stack layer makes app-server thread event delivery connection-aware so resumed/attached threads only emit notifications and approval prompts to subscribed connections.

- Added per-thread subscription tracking in `ThreadState` (`subscribed_connections`) and mapped subscription ids to `(thread_id, connection_id)`.
- Updated listener lifecycle so removing a subscription or closing a connection only removes that connection from the thread’s subscriber set; listener shutdown now happens when the last subscriber is gone.
- Added `connection_closed(connection_id)` plumbing (`lib.rs` -> `message_processor.rs` -> `codex_message_processor.rs`) so disconnect cleanup happens immediately.
- Scoped bespoke event handling outputs through `TargetedOutgoing` to send requests/notifications only to subscribed connections.
- Kept existing threadresume behavior while aligning with the latest split-loop transport structure.
