### PR TITLE
ci: remove actions/cache from rust release workflows

### DIFF
--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -86,16 +86,6 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ${{ github.workspace }}/codex-rs/target/
-          key: cargo-${{ matrix.runner }}-${{ matrix.target }}-release-windows-${{ matrix.bundle }}-${{ hashFiles('**/Cargo.lock') }}
-
       - name: Cargo build (Windows binaries)
         shell: bash
         run: |

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -139,20 +139,6 @@ jobs:
           echo "${cargo_home}/bin" >> "$GITHUB_PATH"
           : > "${cargo_home}/config.toml"
 
-      - uses: actions/cache@v5
-        with:
-          path: |
-            ~/.cargo/bin/
-            ~/.cargo/registry/index/
-            ~/.cargo/registry/cache/
-            ~/.cargo/git/db/
-            ${{ github.workspace }}/.cargo-home/bin/
-            ${{ github.workspace }}/.cargo-home/registry/index/
-            ${{ github.workspace }}/.cargo-home/registry/cache/
-            ${{ github.workspace }}/.cargo-home/git/db/
-            ${{ github.workspace }}/codex-rs/target/
-          key: cargo-${{ matrix.runner }}-${{ matrix.target }}-release-${{ hashFiles('**/Cargo.lock') }}
-
       - if: ${{ matrix.target == 'x86_64-unknown-linux-musl' || matrix.target == 'aarch64-unknown-linux-musl'}}
         name: Install Zig
         uses: mlugg/setup-zig@v2


### PR DESCRIPTION
## Why

`rust-release` cache restore has had very low practical value, while cache save consistently costs significant time (usually adding ~3 minutes to the critical path of a release workflow).

From successful release-tag runs with cache steps (`289` runs total):
- Alpha tags: cache download averaged ~5s/run, cache upload averaged ~230s/run.
- Stable tags: cache download averaged ~5s/run, cache upload averaged ~227s/run.
- Windows release builds specifically: download ~2s/run vs upload ~169-170s/run.

Hard step-level signal from the same successful release-tag runs:
- Cache restore (`Run actions/cache`): `2,314` steps, total `1,515s` (~0.65s/step).
- `95.3%` of restore steps finished in `<=1s`; `99.7%` finished in `<=2s`; `0` steps took `>=10s`.
- Cache save (`Post Run actions/cache`): `2,314` steps, total `66,295s` (~28.65s/step).

Run-level framing:
- Download total was `<=10s` in `288/289` runs (`99.7%`).
- Upload total was `>=120s` in `285/289` runs (`98.6%`).

The net effect is that release jobs are spending time uploading caches that are rarely useful for subsequent runs.

## What Changed

- Removed the `actions/cache@v5` step from `.github/workflows/rust-release.yml`.
- Removed the `actions/cache@v5` step from `.github/workflows/rust-release-windows.yml`.
- Left build, signing, packaging, and publishing flow unchanged.

## Validation

- Queried historical `rust-release` run/job step timing and compared cache download vs upload for alpha and stable release tags.
- Spot-checked release logs and observed repeated `Cache not found ...` followed by `Cache saved ...` patterns.
