### PR TITLE
Fixed screen reader regression in CLI

### DIFF
--- a/codex-rs/tui/src/status_indicator_widget.rs
+++ b/codex-rs/tui/src/status_indicator_widget.rs
@@ -218,9 +218,11 @@ impl Renderable for StatusIndicatorWidget {
             return;
         }
 
-        // Schedule next animation frame.
-        self.frame_requester
-            .schedule_frame_in(Duration::from_millis(32));
+        if self.animations_enabled {
+            // Schedule next animation frame.
+            self.frame_requester
+                .schedule_frame_in(Duration::from_millis(32));
+        }
         let now = Instant::now();
         let elapsed_duration = self.elapsed_duration_at(now);
         let pretty_elapsed = fmt_elapsed_compact(elapsed_duration.as_secs());


### PR DESCRIPTION
The `tui.animations` switch should gate all animations in the TUI, but a recent change introduced a regression that didn't include the gate. This makes it difficult to use the TUI with a screen reader.

This fix addresses #11856
