### PR TITLE
Add experimental Companion web UI for Codex

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ You can also use Codex with an API key, but this requires [additional setup](htt
 - [**Codex Documentation**](https://developers.openai.com/codex)
 - [**Contributing**](./docs/contributing.md)
 - [**Installing & building**](./docs/install.md)
+- [**Companion Web UI**](./docs/companion.md)
 - [**Open source fund**](./docs/open-source-fund.md)
 
 This repository is licensed under the [Apache-2.0 License](LICENSE).

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -805,6 +805,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -823,8 +824,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1513,6 +1516,7 @@ dependencies = [
  "codex-chatgpt",
  "codex-cloud-tasks",
  "codex-common",
+ "codex-companion",
  "codex-core",
  "codex-exec",
  "codex-execpolicy",
@@ -1636,6 +1640,27 @@ dependencies = [
  "pretty_assertions",
  "serde",
  "toml 0.9.11+spec-1.1.0",
+]
+
+[[package]]
+name = "codex-companion"
+version = "0.0.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "base64 0.22.1",
+ "futures",
+ "include_dir",
+ "mime_guess",
+ "pretty_assertions",
+ "rand 0.9.2",
+ "reqwest",
+ "serde",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "url",
+ "urlencoding",
 ]
 
 [[package]]

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -15,6 +15,7 @@ members = [
     "cloud-tasks",
     "cloud-tasks-client",
     "cli",
+    "companion",
     "common",
     "core",
     "hooks",
@@ -80,6 +81,7 @@ codex-backend-client = { path = "backend-client" }
 codex-cloud-requirements = { path = "cloud-requirements" }
 codex-chatgpt = { path = "chatgpt" }
 codex-cli = { path = "cli"}
+codex-companion = { path = "companion" }
 codex-client = { path = "codex-client" }
 codex-common = { path = "common" }
 codex-core = { path = "core" }

--- a/codex-rs/cli/Cargo.toml
+++ b/codex-rs/cli/Cargo.toml
@@ -26,6 +26,7 @@ codex-arg0 = { workspace = true }
 codex-chatgpt = { workspace = true }
 codex-cloud-tasks = { path = "../cloud-tasks" }
 codex-common = { workspace = true, features = ["cli"] }
+codex-companion = { workspace = true }
 codex-core = { workspace = true }
 codex-exec = { workspace = true }
 codex-execpolicy = { workspace = true }

--- a/codex-rs/companion/Cargo.toml
+++ b/codex-rs/companion/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "codex-companion"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[lib]
+name = "codex_companion"
+path = "src/lib.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { workspace = true, default-features = false, features = ["http1", "query", "tokio", "ws"] }
+base64 = { workspace = true }
+futures = { workspace = true }
+include_dir = { workspace = true }
+mime_guess = { workspace = true }
+rand = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+tokio = { workspace = true, features = ["io-util", "macros", "net", "process", "rt-multi-thread", "signal"] }
+tracing = { workspace = true }
+url = { workspace = true }
+urlencoding = { workspace = true }
+
+[dev-dependencies]
+pretty_assertions = { workspace = true }
+reqwest = { workspace = true }
+tokio-tungstenite = { workspace = true }

--- a/codex-rs/companion/src/lib.rs
+++ b/codex-rs/companion/src/lib.rs
@@ -1,0 +1,569 @@
+use anyhow::Context as _;
+use axum::Router;
+use axum::body::Body;
+use axum::extract::Path;
+use axum::extract::Query;
+use axum::extract::State;
+use axum::extract::ws::Message as WsMessage;
+use axum::extract::ws::WebSocket;
+use axum::extract::ws::WebSocketUpgrade;
+use axum::http::HeaderValue;
+use axum::http::StatusCode;
+use axum::http::header::CONTENT_TYPE;
+use axum::response::Html;
+use axum::response::IntoResponse as _;
+use axum::response::Response;
+use axum::routing::get;
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use futures::SinkExt as _;
+use futures::StreamExt as _;
+use include_dir::Dir;
+use rand::RngCore as _;
+use serde::Deserialize;
+use std::net::IpAddr;
+use std::net::Ipv4Addr;
+use std::net::SocketAddr;
+use std::path::PathBuf;
+use std::process::Stdio;
+use std::sync::Arc;
+use tokio::io::AsyncBufReadExt as _;
+use tokio::io::AsyncWriteExt as _;
+use tokio::io::BufReader;
+use tokio::process::Child;
+use tokio::process::Command;
+use tokio::sync::Semaphore;
+use tokio::sync::broadcast;
+use tokio::sync::mpsc;
+use tokio::sync::watch;
+use tracing::debug;
+use tracing::info;
+use tracing::warn;
+use url::Url;
+
+static UI_DIST: Dir = include_dir::include_dir!("$CARGO_MANIFEST_DIR/ui/dist");
+
+#[derive(Debug, Clone)]
+pub struct CompanionOptions {
+    /// Port to bind on localhost. Use 0 to pick an ephemeral port.
+    pub port: u16,
+    /// When true, attempt to open a browser to the Companion URL.
+    pub open_browser: bool,
+    /// Optional UI URL used for local frontend development with HMR.
+    pub ui_dev_url: Option<String>,
+    /// Raw `-c key=value` overrides to forward to the spawned `codex app-server` process.
+    pub config_overrides: Vec<String>,
+    /// Optional initial prompt to pass through to the web UI.
+    pub initial_prompt: Option<String>,
+}
+
+impl CompanionOptions {
+    pub fn new(
+        port: u16,
+        open_browser: bool,
+        ui_dev_url: Option<String>,
+        config_overrides: Vec<String>,
+        initial_prompt: Option<String>,
+    ) -> Self {
+        Self {
+            port,
+            open_browser,
+            ui_dev_url,
+            config_overrides,
+            initial_prompt,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct AppState {
+    token: String,
+    stdout_tx: broadcast::Sender<String>,
+    stdin_tx: mpsc::Sender<String>,
+    ws_slots: Arc<Semaphore>,
+}
+
+#[derive(Deserialize)]
+struct TokenQuery {
+    token: Option<String>,
+}
+
+async fn ui_index(Query(q): Query<TokenQuery>, State(state): State<Arc<AppState>>) -> Response {
+    if q.token.as_deref() != Some(state.token.as_str()) {
+        return (StatusCode::UNAUTHORIZED, "Missing or invalid token.\n").into_response();
+    }
+
+    let Some(file) = UI_DIST.get_file("index.html") else {
+        return (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            "Missing embedded UI assets.\n",
+        )
+            .into_response();
+    };
+
+    let html = match std::str::from_utf8(file.contents()) {
+        Ok(v) => v,
+        Err(_) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Embedded UI is not valid UTF-8.\n",
+            )
+                .into_response();
+        }
+    };
+
+    let mut resp = Html(html).into_response();
+    resp.headers_mut().insert(
+        axum::http::header::CACHE_CONTROL,
+        HeaderValue::from_static("no-store"),
+    );
+    resp
+}
+
+fn asset_response(path: &str, cache_control: &'static str) -> Response {
+    let Some(file) = UI_DIST.get_file(path) else {
+        return (StatusCode::NOT_FOUND, "Asset not found.\n").into_response();
+    };
+
+    let mime = mime_guess::from_path(path).first_or_octet_stream();
+    let mut response = Response::new(Body::from(file.contents().to_vec()));
+    *response.status_mut() = StatusCode::OK;
+    response.headers_mut().insert(
+        CONTENT_TYPE,
+        HeaderValue::from_str(mime.as_ref())
+            .unwrap_or_else(|_| HeaderValue::from_static("application/octet-stream")),
+    );
+    response.headers_mut().insert(
+        axum::http::header::CACHE_CONTROL,
+        HeaderValue::from_static(cache_control),
+    );
+    response
+}
+
+async fn ui_assets(Path(path): Path<String>) -> Response {
+    if path.is_empty() || path.contains("..") {
+        return (StatusCode::BAD_REQUEST, "Invalid asset path.\n").into_response();
+    }
+
+    let normalized = format!("assets/{path}");
+    asset_response(&normalized, "public, max-age=31536000, immutable")
+}
+
+async fn ws_route(
+    Query(q): Query<TokenQuery>,
+    State(state): State<Arc<AppState>>,
+    ws: WebSocketUpgrade,
+) -> Response {
+    if q.token.as_deref() != Some(state.token.as_str()) {
+        return (StatusCode::UNAUTHORIZED, "Missing or invalid token.\n").into_response();
+    }
+
+    let Ok(permit) = state.ws_slots.clone().try_acquire_owned() else {
+        return (StatusCode::CONFLICT, "Only one client is supported.\n").into_response();
+    };
+
+    ws.on_upgrade(move |socket| handle_ws(socket, state, permit))
+        .into_response()
+}
+
+async fn handle_ws(
+    socket: WebSocket,
+    state: Arc<AppState>,
+    _permit: tokio::sync::OwnedSemaphorePermit,
+) {
+    let (mut ws_tx, mut ws_rx) = socket.split();
+
+    let mut app_stdout = state.stdout_tx.subscribe();
+    let stdout_fwd = tokio::spawn(async move {
+        loop {
+            match app_stdout.recv().await {
+                Ok(line) => {
+                    if ws_tx.send(WsMessage::Text(line.into())).await.is_err() {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                    debug!("companion: lagged websocket receiver (skipped {skipped} messages)");
+                    continue;
+                }
+                Err(broadcast::error::RecvError::Closed) => break,
+            }
+        }
+    });
+
+    while let Some(msg) = ws_rx.next().await {
+        let Ok(msg) = msg else {
+            break;
+        };
+        match msg {
+            WsMessage::Text(text) => {
+                if state.stdin_tx.send(text.to_string()).await.is_err() {
+                    break;
+                }
+            }
+            WsMessage::Close(_) => break,
+            WsMessage::Ping(_) => {}
+            _ => {}
+        }
+    }
+
+    stdout_fwd.abort();
+}
+
+fn generate_token() -> String {
+    let mut bytes = [0u8; 24];
+    rand::rng().fill_bytes(&mut bytes);
+    URL_SAFE_NO_PAD.encode(bytes)
+}
+
+fn build_backend_origin(addr: SocketAddr) -> String {
+    format!("http://127.0.0.1:{}", addr.port())
+}
+
+fn build_browser_url(
+    addr: SocketAddr,
+    token: &str,
+    initial_prompt: Option<&str>,
+    ui_dev_url: Option<&str>,
+) -> anyhow::Result<String> {
+    let backend_origin = build_backend_origin(addr);
+
+    let mut url = match ui_dev_url {
+        Some(dev_url) => Url::parse(dev_url)
+            .with_context(|| format!("invalid --companion-ui-dev-url: {dev_url}"))?,
+        None => Url::parse(&backend_origin)?,
+    };
+    {
+        let mut qp = url.query_pairs_mut();
+        qp.append_pair("token", token);
+        if ui_dev_url.is_some() {
+            qp.append_pair("backend", &backend_origin);
+        }
+        if let Some(prompt) = initial_prompt
+            && !prompt.trim().is_empty()
+        {
+            qp.append_pair("prompt", prompt);
+        }
+    }
+    Ok(url.into())
+}
+
+async fn try_open_browser(url: &str) -> anyhow::Result<()> {
+    let mut cmd = if cfg!(target_os = "macos") {
+        let mut cmd = Command::new("open");
+        cmd.arg(url);
+        cmd
+    } else if cfg!(windows) {
+        // `start` is a cmd.exe builtin; the empty title avoids treating the URL as the title.
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", "start", "", url]);
+        cmd
+    } else {
+        let mut cmd = Command::new("xdg-open");
+        cmd.arg(url);
+        cmd
+    };
+
+    let status = cmd
+        .status()
+        .await
+        .context("failed to spawn browser opener")?;
+    if status.success() {
+        Ok(())
+    } else {
+        anyhow::bail!("browser opener exited with status {status}");
+    }
+}
+
+struct RunningCompanion {
+    addr: SocketAddr,
+    token: String,
+    shutdown_tx: watch::Sender<bool>,
+    child: Child,
+    server_task: tokio::task::JoinHandle<anyhow::Result<()>>,
+    io_tasks: Vec<tokio::task::JoinHandle<()>>,
+}
+
+impl RunningCompanion {
+    async fn shutdown(mut self) -> anyhow::Result<()> {
+        let _ = self.shutdown_tx.send(true);
+
+        if let Err(err) = self.child.kill().await {
+            debug!("companion: failed to kill app-server child: {err}");
+        }
+        let _ = self.child.wait().await;
+
+        for task in self.io_tasks {
+            task.abort();
+        }
+        self.server_task.abort();
+
+        Ok(())
+    }
+}
+
+async fn start_companion(
+    options: &CompanionOptions,
+    child_program: PathBuf,
+    child_args: Vec<String>,
+) -> anyhow::Result<RunningCompanion> {
+    let token = generate_token();
+
+    let (stdout_tx, _stdout_rx) = broadcast::channel::<String>(512);
+    let (stdin_tx, mut stdin_rx) = mpsc::channel::<String>(256);
+    let ws_slots = Arc::new(Semaphore::new(1));
+
+    let state = Arc::new(AppState {
+        token: token.clone(),
+        stdout_tx: stdout_tx.clone(),
+        stdin_tx: stdin_tx.clone(),
+        ws_slots,
+    });
+
+    let listener = tokio::net::TcpListener::bind(SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::LOCALHOST),
+        options.port,
+    ))
+    .await
+    .context("failed to bind companion listener")?;
+    let addr = listener.local_addr().context("failed to read local addr")?;
+
+    let (shutdown_tx, shutdown_rx) = watch::channel(false);
+
+    // Spawn the app-server child.
+    let mut child_cmd = Command::new(&child_program);
+    child_cmd.args(&child_args);
+    child_cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = child_cmd.spawn().context("failed to spawn app-server")?;
+    let child_stdin = child.stdin.take().context("app-server stdin unavailable")?;
+    let child_stdout = child
+        .stdout
+        .take()
+        .context("app-server stdout unavailable")?;
+    let child_stderr = child
+        .stderr
+        .take()
+        .context("app-server stderr unavailable")?;
+
+    let mut io_tasks = Vec::new();
+
+    // Task: forward WS -> child stdin.
+    io_tasks.push(tokio::spawn({
+        let mut shutdown_rx = shutdown_rx.clone();
+        async move {
+            let mut stdin = child_stdin;
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx.changed() => break,
+                    msg = stdin_rx.recv() => {
+                        let Some(msg) = msg else { break };
+                        if stdin.write_all(msg.as_bytes()).await.is_err() { break; }
+                        if stdin.write_all(b"\n").await.is_err() { break; }
+                        let _ = stdin.flush().await;
+                    }
+                }
+            }
+        }
+    }));
+
+    // Task: forward child stdout -> WS broadcast.
+    io_tasks.push(tokio::spawn({
+        let mut shutdown_rx = shutdown_rx.clone();
+        let stdout_tx = stdout_tx.clone();
+        async move {
+            let mut lines = BufReader::new(child_stdout).lines();
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx.changed() => break,
+                    next = lines.next_line() => {
+                        let Ok(Some(line)) = next else { break };
+                        let _ = stdout_tx.send(line);
+                    }
+                }
+            }
+        }
+    }));
+
+    // Task: log child stderr.
+    io_tasks.push(tokio::spawn({
+        let mut shutdown_rx = shutdown_rx.clone();
+        async move {
+            let mut lines = BufReader::new(child_stderr).lines();
+            loop {
+                tokio::select! {
+                    _ = shutdown_rx.changed() => break,
+                    next = lines.next_line() => {
+                        let Ok(Some(line)) = next else { break };
+                        warn!("app-server: {line}");
+                    }
+                }
+            }
+        }
+    }));
+
+    let app = Router::new()
+        .route("/", get(ui_index))
+        .route("/assets/{*path}", get(ui_assets))
+        .route("/ws", get(ws_route))
+        .with_state(state);
+
+    let server_task = tokio::spawn({
+        let mut shutdown_rx = shutdown_rx;
+        async move {
+            info!("companion listening on http://{}", addr);
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = shutdown_rx.changed().await;
+                })
+                .await
+                .context("companion http server failed")?;
+            Ok(())
+        }
+    });
+
+    Ok(RunningCompanion {
+        addr,
+        token,
+        shutdown_tx,
+        child,
+        server_task,
+        io_tasks,
+    })
+}
+
+/// Run the Codex Companion server and block until Ctrl-C.
+///
+/// This will:
+/// - Spawn `codex app-server`
+/// - Host a local web UI on `127.0.0.1`
+/// - Bridge app-server JSON-RPC JSONL over a WebSocket
+pub async fn run(options: CompanionOptions) -> anyhow::Result<()> {
+    let codex_exe = std::env::current_exe().context("failed to resolve current executable")?;
+
+    // Spawn `codex app-server` via the same binary, forwarding root `-c` overrides.
+    let mut child_args = vec!["app-server".to_string()];
+    for ov in &options.config_overrides {
+        child_args.push("-c".to_string());
+        child_args.push(ov.clone());
+    }
+
+    let running = start_companion(&options, codex_exe, child_args).await?;
+
+    let url = build_browser_url(
+        running.addr,
+        &running.token,
+        options.initial_prompt.as_deref(),
+        options.ui_dev_url.as_deref(),
+    )?;
+    println!("Companion: {url}");
+    if options.open_browser
+        && let Err(err) = try_open_browser(&url).await
+    {
+        eprintln!("warning: failed to open browser: {err}");
+    }
+
+    tokio::signal::ctrl_c()
+        .await
+        .context("failed to install Ctrl-C handler")?;
+
+    running.shutdown().await?;
+    Ok(())
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[tokio::test]
+    async fn companion_requires_token_for_index() {
+        let opts = CompanionOptions::new(0, false, None, Vec::new(), None);
+        let running = start_companion(
+            &opts,
+            // Spawn a long-lived child that does nothing meaningful; we will kill it in shutdown.
+            PathBuf::from("sh"),
+            vec!["-c".to_string(), "cat >/dev/null".to_string()],
+        )
+        .await
+        .expect("start companion");
+
+        let url = format!("http://127.0.0.1:{}/", running.addr.port());
+        let resp = reqwest::get(url).await.expect("request");
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        running.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn websocket_rejects_missing_token() {
+        let opts = CompanionOptions::new(0, false, None, Vec::new(), None);
+        let running = start_companion(
+            &opts,
+            PathBuf::from("sh"),
+            vec!["-c".to_string(), "cat >/dev/null".to_string()],
+        )
+        .await
+        .expect("start companion");
+
+        let ws_url = format!("ws://127.0.0.1:{}/ws", running.addr.port());
+        let res = tokio_tungstenite::connect_async(ws_url).await;
+        assert!(res.is_err(), "expected connect to fail without token");
+
+        running.shutdown().await.expect("shutdown");
+    }
+
+    #[tokio::test]
+    async fn websocket_accepts_token_and_bridges_echo() {
+        let opts = CompanionOptions::new(0, false, None, Vec::new(), None);
+        let running = start_companion(
+            &opts,
+            PathBuf::from("sh"),
+            vec!["-c".to_string(), "cat".to_string()],
+        )
+        .await
+        .expect("start companion");
+
+        let ws_url = format!(
+            "ws://127.0.0.1:{}/ws?token={}",
+            running.addr.port(),
+            running.token
+        );
+        let (mut ws, _resp) = tokio_tungstenite::connect_async(ws_url)
+            .await
+            .expect("connect");
+
+        ws.send(tokio_tungstenite::tungstenite::Message::Text(
+            "{\"hello\":\"world\"}".to_string().into(),
+        ))
+        .await
+        .expect("send");
+
+        let msg = ws.next().await.expect("ws msg").expect("ws ok");
+        let tokio_tungstenite::tungstenite::Message::Text(line) = msg else {
+            panic!("expected text message");
+        };
+        assert_eq!(line, "{\"hello\":\"world\"}");
+
+        running.shutdown().await.expect("shutdown");
+    }
+
+    #[test]
+    fn build_browser_url_points_to_dev_ui_when_configured() {
+        let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 4321);
+        let url = build_browser_url(
+            addr,
+            "token-123",
+            Some("hello world"),
+            Some("http://127.0.0.1:5173"),
+        )
+        .expect("build browser url");
+        assert_eq!(
+            url,
+            "http://127.0.0.1:5173/?token=token-123&backend=http%3A%2F%2F127.0.0.1%3A4321&prompt=hello+world"
+        );
+    }
+}

