### PR TITLE
Fix memories output schema requirements

### DIFF
--- a/codex-rs/core/src/memories/phase1.rs
+++ b/codex-rs/core/src/memories/phase1.rs
@@ -118,10 +118,10 @@ pub fn output_schema() -> Value {
         "type": "object",
         "properties": {
             "rollout_summary": { "type": "string" },
-            "rollout_slug": { "type": "string" },
+            "rollout_slug": { "type": ["string", "null"] },
             "raw_memory": { "type": "string" }
         },
-        "required": ["rollout_summary", "raw_memory"],
+        "required": ["rollout_summary", "rollout_slug", "raw_memory"],
         "additionalProperties": false
     })
 }


### PR DESCRIPTION
Summary
- make the phase1 memories schema require `rollout_slug` while still allowing it to be `null`
- update the corresponding test to check the required fields and nullable type list

Testing
- Not run (not requested)