### PR TITLE
fix(protocol): make local image test Bazel-friendly

### DIFF
--- a/codex-rs/protocol/src/models.rs
+++ b/codex-rs/protocol/src/models.rs
@@ -1617,10 +1617,14 @@ mod tests {
         let image_url = "data:image/png;base64,abc".to_string();
         let dir = tempdir()?;
         let local_path = dir.path().join("local.png");
-        let png_bytes = include_bytes!(
-            "../../core/src/skills/assets/samples/skill-creator/assets/skill-creator.png"
-        );
-        std::fs::write(&local_path, png_bytes.as_slice())?;
+        // A tiny valid PNG (1x1) so this test doesn't depend on cross-crate file paths, which
+        // break under Bazel sandboxing.
+        const TINY_PNG_BYTES: &[u8] = &[
+            137, 80, 78, 71, 13, 10, 26, 10, 0, 0, 0, 13, 73, 72, 68, 82, 0, 0, 0, 1, 0, 0, 0, 1,
+            8, 6, 0, 0, 0, 31, 21, 196, 137, 0, 0, 0, 11, 73, 68, 65, 84, 120, 156, 99, 96, 0, 2,
+            0, 0, 5, 0, 1, 122, 94, 171, 63, 0, 0, 0, 0, 73, 69, 78, 68, 174, 66, 96, 130,
+        ];
+        std::fs::write(&local_path, TINY_PNG_BYTES)?;
 
         let item = ResponseInputItem::from(vec![
             UserInput::Image {


### PR DESCRIPTION
Fixes Bazel build failure in //codex-rs/protocol:protocol-unit-tests.

The test used include_bytes! to read a PNG from codex-core assets; Cargo can read it,
but Bazel sandboxing can't, so the crate fails to compile.

This change inlines a tiny valid PNG in the test to keep it hermetic.

Related regression: #10590 (cc: @charley-oai)