### PR TITLE
fix: add --test_verbose_timeout_warnings to bazel.yml

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -106,6 +106,7 @@ jobs:
           bazel_args=(
             test
             //...
+            --test_verbose_timeout_warnings
             --build_metadata=REPO_URL=https://github.com/openai/codex.git
             --build_metadata=COMMIT_SHA=$(git rev-parse HEAD)
             --build_metadata=ROLE=CI


### PR DESCRIPTION
This is in response to seeing this on BuildBuddy:

> There were tests whose specified size is too big. Use the --test_verbose_timeout_warnings command line option to see which ones these are.