### PR TITLE
app-server tests: disable shell_snapshot for review suite

### DIFF
--- a/codex-rs/app-server/tests/suite/v2/review.rs
+++ b/codex-rs/app-server/tests/suite/v2/review.rs
@@ -437,6 +437,7 @@ model_provider = "mock_provider"
 
 [features]
 remote_models = false
+shell_snapshot = false
 
 [model_providers.mock_provider]
 name = "Mock provider"


### PR DESCRIPTION
## Why

`suite::v2::review::review_start_with_detached_delivery_returns_new_thread_id` was failing on Windows CI due to an unrelated process crash during shell snapshot initialization (`tokio-runtime-worker` stack overflow).

This review test suite validates review API behavior and should not depend on shell snapshot behavior. Keeping shell snapshot enabled in this fixture made the test flaky for reasons outside the scenario under test.

## What Changed

- Updated the review suite test config in `codex-rs/app-server/tests/suite/v2/review.rs` to set:
  - `shell_snapshot = false`

This keeps the review tests focused on review behavior by disabling shell snapshot initialization in this fixture.

## Verification

- `cargo test -p codex-app-server`
- Confirmed the previously failing Windows CI job for this test now passes on this PR.
