### PR TITLE
fix: add missing SystemConfiguration and DNS permissions to macOS san…

### DIFF
--- a/codex-rs/core/askama.toml
+++ b/codex-rs/core/askama.toml
@@ -1,0 +1,2 @@
+[general]
+dirs = ["templates"]

--- a/codex-rs/core/src/seatbelt_base_policy.sbpl
+++ b/codex-rs/core/src/seatbelt_base_policy.sbpl
@@ -19,6 +19,11 @@
   (require-all
     (path "/dev/null")
     (vnode-type CHARACTER-DEVICE)))
+(allow file-read*
+  (literal "/private/etc/hosts")
+  (literal "/private/etc/resolv.conf")
+  (literal "/private/var/run/resolv.conf")
+)
 
 ; sysctls permitted.
 (allow sysctl-read

--- a/codex-rs/core/src/seatbelt_network_policy.sbpl
+++ b/codex-rs/core/src/seatbelt_network_policy.sbpl
@@ -24,6 +24,23 @@
     ; Read network configuration.
     (global-name "com.apple.SystemConfiguration.DNSConfiguration")
     (global-name "com.apple.SystemConfiguration.configd")
+    (global-name "com.apple.SystemConfiguration.SCNetworkReachability")
+    (global-name "com.apple.SystemConfiguration.NetworkInformation")
+
+    ; mDNS / DNS resolution.
+    (global-name "com.apple.dnssd.service")
+    (global-name "com.apple.mDNSResponder.reHS")
+)
+
+(allow file-read*
+    (subpath "/Library/Preferences/SystemConfiguration")
+    (literal "/private/var/run/resolv.conf")
+    (literal "/private/etc/resolv.conf")
+    (literal "/private/etc/hosts")
+)
+
+(allow network-outbound
+    (literal "/private/var/run/mDNSResponder")
 )
 
 (allow sysctl-read


### PR DESCRIPTION
### Summary
This PR fixes a critical issue where tools relying on the macOS `SystemConfiguration` framework (e.g., `spacetime`, `moon`, `proto`, `uv`) would panic with 'Attempted to create a NULL object' when running inside the Codex sandbox. This was caused by the sandbox policy blocking access to necessary SystemConfiguration mach services and files.

### Changes
- **Seatbelt Network Policy**: Added `mach-lookup` permissions for:
    - `com.apple.SystemConfiguration.SCNetworkReachability`
    - `com.apple.SystemConfiguration.NetworkInformation`
    - `com.apple.dnssd.service` (mDNS)
    - `com.apple.mDNSResponder.reHS`
- **File Access**:
    - Added read access to `/Library/Preferences/SystemConfiguration`.
    - Added read access to essential network config files: `/private/etc/hosts`, `/private/etc/resolv.conf`, and `/private/var/run/resolv.conf`.
- **Unix Socket**: Allowed outbound network access to the `/private/var/run/mDNSResponder` socket.

### Fixes
Fixes #10482

### Verification
- Confirmed that adding these permissions resolves the 'Attempted to create a NULL object' panic in `spacetime publish` and similar commands.
- Verified that DNS resolution works correctly for tools that previously failed.
