### PR TITLE
add a slash command to grant sandbox read access to inaccessible directories

### DIFF
--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -79,6 +79,7 @@ pub mod review_format;
 pub mod review_prompts;
 mod thread_manager;
 pub mod web_search;
+pub mod windows_sandbox_read_grants;
 pub use codex_protocol::protocol::InitialHistory;
 pub use thread_manager::NewThread;
 pub use thread_manager::ThreadManager;

--- a/codex-rs/core/src/windows_sandbox.rs
+++ b/codex-rs/core/src/windows_sandbox.rs
@@ -10,6 +10,7 @@ use codex_protocol::config_types::WindowsSandboxLevel;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::path::Path;
+use std::path::PathBuf;
 
 /// Kill switch for the elevated sandbox NUX on Windows.
 ///
@@ -200,6 +201,25 @@ pub fn run_legacy_setup_preflight(
     )
 }
 
+#[cfg(target_os = "windows")]
+pub fn run_setup_refresh_with_extra_read_roots(
+    policy: &SandboxPolicy,
+    policy_cwd: &Path,
+    command_cwd: &Path,
+    env_map: &HashMap<String, String>,
+    codex_home: &Path,
+    extra_read_roots: Vec<PathBuf>,
+) -> anyhow::Result<()> {
+    codex_windows_sandbox::run_setup_refresh_with_extra_read_roots(
+        policy,
+        policy_cwd,
+        command_cwd,
+        env_map,
+        codex_home,
+        extra_read_roots,
+    )
+}
+
 #[cfg(not(target_os = "windows"))]
 pub fn run_legacy_setup_preflight(
     _policy: &SandboxPolicy,
@@ -209,6 +229,18 @@ pub fn run_legacy_setup_preflight(
     _codex_home: &Path,
 ) -> anyhow::Result<()> {
     anyhow::bail!("legacy Windows sandbox setup is only supported on Windows")
+}
+
+#[cfg(not(target_os = "windows"))]
+pub fn run_setup_refresh_with_extra_read_roots(
+    _policy: &SandboxPolicy,
+    _policy_cwd: &Path,
+    _command_cwd: &Path,
+    _env_map: &HashMap<String, String>,
+    _codex_home: &Path,
+    _extra_read_roots: Vec<PathBuf>,
+) -> anyhow::Result<()> {
+    anyhow::bail!("Windows sandbox read-root refresh is only supported on Windows")
 }
 
 #[cfg(test)]

--- a/codex-rs/core/src/windows_sandbox_read_grants.rs
+++ b/codex-rs/core/src/windows_sandbox_read_grants.rs
@@ -1,0 +1,97 @@
+use crate::protocol::SandboxPolicy;
+use crate::windows_sandbox::run_setup_refresh_with_extra_read_roots;
+use anyhow::Result;
+use std::collections::HashMap;
+use std::path::Path;
+use std::path::PathBuf;
+
+pub fn grant_read_root_non_elevated(
+    policy: &SandboxPolicy,
+    policy_cwd: &Path,
+    command_cwd: &Path,
+    env_map: &HashMap<String, String>,
+    codex_home: &Path,
+    read_root: &Path,
+) -> Result<PathBuf> {
+    if !read_root.is_absolute() {
+        anyhow::bail!("path must be absolute: {}", read_root.display());
+    }
+    if !read_root.exists() {
+        anyhow::bail!("path does not exist: {}", read_root.display());
+    }
+    if !read_root.is_dir() {
+        anyhow::bail!("path must be a directory: {}", read_root.display());
+    }
+
+    let canonical_root = dunce::canonicalize(read_root)?;
+    run_setup_refresh_with_extra_read_roots(
+        policy,
+        policy_cwd,
+        command_cwd,
+        env_map,
+        codex_home,
+        vec![canonical_root.clone()],
+    )?;
+    Ok(canonical_root)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::grant_read_root_non_elevated;
+    use crate::protocol::SandboxPolicy;
+    use std::collections::HashMap;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn policy() -> SandboxPolicy {
+        SandboxPolicy::new_workspace_write_policy()
+    }
+
+    #[test]
+    fn rejects_relative_path() {
+        let tmp = TempDir::new().expect("tempdir");
+        let err = grant_read_root_non_elevated(
+            &policy(),
+            tmp.path(),
+            tmp.path(),
+            &HashMap::new(),
+            tmp.path(),
+            Path::new("relative"),
+        )
+        .expect_err("relative path should fail");
+        assert!(err.to_string().contains("path must be absolute"));
+    }
+
+    #[test]
+    fn rejects_missing_path() {
+        let tmp = TempDir::new().expect("tempdir");
+        let missing = tmp.path().join("does-not-exist");
+        let err = grant_read_root_non_elevated(
+            &policy(),
+            tmp.path(),
+            tmp.path(),
+            &HashMap::new(),
+            tmp.path(),
+            missing.as_path(),
+        )
+        .expect_err("missing path should fail");
+        assert!(err.to_string().contains("path does not exist"));
+    }
+
+    #[test]
+    fn rejects_file_path() {
+        let tmp = TempDir::new().expect("tempdir");
+        let file_path = tmp.path().join("file.txt");
+        std::fs::write(&file_path, "hello").expect("write file");
+        let err = grant_read_root_non_elevated(
+            &policy(),
+            tmp.path(),
+            tmp.path(),
+            &HashMap::new(),
+            tmp.path(),
+            file_path.as_path(),
+        )
+        .expect_err("file path should fail");
+        assert!(err.to_string().contains("path must be a directory"));
+    }
+}

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1826,6 +1826,66 @@ impl App {
                     let _ = preset;
                 }
             }
