### PR TITLE
fix: send unfiltered models over model/list

### DIFF
--- a/codex-rs/app-server-protocol/schema/json/ClientRequest.json
+++ b/codex-rs/app-server-protocol/schema/json/ClientRequest.json
@@ -1128,6 +1128,13 @@
             "null"
           ]
         },
+        "includeHidden": {
+          "description": "When true, include models that are hidden from the default picker list.",
+          "type": [
+            "boolean",
+            "null"
+          ]
+        },
         "limit": {
           "description": "Optional page size; defaults to a reasonable server-side value.",
           "format": "uint32",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -12639,6 +12639,13 @@
               "null"
             ]
           },
+          "includeHidden": {
+            "description": "When true, include models that are hidden from the default picker list.",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
           "limit": {
             "description": "Optional page size; defaults to a reasonable server-side value.",
             "format": "uint32",

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -12597,6 +12597,9 @@
           "model": {
             "type": "string"
           },
+          "showInPicker": {
+            "type": "boolean"
+          },
           "supportedReasoningEfforts": {
             "items": {
               "$ref": "#/definitions/v2/ReasoningEffortOption"
@@ -12621,6 +12624,7 @@
           "id",
           "isDefault",
           "model",
+          "showInPicker",
           "supportedReasoningEfforts"
         ],
         "type": "object"

--- a/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
+++ b/codex-rs/app-server-protocol/schema/json/codex_app_server_protocol.schemas.json
@@ -12578,6 +12578,9 @@
           "displayName": {
             "type": "string"
           },
+          "hidden": {
+            "type": "boolean"
+          },
           "id": {
             "type": "string"
           },
@@ -12596,9 +12599,6 @@
           },
           "model": {
             "type": "string"
-          },
-          "showInPicker": {
-            "type": "boolean"
           },
           "supportedReasoningEfforts": {
             "items": {
@@ -12621,10 +12621,10 @@
           "defaultReasoningEffort",
           "description",
           "displayName",
+          "hidden",
           "id",
           "isDefault",
           "model",
-          "showInPicker",
           "supportedReasoningEfforts"
         ],
         "type": "object"

--- a/codex-rs/app-server-protocol/schema/json/v2/ModelListParams.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ModelListParams.json
@@ -8,6 +8,13 @@
         "null"
       ]
     },
+    "includeHidden": {
+      "description": "When true, include models that are hidden from the default picker list.",
+      "type": [
+        "boolean",
+        "null"
+      ]
+    },
     "limit": {
       "description": "Optional page size; defaults to a reasonable server-side value.",
       "format": "uint32",

--- a/codex-rs/app-server-protocol/schema/json/v2/ModelListResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ModelListResponse.json
@@ -31,6 +31,9 @@
         "displayName": {
           "type": "string"
         },
+        "hidden": {
+          "type": "boolean"
+        },
         "id": {
           "type": "string"
         },
@@ -49,9 +52,6 @@
         },
         "model": {
           "type": "string"
-        },
-        "showInPicker": {
-          "type": "boolean"
         },
         "supportedReasoningEfforts": {
           "items": {
@@ -74,10 +74,10 @@
         "defaultReasoningEffort",
         "description",
         "displayName",
+        "hidden",
         "id",
         "isDefault",
         "model",
-        "showInPicker",
         "supportedReasoningEfforts"
       ],
       "type": "object"

--- a/codex-rs/app-server-protocol/schema/json/v2/ModelListResponse.json
+++ b/codex-rs/app-server-protocol/schema/json/v2/ModelListResponse.json
@@ -50,6 +50,9 @@
         "model": {
           "type": "string"
         },
+        "showInPicker": {
+          "type": "boolean"
+        },
         "supportedReasoningEfforts": {
           "items": {
             "$ref": "#/definitions/ReasoningEffortOption"
@@ -74,6 +77,7 @@
         "id",
         "isDefault",
         "model",
+        "showInPicker",
         "supportedReasoningEfforts"
       ],
       "type": "object"

--- a/codex-rs/app-server-protocol/schema/typescript/v2/Model.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/Model.ts
@@ -5,4 +5,4 @@ import type { InputModality } from "../InputModality";
 import type { ReasoningEffort } from "../ReasoningEffort";
 import type { ReasoningEffortOption } from "./ReasoningEffortOption";
 
-export type Model = { id: string, model: string, upgrade: string | null, displayName: string, description: string, showInPicker: boolean, supportedReasoningEfforts: Array<ReasoningEffortOption>, defaultReasoningEffort: ReasoningEffort, inputModalities: Array<InputModality>, supportsPersonality: boolean, isDefault: boolean, };
+export type Model = { id: string, model: string, upgrade: string | null, displayName: string, description: string, hidden: boolean, supportedReasoningEfforts: Array<ReasoningEffortOption>, defaultReasoningEffort: ReasoningEffort, inputModalities: Array<InputModality>, supportsPersonality: boolean, isDefault: boolean, };

--- a/codex-rs/app-server-protocol/schema/typescript/v2/Model.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/Model.ts
@@ -5,4 +5,4 @@ import type { InputModality } from "../InputModality";
 import type { ReasoningEffort } from "../ReasoningEffort";
 import type { ReasoningEffortOption } from "./ReasoningEffortOption";
 
-export type Model = { id: string, model: string, upgrade: string | null, displayName: string, description: string, supportedReasoningEfforts: Array<ReasoningEffortOption>, defaultReasoningEffort: ReasoningEffort, inputModalities: Array<InputModality>, supportsPersonality: boolean, isDefault: boolean, };
+export type Model = { id: string, model: string, upgrade: string | null, displayName: string, description: string, showInPicker: boolean, supportedReasoningEfforts: Array<ReasoningEffortOption>, defaultReasoningEffort: ReasoningEffort, inputModalities: Array<InputModality>, supportsPersonality: boolean, isDefault: boolean, };

--- a/codex-rs/app-server-protocol/schema/typescript/v2/ModelListParams.ts
+++ b/codex-rs/app-server-protocol/schema/typescript/v2/ModelListParams.ts
@@ -10,4 +10,8 @@ cursor?: string | null,
 /**
  * Optional page size; defaults to a reasonable server-side value.
  */
-limit?: number | null, };
+limit?: number | null, 
+/**
+ * When true, include models that are hidden from the default picker list.
+ */
+includeHidden?: boolean | null, };

--- a/codex-rs/app-server-protocol/src/protocol/common.rs
+++ b/codex-rs/app-server-protocol/src/protocol/common.rs
@@ -1227,7 +1227,8 @@ mod tests {
                 "id": 6,
                 "params": {
                     "limit": null,
-                    "cursor": null
+                    "cursor": null,
+                    "includeHidden": null
                 }
             }),
             serde_json::to_value(&request)?,

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1124,7 +1124,7 @@ pub struct Model {
     pub upgrade: Option<String>,
     pub display_name: String,
     pub description: String,
-    pub show_in_picker: bool,
+    pub hidden: bool,
     pub supported_reasoning_efforts: Vec<ReasoningEffortOption>,
     pub default_reasoning_effort: ReasoningEffort,
     #[serde(default = "default_input_modalities")]

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1110,6 +1110,9 @@ pub struct ModelListParams {
     /// Optional page size; defaults to a reasonable server-side value.
     #[ts(optional = nullable)]
     pub limit: Option<u32>,
+    /// When true, include models that are hidden from the default picker list.
+    #[ts(optional = nullable)]
+    pub include_hidden: Option<bool>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema, TS)]

