### PR TITLE
chore(tui): reduce noisy key logging

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -223,6 +223,7 @@ use crate::tasks::SessionTask;
 use crate::tasks::SessionTaskContext;
 use crate::tools::ToolRouter;
 use crate::tools::context::SharedTurnDiffTracker;
+use crate::tools::handlers::SEARCH_TOOL_BM25_TOOL_NAME;
 use crate::tools::js_repl::JsReplHandle;
 use crate::tools::network_approval::NetworkApprovalService;
 use crate::tools::network_approval::build_blocked_request_observer;
@@ -1672,7 +1673,7 @@ impl Session {
             };
             match response_item {
                 ResponseItem::FunctionCall { name, call_id, .. } => {
-                    if name == "search_tool_bm25" {
+                    if name == SEARCH_TOOL_BM25_TOOL_NAME {
                         search_call_ids.insert(call_id.clone());
                     }
                 }
@@ -6139,7 +6140,7 @@ mod tests {
     #[test]
     fn extract_mcp_tool_selection_from_rollout_reads_search_tool_output() {
         let rollout_items = vec![
-            function_call_rollout_item("search_tool_bm25", "search-1"),
+            function_call_rollout_item(SEARCH_TOOL_BM25_TOOL_NAME, "search-1"),
             function_call_output_rollout_item(
                 "search-1",
                 &json!({
@@ -6165,7 +6166,7 @@ mod tests {
     #[test]
     fn extract_mcp_tool_selection_from_rollout_latest_valid_payload_wins() {
         let rollout_items = vec![
-            function_call_rollout_item("search_tool_bm25", "search-1"),
+            function_call_rollout_item(SEARCH_TOOL_BM25_TOOL_NAME, "search-1"),
             function_call_output_rollout_item(
                 "search-1",
                 &json!({
@@ -6173,7 +6174,7 @@ mod tests {
                 })
                 .to_string(),
             ),
-            function_call_rollout_item("search_tool_bm25", "search-2"),
+            function_call_rollout_item(SEARCH_TOOL_BM25_TOOL_NAME, "search-2"),
             function_call_output_rollout_item(
                 "search-2",
                 &json!({
@@ -6201,7 +6202,7 @@ mod tests {
                 })
                 .to_string(),
             ),
-            function_call_rollout_item("search_tool_bm25", "search-1"),
+            function_call_rollout_item(SEARCH_TOOL_BM25_TOOL_NAME, "search-1"),
             function_call_output_rollout_item("search-1", "{not-json"),
             function_call_output_rollout_item(
                 "unknown-search-call",
@@ -6228,7 +6229,10 @@ mod tests {
 
     #[test]
     fn extract_mcp_tool_selection_from_rollout_returns_none_without_valid_search_output() {
-        let rollout_items = vec![function_call_rollout_item("search_tool_bm25", "search-1")];
+        let rollout_items = vec![function_call_rollout_item(
+            SEARCH_TOOL_BM25_TOOL_NAME,
+            "search-1",
+        )];
         let selected = Session::extract_mcp_tool_selection_from_rollout(&rollout_items);
         assert_eq!(selected, None);
     }

--- a/codex-rs/core/src/mcp_connection_manager.rs
+++ b/codex-rs/core/src/mcp_connection_manager.rs
@@ -908,6 +908,16 @@ pub(crate) fn filter_codex_apps_mcp_tools_only(
         .collect()
 }
 
+pub(crate) fn filter_non_codex_apps_mcp_tools_only(
+    mcp_tools: &HashMap<String, ToolInfo>,
+) -> HashMap<String, ToolInfo> {
+    mcp_tools
+        .iter()
+        .filter(|(_, tool)| tool.server_name != CODEX_APPS_MCP_SERVER_NAME)
+        .map(|(name, tool)| (name.clone(), tool.clone()))
+        .collect()
+}
+
 pub(crate) fn filter_mcp_tools_by_name(
     mcp_tools: &HashMap<String, ToolInfo>,
     selected_tools: &[String],

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -120,7 +120,6 @@ impl Session {
         task: T,
     ) {
         self.abort_all_tasks(TurnAbortReason::Replaced).await;
-        self.clear_mcp_tool_selection().await;
         self.clear_connector_selection().await;
         self.seed_initial_context_if_needed(turn_context.as_ref())
             .await;

--- a/codex-rs/core/src/tools/handlers/mod.rs
+++ b/codex-rs/core/src/tools/handlers/mod.rs
@@ -33,6 +33,7 @@ pub use read_file::ReadFileHandler;
 pub use request_user_input::RequestUserInputHandler;
 pub(crate) use request_user_input::request_user_input_tool_description;
 pub(crate) use search_tool_bm25::DEFAULT_LIMIT as SEARCH_TOOL_BM25_DEFAULT_LIMIT;
+pub(crate) use search_tool_bm25::SEARCH_TOOL_BM25_TOOL_NAME;
 pub use search_tool_bm25::SearchToolBm25Handler;
 pub use shell::ShellCommandHandler;
 pub use shell::ShellHandler;

--- a/codex-rs/core/src/tools/handlers/search_tool_bm25.rs
+++ b/codex-rs/core/src/tools/handlers/search_tool_bm25.rs
@@ -23,6 +23,7 @@ use crate::tools::registry::ToolKind;
 
 pub struct SearchToolBm25Handler;
 
+pub(crate) const SEARCH_TOOL_BM25_TOOL_NAME: &str = "search_tool_bm25";
 pub(crate) const DEFAULT_LIMIT: usize = 8;
 
 fn default_limit() -> usize {
@@ -91,9 +92,9 @@ impl ToolHandler for SearchToolBm25Handler {
         let arguments = match payload {
             ToolPayload::Function { arguments } => arguments,
             _ => {
-                return Err(FunctionCallError::Fatal(
-                    "search_tool_bm25 handler received unsupported payload".to_string(),
-                ));
+                return Err(FunctionCallError::Fatal(format!(
+                    "{SEARCH_TOOL_BM25_TOOL_NAME} handler received unsupported payload"
+                )));
             }
         };
 

--- a/codex-rs/core/src/tools/handlers/search_tool_bm25.rs
+++ b/codex-rs/core/src/tools/handlers/search_tool_bm25.rs
@@ -43,7 +43,6 @@ struct ToolEntry {
     server_name: String,
     title: Option<String>,
     description: Option<String>,
-    connector_id: Option<String>,
     connector_name: Option<String>,
     input_keys: Vec<String>,
     search_text: String,
@@ -67,7 +66,6 @@ impl ToolEntry {
                 .tool
                 .description
                 .map(|description| description.to_string()),
-            connector_id: info.connector_id,
             connector_name: info.connector_name,
             input_keys,
             search_text,
@@ -173,7 +171,6 @@ impl ToolHandler for SearchToolBm25Handler {
                 "server": entry.server_name.clone(),
                 "title": entry.title.clone(),
                 "description": entry.description.clone(),
-                "connector_id": entry.connector_id.clone(),
                 "connector_name": entry.connector_name.clone(),
                 "input_keys": entry.input_keys.clone(),
                 "score": result.score,
@@ -242,12 +239,6 @@ fn build_search_text(name: &str, info: &ToolInfo, input_keys: &[String]) -> Stri
         && !connector_name.trim().is_empty()
     {
         parts.push(connector_name.to_string());
-    }
-
-    if let Some(connector_id) = info.connector_id.as_deref()
-        && !connector_id.trim().is_empty()
-    {
-        parts.push(connector_id.to_string());
     }
 
     if !input_keys.is_empty() {

--- a/codex-rs/core/src/tools/handlers/search_tool_bm25.rs
+++ b/codex-rs/core/src/tools/handlers/search_tool_bm25.rs
@@ -10,7 +10,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 use crate::connectors;
-use crate::features::Feature;
 use crate::function_tool::FunctionCallError;
 use crate::mcp::CODEX_APPS_MCP_SERVER_NAME;
 use crate::mcp_connection_manager::ToolInfo;
@@ -119,15 +118,12 @@ impl ToolHandler for SearchToolBm25Handler {
             .await
             .list_all_tools()
             .await;
-        let mcp_tools = if turn.config.features.enabled(Feature::Apps) {
-            let connectors = connectors::with_app_enabled_state(
-                connectors::accessible_connectors_from_mcp_tools(&mcp_tools),
-                &turn.config,
-            );
-            filter_codex_apps_mcp_tools(mcp_tools, &connectors)
-        } else {
-            mcp_tools
-        };
+
+        let connectors = connectors::with_app_enabled_state(
+            connectors::accessible_connectors_from_mcp_tools(&mcp_tools),
+            &turn.config,
+        );
+        let mcp_tools = filter_codex_apps_mcp_tools(mcp_tools, &connectors);
 
         let mut entries: Vec<ToolEntry> = mcp_tools
             .into_iter()

--- a/codex-rs/core/src/tools/spec.rs
+++ b/codex-rs/core/src/tools/spec.rs
@@ -8,6 +8,7 @@ use crate::features::Features;
 use crate::mcp_connection_manager::ToolInfo;
 use crate::tools::handlers::PLAN_TOOL;
 use crate::tools::handlers::SEARCH_TOOL_BM25_DEFAULT_LIMIT;
+use crate::tools::handlers::SEARCH_TOOL_BM25_TOOL_NAME;
 use crate::tools::handlers::apply_patch::create_apply_patch_freeform_tool;
 use crate::tools::handlers::apply_patch::create_apply_patch_json_tool;
 use crate::tools::handlers::collab::DEFAULT_WAIT_TIMEOUT_MS;
@@ -913,7 +914,7 @@ fn create_search_tool_bm25_tool(app_tools: &HashMap<String, ToolInfo>) -> ToolSp
         SEARCH_TOOL_BM25_DESCRIPTION_TEMPLATE.replace("{{app_names}}", app_names.as_str());
 
     ToolSpec::Function(ResponsesApiTool {
-        name: "search_tool_bm25".to_string(),
+        name: SEARCH_TOOL_BM25_TOOL_NAME.to_string(),
         description,
         strict: false,
         parameters: JsonSchema::Object {
@@ -1507,7 +1508,7 @@ pub(crate) fn build_specs(
         && let Some(app_tools) = app_tools
     {
         builder.push_spec_with_parallel_support(create_search_tool_bm25_tool(&app_tools), true);
-        builder.register_handler("search_tool_bm25", search_tool_handler);
+        builder.register_handler(SEARCH_TOOL_BM25_TOOL_NAME, search_tool_handler);
     }
 
     if let Some(apply_patch_tool_type) = &config.apply_patch_tool_type {
@@ -2579,7 +2580,7 @@ mod tests {
         )
         .build();
 
-        let search_tool = find_tool(&tools, "search_tool_bm25");
+        let search_tool = find_tool(&tools, SEARCH_TOOL_BM25_TOOL_NAME);
         let ToolSpec::Function(ResponsesApiTool { description, .. }) = &search_tool.spec else {
             panic!("expected function tool");
         };

--- a/codex-rs/core/templates/search_tool/tool_description.md
+++ b/codex-rs/core/templates/search_tool/tool_description.md
@@ -10,8 +10,8 @@ Follow this workflow:
    - `query` (required): focused terms that describe the capability you need.
    - `limit` (optional): maximum number of tools to return (default `8`).
 2. Use the returned `tools` list to decide which Apps tools are relevant.
-3. Matching tools are added to available `tools` and available for the remainder of the current turn.
-4. Repeated searches in the same turn are additive: new matches are unioned into `tools`.
+3. Matching tools are added to available `tools` and available for the remainder of the current session/thread.
+4. Repeated searches in the same session/thread are additive: new matches are unioned into `tools`.
 
 Notes:
 - Core tools remain available without searching.

--- a/codex-rs/core/templates/search_tool/tool_description.md
+++ b/codex-rs/core/templates/search_tool/tool_description.md
@@ -2,7 +2,7 @@
 
 Searches over apps tool metadata with BM25 and exposes matching tools for the next model call.
 
-When `search_tool_bm25` is available, apps tools (`mcp__codex_apps__...`) are hidden until you search for them.
+MCP tools of the apps ({{app_names}}) are hidden until you search for them with this tool (`search_tool_bm25`).
 
 Follow this workflow:
 
@@ -23,8 +23,6 @@ Notes:
   - `title`
   - `description`
   - `connector_name`
-  - `connector_id`
   - input schema property keys (`input_keys`)
-- Use `search_tool_bm25` when the user asks to work with one of apps ({{app_names}}) and the exact tool name is not already known.
 - If the needed app is already explicit in the prompt (for example an `apps://...` mention) or already present in the current `tools` list, you can call that tool directly.
-- Do not use `search_tool_bm25` for non-apps/local tasks (filesystem, repo search, or shell-only workflows).
+- Do not use `search_tool_bm25` for non-apps/local tasks (filesystem, repo search, or shell-only workflows) or anything not related to {{app_names}}.

--- a/codex-rs/core/tests/common/apps_test_server.rs
+++ b/codex-rs/core/tests/common/apps_test_server.rs
@@ -1,0 +1,158 @@
+use anyhow::Result;
+use serde_json::Value;
+use serde_json::json;
+use wiremock::Mock;
+use wiremock::MockServer;
+use wiremock::Request;
+use wiremock::Respond;
+use wiremock::ResponseTemplate;
+use wiremock::matchers::method;
+use wiremock::matchers::path;
+use wiremock::matchers::path_regex;
+
+const CONNECTOR_ID: &str = "calendar";
+const CONNECTOR_NAME: &str = "Calendar";
+const PROTOCOL_VERSION: &str = "2025-11-25";
+const SERVER_NAME: &str = "codex-apps-test";
+const SERVER_VERSION: &str = "1.0.0";
+
+#[derive(Clone)]
+pub struct AppsTestServer {
+    pub chatgpt_base_url: String,
+}
+
+impl AppsTestServer {
+    pub async fn mount(server: &MockServer) -> Result<Self> {
+        mount_oauth_metadata(server).await;
+        mount_streamable_http_json_rpc(server).await;
+        Ok(Self {
+            chatgpt_base_url: server.uri(),
+        })
+    }
+}
+
+async fn mount_oauth_metadata(server: &MockServer) {
+    Mock::given(method("GET"))
+        .and(path("/.well-known/oauth-authorization-server/mcp"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "authorization_endpoint": format!("{}/oauth/authorize", server.uri()),
+            "token_endpoint": format!("{}/oauth/token", server.uri()),
+            "scopes_supported": [""],
+        })))
+        .mount(server)
+        .await;
+}
+
+async fn mount_streamable_http_json_rpc(server: &MockServer) {
+    Mock::given(method("POST"))
+        .and(path_regex("^/api/codex/apps/?$"))
+        .respond_with(CodexAppsJsonRpcResponder)
+        .mount(server)
+        .await;
+}
+
+struct CodexAppsJsonRpcResponder;
+
+impl Respond for CodexAppsJsonRpcResponder {
+    fn respond(&self, request: &Request) -> ResponseTemplate {
+        let body: Value = match serde_json::from_slice(&request.body) {
+            Ok(body) => body,
+            Err(error) => {
+                return ResponseTemplate::new(400).set_body_json(json!({
+                    "error": format!("invalid JSON-RPC body: {error}"),
+                }));
+            }
+        };
+
+        let Some(method) = body.get("method").and_then(Value::as_str) else {
+            return ResponseTemplate::new(400).set_body_json(json!({
+                "error": "missing method in JSON-RPC request",
+            }));
+        };
+
+        match method {
+            "initialize" => {
+                let id = body.get("id").cloned().unwrap_or(Value::Null);
+                let protocol_version = body
+                    .pointer("/params/protocolVersion")
+                    .and_then(Value::as_str)
+                    .unwrap_or(PROTOCOL_VERSION);
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "protocolVersion": protocol_version,
+                        "capabilities": {
+                            "tools": {
+                                "listChanged": true
+                            }
+                        },
+                        "serverInfo": {
+                            "name": SERVER_NAME,
+                            "version": SERVER_VERSION
+                        }
+                    }
+                }))
+            }
+            "notifications/initialized" => ResponseTemplate::new(202),
+            "tools/list" => {
+                let id = body.get("id").cloned().unwrap_or(Value::Null);
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": {
+                        "tools": [
+                            {
+                                "name": "calendar_create_event",
+                                "description": "Create a calendar event.",
+                                "inputSchema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "title": { "type": "string" },
+                                        "starts_at": { "type": "string" },
+                                        "timezone": { "type": "string" }
+                                    },
+                                    "required": ["title", "starts_at"],
+                                    "additionalProperties": false
+                                },
+                                "_meta": {
+                                    "connector_id": CONNECTOR_ID,
+                                    "connector_name": CONNECTOR_NAME
+                                }
+                            },
+                            {
+                                "name": "calendar_list_events",
+                                "description": "List calendar events.",
+                                "inputSchema": {
+                                    "type": "object",
+                                    "properties": {
+                                        "query": { "type": "string" },
+                                        "limit": { "type": "integer" }
+                                    },
+                                    "additionalProperties": false
+                                },
+                                "_meta": {
+                                    "connector_id": CONNECTOR_ID,
+                                    "connector_name": CONNECTOR_NAME
+                                }
+                            }
+                        ],
+                        "nextCursor": null
+                    }
+                }))
+            }
+            method if method.starts_with("notifications/") => ResponseTemplate::new(202),
+            _ => {
+                let id = body.get("id").cloned().unwrap_or(Value::Null);
+                ResponseTemplate::new(200).set_body_json(json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": {
+                        "code": -32601,
+                        "message": format!("method not found: {method}")
+                    }
+                }))
+            }
+        }
+    }
+}

--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -12,6 +12,7 @@ use codex_utils_absolute_path::AbsolutePathBuf;
 use regex_lite::Regex;
 use std::path::PathBuf;
 
+pub mod apps_test_server;
 pub mod context_snapshot;
 pub mod process;
 pub mod responses;

--- a/codex-rs/core/tests/suite/search_tool.rs
+++ b/codex-rs/core/tests/suite/search_tool.rs
@@ -1,14 +1,22 @@
 #![cfg(not(target_os = "windows"))]
 #![allow(clippy::unwrap_used, clippy::expect_used)]
 
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::Result;
+use codex_core::CodexThread;
+use codex_core::NewThread;
+use codex_core::config::Config;
 use codex_core::config::types::McpServerConfig;
 use codex_core::config::types::McpServerTransportConfig;
 use codex_core::features::Feature;
 use codex_core::protocol::AskForApproval;
+use codex_core::protocol::EventMsg;
+use codex_core::protocol::Op;
 use codex_core::protocol::SandboxPolicy;
+use codex_protocol::user_input::UserInput;
+use core_test_support::apps_test_server::AppsTestServer;
 use core_test_support::responses::ResponsesRequest;
 use core_test_support::responses::ev_assistant_message;
 use core_test_support::responses::ev_completed;
@@ -19,16 +27,24 @@ use core_test_support::responses::sse;
 use core_test_support::responses::start_mock_server;
 use core_test_support::skip_if_no_network;
 use core_test_support::stdio_server_bin;
+use core_test_support::test_codex::TestCodexBuilder;
 use core_test_support::test_codex::test_codex;
+use core_test_support::wait_for_event;
 use pretty_assertions::assert_eq;
 use serde_json::Value;
 use serde_json::json;
 
 const SEARCH_TOOL_INSTRUCTION_SNIPPETS: [&str; 2] = [
-    "MCP tools of the apps () are hidden until you search for them with this tool",
+    "MCP tools of the apps (Calendar) are hidden until you search for them with this tool",
     "Matching tools are added to available `tools` and available for the remainder of the current session/thread.",
 ];
 const SEARCH_TOOL_BM25_TOOL_NAME: &str = "search_tool_bm25";
+const CALENDAR_CREATE_TOOL: &str = "mcp__codex_apps__calendar_create_event";
+const CALENDAR_LIST_TOOL: &str = "mcp__codex_apps__calendar_list_events";
+const RMCP_ECHO_TOOL: &str = "mcp__rmcp__echo";
+const RMCP_IMAGE_TOOL: &str = "mcp__rmcp__image";
+const CALENDAR_CREATE_QUERY: &str = "create calendar event";
+const CALENDAR_LIST_QUERY: &str = "list calendar events";
 
 fn tool_names(body: &Value) -> Vec<String> {
     body.get("tools")
@@ -100,11 +116,70 @@ fn search_result_tools(payload: &Value) -> Vec<&Value> {
         .collect()
 }
 
+fn rmcp_server_config(command: String) -> McpServerConfig {
+    McpServerConfig {
+        transport: McpServerTransportConfig::Stdio {
+            command,
+            args: Vec::new(),
+            env: None,
+            env_vars: Vec::new(),
+            cwd: None,
+        },
+        enabled: true,
+        required: false,
+        disabled_reason: None,
+        startup_timeout_sec: Some(Duration::from_secs(10)),
+        tool_timeout_sec: None,
+        enabled_tools: None,
+        disabled_tools: None,
+        scopes: None,
+    }
+}
+
+fn configure_apps_with_optional_rmcp(
+    config: &mut Config,
+    apps_base_url: &str,
+    rmcp_server_bin: Option<String>,
+) {
+    config.features.enable(Feature::Apps);
+    config.features.disable(Feature::AppsMcpGateway);
+    config.chatgpt_base_url = apps_base_url.to_string();
+    if let Some(command) = rmcp_server_bin {
+        let mut servers = config.mcp_servers.get().clone();
+        servers.insert("rmcp".to_string(), rmcp_server_config(command));
+        config
+            .mcp_servers
+            .set(servers)
+            .expect("test mcp servers should accept any configuration");
+    }
+}
+
+fn configured_builder(apps_base_url: String, rmcp_server_bin: Option<String>) -> TestCodexBuilder {
+    test_codex().with_config(move |config| {
+        configure_apps_with_optional_rmcp(config, apps_base_url.as_str(), rmcp_server_bin);
+    })
+}
+
+async fn submit_user_input(thread: &Arc<CodexThread>, text: &str) -> Result<()> {
+    thread
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: text.to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+        })
+        .await?;
+    wait_for_event(thread, |event| matches!(event, EventMsg::TurnComplete(_))).await;
+    Ok(())
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn search_tool_flag_adds_tool() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount(&server).await?;
     let mock = mount_sse_sequence(
         &server,
         vec![sse(vec![
@@ -115,9 +190,7 @@ async fn search_tool_flag_adds_tool() -> Result<()> {
     )
     .await;
 
-    let mut builder = test_codex().with_config(|config| {
-        config.features.enable(Feature::Apps);
-    });
+    let mut builder = configured_builder(apps_server.chatgpt_base_url.clone(), None);
     let test = builder.build(&server).await?;
 
     test.submit_turn_with_policies(
@@ -142,6 +215,7 @@ async fn search_tool_adds_discovery_instructions_to_tool_description() -> Result
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount(&server).await?;
     let mock = mount_sse_sequence(
         &server,
         vec![sse(vec![
@@ -152,9 +226,7 @@ async fn search_tool_adds_discovery_instructions_to_tool_description() -> Result
     )
     .await;
 
-    let mut builder = test_codex().with_config(|config| {
-        config.features.enable(Feature::Apps);
-    });
+    let mut builder = configured_builder(apps_server.chatgpt_base_url.clone(), None);
     let test = builder.build(&server).await?;
 
     test.submit_turn_with_policies(
@@ -165,23 +237,24 @@ async fn search_tool_adds_discovery_instructions_to_tool_description() -> Result
     .await?;
 
     let body = mock.single_request().body_json();
-    let search_tool_description =
-        search_tool_description(&body).expect("search tool description should be present");
+    let description = search_tool_description(&body).expect("search tool description should exist");
     assert!(
         SEARCH_TOOL_INSTRUCTION_SNIPPETS
             .iter()
-            .all(|snippet| search_tool_description.contains(snippet)),
-        "search tool description should include search tool workflow: {search_tool_description:?}"
+            .all(|snippet| description.contains(snippet)),
+        "search tool description should include search tool workflow: {description:?}"
     );
 
     Ok(())
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn search_tool_hides_mcp_tools_without_search() -> Result<()> {
+async fn search_tool_hides_apps_tools_without_search_but_keeps_non_app_tools_visible() -> Result<()>
+{
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount(&server).await?;
     let mock = mount_sse_sequence(
         &server,
         vec![sse(vec![
@@ -193,34 +266,10 @@ async fn search_tool_hides_mcp_tools_without_search() -> Result<()> {
     .await;
 
     let rmcp_test_server_bin = stdio_server_bin()?;
-    let mut builder = test_codex().with_config(move |config| {
-        config.features.enable(Feature::Apps);
-        let mut servers = config.mcp_servers.get().clone();
-        servers.insert(
-            "rmcp".to_string(),
-            McpServerConfig {
-                transport: McpServerTransportConfig::Stdio {
-                    command: rmcp_test_server_bin,
-                    args: Vec::new(),
-                    env: None,
-                    env_vars: Vec::new(),
-                    cwd: None,
-                },
-                enabled: true,
-                required: false,
-                disabled_reason: None,
-                startup_timeout_sec: Some(Duration::from_secs(10)),
-                tool_timeout_sec: None,
-                enabled_tools: None,
-                disabled_tools: None,
-                scopes: None,
-            },
-        );
-        config
-            .mcp_servers
-            .set(servers)
-            .expect("test mcp servers should accept any configuration");
-    });
+    let mut builder = configured_builder(
+        apps_server.chatgpt_base_url.clone(),
+        Some(rmcp_test_server_bin),
+    );
     let test = builder.build(&server).await?;
 
     test.submit_turn_with_policies(
@@ -234,15 +283,71 @@ async fn search_tool_hides_mcp_tools_without_search() -> Result<()> {
     let tools = tool_names(&body);
     assert!(
         tools.iter().any(|name| name == SEARCH_TOOL_BM25_TOOL_NAME),
-        "tools list should include {SEARCH_TOOL_BM25_TOOL_NAME} when enabled: {tools:?}"
+        "tools list should include {SEARCH_TOOL_BM25_TOOL_NAME}: {tools:?}"
     );
     assert!(
-        !tools.iter().any(|name| name == "mcp__rmcp__echo"),
-        "tools list should not include MCP tools before search: {tools:?}"
+        tools.iter().any(|name| name == RMCP_ECHO_TOOL),
+        "non-app MCP tools should remain visible in Apps mode: {tools:?}"
     );
     assert!(
-        !tools.iter().any(|name| name == "mcp__rmcp__image"),
-        "tools list should not include MCP tools before search: {tools:?}"
+        tools.iter().any(|name| name == RMCP_IMAGE_TOOL),
+        "non-app MCP tools should remain visible in Apps mode: {tools:?}"
+    );
+    assert!(
+        !tools.iter().any(|name| name == CALENDAR_CREATE_TOOL),
+        "apps tools should stay hidden before search/mention: {tools:?}"
+    );
+    assert!(
+        !tools.iter().any(|name| name == CALENDAR_LIST_TOOL),
+        "apps tools should stay hidden before search/mention: {tools:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_app_mentions_expose_apps_tools_without_search() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount(&server).await?;
+    let mock = mount_sse_sequence(
+        &server,
+        vec![sse(vec![
+            ev_response_created("resp-1"),
+            ev_assistant_message("msg-1", "done"),
+            ev_completed("resp-1"),
+        ])],
+    )
+    .await;
+
+    let rmcp_test_server_bin = stdio_server_bin()?;
+    let mut builder = configured_builder(
+        apps_server.chatgpt_base_url.clone(),
+        Some(rmcp_test_server_bin),
+    );
+    let test = builder.build(&server).await?;
+
+    test.submit_turn_with_policies(
+        "Use [$calendar](app://calendar) and then call tools.",
+        AskForApproval::Never,
+        SandboxPolicy::DangerFullAccess,
+    )
+    .await?;
+
+    let body = mock.single_request().body_json();
+    let tools = tool_names(&body);
+    assert!(
+        tools.iter().any(|name| name == RMCP_ECHO_TOOL),
+        "non-app tools should remain visible: {tools:?}"
+    );
+    assert!(
+        tools.iter().any(|name| name == CALENDAR_CREATE_TOOL),
+        "apps tools should be available after explicit app mention: {tools:?}"
+    );
+    assert!(
+        tools.iter().any(|name| name == CALENDAR_LIST_TOOL),
+        "apps tools should be available after explicit app mention: {tools:?}"
     );
 
     Ok(())
@@ -253,9 +358,10 @@ async fn search_tool_selection_persists_across_turns() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount(&server).await?;
     let call_id = "tool-search";
     let args = json!({
-        "query": "codex_apps",
+        "query": CALENDAR_CREATE_QUERY,
         "limit": 1,
     });
     let responses = vec![
@@ -280,38 +386,14 @@ async fn search_tool_selection_persists_across_turns() -> Result<()> {
     let mock = mount_sse_sequence(&server, responses).await;
 
     let rmcp_test_server_bin = stdio_server_bin()?;
-    let mut builder = test_codex().with_config(move |config| {
-        config.features.enable(Feature::Apps);
-        let mut servers = config.mcp_servers.get().clone();
-        servers.insert(
-            "rmcp".to_string(),
-            McpServerConfig {
-                transport: McpServerTransportConfig::Stdio {
-                    command: rmcp_test_server_bin,
-                    args: Vec::new(),
-                    env: None,
-                    env_vars: Vec::new(),
-                    cwd: None,
-                },
-                enabled: true,
-                required: false,
-                disabled_reason: None,
-                startup_timeout_sec: Some(Duration::from_secs(10)),
-                tool_timeout_sec: None,
-                enabled_tools: None,
-                disabled_tools: None,
-                scopes: None,
-            },
-        );
-        config
-            .mcp_servers
-            .set(servers)
-            .expect("test mcp servers should accept any configuration");
-    });
+    let mut builder = configured_builder(
+        apps_server.chatgpt_base_url.clone(),
+        Some(rmcp_test_server_bin),
+    );
     let test = builder.build(&server).await?;
 
     test.submit_turn_with_policies(
-        "find the echo tool",
+        "find calendar create tool",
         AskForApproval::Never,
         SandboxPolicy::DangerFullAccess,
     )
@@ -333,18 +415,12 @@ async fn search_tool_selection_persists_across_turns() -> Result<()> {
 
     let first_tools = tool_names(&requests[0].body_json());
     assert!(
-        !first_tools.iter().any(|name| name == "mcp__rmcp__echo"),
-        "first request should not include MCP tools before search: {first_tools:?}"
-    );
-
-    let second_tools = tool_names(&requests[1].body_json());
-    assert!(
-        !second_tools.iter().any(|name| name == "mcp__rmcp__echo"),
-        "second request should not include rmcp MCP tools after search: {second_tools:?}"
+        first_tools.iter().any(|name| name == RMCP_ECHO_TOOL),
+        "non-app MCP tools should be available before search: {first_tools:?}"
     );
     assert!(
-        !second_tools.iter().any(|name| name == "mcp__rmcp__image"),
-        "second request should not include rmcp MCP tools after search: {second_tools:?}"
+        !first_tools.iter().any(|name| name == CALENDAR_CREATE_TOOL),
+        "apps tools should not be visible before search: {first_tools:?}"
     );
 
     let search_output_payload = search_tool_output_payload(&requests[1], call_id);
@@ -359,19 +435,42 @@ async fn search_tool_selection_persists_across_turns() -> Result<()> {
             "search results should only include codex_apps tools: {search_output_payload:?}"
         );
     }
+
+    let selected_tools = active_selected_tools(&search_output_payload);
     assert!(
-        !active_selected_tools(&search_output_payload)
+        selected_tools
+            .iter()
+            .any(|tool| tool == CALENDAR_CREATE_TOOL),
+        "calendar create tool should be selected: {search_output_payload:?}"
+    );
+    assert!(
+        !selected_tools
             .iter()
             .any(|tool_name| tool_name.starts_with("mcp__rmcp__")),
         "search should not add rmcp tools to active selection: {search_output_payload:?}"
     );
-    let selected_tools = active_selected_tools(&search_output_payload);
+
+    let second_tools = tool_names(&requests[1].body_json());
+    assert!(
+        second_tools.iter().any(|name| name == RMCP_ECHO_TOOL),
+        "non-app MCP tools should remain visible after search: {second_tools:?}"
+    );
+    for selected_tool in &selected_tools {
+        assert!(
+            second_tools.iter().any(|name| name == selected_tool),
+            "follow-up request should include selected tool {selected_tool:?}: {second_tools:?}"
+        );
+    }
 
     let third_tools = tool_names(&requests[2].body_json());
+    assert!(
+        third_tools.iter().any(|name| name == RMCP_ECHO_TOOL),
+        "non-app MCP tools should remain visible on later turns: {third_tools:?}"
+    );
     for selected_tool in &selected_tools {
         assert!(
             third_tools.iter().any(|name| name == selected_tool),
-            "third request should include selected tool {selected_tool:?}: {third_tools:?}"
+            "subsequent turn should include selected tool {selected_tool:?}: {third_tools:?}"
         );
     }
 
@@ -383,14 +482,15 @@ async fn search_tool_selection_unions_results_within_turn() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
-    let first_call_id = "tool-search-echo";
-    let second_call_id = "tool-search-image";
+    let apps_server = AppsTestServer::mount(&server).await?;
+    let first_call_id = "tool-search-create";
+    let second_call_id = "tool-search-list";
     let first_args = json!({
-        "query": "echo",
+        "query": CALENDAR_CREATE_QUERY,
         "limit": 1,
     });
     let second_args = json!({
-        "query": "image",
+        "query": CALENDAR_LIST_QUERY,
         "limit": 1,
     });
     let responses = vec![
@@ -420,38 +520,14 @@ async fn search_tool_selection_unions_results_within_turn() -> Result<()> {
     let mock = mount_sse_sequence(&server, responses).await;
 
     let rmcp_test_server_bin = stdio_server_bin()?;
-    let mut builder = test_codex().with_config(move |config| {
-        config.features.enable(Feature::Apps);
-        let mut servers = config.mcp_servers.get().clone();
-        servers.insert(
-            "rmcp".to_string(),
-            McpServerConfig {
-                transport: McpServerTransportConfig::Stdio {
-                    command: rmcp_test_server_bin,
-                    args: Vec::new(),
-                    env: None,
-                    env_vars: Vec::new(),
-                    cwd: None,
-                },
-                enabled: true,
-                required: false,
-                disabled_reason: None,
-                startup_timeout_sec: Some(Duration::from_secs(10)),
-                tool_timeout_sec: None,
-                enabled_tools: None,
-                disabled_tools: None,
-                scopes: None,
-            },
-        );
-        config
-            .mcp_servers
-            .set(servers)
-            .expect("test mcp servers should accept any configuration");
-    });
+    let mut builder = configured_builder(
+        apps_server.chatgpt_base_url.clone(),
+        Some(rmcp_test_server_bin),
+    );
     let test = builder.build(&server).await?;
 
     test.submit_turn_with_policies(
-        "find echo and image tools",
+        "find create and list calendar tools",
         AskForApproval::Never,
         SandboxPolicy::DangerFullAccess,
     )
@@ -467,28 +543,16 @@ async fn search_tool_selection_unions_results_within_turn() -> Result<()> {
 
     let first_tools = tool_names(&requests[0].body_json());
     assert!(
-        !first_tools.iter().any(|name| name == "mcp__rmcp__echo"),
-        "first request should not include MCP tools before search: {first_tools:?}"
-    );
-
-    let second_tools = tool_names(&requests[1].body_json());
-    assert!(
-        !second_tools.iter().any(|name| name == "mcp__rmcp__echo"),
-        "second request should not include rmcp tools after first search: {second_tools:?}"
+        first_tools.iter().any(|name| name == RMCP_ECHO_TOOL),
+        "non-app MCP tools should be visible before search: {first_tools:?}"
     );
     assert!(
-        !second_tools.iter().any(|name| name == "mcp__rmcp__image"),
-        "second request should not include rmcp tools after first search: {second_tools:?}"
-    );
-
-    let third_tools = tool_names(&requests[2].body_json());
-    assert!(
-        !third_tools.iter().any(|name| name == "mcp__rmcp__echo"),
-        "third request should not include rmcp tools: {third_tools:?}"
+        !first_tools.iter().any(|name| name == CALENDAR_CREATE_TOOL),
+        "apps tools should be hidden before search: {first_tools:?}"
     );
     assert!(
-        !third_tools.iter().any(|name| name == "mcp__rmcp__image"),
-        "third request should not include rmcp tools: {third_tools:?}"
+        !first_tools.iter().any(|name| name == CALENDAR_LIST_TOOL),
+        "apps tools should be hidden before search: {first_tools:?}"
     );
 
     let second_search_payload = search_tool_output_payload(&requests[2], second_call_id);
@@ -503,11 +567,29 @@ async fn search_tool_selection_unions_results_within_turn() -> Result<()> {
             "search results should only include codex_apps tools: {second_search_payload:?}"
         );
     }
+
+    let selected_tools = active_selected_tools(&second_search_payload);
+    assert_eq!(
+        selected_tools,
+        vec![
+            CALENDAR_CREATE_TOOL.to_string(),
+            CALENDAR_LIST_TOOL.to_string(),
+        ],
+        "two searches in one turn should union selected apps tools"
+    );
+
+    let third_tools = tool_names(&requests[2].body_json());
     assert!(
-        !active_selected_tools(&second_search_payload)
-            .iter()
-            .any(|tool_name| tool_name.starts_with("mcp__rmcp__")),
-        "search should not add rmcp tools to active selection: {second_search_payload:?}"
+        third_tools.iter().any(|name| name == RMCP_ECHO_TOOL),
+        "non-app MCP tools should remain visible after repeated search: {third_tools:?}"
+    );
+    assert!(
+        third_tools.iter().any(|name| name == CALENDAR_CREATE_TOOL),
+        "calendar create should be available after repeated search: {third_tools:?}"
+    );
+    assert!(
+        third_tools.iter().any(|name| name == CALENDAR_LIST_TOOL),
+        "calendar list should be available after repeated search: {third_tools:?}"
     );
 
     Ok(())
@@ -518,9 +600,10 @@ async fn search_tool_selection_restores_when_resumed() -> Result<()> {
     skip_if_no_network!(Ok(()));
 
     let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount(&server).await?;
     let call_id = "tool-search";
     let args = json!({
-        "query": "codex_apps",
+        "query": CALENDAR_CREATE_QUERY,
         "limit": 1,
     });
     let responses = vec![
@@ -547,34 +630,10 @@ async fn search_tool_selection_restores_when_resumed() -> Result<()> {
     let mock = mount_sse_sequence(&server, responses).await;
 
     let rmcp_test_server_bin = stdio_server_bin()?;
-    let mut builder = test_codex().with_config(move |config| {
-        config.features.enable(Feature::Apps);
-        let mut servers = config.mcp_servers.get().clone();
-        servers.insert(
-            "rmcp".to_string(),
-            McpServerConfig {
-                transport: McpServerTransportConfig::Stdio {
-                    command: rmcp_test_server_bin,
-                    args: Vec::new(),
-                    env: None,
-                    env_vars: Vec::new(),
-                    cwd: None,
-                },
-                enabled: true,
-                required: false,
-                disabled_reason: None,
-                startup_timeout_sec: Some(Duration::from_secs(10)),
-                tool_timeout_sec: None,
-                enabled_tools: None,
-                disabled_tools: None,
-                scopes: None,
-            },
-        );
-        config
-            .mcp_servers
-            .set(servers)
-            .expect("test mcp servers should accept any configuration");
-    });
+    let mut builder = configured_builder(
+        apps_server.chatgpt_base_url.clone(),
+        Some(rmcp_test_server_bin.clone()),
+    );
     let test = builder.build(&server).await?;
 
     let home = test.home.clone();
@@ -585,7 +644,7 @@ async fn search_tool_selection_restores_when_resumed() -> Result<()> {
         .expect("rollout path should be available for resume");
 
     test.submit_turn_with_policies(
-        "find the codex apps tools",
+        "find calendar tools",
         AskForApproval::Never,
         SandboxPolicy::DangerFullAccess,
     )
@@ -600,36 +659,17 @@ async fn search_tool_selection_restores_when_resumed() -> Result<()> {
     );
     let search_output_payload = search_tool_output_payload(&requests[1], call_id);
     let selected_tools = active_selected_tools(&search_output_payload);
+    assert!(
+        selected_tools
+            .iter()
+            .any(|name| name == CALENDAR_CREATE_TOOL),
+        "search should select calendar create before resume: {search_output_payload:?}"
+    );
 
-    let rmcp_test_server_bin = stdio_server_bin()?;
-    let mut resume_builder = test_codex().with_config(move |config| {
-        config.features.enable(Feature::Apps);
-        let mut servers = config.mcp_servers.get().clone();
-        servers.insert(
-            "rmcp".to_string(),
-            McpServerConfig {
-                transport: McpServerTransportConfig::Stdio {
-                    command: rmcp_test_server_bin,
-                    args: Vec::new(),
-                    env: None,
-                    env_vars: Vec::new(),
-                    cwd: None,
-                },
-                enabled: true,
-                required: false,
-                disabled_reason: None,
-                startup_timeout_sec: Some(Duration::from_secs(10)),
-                tool_timeout_sec: None,
-                enabled_tools: None,
-                disabled_tools: None,
-                scopes: None,
-            },
-        );
-        config
-            .mcp_servers
-            .set(servers)
-            .expect("test mcp servers should accept any configuration");
-    });
+    let mut resume_builder = configured_builder(
+        apps_server.chatgpt_base_url.clone(),
+        Some(rmcp_test_server_bin),
+    );
     let resumed = resume_builder.resume(&server, home, rollout_path).await?;
     resumed
         .submit_turn_with_policies(
@@ -647,12 +687,376 @@ async fn search_tool_selection_restores_when_resumed() -> Result<()> {
         requests.len()
     );
     let resumed_tools = tool_names(&requests[2].body_json());
+    assert!(
+        resumed_tools.iter().any(|name| name == RMCP_ECHO_TOOL),
+        "non-app tools should remain visible after resume: {resumed_tools:?}"
+    );
     for selected_tool in &selected_tools {
         assert!(
             resumed_tools.iter().any(|name| name == selected_tool),
             "resumed request should include restored selected tool {selected_tool:?}: {resumed_tools:?}"
         );
     }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn search_tool_selection_union_restores_when_resumed_after_multiple_search_calls()
+-> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount(&server).await?;
+    let first_call_id = "tool-search-create";
+    let second_call_id = "tool-search-list";
+    let first_args = json!({
+        "query": CALENDAR_CREATE_QUERY,
+        "limit": 1,
+    });
+    let second_args = json!({
+        "query": CALENDAR_LIST_QUERY,
+        "limit": 1,
+    });
+    let responses = vec![
+        sse(vec![
+            ev_response_created("resp-1"),
+            ev_function_call(
+                first_call_id,
+                SEARCH_TOOL_BM25_TOOL_NAME,
+                &serde_json::to_string(&first_args)?,
+            ),
+            ev_completed("resp-1"),
+        ]),
+        sse(vec![
+            ev_response_created("resp-2"),
+            ev_assistant_message("msg-1", "first search done"),
+            ev_completed("resp-2"),
+        ]),
+        sse(vec![
+            ev_response_created("resp-3"),
+            ev_function_call(
+                second_call_id,
+                SEARCH_TOOL_BM25_TOOL_NAME,
+                &serde_json::to_string(&second_args)?,
+            ),
+            ev_completed("resp-3"),
+        ]),
+        sse(vec![
+            ev_response_created("resp-4"),
+            ev_assistant_message("msg-2", "second search done"),
+            ev_completed("resp-4"),
+        ]),
+        sse(vec![
+            ev_response_created("resp-5"),
+            ev_assistant_message("msg-3", "resumed done"),
+            ev_completed("resp-5"),
+        ]),
+    ];
+    let mock = mount_sse_sequence(&server, responses).await;
+
+    let rmcp_test_server_bin = stdio_server_bin()?;
+    let mut builder = configured_builder(
+        apps_server.chatgpt_base_url.clone(),
+        Some(rmcp_test_server_bin.clone()),
+    );
+    let test = builder.build(&server).await?;
+
+    let home = test.home.clone();
+    let rollout_path = test
+        .session_configured
+        .rollout_path
+        .clone()
+        .expect("rollout path should be available for resume");
+
+    test.submit_turn_with_policies(
+        "find create calendar tool",
+        AskForApproval::Never,
+        SandboxPolicy::DangerFullAccess,
+    )
+    .await?;
+    test.submit_turn_with_policies(
+        "find list calendar tool",
+        AskForApproval::Never,
+        SandboxPolicy::DangerFullAccess,
+    )
+    .await?;
+
+    let requests = mock.requests();
+    assert_eq!(
+        requests.len(),
+        4,
+        "expected 4 requests before resume, got {}",
+        requests.len()
+    );
+
+    let first_search_payload = search_tool_output_payload(&requests[1], first_call_id);
+    let first_result_tools = search_result_tools(&first_search_payload);
+    assert_eq!(
+        first_result_tools.len(),
+        1,
+        "first search should return exactly one tool: {first_search_payload:?}"
+    );
+    assert_eq!(
+        first_result_tools[0].get("name").and_then(Value::as_str),
+        Some(CALENDAR_CREATE_TOOL),
+        "first search should return calendar create tool: {first_search_payload:?}"
+    );
+    let first_selected_tools = active_selected_tools(&first_search_payload);
+    assert_eq!(
+        first_selected_tools,
+        vec![CALENDAR_CREATE_TOOL.to_string()],
+        "first search should only select create tool: {first_search_payload:?}"
+    );
+
+    let second_search_payload = search_tool_output_payload(&requests[3], second_call_id);
+    let second_result_tools = search_result_tools(&second_search_payload);
+    assert_eq!(
+        second_result_tools.len(),
+        1,
+        "second search should return exactly one tool: {second_search_payload:?}"
+    );
+    assert_eq!(
+        second_result_tools[0].get("name").and_then(Value::as_str),
+        Some(CALENDAR_LIST_TOOL),
+        "second search should return calendar list tool: {second_search_payload:?}"
+    );
+    let second_selected_tools = active_selected_tools(&second_search_payload);
+    assert_eq!(
+        second_selected_tools,
+        vec![
+            CALENDAR_CREATE_TOOL.to_string(),
+            CALENDAR_LIST_TOOL.to_string(),
+        ],
+        "multiple searches should persist union before resume: {second_search_payload:?}"
+    );
+
+    let mut resume_builder = configured_builder(
+        apps_server.chatgpt_base_url.clone(),
+        Some(rmcp_test_server_bin),
+    );
+    let resumed = resume_builder.resume(&server, home, rollout_path).await?;
+    resumed
+        .submit_turn_with_policies(
+            "hello after resume with union",
+            AskForApproval::Never,
+            SandboxPolicy::DangerFullAccess,
+        )
+        .await?;
+
+    let requests = mock.requests();
+    assert_eq!(
+        requests.len(),
+        5,
+        "expected 5 requests after resumed turn, got {}",
+        requests.len()
+    );
+
+    let resumed_tools = tool_names(&requests[4].body_json());
+    assert!(
+        resumed_tools.iter().any(|name| name == RMCP_ECHO_TOOL),
+        "non-app tools should remain visible after resume: {resumed_tools:?}"
+    );
+    assert!(
+        resumed_tools
+            .iter()
+            .any(|name| name == CALENDAR_CREATE_TOOL),
+        "resumed turn should restore calendar create tool: {resumed_tools:?}"
+    );
+    assert!(
+        resumed_tools.iter().any(|name| name == CALENDAR_LIST_TOOL),
+        "resumed turn should restore calendar list tool: {resumed_tools:?}"
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn search_tool_selection_restores_when_forked_with_full_history() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount(&server).await?;
+    let call_id = "tool-search";
+    let args = json!({
+        "query": CALENDAR_CREATE_QUERY,
+        "limit": 1,
+    });
+    let responses = vec![
+        sse(vec![
+            ev_response_created("resp-1"),
+            ev_function_call(
+                call_id,
+                SEARCH_TOOL_BM25_TOOL_NAME,
+                &serde_json::to_string(&args)?,
+            ),
+            ev_completed("resp-1"),
+        ]),
+        sse(vec![
+            ev_response_created("resp-2"),
+            ev_assistant_message("msg-1", "done"),
+            ev_completed("resp-2"),
+        ]),
+        sse(vec![
+            ev_response_created("resp-3"),
+            ev_assistant_message("msg-2", "forked done"),
+            ev_completed("resp-3"),
+        ]),
+    ];
+    let mock = mount_sse_sequence(&server, responses).await;
+
+    let rmcp_test_server_bin = stdio_server_bin()?;
+    let mut builder = configured_builder(
+        apps_server.chatgpt_base_url.clone(),
+        Some(rmcp_test_server_bin),
+    );
+    let test = builder.build(&server).await?;
+
+    test.submit_turn_with_policies(
+        "find calendar tools",
+        AskForApproval::Never,
+        SandboxPolicy::DangerFullAccess,
+    )
+    .await?;
+
+    let requests = mock.requests();
+    assert_eq!(
+        requests.len(),
+        2,
+        "expected 2 requests after initial turn, got {}",
+        requests.len()
+    );
+    let search_output_payload = search_tool_output_payload(&requests[1], call_id);
+    let selected_tools = active_selected_tools(&search_output_payload);
+    assert!(
+        selected_tools
+            .iter()
+            .any(|name| name == CALENDAR_CREATE_TOOL),
+        "search should select calendar create: {search_output_payload:?}"
+    );
+
+    let rollout_path = test
+        .codex
+        .rollout_path()
+        .expect("rollout path should exist for fork");
+    let NewThread { thread: forked, .. } = test
+        .thread_manager
+        .fork_thread(usize::MAX, test.config.clone(), rollout_path, false)
+        .await?;
+    submit_user_input(&forked, "hello after fork").await?;
+
+    let requests = mock.requests();
+    assert_eq!(
+        requests.len(),
+        3,
+        "expected 3 requests after forked turn, got {}",
+        requests.len()
+    );
+    let forked_tools = tool_names(&requests[2].body_json());
+    assert!(
+        forked_tools.iter().any(|name| name == RMCP_ECHO_TOOL),
+        "non-app tools should remain visible in forked thread: {forked_tools:?}"
+    );
+    for selected_tool in &selected_tools {
+        assert!(
+            forked_tools.iter().any(|name| name == selected_tool),
+            "forked request should include restored selected tool {selected_tool:?}: {forked_tools:?}"
+        );
+    }
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn search_tool_selection_drops_when_fork_excludes_search_turn() -> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let server = start_mock_server().await;
+    let apps_server = AppsTestServer::mount(&server).await?;
+    let call_id = "tool-search";
+    let args = json!({
+        "query": CALENDAR_CREATE_QUERY,
+        "limit": 1,
+    });
+    let responses = vec![
+        sse(vec![
+            ev_response_created("resp-1"),
+            ev_function_call(
+                call_id,
+                SEARCH_TOOL_BM25_TOOL_NAME,
+                &serde_json::to_string(&args)?,
+            ),
+            ev_completed("resp-1"),
+        ]),
+        sse(vec![
+            ev_response_created("resp-2"),
+            ev_assistant_message("msg-1", "done"),
+            ev_completed("resp-2"),
+        ]),
+        sse(vec![
+            ev_response_created("resp-3"),
+            ev_assistant_message("msg-2", "forked done"),
+            ev_completed("resp-3"),
+        ]),
+    ];
+    let mock = mount_sse_sequence(&server, responses).await;
+
+    let rmcp_test_server_bin = stdio_server_bin()?;
+    let mut builder = configured_builder(
+        apps_server.chatgpt_base_url.clone(),
+        Some(rmcp_test_server_bin),
+    );
+    let test = builder.build(&server).await?;
+
+    test.submit_turn_with_policies(
+        "find calendar tools",
+        AskForApproval::Never,
+        SandboxPolicy::DangerFullAccess,
+    )
+    .await?;
+
+    let requests = mock.requests();
+    assert_eq!(
+        requests.len(),
+        2,
+        "expected 2 requests after initial turn, got {}",
+        requests.len()
+    );
+    let search_output_payload = search_tool_output_payload(&requests[1], call_id);
+    let selected_tools = active_selected_tools(&search_output_payload);
+    assert!(
+        !selected_tools.is_empty(),
+        "search turn should produce selected tools: {search_output_payload:?}"
+    );
+
+    let rollout_path = test
+        .codex
+        .rollout_path()
+        .expect("rollout path should exist for fork");
+    let NewThread { thread: forked, .. } = test
+        .thread_manager
+        .fork_thread(0, test.config.clone(), rollout_path, false)
+        .await?;
+    submit_user_input(&forked, "hello after fork").await?;
+
+    let requests = mock.requests();
+    assert_eq!(
+        requests.len(),
+        3,
+        "expected 3 requests after forked turn, got {}",
+        requests.len()
+    );
+    let forked_tools = tool_names(&requests[2].body_json());
+    assert!(
+        forked_tools.iter().any(|name| name == RMCP_ECHO_TOOL),
+        "non-app tools should remain visible in forked thread: {forked_tools:?}"
+    );
+    assert!(
+        !forked_tools
+            .iter()
+            .any(|name| name.starts_with("mcp__codex_apps__")),
+        "forked history without search turn should not restore apps tools: {forked_tools:?}"
+    );
 
     Ok(())
 }

--- a/codex-rs/core/tests/suite/search_tool.rs
+++ b/codex-rs/core/tests/suite/search_tool.rs
@@ -25,7 +25,7 @@ use serde_json::Value;
 use serde_json::json;
 
 const SEARCH_TOOL_INSTRUCTION_SNIPPETS: [&str; 2] = [
-    "apps tools (`mcp__codex_apps__...`) are hidden until you search for them.",
+    "MCP tools of the apps () are hidden until you search for them with this tool",
     "Matching tools are added to available `tools` and available for the remainder of the current session/thread.",
 ];
 const SEARCH_TOOL_BM25_TOOL_NAME: &str = "search_tool_bm25";


### PR DESCRIPTION
### Why
The previous `codex-tui` unhandled key logging path was too noisy during day-to-day development while still retaining little operational value.

### What changed
- Removed the `debug-logs` feature from `codex-rs/tui/Cargo.toml`.
- Changed unhandled key event logging in `codex-rs/tui/src/bottom_pane/textarea.rs` from `tracing::debug!` behind `#[cfg(feature = "debug-logs")]` to `tracing::trace!` behind `#[cfg(debug_assertions)]`.
- Kept the signal available for deep debugging without exposing it in normal workflows.

### Verification
- Confirmed no `debug-logs` references remain in `codex-rs/tui`.
