### PR TITLE
feat: split SDKs by target for NPM

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -601,6 +601,9 @@ jobs:
             "codex-npm-win32-*-${version}.tgz"
             "codex-responses-api-proxy-npm-${version}.tgz"
             "codex-sdk-npm-${version}.tgz"
+            "codex-sdk-npm-linux-*-${version}.tgz"
+            "codex-sdk-npm-darwin-*-${version}.tgz"
+            "codex-sdk-npm-win32-*-${version}.tgz"
           )
           for pattern in "${patterns[@]}"; do
             gh release download "$tag" \
@@ -635,6 +638,11 @@ jobs:
             case "${filename}" in
               codex-npm-linux-*-"${VERSION}".tgz|codex-npm-darwin-*-"${VERSION}".tgz|codex-npm-win32-*-"${VERSION}".tgz)
                 platform="${filename#codex-npm-}"
+                platform="${platform%-${VERSION}.tgz}"
+                tag="${prefix}${platform}"
+                ;;
+              codex-sdk-npm-linux-*-"${VERSION}".tgz|codex-sdk-npm-darwin-*-"${VERSION}".tgz|codex-sdk-npm-win32-*-"${VERSION}".tgz)
+                platform="${filename#codex-sdk-npm-}"
                 platform="${platform%-${VERSION}.tgz}"
                 tag="${prefix}${platform}"
                 ;;

--- a/codex-cli/scripts/README.md
+++ b/codex-cli/scripts/README.md
@@ -18,6 +18,11 @@ When `--package codex` is provided, the staging helper builds the lightweight
 `@openai/codex` meta package plus all platform-native `@openai/codex` variants
 that are later published under platform-specific dist-tags.
 
+When `--package codex-sdk` is provided, the staging helper now follows the same
+pattern: it builds a lightweight `@openai/codex-sdk` meta package plus
+platform-native `@openai/codex-sdk` variants published under platform-specific
+dist-tags.
+
 If you need to invoke `build_npm_package.py` directly, run
 `codex-cli/scripts/install_native_deps.py` first and pass `--vendor-src` pointing to the
 directory that contains the populated `vendor/` tree.

--- a/scripts/stage_npm_packages.py
+++ b/scripts/stage_npm_packages.py
@@ -27,6 +27,7 @@ _SPEC.loader.exec_module(_BUILD_MODULE)
 PACKAGE_NATIVE_COMPONENTS = getattr(_BUILD_MODULE, "PACKAGE_NATIVE_COMPONENTS", {})
 PACKAGE_EXPANSIONS = getattr(_BUILD_MODULE, "PACKAGE_EXPANSIONS", {})
 CODEX_PLATFORM_PACKAGES = getattr(_BUILD_MODULE, "CODEX_PLATFORM_PACKAGES", {})
+CODEX_SDK_PLATFORM_PACKAGES = getattr(_BUILD_MODULE, "CODEX_SDK_PLATFORM_PACKAGES", {})
 
 
 def parse_args() -> argparse.Namespace:
@@ -134,6 +135,9 @@ def tarball_name_for_package(package: str, version: str) -> str:
     if package in CODEX_PLATFORM_PACKAGES:
         platform = package.removeprefix("codex-")
         return f"codex-npm-{platform}-{version}.tgz"
+    if package in CODEX_SDK_PLATFORM_PACKAGES:
+        platform = package.removeprefix("codex-sdk-")
+        return f"codex-sdk-npm-{platform}-{version}.tgz"
     return f"{package}-npm-{version}.tgz"
 
 

--- a/sdk/typescript/README.md
+++ b/sdk/typescript/README.md
@@ -11,6 +11,7 @@ npm install @openai/codex-sdk
 ```
 
 Requires Node.js 18+.
+The package installs a platform-specific native Codex binary via optional dependencies.
 
 ## Quickstart
 


### PR DESCRIPTION
Description

## Why

@openai/codex-sdk publish was failing in release with:

npm ERR! E413 Payload Too Large

The SDK tarball currently bundles binaries for all platforms, which pushes the package over npm’s payload
limits.

## What changed

1. Implemented CLI-style packaging for SDK: one lightweight meta package plus platform-specific native tarballs.
2. Added SDK platform package variants in the staging/build tooling:
  - codex-sdk-linux-x64
  - codex-sdk-linux-arm64
  - codex-sdk-darwin-x64
  - codex-sdk-darwin-arm64
  - codex-sdk-win32-x64
  - codex-sdk-win32-arm64
3. Updated codex-sdk meta package generation:
  - keeps JS/TS output (dist) only
  - adds optionalDependencies pointing to platform-specific SDK variants via npm aliasing.
4. Updated SDK runtime binary resolution to match the new layout:
  - resolve platform package via require.resolve(...)
  - fallback to local vendor/ when present (dev/back-compat path).
5. Updated release pipeline publish logic:
  - download and publish new codex-sdk-npm-<platform>-<version>.tgz artifacts
  - publish them with platform tags (including alpha-prefixed tags for prereleases), matching existing CLI behavior.
6. Updated docs for staging flow and SDK install behavior.

## Expected impact

1. @openai/codex-sdk main tarball is much smaller (no multi-platform vendor payload).
2. npm publish no longer hits payload limits.
3. Consumers install only the binary for their platform.
4. No SDK API surface changes.

## Validation

1. pnpm --filter @openai/codex-sdk run build passed.
2. pnpm --filter @openai/codex-sdk run lint passed.
3. pnpm --filter @openai/codex-sdk exec jest tests/exec.test.ts passed.
4. Python staging scripts compile (py_compile) passed.
5. Full SDK Jest suite could not run in this sandbox due to listen EPERM 127.0.0.1 restrictions.