### PR TITLE
feat(sleep-inhibitor): add Linux and Windows idle-sleep prevention

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2531,7 +2531,6 @@ name = "codex-utils-sleep-inhibitor"
 version = "0.0.0"
 dependencies = [
  "core-foundation 0.9.4",
- "dbus",
  "libc",
  "tracing",
  "windows-sys 0.60.2",

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2533,7 +2533,7 @@ dependencies = [
  "core-foundation 0.9.4",
  "libc",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2533,7 +2533,7 @@ dependencies = [
  "core-foundation 0.9.4",
  "libc",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -2531,7 +2531,10 @@ name = "codex-utils-sleep-inhibitor"
 version = "0.0.0"
 dependencies = [
  "core-foundation 0.9.4",
+ "dbus",
+ "libc",
  "tracing",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -654,7 +654,11 @@ pub const FEATURES: &[FeatureSpec] = &[
     FeatureSpec {
         id: Feature::PreventIdleSleep,
         key: "prevent_idle_sleep",
-        stage: if cfg!(target_os = "macos") {
+        stage: if cfg!(any(
+            target_os = "macos",
+            target_os = "linux",
+            target_os = "windows"
+        )) {
             Stage::Experimental {
                 name: "Prevent sleep while running",
                 menu_description: "Keep your computer awake while Codex is running a thread.",

--- a/codex-rs/utils/sleep-inhibitor/Cargo.toml
+++ b/codex-rs/utils/sleep-inhibitor/Cargo.toml
@@ -17,7 +17,7 @@ core-foundation = "0.9"
 libc = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-windows-sys = { version = "0.52", features = [
+windows-sys = { version = "0.61.2", features = [
     "Win32_Foundation",
     "Win32_System_Power",
     "Win32_System_SystemServices",

--- a/codex-rs/utils/sleep-inhibitor/Cargo.toml
+++ b/codex-rs/utils/sleep-inhibitor/Cargo.toml
@@ -12,7 +12,6 @@ core-foundation = "0.9"
 tracing = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-dbus = "0.9"
 tracing = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/codex-rs/utils/sleep-inhibitor/Cargo.toml
+++ b/codex-rs/utils/sleep-inhibitor/Cargo.toml
@@ -10,3 +10,16 @@ workspace = true
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"
 tracing = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+dbus = "0.9"
+tracing = { workspace = true }
+
+[target.'cfg(target_os = "windows")'.dependencies]
+tracing = { workspace = true }
+windows-sys = { version = "0.60.2", features = [
+    "Win32_Foundation",
+    "Win32_System_Power",
+    "Win32_System_SystemServices",
+    "Win32_System_Threading",
+] }

--- a/codex-rs/utils/sleep-inhibitor/Cargo.toml
+++ b/codex-rs/utils/sleep-inhibitor/Cargo.toml
@@ -16,7 +16,7 @@ tracing = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
 tracing = { workspace = true }
-windows-sys = { version = "0.60.2", features = [
+windows-sys = { version = "0.52", features = [
     "Win32_Foundation",
     "Win32_System_Power",
     "Win32_System_SystemServices",

--- a/codex-rs/utils/sleep-inhibitor/Cargo.toml
+++ b/codex-rs/utils/sleep-inhibitor/Cargo.toml
@@ -7,16 +7,16 @@ license.workspace = true
 [lints]
 workspace = true
 
+[dependencies]
+tracing = { workspace = true }
+
 [target.'cfg(target_os = "macos")'.dependencies]
 core-foundation = "0.9"
-tracing = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 libc = { workspace = true }
-tracing = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]
-tracing = { workspace = true }
 windows-sys = { version = "0.52", features = [
     "Win32_Foundation",
     "Win32_System_Power",

--- a/codex-rs/utils/sleep-inhibitor/Cargo.toml
+++ b/codex-rs/utils/sleep-inhibitor/Cargo.toml
@@ -12,6 +12,7 @@ core-foundation = "0.9"
 tracing = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }
 tracing = { workspace = true }
 
 [target.'cfg(target_os = "windows")'.dependencies]

--- a/codex-rs/utils/sleep-inhibitor/src/dummy.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/dummy.rs
@@ -1,12 +1,15 @@
 #[derive(Debug, Default)]
 pub(crate) struct SleepInhibitor;
+use crate::PlatformSleepInhibitor;
 
 impl SleepInhibitor {
     pub(crate) fn new() -> Self {
         Self
     }
+}
 
-    pub(crate) fn acquire(&mut self) {}
+impl PlatformSleepInhibitor for SleepInhibitor {
+    fn acquire(&mut self) {}
 
-    pub(crate) fn release(&mut self) {}
+    fn release(&mut self) {}
 }

--- a/codex-rs/utils/sleep-inhibitor/src/dummy.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/dummy.rs
@@ -1,15 +1,12 @@
 #[derive(Debug, Default)]
 pub(crate) struct SleepInhibitor;
-use crate::PlatformSleepInhibitor;
 
 impl SleepInhibitor {
     pub(crate) fn new() -> Self {
         Self
     }
-}
 
-impl PlatformSleepInhibitor for SleepInhibitor {
-    fn acquire(&mut self) {}
+    pub(crate) fn acquire(&mut self) {}
 
-    fn release(&mut self) {}
+    pub(crate) fn release(&mut self) {}
 }

--- a/codex-rs/utils/sleep-inhibitor/src/lib.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/lib.rs
@@ -25,18 +25,11 @@ use macos as imp;
 #[cfg(target_os = "windows")]
 use windows_inhibitor as imp;
 
-use std::fmt::Debug;
-
 /// Keeps the machine awake while a turn is in progress when enabled.
 #[derive(Debug)]
 pub struct SleepInhibitor {
     enabled: bool,
     platform: imp::SleepInhibitor,
-}
-
-pub(crate) trait PlatformSleepInhibitor: Debug {
-    fn acquire(&mut self);
-    fn release(&mut self);
 }
 
 impl SleepInhibitor {

--- a/codex-rs/utils/sleep-inhibitor/src/lib.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/lib.rs
@@ -25,11 +25,18 @@ use macos as imp;
 #[cfg(target_os = "windows")]
 use windows_inhibitor as imp;
 
+use std::fmt::Debug;
+
 /// Keeps the machine awake while a turn is in progress when enabled.
 #[derive(Debug)]
 pub struct SleepInhibitor {
     enabled: bool,
     platform: imp::SleepInhibitor,
+}
+
+pub(crate) trait PlatformSleepInhibitor: Debug {
+    fn acquire(&mut self);
+    fn release(&mut self);
 }
 
 impl SleepInhibitor {

--- a/codex-rs/utils/sleep-inhibitor/src/lib.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/lib.rs
@@ -4,7 +4,7 @@
 //! - macOS: Uses native IOKit power assertions instead of spawning `caffeinate`.
 //! - Linux: Spawns `systemd-inhibit` or `gnome-session-inhibit` while active.
 //! - Windows: Uses `PowerCreateRequest` + `PowerSetRequest` with
-//!   `PowerRequestExecutionRequired`.
+//!   `PowerRequestSystemRequired`.
 //! - Other platforms: No-op backend.
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]

--- a/codex-rs/utils/sleep-inhibitor/src/lib.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/lib.rs
@@ -3,15 +3,23 @@
 //! On macOS this uses native IOKit power assertions instead of spawning
 //! `caffeinate`, so assertion lifecycle is tied directly to Rust object lifetime.
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 mod dummy;
+#[cfg(target_os = "linux")]
+mod linux_inhibitor;
 #[cfg(target_os = "macos")]
 mod macos;
+#[cfg(target_os = "windows")]
+mod windows_inhibitor;
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 use dummy as imp;
+#[cfg(target_os = "linux")]
+use linux_inhibitor as imp;
 #[cfg(target_os = "macos")]
 use macos as imp;
+#[cfg(target_os = "windows")]
+use windows_inhibitor as imp;
 
 /// Keeps the machine awake while a turn is in progress when enabled.
 #[derive(Debug)]

--- a/codex-rs/utils/sleep-inhibitor/src/lib.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/lib.rs
@@ -1,7 +1,11 @@
 //! Cross-platform helper for preventing idle sleep while a turn is running.
 //!
-//! On macOS this uses native IOKit power assertions instead of spawning
-//! `caffeinate`, so assertion lifecycle is tied directly to Rust object lifetime.
+//! Platform-specific behavior:
+//! - macOS: Uses native IOKit power assertions instead of spawning `caffeinate`.
+//! - Linux: Spawns `systemd-inhibit` or `gnome-session-inhibit` while active.
+//! - Windows: Uses `PowerCreateRequest` + `PowerSetRequest` with
+//!   `PowerRequestExecutionRequired`.
+//! - Other platforms: No-op backend.
 
 #[cfg(not(any(target_os = "linux", target_os = "macos", target_os = "windows")))]
 mod dummy;

--- a/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
@@ -228,3 +228,13 @@ fn spawn_backend(backend: LinuxBackend) -> Result<Child, std::io::Error> {
 fn child_exited(error: &std::io::Error) -> bool {
     matches!(error.kind(), std::io::ErrorKind::InvalidInput)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::BLOCKER_SLEEP_SECONDS;
+
+    #[test]
+    fn sleep_seconds_is_i32_max() {
+        assert_eq!(BLOCKER_SLEEP_SECONDS, format!("{}", i32::MAX));
+    }
+}

--- a/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
@@ -1,4 +1,3 @@
-use crate::PlatformSleepInhibitor;
 use std::os::unix::process::CommandExt;
 use std::process::Child;
 use std::process::Command;
@@ -40,10 +39,8 @@ impl LinuxSleepInhibitor {
     pub(crate) fn new() -> Self {
         Self::default()
     }
-}
 
-impl PlatformSleepInhibitor for LinuxSleepInhibitor {
-    fn acquire(&mut self) {
+    pub(crate) fn acquire(&mut self) {
         if let InhibitState::Active { backend, child } = &mut self.state {
             match child.try_wait() {
                 Ok(None) => return,
@@ -145,7 +142,7 @@ impl PlatformSleepInhibitor for LinuxSleepInhibitor {
         }
     }
 
-    fn release(&mut self) {
+    pub(crate) fn release(&mut self) {
         match std::mem::take(&mut self.state) {
             InhibitState::Inactive => {}
             InhibitState::Active { backend, mut child } => {

--- a/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
@@ -104,6 +104,24 @@ impl PlatformSleepInhibitor for LinuxSleepInhibitor {
                                 "Failed to query Linux sleep inhibitor backend status after spawn"
                             );
                         }
+                        if let Err(kill_error) = child.kill()
+                            && !child_exited(&kill_error)
+                        {
+                            warn!(
+                                ?backend,
+                                reason = %kill_error,
+                                "Failed to stop Linux sleep inhibitor backend after status probe failure"
+                            );
+                        }
+                        if let Err(wait_error) = child.wait()
+                            && !child_exited(&wait_error)
+                        {
+                            warn!(
+                                ?backend,
+                                reason = %wait_error,
+                                "Failed to reap Linux sleep inhibitor backend after status probe failure"
+                            );
+                        }
                     }
                 },
                 Err(error) => {

--- a/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
@@ -170,6 +170,9 @@ impl Drop for LinuxSleepInhibitor {
 }
 
 fn spawn_backend(backend: LinuxBackend) -> Result<Child, std::io::Error> {
+    // Ensure the helper receives SIGTERM when the original parent dies.
+    // `parent_pid` is captured before spawn and checked in `pre_exec` to avoid
+    // the fork/exec race where the parent exits before PDEATHSIG is armed.
     let parent_pid = unsafe { libc::getpid() };
     let mut command = match backend {
         LinuxBackend::SystemdInhibit => {

--- a/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
@@ -215,7 +215,7 @@ fn spawn_backend(backend: LinuxBackend) -> Result<Child, std::io::Error> {
     // performs libc setup for the child process and returns an `io::Error`
     // when parent-death signal setup fails.
     unsafe {
-        command.pre_exec(|| {
+        command.pre_exec(move || {
             if libc::prctl(libc::PR_SET_PDEATHSIG, libc::SIGTERM) == -1 {
                 return Err(std::io::Error::last_os_error());
             }

--- a/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
@@ -58,9 +58,8 @@ impl PlatformSleepInhibitor for LinuxSleepInhibitor {
                     warn!(
                         ?backend,
                         reason = %error,
-                        "Failed to query Linux sleep inhibitor backend status"
+                        "Failed to query Linux sleep inhibitor backend status; attempting restart"
                     );
-                    return;
                 }
             }
         }

--- a/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
@@ -5,11 +5,15 @@ use tracing::warn;
 
 const ASSERTION_REASON: &str = "Codex is running an active turn";
 const APP_ID: &str = "codex";
+// Keep the blocker process alive "long enough" without needing restarts.
+// This is `i32::MAX` seconds, which is accepted by common `sleep` implementations.
 const BLOCKER_SLEEP_SECONDS: &str = "2147483647";
 
 #[derive(Debug, Default)]
 pub(crate) struct LinuxSleepInhibitor {
     state: InhibitState,
+    preferred_backend: Option<LinuxBackend>,
+    missing_backend_logged: bool,
 }
 
 #[derive(Debug, Default)]
@@ -36,34 +40,87 @@ impl LinuxSleepInhibitor {
 
 impl PlatformSleepInhibitor for LinuxSleepInhibitor {
     fn acquire(&mut self) {
-        if let InhibitState::Active { child, .. } = &mut self.state
-            && child.try_wait().ok().flatten().is_none()
-        {
-            return;
-        }
-
-        self.state = InhibitState::Inactive;
-
-        for backend in [
-            LinuxBackend::SystemdInhibit,
-            LinuxBackend::GnomeSessionInhibit,
-        ] {
-            match spawn_backend(backend) {
-                Ok(child) => {
-                    self.state = InhibitState::Active { backend, child };
-                    return;
+        if let InhibitState::Active { backend, child } = &mut self.state {
+            match child.try_wait() {
+                Ok(None) => return,
+                Ok(Some(status)) => {
+                    warn!(
+                        ?backend,
+                        ?status,
+                        "Linux sleep inhibitor backend exited unexpectedly; attempting fallback"
+                    );
                 }
                 Err(error) => {
                     warn!(
                         ?backend,
                         reason = %error,
-                        "Failed to start Linux sleep inhibitor backend"
+                        "Failed to query Linux sleep inhibitor backend status"
                     );
                 }
             }
         }
 
-        warn!("No Linux sleep inhibitor backend is available");
+        self.state = InhibitState::Inactive;
+        let should_log_backend_failures = !self.missing_backend_logged;
+        let backends = match self.preferred_backend {
+            Some(LinuxBackend::SystemdInhibit) => [
+                LinuxBackend::SystemdInhibit,
+                LinuxBackend::GnomeSessionInhibit,
+            ],
+            Some(LinuxBackend::GnomeSessionInhibit) => [
+                LinuxBackend::GnomeSessionInhibit,
+                LinuxBackend::SystemdInhibit,
+            ],
+            None => [
+                LinuxBackend::SystemdInhibit,
+                LinuxBackend::GnomeSessionInhibit,
+            ],
+        };
+
+        for backend in backends {
+            match spawn_backend(backend) {
+                Ok(mut child) => match child.try_wait() {
+                    Ok(None) => {
+                        self.state = InhibitState::Active { backend, child };
+                        self.preferred_backend = Some(backend);
+                        self.missing_backend_logged = false;
+                        return;
+                    }
+                    Ok(Some(status)) => {
+                        if should_log_backend_failures {
+                            warn!(
+                                ?backend,
+                                ?status,
+                                "Linux sleep inhibitor backend exited immediately"
+                            );
+                        }
+                    }
+                    Err(error) => {
+                        if should_log_backend_failures {
+                            warn!(
+                                ?backend,
+                                reason = %error,
+                                "Failed to query Linux sleep inhibitor backend status after spawn"
+                            );
+                        }
+                    }
+                },
+                Err(error) => {
+                    if should_log_backend_failures && error.kind() != std::io::ErrorKind::NotFound {
+                        warn!(
+                            ?backend,
+                            reason = %error,
+                            "Failed to start Linux sleep inhibitor backend"
+                        );
+                    }
+                }
+            }
+        }
+
+        if should_log_backend_failures {
+            warn!("No Linux sleep inhibitor backend is available");
+            self.missing_backend_logged = true;
+        }
     }
 
     fn release(&mut self) {

--- a/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
@@ -85,6 +85,12 @@ impl PlatformSleepInhibitor for LinuxSleepInhibitor {
     }
 }
 
+impl Drop for LinuxSleepInhibitor {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
 fn spawn_backend(backend: LinuxBackend) -> Result<Child, std::io::Error> {
     match backend {
         LinuxBackend::SystemdInhibit => Command::new("systemd-inhibit")

--- a/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
@@ -56,6 +56,7 @@ impl PlatformSleepInhibitor for LinuxSleepInhibitor {
                         reason = %error,
                         "Failed to query Linux sleep inhibitor backend status"
                     );
+                    return;
                 }
             }
         }
@@ -152,7 +153,7 @@ fn spawn_backend(backend: LinuxBackend) -> Result<Child, std::io::Error> {
     match backend {
         LinuxBackend::SystemdInhibit => Command::new("systemd-inhibit")
             .args([
-                "--what=sleep",
+                "--what=idle",
                 "--mode=block",
                 "--who",
                 APP_ID,
@@ -166,7 +167,7 @@ fn spawn_backend(backend: LinuxBackend) -> Result<Child, std::io::Error> {
         LinuxBackend::GnomeSessionInhibit => Command::new("gnome-session-inhibit")
             .args([
                 "--inhibit",
-                "suspend",
+                "idle",
                 "--reason",
                 ASSERTION_REASON,
                 "sleep",

--- a/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
@@ -1,0 +1,166 @@
+use crate::PlatformSleepInhibitor;
+use dbus::arg::OwnedFd;
+use dbus::blocking::Connection;
+use std::time::Duration;
+use tracing::warn;
+
+const ASSERTION_REASON: &str = "Codex is running an active turn";
+const APP_ID: &str = "codex";
+const DBUS_TIMEOUT: Duration = Duration::from_secs(2);
+const GNOME_INHIBIT_SUSPEND_SESSION_FLAG: u32 = 4;
+
+#[derive(Debug, Default)]
+pub(crate) struct LinuxSleepInhibitor {
+    state: InhibitState,
+}
+
+#[derive(Debug, Default)]
+enum InhibitState {
+    #[default]
+    Inactive,
+    Logind(OwnedFd),
+    Cookie {
+        api: CookieApi,
+        cookie: u32,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum CookieApi {
+    Gnome,
+    FreedesktopPower,
+    FreedesktopScreensaver,
+}
+
+impl CookieApi {
+    fn service_name(self) -> &'static str {
+        match self {
+            Self::Gnome => "org.gnome.SessionManager",
+            Self::FreedesktopPower => "org.freedesktop.PowerManagement",
+            Self::FreedesktopScreensaver => "org.freedesktop.ScreenSaver",
+        }
+    }
+
+    fn object_path(self) -> &'static str {
+        match self {
+            Self::Gnome => "/org/gnome/SessionManager",
+            Self::FreedesktopPower => "/org/freedesktop/PowerManagement/Inhibit",
+            Self::FreedesktopScreensaver => "/org/freedesktop/ScreenSaver",
+        }
+    }
+
+    fn interface_name(self) -> &'static str {
+        match self {
+            Self::Gnome => "org.gnome.SessionManager",
+            Self::FreedesktopPower => "org.freedesktop.PowerManagement.Inhibit",
+            Self::FreedesktopScreensaver => "org.freedesktop.ScreenSaver",
+        }
+    }
+
+    fn uninhibit_method(self) -> &'static str {
+        match self {
+            Self::Gnome => "Uninhibit",
+            Self::FreedesktopPower | Self::FreedesktopScreensaver => "UnInhibit",
+        }
+    }
+}
+
+impl LinuxSleepInhibitor {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl PlatformSleepInhibitor for LinuxSleepInhibitor {
+    fn acquire(&mut self) {
+        if !matches!(self.state, InhibitState::Inactive) {
+            return;
+        }
+
+        match acquire_logind_inhibitor() {
+            Ok(state) => {
+                self.state = state;
+                return;
+            }
+            Err(error) => {
+                warn!(
+                    error = %error,
+                    "Failed to acquire sleep inhibitor via org.freedesktop.login1"
+                );
+            }
+        }
+
+        for api in [
+            CookieApi::Gnome,
+            CookieApi::FreedesktopPower,
+            CookieApi::FreedesktopScreensaver,
+        ] {
+            match acquire_cookie_inhibitor(api) {
+                Ok(state) => {
+                    self.state = state;
+                    return;
+                }
+                Err(error) => {
+                    warn!(?api, error = %error, "Failed to acquire sleep inhibitor via D-Bus");
+                }
+            }
+        }
+
+        warn!("No Linux sleep inhibition API is available");
+    }
+
+    fn release(&mut self) {
+        match std::mem::take(&mut self.state) {
+            InhibitState::Inactive => {}
+            InhibitState::Logind(fd) => drop(fd),
+            InhibitState::Cookie { api, cookie } => {
+                if let Err(error) = release_cookie_inhibitor(api, cookie) {
+                    warn!(?api, error = %error, "Failed to release D-Bus sleep inhibitor");
+                }
+            }
+        }
+    }
+}
+
+fn acquire_logind_inhibitor() -> Result<InhibitState, dbus::Error> {
+    let connection = Connection::new_system()?;
+    let proxy = connection.with_proxy(
+        "org.freedesktop.login1",
+        "/org/freedesktop/login1",
+        DBUS_TIMEOUT,
+    );
+    let (fd,): (OwnedFd,) = proxy.method_call(
+        "org.freedesktop.login1.Manager",
+        "Inhibit",
+        ("sleep", APP_ID, ASSERTION_REASON, "block"),
+    )?;
+    Ok(InhibitState::Logind(fd))
+}
+
+fn acquire_cookie_inhibitor(api: CookieApi) -> Result<InhibitState, dbus::Error> {
+    let connection = Connection::new_session()?;
+    let proxy = connection.with_proxy(api.service_name(), api.object_path(), DBUS_TIMEOUT);
+    let (cookie,): (u32,) = match api {
+        CookieApi::Gnome => proxy.method_call(
+            api.interface_name(),
+            "Inhibit",
+            (
+                APP_ID,
+                0_u32,
+                ASSERTION_REASON,
+                GNOME_INHIBIT_SUSPEND_SESSION_FLAG,
+            ),
+        )?,
+        CookieApi::FreedesktopPower | CookieApi::FreedesktopScreensaver => {
+            proxy.method_call(api.interface_name(), "Inhibit", (APP_ID, ASSERTION_REASON))?
+        }
+    };
+    Ok(InhibitState::Cookie { api, cookie })
+}
+
+fn release_cookie_inhibitor(api: CookieApi, cookie: u32) -> Result<(), dbus::Error> {
+    let connection = Connection::new_session()?;
+    let proxy = connection.with_proxy(api.service_name(), api.object_path(), DBUS_TIMEOUT);
+    let _: () = proxy.method_call(api.interface_name(), api.uninhibit_method(), (cookie,))?;
+    Ok(())
+}

--- a/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/linux_inhibitor.rs
@@ -56,7 +56,8 @@ impl PlatformSleepInhibitor for LinuxSleepInhibitor {
                 Err(error) => {
                     warn!(
                         ?backend,
-                        error, "Failed to start Linux sleep inhibitor backend"
+                        reason = %error,
+                        "Failed to start Linux sleep inhibitor backend"
                     );
                 }
             }

--- a/codex-rs/utils/sleep-inhibitor/src/windows_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/windows_inhibitor.rs
@@ -70,7 +70,7 @@ impl PowerRequest {
         // SAFETY: `context` points to a valid `REASON_CONTEXT` for the duration
         // of the call and Windows copies the relevant data before returning.
         let handle = unsafe { PowerCreateRequest(&context) };
-        if handle == 0 || handle == INVALID_HANDLE_VALUE {
+        if handle.is_null() || handle == INVALID_HANDLE_VALUE {
             let error = std::io::Error::last_os_error();
             return Err(format!("PowerCreateRequest failed: {error}"));
         }

--- a/codex-rs/utils/sleep-inhibitor/src/windows_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/windows_inhibitor.rs
@@ -1,4 +1,3 @@
-use crate::PlatformSleepInhibitor;
 use std::ffi::OsStr;
 use std::iter::once;
 use std::os::windows::ffi::OsStrExt;
@@ -28,10 +27,8 @@ impl WindowsSleepInhibitor {
     pub(crate) fn new() -> Self {
         Self::default()
     }
-}
 
-impl PlatformSleepInhibitor for WindowsSleepInhibitor {
-    fn acquire(&mut self) {
+    pub(crate) fn acquire(&mut self) {
         if self.request.is_some() {
             return;
         }
@@ -49,7 +46,7 @@ impl PlatformSleepInhibitor for WindowsSleepInhibitor {
         }
     }
 
-    fn release(&mut self) {
+    pub(crate) fn release(&mut self) {
         self.request = None;
     }
 }

--- a/codex-rs/utils/sleep-inhibitor/src/windows_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/windows_inhibitor.rs
@@ -1,0 +1,93 @@
+use crate::PlatformSleepInhibitor;
+use std::ffi::OsStr;
+use std::iter::once;
+use std::os::windows::ffi::OsStrExt;
+use tracing::warn;
+use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::System::Power::POWER_REQUEST_TYPE;
+use windows_sys::Win32::System::Power::PowerClearRequest;
+use windows_sys::Win32::System::Power::PowerCreateRequest;
+use windows_sys::Win32::System::Power::PowerRequestExecutionRequired;
+use windows_sys::Win32::System::Power::PowerSetRequest;
+use windows_sys::Win32::System::SystemServices::POWER_REQUEST_CONTEXT_VERSION;
+use windows_sys::Win32::System::Threading::POWER_REQUEST_CONTEXT_SIMPLE_STRING;
+use windows_sys::Win32::System::Threading::REASON_CONTEXT;
+use windows_sys::Win32::System::Threading::REASON_CONTEXT_0;
+
+const ASSERTION_REASON: &str = "Codex is running an active turn";
+
+#[derive(Debug, Default)]
+pub(crate) struct WindowsSleepInhibitor {
+    request: Option<PowerRequest>,
+}
+
+impl WindowsSleepInhibitor {
+    pub(crate) fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl PlatformSleepInhibitor for WindowsSleepInhibitor {
+    fn acquire(&mut self) {
+        if self.request.is_some() {
+            return;
+        }
+
+        match PowerRequest::new_execution_required(ASSERTION_REASON) {
+            Ok(request) => {
+                self.request = Some(request);
+            }
+            Err(error) => {
+                warn!(
+                    reason = error,
+                    "Failed to acquire Windows sleep-prevention request"
+                );
+            }
+        }
+    }
+
+    fn release(&mut self) {
+        self.request = None;
+    }
+}
+
+#[derive(Debug)]
+struct PowerRequest {
+    handle: windows_sys::Win32::Foundation::HANDLE,
+    request_type: POWER_REQUEST_TYPE,
+}
+
+impl PowerRequest {
+    fn new_execution_required(reason: &str) -> Result<Self, &'static str> {
+        let mut wide_reason: Vec<u16> = OsStr::new(reason).encode_wide().chain(once(0)).collect();
+        let context = REASON_CONTEXT {
+            Version: POWER_REQUEST_CONTEXT_VERSION,
+            Flags: POWER_REQUEST_CONTEXT_SIMPLE_STRING,
+            Reason: REASON_CONTEXT_0 {
+                SimpleReasonString: wide_reason.as_mut_ptr(),
+            },
+        };
+        let handle = unsafe { PowerCreateRequest(&context) };
+        if handle.is_null() {
+            return Err("PowerCreateRequest failed");
+        }
+
+        let request_type = PowerRequestExecutionRequired;
+        if unsafe { PowerSetRequest(handle, request_type) } == 0 {
+            let _ = unsafe { CloseHandle(handle) };
+            return Err("PowerSetRequest failed");
+        }
+
+        Ok(Self {
+            handle,
+            request_type,
+        })
+    }
+}
+
+impl Drop for PowerRequest {
+    fn drop(&mut self) {
+        let _ = unsafe { PowerClearRequest(self.handle, self.request_type) };
+        let _ = unsafe { CloseHandle(self.handle) };
+    }
+}

--- a/codex-rs/utils/sleep-inhibitor/src/windows_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/windows_inhibitor.rs
@@ -4,6 +4,7 @@ use std::iter::once;
 use std::os::windows::ffi::OsStrExt;
 use tracing::warn;
 use windows_sys::Win32::Foundation::CloseHandle;
+use windows_sys::Win32::Foundation::INVALID_HANDLE_VALUE;
 use windows_sys::Win32::System::Power::POWER_REQUEST_TYPE;
 use windows_sys::Win32::System::Power::PowerClearRequest;
 use windows_sys::Win32::System::Power::PowerCreateRequest;
@@ -68,7 +69,7 @@ impl PowerRequest {
             },
         };
         let handle = unsafe { PowerCreateRequest(&context) };
-        if handle == 0 {
+        if handle == 0 || handle == INVALID_HANDLE_VALUE {
             let error = std::io::Error::last_os_error();
             return Err(format!("PowerCreateRequest failed: {error}"));
         }

--- a/codex-rs/utils/sleep-inhibitor/src/windows_inhibitor.rs
+++ b/codex-rs/utils/sleep-inhibitor/src/windows_inhibitor.rs
@@ -68,7 +68,7 @@ impl PowerRequest {
             },
         };
         let handle = unsafe { PowerCreateRequest(&context) };
-        if handle.is_null() {
+        if handle == 0 {
             let error = std::io::Error::last_os_error();
             return Err(format!("PowerCreateRequest failed: {error}"));
         }


### PR DESCRIPTION
## Background
- follow-up to previous macOS-only PR: https://github.com/openai/codex/pull/11711
- follow-up macOS refactor PR (current structural approach used here): https://github.com/openai/codex/pull/12340

## Summary
- extend `codex-utils-sleep-inhibitor` with Linux and Windows backends while preserving existing macOS behavior
- Linux backend:
  - use `systemd-inhibit` (`--what=idle --mode=block`) when available
  - fall back to `gnome-session-inhibit` (`--inhibit idle`) when available
  - keep no-op behavior if neither backend exists on host
- Windows backend:
  - use Win32 power request handles (`PowerCreateRequest` + `PowerSetRequest` / `PowerClearRequest`) with `PowerRequestSystemRequired`
- make `prevent_idle_sleep` Experimental on macOS/Linux/Windows; keep under development on other targets

## Testing
- `just fmt`
- `cargo test -p codex-utils-sleep-inhibitor`
- `cargo test -p codex-core features::tests::`
- `cargo test -p codex-tui chatwidget::tests::`
- `just fix -p codex-utils-sleep-inhibitor`
- `just fix -p codex-core`

## Semantics and API references
- Goal remains: prevent idle system sleep while a turn is running.
- Linux:
  - `systemd-inhibit` / login1 inhibitor model:
    - https://www.freedesktop.org/software/systemd/man/latest/systemd-inhibit.html
    - https://www.freedesktop.org/software/systemd/man/org.freedesktop.login1.html
    - https://systemd.io/INHIBITOR_LOCKS/
  - xdg-desktop-portal Inhibit (relevant for sandboxed apps):
    - https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Inhibit.html
- Windows:
  - `PowerCreateRequest`:
    - https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-powercreaterequest
  - `PowerSetRequest`:
    - https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-powersetrequest
  - `PowerClearRequest`:
    - https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-powerclearrequest
  - `SetThreadExecutionState` (alternative baseline API):
    - https://learn.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-setthreadexecutionstate

## Chromium vs this PR
- Chromium Linux backend:
  - https://github.com/chromium/chromium/blob/main/services/device/wake_lock/power_save_blocker/power_save_blocker_linux.cc
- Chromium Windows backend:
  - https://github.com/chromium/chromium/blob/main/services/device/wake_lock/power_save_blocker/power_save_blocker_win.cc
- Electron powerSaveBlocker entry point:
  - https://github.com/electron/electron/blob/main/shell/browser/api/electron_api_power_save_blocker.cc

## Why we differ from Chromium
- Linux implementation mechanism:
  - Chromium uses in-process D-Bus APIs plus UI-integrated screen-saver suspension.
  - This PR uses command-based inhibitor backends (`systemd-inhibit`, `gnome-session-inhibit`) instead of linking a Linux D-Bus client in this crate.
  - Reason: keep `codex-utils-sleep-inhibitor` dependency-light and avoid Linux CI/toolchain fragility from new native D-Bus linkage, while preserving the same runtime intent (hold an inhibitor while a turn runs).
- Linux UI integration scope:
  - Chromium also uses `display::Screen::SuspendScreenSaver()` in its UI stack.
  - Codex `codex-rs` does not have that display abstraction in this crate, so this PR scopes Linux behavior to process-level sleep inhibition only.
- Windows wake-lock type breadth:
  - Chromium supports both display/system wake-lock types and extra display-specific handling for some pre-Win11 scenarios.
  - Codex’s feature is scoped to turn execution continuity (not forcing display on), so this PR uses `PowerRequestSystemRequired` only.

