### PR TITLE
Suppress review startup error event on cancellation

### DIFF
--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -67,15 +67,17 @@ impl SessionTask for ReviewTask {
         {
             Ok(receiver) => process_review_events(session.clone(), ctx.clone(), receiver).await,
             Err(err) => {
-                session
-                    .clone_session()
-                    .send_event(
-                        ctx.as_ref(),
-                        EventMsg::Error(err.to_error_event(Some(
-                            "Failed to start review delegate".to_string(),
-                        )),
-                    )
-                    .await;
+                if !cancellation_token.is_cancelled() && !matches!(err, CodexErr::TurnAborted) {
+                    session
+                        .clone_session()
+                        .send_event(
+                            ctx.as_ref(),
+                            EventMsg::Error(err.to_error_event(Some(
+                                "Failed to start review delegate".to_string(),
+                            )),
+                        )
+                        .await;
+                }
                 None
             }
         };


### PR DESCRIPTION
## Summary
- Suppress noisy startup-error surfacing for `/review` when the task is cancelled during sub-agent spawn/setup.
- Keep explicit error reporting for genuine review startup failures (e.g., invalid delegate context).
- Continue forwarding sub-agent failures explicitly and failing tests coverage from previous commit:
  - delegate `submit` failures no longer silently ignored,
  - one-shot bridge/shutdown send failures terminate forwarding,
  - review startup errors emit user-visible `Error` + `ExitedReviewMode` + `TurnComplete`.

## Notes
- This PR incorporates the previous silent-error hardening changes plus the review-cancellation feedback fix.
- Not run locally in this environment because `cargo`, `rustc`, and `just` are unavailable.
