### PR TITLE
Fix rust-release failures in musl linking and release asset upload

### DIFF
--- a/.github/workflows/rust-ci.yml
+++ b/.github/workflows/rust-ci.yml
@@ -99,6 +99,8 @@ jobs:
       USE_SCCACHE: ${{ startsWith(matrix.runner, 'windows') && 'false' || 'true' }}
       CARGO_INCREMENTAL: "0"
       SCCACHE_CACHE_SIZE: 10G
+      # In rust-ci, representative release-profile checks use thin LTO for faster feedback.
+      CARGO_PROFILE_RELEASE_LTO: ${{ matrix.profile == 'release' && 'thin' || 'fat' }}
 
     strategy:
       fail-fast: false
@@ -160,6 +162,12 @@ jobs:
             runs_on:
               group: codex-runners
               labels: codex-linux-x64
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
+            profile: release
+            runs_on:
+              group: codex-runners
+              labels: codex-linux-arm64
           - runner: windows-x64
             target: x86_64-pc-windows-msvc
             profile: release


### PR DESCRIPTION
## Problem
`rust-release` was failing for two independent reasons:

1. `aarch64-unknown-linux-musl` failed at link time with `/usr/bin/ld: cannot find -lcap` when building binaries that transitively pull in `codex-linux-sandbox`.
2. The `release` job failed in `Create GitHub Release` with `Not Found` from the release-assets API because `files: dist/**` included many files named `cargo-timing.html`, which triggered conflicting delete/upload operations for the same release asset name.

## Why this is the right fix
`codex-linux-sandbox` builds vendored bubblewrap and links `libcap`. In musl jobs, distro `libcap-dev` provides host/glibc artifacts, which are not valid for musl cross-linking. Building/staging target-compatible `libcap` in the musl tool bootstrap and pointing `pkg-config` at it fixes the linker mismatch directly.

For release assets, `softprops/action-gh-release` uploads by basename. Allowing multiple `cargo-timing.html` files into `dist/**` creates asset-name collisions and racey API behavior. Removing those files from `dist/` before release upload prevents the collision.

## What changed
- Updated `.github/scripts/install-musl-build-tools.sh` to install tooling needed to fetch/build libcap sources (`curl`, `xz-utils`, certs).
- Added deterministic libcap bootstrap in the musl tool root:
  - download `libcap-2.75` from kernel.org
  - verify SHA256
  - build with the target musl compiler (`*-linux-musl-gcc`)
  - stage `libcap.a` and headers under the target tool root
  - generate a target-scoped `libcap.pc`
- Exported target `PKG_CONFIG_PATH` so builds resolve the staged musl libcap instead of host pkg-config/lib paths.
- Updated `.github/workflows/rust-ci.yml` to add a `release` matrix entry for `aarch64-unknown-linux-musl` on the ARM runner.
- Updated `.github/workflows/rust-ci.yml` to set `CARGO_PROFILE_RELEASE_LTO=thin` for `release` matrix entries (and keep `fat` for non-release entries), matching the release-build tradeoff already used in `rust-release.yml` while reducing CI runtime.
- Updated `.github/workflows/rust-release.yml` release cleanup to remove `cargo-timing.html` files from `dist/` before `Create GitHub Release` (`files: dist/**`).

## Verification
- Reproduced the original musl failure in CI-like containers:
  - `aarch64-unknown-linux-musl` failed with `cannot find -lcap`.
- Verified the underlying mismatch by forcing host libcap into the link:
  - link then failed with glibc-specific unresolved symbols (`__isoc23_*`, `__*_chk`), confirming host libcap was unsuitable.
- Verified the musl fix in CI-like containers after this change:
  - `cargo build -p codex-linux-sandbox --target aarch64-unknown-linux-musl --release` -> pass
  - `cargo build -p codex-linux-sandbox --target x86_64-unknown-linux-musl --release` -> pass
- Triggered `rust-ci` on this branch and confirmed the new job appears:
  - `Lint/Build — ubuntu-24.04-arm - aarch64-unknown-linux-musl (release)`
- Confirmed the release-asset failure mode in GitHub Actions for `rust-release` run `21938547951` (`release` job), where duplicate `cargo-timing.html` assets caused `Not Found` responses from release asset update/delete API calls.
