### PR TITLE
Fix prompt wording and correct a tooltip comment grammar issue

### DIFF
--- a/codex-rs/core/gpt-5.1-codex-max_prompt.md
+++ b/codex-rs/core/gpt-5.1-codex-max_prompt.md
@@ -57,7 +57,7 @@ You are producing plain text that will later be styled by the CLI. Follow these 
   * Lead with a quick explanation of the change, and then give more details on the context covering where and why a change was made. Do not start this explanation with "summary", just jump right in.
   * If there are natural next steps the user may want to take, suggest them at the end of your response. Do not make suggestions if there are no natural next steps.
   * When suggesting multiple options, use numeric lists for the suggestions so the user can quickly respond with a single number.
-- The user does not command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
+- The user does not see command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
 
 ### Final answer structure and style guidelines
 

--- a/codex-rs/core/gpt-5.2-codex_prompt.md
+++ b/codex-rs/core/gpt-5.2-codex_prompt.md
@@ -57,7 +57,7 @@ You are producing plain text that will later be styled by the CLI. Follow these 
   * Lead with a quick explanation of the change, and then give more details on the context covering where and why a change was made. Do not start this explanation with "summary", just jump right in.
   * If there are natural next steps the user may want to take, suggest them at the end of your response. Do not make suggestions if there are no natural next steps.
   * When suggesting multiple options, use numeric lists for the suggestions so the user can quickly respond with a single number.
-- The user does not command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
+- The user does not see command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
 
 ### Final answer structure and style guidelines
 

--- a/codex-rs/core/gpt_5_codex_prompt.md
+++ b/codex-rs/core/gpt_5_codex_prompt.md
@@ -45,7 +45,7 @@ You are producing plain text that will later be styled by the CLI. Follow these 
   * Lead with a quick explanation of the change, and then give more details on the context covering where and why a change was made. Do not start this explanation with "summary", just jump right in.
   * If there are natural next steps the user may want to take, suggest them at the end of your response. Do not make suggestions if there are no natural next steps.
   * When suggesting multiple options, use numeric lists for the suggestions so the user can quickly respond with a single number.
-- The user does not command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
+- The user does not see command execution outputs. When asked to show the output of a command (e.g. `git show`), relay the important details in your answer or summarize the key lines so the user understands the result.
 
 ### Final answer structure and style guidelines
 

--- a/codex-rs/core/templates/agents/orchestrator.md
+++ b/codex-rs/core/templates/agents/orchestrator.md
@@ -88,7 +88,7 @@ When the user asks for a review, you default to a code-review mindset. Your resp
 If `spawn_agent` is unavailable or fails, ignore this section and proceed solo.
 
 ## Core rule
-Sub-agents are their to make you go fast and time is a big constraint so leverage them smartly as much as you can.
+Sub-agents are there to make you go fast and time is a big constraint so leverage them smartly as much as you can.
 
 ## General guidelines
 - Prefer multiple sub-agents to parallelize your work. Time is a constraint so parallelism resolve the task faster.

--- a/codex-rs/docs/bazel.md
+++ b/codex-rs/docs/bazel.md
@@ -55,7 +55,7 @@ When you add a new crate or binary:
    test itself uses Seatbelt (the sandbox does as well, and it cannot be nested).
    To limit the blast radius, consider isolating such tests to a separate crate.
 
-If you see build issue and are not sure how to apply the proper customizations, feel free to ping zbarsky or mbolin.
+If you see build issues and are not sure how to apply the proper customizations, feel free to ping zbarsky or mbolin.
 
 ## References
 

--- a/codex-rs/docs/protocol_v1.md
+++ b/codex-rs/docs/protocol_v1.md
@@ -6,7 +6,7 @@ NOTE: The code might not completely match this spec. There are a few minor chang
 
 ## Entities
 
-These are entities exit on the codex backend. The intent of this section is to establish vocabulary and construct a shared mental model for the `Codex` core system.
+These are entities that exist on the codex backend. The intent of this section is to establish vocabulary and construct a shared mental model for the `Codex` core system.
 
 0. `Model`
    - In our case, this is the Responses REST API

--- a/codex-rs/tui/src/custom_terminal.rs
+++ b/codex-rs/tui/src/custom_terminal.rs
@@ -300,7 +300,7 @@ where
     /// [`std::io::Error`] and the terminal will not be updated.
     ///
     /// The [`CompletedFrame`] returned by this method can be useful for debugging or testing
-    /// purposes, but it is often not used in regular applicationss.
+    /// purposes, but it is often not used in regular applications.
     ///
     /// The render callback should fully render the entire frame when called, including areas that
     /// are unchanged from the previous frame. This is because each frame is compared to the

--- a/codex-rs/tui/src/tooltips.rs
+++ b/codex-rs/tui/src/tooltips.rs
@@ -345,7 +345,7 @@ from_date = "2000-01-01"
 # Each [[announcements]] entry is evaluated in order; the last matching one is shown.
 # Dates are UTC, formatted as YYYY-MM-DD. The from_date is inclusive and the to_date is exclusive.
 # version_regex matches against the CLI version (env!("CARGO_PKG_VERSION")); omit to apply to all versions.
-# target_app specify which app should display the announcement (cli, vsce, ...).
+# target_app specifies which app should display the announcement (cli, vsce, ...).
 
 [[announcements]]
 content = "Welcome to Codex! Check out the new onboarding flow."


### PR DESCRIPTION
Fix typos/wording in three prompt instruction files and one tooltip comment:
  - codex-rs/core/gpt-5.1-codex-max_prompt.md
  - codex-rs/core/gpt-5.2-codex_prompt.md
  - codex-rs/core/gpt_5_codex_prompt.md
  - codex-rs/tui/src/tooltips.rs


This is text-only and does not change runtime behavior. No functional/test-impact changes expected.

GitHub Copilot pull request summary:

> This pull request addresses several minor documentation and wording improvements across multiple files. The changes primarily correct typos, clarify language, and improve consistency in documentation and prompt templates.
> 
> Documentation and prompt template improvements:
> 
> * Fixed a typo in the orchestrator agent template by correcting "their" to "there" in the sub-agents guidance.
> * Improved clarity in the Bazel documentation by changing "build issue" to "build issues".
> * Clarified entity description in the protocol documentation by changing "entities exit" to "entities that exist".
> * Corrected a typo in the terminal documentation by changing "applicationss" to "applications".
> * Fixed wording in the tooltips configuration by changing "target_app specify" to "target_app specifies".
> 
> Prompt and instruction consistency:
> 
> * Updated prompt templates (`gpt_5_codex_prompt.md`, `gpt-5.1-codex-max_prompt.md`, and `gpt-5.2-codex_prompt.md`) to clarify that the user does not see command execution outputs, improving instruction consistency. [[1]](diffhunk://#diff-c27e00611dc4aba351da18db73470be6016c46da8cb73e22dfed689207af42e0L48-R48) [[2]](diffhunk://#diff-2dddb416edf414d45ab49be3900cda7ece57977f705b105ed95f66216a8f4ef2L60-R60)