### PR TITLE
support app usage analytics

### DIFF
--- a/codex-rs/core/src/analytics_client.rs
+++ b/codex-rs/core/src/analytics_client.rs
@@ -95,7 +95,7 @@ impl AnalyticsEventsQueue {
         let mut emitted = self
             .app_used_emitted_keys
             .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         if emitted.len() >= ANALYTICS_APP_USED_DEDUPE_MAX_KEYS {
             emitted.clear();
         }

--- a/codex-rs/core/src/analytics_client.rs
+++ b/codex-rs/core/src/analytics_client.rs
@@ -17,15 +17,18 @@ use tokio::sync::mpsc;
 pub(crate) struct TrackEventsContext {
     pub(crate) model_slug: String,
     pub(crate) thread_id: String,
+    pub(crate) turn_id: String,
 }
 
 pub(crate) fn build_track_events_context(
     model_slug: String,
     thread_id: String,
+    turn_id: String,
 ) -> TrackEventsContext {
     TrackEventsContext {
         model_slug,
         thread_id,
+        turn_id,
     }
 }
 
@@ -33,6 +36,12 @@ pub(crate) struct SkillInvocation {
     pub(crate) skill_name: String,
     pub(crate) skill_scope: SkillScope,
     pub(crate) skill_path: PathBuf,
+}
+
+pub(crate) struct AppInvocation {
+    pub(crate) connector_id: Option<String>,
+    pub(crate) app_name: Option<String>,
+    pub(crate) invoke_type: Option<String>,
 }
 
 #[derive(Clone)]
@@ -50,7 +59,17 @@ impl AnalyticsEventsQueue {
         let (sender, mut receiver) = mpsc::channel(ANALYTICS_EVENTS_QUEUE_SIZE);
         tokio::spawn(async move {
             while let Some(job) = receiver.recv().await {
-                send_track_skill_invocations(&auth_manager, job).await;
+                match job {
+                    TrackEventsJob::SkillInvocations(job) => {
+                        send_track_skill_invocations(&auth_manager, job).await;
+                    }
+                    TrackEventsJob::AppMentions(job) => {
+                        send_track_app_mentions(&auth_manager, job).await;
+                    }
+                    TrackEventsJob::AppUsed(job) => {
+                        send_track_app_used(&auth_manager, job).await;
+                    }
+                }
             }
         });
         Self { sender }
@@ -84,12 +103,47 @@ impl AnalyticsEventsClient {
             invocations,
         );
     }
+
+    pub(crate) fn track_app_mentions(
+        &self,
+        tracking: TrackEventsContext,
+        mentions: Vec<AppInvocation>,
+    ) {
+        track_app_mentions(
+            &self.queue,
+            Arc::clone(&self.config),
+            Some(tracking),
+            mentions,
+        );
+    }
+
+    pub(crate) fn track_app_used(&self, tracking: TrackEventsContext, app: AppInvocation) {
+        track_app_used(&self.queue, Arc::clone(&self.config), Some(tracking), app);
+    }
 }
 
