### PR TITLE
app-server: include current turn status on thread resume

### DIFF
--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -15593,6 +15593,16 @@
           "approvalPolicy": {
             "$ref": "#/definitions/v2/AskForApproval"
           },
+          "currentTurnStatus": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/v2/TurnStatus"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
           "cwd": {
             "type": "string"
           },

--- a/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ThreadResumeResponse.json
@@ -1584,6 +1584,16 @@
     "approvalPolicy": {
       "$ref": "#/definitions/AskForApproval"
     },
+    "currentTurnStatus": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/TurnStatus"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "cwd": {
       "type": "string"
     },

--- a/codex-rs/app-server-protocol/schema/typescript/v2/ThreadResumeResponse.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/ThreadResumeResponse.ts
@@ -5,5 +5,6 @@ import type { ReasoningEffort } from "../ReasoningEffort";
 import type { AskForApproval } from "./AskForApproval";
 import type { SandboxPolicy } from "./SandboxPolicy";
 import type { Thread } from "./Thread";
+import type { TurnStatus } from "./TurnStatus";
 
-export type ThreadResumeResponse = { thread: Thread, model: string, modelProvider: string, cwd: string, approvalPolicy: AskForApproval, sandbox: SandboxPolicy, reasoningEffort: ReasoningEffort | null, };
+export type ThreadResumeResponse = { thread: Thread, model: string, modelProvider: string, cwd: string, approvalPolicy: AskForApproval, sandbox: SandboxPolicy, reasoningEffort: ReasoningEffort | null, currentTurnStatus: TurnStatus | null, };

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1536,6 +1536,7 @@ pub struct ThreadResumeResponse {
     pub approval_policy: AskForApproval,
     pub sandbox: SandboxPolicy,
     pub reasoning_effort: Option<ReasoningEffort>,
+    pub current_turn_status: Option<TurnStatus>,
 }
 
 #[derive(

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -191,14 +191,14 @@ Start a fresh thread when you need a new Codex conversation.
 
 Valid `personality` values are `"friendly"`, `"pragmatic"`, and `"none"`. When `"none"` is selected, the personality placeholder is replaced with an empty string.
 
-To continue a stored session, call `thread/resume` with the `thread.id` you previously recorded. The response shape matches `thread/start`, and no additional notifications are emitted. You can also pass the same configuration overrides supported by `thread/start`, such as `personality`:
+To continue a stored session, call `thread/resume` with the `thread.id` you previously recorded. The response shape is the same as `thread/start` plus `currentTurnStatus`, and no additional notifications are emitted. You can also pass the same configuration overrides supported by `thread/start`, such as `personality`:
 
 ```json
 { "method": "thread/resume", "id": 11, "params": {
     "threadId": "thr_123",
     "personality": "friendly"
 } }
-{ "id": 11, "result": { "thread": { "id": "thr_123", … } } }
+{ "id": 11, "result": { "thread": { "id": "thr_123", … }, "currentTurnStatus": "inProgress" } }
 ```
 
 To branch from a stored session, call `thread/fork` with the `thread.id`. This creates a new thread id and emits a `thread/started` notification for it:


### PR DESCRIPTION
Adds currentTurnStatus to thread/resume responses so clients can immediately render the same turn lifecycle state (inProgress, completed, failed, etc.) after reconnecting/resuming.

Updates resume behavior to reuse an already running in-memory thread even when resume overrides are provided, preserving in-flight turn continuity instead of spawning a new thread.

Includes protocol/schema/docs updates and new v2 resume tests covering both completed-history and in-progress-with-overrides cases.

Fixes https://linear.app/openai/issue/CODEX-4963

Testing
* New CI test
* Manually tested with Codex App