### PR TITLE
Increased file watcher debounce duration from 1s to 10s

### DIFF
--- a/codex-rs/core/src/file_watcher.rs
+++ b/codex-rs/core/src/file_watcher.rs
@@ -39,7 +39,7 @@ struct FileWatcherInner {
     watched_paths: HashMap<PathBuf, RecursiveMode>,
 }
 
-const WATCHER_THROTTLE_INTERVAL: Duration = Duration::from_secs(1);
+const WATCHER_THROTTLE_INTERVAL: Duration = Duration::from_secs(10);
 
 /// Coalesces bursts of paths and emits at most once per interval.
 struct ThrottledPaths {


### PR DESCRIPTION
Users were reporting that when they were actively editing a skill file, they would see frequent errors (one per second) across all of their active session until they fixed all frontmatter parse errors. This change will reduce the chatter at the expense of a slightly longer delay before skills are updated in the UI.

This addresses #11385