--- a/codex-rs/app-server-protocol/src/protocol/v2.rs
+++ b/codex-rs/app-server-protocol/src/protocol/v2.rs
@@ -1121,6 +1121,7 @@ pub struct Model {
     pub upgrade: Option<String>,
     pub display_name: String,
     pub description: String,
+    pub show_in_picker: bool,
     pub supported_reasoning_efforts: Vec<ReasoningEffortOption>,
     pub default_reasoning_effort: ReasoningEffort,
     #[serde(default = "default_input_modalities")]

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -131,7 +131,7 @@ Example with notification opt-out:
 - `turn/interrupt` — request cancellation of an in-flight turn by `(thread_id, turn_id)`; success is an empty `{}` response and the turn finishes with `status: "interrupted"`.
 - `review/start` — kick off Codex’s automated reviewer for a thread; responds like `turn/start` and emits `item/started`/`item/completed` notifications with `enteredReviewMode` and `exitedReviewMode` items, plus a final assistant `agentMessage` containing the review.
 - `command/exec` — run a single command under the server sandbox without starting a thread/turn (handy for utilities and validation).
-- `model/list` — list available models (set `includeHidden: true` to include entries hidden from the default picker list), with reasoning effort options and optional `upgrade` model ids.
+- `model/list` — list available models (set `includeHidden: true` to include entries with `hidden: true`), with reasoning effort options and optional `upgrade` model ids.
 - `experimentalFeature/list` — list feature flags with stage metadata (`beta`, `underDevelopment`, `stable`, etc.), enabled/default-enabled state, and cursor pagination. For non-beta flags, `displayName`/`description`/`announcement` are `null`.
 - `collaborationMode/list` — list available collaboration mode presets (experimental, no pagination).
 - `skills/list` — list skills for one or more `cwd` values (optional `forceReload`).

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -131,7 +131,7 @@ Example with notification opt-out:
 - `turn/interrupt` — request cancellation of an in-flight turn by `(thread_id, turn_id)`; success is an empty `{}` response and the turn finishes with `status: "interrupted"`.
 - `review/start` — kick off Codex’s automated reviewer for a thread; responds like `turn/start` and emits `item/started`/`item/completed` notifications with `enteredReviewMode` and `exitedReviewMode` items, plus a final assistant `agentMessage` containing the review.
 - `command/exec` — run a single command under the server sandbox without starting a thread/turn (handy for utilities and validation).
-- `model/list` — list available models (with reasoning effort options and optional `upgrade` model ids).
+- `model/list` — list available models (including entries with `showInPicker: false`), with reasoning effort options and optional `upgrade` model ids.
 - `experimentalFeature/list` — list feature flags with stage metadata (`beta`, `underDevelopment`, `stable`, etc.), enabled/default-enabled state, and cursor pagination. For non-beta flags, `displayName`/`description`/`announcement` are `null`.
 - `collaborationMode/list` — list available collaboration mode presets (experimental, no pagination).
 - `skills/list` — list skills for one or more `cwd` values (optional `forceReload`).

--- a/codex-rs/app-server/README.md
+++ b/codex-rs/app-server/README.md
@@ -131,7 +131,7 @@ Example with notification opt-out:
 - `turn/interrupt` — request cancellation of an in-flight turn by `(thread_id, turn_id)`; success is an empty `{}` response and the turn finishes with `status: "interrupted"`.
 - `review/start` — kick off Codex’s automated reviewer for a thread; responds like `turn/start` and emits `item/started`/`item/completed` notifications with `enteredReviewMode` and `exitedReviewMode` items, plus a final assistant `agentMessage` containing the review.
 - `command/exec` — run a single command under the server sandbox without starting a thread/turn (handy for utilities and validation).
-- `model/list` — list available models (including entries with `showInPicker: false`), with reasoning effort options and optional `upgrade` model ids.
+- `model/list` — list available models (set `includeHidden: true` to include entries hidden from the default picker list), with reasoning effort options and optional `upgrade` model ids.
 - `experimentalFeature/list` — list feature flags with stage metadata (`beta`, `underDevelopment`, `stable`, etc.), enabled/default-enabled state, and cursor pagination. For non-beta flags, `displayName`/`description`/`announcement` are `null`.
 - `collaborationMode/list` — list available collaboration mode presets (experimental, no pagination).
 - `skills/list` — list skills for one or more `cwd` values (optional `forceReload`).

--- a/codex-rs/app-server/src/codex_message_processor.rs
+++ b/codex-rs/app-server/src/codex_message_processor.rs
@@ -3393,10 +3393,15 @@ impl CodexMessageProcessor {
         request_id: ConnectionRequestId,
         params: ModelListParams,
     ) {
-        let ModelListParams { limit, cursor } = params;
+        let ModelListParams {
+            limit,
+            cursor,
+            include_hidden,
+        } = params;
         let mut config = (*config).clone();
         config.features.enable(Feature::RemoteModels);
-        let models = supported_models(thread_manager, &config).await;
+        let models =
+            supported_models(thread_manager, &config, include_hidden.unwrap_or(false)).await;
         let total = models.len();
 
         if total == 0 {

--- a/codex-rs/app-server/src/models.rs
+++ b/codex-rs/app-server/src/models.rs
@@ -29,7 +29,7 @@ fn model_from_preset(preset: ModelPreset) -> Model {
         upgrade: preset.upgrade.map(|upgrade| upgrade.id),
         display_name: preset.display_name.to_string(),
         description: preset.description.to_string(),
-        show_in_picker: preset.show_in_picker,
+        hidden: !preset.show_in_picker,
         supported_reasoning_efforts: reasoning_efforts_from_preset(
             preset.supported_reasoning_efforts,
         ),

--- a/codex-rs/app-server/src/models.rs
+++ b/codex-rs/app-server/src/models.rs
@@ -8,11 +8,16 @@ use codex_core::models_manager::manager::RefreshStrategy;
 use codex_protocol::openai_models::ModelPreset;
 use codex_protocol::openai_models::ReasoningEffortPreset;
 
-pub async fn supported_models(thread_manager: Arc<ThreadManager>, config: &Config) -> Vec<Model> {
+pub async fn supported_models(
+    thread_manager: Arc<ThreadManager>,
+    config: &Config,
+    include_hidden: bool,
+) -> Vec<Model> {
     thread_manager
         .list_models(config, RefreshStrategy::OnlineIfUncached)
         .await
         .into_iter()
+        .filter(|preset| include_hidden || preset.show_in_picker)
         .map(model_from_preset)
         .collect()
 }

--- a/codex-rs/app-server/src/models.rs
+++ b/codex-rs/app-server/src/models.rs
@@ -13,7 +13,6 @@ pub async fn supported_models(thread_manager: Arc<ThreadManager>, config: &Confi
         .list_models(config, RefreshStrategy::OnlineIfUncached)
         .await
         .into_iter()
-        .filter(|preset| preset.show_in_picker)
         .map(model_from_preset)
         .collect()
 }
@@ -25,6 +24,7 @@ fn model_from_preset(preset: ModelPreset) -> Model {
         upgrade: preset.upgrade.map(|upgrade| upgrade.id),
         display_name: preset.display_name.to_string(),
         description: preset.description.to_string(),
+        show_in_picker: preset.show_in_picker,
         supported_reasoning_efforts: reasoning_efforts_from_preset(
             preset.supported_reasoning_efforts,
         ),

--- a/codex-rs/app-server/tests/suite/v2/model_list.rs
+++ b/codex-rs/app-server/tests/suite/v2/model_list.rs
@@ -55,7 +55,7 @@ async fn list_models_returns_all_models_with_large_limit() -> Result<()> {
             upgrade: None,
             display_name: "gpt-5.2-codex".to_string(),
             description: "Latest frontier agentic coding model.".to_string(),
-            show_in_picker: true,
+            hidden: false,
             supported_reasoning_efforts: vec![
                 ReasoningEffortOption {
                     reasoning_effort: ReasoningEffort::Low,
@@ -86,7 +86,7 @@ async fn list_models_returns_all_models_with_large_limit() -> Result<()> {
             upgrade: Some("gpt-5.2-codex".to_string()),
             display_name: "gpt-5.1-codex-max".to_string(),
             description: "Codex-optimized flagship for deep and fast reasoning.".to_string(),
-            show_in_picker: true,
+            hidden: false,
             supported_reasoning_efforts: vec![
                 ReasoningEffortOption {
                     reasoning_effort: ReasoningEffort::Low,
@@ -117,7 +117,7 @@ async fn list_models_returns_all_models_with_large_limit() -> Result<()> {
             upgrade: Some("gpt-5.2-codex".to_string()),
             display_name: "gpt-5.1-codex-mini".to_string(),
             description: "Optimized for codex. Cheaper, faster, but less capable.".to_string(),
-            show_in_picker: true,
+            hidden: false,
             supported_reasoning_efforts: vec![
                 ReasoningEffortOption {
                     reasoning_effort: ReasoningEffort::Medium,
@@ -142,7 +142,7 @@ async fn list_models_returns_all_models_with_large_limit() -> Result<()> {
             description:
                 "Latest frontier model with improvements across knowledge, reasoning and coding"
                     .to_string(),
-            show_in_picker: true,
+            hidden: false,
             supported_reasoning_efforts: vec![
                 ReasoningEffortOption {
                     reasoning_effort: ReasoningEffort::Low,
@@ -205,7 +205,7 @@ async fn list_models_includes_hidden_models() -> Result<()> {
         next_cursor,
     } = to_response::<ModelListResponse>(response)?;
 
-    assert!(items.iter().any(|item| !item.show_in_picker));
+    assert!(items.iter().any(|item| item.hidden));
     assert!(next_cursor.is_none());
     Ok(())
 }


### PR DESCRIPTION
### What
to unblock filtering models in VSCE, change `model/list` app-server endpoint to send all models + visibility field `showInPicker` so filtering can be done in VSCE if desired.

### Tests
Updated tests.