### PR TITLE
Fix Windows npm install regression from dist-tag packaging change

### DIFF
--- a/codex-cli/scripts/README.md
+++ b/codex-cli/scripts/README.md
@@ -15,8 +15,8 @@ This downloads the native artifacts once, hydrates `vendor/` for each package, a
 tarballs to `dist/npm/`.
 
 When `--package codex` is provided, the staging helper builds the lightweight
-`@openai/codex` meta package plus all platform-native `@openai/codex` variants
-that are later published under platform-specific dist-tags.
+`@openai/codex` meta package plus all platform-native packages (for example
+`@openai/codex-win32-x64`) that are consumed as optional dependencies.
 
 If you need to invoke `build_npm_package.py` directly, run
 `codex-cli/scripts/install_native_deps.py` first and pass `--vendor-src` pointing to the

--- a/codex-cli/scripts/build_npm_package.py
+++ b/codex-cli/scripts/build_npm_package.py
@@ -16,8 +16,8 @@ RESPONSES_API_PROXY_NPM_ROOT = REPO_ROOT / "codex-rs" / "responses-api-proxy" / 
 CODEX_SDK_ROOT = REPO_ROOT / "sdk" / "typescript"
 CODEX_NPM_NAME = "@openai/codex"
 
-# `npm_name` is the local optional-dependency alias consumed by `bin/codex.js`.
-# The underlying package published to npm is always `@openai/codex`.
+# `npm_name` is the platform package consumed by `bin/codex.js` as an
+# optional dependency of the meta package.
 CODEX_PLATFORM_PACKAGES: dict[str, dict[str, str]] = {
     "codex-linux-x64": {
         "npm_name": "@openai/codex-linux-x64",
@@ -263,7 +263,7 @@ def stage_sources(staging_dir: Path, version: str, package: str) -> None:
             codex_package_json = json.load(fh)
 
         package_json = {
-            "name": CODEX_NPM_NAME,
+            "name": platform_package["npm_name"],
             "version": platform_version,
             "license": codex_package_json.get("license", "Apache-2.0"),
             "os": [platform_package["os"]],
@@ -304,9 +304,8 @@ def stage_sources(staging_dir: Path, version: str, package: str) -> None:
     if package == "codex":
         package_json["files"] = ["bin"]
         package_json["optionalDependencies"] = {
-            CODEX_PLATFORM_PACKAGES[platform_package]["npm_name"]: (
-                f"npm:{CODEX_NPM_NAME}@"
-                f"{compute_platform_package_version(version, CODEX_PLATFORM_PACKAGES[platform_package]['npm_tag'])}"
+            CODEX_PLATFORM_PACKAGES[platform_package]["npm_name"]: compute_platform_package_version(
+                version, CODEX_PLATFORM_PACKAGES[platform_package]["npm_tag"]
             )
             for platform_package in PACKAGE_EXPANSIONS["codex"]
             if platform_package != "codex"


### PR DESCRIPTION
The recent packaging migration in #11339 switched platform artifacts to be published as `@openai/codex` with platform-specific versions and wired the meta package via npm alias optional dependencies (for example `@openai/codex-win32-x64 -> npm:@openai/codex@0.101.0-win32-x64`).

This caused runtime failures on Windows where `codex` reports: `Missing optional dependency @openai/codex-win32-x64`.

### What changed
- Updated `codex-cli/scripts/build_npm_package.py` to publish platform artifacts under their concrete package names:
  - `@openai/codex-win32-x64`
  - `@openai/codex-win32-arm64`
  - `@openai/codex-linux-x64`
  - `@openai/codex-linux-arm64`
  - `@openai/codex-darwin-x64`
  - `@openai/codex-darwin-arm64`
- Updated meta package `optionalDependencies` to use plain version references (e.g. `0.101.0-win32-x64`) instead of npm alias syntax to `@openai/codex`.
- Updated `codex-cli/scripts/README.md` to reflect that platform-native artifacts are separate optional dependency packages.

### Why
`bin/codex.js` resolves platform packages by name (`@openai/codex-win32-x64`, etc). Publishing platform tarballs under `@openai/codex` introduces alias indirection that can fail to materialize these package names at install time, especially on Windows. Publishing under the concrete names restores direct name alignment and reliable resolution.

Addresses https://github.com/openai/codex/issues/11744