### PR TITLE
test(app-server): stabilize app/list thread feature-flag test by using file-backed MCP OAuth creds

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/app_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/app_list.rs
@@ -120,6 +120,7 @@ async fn list_apps_uses_thread_feature_flag_when_thread_id_is_provided() -> Resu
         format!(
             r#"
 chatgpt_base_url = "{server_url}"
+mcp_oauth_credentials_store = "file"
 
 [features]
 connectors = false
@@ -791,6 +792,7 @@ fn write_connectors_config(codex_home: &std::path::Path, base_url: &str) -> std:
         format!(
             r#"
 chatgpt_base_url = "{base_url}"
+mcp_oauth_credentials_store = "file"
 
 [features]
 connectors = true


### PR DESCRIPTION
## Why

`suite::v2::app_list::list_apps_uses_thread_feature_flag_when_thread_id_is_provided` has been flaky in CI. The test exercises `thread/start`, which initializes `codex_apps`. In CI/Linux, that path can reach OS keyring-backed MCP OAuth credential lookup (`Codex MCP Credentials`) and intermittently abort the MCP process (observed stack overflow in `zbus`), causing the test to fail before the assertion logic runs.

## What Changed

- Updated the test config in `codex-rs/app-server/tests/suite/v2/app_list.rs` to set `mcp_oauth_credentials_store = "file"` in both relevant config-writing paths:
  - The in-test config override inside `list_apps_uses_thread_feature_flag_when_thread_id_is_provided`
  - `write_connectors_config(...)`, which is used by the v2 `app_list` test suite
- This keeps test coverage focused on thread-scoped app feature flags while removing OS keyring/DBus dependency from this test path.

## How It Was Verified

- `cargo test -p codex-app-server`
- `cargo test -p codex-app-server list_apps_uses_thread_feature_flag_when_thread_id_is_provided -- --nocapture`
