### PR TITLE
Handle model-switch base instructions after compaction

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4368,7 +4368,7 @@ pub(crate) async fn run_turn(
 
                 // as long as compaction works well in getting us way below the token limit, we shouldn't worry about being in an infinite loop.
                 if token_limit_reached && needs_follow_up {
-                    if run_auto_compact(&sess, &turn_context, false).await.is_err() {
+                    if run_auto_compact(&sess, &turn_context).await.is_err() {
                         return None;
                     }
                     continue;
@@ -4433,23 +4433,12 @@ async fn run_pre_sampling_compact(
     turn_context: &Arc<TurnContext>,
 ) -> CodexResult<()> {
     let total_usage_tokens_before_compaction = sess.get_total_token_usage().await;
-    let previous_model = sess.previous_model().await;
-    let previous_model_compaction_ran = maybe_run_previous_model_inline_compact(
+    maybe_run_previous_model_inline_compact(
         sess,
         turn_context,
         total_usage_tokens_before_compaction,
     )
     .await?;
-    if previous_model_compaction_ran
-        && let Some(model_switch_item) = sess.build_model_instructions_update_item(
-            None,
-            previous_model.as_deref(),
-            turn_context.as_ref(),
-        )
-    {
-        sess.record_conversation_items(turn_context.as_ref(), &[model_switch_item])
-            .await;
-    }
     let total_usage_tokens = sess.get_total_token_usage().await;
     let auto_compact_limit = turn_context
         .model_info
@@ -4457,18 +4446,24 @@ async fn run_pre_sampling_compact(
         .unwrap_or(i64::MAX);
     // Compact if the total usage tokens are greater than the auto compact limit
     if total_usage_tokens >= auto_compact_limit {
-        run_auto_compact(sess, turn_context, false).await?;
+        run_auto_compact(sess, turn_context).await?;
     }
     Ok(())
 }
 
+/// Runs pre-sampling compaction against the previous model when switching to a smaller
+/// context-window model.
+///
+/// Returns `Ok(())` when compaction either completed successfully or was skipped because the
+/// model/context-window preconditions were not met. Returns `Err(_)` only when compaction was
+/// attempted and failed.
 async fn maybe_run_previous_model_inline_compact(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
     total_usage_tokens: i64,
-) -> CodexResult<bool> {
+) -> CodexResult<()> {
     let Some(previous_model) = sess.previous_model().await else {
-        return Ok(false);
+        return Ok(());
     };
     let previous_turn_context = Arc::new(
         turn_context
@@ -4477,10 +4472,10 @@ async fn maybe_run_previous_model_inline_compact(
     );
 
     let Some(old_context_window) = previous_turn_context.model_context_window() else {
-        return Ok(false);
+        return Ok(());
     };
     let Some(new_context_window) = turn_context.model_context_window() else {
-        return Ok(false);
+        return Ok(());
     };
     let new_auto_compact_limit = turn_context
         .model_info
@@ -4490,31 +4485,16 @@ async fn maybe_run_previous_model_inline_compact(
         && previous_turn_context.model_info.slug != turn_context.model_info.slug
         && old_context_window > new_context_window;
     if should_run {
-        run_auto_compact(sess, &previous_turn_context, true).await?;
-        return Ok(true);
+        run_auto_compact(sess, &previous_turn_context).await?;
     }
-    Ok(false)
+    Ok(())
 }
 
-async fn run_auto_compact(
-    sess: &Arc<Session>,
-    turn_context: &Arc<TurnContext>,
-    strip_trailing_model_switch_update: bool,
-) -> CodexResult<()> {
+async fn run_auto_compact(sess: &Arc<Session>, turn_context: &Arc<TurnContext>) -> CodexResult<()> {
     if should_use_remote_compact_task(&turn_context.provider) {
-        run_inline_remote_auto_compact_task(
-            Arc::clone(sess),
-            Arc::clone(turn_context),
-            strip_trailing_model_switch_update,
-        )
-        .await?;
+        run_inline_remote_auto_compact_task(Arc::clone(sess), Arc::clone(turn_context)).await?;
     } else {
-        run_inline_auto_compact_task(
-            Arc::clone(sess),
-            Arc::clone(turn_context),
-            strip_trailing_model_switch_update,
-        )
-        .await?;
+        run_inline_auto_compact_task(Arc::clone(sess), Arc::clone(turn_context)).await?;
     }
     Ok(())
 }

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::Prompt;
 use crate::codex::Session;
 use crate::codex::TurnContext;
-use crate::compact::strip_trailing_model_switch_update_for_compaction_request;
+use crate::compact::extract_trailing_model_switch_update_for_compaction_request;
 use crate::context_manager::ContextManager;
 use crate::context_manager::TotalTokenUsageBreakdown;
 use crate::context_manager::estimate_response_item_model_visible_bytes;
@@ -25,9 +25,8 @@ use tracing::info;
 pub(crate) async fn run_inline_remote_auto_compact_task(
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
-    strip_trailing_model_switch_update: bool,
 ) -> CodexResult<()> {
-    run_remote_compact_task_inner(&sess, &turn_context, strip_trailing_model_switch_update).await?;
+    run_remote_compact_task_inner(&sess, &turn_context).await?;
     Ok(())
 }
 
@@ -42,18 +41,14 @@ pub(crate) async fn run_remote_compact_task(
     });
     sess.send_event(&turn_context, start_event).await;
 
-    run_remote_compact_task_inner(&sess, &turn_context, false).await
+    run_remote_compact_task_inner(&sess, &turn_context).await
 }
 
 async fn run_remote_compact_task_inner(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
-    strip_trailing_model_switch_update: bool,
 ) -> CodexResult<()> {
-    if let Err(err) =
-        run_remote_compact_task_inner_impl(sess, turn_context, strip_trailing_model_switch_update)
-            .await
-    {
+    if let Err(err) = run_remote_compact_task_inner_impl(sess, turn_context).await {
         let event = EventMsg::Error(
             err.to_error_event(Some("Error running remote compact task".to_string())),
         );
@@ -66,15 +61,15 @@ async fn run_remote_compact_task_inner(
 async fn run_remote_compact_task_inner_impl(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
-    strip_trailing_model_switch_update: bool,
 ) -> CodexResult<()> {
     let compaction_item = TurnItem::ContextCompaction(ContextCompactionItem::new());
     sess.emit_turn_item_started(turn_context, &compaction_item)
         .await;
     let mut history = sess.clone_history().await;
-    if strip_trailing_model_switch_update {
-        strip_trailing_model_switch_update_for_compaction_request(&mut history);
-    }
+    // Keep compaction prompts in-distribution: if a model-switch update was injected at the
+    // tail of history (between turns), exclude it from the compaction request payload.
+    let stripped_model_switch_item =
+        extract_trailing_model_switch_update_for_compaction_request(&mut history);
     let base_instructions = sess.get_base_instructions().await;
     let deleted_items = trim_function_call_history_to_fit_context_window(
         &mut history,
@@ -130,6 +125,11 @@ async fn run_remote_compact_task_inner_impl(
     new_history = sess
         .process_compacted_history(turn_context, new_history)
         .await;
+    // Reattach the stripped model-switch update only after successful compaction so the model
+    // still sees the switch instructions on the next real sampling request.
+    if let Some(model_switch_item) = stripped_model_switch_item {
+        new_history.push(model_switch_item);
+    }
 
     if !ghost_snapshots.is_empty() {
         new_history.extend(ghost_snapshots);

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::Prompt;
 use crate::codex::Session;
 use crate::codex::TurnContext;
+use crate::compact::strip_trailing_model_switch_update_for_compaction_request;
 use crate::context_manager::ContextManager;
 use crate::context_manager::TotalTokenUsageBreakdown;
 use crate::context_manager::estimate_response_item_model_visible_bytes;
@@ -24,8 +25,9 @@ use tracing::info;
 pub(crate) async fn run_inline_remote_auto_compact_task(
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
+    strip_trailing_model_switch_update: bool,
 ) -> CodexResult<()> {
-    run_remote_compact_task_inner(&sess, &turn_context).await?;
+    run_remote_compact_task_inner(&sess, &turn_context, strip_trailing_model_switch_update).await?;
     Ok(())
 }
 
@@ -40,14 +42,18 @@ pub(crate) async fn run_remote_compact_task(
     });
     sess.send_event(&turn_context, start_event).await;
 
-    run_remote_compact_task_inner(&sess, &turn_context).await
+    run_remote_compact_task_inner(&sess, &turn_context, false).await
 }
 
 async fn run_remote_compact_task_inner(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
+    strip_trailing_model_switch_update: bool,
 ) -> CodexResult<()> {
-    if let Err(err) = run_remote_compact_task_inner_impl(sess, turn_context).await {
+    if let Err(err) =
+        run_remote_compact_task_inner_impl(sess, turn_context, strip_trailing_model_switch_update)
+            .await
+    {
         let event = EventMsg::Error(
             err.to_error_event(Some("Error running remote compact task".to_string())),
         );
@@ -60,11 +66,15 @@ async fn run_remote_compact_task_inner(
 async fn run_remote_compact_task_inner_impl(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
+    strip_trailing_model_switch_update: bool,
 ) -> CodexResult<()> {
     let compaction_item = TurnItem::ContextCompaction(ContextCompactionItem::new());
     sess.emit_turn_item_started(turn_context, &compaction_item)
         .await;
     let mut history = sess.clone_history().await;
+    if strip_trailing_model_switch_update {
+        strip_trailing_model_switch_update_for_compaction_request(&mut history);
+    }
     let base_instructions = sess.get_base_instructions().await;
     let deleted_items = trim_function_call_history_to_fit_context_window(
         &mut history,

--- a/codex-rs/core/tests/suite/compact.rs
+++ b/codex-rs/core/tests/suite/compact.rs
@@ -142,6 +142,15 @@ fn assert_pre_sampling_switch_compaction_requests(
         body_contains_text(&compact_body, SUMMARIZATION_PROMPT),
         "pre-sampling compact request should include summarization prompt"
     );
+    assert!(
+        !compact_body.contains("<model_switch>"),
+        "pre-sampling compact request should strip trailing model-switch update item"
+    );
+    let follow_up_body = follow_up.to_string();
+    assert!(
+        follow_up_body.contains("<model_switch>"),
+        "follow-up request after successful model-switch compaction should include model-switch update item"
+    );
 }
 
 async fn assert_compaction_uses_turn_lifecycle_id(codex: &std::sync::Arc<codex_core::CodexThread>) {


### PR DESCRIPTION
Strip trailing <model_switch> during model-switch compaction request, and append <model_switch> after model switch compaction