### PR TITLE
fix: make project_doc skill-render tests deterministic

### DIFF
--- a/codex-rs/core/src/project_doc.rs
+++ b/codex-rs/core/src/project_doc.rs
@@ -263,7 +263,9 @@ mod tests {
     use super::*;
     use crate::config::ConfigBuilder;
     use crate::features::Feature;
-    use crate::skills::load_skills;
+    use crate::skills::loader::SkillRoot;
+    use crate::skills::loader::load_skills_from_roots;
+    use codex_protocol::protocol::SkillScope;
     use std::fs;
     use std::path::PathBuf;
     use tempfile::TempDir;
@@ -300,6 +302,13 @@ mod tests {
             .map(std::string::ToString::to_string)
             .collect();
         config
+    }
+
+    fn load_test_skills(config: &Config) -> crate::skills::SkillLoadOutcome {
+        load_skills_from_roots([SkillRoot {
+            path: config.codex_home.join("skills"),
+            scope: SkillScope::User,
+        }])
     }
 
     /// AGENTS.md missing – should yield `None`.
@@ -542,7 +551,7 @@ mod tests {
             "extract from pdfs",
         );
 
-        let skills = load_skills(&cfg);
+        let skills = load_test_skills(&cfg);
         let res = get_user_instructions(
             &cfg,
             skills.errors.is_empty().then_some(skills.skills.as_slice()),
@@ -569,7 +578,7 @@ mod tests {
         let cfg = make_config(&tmp, 4096, None).await;
         create_skill(cfg.codex_home.clone(), "linting", "run clippy");
 
-        let skills = load_skills(&cfg);
+        let skills = load_test_skills(&cfg);
         let res = get_user_instructions(
             &cfg,
             skills.errors.is_empty().then_some(skills.skills.as_slice()),


### PR DESCRIPTION
## Why
`project_doc::tests::skills_are_appended_to_project_doc` and `project_doc::tests::skills_render_without_project_doc` were assuming a single synthetic skill in test setup, but they called `load_skills(&cfg)`, which loads from repo/user/system roots.

That made the assertions environment-dependent. After [#11531](https://github.com/openai/codex/pull/11531) added `.codex/skills/test-tui/SKILL.md`, the repo-scoped `test-tui` skill began appearing in these test outputs and exposed the flake.

## What Changed
- Added a test-only helper in `codex-rs/core/src/project_doc.rs` that loads skills from an explicit root via `load_skills_from_roots`.
- Scoped that root to `codex_home/skills` with `SkillScope::User`.
- Updated both affected tests to use this helper instead of `load_skills(&cfg)`:
  - `skills_are_appended_to_project_doc`
  - `skills_render_without_project_doc`

This keeps the tests focused on the fixture skills they create, independent of ambient repo/home skills.

## Verification
- `cargo test -p codex-core project_doc::tests::skills_render_without_project_doc -- --exact`
- `cargo test -p codex-core project_doc::tests::skills_are_appended_to_project_doc -- --exact`
