### PR TITLE
rust-release: exclude cargo-timing.html from release assets

### DIFF
--- a/.github/workflows/rust-release.yml
+++ b/.github/workflows/rust-release.yml
@@ -424,6 +424,11 @@ jobs:
         run: |
           rm -rf dist/shell-tool-mcp*
           rm -rf dist/windows-binaries*
+          # cargo-timing.html appears under multiple target-specific directories.
+          # If included in files: dist/**, release upload races on duplicate
+          # asset names and can fail with 404s.
+          find dist -type f -name 'cargo-timing.html' -delete
+          find dist -type d -empty -delete
 
           ls -R dist/
 


### PR DESCRIPTION
## Why
The `release` job in `.github/workflows/rust-release.yml` uploads `files: dist/**` via `softprops/action-gh-release`. The downloaded timing artifacts include multiple files with the same basename, `cargo-timing.html` (one per target), which causes release asset collisions/races and can fail with GitHub release-assets API `404 Not Found` errors.

## What Changed
- Updated the existing cleanup step before `Create GitHub Release` to remove all `cargo-timing.html` files from `dist/`.
- Removed any now-empty directories after deleting those timing files.

Relevant change:
- https://github.com/openai/codex/blob/daba003d32f299579e9b89240aa8ebdc9f161424/.github/workflows/rust-release.yml#L423

## Verification
- Confirmed from failing release logs that multiple `cargo-timing.html` files were being included in `dist/**` and that the release step failed while operating on duplicate-named assets.
- Verified the workflow now deletes those files before the release upload step, so `cargo-timing.html` is no longer part of the release asset set.