--- a/codex-rs/companion/ui/index.html
+++ b/codex-rs/companion/ui/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Codex Companion</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/codex-rs/companion/ui/package.json
+++ b/codex-rs/companion/ui/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "codex-companion-ui",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "dompurify": "^3.2.6",
+    "marked": "^16.4.1",
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.12",
+    "@types/react-dom": "^19.1.9",
+    "@vitejs/plugin-react": "^5.0.4",
+    "typescript": "^5.9.2",
+    "vite": "^7.1.7"
+  },
+  "engines": {
+    "node": ">=22"
+  }
+}

--- a/codex-rs/companion/ui/pnpm-lock.yaml
+++ b/codex-rs/companion/ui/pnpm-lock.yaml
@@ -1,0 +1,1145 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      dompurify:
+        specifier: ^3.2.6
+        version: 3.3.1
+      marked:
+        specifier: ^16.4.1
+        version: 16.4.2
+      react:
+        specifier: ^19.1.1
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.1.1
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.1.12
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.1.9
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^5.0.4
+        version: 5.1.4(vite@7.3.1)
+      typescript:
+        specifier: ^5.9.2
+        version: 5.9.3
+      vite:
+        specifier: ^7.1.7
+        version: 7.3.1
+
+packages:
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/compat-data@7.29.0':
+    resolution: {integrity: sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/core@7.29.0':
+    resolution: {integrity: sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/generator@7.29.1':
+    resolution: {integrity: sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-compilation-targets@7.28.6':
+    resolution: {integrity: sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-globals@7.28.0':
+    resolution: {integrity: sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-imports@7.28.6':
+    resolution: {integrity: sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-module-transforms@7.28.6':
+    resolution: {integrity: sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0
+
+  '@babel/helper-plugin-utils@7.28.6':
+    resolution: {integrity: sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-option@7.27.1':
+    resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helpers@7.28.6':
+    resolution: {integrity: sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1':
+    resolution: {integrity: sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1':
+    resolution: {integrity: sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==}
+    engines: {node: '>=6.9.0'}
+    peerDependencies:
+      '@babel/core': ^7.0.0-0
+
+  '@babel/template@7.28.6':
+    resolution: {integrity: sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.29.0':
+    resolution: {integrity: sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@esbuild/aix-ppc64@0.27.3':
+    resolution: {integrity: sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.27.3':
+    resolution: {integrity: sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.3':
+    resolution: {integrity: sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.3':
+    resolution: {integrity: sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.27.3':
+    resolution: {integrity: sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.3':
+    resolution: {integrity: sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    resolution: {integrity: sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.3':
+    resolution: {integrity: sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.27.3':
+    resolution: {integrity: sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.3':
+    resolution: {integrity: sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.27.3':
+    resolution: {integrity: sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.3':
+    resolution: {integrity: sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.27.3':
+    resolution: {integrity: sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.3':
+    resolution: {integrity: sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.27.3':
+    resolution: {integrity: sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.3':
+    resolution: {integrity: sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.27.3':
+    resolution: {integrity: sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.3':
+    resolution: {integrity: sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    resolution: {integrity: sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.3':
+    resolution: {integrity: sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    resolution: {integrity: sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.3':
+    resolution: {integrity: sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.27.3':
+    resolution: {integrity: sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.27.3':
+    resolution: {integrity: sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.3':
+    resolution: {integrity: sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/remapping@2.3.5':
+    resolution: {integrity: sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@rolldown/pluginutils@1.0.0-rc.3':
+    resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    resolution: {integrity: sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    resolution: {integrity: sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    resolution: {integrity: sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    resolution: {integrity: sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    resolution: {integrity: sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    resolution: {integrity: sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
+    cpu: [loong64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    resolution: {integrity: sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    resolution: {integrity: sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    resolution: {integrity: sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    resolution: {integrity: sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    resolution: {integrity: sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==}
+    cpu: [x64]
+    os: [win32]
+
+  '@types/babel__core@7.20.5':
+    resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
+
+  '@types/babel__generator@7.27.0':
+    resolution: {integrity: sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==}
+
+  '@types/babel__template@7.4.4':
+    resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
+
+  '@types/babel__traverse@7.28.0':
+    resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
+  '@vitejs/plugin-react@5.1.4':
+    resolution: {integrity: sha512-VIcFLdRi/VYRU8OL/puL7QXMYafHmqOnwTZY50U1JPlCNj30PxCMx65c494b1K9be9hX83KVt0+gTEwTWLqToA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      vite: ^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0
+
+  baseline-browser-mapping@2.9.19:
+    resolution: {integrity: sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==}
+    hasBin: true
+
+  browserslist@4.28.1:
+    resolution: {integrity: sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  caniuse-lite@1.0.30001769:
+    resolution: {integrity: sha512-BCfFL1sHijQlBGWBMuJyhZUhzo7wer5sVj9hqekB/7xn0Ypy+pER/edCYQm4exbXj4WiySGp40P8UuTh6w1srg==}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  dompurify@3.3.1:
+    resolution: {integrity: sha512-qkdCKzLNtrgPFP1Vo+98FRzJnBRGe4ffyCea9IwHB1fyxPOeNTHpLKYGd4Uk9xvNoH0ZoOjwZxNptyMwqrId1Q==}
+
+  electron-to-chromium@1.5.286:
+    resolution: {integrity: sha512-9tfDXhJ4RKFNerfjdCcZfufu49vg620741MNs26a9+bhLThdB+plgMeou98CAaHu/WATj2iHOOHTp1hWtABj2A==}
+
+  esbuild@0.27.3:
+    resolution: {integrity: sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  gensync@1.0.0-beta.2:
+    resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
+    engines: {node: '>=6.9.0'}
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  jsesc@3.1.0:
+    resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  json5@2.2.3:
+    resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
+    engines: {node: '>=6'}
+    hasBin: true
+
+  lru-cache@5.1.1:
+    resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  nanoid@3.3.11:
+    resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  node-releases@2.0.27:
+    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@4.0.3:
+    resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
+    engines: {node: '>=12'}
+
+  postcss@8.5.6:
+    resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  react-dom@19.2.4:
+    resolution: {integrity: sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==}
+    peerDependencies:
+      react: ^19.2.4
+
+  react-refresh@0.18.0:
+    resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.4:
+    resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
+    engines: {node: '>=0.10.0'}
+
+  rollup@4.57.1:
+    resolution: {integrity: sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  tinyglobby@0.2.15:
+    resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
+    engines: {node: '>=12.0.0'}
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  vite@7.3.1:
+    resolution: {integrity: sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      lightningcss: ^1.21.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  yallist@3.1.1:
+    resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+snapshots:
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/compat-data@7.29.0': {}
+
+  '@babel/core@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-compilation-targets': 7.28.6
+      '@babel/helper-module-transforms': 7.28.6(@babel/core@7.29.0)
+      '@babel/helpers': 7.28.6
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/remapping': 2.3.5
+      convert-source-map: 2.0.0
+      debug: 4.4.3
+      gensync: 1.0.0-beta.2
+      json5: 2.2.3
+      semver: 6.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/generator@7.29.1':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+      jsesc: 3.1.0
+
+  '@babel/helper-compilation-targets@7.28.6':
+    dependencies:
+      '@babel/compat-data': 7.29.0
+      '@babel/helper-validator-option': 7.27.1
+      browserslist: 4.28.1
+      lru-cache: 5.1.1
+      semver: 6.3.1
+
+  '@babel/helper-globals@7.28.0': {}
+
+  '@babel/helper-module-imports@7.28.6':
+    dependencies:
+      '@babel/traverse': 7.29.0
+      '@babel/types': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-module-transforms@7.28.6(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-module-imports': 7.28.6
+      '@babel/helper-validator-identifier': 7.28.5
+      '@babel/traverse': 7.29.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/helper-plugin-utils@7.28.6': {}
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/helper-validator-option@7.27.1': {}
+
+  '@babel/helpers@7.28.6':
+    dependencies:
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/plugin-transform-react-jsx-self@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/plugin-transform-react-jsx-source@7.27.1(@babel/core@7.29.0)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/helper-plugin-utils': 7.28.6
+
+  '@babel/template@7.28.6':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+
+  '@babel/traverse@7.29.0':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/generator': 7.29.1
+      '@babel/helper-globals': 7.28.0
+      '@babel/parser': 7.29.0
+      '@babel/template': 7.28.6
+      '@babel/types': 7.29.0
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@esbuild/aix-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/android-arm@0.27.3':
+    optional: true
+
+  '@esbuild/android-x64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.27.3':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.27.3':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.3':
+    optional: true
+
+  '@esbuild/linux-x64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.27.3':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/sunos-x64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.3':
+    optional: true
+
+  '@esbuild/win32-ia32@0.27.3':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.3':
+    optional: true
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/remapping@2.3.5':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@rolldown/pluginutils@1.0.0-rc.3': {}
+
+  '@rollup/rollup-android-arm-eabi@4.57.1':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.57.1':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.57.1':
+    optional: true
+
+  '@types/babel__core@7.20.5':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      '@types/babel__generator': 7.27.0
+      '@types/babel__template': 7.4.4
+      '@types/babel__traverse': 7.28.0
+
+  '@types/babel__generator@7.27.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/babel__template@7.4.4':
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+
+  '@types/babel__traverse@7.28.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@types/estree@1.0.8': {}
+
+  '@types/react-dom@19.2.3(@types/react@19.2.14)':
+    dependencies:
+      '@types/react': 19.2.14
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
+
+  '@types/trusted-types@2.0.7':
+    optional: true
+
+  '@vitejs/plugin-react@5.1.4(vite@7.3.1)':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-rc.3
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 7.3.1
+    transitivePeerDependencies:
+      - supports-color
+
+  baseline-browser-mapping@2.9.19: {}
+
+  browserslist@4.28.1:
+    dependencies:
+      baseline-browser-mapping: 2.9.19
+      caniuse-lite: 1.0.30001769
+      electron-to-chromium: 1.5.286
+      node-releases: 2.0.27
+      update-browserslist-db: 1.2.3(browserslist@4.28.1)
+
+  caniuse-lite@1.0.30001769: {}
+
+  convert-source-map@2.0.0: {}
+
+  csstype@3.2.3: {}
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  dompurify@3.3.1:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
+  electron-to-chromium@1.5.286: {}
+
+  esbuild@0.27.3:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.3
+      '@esbuild/android-arm': 0.27.3
+      '@esbuild/android-arm64': 0.27.3
+      '@esbuild/android-x64': 0.27.3
+      '@esbuild/darwin-arm64': 0.27.3
+      '@esbuild/darwin-x64': 0.27.3
+      '@esbuild/freebsd-arm64': 0.27.3
+      '@esbuild/freebsd-x64': 0.27.3
+      '@esbuild/linux-arm': 0.27.3
+      '@esbuild/linux-arm64': 0.27.3
+      '@esbuild/linux-ia32': 0.27.3
+      '@esbuild/linux-loong64': 0.27.3
+      '@esbuild/linux-mips64el': 0.27.3
+      '@esbuild/linux-ppc64': 0.27.3
+      '@esbuild/linux-riscv64': 0.27.3
+      '@esbuild/linux-s390x': 0.27.3
+      '@esbuild/linux-x64': 0.27.3
+      '@esbuild/netbsd-arm64': 0.27.3
+      '@esbuild/netbsd-x64': 0.27.3
+      '@esbuild/openbsd-arm64': 0.27.3
+      '@esbuild/openbsd-x64': 0.27.3
+      '@esbuild/openharmony-arm64': 0.27.3
+      '@esbuild/sunos-x64': 0.27.3
+      '@esbuild/win32-arm64': 0.27.3
+      '@esbuild/win32-ia32': 0.27.3
+      '@esbuild/win32-x64': 0.27.3
+
+  escalade@3.2.0: {}
+
+  fdir@6.5.0(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fsevents@2.3.3:
+    optional: true
+
+  gensync@1.0.0-beta.2: {}
+
+  js-tokens@4.0.0: {}
+
+  jsesc@3.1.0: {}
+
+  json5@2.2.3: {}
+
+  lru-cache@5.1.1:
+    dependencies:
+      yallist: 3.1.1
+
+  marked@16.4.2: {}
+
+  ms@2.1.3: {}
+
+  nanoid@3.3.11: {}
+
+  node-releases@2.0.27: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@4.0.3: {}
+
+  postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  react-dom@19.2.4(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+      scheduler: 0.27.0
+
+  react-refresh@0.18.0: {}
+
+  react@19.2.4: {}
+
+  rollup@4.57.1:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.57.1
+      '@rollup/rollup-android-arm64': 4.57.1
+      '@rollup/rollup-darwin-arm64': 4.57.1
+      '@rollup/rollup-darwin-x64': 4.57.1
+      '@rollup/rollup-freebsd-arm64': 4.57.1
+      '@rollup/rollup-freebsd-x64': 4.57.1
+      '@rollup/rollup-linux-arm-gnueabihf': 4.57.1
+      '@rollup/rollup-linux-arm-musleabihf': 4.57.1
+      '@rollup/rollup-linux-arm64-gnu': 4.57.1
+      '@rollup/rollup-linux-arm64-musl': 4.57.1
+      '@rollup/rollup-linux-loong64-gnu': 4.57.1
+      '@rollup/rollup-linux-loong64-musl': 4.57.1
+      '@rollup/rollup-linux-ppc64-gnu': 4.57.1
+      '@rollup/rollup-linux-ppc64-musl': 4.57.1
+      '@rollup/rollup-linux-riscv64-gnu': 4.57.1
+      '@rollup/rollup-linux-riscv64-musl': 4.57.1
+      '@rollup/rollup-linux-s390x-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-gnu': 4.57.1
+      '@rollup/rollup-linux-x64-musl': 4.57.1
+      '@rollup/rollup-openbsd-x64': 4.57.1
+      '@rollup/rollup-openharmony-arm64': 4.57.1
+      '@rollup/rollup-win32-arm64-msvc': 4.57.1
+      '@rollup/rollup-win32-ia32-msvc': 4.57.1
+      '@rollup/rollup-win32-x64-gnu': 4.57.1
+      '@rollup/rollup-win32-x64-msvc': 4.57.1
+      fsevents: 2.3.3
+
+  scheduler@0.27.0: {}
+
+  semver@6.3.1: {}
+
+  source-map-js@1.2.1: {}
+
+  tinyglobby@0.2.15:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+
+  typescript@5.9.3: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.1):
+    dependencies:
+      browserslist: 4.28.1
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  vite@7.3.1:
+    dependencies:
+      esbuild: 0.27.3
+      fdir: 6.5.0(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.57.1
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  yallist@3.1.1: {}

--- a/codex-rs/companion/ui/src/App.tsx
+++ b/codex-rs/companion/ui/src/App.tsx
@@ -1,0 +1,888 @@
+import { useCallback, useEffect, useReducer, useRef } from "react";
+import { ChatFeed } from "./components/ChatFeed";
+import { Composer } from "./components/Composer";
+import { DevLogPanel } from "./components/DevLogPanel";
+import { Sidebar } from "./components/Sidebar";
+import { TopBar } from "./components/TopBar";
+import { normalizePreview, nowClock } from "./lib/time";
+import { appReducer, initialState } from "./state/reducer";
+import { JsonValue, TimelineEntry, ThreadSummary } from "./types";
+
+interface AppProps {
+  initialPrompt: string;
+  token: string;
+  backend: string | null;
+}
+
+interface PendingRequest {
+  method: string;
+  reject: (error: Error) => void;
+  resolve: (value: unknown) => void;
+}
+
+interface ThreadListPage {
+  nextCursor: string | null;
+  threads: ThreadSummary[];
+}
+
+function textContentFromUserInput(input: unknown): string {
+  if (!Array.isArray(input)) {
+    return "";
+  }
+
+  return input
+    .filter((value) => typeof value === "object" && value !== null && (value as { type?: string }).type === "text")
+    .map((value) => String((value as { text?: string }).text ?? ""))
+    .join("");
+}
+
+function timelineFromItem(item: Record<string, unknown>): TimelineEntry {
+  const itemId = String(item.id ?? "");
+  const type = String(item.type ?? "unknown");
+
+  if (type === "userMessage") {
+    return {
+      key: `item:${itemId}`,
+      kind: "user",
+      label: "User",
+      text: textContentFromUserInput(item.content),
+      status: itemId.length > 0 ? `item ${itemId}` : undefined,
+      createdAt: Date.now(),
+    };
+  }
+
+  if (type === "agentMessage") {
+    return {
+      key: `item:${itemId}`,
+      kind: "assistant",
+      label: "Assistant",
+      text: String(item.text ?? ""),
+      status: itemId.length > 0 ? `item ${itemId}` : undefined,
+      createdAt: Date.now(),
+    };
+  }
+
+  if (type === "reasoning") {
+    const summary = Array.isArray(item.summary) ? item.summary.join("\n") : "";
+    const content = Array.isArray(item.content) ? item.content.join("\n") : "";
+    return {
+      key: `item:${itemId}`,
+      kind: "reasoning",
+      label: "Reasoning",
+      text: summary || content || "",
+      status: itemId.length > 0 ? `item ${itemId}` : undefined,
+      createdAt: Date.now(),
+    };
+  }
+
+  if (type === "commandExecution") {
+    const status = String(item.status ?? "inProgress");
+    const command = String(item.command ?? "");
+    const cwd = String(item.cwd ?? "");
+    const output = String(item.aggregatedOutput ?? "");
+    return {
+      key: `item:${itemId}`,
+      kind: "command",
+      label: "Command",
+      text: `cwd: ${cwd}\ncmd: ${command}\n\n${output}`,
+      status,
+      createdAt: Date.now(),
+    };
+  }
+
+  if (type === "fileChange") {
+    const status = String(item.status ?? "inProgress");
+    const changes = Array.isArray(item.changes) ? item.changes : [];
+    const diff = changes
+      .map((change) => {
+        if (typeof change !== "object" || change === null) {
+          return "update";
+        }
+        const changeObj = change as { kind?: string; path?: string };
+        return `${changeObj.kind ?? "update"} ${changeObj.path ?? ""}`.trim();
+      })
+      .join("\n");
+
+    return {
+      key: `item:${itemId}`,
+      kind: "file-change",
+      label: "File change",
+      text: diff || "(no files listed)",
+      status,
+      createdAt: Date.now(),
+    };
+  }
+
+  if (type === "webSearch") {
+    return {
+      key: `item:${itemId}`,
+      kind: "notification",
+      label: "Web search",
+      text: String(item.query ?? ""),
+      status: "search",
+      createdAt: Date.now(),
+    };
+  }
+
+  if (type === "plan") {
+    return {
+      key: `item:${itemId}`,
+      kind: "notification",
+      label: "Plan",
+      text: String(item.text ?? ""),
+      status: "draft",
+      createdAt: Date.now(),
+    };
+  }
+
+  return {
+    key: `item:${itemId}`,
+    kind: "notification",
+    label: `Item:${type}`,
+    text: JSON.stringify(item),
+    createdAt: Date.now(),
+  };
+}
+
+function normalizeThreads(raw: unknown): ThreadSummary[] {
+  if (!Array.isArray(raw)) {
+    return [];
+  }
+
+  return raw
+    .map((item) => {
+      if (typeof item !== "object" || item === null) {
+        return null;
+      }
+      const thread = item as Record<string, unknown>;
+      const id = String(thread.id ?? "");
+      if (id.length === 0) {
+        return null;
+      }
+      const preview = normalizePreview(String(thread.preview ?? ""));
+      const title = preview.length > 0 ? preview : "Untitled session";
+      const updatedAtRaw = thread.updatedAt ?? thread.updated_at;
+      const updatedAt = typeof updatedAtRaw === "number" ? updatedAtRaw : undefined;
+      return {
+        id,
+        title,
+        preview,
+        searchText: `${title} ${preview}`.toLowerCase(),
+        updatedAt,
+      };
+    })
+    .filter((item): item is ThreadSummary => item !== null)
+    .sort((left, right) => (right.updatedAt ?? 0) - (left.updatedAt ?? 0));
+}
+
+function waitMs(ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+export function App({ initialPrompt, token, backend }: AppProps) {
+  const [state, dispatch] = useReducer(appReducer, initialState);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const nextRpcIdRef = useRef(1);
+  const nextLogIdRef = useRef(1);
+  const pendingRef = useRef<Map<number, PendingRequest>>(new Map());
+  const threadIdRef = useRef<string | null>(null);
+  const activeApprovalsRef = useRef<Record<number, true>>({});
+  const initialPromptSentRef = useRef(false);
+
+  useEffect(() => {
+    threadIdRef.current = state.threadId;
+  }, [state.threadId]);
+
+  useEffect(() => {
+    activeApprovalsRef.current = state.activeApprovals;
+  }, [state.activeApprovals]);
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = state.theme;
+  }, [state.theme]);
+
+  const appendLog = useCallback((direction: "in" | "out" | "info" | "error", value: unknown) => {
+    const text = typeof value === "string" ? value : JSON.stringify(value);
+    dispatch({
+      type: "append_log",
+      log: {
+        id: nextLogIdRef.current++,
+        direction,
+        at: Date.now(),
+        text,
+      },
+    });
+  }, []);
+
+  const appendSystem = useCallback(
+    (text: string, status: "ok" | "warn" | "error" = "ok") => {
+      dispatch({
+        type: "upsert_entry",
+        entry: {
+          key: `system:${Date.now()}:${Math.random().toString(16).slice(2)}`,
+          kind: status === "error" ? "notification" : "system",
+          label: status === "error" ? "Error" : "System",
+          text,
+          status,
+          meta: nowClock(),
+          createdAt: Date.now(),
+        },
+      });
+    },
+    [],
+  );
+
+  const rpcSend = useCallback(
+    (payload: Record<string, JsonValue>) => {
+      const socket = wsRef.current;
+      if (!socket || socket.readyState !== WebSocket.OPEN) {
+        throw new Error("WebSocket not connected");
+      }
+      appendLog("out", payload);
+      socket.send(JSON.stringify(payload));
+    },
+    [appendLog],
+  );
+
+  const rpcRequest = useCallback(
+    (method: string, params: Record<string, JsonValue> | null = null) => {
+      const id = nextRpcIdRef.current++;
+      const payload: Record<string, JsonValue> = {
+        id,
+        method,
+      };
+      if (params !== null) {
+        payload.params = params;
+      }
+
+      return new Promise<unknown>((resolve, reject) => {
+        pendingRef.current.set(id, {
+          resolve,
+          reject,
+          method,
+        });
+
+        try {
+          rpcSend(payload);
+        } catch (error) {
+          pendingRef.current.delete(id);
+          reject(error);
+        }
+      });
+    },
+    [rpcSend],
+  );
+
+  const rpcNotify = useCallback(
+    (method: string, params: Record<string, JsonValue> | null = null) => {
+      const payload: Record<string, JsonValue> = { method };
+      if (params !== null) {
+        payload.params = params;
+      }
+      rpcSend(payload);
+    },
+    [rpcSend],
+  );
+
+  const fetchThreadsPage = useCallback(
+    async (cursor: string | null = null): Promise<ThreadListPage> => {
+      const params: Record<string, JsonValue> = {
+        limit: 30,
+        modelProviders: [],
+        sourceKinds: ["cli", "vscode", "appServer", "exec"],
+        sortKey: "updated_at",
+      };
+      if (cursor) {
+        params.cursor = cursor;
+      }
+
+      const result = (await rpcRequest("thread/list", params)) as {
+        data?: unknown;
+        nextCursor?: unknown;
+        next_cursor?: unknown;
+      };
+
+      const nextCursorValue = result?.nextCursor ?? result?.next_cursor;
+      return {
+        threads: normalizeThreads(result?.data),
+        nextCursor: typeof nextCursorValue === "string" && nextCursorValue.length > 0 ? nextCursorValue : null,
+      };
+    },
+    [rpcRequest],
+  );
+
+  const refreshThreads = useCallback(async () => {
+    const page = await fetchThreadsPage();
+    dispatch({
+      type: "set_threads",
+      threads: page.threads,
+      nextCursor: page.nextCursor,
+    });
+    return page.threads;
+  }, [fetchThreadsPage]);
+
+  const loadMoreThreads = useCallback(async () => {
+    if (!state.threadsNextCursor || state.threadsLoadingMore) {
+      return;
+    }
+
+    dispatch({ type: "set_threads_loading_more", loading: true });
+    try {
+      const page = await fetchThreadsPage(state.threadsNextCursor);
+      dispatch({
+        type: "append_threads",
+        threads: page.threads,
+        nextCursor: page.nextCursor,
+      });
+    } catch (error) {
+      dispatch({ type: "set_threads_loading_more", loading: false });
+      appendSystem(`thread/list failed: ${String((error as Error).message ?? error)}`, "warn");
+    }
+  }, [appendSystem, fetchThreadsPage, state.threadsLoadingMore, state.threadsNextCursor]);
+
+  const refreshThreadsWithRetry = useCallback(async () => {
+    let lastError: Error | null = null;
+    for (const delayMs of [0, 200, 700, 1400]) {
+      if (delayMs > 0) {
+        await waitMs(delayMs);
+      }
+      try {
+        await refreshThreads();
+        return;
+      } catch (error) {
+        lastError = error as Error;
+      }
+    }
+
+    throw lastError ?? new Error("thread/list failed");
+  }, [refreshThreads]);
+
+  const renderThreadHistory = useCallback((thread: unknown) => {
+    if (typeof thread !== "object" || thread === null) {
+      return;
+    }
+
+    const turns = (thread as { turns?: unknown }).turns;
+    if (!Array.isArray(turns)) {
+      return;
+    }
+
+    for (const turn of turns) {
+      if (typeof turn !== "object" || turn === null) {
+        continue;
+      }
+      const items = (turn as { items?: unknown }).items;
+      if (!Array.isArray(items)) {
+        continue;
+      }
+      for (const item of items) {
+        if (typeof item !== "object" || item === null) {
+          continue;
+        }
+        const entry = timelineFromItem(item as Record<string, unknown>);
+        dispatch({ type: "upsert_entry", entry });
+
+        const itemId = String((item as { id?: unknown }).id ?? "");
+        if (itemId.length > 0) {
+          dispatch({ type: "set_item_key", itemId, key: entry.key });
+        }
+      }
+    }
+  }, []);
+
+  const startNewThread = useCallback(async () => {
+    dispatch({ type: "clear_timeline" });
+    try {
+      const result = (await rpcRequest("thread/start", {})) as {
+        thread?: { id?: string };
+      };
+      const threadId = result.thread?.id ?? null;
+      dispatch({ type: "set_thread", threadId });
+      appendSystem("thread started", "ok");
+      try {
+        await refreshThreads();
+      } catch (error) {
+        appendSystem(`thread/list failed: ${String((error as Error).message ?? error)}`, "warn");
+      }
+    } catch (error) {
+      appendSystem(`thread/start failed: ${String((error as Error).message ?? error)}`, "error");
+    }
+  }, [appendSystem, refreshThreads, rpcRequest]);
+
+  const resumeThread = useCallback(
+    async (threadId: string) => {
+      if (threadId.trim().length === 0) {
+        return;
+      }
+
+      dispatch({ type: "clear_timeline" });
+      try {
+        const result = (await rpcRequest("thread/resume", {
+          threadId,
+        })) as {
+          thread?: { id?: string } & Record<string, unknown>;
+        };
+
+        dispatch({ type: "set_thread", threadId: result.thread?.id ?? threadId });
+        appendSystem(`resumed ${threadId}`, "ok");
+        renderThreadHistory(result.thread);
+        try {
+          await refreshThreads();
+        } catch (error) {
+          appendSystem(`thread/list failed: ${String((error as Error).message ?? error)}`, "warn");
+        }
+      } catch (error) {
+        appendSystem(`thread/resume failed: ${String((error as Error).message ?? error)}`, "error");
+      }
+    },
+    [appendSystem, refreshThreads, renderThreadHistory, rpcRequest],
+  );
+
+  const sendPrompt = useCallback(
+    async (text: string) => {
+      const threadId = threadIdRef.current;
+      if (!threadId) {
+        appendSystem("No active thread. Start or resume a thread first.", "warn");
+        return;
+      }
+
+      const trimmed = text.trim();
+      if (trimmed.length === 0) {
+        return;
+      }
+
+      const input: JsonValue[] = [
+        {
+          type: "text",
+          text: trimmed,
+          textElements: [],
+        },
+      ];
+
+      try {
+        await rpcRequest("turn/start", {
+          threadId,
+          input,
+        });
+      } catch (error) {
+        appendSystem(`turn/start failed: ${String((error as Error).message ?? error)}`, "error");
+      }
+    },
+    [appendSystem, rpcRequest],
+  );
+
+  const handleApprovalDecision = useCallback(
+    (requestId: number, decision: "accept" | "acceptForSession" | "decline" | "cancel") => {
+      try {
+        rpcSend({
+          id: requestId,
+          result: {
+            decision,
+          },
+        });
+        dispatch({
+          type: "complete_approval",
+          requestId,
+          status: `sent: ${decision}`,
+        });
+      } catch (error) {
+        appendSystem(`failed to respond to approval: ${String((error as Error).message ?? error)}`, "error");
+      }
+    },
+    [appendSystem, rpcSend],
+  );
+
+  const handleServerRequest = useCallback(
+    (payload: Record<string, unknown>) => {
+      const method = String(payload.method ?? "");
+      const requestId = payload.id;
+      const params = (payload.params ?? {}) as Record<string, unknown>;
+
+      if (typeof requestId !== "number") {
+        appendSystem(`unsupported server request id for ${method}`, "warn");
+        return;
+      }
+
+      if (method === "item/commandExecution/requestApproval" || method === "item/fileChange/requestApproval") {
+        if (activeApprovalsRef.current[requestId]) {
+          return;
+        }
+
+        dispatch({ type: "activate_approval", requestId });
+
+        const isCommand = method.includes("commandExecution");
+        const reason = String(params.reason ?? "Approval requested.");
+        const detail = isCommand
+          ? `command: ${String(params.command ?? "(unknown)")}\ncwd: ${String(params.cwd ?? "(unknown)")}`
+          : `itemId: ${String(params.itemId ?? "")}`;
+
+        dispatch({
+          type: "upsert_entry",
+          entry: {
+            key: `approval:${requestId}`,
+            kind: "approval",
+            label: isCommand ? "Command approval" : "File change approval",
+            text: `${reason}\n\n${detail}`,
+            status: "approval",
+            requestId,
+            method,
+            createdAt: Date.now(),
+          },
+        });
+        return;
+      }
+
+      dispatch({
+        type: "upsert_entry",
+        entry: {
+          key: `serverreq:${requestId}:${method}`,
+          kind: "notification",
+          label: "Server request",
+          text: JSON.stringify(params),
+          status: method,
+          createdAt: Date.now(),
+        },
+      });
+
+      try {
+        rpcSend({
+          id: requestId,
+          error: {
+            code: -32601,
+            message: `Unimplemented client handler for ${method}`,
+          },
+        });
+      } catch {
+        appendSystem(`failed to reject unimplemented method ${method}`, "warn");
+      }
+    },
+    [appendSystem, rpcSend],
+  );
+
+  const handleNotification = useCallback(
+    (payload: Record<string, unknown>) => {
+      const method = String(payload.method ?? "");
+      const params = (payload.params ?? {}) as Record<string, unknown>;
+
+      if (method === "thread/started") {
+        const threadObj = params.thread as { id?: string } | undefined;
+        dispatch({ type: "set_thread", threadId: threadObj?.id ?? null });
+        refreshThreads().catch((error) => {
+          appendSystem(`thread/list failed: ${String((error as Error).message ?? error)}`, "warn");
+        });
+        return;
+      }
+
+      if (method === "turn/started") {
+        dispatch({ type: "set_stream_active", active: true });
+        appendSystem("turn started", "ok");
+        return;
+      }
+
+      if (method === "turn/completed") {
+        dispatch({ type: "set_stream_active", active: false });
+        appendSystem("turn completed", "ok");
+        refreshThreads().catch((error) => {
+          appendSystem(`thread/list failed: ${String((error as Error).message ?? error)}`, "warn");
+        });
+        return;
+      }
+
+      if (method === "turn/failed" || method === "error") {
+        dispatch({ type: "set_stream_active", active: false });
+        appendSystem(`${method}: ${JSON.stringify(params.error ?? params)}`, "error");
+        refreshThreads().catch((error) => {
+          appendSystem(`thread/list failed: ${String((error as Error).message ?? error)}`, "warn");
+        });
+        return;
+      }
+
+      if (method === "item/started" || method === "item/completed") {
+        const item = params.item;
+        if (typeof item === "object" && item !== null) {
+          const entry = timelineFromItem(item as Record<string, unknown>);
+          dispatch({ type: "upsert_entry", entry });
+          const itemId = String((item as { id?: unknown }).id ?? "");
+          if (itemId.length > 0) {
+            dispatch({ type: "set_item_key", itemId, key: entry.key });
+          }
+        }
+        return;
+      }
+
+      if (
+        method === "item/agentMessage/delta" ||
+        method === "item/commandExecution/outputDelta" ||
+        method === "item/fileChange/outputDelta"
+      ) {
+        const itemId = String(params.itemId ?? "");
+        if (itemId.length > 0) {
+          dispatch({ type: "append_delta", itemId, delta: String(params.delta ?? "") });
+          dispatch({ type: "set_stream_active", active: true });
+        }
+        return;
+      }
+
+      dispatch({
+        type: "upsert_entry",
+        entry: {
+          key: `notification:${Date.now()}:${method}`,
+          kind: "notification",
+          label: method,
+          text: JSON.stringify(params),
+          status: "notif",
+          createdAt: Date.now(),
+        },
+      });
+    },
+    [appendSystem, refreshThreads],
+  );
+
+  const initialize = useCallback(async () => {
+    await rpcRequest("initialize", {
+      clientInfo: {
+        name: "codex_companion",
+        title: "Codex Companion",
+        version: "0.0.0-dev",
+      },
+      capabilities: {
+        experimentalApi: true,
+      },
+    });
+
+    rpcNotify("initialized");
+    dispatch({ type: "set_initialized", initialized: true });
+    try {
+      await refreshThreadsWithRetry();
+    } catch (error) {
+      appendSystem(`thread/list failed: ${String((error as Error).message ?? error)}`, "warn");
+    }
+    await startNewThread();
+
+    if (initialPrompt.trim().length > 0 && !initialPromptSentRef.current) {
+      initialPromptSentRef.current = true;
+      await sendPrompt(initialPrompt.trim());
+    }
+  }, [appendSystem, initialPrompt, refreshThreadsWithRetry, rpcNotify, rpcRequest, sendPrompt, startNewThread]);
+
+  const connect = useCallback(() => {
+    if (token.length === 0) {
+      dispatch({
+        type: "set_connection",
+        connection: "missing-token",
+        statusText: "missing token",
+      });
+      appendSystem("Missing token. Use the URL printed by `codex --companion`.", "error");
+      return;
+    }
+
+    dispatch({
+      type: "set_connection",
+      connection: "connecting",
+      statusText: "connecting",
+    });
+
+    let backendUrl: URL;
+    try {
+      backendUrl = backend ? new URL(backend) : new URL(window.location.origin);
+    } catch {
+      dispatch({
+        type: "set_connection",
+        connection: "error",
+        statusText: "bad backend URL",
+      });
+      appendSystem("Invalid backend URL in `backend` query param.", "error");
+      return;
+    }
+    const protocol = backendUrl.protocol === "https:" ? "wss:" : "ws:";
+    const wsUrl = `${protocol}//${backendUrl.host}/ws?token=${encodeURIComponent(token)}`;
+    const socket = new WebSocket(wsUrl);
+    wsRef.current = socket;
+
+    socket.addEventListener("open", () => {
+      dispatch({
+        type: "set_connection",
+        connection: "connected",
+        statusText: "connected",
+      });
+
+      initialize().catch((error) => {
+        appendSystem(`initialize failed: ${String((error as Error).message ?? error)}`, "error");
+      });
+    });
+
+    socket.addEventListener("message", (event) => {
+      let payload: Record<string, unknown>;
+      try {
+        payload = JSON.parse(String(event.data)) as Record<string, unknown>;
+      } catch (error) {
+        appendSystem(`bad JSON from server: ${String(error)}`, "error");
+        return;
+      }
+
+      appendLog("in", payload);
+
+      if (typeof payload.id === "number" && ("result" in payload || "error" in payload) && !("method" in payload)) {
+        const pending = pendingRef.current.get(payload.id);
+        pendingRef.current.delete(payload.id);
+        if (!pending) {
+          return;
+        }
+
+        if ("error" in payload) {
+          const rpcError = payload.error as { message?: string } | undefined;
+          pending.reject(new Error(rpcError?.message ?? "RPC error"));
+        } else {
+          pending.resolve(payload.result);
+        }
+        return;
+      }
+
+      if (typeof payload.id === "number" && typeof payload.method === "string") {
+        handleServerRequest(payload);
+        return;
+      }
+
+      if (typeof payload.method === "string") {
+        handleNotification(payload);
+      }
+    });
+
+    socket.addEventListener("close", () => {
+      dispatch({
+        type: "set_connection",
+        connection: "disconnected",
+        statusText: "disconnected",
+      });
+      dispatch({ type: "set_initialized", initialized: false });
+      dispatch({ type: "set_stream_active", active: false });
+    });
+
+    socket.addEventListener("error", () => {
+      dispatch({
+        type: "set_connection",
+        connection: "error",
+        statusText: "socket error",
+      });
+      appendLog("error", "socket error");
+    });
+  }, [appendLog, appendSystem, backend, handleNotification, handleServerRequest, initialize, token]);
+
+  const reconnect = useCallback(() => {
+    if (wsRef.current) {
+      wsRef.current.close();
+    }
+
+    for (const pending of pendingRef.current.values()) {
+      pending.reject(new Error(`connection reset while waiting for ${pending.method}`));
+    }
+    pendingRef.current.clear();
+    nextRpcIdRef.current = 1;
+    connect();
+  }, [connect]);
+
+  useEffect(() => {
+    connect();
+
+    return () => {
+      if (wsRef.current) {
+        wsRef.current.close();
+      }
+      for (const pending of pendingRef.current.values()) {
+        pending.reject(new Error("connection closed"));
+      }
+      pendingRef.current.clear();
+    };
+  }, [connect]);
+
+  useEffect(() => {
+    if (state.connection !== "connected" || !state.initialized) {
+      return;
+    }
+
+    const intervalId = window.setInterval(() => {
+      refreshThreads().catch(() => undefined);
+    }, 5000);
+
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [refreshThreads, state.connection, state.initialized]);
+
+  return (
+    <div className="app-shell">
+      <TopBar
+        connection={state.connection}
+        logOpen={state.logPanelOpen}
+        onReconnect={reconnect}
+        onToggleLog={() => dispatch({ type: "set_log_panel", open: !state.logPanelOpen })}
+        onToggleSidebar={() => dispatch({ type: "set_sidebar", open: !state.sidebarOpen })}
+        onToggleTheme={() => dispatch({ type: "set_theme", theme: state.theme === "dark" ? "light" : "dark" })}
+        sidebarOpen={state.sidebarOpen}
+        statusText={state.statusText}
+        streamActive={state.streamActive}
+        theme={state.theme}
+        threadId={state.threadId}
+      />
+
+      <div className="app-content">
+        <Sidebar
+          activeThreadId={state.threadId}
+          onDismissMobile={() => dispatch({ type: "set_sidebar", open: false })}
+          onLoadMore={() => {
+            loadMoreThreads().catch(() => undefined);
+          }}
+          onNewThread={() => {
+            dispatch({ type: "set_sidebar", open: false });
+            startNewThread().catch(() => undefined);
+          }}
+          onRefresh={() => {
+            refreshThreads().catch((error) => {
+              appendSystem(`thread/list failed: ${String((error as Error).message ?? error)}`, "warn");
+            });
+          }}
+          onResumeThread={(id) => {
+            resumeThread(id).catch(() => undefined);
+          }}
+          loadingMore={state.threadsLoadingMore}
+          nextCursor={state.threadsNextCursor}
+          open={state.sidebarOpen}
+          threads={state.threads}
+          threadsLoaded={state.threadsLoaded}
+        />
+
+        <main className="main-panel">
+          <ChatFeed
+            activeApprovals={state.activeApprovals}
+            entries={state.timeline}
+            onApprovalDecision={handleApprovalDecision}
+          />
+          <Composer
+            disabled={state.connection !== "connected" || !state.threadId || !state.initialized}
+            onSubmit={(text) => {
+              sendPrompt(text).catch(() => undefined);
+            }}
+          />
+        </main>
+      </div>
+
+      <DevLogPanel
+        logs={state.logs}
+        onClose={() => dispatch({ type: "set_log_panel", open: false })}
+        open={state.logPanelOpen}
+      />
+
+      {state.sidebarOpen ? (
+        <button
+          aria-label="Close sessions sidebar"
+          className="sidebar-backdrop"
+          onClick={() => dispatch({ type: "set_sidebar", open: false })}
+          type="button"
+        />
+      ) : null}
+    </div>
+  );
+}

--- a/codex-rs/companion/ui/src/components/ApprovalCard.tsx
+++ b/codex-rs/companion/ui/src/components/ApprovalCard.tsx
@@ -1,0 +1,49 @@
+import { TimelineEntry } from "../types";
+
+interface ApprovalCardProps {
+  entry: TimelineEntry;
+  disabled: boolean;
+  onDecision: (requestId: number, decision: "accept" | "acceptForSession" | "decline" | "cancel") => void;
+}
+
+export function ApprovalCard({ entry, disabled, onDecision }: ApprovalCardProps) {
+  if (typeof entry.requestId !== "number") {
+    return null;
+  }
+
+  return (
+    <div className="approval-card">
+      <p className="approval-card__heading">Approval needed</p>
+      <pre>{entry.text}</pre>
+      <div className="approval-card__actions">
+        <button className="solid-btn" disabled={disabled} onClick={() => onDecision(entry.requestId!, "accept")} type="button">
+          Accept
+        </button>
+        <button
+          className="ghost-btn"
+          disabled={disabled}
+          onClick={() => onDecision(entry.requestId!, "acceptForSession")}
+          type="button"
+        >
+          Accept for session
+        </button>
+        <button
+          className="ghost-btn"
+          disabled={disabled}
+          onClick={() => onDecision(entry.requestId!, "decline")}
+          type="button"
+        >
+          Decline
+        </button>
+        <button
+          className="danger-btn"
+          disabled={disabled}
+          onClick={() => onDecision(entry.requestId!, "cancel")}
+          type="button"
+        >
+          Cancel
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/codex-rs/companion/ui/src/components/ChatFeed.tsx
+++ b/codex-rs/companion/ui/src/components/ChatFeed.tsx
@@ -1,0 +1,113 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { renderMarkdown } from "../lib/markdown";
+import { TimelineEntry } from "../types";
+import { ApprovalCard } from "./ApprovalCard";
+
+interface ChatFeedProps {
+  entries: TimelineEntry[];
+  activeApprovals: Record<number, true>;
+  onApprovalDecision: (
+    requestId: number,
+    decision: "accept" | "acceptForSession" | "decline" | "cancel",
+  ) => void;
+}
+
+export function ChatFeed({ entries, activeApprovals, onApprovalDecision }: ChatFeedProps) {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const [stickToBottom, setStickToBottom] = useState(true);
+
+  useEffect(() => {
+    if (!stickToBottom) {
+      return;
+    }
+    if (!scrollRef.current) {
+      return;
+    }
+    scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+  }, [entries, stickToBottom]);
+
+  const groups = useMemo(() => {
+    const out: TimelineEntry[][] = [];
+    for (const entry of entries) {
+      const previous = out.at(-1);
+      if (
+        previous &&
+        previous[0].kind === entry.kind &&
+        entry.kind !== "approval" &&
+        entry.kind !== "system" &&
+        entry.kind !== "notification"
+      ) {
+        previous.push(entry);
+      } else {
+        out.push([entry]);
+      }
+    }
+    return out;
+  }, [entries]);
+
+  return (
+    <section
+      className="chat-feed"
+      onScroll={(event) => {
+        const target = event.currentTarget;
+        const bottomGap = target.scrollHeight - target.clientHeight - target.scrollTop;
+        setStickToBottom(bottomGap < 48);
+      }}
+      ref={scrollRef}
+    >
+      {groups.length === 0 ? <p className="empty-note">Start a session and send a prompt to begin.</p> : null}
+
+      {groups.map((group) => {
+        const representative = group[0];
+
+        return (
+          <article className={`entry entry--${representative.kind}`} key={representative.key}>
+            <header>
+              <span>{representative.label}</span>
+              {representative.status ? <span className="entry-status">{representative.status}</span> : null}
+            </header>
+
+            {group.map((entry) => {
+              if (entry.kind === "approval") {
+                return (
+                  <ApprovalCard
+                    disabled={!activeApprovals[entry.requestId ?? -1]}
+                    entry={entry}
+                    key={entry.key}
+                    onDecision={onApprovalDecision}
+                  />
+                );
+              }
+
+              if (entry.kind === "assistant" || entry.kind === "reasoning") {
+                return (
+                  <div
+                    className="entry-markdown"
+                    dangerouslySetInnerHTML={{ __html: renderMarkdown(entry.text) }}
+                    key={entry.key}
+                  />
+                );
+              }
+
+              if (entry.kind === "command" || entry.kind === "file-change") {
+                return (
+                  <pre className="entry-pre" key={entry.key}>
+                    {entry.text}
+                  </pre>
+                );
+              }
+
+              return (
+                <p className="entry-text" key={entry.key}>
+                  {entry.text}
+                </p>
+              );
+            })}
+
+            {representative.meta ? <p className="entry-meta">{representative.meta}</p> : null}
+          </article>
+        );
+      })}
+    </section>
+  );
+}

--- a/codex-rs/companion/ui/src/components/Composer.tsx
+++ b/codex-rs/companion/ui/src/components/Composer.tsx
@@ -1,0 +1,46 @@
+import { FormEvent, KeyboardEvent, useState } from "react";
+
+interface ComposerProps {
+  disabled: boolean;
+  onSubmit: (text: string) => void;
+}
+
+export function Composer({ disabled, onSubmit }: ComposerProps) {
+  const [value, setValue] = useState("");
+
+  function submit(event?: FormEvent) {
+    event?.preventDefault();
+    const text = value.trim();
+    if (text.length === 0) {
+      return;
+    }
+    onSubmit(text);
+    setValue("");
+  }
+
+  return (
+    <form className="composer" onSubmit={submit}>
+      <textarea
+        disabled={disabled}
+        onChange={(event) => setValue(event.target.value)}
+        onKeyDown={(event: KeyboardEvent<HTMLTextAreaElement>) => {
+          if (event.key === "Enter" && !event.shiftKey) {
+            event.preventDefault();
+            submit();
+          }
+        }}
+        placeholder="Send a message to Codex"
+        value={value}
+      />
+      <div className="composer__actions">
+        <p>
+          Enter to send, Shift+Enter for newline
+          {disabled ? " · waiting for connection" : ""}
+        </p>
+        <button className="solid-btn" disabled={disabled} type="submit">
+          Send
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/codex-rs/companion/ui/src/components/DevLogPanel.tsx
+++ b/codex-rs/companion/ui/src/components/DevLogPanel.tsx
@@ -1,0 +1,37 @@
+import { RawLogEntry } from "../types";
+
+interface DevLogPanelProps {
+  logs: RawLogEntry[];
+  open: boolean;
+  onClose: () => void;
+}
+
+export function DevLogPanel({ logs, open, onClose }: DevLogPanelProps) {
+  if (!open) {
+    return null;
+  }
+
+  return (
+    <>
+      <button aria-label="Close JSON-RPC log drawer" className="devlog-backdrop" onClick={onClose} type="button" />
+      <section className={`devlog ${open ? "devlog--open" : ""}`}>
+        <div className="devlog__header">
+          <p>JSON-RPC log</p>
+          <button className="ghost-btn" onClick={onClose} type="button">
+            Close
+          </button>
+        </div>
+
+        <div className="devlog__body">
+          {logs.length === 0 ? <p className="empty-note">No transport activity yet.</p> : null}
+
+          {logs.map((log) => (
+            <pre className={`log-line log-line--${log.direction}`} key={log.id}>
+              [{new Date(log.at).toLocaleTimeString()}] {log.direction.toUpperCase()} {log.text}
+            </pre>
+          ))}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/codex-rs/companion/ui/src/components/Sidebar.tsx
+++ b/codex-rs/companion/ui/src/components/Sidebar.tsx
@@ -1,0 +1,114 @@
+import { useMemo, useState } from "react";
+import { formatTimestamp } from "../lib/time";
+import { ThreadSummary } from "../types";
+
+interface SidebarProps {
+  open: boolean;
+  threads: ThreadSummary[];
+  threadsLoaded: boolean;
+  nextCursor: string | null;
+  loadingMore: boolean;
+  activeThreadId: string | null;
+  onRefresh: () => void;
+  onLoadMore: () => void;
+  onNewThread: () => void;
+  onResumeThread: (id: string) => void;
+  onDismissMobile: () => void;
+}
+
+export function Sidebar({
+  open,
+  threads,
+  threadsLoaded,
+  nextCursor,
+  loadingMore,
+  activeThreadId,
+  onRefresh,
+  onLoadMore,
+  onNewThread,
+  onResumeThread,
+  onDismissMobile,
+}: SidebarProps) {
+  const [searchText, setSearchText] = useState("");
+  const normalizedSearchText = searchText.trim().toLowerCase();
+  const filteredThreads = useMemo(() => {
+    if (normalizedSearchText.length === 0) {
+      return threads;
+    }
+
+    return threads.filter((thread) => thread.searchText.includes(normalizedSearchText));
+  }, [normalizedSearchText, threads]);
+
+  return (
+    <aside className={`sidebar ${open ? "sidebar--open" : ""}`}>
+      <div className="sidebar__header">
+        <p>Sessions</p>
+        <div className="stacked-actions">
+          <button className="ghost-btn" onClick={onRefresh} type="button">
+            Refresh
+          </button>
+          <button className="solid-btn" onClick={onNewThread} type="button">
+            New session
+          </button>
+        </div>
+      </div>
+
+      <div className="session-search">
+        <input
+          onChange={(event) => setSearchText(event.target.value)}
+          placeholder="Search sessions"
+          type="search"
+          value={searchText}
+        />
+      </div>
+
+      <div
+        className="thread-list"
+        onScroll={(event) => {
+          if (!nextCursor || loadingMore) {
+            return;
+          }
+          const target = event.currentTarget;
+          const distanceToBottom = target.scrollHeight - target.clientHeight - target.scrollTop;
+          if (distanceToBottom < 120) {
+            onLoadMore();
+          }
+        }}
+      >
+        {!threadsLoaded ? <p className="empty-note">Loading sessions...</p> : null}
+        {threadsLoaded && threads.length === 0 ? <p className="empty-note">No sessions yet.</p> : null}
+        {threadsLoaded && threads.length > 0 && filteredThreads.length === 0 ? (
+          <p className="empty-note">No sessions match your search.</p>
+        ) : null}
+
+        {filteredThreads.map((thread) => (
+          <button
+            className={`thread-card ${activeThreadId === thread.id ? "thread-card--active" : ""}`}
+            key={thread.id}
+            onClick={() => {
+              onResumeThread(thread.id);
+              onDismissMobile();
+            }}
+            type="button"
+          >
+            <p className="thread-card__title" title={thread.title}>
+              {thread.title}
+            </p>
+            {thread.preview.length > 0 && thread.preview !== thread.title ? (
+              <p className="thread-card__preview">{thread.preview}</p>
+            ) : null}
+            <div className="thread-card__meta">
+              <span>{formatTimestamp(thread.updatedAt) || "No messages yet"}</span>
+            </div>
+          </button>
+        ))}
+
+        {threadsLoaded && nextCursor ? (
+          <button className="ghost-btn load-more-btn" disabled={loadingMore} onClick={onLoadMore} type="button">
+            {loadingMore ? "Loading more…" : "Load more sessions"}
+          </button>
+        ) : null}
+      </div>
+    </aside>
+  );
+}

--- a/codex-rs/companion/ui/src/components/TopBar.tsx
+++ b/codex-rs/companion/ui/src/components/TopBar.tsx
@@ -1,0 +1,71 @@
+import { ConnectionStatus } from "../types";
+
+interface TopBarProps {
+  connection: ConnectionStatus;
+  statusText: string;
+  streamActive: boolean;
+  threadId: string | null;
+  logOpen: boolean;
+  sidebarOpen: boolean;
+  onToggleSidebar: () => void;
+  onToggleLog: () => void;
+  onReconnect: () => void;
+  theme: "dark" | "light";
+  onToggleTheme: () => void;
+}
+
+export function TopBar({
+  connection,
+  statusText,
+  streamActive,
+  threadId,
+  logOpen,
+  sidebarOpen,
+  onToggleSidebar,
+  onToggleLog,
+  onReconnect,
+  theme,
+  onToggleTheme,
+}: TopBarProps) {
+  const shortThreadId = threadId ? threadId.slice(0, 8) : null;
+
+  return (
+    <header className="topbar">
+      <div className="topbar__left">
+        <button
+          aria-label="Toggle sessions sidebar"
+          className={`ghost-btn mobile-only ${sidebarOpen ? "is-active" : ""}`}
+          onClick={onToggleSidebar}
+          type="button"
+        >
+          Sessions
+        </button>
+        <div>
+          <h1 className="topbar__product">Codex Companion</h1>
+          <p className="topbar__subtitle">
+            {shortThreadId ? `Active session ${shortThreadId}` : "Start a session to begin"}
+          </p>
+        </div>
+      </div>
+
+      <div className="topbar__right">
+        <div className={`status status--${connection}`}>
+          <span className="status__dot" aria-hidden="true" />
+          <span>{statusText}</span>
+        </div>
+        <div className={`status-chip ${streamActive ? "status-chip--live" : ""}`}>
+          {streamActive ? "Responding" : "Idle"}
+        </div>
+        <button className="ghost-btn" onClick={onReconnect} type="button">
+          Reconnect
+        </button>
+        <button className={`ghost-btn ${logOpen ? "is-active" : ""}`} onClick={onToggleLog} type="button">
+          JSON-RPC Log
+        </button>
+        <button className="ghost-btn" onClick={onToggleTheme} type="button">
+          {theme === "dark" ? "Light" : "Dark"}
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/codex-rs/companion/ui/src/lib/markdown.ts
+++ b/codex-rs/companion/ui/src/lib/markdown.ts
@@ -1,0 +1,14 @@
+import DOMPurify from "dompurify";
+import { marked } from "marked";
+
+marked.setOptions({
+  breaks: true,
+  gfm: true,
+});
+
+export function renderMarkdown(markdown: string): string {
+  const html = marked.parse(markdown ?? "") as string;
+  return DOMPurify.sanitize(html, {
+    USE_PROFILES: { html: true },
+  });
+}

--- a/codex-rs/companion/ui/src/lib/time.ts
+++ b/codex-rs/companion/ui/src/lib/time.ts
@@ -1,0 +1,20 @@
+export function formatTimestamp(seconds?: number): string {
+  if (!seconds) {
+    return "";
+  }
+  const date = new Date(seconds * 1000);
+  return date.toLocaleString();
+}
+
+export function normalizePreview(text: string): string {
+  const normalized = text.replace(/\s+/g, " ").trim();
+  return normalized;
+}
+
+export function nowClock(): string {
+  const date = new Date();
+  const hh = String(date.getHours()).padStart(2, "0");
+  const mm = String(date.getMinutes()).padStart(2, "0");
+  const ss = String(date.getSeconds()).padStart(2, "0");
+  return `${hh}:${mm}:${ss}`;
+}

--- a/codex-rs/companion/ui/src/main.tsx
+++ b/codex-rs/companion/ui/src/main.tsx
@@ -1,0 +1,15 @@
+import { createRoot } from "react-dom/client";
+import { App } from "./App";
+import "./styles.css";
+
+const root = document.getElementById("root");
+if (!root) {
+  throw new Error("Missing #root element");
+}
+
+const query = new URLSearchParams(window.location.search);
+const token = query.get("token") ?? "";
+const initialPrompt = query.get("prompt") ?? "";
+const backend = query.get("backend");
+
+createRoot(root).render(<App backend={backend} initialPrompt={initialPrompt} token={token} />);

--- a/codex-rs/companion/ui/src/state/reducer.ts
+++ b/codex-rs/companion/ui/src/state/reducer.ts
@@ -1,0 +1,200 @@
+import { AppAction, AppState, TimelineEntry } from "../types";
+
+function upsertTimeline(timeline: TimelineEntry[], entry: TimelineEntry): TimelineEntry[] {
+  const index = timeline.findIndex((item) => item.key === entry.key);
+  if (index === -1) {
+    return [...timeline, entry];
+  }
+
+  const next = [...timeline];
+  next[index] = {
+    ...next[index],
+    ...entry,
+    createdAt: next[index].createdAt,
+  };
+  return next;
+}
+
+export const initialState: AppState = {
+  connection: "connecting",
+  statusText: "connecting",
+  initialized: false,
+  threadId: null,
+  threads: [],
+  threadsLoaded: false,
+  threadsNextCursor: null,
+  threadsLoadingMore: false,
+  timeline: [],
+  itemToTimeline: {},
+  activeApprovals: {},
+  logs: [],
+  logPanelOpen: false,
+  sidebarOpen: false,
+  streamActive: false,
+  theme: window.matchMedia("(prefers-color-scheme: light)").matches ? "light" : "dark",
+};
+
+export function appReducer(state: AppState, action: AppAction): AppState {
+  switch (action.type) {
+    case "set_connection":
+      return {
+        ...state,
+        connection: action.connection,
+        statusText: action.statusText,
+      };
+
+    case "set_initialized":
+      return {
+        ...state,
+        initialized: action.initialized,
+      };
+
+    case "set_thread":
+      return {
+        ...state,
+        threadId: action.threadId,
+      };
+
+    case "set_threads":
+      return {
+        ...state,
+        threads: action.threads,
+        threadsLoaded: true,
+        threadsNextCursor: action.nextCursor,
+        threadsLoadingMore: false,
+      };
+
+    case "append_threads": {
+      const existingIds = new Set(state.threads.map((thread) => thread.id));
+      const appended = [...state.threads];
+      for (const thread of action.threads) {
+        if (existingIds.has(thread.id)) {
+          continue;
+        }
+        existingIds.add(thread.id);
+        appended.push(thread);
+      }
+
+      return {
+        ...state,
+        threads: appended,
+        threadsLoaded: true,
+        threadsNextCursor: action.nextCursor,
+        threadsLoadingMore: false,
+      };
+    }
+
+    case "set_threads_loading_more":
+      return {
+        ...state,
+        threadsLoadingMore: action.loading,
+      };
+
+    case "clear_timeline":
+      return {
+        ...state,
+        timeline: [],
+        itemToTimeline: {},
+        activeApprovals: {},
+        streamActive: false,
+      };
+
+    case "upsert_entry":
+      return {
+        ...state,
+        timeline: upsertTimeline(state.timeline, action.entry),
+      };
+
+    case "append_delta": {
+      const key = state.itemToTimeline[action.itemId] ?? `item:${action.itemId}`;
+      const existing = state.timeline.find((entry) => entry.key === key);
+      const currentText = existing?.text ?? "";
+      return {
+        ...state,
+        itemToTimeline: {
+          ...state.itemToTimeline,
+          [action.itemId]: key,
+        },
+        timeline: upsertTimeline(state.timeline, {
+          key,
+          kind: existing?.kind ?? "assistant",
+          label: existing?.label ?? "Assistant",
+          text: `${currentText}${action.delta}`,
+          status: existing?.status,
+          meta: existing?.meta,
+          createdAt: existing?.createdAt ?? Date.now(),
+        }),
+      };
+    }
+
+    case "set_item_key":
+      return {
+        ...state,
+        itemToTimeline: {
+          ...state.itemToTimeline,
+          [action.itemId]: action.key,
+        },
+      };
+
+    case "activate_approval":
+      return {
+        ...state,
+        activeApprovals: {
+          ...state.activeApprovals,
+          [action.requestId]: true,
+        },
+      };
+
+    case "complete_approval":
+      return {
+        ...state,
+        activeApprovals: Object.fromEntries(
+          Object.entries(state.activeApprovals).filter(([id]) => Number(id) !== action.requestId),
+        ),
+        timeline: state.timeline.map((entry) => {
+          if (entry.requestId !== action.requestId) {
+            return entry;
+          }
+          return {
+            ...entry,
+            status: action.status,
+          };
+        }),
+      };
+
+    case "set_log_panel":
+      return {
+        ...state,
+        logPanelOpen: action.open,
+      };
+
+    case "append_log": {
+      const logs = [action.log, ...state.logs].slice(0, 600);
+      return {
+        ...state,
+        logs,
+      };
+    }
+
+    case "set_sidebar":
+      return {
+        ...state,
+        sidebarOpen: action.open,
+      };
+
+    case "set_stream_active":
+      return {
+        ...state,
+        streamActive: action.active,
+      };
+
+    case "set_theme":
+      return {
+        ...state,
+        theme: action.theme,
+      };
+
+    default:
+      return state;
+  }
+}

--- a/codex-rs/companion/ui/src/styles.css
+++ b/codex-rs/companion/ui/src/styles.css
@@ -1,0 +1,823 @@
+@font-face {
+  font-family: "OpenAI Sans";
+  src: url("https://cdn.openai.com/common/fonts/openai-sans/OpenAISans-Regular.woff2") format("woff2");
+  font-style: normal;
+  font-weight: 400;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "OpenAI Sans";
+  src: url("https://cdn.openai.com/common/fonts/openai-sans/OpenAISans-RegularItalic.woff2") format("woff2");
+  font-style: italic;
+  font-weight: 400;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "OpenAI Sans";
+  src: url("https://cdn.openai.com/common/fonts/openai-sans/OpenAISans-Medium.woff2") format("woff2");
+  font-style: normal;
+  font-weight: 500;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "OpenAI Sans";
+  src: url("https://cdn.openai.com/common/fonts/openai-sans/OpenAISans-Semibold.woff2") format("woff2");
+  font-style: normal;
+  font-weight: 600;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "OpenAI Sans";
+  src: url("https://cdn.openai.com/common/fonts/openai-sans/OpenAISans-Bold.woff2") format("woff2");
+  font-style: normal;
+  font-weight: 700;
+  font-display: swap;
+}
+
+:root {
+  --font-ui: "OpenAI Sans", ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  --radius-panel: 14px;
+  --radius-control: 10px;
+  --space-1: 4px;
+  --space-2: 8px;
+  --space-3: 12px;
+  --space-4: 16px;
+  --space-5: 20px;
+  --duration-fast: 120ms;
+  --duration-base: 180ms;
+  --easing-standard: cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+:root,
+:root[data-theme="dark"] {
+  --bg-app: #0d1117;
+  --bg-panel: #111827;
+  --bg-elevated: #1b2432;
+  --fg-primary: #f7f9fc;
+  --fg-secondary: #d1d7e4;
+  --fg-muted: #8d9ab0;
+  --border-subtle: #2a3446;
+  --border-strong: #3d4b61;
+  --accent: #10a37f;
+  --accent-hover: #13b28c;
+  --focus-ring: #57d3b4;
+  --danger: #dc5a63;
+  --warning: #c79a38;
+  --ok: #22b58d;
+  --entry-user: rgba(16, 163, 127, 0.14);
+  --entry-assistant: rgba(255, 255, 255, 0.03);
+  --entry-system: rgba(141, 154, 176, 0.12);
+  --backdrop: rgba(8, 12, 20, 0.7);
+  --shell-glow: radial-gradient(56rem 42rem at -3% -8%, rgba(16, 163, 127, 0.12), transparent 62%);
+}
+
+:root[data-theme="light"] {
+  --bg-app: #f5f7fa;
+  --bg-panel: #ffffff;
+  --bg-elevated: #f6f8fb;
+  --fg-primary: #111827;
+  --fg-secondary: #253247;
+  --fg-muted: #5f6f8a;
+  --border-subtle: #d7deea;
+  --border-strong: #c1cbda;
+  --accent: #0f8f70;
+  --accent-hover: #0b7b60;
+  --focus-ring: #2fba97;
+  --danger: #cf4c55;
+  --warning: #b78623;
+  --ok: #0f8f70;
+  --entry-user: rgba(15, 143, 112, 0.11);
+  --entry-assistant: rgba(17, 24, 39, 0.03);
+  --entry-system: rgba(95, 111, 138, 0.1);
+  --backdrop: rgba(13, 17, 24, 0.3);
+  --shell-glow: radial-gradient(56rem 42rem at -3% -8%, rgba(15, 143, 112, 0.12), transparent 62%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body,
+#root {
+  margin: 0;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
+body {
+  font-family: var(--font-ui);
+  color: var(--fg-primary);
+  background: var(--shell-glow), var(--bg-app);
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+button,
+input,
+textarea {
+  font: inherit;
+  color: inherit;
+}
+
+button {
+  border: 0;
+  background: transparent;
+}
+
+input,
+textarea {
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-control);
+  background: var(--bg-elevated);
+  color: var(--fg-primary);
+}
+
+input::placeholder,
+textarea::placeholder {
+  color: var(--fg-muted);
+}
+
+input:focus-visible,
+textarea:focus-visible,
+button:focus-visible {
+  outline: 2px solid var(--focus-ring);
+  outline-offset: 1px;
+}
+
+.app-shell {
+  width: 100%;
+  height: 100vh;
+  height: 100dvh;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  overflow: hidden;
+}
+
+.topbar {
+  flex: 0 0 auto;
+  min-width: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-3);
+  padding: 10px var(--space-3);
+  border-radius: var(--radius-panel);
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-panel);
+}
+
+.topbar__left,
+.topbar__right {
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.topbar__left {
+  flex: 1 1 auto;
+}
+
+.topbar__right {
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.topbar__product {
+  margin: 0;
+  font-size: 14px;
+  line-height: 20px;
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.topbar__subtitle {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 12px;
+  line-height: 16px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.status {
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-elevated);
+  color: var(--fg-secondary);
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 10px;
+  height: 28px;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.status__dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: var(--warning);
+}
+
+.status--connected .status__dot {
+  background: var(--ok);
+}
+
+.status--disconnected .status__dot,
+.status--error .status__dot,
+.status--missing-token .status__dot {
+  background: var(--danger);
+}
+
+.status-chip {
+  border: 1px solid var(--border-subtle);
+  border-radius: 999px;
+  background: var(--bg-elevated);
+  color: var(--fg-muted);
+  padding: 0 10px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  font-size: 12px;
+  line-height: 1;
+}
+
+.status-chip--live {
+  color: var(--fg-primary);
+  border-color: color-mix(in srgb, var(--accent), var(--border-strong) 38%);
+  background: color-mix(in srgb, var(--accent), var(--bg-elevated) 84%);
+}
+
+.app-content {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  display: grid;
+  grid-template-columns: minmax(260px, 320px) minmax(0, 1fr);
+  gap: var(--space-3);
+  overflow: hidden;
+}
+
+.sidebar,
+.main-panel {
+  min-height: 0;
+  min-width: 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-panel);
+  background: var(--bg-panel);
+}
+
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.sidebar__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.sidebar__header p {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 12px;
+  line-height: 16px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.stacked-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.session-search {
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.session-search input {
+  width: 100%;
+  height: 32px;
+  padding: 0 10px;
+}
+
+.thread-list {
+  flex: 1 1 auto;
+  min-height: 0;
+  padding: var(--space-2);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.thread-card {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid var(--border-subtle);
+  background: transparent;
+  color: var(--fg-primary);
+  text-align: left;
+  padding: 10px;
+  transition:
+    border-color var(--duration-base) var(--easing-standard),
+    background var(--duration-base) var(--easing-standard);
+}
+
+.thread-card:hover {
+  border-color: var(--border-strong);
+  background: color-mix(in srgb, var(--bg-elevated), transparent 22%);
+}
+
+.thread-card--active {
+  border-color: color-mix(in srgb, var(--accent), var(--border-strong) 44%);
+  background: color-mix(in srgb, var(--accent), var(--bg-panel) 91%);
+}
+
+.thread-card__title {
+  margin: 0;
+  font-size: 13px;
+  line-height: 20px;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.thread-card__preview {
+  margin: 0;
+  margin-top: 2px;
+  color: var(--fg-muted);
+  font-size: 12px;
+  line-height: 16px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.thread-card__meta {
+  margin-top: 6px;
+  color: var(--fg-muted);
+  font-size: 11px;
+  line-height: 14px;
+  font-family: var(--font-mono);
+}
+
+.thread-card__meta span {
+  display: block;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.load-more-btn {
+  width: 100%;
+  margin-top: var(--space-1);
+}
+
+.main-panel {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.chat-feed {
+  flex: 1 1 auto;
+  min-height: 0;
+  min-width: 0;
+  padding: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.entry {
+  border: 1px solid var(--border-subtle);
+  border-radius: 12px;
+  padding: 10px 12px;
+  min-width: 0;
+}
+
+.entry > header {
+  margin-bottom: 8px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+  color: var(--fg-muted);
+  font-size: 11px;
+  line-height: 14px;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.entry-status {
+  padding: 2px 6px;
+  border-radius: 999px;
+  border: 1px solid var(--border-subtle);
+  background: var(--bg-elevated);
+  font-family: var(--font-mono);
+  font-size: 11px;
+}
+
+.entry--user {
+  background: var(--entry-user);
+}
+
+.entry--assistant {
+  background: var(--entry-assistant);
+}
+
+.entry--reasoning,
+.entry--command,
+.entry--file-change {
+  background: color-mix(in srgb, var(--entry-assistant), var(--entry-system) 52%);
+}
+
+.entry--system,
+.entry--notification,
+.entry--approval {
+  background: var(--entry-system);
+}
+
+.entry-text,
+.entry-meta {
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.55;
+  overflow-wrap: break-word;
+}
+
+.entry-meta {
+  margin-top: 8px;
+  color: var(--fg-muted);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.entry-pre,
+.approval-card pre,
+.log-line {
+  margin: 0;
+  white-space: pre-wrap;
+  overflow-wrap: break-word;
+  font-family: var(--font-mono);
+}
+
+.entry-pre {
+  font-size: 12px;
+  line-height: 1.48;
+}
+
+.entry-markdown {
+  line-height: 1.6;
+}
+
+.entry-markdown p {
+  margin: 0 0 10px;
+}
+
+.entry-markdown :last-child {
+  margin-bottom: 0;
+}
+
+.entry-markdown pre {
+  margin: 10px 0;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  padding: 10px;
+  background: var(--bg-elevated);
+  overflow: auto;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.entry-markdown code {
+  padding: 1px 4px;
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  background: color-mix(in srgb, var(--bg-elevated), transparent 8%);
+  font-size: 0.9em;
+}
+
+.entry-markdown pre code {
+  padding: 0;
+  background: transparent;
+}
+
+.entry-markdown ul,
+.entry-markdown ol {
+  margin: 8px 0 10px 20px;
+}
+
+.entry-markdown table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 10px 0;
+  display: block;
+  overflow-x: auto;
+}
+
+.entry-markdown th,
+.entry-markdown td {
+  border: 1px solid var(--border-subtle);
+  padding: 6px;
+  text-align: left;
+}
+
+.approval-card {
+  border: 1px dashed color-mix(in srgb, var(--warning), var(--border-subtle) 46%);
+  border-radius: 10px;
+  padding: 10px;
+  background: color-mix(in srgb, var(--warning), transparent 90%);
+}
+
+.approval-card__heading {
+  margin: 0 0 8px;
+  color: var(--warning);
+  font-size: 11px;
+  line-height: 14px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.approval-card__actions {
+  margin-top: 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+}
+
+.composer {
+  flex: 0 0 auto;
+  border-top: 1px solid var(--border-subtle);
+  background: var(--bg-panel);
+  padding: var(--space-3);
+  display: grid;
+  gap: var(--space-2);
+}
+
+.composer textarea {
+  width: 100%;
+  min-height: 100px;
+  max-height: min(35dvh, 260px);
+  resize: vertical;
+  padding: 10px 12px;
+  line-height: 1.55;
+}
+
+.composer__actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.composer__actions p {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.devlog {
+  position: fixed;
+  right: var(--space-3);
+  top: var(--space-3);
+  bottom: var(--space-3);
+  width: min(640px, calc(100vw - 24px));
+  z-index: 90;
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-panel);
+  background: color-mix(in srgb, var(--bg-panel), transparent 2%);
+  transform: translateX(108%);
+  transition: transform var(--duration-base) var(--easing-standard);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.devlog--open {
+  transform: translateX(0);
+}
+
+.devlog-backdrop {
+  position: fixed;
+  inset: 0;
+  border: 0;
+  background: var(--backdrop);
+  z-index: 85;
+}
+
+.devlog__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-3);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.devlog__header p {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 12px;
+  line-height: 16px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.devlog__body {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+  padding: var(--space-3);
+}
+
+.log-line {
+  margin-bottom: 8px;
+  font-size: 11px;
+  line-height: 16px;
+}
+
+.log-line--in {
+  color: color-mix(in srgb, var(--accent), var(--fg-primary) 56%);
+}
+
+.log-line--out {
+  color: color-mix(in srgb, var(--ok), var(--fg-primary) 56%);
+}
+
+.log-line--error {
+  color: var(--danger);
+}
+
+.empty-note {
+  margin: 0;
+  color: var(--fg-muted);
+  font-size: 12px;
+  line-height: 16px;
+}
+
+.ghost-btn,
+.solid-btn,
+.danger-btn {
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid var(--border-subtle);
+  font-size: 12px;
+  line-height: 1;
+  font-weight: 500;
+  padding: 0 10px;
+  cursor: pointer;
+  transition:
+    border-color var(--duration-fast) var(--easing-standard),
+    background var(--duration-fast) var(--easing-standard),
+    color var(--duration-fast) var(--easing-standard);
+}
+
+.ghost-btn {
+  background: var(--bg-elevated);
+  color: var(--fg-secondary);
+}
+
+.ghost-btn:hover {
+  border-color: var(--border-strong);
+  color: var(--fg-primary);
+}
+
+.ghost-btn.is-active {
+  border-color: color-mix(in srgb, var(--accent), var(--border-strong) 40%);
+  color: var(--fg-primary);
+  background: color-mix(in srgb, var(--accent), var(--bg-elevated) 90%);
+}
+
+.solid-btn {
+  border-color: color-mix(in srgb, var(--accent), var(--border-subtle) 36%);
+  background: var(--accent);
+  color: #fff;
+}
+
+.solid-btn:hover {
+  background: var(--accent-hover);
+}
+
+.danger-btn {
+  border-color: color-mix(in srgb, var(--danger), var(--border-subtle) 46%);
+  color: color-mix(in srgb, var(--danger), var(--fg-primary) 32%);
+  background: color-mix(in srgb, var(--danger), transparent 90%);
+}
+
+.danger-btn:hover {
+  background: color-mix(in srgb, var(--danger), transparent 86%);
+}
+
+.ghost-btn:disabled,
+.solid-btn:disabled,
+.danger-btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+.mobile-only {
+  display: none;
+}
+
+.sidebar-backdrop {
+  display: none;
+}
+
+@media (max-width: 1024px) {
+  .app-content {
+    grid-template-columns: 1fr;
+  }
+
+  .sidebar {
+    position: fixed;
+    left: var(--space-3);
+    top: var(--space-3);
+    width: min(360px, calc(100vw - 24px));
+    height: calc(100vh - 24px);
+    height: calc(100dvh - 24px);
+    z-index: 100;
+    transform: translateX(-115%);
+    transition: transform var(--duration-base) var(--easing-standard);
+  }
+
+  .sidebar--open {
+    transform: translateX(0);
+  }
+
+  .mobile-only {
+    display: inline-flex;
+  }
+
+  .sidebar-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    border: 0;
+    z-index: 80;
+    background: var(--backdrop);
+  }
+}
+
+@media (max-width: 760px) {
+  .app-shell {
+    padding: var(--space-2);
+    gap: var(--space-2);
+  }
+
+  .topbar {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .topbar__right {
+    justify-content: flex-start;
+  }
+
+  .chat-feed {
+    padding: var(--space-3);
+  }
+
+  .composer__actions {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .devlog {
+    right: var(--space-2);
+    top: var(--space-2);
+    bottom: var(--space-2);
+    width: calc(100vw - 16px);
+  }
+}

--- a/codex-rs/companion/ui/src/types.ts
+++ b/codex-rs/companion/ui/src/types.ts
@@ -1,0 +1,115 @@
+export type JsonValue =
+  | string
+  | number
+  | boolean
+  | null
+  | JsonValue[]
+  | { [key: string]: JsonValue };
+
+export interface RpcRequest {
+  id: number;
+  method: string;
+  params?: JsonValue;
+}
+
+export interface RpcNotification {
+  method: string;
+  params?: JsonValue;
+}
+
+export interface RpcSuccess {
+  id: number;
+  result: JsonValue;
+}
+
+export interface RpcError {
+  id: number;
+  error: {
+    code: number;
+    message: string;
+    data?: JsonValue;
+  };
+}
+
+export type IncomingRpc =
+  | RpcSuccess
+  | RpcError
+  | ({ id: number; method: string; params?: JsonValue } & Record<string, JsonValue>)
+  | ({ method: string; params?: JsonValue } & Record<string, JsonValue>);
+
+export type ConnectionStatus = "connecting" | "connected" | "disconnected" | "error" | "missing-token";
+
+export interface ThreadSummary {
+  id: string;
+  title: string;
+  preview: string;
+  searchText: string;
+  updatedAt?: number;
+}
+
+export type TimelineKind =
+  | "system"
+  | "user"
+  | "assistant"
+  | "reasoning"
+  | "command"
+  | "file-change"
+  | "approval"
+  | "notification";
+
+export interface TimelineEntry {
+  key: string;
+  kind: TimelineKind;
+  label: string;
+  text: string;
+  status?: string;
+  meta?: string;
+  requestId?: number;
+  method?: string;
+  createdAt: number;
+}
+
+export interface RawLogEntry {
+  id: number;
+  direction: "in" | "out" | "info" | "error";
+  at: number;
+  text: string;
+}
+
+export interface AppState {
+  connection: ConnectionStatus;
+  statusText: string;
+  initialized: boolean;
+  threadId: string | null;
+  threads: ThreadSummary[];
+  threadsLoaded: boolean;
+  threadsNextCursor: string | null;
+  threadsLoadingMore: boolean;
+  timeline: TimelineEntry[];
+  itemToTimeline: Record<string, string>;
+  activeApprovals: Record<number, true>;
+  logs: RawLogEntry[];
+  logPanelOpen: boolean;
+  sidebarOpen: boolean;
+  streamActive: boolean;
+  theme: "dark" | "light";
+}
+
+export type AppAction =
+  | { type: "set_connection"; connection: ConnectionStatus; statusText: string }
+  | { type: "set_initialized"; initialized: boolean }
+  | { type: "set_thread"; threadId: string | null }
+  | { type: "set_threads"; threads: ThreadSummary[]; nextCursor: string | null }
+  | { type: "append_threads"; threads: ThreadSummary[]; nextCursor: string | null }
+  | { type: "set_threads_loading_more"; loading: boolean }
+  | { type: "clear_timeline" }
+  | { type: "upsert_entry"; entry: TimelineEntry }
+  | { type: "append_delta"; itemId: string; delta: string }
+  | { type: "set_item_key"; itemId: string; key: string }
+  | { type: "activate_approval"; requestId: number }
+  | { type: "complete_approval"; requestId: number; status: string }
+  | { type: "set_log_panel"; open: boolean }
+  | { type: "append_log"; log: RawLogEntry }
+  | { type: "set_sidebar"; open: boolean }
+  | { type: "set_stream_active"; active: boolean }
+  | { type: "set_theme"; theme: "dark" | "light" };

--- a/codex-rs/companion/ui/src/vite-env.d.ts
+++ b/codex-rs/companion/ui/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/codex-rs/companion/ui/tsconfig.json
+++ b/codex-rs/companion/ui/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": false,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "types": ["vite/client"]
+  },
+  "include": ["src"]
+}

--- a/codex-rs/companion/ui/vite.config.ts
+++ b/codex-rs/companion/ui/vite.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: "dist",
+    emptyOutDir: true,
+    sourcemap: false
+  }
+});

--- a/docs/companion.md
+++ b/docs/companion.md
@@ -1,0 +1,71 @@
+# Companion Web UI
+
+Codex includes an experimental, local web UI backed by `codex app-server`.
+
+## Usage
+
+Run:
+
+```sh
+codex --companion
+```
+
+Codex will:
+
+- Start a local HTTP server bound to `127.0.0.1`
+- Print a URL containing a per-run session token
+- Open that URL in your browser (disable with `--companion-no-open`)
+
+Optional flags:
+
+- `--companion-port <PORT>`: bind a specific port (default `0` picks a free port)
+- `--companion-no-open`: don’t auto-open the browser
+- `--companion-ui-dev-url <URL>`: use an external frontend URL (for example Vite) instead of embedded UI assets
+
+## Security Model
+
+- The server binds only to `127.0.0.1` (localhost).
+- The UI entrypoint (`/`) and transport websocket (`/ws`) require a per-run random `token` included in the URL.
+
+## Frontend Development
+
+The Companion frontend is a React app in `codex-rs/companion/ui`.
+
+```sh
+cd codex-rs/companion/ui
+pnpm install --ignore-workspace
+pnpm build
+```
+
+This writes production assets to `codex-rs/companion/ui/dist`, which are embedded into the Rust binary.
+
+### Live Reload (Vite HMR)
+
+For UI development, run Companion against a Vite dev server so frontend edits live-reload without restarting Codex:
+
+Terminal 1:
+
+```sh
+cd codex-rs/companion/ui
+pnpm install --ignore-workspace
+pnpm dev --host 127.0.0.1 --port 5173
+```
+
+Terminal 2:
+
+```sh
+cd codex-rs
+RUSTC="$(rustup which rustc --toolchain 1.93.0)" \
+"$(rustup which cargo --toolchain 1.93.0)" run -p codex-cli -- \
+  --companion \
+  --companion-no-open \
+  --companion-port 4321 \
+  --companion-ui-dev-url http://127.0.0.1:5173
+```
+
+Open the printed `Companion:` URL. The React app will come from Vite (`5173`) while WebSocket/API traffic is routed to Companion (`4321`).
+
+## Troubleshooting
+
+- If the browser opens but shows “Missing token”, use the exact URL printed in your terminal.
+- If you’re running over SSH, use `--companion-no-open` and copy the printed URL into a browser on the same machine.


### PR DESCRIPTION
## Summary

This PR introduces an experimental Companion web experience for Codex, powered by `codex app-server`.

### What’s included

- Adds a new `--companion` CLI mode to launch a local browser UI.
- Adds companion server crate: `codex-rs/companion`.
  - Hosts UI on localhost.
  - Enforces per-run token auth for `/` and `/ws`.
  - Bridges JSON-RPC JSONL between browser websocket and spawned `codex app-server`.
- Adds a React/Vite Companion frontend under `codex-rs/companion/ui` with:
  - Session list + text search.
  - Session resume/new-session controls.
  - Live chat/timeline stream rendering.
  - Approval cards for command/file approval requests.
  - JSON-RPC log drawer.
  - Themed, full-height layout with independent scroll regions.
  - Session pagination/lazy loading support from `thread/list` cursors.
- Adds Companion docs (`docs/companion.md`) including usage and local frontend development workflow.
- Adds optional dev workflow flag:
  - `--companion-ui-dev-url <URL>` to use a local Vite dev server (HMR) while keeping websocket/API traffic on companion backend.

## CLI surface

- `--companion`
- `--companion-port <PORT>`
- `--companion-no-open`
- `--companion-ui-dev-url <URL>`

## Validation

- `just fmt`
- `just fix -p codex-companion`
- `just fix -p codex-cli`
- `cargo test -p codex-companion`
- `cargo test -p codex-cli`
- `pnpm build` in `codex-rs/companion/ui`

## Feedback requested

I’d love focused feedback on:

1. Companion CLI/API surface (`--companion*` flags and defaults).
2. Security model (token + localhost assumptions).
3. UX/layout decisions for sessions/chat/log drawer.
4. Whether this should remain behind experimental labeling as-is or be feature-gated differently.
