### PR TITLE
fix: run windows release signing on GitHub-hosted x64 runners

### DIFF
--- a/.github/scripts/stage-and-compress-windows-release-artifacts.sh
+++ b/.github/scripts/stage-and-compress-windows-release-artifacts.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if [[ "$#" -lt 1 ]]; then
+  echo "usage: $0 <target> [<target> ...]"
+  exit 1
+fi
+
+process_target() {
+  local target="$1"
+  local release_dir="target/${target}/release"
+  local dest="dist/${target}"
+  local repo_root
+  repo_root="$(pwd)"
+
+  ls -lh "${release_dir}/codex.exe"
+  ls -lh "${release_dir}/codex-responses-api-proxy.exe"
+  ls -lh "${release_dir}/codex-windows-sandbox-setup.exe"
+  ls -lh "${release_dir}/codex-command-runner.exe"
+
+  mkdir -p "$dest"
+  cp "${release_dir}/codex.exe" "$dest/codex-${target}.exe"
+  cp "${release_dir}/codex-responses-api-proxy.exe" "$dest/codex-responses-api-proxy-${target}.exe"
+  cp "${release_dir}/codex-windows-sandbox-setup.exe" "$dest/codex-windows-sandbox-setup-${target}.exe"
+  cp "${release_dir}/codex-command-runner.exe" "$dest/codex-command-runner-${target}.exe"
+
+  for f in "$dest"/*; do
+    local base
+    base="$(basename "$f")"
+
+    if [[ "$base" == *.tar.gz || "$base" == *.zip || "$base" == *.dmg ]]; then
+      continue
+    fi
+
+    if [[ "$base" == *.sigstore ]]; then
+      continue
+    fi
+
+    tar -C "$dest" -czf "$dest/${base}.tar.gz" "$base"
+
+    if [[ "$base" == "codex-${target}.exe" ]]; then
+      local bundle_dir
+      local runner_src
+      local setup_src
+      bundle_dir="$(mktemp -d)"
+      runner_src="$dest/codex-command-runner-${target}.exe"
+      setup_src="$dest/codex-windows-sandbox-setup-${target}.exe"
+
+      if [[ -f "$runner_src" && -f "$setup_src" ]]; then
+        cp "$dest/$base" "$bundle_dir/$base"
+        cp "$runner_src" "$bundle_dir/codex-command-runner.exe"
+        cp "$setup_src" "$bundle_dir/codex-windows-sandbox-setup.exe"
+        (cd "$bundle_dir" && 7z a "$repo_root/$dest/${base}.zip" .)
+      else
+        echo "warning: missing sandbox binaries; falling back to single-binary zip"
+        echo "warning: expected $runner_src and $setup_src"
+        (cd "$dest" && 7z a "${base}.zip" "$base")
+      fi
+
+      rm -rf "$bundle_dir"
+    else
+      (cd "$dest" && 7z a "${base}.zip" "$base")
+    fi
+
+    "${GITHUB_WORKSPACE}/.github/workflows/zstd" -T0 -19 "$dest/$base"
+  done
+}
+
+for target in "$@"; do
+  process_target "$target"
+done

--- a/.github/workflows/rust-release-windows.yml
+++ b/.github/workflows/rust-release-windows.yml
@@ -121,8 +121,8 @@ jobs:
   build-windows:
     needs:
       - build-windows-binaries
-    name: Build - ${{ matrix.runner }} - ${{ matrix.target }}
-    runs-on: ${{ matrix.runs_on }}
+    name: Build - windows-x64 - ${{ matrix.target }}
+    runs-on: windows-2022
     timeout-minutes: 60
     permissions:
       contents: read
@@ -135,16 +135,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: windows-x64
-            target: x86_64-pc-windows-msvc
-            runs_on:
-              group: codex-runners
-              labels: codex-windows-x64
-          - runner: windows-arm64
-            target: aarch64-pc-windows-msvc
-            runs_on:
-              group: codex-runners
-              labels: codex-windows-arm64
+          - target: x86_64-pc-windows-msvc
+          - target: aarch64-pc-windows-msvc
 
     steps:
       - uses: actions/checkout@v6
@@ -161,14 +153,8 @@ jobs:
           name: windows-binaries-${{ matrix.target }}-helpers
           path: codex-rs/target/${{ matrix.target }}/release
 
-      - name: Verify binaries
-        shell: bash
-        run: |
-          set -euo pipefail
-          ls -lh target/${{ matrix.target }}/release/codex.exe
-          ls -lh target/${{ matrix.target }}/release/codex-responses-api-proxy.exe
-          ls -lh target/${{ matrix.target }}/release/codex-windows-sandbox-setup.exe
-          ls -lh target/${{ matrix.target }}/release/codex-command-runner.exe
+      - name: Install DotSlash
+        uses: facebook/install-dotslash@v2
 
       - name: Sign Windows binaries with Azure Trusted Signing
         uses: ./.github/actions/windows-code-sign
@@ -181,81 +167,11 @@ jobs:
           account-name: ${{ secrets.AZURE_TRUSTED_SIGNING_ACCOUNT_NAME }}
           certificate-profile-name: ${{ secrets.AZURE_TRUSTED_SIGNING_CERTIFICATE_PROFILE_NAME }}
 
-      - name: Stage artifacts
+      - name: Stage and compress Windows release artifacts
         shell: bash
         run: |
-          dest="dist/${{ matrix.target }}"
-          mkdir -p "$dest"
-
-          cp target/${{ matrix.target }}/release/codex.exe "$dest/codex-${{ matrix.target }}.exe"
-          cp target/${{ matrix.target }}/release/codex-responses-api-proxy.exe "$dest/codex-responses-api-proxy-${{ matrix.target }}.exe"
-          cp target/${{ matrix.target }}/release/codex-windows-sandbox-setup.exe "$dest/codex-windows-sandbox-setup-${{ matrix.target }}.exe"
-          cp target/${{ matrix.target }}/release/codex-command-runner.exe "$dest/codex-command-runner-${{ matrix.target }}.exe"
-
-      - name: Install DotSlash
-        uses: facebook/install-dotslash@v2
-
-      - name: Compress artifacts
-        shell: bash
-        run: |
-          # Path that contains the uncompressed binaries for the current
-          # ${{ matrix.target }}
-          dest="dist/${{ matrix.target }}"
-          repo_root=$PWD
-
-          # For compatibility with environments that lack the `zstd` tool we
-          # additionally create a `.tar.gz` and `.zip` for every Windows binary.
-          # The end result is:
-          #   codex-<target>.zst
-          #   codex-<target>.tar.gz
-          #   codex-<target>.zip
-          for f in "$dest"/*; do
-            base="$(basename "$f")"
-            # Skip files that are already archives (shouldn't happen, but be
-            # safe).
-            if [[ "$base" == *.tar.gz || "$base" == *.zip || "$base" == *.dmg ]]; then
-              continue
-            fi
-
-            # Don't try to compress signature bundles.
-            if [[ "$base" == *.sigstore ]]; then
-              continue
-            fi
-
-            # Create per-binary tar.gz
-            tar -C "$dest" -czf "$dest/${base}.tar.gz" "$base"
-
-            # Create zip archive for Windows binaries.
-            # Must run from inside the dest dir so 7z won't embed the
-            # directory path inside the zip.
-            if [[ "$base" == "codex-${{ matrix.target }}.exe" ]]; then
-              # Bundle the sandbox helper binaries into the main codex zip so
-              # WinGet installs include the required helpers next to codex.exe.
-              # Fall back to the single-binary zip if the helpers are missing
-              # to avoid breaking releases.
-              bundle_dir="$(mktemp -d)"
-              runner_src="$dest/codex-command-runner-${{ matrix.target }}.exe"
-              setup_src="$dest/codex-windows-sandbox-setup-${{ matrix.target }}.exe"
-              if [[ -f "$runner_src" && -f "$setup_src" ]]; then
-                cp "$dest/$base" "$bundle_dir/$base"
-                cp "$runner_src" "$bundle_dir/codex-command-runner.exe"
-                cp "$setup_src" "$bundle_dir/codex-windows-sandbox-setup.exe"
-                # Use an absolute path so bundle zips land in the real dist
-                # dir even when 7z runs from a temp directory.
-                (cd "$bundle_dir" && 7z a "$repo_root/$dest/${base}.zip" .)
-              else
-                echo "warning: missing sandbox binaries; falling back to single-binary zip"
-                echo "warning: expected $runner_src and $setup_src"
-                (cd "$dest" && 7z a "${base}.zip" "$base")
-              fi
-              rm -rf "$bundle_dir"
-            else
-              (cd "$dest" && 7z a "${base}.zip" "$base")
-            fi
-
-            # Keep raw executables and produce .zst alongside them.
-            "${GITHUB_WORKSPACE}/.github/workflows/zstd" -T0 -19 "$dest/$base"
-          done
+          bash "$GITHUB_WORKSPACE/.github/scripts/stage-and-compress-windows-release-artifacts.sh" \
+            ${{ matrix.target }}
 
       - uses: actions/upload-artifact@v6
         with:


### PR DESCRIPTION
## Why
`build-windows` used self-hosted `codex-runners` labels, including `codex-windows-arm64`. In practice those runners can be scarce, which adds queue time on release workflows.

The signing step does not require architecture-matched hosts, so we can run both Windows targets on GitHub-hosted x64 runners while still keeping per-target parallelism.

## What Changed
- Updated `.github/workflows/rust-release-windows.yml` so `build-windows` runs on `windows-2022` instead of `codex-runners` labels.
- Kept `build-windows` as a 2-target matrix (`x86_64-pc-windows-msvc` and `aarch64-pc-windows-msvc`) so signing and packaging still run in parallel.
- Simplified the matrix entries to be target-only (removed runner-specific fields that were only needed for self-hosted selection).
- Moved `facebook/install-dotslash@v2` earlier in the job.
- Extracted the staging/compression logic into `.github/scripts/stage-and-compress-windows-release-artifacts.sh` and invoke it from the workflow for each target.

## Verification
- `bash -n .github/scripts/stage-and-compress-windows-release-artifacts.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/rust-release-windows.yml")'`
- Confirmed no new VS Code diagnostics for:
  - `.github/workflows/rust-release-windows.yml`
  - `.github/scripts/stage-and-compress-windows-release-artifacts.sh`
