### PR TITLE
fix(codex-rs): using ok()? instead of unwrap_or_default()

### DIFF
--- a/codex-rs/tui/src/update_action.rs
+++ b/codex-rs/tui/src/update_action.rs
@@ -29,7 +29,7 @@ impl UpdateAction {
 
 #[cfg(not(debug_assertions))]
 pub(crate) fn get_update_action() -> Option<UpdateAction> {
-    let exe = std::env::current_exe().unwrap_or_default();
+    let exe = std::env::current_exe().ok()?;
     let managed_by_npm = std::env::var_os("CODEX_MANAGED_BY_NPM").is_some();
     let managed_by_bun = std::env::var_os("CODEX_MANAGED_BY_BUN").is_some();
 


### PR DESCRIPTION
# External (non-OpenAI) Pull Request Requirements

Before opening this Pull Request, please read the dedicated "Contributing" markdown file or your PR may be closed:
https://github.com/openai/codex/blob/main/docs/contributing.md

If your PR conforms to our contribution guidelines, replace this text with a detailed and high quality description of your changes.

Include a link to a bug report or enhancement request.
current_exe() may return an result which is err.  
https://doc.rust-lang.org/std/env/fn.current_exe.html
if using unwrap_or_default, exe would be empty and cause error.  
just using ok()?; here.
