### PR TITLE
app-server: stabilize detached review start on Windows

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/review.rs
+++ b/codex-rs/app-server/tests/suite/v2/review.rs
@@ -437,6 +437,7 @@ model_provider = "mock_provider"
 
 [features]
 remote_models = false
+shell_snapshot = false
 
 [model_providers.mock_provider]
 name = "Mock provider"


### PR DESCRIPTION
## Why

`review_start_with_detached_delivery_returns_new_thread_id` has been failing on Windows CI. The failure mode is a process crash (`tokio-runtime-worker` stack overflow) during detached review setup, which causes EOF in the test harness.

This test is intended to validate detached review thread identity, not shell snapshot behavior. We also still want detached review to avoid unnecessary rollout-path rediscovery when the parent thread is already loaded.

## What Changed

- Updated detached review startup in `codex-rs/app-server/src/codex_message_processor.rs`:
  - `start_detached_review` now receives the loaded parent thread.
  - It prefers `parent_thread.rollout_path()`.
  - It falls back to `find_thread_path_by_id_str(...)` only if the in-memory path is unavailable.
- Hardened the review test fixture in `codex-rs/app-server/tests/suite/v2/review.rs` by setting `shell_snapshot = false` in test config, so this test no longer depends on unrelated Windows PowerShell snapshot initialization.

## Verification

- `cargo test -p codex-app-server`
- Verified `suite::v2::review::review_start_with_detached_delivery_returns_new_thread_id` passes locally.

## Notes

- Related context: rollout-path lookup behavior changed in #10532.
