### PR TITLE
ci: capture cargo timings in Rust CI and release workflows

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -380,7 +380,15 @@ jobs:
           cargo chef cook --recipe-path "$RECIPE" --target ${{ matrix.target }} --release --all-features
 
       - name: cargo clippy
-        run: cargo clippy --target ${{ matrix.target }} --all-features --tests --profile ${{ matrix.profile }} -- -D warnings
+        run: cargo clippy --target ${{ matrix.target }} --all-features --tests --profile ${{ matrix.profile }} --timings -- -D warnings
+
+      - name: Upload Cargo timings (clippy)
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: cargo-timings-rust-ci-clippy-${{ matrix.target }}-${{ matrix.profile }}
+          path: codex-rs/target/**/cargo-timings/cargo-timing.html
+          if-no-files-found: warn
 
       # Save caches explicitly; make non-fatal so cache packaging
       # never fails the overall job. Only save when key wasn't hit.
@@ -567,10 +575,18 @@ jobs:
 
       - name: tests
         id: test
-        run: cargo nextest run --all-features --no-fail-fast --target ${{ matrix.target }} --cargo-profile ci-test
+        run: cargo nextest run --all-features --no-fail-fast --target ${{ matrix.target }} --cargo-profile ci-test --timings
         env:
           RUST_BACKTRACE: 1
           NEXTEST_STATUS_LEVEL: leak
+
+      - name: Upload Cargo timings (nextest)
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: cargo-timings-rust-ci-nextest-${{ matrix.target }}-${{ matrix.profile }}
+          path: codex-rs/target/**/cargo-timings/cargo-timing.html
+          if-no-files-found: warn
 
       - name: Save cargo home cache
         if: always() && !cancelled() && steps.cache_cargo_home_restore.outputs.cache-hit != 'true'

--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -89,7 +89,14 @@ jobs:
       - name: Cargo build (Windows binaries)
         shell: bash
         run: |
-          cargo build --target ${{ matrix.target }} --release ${{ matrix.build_args }}
+          cargo build --target ${{ matrix.target }} --release --timings ${{ matrix.build_args }}
+
+      - name: Upload Cargo timings
+        uses: actions/upload-artifact@v6
+        with:
+          name: cargo-timings-rust-release-windows-${{ matrix.target }}-${{ matrix.bundle }}
+          path: codex-rs/target/**/cargo-timings/cargo-timing.html
+          if-no-files-found: warn
 
       - name: Stage Windows binaries
         shell: bash

--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -205,7 +205,14 @@ jobs:
       - name: Cargo build
         shell: bash
         run: |
-          cargo build --target ${{ matrix.target }} --release --bin codex --bin codex-responses-api-proxy
+          cargo build --target ${{ matrix.target }} --release --timings --bin codex --bin codex-responses-api-proxy
+
+      - name: Upload Cargo timings
+        uses: actions/upload-artifact@v6
+        with:
+          name: cargo-timings-rust-release-${{ matrix.target }}
+          path: codex-rs/target/**/cargo-timings/cargo-timing.html
+          if-no-files-found: warn
 
       - if: ${{ contains(matrix.target, 'linux') }}
         name: Cosign Linux artifacts


### PR DESCRIPTION
## Why
We want actionable build-hotspot data from CI so we can tune Rust workflow performance (for example, target coverage, cache behavior, and job shape) based on actual compile-time bottlenecks.

`cargo` timing reports are lightweight and provide a direct way to inspect where compilation time is spent.

## What Changed
- Updated `.github/workflows/rust-release.yml` to run `cargo build` with `--timings` and upload `target/**/cargo-timings/cargo-timing.html`.
- Updated `.github/workflows/rust-release-windows.yml` to run `cargo build` with `--timings` and upload `target/**/cargo-timings/cargo-timing.html`.
- Updated `.github/workflows/rust-ci.yml` to:
  - run `cargo clippy` with `--timings`
  - run `cargo nextest run` with `--timings` (stable-compatible)
  - upload `target/**/cargo-timings/cargo-timing.html` artifacts for both the clippy and nextest jobs

Artifacts are matrix-scoped via artifact names so timings can be compared per target/profile.

## Verification
- Confirmed the net diff is limited to:
  - `.github/workflows/rust-ci.yml`
  - `.github/workflows/rust-release.yml`
  - `.github/workflows/rust-release-windows.yml`
- Verified timing uploads are added immediately after the corresponding timed commands in each workflow.
- Confirmed stable Cargo accepts plain `--timings` for the compile phase (`cargo test --no-run --timings`) and generates `target/cargo-timings/cargo-timing.html`.
- Ran VS Code diagnostics on modified workflow files; no new diagnostics were introduced by these changes.
