### PR TITLE
Add new apps_mcp_gateway

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -188,6 +188,9 @@
             "apps": {
               "type": "boolean"
             },
+            "apps_mcp_gateway": {
+              "type": "boolean"
+            },
             "child_agents_md": {
               "type": "boolean"
             },
@@ -1270,6 +1273,9 @@
           "type": "boolean"
         },
         "apps": {
+          "type": "boolean"
+        },
+        "apps_mcp_gateway": {
           "type": "boolean"
         },
         "child_agents_md": {

--- a/codex-rs/core/src/connectors.rs
+++ b/codex-rs/core/src/connectors.rs
@@ -19,7 +19,6 @@ use crate::config::Config;
 use crate::features::Feature;
 use crate::mcp::CODEX_APPS_MCP_SERVER_NAME;
 use crate::mcp::auth::compute_auth_statuses;
-use crate::mcp::codex_apps_mcp_url;
 use crate::mcp::with_codex_apps_mcp;
 use crate::mcp_connection_manager::DEFAULT_STARTUP_TIMEOUT;
 use crate::mcp_connection_manager::McpConnectionManager;
@@ -30,7 +29,6 @@ pub const CONNECTORS_CACHE_TTL: Duration = Duration::from_secs(3600);
 #[derive(Clone, PartialEq, Eq)]
 struct AccessibleConnectorsCacheKey {
     chatgpt_base_url: String,
-    apps_mcp_cache_key: String,
     account_id: Option<String>,
     chatgpt_user_id: Option<String>,
     is_workspace_account: bool,
@@ -144,7 +142,6 @@ fn accessible_connectors_cache_key(
         .is_some_and(|token_data| token_data.id_token.is_workspace_account());
     AccessibleConnectorsCacheKey {
         chatgpt_base_url: config.chatgpt_base_url.clone(),
-        apps_mcp_cache_key: codex_apps_mcp_url(config),
         account_id,
         chatgpt_user_id,
         is_workspace_account,

--- a/codex-rs/core/src/connectors.rs
+++ b/codex-rs/core/src/connectors.rs
@@ -19,6 +19,7 @@ use crate::config::Config;
 use crate::features::Feature;
 use crate::mcp::CODEX_APPS_MCP_SERVER_NAME;
 use crate::mcp::auth::compute_auth_statuses;
+use crate::mcp::codex_apps_mcp_url;
 use crate::mcp::with_codex_apps_mcp;
 use crate::mcp_connection_manager::DEFAULT_STARTUP_TIMEOUT;
 use crate::mcp_connection_manager::McpConnectionManager;
@@ -29,6 +30,7 @@ pub const CONNECTORS_CACHE_TTL: Duration = Duration::from_secs(3600);
 #[derive(Clone, PartialEq, Eq)]
 struct AccessibleConnectorsCacheKey {
     chatgpt_base_url: String,
+    apps_mcp_cache_key: String,
     account_id: Option<String>,
     chatgpt_user_id: Option<String>,
     is_workspace_account: bool,
@@ -142,6 +144,7 @@ fn accessible_connectors_cache_key(
         .is_some_and(|token_data| token_data.id_token.is_workspace_account());
     AccessibleConnectorsCacheKey {
         chatgpt_base_url: config.chatgpt_base_url.clone(),
+        apps_mcp_cache_key: codex_apps_mcp_url(config),
         account_id,
         chatgpt_user_id,
         is_workspace_account,

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -119,6 +119,8 @@ pub enum Feature {
     Collab,
     /// Enable apps.
     Apps,
+    /// Route apps MCP calls through the configured gateway.
+    AppsMcpGateway,
     /// Allow prompting and installing missing MCP dependencies.
     SkillMcpDependencyInstall,
     /// Prompt for missing skill env var dependencies.
@@ -552,6 +554,12 @@ pub const FEATURES: &[FeatureSpec] = &[
             menu_description: "Use a connected ChatGPT App using \"$\". Install Apps via /apps command. Restart Codex after enabling.",
             announcement: "NEW: Use ChatGPT Apps (Connectors) in Codex via $ mentions. Enable in /experimental and restart Codex!",
         },
+        default_enabled: false,
+    },
+    FeatureSpec {
+        id: Feature::AppsMcpGateway,
+        key: "apps_mcp_gateway",
+        stage: Stage::UnderDevelopment,
         default_enabled: false,
     },
     FeatureSpec {

--- a/codex-rs/core/src/mcp/mod.rs
+++ b/codex-rs/core/src/mcp/mod.rs
@@ -30,6 +30,15 @@ const MCP_TOOL_NAME_PREFIX: &str = "mcp";
 const MCP_TOOL_NAME_DELIMITER: &str = "__";
 pub(crate) const CODEX_APPS_MCP_SERVER_NAME: &str = "codex_apps";
 const CODEX_CONNECTORS_TOKEN_ENV_VAR: &str = "CODEX_CONNECTORS_TOKEN";
+const OPENAI_API_BASE_URL: &str = "https://api.openai.com";
+const CONNECTORS_MCP_PATH: &str = "/v1/connectors/mcp/";
+
+// Legacy vs new MCP gateway
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CodexAppsMcpGateway {
+    LegacyMCPGateway,
+    MCPGateway,
+}
 
 fn codex_apps_mcp_bearer_token_env_var() -> Option<String> {
     match env::var(CODEX_CONNECTORS_TOKEN_ENV_VAR) {
@@ -65,7 +74,15 @@ fn codex_apps_mcp_http_headers(auth: Option<&CodexAuth>) -> Option<HashMap<Strin
     }
 }
 
-fn codex_apps_mcp_url(base_url: &str) -> String {
+fn selected_config_codex_apps_mcp_gateway(config: &Config) -> CodexAppsMcpGateway {
+    if config.features.enabled(Feature::AppsMcpGateway) {
+        CodexAppsMcpGateway::MCPGateway
+    } else {
+        CodexAppsMcpGateway::LegacyMCPGateway
+    }
+}
+
+fn normalize_codex_apps_base_url(base_url: &str) -> String {
     let mut base_url = base_url.trim_end_matches('/').to_string();
     if (base_url.starts_with("https://chatgpt.com")
         || base_url.starts_with("https://chat.openai.com"))
@@ -73,6 +90,15 @@ fn codex_apps_mcp_url(base_url: &str) -> String {
     {
         base_url = format!("{base_url}/backend-api");
     }
+    base_url
+}
+
+fn codex_apps_mcp_url_for_gateway(base_url: &str, gateway: CodexAppsMcpGateway) -> String {
+    if gateway == CodexAppsMcpGateway::MCPGateway {
+        return format!("{OPENAI_API_BASE_URL}{CONNECTORS_MCP_PATH}");
+    }
+
+    let base_url = normalize_codex_apps_base_url(base_url);
     if base_url.contains("/backend-api") {
         format!("{base_url}/wham/apps")
     } else if base_url.contains("/api/codex") {
@@ -82,6 +108,13 @@ fn codex_apps_mcp_url(base_url: &str) -> String {
     }
 }
 
+pub(crate) fn codex_apps_mcp_url(config: &Config) -> String {
+    codex_apps_mcp_url_for_gateway(
+        &config.chatgpt_base_url,
+        selected_config_codex_apps_mcp_gateway(config),
+    )
+}
+
 fn codex_apps_mcp_server_config(config: &Config, auth: Option<&CodexAuth>) -> McpServerConfig {
     let bearer_token_env_var = codex_apps_mcp_bearer_token_env_var();
     let http_headers = if bearer_token_env_var.is_some() {
@@ -89,7 +122,7 @@ fn codex_apps_mcp_server_config(config: &Config, auth: Option<&CodexAuth>) -> Mc
     } else {
         codex_apps_mcp_http_headers(auth)
     };
-    let url = codex_apps_mcp_url(&config.chatgpt_base_url);
+    let url = codex_apps_mcp_url(config);
 
     McpServerConfig {
         transport: McpServerTransportConfig::StreamableHttp {
@@ -384,5 +417,94 @@ mod tests {
         expected.insert("beta".to_string(), expected_beta);
 
         assert_eq!(group_tools_by_server(&tools), expected);
+    }
+
+    #[test]
+    fn codex_apps_mcp_url_for_default_gateway_keeps_existing_paths() {
+        assert_eq!(
+            codex_apps_mcp_url_for_gateway(
+                "https://chatgpt.com/backend-api",
+                CodexAppsMcpGateway::LegacyMCPGateway
+            ),
+            "https://chatgpt.com/backend-api/wham/apps"
+        );
+        assert_eq!(
+            codex_apps_mcp_url_for_gateway(
+                "https://chat.openai.com",
+                CodexAppsMcpGateway::LegacyMCPGateway
+            ),
+            "https://chat.openai.com/backend-api/wham/apps"
+        );
+        assert_eq!(
+            codex_apps_mcp_url_for_gateway(
+                "http://localhost:8080/api/codex",
+                CodexAppsMcpGateway::LegacyMCPGateway
+            ),
+            "http://localhost:8080/api/codex/apps"
+        );
+        assert_eq!(
+            codex_apps_mcp_url_for_gateway(
+                "http://localhost:8080",
+                CodexAppsMcpGateway::LegacyMCPGateway
+            ),
+            "http://localhost:8080/api/codex/apps"
+        );
+    }
+
+    #[test]
+    fn codex_apps_mcp_url_for_gateway_2_uses_openai_connectors_gateway() {
+        let expected_url = format!("{OPENAI_API_BASE_URL}{CONNECTORS_MCP_PATH}");
+
+        assert_eq!(
+            codex_apps_mcp_url_for_gateway(
+                "https://chatgpt.com/backend-api",
+                CodexAppsMcpGateway::MCPGateway
+            ),
+            expected_url.as_str()
+        );
+        assert_eq!(
+            codex_apps_mcp_url_for_gateway(
+                "https://chat.openai.com",
+                CodexAppsMcpGateway::MCPGateway
+            ),
+            expected_url.as_str()
+        );
+        assert_eq!(
+            codex_apps_mcp_url_for_gateway(
+                "http://localhost:8080/api/codex",
+                CodexAppsMcpGateway::MCPGateway
+            ),
+            expected_url.as_str()
+        );
+        assert_eq!(
+            codex_apps_mcp_url_for_gateway(
+                "http://localhost:8080",
+                CodexAppsMcpGateway::MCPGateway
+            ),
+            expected_url.as_str()
+        );
+    }
+
+    #[test]
+    fn codex_apps_mcp_url_uses_default_gateway_when_feature_is_disabled() {
+        let mut config = crate::config::test_config();
+        config.chatgpt_base_url = "https://chatgpt.com".to_string();
+
+        assert_eq!(
+            codex_apps_mcp_url(&config),
+            "https://chatgpt.com/backend-api/wham/apps"
+        );
+    }
+
+    #[test]
+    fn codex_apps_mcp_url_uses_openai_connectors_gateway_when_feature_is_enabled() {
+        let mut config = crate::config::test_config();
+        config.chatgpt_base_url = "https://chatgpt.com".to_string();
+        config.features.enable(Feature::AppsMcpGateway);
+
+        assert_eq!(
+            codex_apps_mcp_url(&config),
+            format!("{OPENAI_API_BASE_URL}{CONNECTORS_MCP_PATH}")
+        );
     }
 }

--- a/codex-rs/core/src/mcp/mod.rs
+++ b/codex-rs/core/src/mcp/mod.rs
@@ -30,8 +30,8 @@ const MCP_TOOL_NAME_PREFIX: &str = "mcp";
 const MCP_TOOL_NAME_DELIMITER: &str = "__";
 pub(crate) const CODEX_APPS_MCP_SERVER_NAME: &str = "codex_apps";
 const CODEX_CONNECTORS_TOKEN_ENV_VAR: &str = "CODEX_CONNECTORS_TOKEN";
-const OPENAI_API_BASE_URL: &str = "https://api.openai.com";
-const CONNECTORS_MCP_PATH: &str = "/v1/connectors/mcp/";
+const OPENAI_CONNECTORS_MCP_BASE_URL: &str = "https://api.openai.com";
+const OPENAI_CONNECTORS_MCP_PATH: &str = "/v1/connectors/mcp/";
 
 // Legacy vs new MCP gateway
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -95,7 +95,7 @@ fn normalize_codex_apps_base_url(base_url: &str) -> String {
 
 fn codex_apps_mcp_url_for_gateway(base_url: &str, gateway: CodexAppsMcpGateway) -> String {
     if gateway == CodexAppsMcpGateway::MCPGateway {
-        return format!("{OPENAI_API_BASE_URL}{CONNECTORS_MCP_PATH}");
+        return format!("{OPENAI_CONNECTORS_MCP_BASE_URL}{OPENAI_CONNECTORS_MCP_PATH}");
     }
 
     let base_url = normalize_codex_apps_base_url(base_url);
@@ -452,8 +452,8 @@ mod tests {
     }
 
     #[test]
-    fn codex_apps_mcp_url_for_gateway_2_uses_openai_connectors_gateway() {
-        let expected_url = format!("{OPENAI_API_BASE_URL}{CONNECTORS_MCP_PATH}");
+    fn codex_apps_mcp_url_for_gateway_uses_openai_connectors_gateway() {
+        let expected_url = format!("{OPENAI_CONNECTORS_MCP_BASE_URL}{OPENAI_CONNECTORS_MCP_PATH}");
 
         assert_eq!(
             codex_apps_mcp_url_for_gateway(
@@ -504,12 +504,12 @@ mod tests {
 
         assert_eq!(
             codex_apps_mcp_url(&config),
-            format!("{OPENAI_API_BASE_URL}{CONNECTORS_MCP_PATH}")
+            format!("{OPENAI_CONNECTORS_MCP_BASE_URL}{OPENAI_CONNECTORS_MCP_PATH}")
         );
     }
 
     #[test]
-    fn with_codex_apps_mcp_uses_apps_gateway_only_with_apps_enabled() {
+    fn codex_apps_server_config_switches_gateway_with_flags() {
         let mut config = crate::config::test_config();
         config.chatgpt_base_url = "https://chatgpt.com".to_string();
 
@@ -539,7 +539,7 @@ mod tests {
             _ => panic!("expected streamable http transport for codex apps"),
         };
 
-        let expected_url = format!("{OPENAI_API_BASE_URL}{CONNECTORS_MCP_PATH}");
+        let expected_url = format!("{OPENAI_CONNECTORS_MCP_BASE_URL}{OPENAI_CONNECTORS_MCP_PATH}");
         assert_eq!(url, &expected_url);
     }
 }

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -170,6 +170,7 @@ pub(crate) struct ToolInfo {
 
 #[derive(Clone)]
 struct CachedCodexAppsTools {
+    cache_key: String,
     expires_at: Instant,
     tools: Vec<ToolInfo>,
 }
@@ -252,6 +253,7 @@ struct ManagedClient {
     tools: Vec<ToolInfo>,
     tool_filter: ToolFilter,
     tool_timeout: Option<Duration>,
+    codex_apps_tools_cache_key: Option<String>,
     server_supports_sandbox_state_capability: bool,
 }
 
@@ -287,6 +289,8 @@ impl AsyncManagedClient {
         tx_event: Sender<Event>,
         elicitation_requests: ElicitationRequestManager,
     ) -> Self {
+        let codex_apps_tools_cache_key =
+            codex_apps_tools_cache_key_for_transport(&server_name, &config.transport);
         let tool_filter = ToolFilter::from_config(&config);
         let fut = async move {
             if let Err(error) = validate_mcp_server_name(&server_name) {
@@ -301,6 +305,7 @@ impl AsyncManagedClient {
                 config.startup_timeout_sec.or(Some(DEFAULT_STARTUP_TIMEOUT)),
                 config.tool_timeout_sec.unwrap_or(DEFAULT_TOOL_TIMEOUT),
                 tool_filter,
+                codex_apps_tools_cache_key,
                 tx_event,
                 elicitation_requests,
             )
@@ -521,10 +526,18 @@ impl McpConnectionManager {
                 let rmcp_client = client.client;
                 let tool_timeout = client.tool_timeout;
                 let tool_filter = client.tool_filter;
+                let codex_apps_tools_cache_key = client.codex_apps_tools_cache_key;
                 let mut server_tools = client.tools;
 
                 if server_name == CODEX_APPS_MCP_SERVER_NAME {
-                    match list_tools_for_client(server_name, &rmcp_client, tool_timeout).await {
+                    match list_tools_for_client(
+                        server_name,
+                        &rmcp_client,
+                        tool_timeout,
+                        codex_apps_tools_cache_key.as_deref(),
+                    )
+                    .await
+                    {
                         Ok(fresh_or_cached_tools) => {
                             server_tools = fresh_or_cached_tools;
                         }
@@ -565,7 +578,9 @@ impl McpConnectionManager {
             format!("failed to refresh tools for MCP server '{CODEX_APPS_MCP_SERVER_NAME}'")
         })?;
 
-        write_cached_codex_apps_tools(&tools);
+        if let Some(cache_key) = managed_client.codex_apps_tools_cache_key.as_deref() {
+            write_cached_codex_apps_tools(cache_key, &tools);
+        }
         Ok(())
     }
 
@@ -938,6 +953,19 @@ fn normalize_codex_apps_tool_title(
     value.to_string()
 }
 
+fn codex_apps_tools_cache_key_for_transport(
+    server_name: &str,
+    transport: &McpServerTransportConfig,
+) -> Option<String> {
+    if server_name != CODEX_APPS_MCP_SERVER_NAME {
+        return None;
+    }
+    match transport {
+        McpServerTransportConfig::StreamableHttp { url, .. } => Some(url.clone()),
+        _ => None,
+    }
+}
+
 fn resolve_bearer_token(
     server_name: &str,
     bearer_token_env_var: Option<&str>,
@@ -989,6 +1017,7 @@ async fn start_server_task(
     startup_timeout: Option<Duration>, // TODO: cancel_token should handle this.
     tool_timeout: Duration,
     tool_filter: ToolFilter,
+    codex_apps_tools_cache_key: Option<String>,
     tx_event: Sender<Event>,
     elicitation_requests: ElicitationRequestManager,
 ) -> Result<ManagedClient, StartupOutcomeError> {
@@ -1027,9 +1056,14 @@ async fn start_server_task(
         .await
         .map_err(StartupOutcomeError::from)?;
 
-    let tools = list_tools_for_client(&server_name, &client, startup_timeout)
-        .await
-        .map_err(StartupOutcomeError::from)?;
+    let tools = list_tools_for_client(
+        &server_name,
+        &client,
+        startup_timeout,
+        codex_apps_tools_cache_key.as_deref(),
+    )
+    .await
+    .map_err(StartupOutcomeError::from)?;
 
     let server_supports_sandbox_state_capability = initialize_result
         .capabilities
@@ -1043,6 +1077,7 @@ async fn start_server_task(
         tools,
         tool_timeout: Some(tool_timeout),
         tool_filter,
+        codex_apps_tools_cache_key,
         server_supports_sandbox_state_capability,
     };
 
@@ -1097,21 +1132,25 @@ async fn list_tools_for_client(
     server_name: &str,
     client: &Arc<RmcpClient>,
     timeout: Option<Duration>,
+    cache_key: Option<&str>,
 ) -> Result<Vec<ToolInfo>> {
     if server_name == CODEX_APPS_MCP_SERVER_NAME
-        && let Some(cached_tools) = read_cached_codex_apps_tools()
+        && let Some(cache_key) = cache_key
+        && let Some(cached_tools) = read_cached_codex_apps_tools(cache_key)
     {
         return Ok(cached_tools);
     }
 
     let tools = list_tools_for_client_uncached(server_name, client, timeout).await?;
-    if server_name == CODEX_APPS_MCP_SERVER_NAME {
-        write_cached_codex_apps_tools(&tools);
+    if server_name == CODEX_APPS_MCP_SERVER_NAME
+        && let Some(cache_key) = cache_key
+    {
+        write_cached_codex_apps_tools(cache_key, &tools);
     }
     Ok(tools)
 }
 
-fn read_cached_codex_apps_tools() -> Option<Vec<ToolInfo>> {
+fn read_cached_codex_apps_tools(cache_key: &str) -> Option<Vec<ToolInfo>> {
     let mut cache_guard = CODEX_APPS_TOOLS_CACHE
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
@@ -1119,19 +1158,26 @@ fn read_cached_codex_apps_tools() -> Option<Vec<ToolInfo>> {
 
     if let Some(cached) = cache_guard.as_ref()
         && now < cached.expires_at
+        && cached.cache_key == cache_key
     {
         return Some(cached.tools.clone());
     }
 
-    *cache_guard = None;
+    if cache_guard
+        .as_ref()
+        .is_some_and(|cached| now >= cached.expires_at)
+    {
+        *cache_guard = None;
+    }
     None
 }
 
-fn write_cached_codex_apps_tools(tools: &[ToolInfo]) {
+fn write_cached_codex_apps_tools(cache_key: &str, tools: &[ToolInfo]) {
     let mut cache_guard = CODEX_APPS_TOOLS_CACHE
         .lock()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     *cache_guard = Some(CachedCodexAppsTools {
+        cache_key: cache_key.to_string(),
         expires_at: Instant::now() + CODEX_APPS_TOOLS_CACHE_TTL,
         tools: tools.to_vec(),
     });
@@ -1270,6 +1316,21 @@ mod tests {
             connector_id: None,
             connector_name: None,
         }
+    }
+
+    fn with_clean_codex_apps_tools_cache<T>(f: impl FnOnce() -> T) -> T {
+        let previous_cache = {
+            let mut cache_guard = CODEX_APPS_TOOLS_CACHE
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            cache_guard.take()
+        };
+        let result = f();
+        let mut cache_guard = CODEX_APPS_TOOLS_CACHE
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *cache_guard = previous_cache;
+        result
     }
 
     #[test]
@@ -1422,6 +1483,42 @@ mod tests {
         assert_eq!(filtered.len(), 1);
         assert_eq!(filtered[0].server_name, "server1");
         assert_eq!(filtered[0].tool_name, "tool_a");
+    }
+
+    #[test]
+    fn codex_apps_tools_cache_key_uses_streamable_http_url() {
+        let transport = McpServerTransportConfig::StreamableHttp {
+            url: "https://chatgpt.com/backend-api/wham/apps".to_string(),
+            http_headers: None,
+            env_http_headers: None,
+            bearer_token_env_var: None,
+        };
+
+        assert_eq!(
+            codex_apps_tools_cache_key_for_transport(CODEX_APPS_MCP_SERVER_NAME, &transport),
+            Some("https://chatgpt.com/backend-api/wham/apps".to_string())
+        );
+    }
+
+    #[test]
+    fn codex_apps_tools_cache_is_partitioned_by_cache_key() {
+        with_clean_codex_apps_tools_cache(|| {
+            let tools_gateway_1 = vec![create_test_tool(CODEX_APPS_MCP_SERVER_NAME, "one")];
+            let tools_gateway_2 = vec![create_test_tool(CODEX_APPS_MCP_SERVER_NAME, "two")];
+
+            write_cached_codex_apps_tools("https://one.example/apps", &tools_gateway_1);
+            let cached_gateway_1 = read_cached_codex_apps_tools("https://one.example/apps")
+                .expect("cache entry exists for first gateway");
+            assert_eq!(cached_gateway_1.len(), 1);
+            assert_eq!(cached_gateway_1[0].tool_name, "one");
+            assert!(read_cached_codex_apps_tools("https://two.example/apps").is_none());
+
+            write_cached_codex_apps_tools("https://two.example/apps", &tools_gateway_2);
+            let cached_gateway_2 = read_cached_codex_apps_tools("https://two.example/apps")
+                .expect("cache entry exists for second gateway");
+            assert_eq!(cached_gateway_2.len(), 1);
+            assert_eq!(cached_gateway_2[0].tool_name, "two");
+        });
     }
 
     #[test]

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -1463,6 +1463,29 @@ mod tests {
     }
 
     #[test]
+    fn codex_apps_tools_cache_is_cleared_when_expired() {
+        with_clean_codex_apps_tools_cache(|| {
+            let tools = vec![create_test_tool(CODEX_APPS_MCP_SERVER_NAME, "stale_tool")];
+            write_cached_codex_apps_tools(&tools);
+
+            {
+                let mut cache_guard = CODEX_APPS_TOOLS_CACHE
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                cache_guard.as_mut().expect("cache exists").expires_at =
+                    Instant::now() - Duration::from_secs(1);
+            }
+
+            assert!(read_cached_codex_apps_tools().is_none());
+
+            let cache_guard = CODEX_APPS_TOOLS_CACHE
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            assert!(cache_guard.is_none());
+        });
+    }
+
+    #[test]
     fn mcp_init_error_display_prompts_for_github_pat() {
         let server_name = "github";
         let entry = McpAuthStatusEntry {


### PR DESCRIPTION
Adds a new apps_mcp_gateway flag to route Apps MCP calls through https://api.openai.com/v1/connectors/mcp/ when enabled, while keeping legacy MCP routing as default.