### PR TITLE
feat: try to fix bugs I saw in the wild in the resource parsing logic

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -84,11 +84,13 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          cpu_model="$(lscpu | awk -F: '/Model name/ {gsub(/^[ \t]+/, "", $2); print $2; exit}')"
+          total_ram="$(awk '/MemTotal/ {printf "%.1f GiB\n", $2 / 1024 / 1024}' /proc/meminfo)"
           echo "Runner: ${RUNNER_NAME:-unknown}"
           echo "OS: $(uname -a)"
-          echo "CPU model: $(lscpu | awk -F: '/Model name/ {gsub(/^[ \t]+/,\"\",$2); print $2; exit}')"
+          echo "CPU model: ${cpu_model}"
           echo "Logical CPUs: $(nproc)"
-          echo "Total RAM: $(awk '/MemTotal/ {printf \"%.1f GiB\\n\", $2 / 1024 / 1024}' /proc/meminfo)"
+          echo "Total RAM: ${total_ram}"
           echo "Disk usage:"
           df -h .
       - name: Print runner specs (macOS)
@@ -96,13 +98,14 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          total_ram="$(sysctl -n hw.memsize | awk '{printf "%.1f GiB\n", $1 / 1024 / 1024 / 1024}')"
           echo "Runner: ${RUNNER_NAME:-unknown}"
           echo "OS: $(sw_vers -productName) $(sw_vers -productVersion)"
           echo "Hardware model: $(sysctl -n hw.model)"
           echo "CPU architecture: $(uname -m)"
           echo "Logical CPUs: $(sysctl -n hw.logicalcpu)"
           echo "Physical CPUs: $(sysctl -n hw.physicalcpu)"
-          echo "Total RAM: $(sysctl -n hw.memsize | awk '{printf \"%.1f GiB\\n\", $1 / 1024 / 1024 / 1024}')"
+          echo "Total RAM: ${total_ram}"
           echo "Disk usage:"
           df -h .
       - name: Install Linux bwrap build dependencies


### PR DESCRIPTION
I gave Codex the following bug report about the logic to report the host's resources introduced in https://github.com/openai/codex/pull/11488 and this PR is its proposed fix.

The fix seems like an escaping issue, mostly.

---

The logic to print out the runner specs has an awk error on Mac:

```
Runner: GitHub Actions 1014936475
OS: macOS 15.7.3
Hardware model: VirtualMac2,1
CPU architecture: arm64
Logical CPUs: 5
Physical CPUs: 5
awk: syntax error at source line 1
 context is
	{printf >>>  \ <<< "%.1f GiB\\n\", $1 / 1024 / 1024 / 1024}
awk: illegal statement at source line 1
Total RAM: 
Disk usage:
Filesystem      Size    Used   Avail Capacity iused ifree %iused  Mounted on
/dev/disk3s5   320Gi   237Gi    64Gi    79%    2.0M  671M    0%   /System/Volumes/Data
```

as well as Linux:

```
Runner: GitHub Actions 1014936469
OS: Linux runnervmwffz4 6.11.0-1018-azure #18~24.04.1-Ubuntu SMP Sat Jun 28 04:46:03 UTC 2025 x86_64 x86_64 x86_64 GNU/Linux
awk: cmd. line:1: /Model name/ {gsub(/^[ \t]+/,\"\",$2); print $2; exit}
awk: cmd. line:1:                              ^ backslash not last character on line
CPU model: 
Logical CPUs: 4
awk: cmd. line:1: /MemTotal/ {printf \"%.1f GiB\\n\", $2 / 1024 / 1024}
awk: cmd. line:1:                    ^ backslash not last character on line
Total RAM: 
Disk usage:
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        72G   50G   22G  70% /
```