### PR TITLE
fix: use dash-separated HTTP header name for session ID (#11732)

### DIFF
--- a/codex-rs/codex-api/src/requests/headers.rs
+++ b/codex-rs/codex-api/src/requests/headers.rs
@@ -5,7 +5,7 @@ use http::HeaderValue;
 pub fn build_conversation_headers(conversation_id: Option<String>) -> HeaderMap {
     let mut headers = HeaderMap::new();
     if let Some(id) = conversation_id {
-        insert_header(&mut headers, "session_id", &id);
+        insert_header(&mut headers, "session-id", &id);
     }
     headers
 }

--- a/codex-rs/codex-api/tests/clients.rs
+++ b/codex-rs/codex-api/tests/clients.rs
@@ -330,7 +330,7 @@ async fn azure_default_store_attaches_ids_and_headers() -> Result<()> {
     let req = &requests[0];
 
     assert_eq!(
-        req.headers.get("session_id").and_then(|v| v.to_str().ok()),
+        req.headers.get("session-id").and_then(|v| v.to_str().ok()),
         Some("sess_123")
     );
     assert_eq!(

--- a/codex-rs/core/tests/suite/client.rs
+++ b/codex-rs/core/tests/suite/client.rs
@@ -407,7 +407,7 @@ async fn includes_conversation_id_and_model_headers_in_request() {
 
     let request = resp_mock.single_request();
     assert_eq!(request.path(), "/v1/responses");
-    let request_session_id = request.header("session_id").expect("session_id header");
+    let request_session_id = request.header("session-id").expect("session-id header");
     let request_authorization = request
         .header("authorization")
         .expect("authorization header");
@@ -515,7 +515,7 @@ async fn chatgpt_auth_sends_correct_request() {
         .expect("chatgpt-account-id header");
     let request_body = request.body_json();
 
-    let session_id = request.header("session_id").expect("session_id header");
+    let session_id = request.header("session-id").expect("session-id header");
     assert_eq!(session_id, thread_id.to_string());
 
     assert_eq!(request_originator, originator().value);


### PR DESCRIPTION
## Summary

Replace underscore-separated `session_id` HTTP header with dash-separated `session-id` to comply with HTTP best practices.

## Problem

The Codex client sends a `session_id` HTTP header in API requests. Many proxies and gateways (e.g., Envoy, nginx) reject or silently drop headers containing underscores by default, as this aligns with [RFC 7230](https://tools.ietf.org/html/rfc7230) conventions and common production hardening practices.

This causes requests to fail when routed through infrastructure that enforces strict header name validation.

## Fix

- Rename `session_id` → `session-id` in `codex-rs/codex-api/src/requests/headers.rs`
- Update corresponding test assertions in `codex-rs/codex-api/tests/clients.rs` and `codex-rs/core/tests/suite/client.rs`

## Impact

This is a breaking change for any server-side code that reads the `session_id` header by name. The OpenAI backend should be updated to accept `session-id` (or both) before merging.

Fixes #11732