-struct TrackEventsJob {
+enum TrackEventsJob {
+    SkillInvocations(TrackSkillInvocationsJob),
+    AppMentions(TrackAppMentionsJob),
+    AppUsed(TrackAppUsedJob),
+}
+
+struct TrackSkillInvocationsJob {
     config: Arc<Config>,
     tracking: TrackEventsContext,
     invocations: Vec<SkillInvocation>,
+}
+
+struct TrackAppMentionsJob {
+    config: Arc<Config>,
+    tracking: TrackEventsContext,
+    mentions: Vec<AppInvocation>,
+}
+
+struct TrackAppUsedJob {
+    config: Arc<Config>,
+    tracking: TrackEventsContext,
+    app: AppInvocation,
 }
 
 const ANALYTICS_EVENTS_QUEUE_SIZE: usize = 256;
@@ -97,25 +151,56 @@ const ANALYTICS_EVENTS_TIMEOUT: Duration = Duration::from_secs(10);
 
 #[derive(Serialize)]
 struct TrackEventsRequest {
-    events: Vec<TrackEvent>,
+    events: Vec<TrackEventRequest>,
 }
 
 #[derive(Serialize)]
-struct TrackEvent {
+#[serde(untagged)]
+enum TrackEventRequest {
+    SkillInvocation(SkillInvocationEventRequest),
+    AppMentioned(CodexAppMentionedEventRequest),
+    AppUsed(CodexAppUsedEventRequest),
+}
+
+#[derive(Serialize)]
+struct SkillInvocationEventRequest {
     event_type: &'static str,
     skill_id: String,
     skill_name: String,
-    event_params: TrackEventParams,
+    event_params: SkillInvocationEventParams,
 }
 
 #[derive(Serialize)]
-struct TrackEventParams {
+struct SkillInvocationEventParams {
     product_client_id: Option<String>,
     skill_scope: Option<String>,
     repo_url: Option<String>,
     thread_id: Option<String>,
     invoke_type: Option<String>,
     model_slug: Option<String>,
+}
+
+#[derive(Serialize)]
+struct CodexAppMetadata {
+    connector_id: Option<String>,
+    thread_id: Option<String>,
+    turn_id: Option<String>,
+    app_name: Option<String>,
+    product_client_id: Option<String>,
+    invoke_type: Option<String>,
+    model_slug: Option<String>,
+}
+
+#[derive(Serialize)]
+struct CodexAppMentionedEventRequest {
+    event_type: &'static str,
+    event_params: CodexAppMetadata,
+}
+
+#[derive(Serialize)]
+struct CodexAppUsedEventRequest {
+    event_type: &'static str,
+    event_params: CodexAppMetadata,
 }
 
 pub(crate) fn track_skill_invocations(
@@ -133,34 +218,63 @@ pub(crate) fn track_skill_invocations(
     if invocations.is_empty() {
         return;
     }
-    let job = TrackEventsJob {
+    let job = TrackEventsJob::SkillInvocations(TrackSkillInvocationsJob {
         config,
         tracking,
         invocations,
-    };
+    });
     queue.try_send(job);
 }
 
-async fn send_track_skill_invocations(auth_manager: &AuthManager, job: TrackEventsJob) {
-    let TrackEventsJob {
+pub(crate) fn track_app_mentions(
+    queue: &AnalyticsEventsQueue,
+    config: Arc<Config>,
+    tracking: Option<TrackEventsContext>,
+    mentions: Vec<AppInvocation>,
+) {
+    if config.analytics_enabled == Some(false) {
+        return;
+    }
+    let Some(tracking) = tracking else {
+        return;
+    };
+    if mentions.is_empty() {
+        return;
+    }
+    let job = TrackEventsJob::AppMentions(TrackAppMentionsJob {
+        config,
+        tracking,
+        mentions,
+    });
+    queue.try_send(job);
+}
+
+pub(crate) fn track_app_used(
+    queue: &AnalyticsEventsQueue,
+    config: Arc<Config>,
+    tracking: Option<TrackEventsContext>,
+    app: AppInvocation,
+) {
+    if config.analytics_enabled == Some(false) {
+        return;
+    }
+    let Some(tracking) = tracking else {
+        return;
+    };
+    let job = TrackEventsJob::AppUsed(TrackAppUsedJob {
+        config,
+        tracking,
+        app,
+    });
+    queue.try_send(job);
+}
+
+async fn send_track_skill_invocations(auth_manager: &AuthManager, job: TrackSkillInvocationsJob) {
+    let TrackSkillInvocationsJob {
         config,
         tracking,
         invocations,
     } = job;
-    let Some(auth) = auth_manager.auth().await else {
-        return;
-    };
-    if !auth.is_chatgpt_auth() {
-        return;
-    }
-    let access_token = match auth.get_token() {
-        Ok(token) => token,
-        Err(_) => return,
-    };
-    let Some(account_id) = auth.get_account_id() else {
-        return;
-    };
-
     let mut events = Vec::with_capacity(invocations.len());
     for invocation in invocations {
         let skill_scope = match invocation.skill_scope {
@@ -183,20 +297,92 @@ async fn send_track_skill_invocations(auth_manager: &AuthManager, job: TrackEven
             invocation.skill_path.as_path(),
             invocation.skill_name.as_str(),
         );
-        events.push(TrackEvent {
-            event_type: "skill_invocation",
-            skill_id,
-            skill_name: invocation.skill_name.clone(),
-            event_params: TrackEventParams {
-                thread_id: Some(tracking.thread_id.clone()),
-                invoke_type: Some("explicit".to_string()),
-                model_slug: Some(tracking.model_slug.clone()),
-                product_client_id: Some(crate::default_client::originator().value),
-                repo_url,
-                skill_scope: Some(skill_scope.to_string()),
+        events.push(TrackEventRequest::SkillInvocation(
+            SkillInvocationEventRequest {
+                event_type: "skill_invocation",
+                skill_id,
+                skill_name: invocation.skill_name.clone(),
+                event_params: SkillInvocationEventParams {
+                    thread_id: Some(tracking.thread_id.clone()),
+                    invoke_type: Some("explicit".to_string()),
+                    model_slug: Some(tracking.model_slug.clone()),
+                    product_client_id: Some(crate::default_client::originator().value),
+                    repo_url,
+                    skill_scope: Some(skill_scope.to_string()),
+                },
             },
-        });
+        ));
     }
+
+    send_track_events(auth_manager, config, events).await;
+}
+
+async fn send_track_app_mentions(auth_manager: &AuthManager, job: TrackAppMentionsJob) {
+    let TrackAppMentionsJob {
+        config,
+        tracking,
+        mentions,
+    } = job;
+    let events = mentions
+        .into_iter()
+        .map(|mention| {
+            TrackEventRequest::AppMentioned(CodexAppMentionedEventRequest {
+                event_type: "codex_app_mentioned",
+                event_params: codex_app_metadata(&tracking, mention),
+            })
+        })
+        .collect::<Vec<_>>();
+
+    send_track_events(auth_manager, config, events).await;
+}
+
+async fn send_track_app_used(auth_manager: &AuthManager, job: TrackAppUsedJob) {
+    let TrackAppUsedJob {
+        config,
+        tracking,
+        app,
+    } = job;
+    let events = vec![TrackEventRequest::AppUsed(CodexAppUsedEventRequest {
+        event_type: "codex_app_used",
+        event_params: codex_app_metadata(&tracking, app),
+    })];
+
+    send_track_events(auth_manager, config, events).await;
+}
+
+fn codex_app_metadata(tracking: &TrackEventsContext, app: AppInvocation) -> CodexAppMetadata {
+    CodexAppMetadata {
+        connector_id: app.connector_id,
+        thread_id: Some(tracking.thread_id.clone()),
+        turn_id: Some(tracking.turn_id.clone()),
+        app_name: app.app_name,
+        product_client_id: Some(crate::default_client::originator().value),
+        invoke_type: app.invoke_type,
+        model_slug: Some(tracking.model_slug.clone()),
+    }
+}
+
+async fn send_track_events(
+    auth_manager: &AuthManager,
+    config: Arc<Config>,
+    events: Vec<TrackEventRequest>,
+) {
+    if events.is_empty() {
+        return;
+    }
+    let Some(auth) = auth_manager.auth().await else {
+        return;
+    };
+    if !auth.is_chatgpt_auth() {
+        return;
+    }
+    let access_token = match auth.get_token() {
+        Ok(token) => token,
+        Err(_) => return,
+    };
+    let Some(account_id) = auth.get_account_id() else {
+        return;
+    };
 
     let base_url = config.chatgpt_base_url.trim_end_matches('/');
     let url = format!("{base_url}/codex/analytics-events/events");
@@ -269,8 +455,15 @@ fn normalize_path_for_skill_id(
 
 #[cfg(test)]
 mod tests {
+    use super::AppInvocation;
+    use super::CodexAppMentionedEventRequest;
+    use super::CodexAppUsedEventRequest;
+    use super::TrackEventRequest;
+    use super::TrackEventsContext;
+    use super::codex_app_metadata;
     use super::normalize_path_for_skill_id;
     use pretty_assertions::assert_eq;
+    use serde_json::json;
     use std::path::PathBuf;
 
     fn expected_absolute_path(path: &PathBuf) -> String {
@@ -327,5 +520,81 @@ mod tests {
         let expected = expected_absolute_path(&skill_path);
 
         assert_eq!(path, expected);
+    }
+
+    #[test]
+    fn app_mentioned_event_serializes_expected_shape() {
+        let tracking = TrackEventsContext {
+            model_slug: "gpt-5".to_string(),
+            thread_id: "thread-1".to_string(),
+            turn_id: "turn-1".to_string(),
+        };
+        let event = TrackEventRequest::AppMentioned(CodexAppMentionedEventRequest {
+            event_type: "codex_app_mentioned",
+            event_params: codex_app_metadata(
+                &tracking,
+                AppInvocation {
+                    connector_id: Some("calendar".to_string()),
+                    app_name: Some("Calendar".to_string()),
+                    invoke_type: Some("explicit".to_string()),
+                },
+            ),
+        });
+
+        let payload = serde_json::to_value(&event).expect("serialize app mentioned event");
+
+        assert_eq!(
+            payload,
+            json!({
+                "event_type": "codex_app_mentioned",
+                "event_params": {
+                    "connector_id": "calendar",
+                    "thread_id": "thread-1",
+                    "turn_id": "turn-1",
+                    "app_name": "Calendar",
+                    "product_client_id": crate::default_client::originator().value,
+                    "invoke_type": "explicit",
+                    "model_slug": "gpt-5"
+                }
+            })
+        );
+    }
+
+    #[test]
+    fn app_used_event_serializes_expected_shape() {
+        let tracking = TrackEventsContext {
+            model_slug: "gpt-5".to_string(),
+            thread_id: "thread-2".to_string(),
+            turn_id: "turn-2".to_string(),
+        };
+        let event = TrackEventRequest::AppUsed(CodexAppUsedEventRequest {
+            event_type: "codex_app_used",
+            event_params: codex_app_metadata(
+                &tracking,
+                AppInvocation {
+                    connector_id: Some("drive".to_string()),
+                    app_name: Some("Google Drive".to_string()),
+                    invoke_type: Some("implicit".to_string()),
+                },
+            ),
+        });
+
+        let payload = serde_json::to_value(&event).expect("serialize app used event");
+
+        assert_eq!(
+            payload,
+            json!({
+                "event_type": "codex_app_used",
+                "event_params": {
+                    "connector_id": "drive",
+                    "thread_id": "thread-2",
+                    "turn_id": "turn-2",
+                    "app_name": "Google Drive",
+                    "product_client_id": crate::default_client::originator().value,
+                    "invoke_type": "implicit",
+                    "model_slug": "gpt-5"
+                }
+            })
+        );
     }
 }

--- a/codex-rs/core/src/analytics_client.rs
+++ b/codex-rs/core/src/analytics_client.rs
@@ -67,7 +67,7 @@ impl AnalyticsEventsQueue {
                         send_track_skill_invocations(&auth_manager, job).await;
                     }
                     TrackEventsJob::AppMentioned(job) => {
-                        send_track_app_mentions(&auth_manager, job).await;
+                        send_track_app_mentioned(&auth_manager, job).await;
                     }
                     TrackEventsJob::AppUsed(job) => {
                         send_track_app_used(&auth_manager, job).await;
@@ -341,7 +341,7 @@ async fn send_track_skill_invocations(auth_manager: &AuthManager, job: TrackSkil
     send_track_events(auth_manager, config, events).await;
 }
 
-async fn send_track_app_mentions(auth_manager: &AuthManager, job: TrackAppMentionedJob) {
+async fn send_track_app_mentioned(auth_manager: &AuthManager, job: TrackAppMentionedJob) {
     let TrackAppMentionedJob {
         config,
         tracking,

--- a/codex-rs/core/src/analytics_client.rs
+++ b/codex-rs/core/src/analytics_client.rs
@@ -84,7 +84,7 @@ impl AnalyticsEventsQueue {
     fn try_send(&self, job: TrackEventsJob) {
         if self.sender.try_send(job).is_err() {
             //TODO: add a metric for this
-            tracing::warn!("dropping skill analytics events: queue is full");
+            tracing::warn!("dropping analytics events: queue is full");
         }
     }
 

--- a/codex-rs/core/src/analytics_client.rs
+++ b/codex-rs/core/src/analytics_client.rs
@@ -66,7 +66,7 @@ impl AnalyticsEventsQueue {
                     TrackEventsJob::SkillInvocations(job) => {
                         send_track_skill_invocations(&auth_manager, job).await;
                     }
-                    TrackEventsJob::AppMentions(job) => {
+                    TrackEventsJob::AppMentioned(job) => {
                         send_track_app_mentions(&auth_manager, job).await;
                     }
                     TrackEventsJob::AppUsed(job) => {
@@ -144,7 +144,7 @@ impl AnalyticsEventsClient {
 
 enum TrackEventsJob {
     SkillInvocations(TrackSkillInvocationsJob),
-    AppMentions(TrackAppMentionsJob),
+    AppMentioned(TrackAppMentionedJob),
     AppUsed(TrackAppUsedJob),
 }
 
@@ -154,7 +154,7 @@ struct TrackSkillInvocationsJob {
     invocations: Vec<SkillInvocation>,
 }
 
-struct TrackAppMentionsJob {
+struct TrackAppMentionedJob {
     config: Arc<Config>,
     tracking: TrackEventsContext,
     mentions: Vec<AppInvocation>,
@@ -262,7 +262,7 @@ pub(crate) fn track_app_mentions(
     if mentions.is_empty() {
         return;
     }
-    let job = TrackEventsJob::AppMentions(TrackAppMentionsJob {
+    let job = TrackEventsJob::AppMentioned(TrackAppMentionedJob {
         config,
         tracking,
         mentions,
@@ -341,8 +341,8 @@ async fn send_track_skill_invocations(auth_manager: &AuthManager, job: TrackSkil
     send_track_events(auth_manager, config, events).await;
 }
 
-async fn send_track_app_mentions(auth_manager: &AuthManager, job: TrackAppMentionsJob) {
-    let TrackAppMentionsJob {
+async fn send_track_app_mentions(auth_manager: &AuthManager, job: TrackAppMentionedJob) {
+    let TrackAppMentionedJob {
         config,
         tracking,
         mentions,

--- a/codex-rs/core/src/analytics_client.rs
+++ b/codex-rs/core/src/analytics_client.rs
@@ -124,12 +124,12 @@ impl AnalyticsEventsClient {
         );
     }
 
-    pub(crate) fn track_app_mentions(
+    pub(crate) fn track_app_mentioned(
         &self,
         tracking: TrackEventsContext,
         mentions: Vec<AppInvocation>,
     ) {
-        track_app_mentions(
+        track_app_mentioned(
             &self.queue,
             Arc::clone(&self.config),
             Some(tracking),
@@ -247,7 +247,7 @@ pub(crate) fn track_skill_invocations(
     queue.try_send(job);
 }
 
-pub(crate) fn track_app_mentions(
+pub(crate) fn track_app_mentioned(
     queue: &AnalyticsEventsQueue,
     config: Arc<Config>,
     tracking: Option<TrackEventsContext>,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -14,6 +14,7 @@ use crate::agent::AgentStatus;
 use crate::agent::MAX_THREAD_SPAWN_DEPTH;
 use crate::agent::agent_status_from_event;
 use crate::analytics_client::AnalyticsEventsClient;
+use crate::analytics_client::AppInvocation;
 use crate::analytics_client::build_track_events_context;
 use crate::apps::render_apps_section;
 use crate::compact;
@@ -4205,7 +4206,11 @@ pub(crate) async fn run_turn(
 
     let otel_manager = turn_context.otel_manager.clone();
     let thread_id = sess.conversation_id.to_string();
-    let tracking = build_track_events_context(turn_context.model_info.slug.clone(), thread_id);
+    let tracking = build_track_events_context(
+        turn_context.model_info.slug.clone(),
+        thread_id,
+        turn_context.sub_id.clone(),
+    );
     let SkillInjections {
         items: skill_items,
         warnings: skill_warnings,
@@ -4228,6 +4233,23 @@ pub(crate) async fn run_turn(
         &available_connectors,
         &skill_name_counts_lower,
     ));
+    let connector_names_by_id = available_connectors
+        .iter()
+        .map(|connector| (connector.id.as_str(), connector.name.as_str()))
+        .collect::<HashMap<&str, &str>>();
+    let app_mentions = explicitly_enabled_connectors
+        .iter()
+        .map(|connector_id| AppInvocation {
+            connector_id: Some(connector_id.clone()),
+            app_name: connector_names_by_id
+                .get(connector_id.as_str())
+                .map(|name| (*name).to_string()),
+            invoke_type: Some("explicit".to_string()),
+        })
+        .collect::<Vec<_>>();
+    sess.services
+        .analytics_events_client
+        .track_app_mentions(tracking.clone(), app_mentions);
     sess.merge_connector_selection(explicitly_enabled_connectors.clone())
         .await;
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4227,8 +4227,8 @@ pub(crate) async fn run_turn(
             .await;
     }
 
-    let mut mentioned_connector_ids = collect_explicit_app_ids(&input);
-    mentioned_connector_ids.extend(collect_explicit_app_ids_from_skill_items(
+    let mut explicitly_enabled_connectors = collect_explicit_app_ids(&input);
+    explicitly_enabled_connectors.extend(collect_explicit_app_ids_from_skill_items(
         &skill_items,
         &available_connectors,
         &skill_name_counts_lower,
@@ -4237,7 +4237,7 @@ pub(crate) async fn run_turn(
         .iter()
         .map(|connector| (connector.id.as_str(), connector.name.as_str()))
         .collect::<HashMap<&str, &str>>();
-    let mentioned_app_invocations = mentioned_connector_ids
+    let mentioned_app_invocations = explicitly_enabled_connectors
         .iter()
         .map(|connector_id| AppInvocation {
             connector_id: Some(connector_id.clone()),
@@ -4250,7 +4250,7 @@ pub(crate) async fn run_turn(
     sess.services
         .analytics_events_client
         .track_app_mentions(tracking.clone(), mentioned_app_invocations);
-    sess.merge_connector_selection(mentioned_connector_ids.clone())
+    sess.merge_connector_selection(explicitly_enabled_connectors.clone())
         .await;
 
     let initial_input_for_turn: ResponseInputItem = ResponseInputItem::from(input.clone());
@@ -4329,7 +4329,7 @@ pub(crate) async fn run_turn(
             &mut client_session,
             turn_metadata_header.as_deref(),
             sampling_request_input,
-            &mentioned_connector_ids,
+            &explicitly_enabled_connectors,
             skills_outcome.as_ref(),
             cancellation_token.child_token(),
         )
@@ -4537,7 +4537,7 @@ fn collect_explicit_app_ids_from_skill_items(
 fn filter_connectors_for_input(
     connectors: Vec<connectors::AppInfo>,
     input: &[ResponseItem],
-    mentioned_connector_ids: &HashSet<String>,
+    explicitly_enabled_connectors: &HashSet<String>,
     skill_name_counts_lower: &HashMap<String, usize>,
 ) -> Vec<connectors::AppInfo> {
     let connectors = connectors
@@ -4549,7 +4549,7 @@ fn filter_connectors_for_input(
     }
 
     let user_messages = collect_user_messages(input);
-    if user_messages.is_empty() && mentioned_connector_ids.is_empty() {
+    if user_messages.is_empty() && explicitly_enabled_connectors.is_empty() {
         return Vec::new();
     }
 
@@ -4561,7 +4561,7 @@ fn filter_connectors_for_input(
         .collect::<HashSet<String>>();
 
     let connector_slug_counts = build_connector_slug_counts(&connectors);
-    let mut allowed_connector_ids = mentioned_connector_ids.clone();
+    let mut allowed_connector_ids = explicitly_enabled_connectors.clone();
     for path in mentions
         .paths
         .iter()
@@ -4651,7 +4651,7 @@ async fn run_sampling_request(
     client_session: &mut ModelClientSession,
     turn_metadata_header: Option<&str>,
     input: Vec<ResponseItem>,
-    mentioned_connector_ids: &HashSet<String>,
+    explicitly_enabled_connectors: &HashSet<String>,
     skills_outcome: Option<&SkillLoadOutcome>,
     cancellation_token: CancellationToken,
 ) -> CodexResult<SamplingRequestResult> {
@@ -4659,7 +4659,7 @@ async fn run_sampling_request(
         sess.as_ref(),
         turn_context.as_ref(),
         &input,
-        mentioned_connector_ids,
+        explicitly_enabled_connectors,
         skills_outcome,
         &cancellation_token,
     )
@@ -4774,7 +4774,7 @@ async fn built_tools(
     sess: &Session,
     turn_context: &TurnContext,
     input: &[ResponseItem],
-    mentioned_connector_ids: &HashSet<String>,
+    explicitly_enabled_connectors: &HashSet<String>,
     skills_outcome: Option<&SkillLoadOutcome>,
     cancellation_token: &CancellationToken,
 ) -> CodexResult<Arc<ToolRouter>> {
@@ -4787,8 +4787,8 @@ async fn built_tools(
         .or_cancel(cancellation_token)
         .await?;
 
-    let mut effective_mentioned_connector_ids = mentioned_connector_ids.clone();
-    effective_mentioned_connector_ids.extend(sess.get_connector_selection().await);
+    let mut effective_explicitly_enabled_connectors = explicitly_enabled_connectors.clone();
+    effective_explicitly_enabled_connectors.extend(sess.get_connector_selection().await);
 
     let connectors_for_tools = if turn_context.config.features.enabled(Feature::Apps) {
         let skill_name_counts_lower = skills_outcome.map_or_else(HashMap::new, |outcome| {
@@ -4801,7 +4801,7 @@ async fn built_tools(
         Some(filter_connectors_for_input(
             connectors,
             input,
-            &effective_mentioned_connector_ids,
+            &effective_explicitly_enabled_connectors,
             &skill_name_counts_lower,
         ))
     } else {
@@ -5793,13 +5793,13 @@ mod tests {
             make_connector("two", "Foo-Bar"),
         ];
         let input = vec![user_message("use $foo-bar")];
-        let mentioned_connector_ids = HashSet::new();
+        let explicitly_enabled_connectors = HashSet::new();
         let skill_name_counts_lower = HashMap::new();
 
         let selected = filter_connectors_for_input(
             connectors,
             &input,
-            &mentioned_connector_ids,
+            &explicitly_enabled_connectors,
             &skill_name_counts_lower,
         );
 
@@ -5810,13 +5810,13 @@ mod tests {
     fn filter_connectors_for_input_skips_when_skill_name_conflicts() {
         let connectors = vec![make_connector("one", "Todoist")];
         let input = vec![user_message("use $todoist")];
-        let mentioned_connector_ids = HashSet::new();
+        let explicitly_enabled_connectors = HashSet::new();
         let skill_name_counts_lower = HashMap::from([("todoist".to_string(), 1)]);
 
         let selected = filter_connectors_for_input(
             connectors,
             &input,
-            &mentioned_connector_ids,
+            &explicitly_enabled_connectors,
             &skill_name_counts_lower,
         );
 
@@ -5828,11 +5828,11 @@ mod tests {
         let mut connector = make_connector("calendar", "Calendar");
         connector.is_enabled = false;
         let input = vec![user_message("use $calendar")];
-        let mentioned_connector_ids = HashSet::new();
+        let explicitly_enabled_connectors = HashSet::new();
         let selected = filter_connectors_for_input(
             vec![connector],
             &input,
-            &mentioned_connector_ids,
+            &explicitly_enabled_connectors,
             &HashMap::new(),
         );
 
@@ -5907,11 +5907,11 @@ mod tests {
         let mut selected_mcp_tools =
             filter_mcp_tools_by_name(mcp_tools.clone(), &selected_tool_names);
         let connectors = connectors::accessible_connectors_from_mcp_tools(&mcp_tools);
-        let mentioned_connector_ids = HashSet::new();
+        let explicitly_enabled_connectors = HashSet::new();
         let connectors = filter_connectors_for_input(
             connectors,
             &[user_message("run the selected tools")],
-            &mentioned_connector_ids,
+            &explicitly_enabled_connectors,
             &HashMap::new(),
         );
         let apps_mcp_tools = filter_codex_apps_mcp_tools_only(mcp_tools, &connectors);
@@ -5950,11 +5950,11 @@ mod tests {
         let mut selected_mcp_tools =
             filter_mcp_tools_by_name(mcp_tools.clone(), &selected_tool_names);
         let connectors = connectors::accessible_connectors_from_mcp_tools(&mcp_tools);
-        let mentioned_connector_ids = HashSet::new();
+        let explicitly_enabled_connectors = HashSet::new();
         let connectors = filter_connectors_for_input(
             connectors,
             &[user_message("use $calendar and then echo the response")],
-            &mentioned_connector_ids,
+            &explicitly_enabled_connectors,
             &HashMap::new(),
         );
         let apps_mcp_tools = filter_codex_apps_mcp_tools_only(mcp_tools, &connectors);

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4249,7 +4249,7 @@ pub(crate) async fn run_turn(
         .collect::<Vec<_>>();
     sess.services
         .analytics_events_client
-        .track_app_mentions(tracking.clone(), mentioned_app_invocations);
+        .track_app_mentioned(tracking.clone(), mentioned_app_invocations);
     sess.merge_connector_selection(explicitly_enabled_connectors.clone())
         .await;
 

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -232,6 +232,16 @@ async fn maybe_track_codex_app_used(
     let (connector_id, app_name) = metadata
         .map(|metadata| (metadata.connector_id, metadata.app_name))
         .unwrap_or((None, None));
+    let invoke_type = if let Some(connector_id) = connector_id.as_deref() {
+        let mentioned_connector_ids = sess.get_connector_selection().await;
+        if mentioned_connector_ids.contains(connector_id) {
+            "explicit"
+        } else {
+            "implicit"
+        }
+    } else {
+        "implicit"
+    };
 
     let tracking = build_track_events_context(
         turn_context.model_info.slug.clone(),
@@ -243,7 +253,7 @@ async fn maybe_track_codex_app_used(
         AppInvocation {
             connector_id,
             app_name,
-            invoke_type: Some("implicit".to_string()),
+            invoke_type: Some(invoke_type.to_string()),
         },
     );
 }

--- a/codex-rs/core/src/mcp_tool_call.rs
+++ b/codex-rs/core/src/mcp_tool_call.rs
@@ -3,6 +3,8 @@ use std::time::Instant;
 
 use tracing::error;
 
+use crate::analytics_client::AppInvocation;
+use crate::analytics_client::build_track_events_context;
 use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::mcp::CODEX_APPS_MCP_SERVER_NAME;
@@ -102,6 +104,7 @@ pub(crate) async fn handle_mcp_tool_call(
                     tool_call_end_event.clone(),
                 )
                 .await;
+                maybe_track_codex_app_used(sess.as_ref(), turn_context, &server, &tool_name).await;
                 result
             }
             McpToolApprovalDecision::Decline => {
@@ -166,6 +169,7 @@ pub(crate) async fn handle_mcp_tool_call(
     });
 
     notify_mcp_tool_call_event(sess.as_ref(), turn_context, tool_call_end_event.clone()).await;
+    maybe_track_codex_app_used(sess.as_ref(), turn_context, &server, &tool_name).await;
 
     let status = if result.is_ok() { "ok" } else { "error" };
     turn_context
@@ -208,6 +212,40 @@ fn sanitize_mcp_tool_result_for_model(
 
 async fn notify_mcp_tool_call_event(sess: &Session, turn_context: &TurnContext, event: EventMsg) {
     sess.send_event(turn_context, event).await;
+}
+
+struct McpAppUsageMetadata {
+    connector_id: Option<String>,
+    app_name: Option<String>,
+}
+
+async fn maybe_track_codex_app_used(
+    sess: &Session,
+    turn_context: &TurnContext,
+    server: &str,
+    tool_name: &str,
+) {
+    if server != CODEX_APPS_MCP_SERVER_NAME {
+        return;
+    }
+    let metadata = lookup_mcp_app_usage_metadata(sess, server, tool_name).await;
+    let (connector_id, app_name) = metadata
+        .map(|metadata| (metadata.connector_id, metadata.app_name))
+        .unwrap_or((None, None));
+
+    let tracking = build_track_events_context(
+        turn_context.model_info.slug.clone(),
+        sess.conversation_id.to_string(),
+        turn_context.sub_id.clone(),
+    );
+    sess.services.analytics_events_client.track_app_used(
+        tracking,
+        AppInvocation {
+            connector_id,
+            app_name,
+            invoke_type: Some("implicit".to_string()),
+        },
+    );
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -326,6 +364,31 @@ async fn lookup_mcp_tool_metadata(
                     connector_name: tool_info.connector_name,
                     tool_title: tool_info.tool.title,
                 })
+        } else {
+            None
+        }
+    })
+}
+
+async fn lookup_mcp_app_usage_metadata(
+    sess: &Session,
+    server: &str,
+    tool_name: &str,
+) -> Option<McpAppUsageMetadata> {
+    let tools = sess
+        .services
+        .mcp_connection_manager
+        .read()
+        .await
+        .list_all_tools()
+        .await;
+
+    tools.into_values().find_map(|tool_info| {
+        if tool_info.server_name == server && tool_info.tool_name == tool_name {
+            Some(McpAppUsageMetadata {
+                connector_id: tool_info.connector_id,
+                app_name: tool_info.connector_name,
+            })
         } else {
             None
         }


### PR DESCRIPTION
Emit app mentioned and app used events. Dedup by (turn_id, connector_id)

Example event params:
{
    "event_type": "codex_app_used",
    "connector_id": "asdk_app_xxx",
    "thread_id": "019c5527-36d4-xxx",
    "turn_id": "019c552c-cd17-xxx",
    "app_name": "Slack (OpenAI Internal)",
    "product_client_id": "codex_cli_rs",
    "invoke_type": "explicit",
    "model_slug": "gpt-5.3-codex"
}