### PR TITLE
Consolidate search_tool feature into apps

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -248,6 +248,9 @@
             "runtime_metrics": {
               "type": "boolean"
             },
+            "search_tool": {
+              "type": "boolean"
+            },
             "shell_snapshot": {
               "type": "boolean"
             },
@@ -1327,6 +1330,9 @@
           "type": "boolean"
         },
         "runtime_metrics": {
+          "type": "boolean"
+        },
+        "search_tool": {
           "type": "boolean"
         },
         "shell_snapshot": {

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -248,9 +248,6 @@
             "runtime_metrics": {
               "type": "boolean"
             },
-            "search_tool": {
-              "type": "boolean"
-            },
             "shell_snapshot": {
               "type": "boolean"
             },
@@ -1330,9 +1327,6 @@
           "type": "boolean"
         },
         "runtime_metrics": {
-          "type": "boolean"
-        },
-        "search_tool": {
           "type": "boolean"
         },
         "shell_snapshot": {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4389,7 +4389,7 @@ async fn built_tools(
         None
     };
 
-    if turn_context.config.features.enabled(Feature::SearchTool) {
+    if turn_context.config.features.enabled(Feature::Apps) {
         let mut selected_mcp_tools =
             if let Some(selected_tools) = sess.get_mcp_tool_selection().await {
                 filter_mcp_tools_by_name(mcp_tools.clone(), &selected_tools)

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -89,8 +89,6 @@ pub enum Feature {
     /// Allow the model to request web searches that fetch cached content.
     /// Takes precedence over `WebSearchRequest`.
     WebSearchCached,
-    /// Allow the model to search MCP tools via BM25 before exposing them.
-    SearchTool,
     /// Use the bubblewrap-based Linux sandbox pipeline.
     UseLinuxSandboxBwrap,
     /// Allow the model to request approval and propose exec rules.
@@ -440,12 +438,6 @@ pub const FEATURES: &[FeatureSpec] = &[
         id: Feature::WebSearchCached,
         key: "web_search_cached",
         stage: Stage::Deprecated,
-        default_enabled: false,
-    },
-    FeatureSpec {
-        id: Feature::SearchTool,
-        key: "search_tool",
-        stage: Stage::UnderDevelopment,
         default_enabled: false,
     },
     // Experimental program. Rendered in the `/experimental` menu for users.

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -89,6 +89,8 @@ pub enum Feature {
     /// Allow the model to request web searches that fetch cached content.
     /// Takes precedence over `WebSearchRequest`.
     WebSearchCached,
+    /// Legacy search-tool feature flag kept for backward compatibility.
+    SearchTool,
     /// Use the bubblewrap-based Linux sandbox pipeline.
     UseLinuxSandboxBwrap,
     /// Allow the model to request approval and propose exec rules.
@@ -438,6 +440,12 @@ pub const FEATURES: &[FeatureSpec] = &[
         id: Feature::WebSearchCached,
         key: "web_search_cached",
         stage: Stage::Deprecated,
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::SearchTool,
+        key: "search_tool",
+        stage: Stage::Removed,
         default_enabled: false,
     },
     // Experimental program. Rendered in the `/experimental` menu for users.

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -58,7 +58,7 @@ impl ToolsConfig {
         let include_collab_tools = features.enabled(Feature::Collab);
         let include_collaboration_modes_tools = features.enabled(Feature::CollaborationModes);
         let request_rule_enabled = features.enabled(Feature::RequestRule);
-        let include_search_tool = features.enabled(Feature::SearchTool);
+        let include_search_tool = features.enabled(Feature::Apps);
 
         let shell_type = if !features.enabled(Feature::ShellTool) {
             ConfigShellToolType::Disabled

--- a/codex-rs/core/tests/suite/search_tool.rs
+++ b/codex-rs/core/tests/suite/search_tool.rs
@@ -111,7 +111,7 @@ async fn search_tool_flag_adds_tool() -> Result<()> {
     .await;
 
     let mut builder = test_codex().with_config(|config| {
-        config.features.enable(Feature::SearchTool);
+        config.features.enable(Feature::Apps);
     });
     let test = builder.build(&server).await?;
 
@@ -148,7 +148,7 @@ async fn search_tool_adds_developer_instructions() -> Result<()> {
     .await;
 
     let mut builder = test_codex().with_config(|config| {
-        config.features.enable(Feature::SearchTool);
+        config.features.enable(Feature::Apps);
     });
     let test = builder.build(&server).await?;
 
@@ -190,7 +190,7 @@ async fn search_tool_hides_mcp_tools_without_search() -> Result<()> {
 
     let rmcp_test_server_bin = stdio_server_bin()?;
     let mut builder = test_codex().with_config(move |config| {
-        config.features.enable(Feature::SearchTool);
+        config.features.enable(Feature::Apps);
         let mut servers = config.mcp_servers.get().clone();
         servers.insert(
             "rmcp".to_string(),
@@ -273,7 +273,7 @@ async fn search_tool_selection_persists_within_turn_and_resets_next_turn() -> Re
 
     let rmcp_test_server_bin = stdio_server_bin()?;
     let mut builder = test_codex().with_config(move |config| {
-        config.features.enable(Feature::SearchTool);
+        config.features.enable(Feature::Apps);
         let mut servers = config.mcp_servers.get().clone();
         servers.insert(
             "rmcp".to_string(),
@@ -401,7 +401,7 @@ async fn search_tool_selection_unions_results_within_turn() -> Result<()> {
 
     let rmcp_test_server_bin = stdio_server_bin()?;
     let mut builder = test_codex().with_config(move |config| {
-        config.features.enable(Feature::SearchTool);
+        config.features.enable(Feature::Apps);
         let mut servers = config.mcp_servers.get().clone();
         servers.insert(
             "rmcp".to_string(),


### PR DESCRIPTION
## Summary
- Remove `Feature::SearchTool` and the `search_tool` config key from the feature registry/schema.
- Gate `search_tool_bm25` exposure via `Feature::Apps` in `core/src/tools/spec.rs`.
- Update MCP selection logic in `core/src/codex.rs` to use `Feature::Apps` for search-tool behavior.
- Update `core/tests/suite/search_tool.rs` to enable `Feature::Apps`.
- Regenerate `core/config.schema.json` via `just write-config-schema`.

## Testing
- `just fmt`
- `cargo test -p codex-core --test all suite::search_tool::`

## Tickets
- None
