### PR TITLE
test(app-server): increase flow test timeout to reduce flake

### DIFF
--- a/codex-rs/app-server/tests/suite/codex_message_processor_flow.rs
+++ b/codex-rs/app-server/tests/suite/codex_message_processor_flow.rs
@@ -36,7 +36,7 @@ use std::path::Path;
 use tempfile::TempDir;
 use tokio::time::timeout;
 
-const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+const DEFAULT_READ_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(45);
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn test_codex_jsonrpc_conversation_flow() -> Result<()> {


### PR DESCRIPTION
## Summary
- increase `DEFAULT_READ_TIMEOUT` in `codex_message_processor_flow` from 20s to 45s
- keep test behavior the same while avoiding platform timing flakes

## Why
Windows ARM64 CI showed these tests taking about 24s before `task_complete`, which could fail early and produce wiremock request-count mismatches.

## Testing
- just fmt
- cargo test -p codex-app-server codex_message_processor_flow -- --nocapture