### PR TITLE
app-server-test-client websocket client and thread tools

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -1420,6 +1420,8 @@ dependencies = [
  "codex-protocol",
  "serde",
  "serde_json",
+ "tungstenite",
+ "url",
  "uuid",
 ]
 

--- a/codex-rs/app-server-test-client/Cargo.toml
+++ b/codex-rs/app-server-test-client/Cargo.toml
@@ -14,4 +14,6 @@ codex-app-server-protocol = { workspace = true }
 codex-protocol = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+tungstenite = { workspace = true }
+url = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }

--- a/codex-rs/app-server-test-client/README.md
+++ b/codex-rs/app-server-test-client/README.md
@@ -1,2 +1,19 @@
 # App Server Test Client
-Exercises simple `codex app-server` flows end-to-end, logging JSON-RPC messages sent between client and server to stdout.
+Quickstart for running and hitting `codex app-server`.
+
+## Quickstart
+
+Run from `<reporoot>/codex-rs`.
+
+```bash
+# 1) Build debug codex binary
+cargo build -p codex-cli --bin codex
+
+# 2) Start websocket app-server in background
+cargo run -p codex-app-server-test-client -- \
+  --codex-bin ./target/debug/codex \
+  serve --listen ws://127.0.0.1:4222 --kill
+
+# 3) Call app-server (defaults to ws://127.0.0.1:4222)
+cargo run -p codex-app-server-test-client -- model-list
+```


### PR DESCRIPTION
- add websocket endpoint mode with default ws://127.0.0.1:4222 while keeping stdio codex-bin path compatibility
- add thread-resume (follow stream) and thread-list commands for manual thread lifecycle testing
- quickstart docs