### PR TITLE
fix(nix): use correct version from Cargo.toml in flake build

### DIFF
--- a/codex-rs/default.nix
+++ b/codex-rs/default.nix
@@ -5,6 +5,7 @@
   rustPlatform,
   pkg-config,
   lib,
+  version ? "0.0.0",
   ...
 }:
 rustPlatform.buildRustPackage (_: {
@@ -12,10 +13,18 @@ rustPlatform.buildRustPackage (_: {
     PKG_CONFIG_PATH = "${openssl.dev}/lib/pkgconfig:$PKG_CONFIG_PATH";
   };
   pname = "codex-rs";
-  version = "0.1.0";
+  inherit version;
   cargoLock.lockFile = ./Cargo.lock;
   doCheck = false;
   src = ./.;
+
+  # Patch the workspace Cargo.toml so that cargo embeds the correct version in
+  # CARGO_PKG_VERSION (which the binary reads via env!("CARGO_PKG_VERSION")).
+  # On release commits the Cargo.toml already contains the real version and
+  # this sed is a no-op.
+  postPatch = ''
+    sed -i 's/^version = "0\.0\.0"$/version = "${version}"/' Cargo.toml
+  '';
   nativeBuildInputs = [
     cmake
     llvmPackages.clang


### PR DESCRIPTION
## Summary

- When building via `nix build`, the binary reports `codex-cli 0.0.0` because the workspace `Cargo.toml` uses `0.0.0` as a placeholder on `main`. This causes the update checker to always prompt users to upgrade even when running the latest code.
- Reads the version from `codex-rs/Cargo.toml` at flake evaluation time using `builtins.fromTOML` and patches it into the workspace `Cargo.toml` before cargo builds via `postPatch`.
- On release commits (e.g. tag `rust-v0.101.0`), the real version is used as-is. On `main` branch builds, falls back to `0.0.0-dev+<shortRev>` (or `0.0.0-dev+dirty`), which the update checker's `parse_version` ignores — suppressing the spurious upgrade prompt.

| Scenario | Cargo.toml version | Nix `version` | Binary reports | Upgrade nag? |
|---|---|---|---|---|
| Release commit (e.g. `rust-v0.101.0`) | `0.101.0` | `0.101.0` | `codex-cli 0.101.0` | Only if newer exists |
| Main branch (committed) | `0.0.0` | `0.0.0-dev+b934ffc` | `codex-cli 0.0.0-dev+b934ffc` | No |
| Main branch (uncommitted) | `0.0.0` | `0.0.0-dev+dirty` | `codex-cli 0.0.0-dev+dirty` | No |

## Test plan

- [ ] `nix build` from `main` branch and verify `codex --version` reports `0.0.0-dev+<shortRev>` instead of `0.0.0`
- [ ] Verify the update checker does not show a spurious upgrade prompt for dev builds
- [ ] Confirm that on a release commit where `Cargo.toml` has a real version, the binary reports that version correctly