### PR TITLE
codex-api: allow provider-specific request body overrides via extra_body_params (deep-merged for HTTP Responses)

### DIFF
--- a/codex-rs/codex-api/src/endpoint/memories.rs
+++ b/codex-rs/codex-api/src/endpoint/memories.rs
@@ -152,6 +152,7 @@ mod tests {
                 retry_transport: true,
             },
             stream_idle_timeout: Duration::from_secs(1),
+            extra_body_params: None,
         }
     }
 

--- a/codex-rs/codex-api/src/endpoint/models.rs
+++ b/codex-rs/codex-api/src/endpoint/models.rs
@@ -145,6 +145,7 @@ mod tests {
                 retry_transport: true,
             },
             stream_idle_timeout: Duration::from_secs(1),
+            extra_body_params: None,
         }
     }
 

--- a/codex-rs/codex-api/src/endpoint/responses.rs
+++ b/codex-rs/codex-api/src/endpoint/responses.rs
@@ -1,6 +1,7 @@
 use crate::auth::AuthProvider;
 use crate::common::ResponseStream;
 use crate::common::ResponsesApiRequest;
+use crate::common::deep_merge_json;
 use crate::endpoint::session::EndpointSession;
 use crate::error::ApiError;
 use crate::provider::Provider;
@@ -72,6 +73,9 @@ impl<T: HttpTransport, A: AuthProvider> ResponsesClient<T, A> {
             .map_err(|e| ApiError::Stream(format!("failed to encode responses request: {e}")))?;
         if request.store && self.session.provider().is_azure_responses_endpoint() {
             attach_item_ids(&mut body, &request.input);
+        }
+        if let Some(extra) = &request.extra_body_params {
+            deep_merge_json(&mut body, extra);
         }
 
         let mut headers = extra_headers;

--- a/codex-rs/codex-api/src/provider.rs
+++ b/codex-rs/codex-api/src/provider.rs
@@ -47,6 +47,7 @@ pub struct Provider {
     pub headers: HeaderMap,
     pub retry: RetryConfig,
     pub stream_idle_timeout: Duration,
+    pub extra_body_params: Option<HashMap<String, serde_json::Value>>,
 }
 
 impl Provider {

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -469,6 +469,11 @@
           "description": "Value to use with `Authorization: Bearer <token>` header. Use of this config is discouraged in favor of `env_key` for security reasons, but this may be necessary when using this programmatically.",
           "type": "string"
         },
+        "extra_body_params": {
+          "additionalProperties": true,
+          "description": "Optional JSON object to merge into request body for provider-specific parameters.",
+          "type": "object"
+        },
         "http_headers": {
           "additionalProperties": {
             "type": "string"

--- a/codex-rs/core/src/client.rs
+++ b/codex-rs/core/src/client.rs
@@ -512,6 +512,7 @@ impl ModelClientSession {
             include,
             prompt_cache_key,
             text,
+            extra_body_params: provider.extra_body_params.clone(),
         };
         Ok(request)
     }

--- a/codex-rs/core/src/client_common.rs
+++ b/codex-rs/core/src/client_common.rs
@@ -264,6 +264,7 @@ mod tests {
                 verbosity: Some(OpenAiVerbosity::Low),
                 format: None,
             }),
+            extra_body_params: None,
         };
 
         let v = serde_json::to_value(&req).expect("json");
@@ -302,6 +303,7 @@ mod tests {
             include: vec![],
             prompt_cache_key: None,
             text: Some(text_controls),
+            extra_body_params: None,
         };
 
         let v = serde_json::to_value(&req).expect("json");
@@ -338,6 +340,7 @@ mod tests {
             include: vec![],
             prompt_cache_key: None,
             text: None,
+            extra_body_params: None,
         };
 
         let v = serde_json::to_value(&req).expect("json");

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -3965,6 +3965,7 @@ model_verbosity = "high"
             query_params: None,
             http_headers: None,
             env_http_headers: None,
+            extra_body_params: None,
             request_max_retries: Some(4),
             stream_max_retries: Some(10),
             stream_idle_timeout_ms: Some(300_000),

--- a/codex-rs/core/src/models_manager/manager.rs
+++ b/codex-rs/core/src/models_manager/manager.rs
@@ -464,6 +464,7 @@ mod tests {
             query_params: None,
             http_headers: None,
             env_http_headers: None,
+            extra_body_params: None,
             request_max_retries: Some(0),
             stream_max_retries: Some(0),
             stream_idle_timeout_ms: Some(5_000),


### PR DESCRIPTION
This change adds support for injecting provider-specific JSON fields into the outgoing request body via a new `extra_body_params` config option. This is useful for providers like OpenRouter (and other OpenAI-compatible gateways) that accept additional top-level or nested request parameters not modeled in Codex’s typed request structs.

#### What changed

* **New config field:** `extra_body_params` added to `ModelProviderInfo` (and propagated into `Provider`) and exposed in `config.schema.json` as an optional JSON object.
* **Request plumbing:** `ResponsesApiRequest` now includes `extra_body_params`, populated from the selected provider in `ModelClientSession`.
* **HTTP Responses endpoint:** merges `extra_body_params` into the serialized request body using a **deep merge** strategy:

  * Nested objects are merged recursively.
  * Non-object values overwrite existing keys.
* **WebSocket Responses:** merges `extra_body_params` into the encoded request payload (top-level insertion). (Note: this is currently a shallow merge approach for WS payloads.)
* **Tests/config updates:** updated endpoint test provider stubs to include `extra_body_params: None`, and added a new TOML deserialization test covering nested objects.

#### Example usage

```toml
[model_providers.openrouter]
name = "OpenRouter"
base_url = "https://openrouter.ai/api/v1"
env_key = "OPENROUTER_API_KEY"
extra_body_params = { provider = { sort = "throughput" }, max_tokens = 4096 }
```

#### Why

Codex’s request model can’t anticipate all provider-specific knobs. `extra_body_params` provides a safe escape hatch to pass through custom fields while keeping the default request shape intact.

#### Notes

* Deep merge is applied for **HTTP Responses** requests.
* WebSocket path currently inserts top-level keys (no recursive merge yet).
