### PR TITLE
Fix config test on macOS

### DIFF
--- a/codex-rs/core/src/config/service.rs
+++ b/codex-rs/core/src/config/service.rs
@@ -903,6 +903,16 @@ remote_models = true
             },
         );
         let layers = response.layers.expect("layers present");
+        // Local macOS machines can surface an MDM-managed config layer at the
+        // top of the stack; ignore it so this test stays focused on file/user/system ordering.
+        let layers = if matches!(
+            layers.first().map(|layer| &layer.name),
+            Some(ConfigLayerSource::LegacyManagedConfigTomlFromMdm)
+        ) {
+            &layers[1..]
+        } else {
+            layers.as_slice()
+        };
         assert_eq!(layers.len(), 3, "expected three layers");
         assert_eq!(
             layers.first().unwrap().name,
@@ -1117,6 +1127,16 @@ remote_models = true
             },
         );
         let layers = response.layers.expect("layers");
+        // Local macOS machines can surface an MDM-managed config layer at the
+        // top of the stack; ignore it so this test stays focused on file/session/user ordering.
+        let layers = if matches!(
+            layers.first().map(|layer| &layer.name),
+            Some(ConfigLayerSource::LegacyManagedConfigTomlFromMdm)
+        ) {
+            &layers[1..]
+        } else {
+            layers.as_slice()
+        };
         assert_eq!(
             layers.first().unwrap().name,
             ConfigLayerSource::LegacyManagedConfigTomlFromFile { file: managed_file }

--- a/codex-rs/core/src/config_loader/tests.rs
+++ b/codex-rs/core/src/config_loader/tests.rs
@@ -240,7 +240,9 @@ async fn returns_empty_when_all_layers_missing() {
     let overrides = LoaderOverrides {
         managed_config_path: Some(managed_path),
         #[cfg(target_os = "macos")]
-        managed_preferences_base64: None,
+        // Force managed preferences to resolve as empty so this test does not
+        // inherit non-empty machine-specific managed state.
+        managed_preferences_base64: Some(String::new()),
         macos_managed_config_requirements_base64: None,
     };
 


### PR DESCRIPTION
When running these tests locally, you may have system-wide config or requirements files. This makes the tests ignore these files.