### PR TITLE
tui: render markdown tables with aligned box output

### DIFF
--- a/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_complex_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_complex_snapshot.snap
@@ -28,9 +28,13 @@ Image: alt text
 ———
 
 Table below (alignment test):
-| Left | Center | Right |
-|:-----|:------:|------:|
-| a    |   b    |     c |
+
+┌──────┬────────┬───────┐
+│ Left │ Center │ Right │
+├──────┼────────┼───────┤
+│ a    │   b    │     c │
+└──────┴────────┴───────┘
+
 Inline HTML: <sup>sup</sup> and <sub>sub</sub>.
 HTML block:
 <div style="border:1px solid #ccc;padding:2px">inline block</div>


### PR DESCRIPTION
## Summary
- enable markdown table parsing in the TUI markdown renderer
- add table state handling for rows/cells and render aligned box-drawing tables
- keep table lines unwrapped so column structure stays intact at narrow wrap widths
- add focused table tests and update the complex markdown snapshot

## Validation
- `cd codex-rs && just fmt`
- `cd codex-rs && cargo test -p codex-tui`
- `cd codex-rs && just fix -p codex-tui`
- `cd codex-rs && cargo build --release -p codex-tui`