### PR TITLE
feat: increase windows workers stack

### DIFF
--- a/codex-rs/arg0/src/lib.rs
+++ b/codex-rs/arg0/src/lib.rs
@@ -12,6 +12,8 @@ const LINUX_SANDBOX_ARG0: &str = "codex-linux-sandbox";
 const APPLY_PATCH_ARG0: &str = "apply_patch";
 const MISSPELLED_APPLY_PATCH_ARG0: &str = "applypatch";
 const LOCK_FILENAME: &str = ".lock";
+#[cfg(target_os = "windows")]
+const WINDOWS_TOKIO_WORKER_STACK_SIZE_BYTES: usize = 16 * 1024 * 1024;
 
 /// Keeps the per-session PATH entry alive and locked for the process lifetime.
 pub struct Arg0PathEntryGuard {
@@ -112,7 +114,7 @@ where
 
     // Regular invocation – create a Tokio runtime and execute the provided
     // async entry-point.
-    let runtime = tokio::runtime::Runtime::new()?;
+    let runtime = build_runtime()?;
     runtime.block_on(async move {
         let codex_linux_sandbox_exe: Option<PathBuf> = if cfg!(target_os = "linux") {
             std::env::current_exe().ok()
@@ -122,6 +124,18 @@ where
 
         main_fn(codex_linux_sandbox_exe).await
     })
+}
+
+fn build_runtime() -> anyhow::Result<tokio::runtime::Runtime> {
+    let mut builder = tokio::runtime::Builder::new_multi_thread();
+    builder.enable_all();
+    #[cfg(target_os = "windows")]
+    {
+        // Defensive hardening: Windows worker threads have lower effective
+        // stack headroom, so use a larger stack for runtime workers.
+        builder.thread_stack_size(WINDOWS_TOKIO_WORKER_STACK_SIZE_BYTES);
+    }
+    Ok(builder.build()?)
 }
 
 const ILLEGAL_ENV_VAR_PREFIX: &str = "CODEX_";


### PR DESCRIPTION
Switched arg0 runtime initialization from tokio::runtime::Runtime::new() to an explicit multi-thread builder that sets the thread stack size to 16MiB.

This is only for Windows for now but we might need to do this for others in the future. This is required because Codex becomes quite large and Windows tends to consume stack a little bit faster (this is a known thing even though everyone seems to have different theory on it)