### PR TITLE
Context update marker

### DIFF
--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -1,16 +1,12 @@
 use crate::codex::TurnContext;
 use crate::context_manager::normalize;
-use crate::instructions::SkillInstructions;
-use crate::instructions::UserInstructions;
-use crate::session_prefix::is_session_prefix;
+use crate::session_prefix::is_contextual_user_message;
 use crate::truncate::TruncationPolicy;
 use crate::truncate::approx_token_count;
 use crate::truncate::approx_tokens_from_byte_count_i64;
 use crate::truncate::truncate_function_output_items_with_policy;
 use crate::truncate::truncate_text;
-use crate::user_shell_command::is_user_shell_command_text;
 use codex_protocol::models::BaseInstructions;
-use codex_protocol::models::ContentItem;
 use codex_protocol::models::FunctionCallOutputBody;
 use codex_protocol::models::FunctionCallOutputContentItem;
 use codex_protocol::models::FunctionCallOutputPayload;
@@ -448,29 +444,7 @@ pub(crate) fn is_user_turn_boundary(item: &ResponseItem) -> bool {
         return false;
     }
 
-    if UserInstructions::is_user_instructions(content)
-        || SkillInstructions::is_skill_instructions(content)
-    {
-        return false;
-    }
-
-    for content_item in content {
-        match content_item {
-            ContentItem::InputText { text } => {
-                if is_session_prefix(text) || is_user_shell_command_text(text) {
-                    return false;
-                }
-            }
-            ContentItem::OutputText { text } => {
-                if is_session_prefix(text) {
-                    return false;
-                }
-            }
-            ContentItem::InputImage { .. } => {}
-        }
-    }
-
-    true
+    !is_contextual_user_message(content)
 }
 
 fn user_message_positions(items: &[ResponseItem]) -> Vec<usize> {

--- a/codex-rs/core/src/context_manager/history_tests.rs
+++ b/codex-rs/core/src/context_manager/history_tests.rs
@@ -561,6 +561,8 @@ fn drop_last_n_user_turns_preserves_prefix() {
 
 #[test]
 fn drop_last_n_user_turns_ignores_session_prefix_user_messages() {
+    let context_update =
+        "<context_update>\n<environment_context>delta</environment_context>\n</context_update>";
     let items = vec![
         user_input_text_msg("<environment_context>ctx</environment_context>"),
         user_input_text_msg("<user_instructions>do the thing</user_instructions>"),
@@ -571,6 +573,7 @@ fn drop_last_n_user_turns_ignores_session_prefix_user_messages() {
             "<skill>\n<name>demo</name>\n<path>skills/demo/SKILL.md</path>\nbody\n</skill>",
         ),
         user_input_text_msg("<user_shell_command>echo 42</user_shell_command>"),
+        user_input_text_msg(context_update),
         user_input_text_msg("turn 1 user"),
         assistant_msg("turn 1 assistant"),
         user_input_text_msg("turn 2 user"),
@@ -591,6 +594,7 @@ fn drop_last_n_user_turns_ignores_session_prefix_user_messages() {
             "<skill>\n<name>demo</name>\n<path>skills/demo/SKILL.md</path>\nbody\n</skill>",
         ),
         user_input_text_msg("<user_shell_command>echo 42</user_shell_command>"),
+        user_input_text_msg(context_update),
         user_input_text_msg("turn 1 user"),
         assistant_msg("turn 1 assistant"),
     ];
@@ -610,6 +614,7 @@ fn drop_last_n_user_turns_ignores_session_prefix_user_messages() {
             "<skill>\n<name>demo</name>\n<path>skills/demo/SKILL.md</path>\nbody\n</skill>",
         ),
         user_input_text_msg("<user_shell_command>echo 42</user_shell_command>"),
+        user_input_text_msg(context_update),
     ];
 
     let mut history = create_history_with_items(vec![
@@ -622,6 +627,7 @@ fn drop_last_n_user_turns_ignores_session_prefix_user_messages() {
             "<skill>\n<name>demo</name>\n<path>skills/demo/SKILL.md</path>\nbody\n</skill>",
         ),
         user_input_text_msg("<user_shell_command>echo 42</user_shell_command>"),
+        user_input_text_msg(context_update),
         user_input_text_msg("turn 1 user"),
         assistant_msg("turn 1 assistant"),
         user_input_text_msg("turn 2 user"),
@@ -640,6 +646,7 @@ fn drop_last_n_user_turns_ignores_session_prefix_user_messages() {
             "<skill>\n<name>demo</name>\n<path>skills/demo/SKILL.md</path>\nbody\n</skill>",
         ),
         user_input_text_msg("<user_shell_command>echo 42</user_shell_command>"),
+        user_input_text_msg(context_update),
         user_input_text_msg("turn 1 user"),
         assistant_msg("turn 1 assistant"),
         user_input_text_msg("turn 2 user"),

--- a/codex-rs/core/src/session_prefix.rs
+++ b/codex-rs/core/src/session_prefix.rs
@@ -1,3 +1,9 @@
+use codex_protocol::models::ContentItem;
+
+use crate::instructions::SkillInstructions;
+use crate::instructions::UserInstructions;
+use crate::user_shell_command::is_user_shell_command_text;
+
 /// Helpers for identifying model-visible "session prefix" messages.
 ///
 /// A session prefix is a user-role message that carries configuration or state needed by
@@ -6,10 +12,99 @@
 /// boundaries.
 pub(crate) const ENVIRONMENT_CONTEXT_OPEN_TAG: &str = "<environment_context>";
 pub(crate) const TURN_ABORTED_OPEN_TAG: &str = "<turn_aborted>";
+pub(crate) const CONTEXT_UPDATE_OPEN_TAG: &str = "<context_update>";
 
 /// Returns true if `text` starts with a session prefix marker (case-insensitive).
 pub(crate) fn is_session_prefix(text: &str) -> bool {
     let trimmed = text.trim_start();
     let lowered = trimmed.to_ascii_lowercase();
-    lowered.starts_with(ENVIRONMENT_CONTEXT_OPEN_TAG) || lowered.starts_with(TURN_ABORTED_OPEN_TAG)
+    lowered.starts_with(ENVIRONMENT_CONTEXT_OPEN_TAG)
+        || lowered.starts_with(TURN_ABORTED_OPEN_TAG)
+        || lowered.starts_with(CONTEXT_UPDATE_OPEN_TAG)
+}
+
+pub(crate) fn is_contextual_user_message(content: &[ContentItem]) -> bool {
+    if UserInstructions::is_user_instructions(content)
+        || SkillInstructions::is_skill_instructions(content)
+    {
+        return true;
+    }
+
+    content.iter().any(|content_item| match content_item {
+        ContentItem::InputText { text } => {
+            is_session_prefix(text) || is_user_shell_command_text(text)
+        }
+        ContentItem::OutputText { text } => is_session_prefix(text),
+        ContentItem::InputImage { .. } => false,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use codex_protocol::models::ContentItem;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn recognizes_context_update_session_prefix() {
+        assert!(is_session_prefix(
+            "<context_update>\nfoo\n</context_update>"
+        ));
+        assert!(is_session_prefix(
+            "   <context_update>\nfoo\n</context_update>"
+        ));
+        assert!(is_session_prefix(
+            "<CONTEXT_UPDATE>\nfoo\n</CONTEXT_UPDATE>"
+        ));
+    }
+
+    #[test]
+    fn recognizes_legacy_session_prefixes() {
+        assert!(is_session_prefix(
+            "<environment_context>foo</environment_context>"
+        ));
+        assert!(is_session_prefix("<turn_aborted>foo</turn_aborted>"));
+    }
+
+    #[test]
+    fn does_not_treat_plain_text_as_session_prefix() {
+        assert_eq!(is_session_prefix("normal user message"), false);
+    }
+
+    #[test]
+    fn contextual_user_message_detects_context_markers_and_wrappers() {
+        let shell = [ContentItem::InputText {
+            text: "<user_shell_command>echo hi</user_shell_command>".to_string(),
+        }];
+        let context_update = [ContentItem::InputText {
+            text: "<context_update>\nfoo\n</context_update>".to_string(),
+        }];
+        let user_instructions = [ContentItem::InputText {
+            text: "# AGENTS.md instructions for test\n\n<INSTRUCTIONS>\nfoo\n</INSTRUCTIONS>"
+                .to_string(),
+        }];
+        let skill = [ContentItem::InputText {
+            text: "<skill>\n<name>demo</name>\n<path>skills/demo/SKILL.md</path>\nbody\n</skill>"
+                .to_string(),
+        }];
+
+        assert!(is_contextual_user_message(&shell));
+        assert!(is_contextual_user_message(&context_update));
+        assert!(is_contextual_user_message(&user_instructions));
+        assert!(is_contextual_user_message(&skill));
+    }
+
+    #[test]
+    fn contextual_user_message_keeps_real_user_content() {
+        let real_message = [
+            ContentItem::InputText {
+                text: "normal user message".to_string(),
+            },
+            ContentItem::InputImage {
+                image_url: "https://example.com/img.png".to_string(),
+            },
+        ];
+
+        assert_eq!(is_contextual_user_message(&real_message), false);
+    }
 }

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -1951,7 +1951,7 @@ pub struct TurnContextItem {
     pub cwd: PathBuf,
     pub approval_policy: AskForApproval,
     pub sandbox_policy: SandboxPolicy,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub network: Option<TurnContextNetworkItem>,
     pub model: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -1951,7 +1951,7 @@ pub struct TurnContextItem {
     pub cwd: PathBuf,
     pub approval_policy: AskForApproval,
     pub sandbox_policy: SandboxPolicy,
-    #[serde(default)]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub network: Option<TurnContextNetworkItem>,
     pub model: String,
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -1951,7 +1951,7 @@ pub struct TurnContextItem {
     pub cwd: PathBuf,
     pub approval_policy: AskForApproval,
     pub sandbox_policy: SandboxPolicy,
-    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
     pub network: Option<TurnContextNetworkItem>,
     pub model: String,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary

This PR introduces a small, low-risk infrastructure step toward the context-update design by unifying contextual user-message
classification and adding support for the new `<context_update>` marker.

### What it does

- Adds `<context_update>` to session-prefix detection.
- Introduces a single shared helper for contextual user-message detection:
  - `is_contextual_user_message(content: &[ContentItem])`
- Refactors both callsites to use the shared helper:
  - `event_mapping::parse_user_message`
  - `context_manager::is_user_turn_boundary`
- Extends tests to cover `<context_update>` across parsing and turn-boundary behavior.

### What it does **not** do

- Does **not** change context message emission yet.
- Does **not** introduce envelope assembly/state-diff plumbing yet.
- Keeps existing legacy contextual wrappers fully recognized.

## Rationale

Before this change, contextual-user detection logic was duplicated in two places.
That made it easy for parsing and user-turn boundary rules to drift.

This PR centralizes that logic and adds marker recognition now, so future PRs that emit `<context_update>` can rely on a
single classification contract.