+            AppEvent::BeginWindowsSandboxGrantReadRoot { path } => {
+                #[cfg(target_os = "windows")]
+                {
+                    self.chat_widget
+                        .add_to_history(history_cell::new_info_event(
+                            format!("Granting sandbox read access to {path} ..."),
+                            None,
+                        ));
+
+                    let policy = self.config.sandbox_policy.get().clone();
+                    let policy_cwd = self.config.cwd.clone();
+                    let command_cwd = self.config.cwd.clone();
+                    let env_map: std::collections::HashMap<String, String> =
+                        std::env::vars().collect();
+                    let codex_home = self.config.codex_home.clone();
+                    let tx = self.app_event_tx.clone();
+
+                    tokio::task::spawn_blocking(move || {
+                        let requested_path = PathBuf::from(path);
+                        let event = match codex_core::windows_sandbox_read_grants::grant_read_root_non_elevated(
+                            &policy,
+                            policy_cwd.as_path(),
+                            command_cwd.as_path(),
+                            &env_map,
+                            codex_home.as_path(),
+                            requested_path.as_path(),
+                        ) {
+                            Ok(canonical_path) => AppEvent::WindowsSandboxGrantReadRootCompleted {
+                                path: canonical_path,
+                                error: None,
+                            },
+                            Err(err) => AppEvent::WindowsSandboxGrantReadRootCompleted {
+                                path: requested_path,
+                                error: Some(err.to_string()),
+                            },
+                        };
+                        tx.send(event);
+                    });
+                }
+                #[cfg(not(target_os = "windows"))]
+                {
+                    let _ = path;
+                }
+            }
+            AppEvent::WindowsSandboxGrantReadRootCompleted { path, error } => match error {
+                Some(err) => {
+                    self.chat_widget
+                        .add_to_history(history_cell::new_error_event(format!(
+                            "Failed to grant sandbox read access for {}: {err}",
+                            path.display()
+                        )));
+                }
+                None => {
+                    self.chat_widget
+                        .add_to_history(history_cell::new_info_event(
+                            format!("Sandbox read access granted for {}", path.display()),
+                            None,
+                        ));
+                }
+            },
             AppEvent::EnableWindowsSandboxForAgentMode { preset, mode } => {
                 #[cfg(target_os = "windows")]
                 {

--- a/codex-rs/tui/src/app.rs
+++ b/codex-rs/tui/src/app.rs
@@ -1873,10 +1873,7 @@ impl App {
             AppEvent::WindowsSandboxGrantReadRootCompleted { path, error } => match error {
                 Some(err) => {
                     self.chat_widget
-                        .add_to_history(history_cell::new_error_event(format!(
-                            "Failed to grant sandbox read access for {}: {err}",
-                            path.display()
-                        )));
+                        .add_to_history(history_cell::new_error_event(format!("Error: {err}")));
                 }
                 None => {
                     self.chat_widget

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -218,6 +218,19 @@ pub(crate) enum AppEvent {
         preset: ApprovalPreset,
     },
 
+    /// Begin a non-elevated grant of read access for an additional directory.
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+    BeginWindowsSandboxGrantReadRoot {
+        path: String,
+    },
+
+    /// Result of attempting to grant read access for an additional directory.
+    #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
+    WindowsSandboxGrantReadRootCompleted {
+        path: PathBuf,
+        error: Option<String>,
+    },
+
     /// Enable the Windows sandbox feature and switch to Agent mode.
     #[cfg_attr(not(target_os = "windows"), allow(dead_code))]
     EnableWindowsSandboxForAgentMode {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3357,7 +3357,7 @@ impl ChatWidget {
             }
             SlashCommand::SandboxReadRoot => {
                 self.add_error_message(
-                    "Usage: /sandbox-read-root <absolute-directory-path>".to_string(),
+                    "Usage: /sandbox-add-read-dir <absolute-directory-path>".to_string(),
                 );
             }
             SlashCommand::Experimental => {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3355,6 +3355,11 @@ impl ChatWidget {
                     // Not supported; on non-Windows this command should never be reachable.
                 };
             }
+            SlashCommand::SandboxReadRoot => {
+                self.add_error_message(
+                    "Usage: /sandbox-read-root <absolute-directory-path>".to_string(),
+                );
+            }
             SlashCommand::Experimental => {
                 self.open_experimental_popup();
             }
@@ -3549,6 +3554,18 @@ impl ChatWidget {
                         user_facing_hint: None,
                     },
                 });
+                self.bottom_pane.drain_pending_submission_state();
+            }
+            SlashCommand::SandboxReadRoot if !trimmed.is_empty() => {
+                let Some((prepared_args, _prepared_elements)) =
+                    self.bottom_pane.prepare_inline_args_submission(false)
+                else {
+                    return;
+                };
+                self.app_event_tx
+                    .send(AppEvent::BeginWindowsSandboxGrantReadRoot {
+                        path: prepared_args,
+                    });
                 self.bottom_pane.drain_pending_submission_state();
             }
             _ => self.dispatch_command(cmd),

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -17,7 +17,7 @@ pub enum SlashCommand {
     Permissions,
     #[strum(serialize = "setup-default-sandbox")]
     ElevateSandbox,
-    #[strum(serialize = "sandbox-read-root")]
+    #[strum(serialize = "sandbox-add-read-dir")]
     SandboxReadRoot,
     Experimental,
     Skills,
@@ -80,7 +80,9 @@ impl SlashCommand {
             SlashCommand::Approvals => "choose what Codex is allowed to do",
             SlashCommand::Permissions => "choose what Codex is allowed to do",
             SlashCommand::ElevateSandbox => "set up elevated agent sandbox",
-            SlashCommand::SandboxReadRoot => "grant sandbox read access: /sandbox-read-root <path>",
+            SlashCommand::SandboxReadRoot => {
+                "grant sandbox read access: /sandbox-add-read-dir <path>"
+            }
             SlashCommand::Experimental => "toggle experimental features",
             SlashCommand::Mcp => "list configured MCP tools",
             SlashCommand::Apps => "manage apps",

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -17,6 +17,8 @@ pub enum SlashCommand {
     Permissions,
     #[strum(serialize = "setup-default-sandbox")]
     ElevateSandbox,
+    #[strum(serialize = "sandbox-read-root")]
+    SandboxReadRoot,
     Experimental,
     Skills,
     Review,
@@ -77,7 +79,8 @@ impl SlashCommand {
             SlashCommand::Agent => "switch the active agent thread",
             SlashCommand::Approvals => "choose what Codex is allowed to do",
             SlashCommand::Permissions => "choose what Codex is allowed to do",
-            SlashCommand::ElevateSandbox => "set up default agent sandbox",
+            SlashCommand::ElevateSandbox => "set up elevated agent sandbox",
+            SlashCommand::SandboxReadRoot => "grant sandbox read access: /sandbox-read-root <path>",
             SlashCommand::Experimental => "toggle experimental features",
             SlashCommand::Mcp => "list configured MCP tools",
             SlashCommand::Apps => "manage apps",
@@ -97,7 +100,10 @@ impl SlashCommand {
     pub fn supports_inline_args(self) -> bool {
         matches!(
             self,
-            SlashCommand::Review | SlashCommand::Rename | SlashCommand::Plan
+            SlashCommand::Review
+                | SlashCommand::Rename
+                | SlashCommand::Plan
+                | SlashCommand::SandboxReadRoot
         )
     }
 
@@ -115,6 +121,7 @@ impl SlashCommand {
             | SlashCommand::Approvals
             | SlashCommand::Permissions
             | SlashCommand::ElevateSandbox
+            | SlashCommand::SandboxReadRoot
             | SlashCommand::Experimental
             | SlashCommand::Review
             | SlashCommand::Plan
@@ -142,6 +149,7 @@ impl SlashCommand {
 
     fn is_visible(self) -> bool {
         match self {
+            SlashCommand::SandboxReadRoot => cfg!(target_os = "windows"),
             SlashCommand::Rollout | SlashCommand::TestApproval => cfg!(debug_assertions),
             _ => true,
         }

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -81,7 +81,7 @@ impl SlashCommand {
             SlashCommand::Permissions => "choose what Codex is allowed to do",
             SlashCommand::ElevateSandbox => "set up elevated agent sandbox",
             SlashCommand::SandboxReadRoot => {
-                "grant sandbox read access: /sandbox-add-read-dir <path>"
+                "let sandbox read a directory: /sandbox-add-read-dir <absolute_path>"
             }
             SlashCommand::Experimental => "toggle experimental features",
             SlashCommand::Mcp => "list configured MCP tools",

--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -83,6 +83,8 @@ pub use setup::run_elevated_setup;
 #[cfg(target_os = "windows")]
 pub use setup::run_setup_refresh;
 #[cfg(target_os = "windows")]
+pub use setup::run_setup_refresh_with_extra_read_roots;
+#[cfg(target_os = "windows")]
 pub use setup::sandbox_dir;
 #[cfg(target_os = "windows")]
 pub use setup::sandbox_secrets_dir;

--- a/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
+++ b/codex-rs/windows-sandbox-rs/src/setup_orchestrator.rs
@@ -62,6 +62,47 @@ pub fn run_setup_refresh(
     env_map: &HashMap<String, String>,
     codex_home: &Path,
 ) -> Result<()> {
+    run_setup_refresh_inner(
+        policy,
+        policy_cwd,
+        command_cwd,
+        env_map,
+        codex_home,
+        None,
+        None,
+    )
+}
+
+pub fn run_setup_refresh_with_extra_read_roots(
+    policy: &SandboxPolicy,
+    policy_cwd: &Path,
+    command_cwd: &Path,
+    env_map: &HashMap<String, String>,
+    codex_home: &Path,
+    extra_read_roots: Vec<PathBuf>,
+) -> Result<()> {
+    let mut read_roots = gather_read_roots(command_cwd, policy);
+    read_roots.extend(extra_read_roots);
+    run_setup_refresh_inner(
+        policy,
+        policy_cwd,
+        command_cwd,
+        env_map,
+        codex_home,
+        Some(read_roots),
+        Some(Vec::new()),
+    )
+}
+
+fn run_setup_refresh_inner(
+    policy: &SandboxPolicy,
+    policy_cwd: &Path,
+    command_cwd: &Path,
+    env_map: &HashMap<String, String>,
+    codex_home: &Path,
+    read_roots_override: Option<Vec<PathBuf>>,
+    write_roots_override: Option<Vec<PathBuf>>,
+) -> Result<()> {
     // Skip in danger-full-access.
     if matches!(
         policy,
@@ -75,8 +116,8 @@ pub fn run_setup_refresh(
         command_cwd,
         env_map,
         codex_home,
-        None,
-        None,
+        read_roots_override,
+        write_roots_override,
     );
     let payload = ElevationPayload {
         version: SETUP_VERSION,


### PR DESCRIPTION
There is an edge case where a directory is not readable by the sandbox. In practice, we've seen very little of it, but it can happen so this slash command unlocks users when it does.

Future idea is to make this a tool that the agent knows about so it can be more integrated.
