### PR TITLE
fix(core): execpolicy matching for redirected shell scripts

### DIFF
--- a/codex-rs/shell-command/src/bash.rs
+++ b/codex-rs/shell-command/src/bash.rs
@@ -253,9 +253,8 @@ fn parse_plain_command_from_node(
                 }
                 words.push(concatenated);
             }
-            kind
-                if allow_command_attachments
-                    && matches!(kind, "file_redirect" | "variable_assignment" | "comment") => {}
+            kind if allow_command_attachments
+                && matches!(kind, "file_redirect" | "variable_assignment" | "comment") => {}
             _ => return None,
         }
     }


### PR DESCRIPTION
## Summary
Fix execpolicy matching when a wrapped shell script contains redirection (for example `> /tmp/log` or `2>&1`).

Fixes #10321.

Before this change, commands like `gh run view ... > /tmp/log` or `xcodebuild ... 2>&1` could repeatedly prompt for approval even after selecting "Yes, and don't ask again".

## Problem
Approval persistence relies on extracting inner command prefixes from wrapper invocations such as `zsh -lc "..."`.

For redirected scripts, `core/src/exec_policy.rs` called `parse_shell_lc_plain_commands`, which rejects redirections by design. That forced fallback to the outer wrapper argv (`zsh -lc ...`), so saved prefix rules such as `["gh", "run", "view"]` did not match future runs.

## Root Cause
- `commands_for_exec_policy` used a parser that only accepts "plain" word-only commands.
- Redirected shell scripts were treated as unparseable and matched against wrapper argv instead of the actual inner command.
- Result: approval rules appeared to be "not remembered" for many real commands that include redirection.

## Fix
1. Add execpolicy-focused shell parsing path in `shell-command/src/bash.rs`:
   - `parse_shell_lc_commands_for_exec_policy` accepts redirected statements and command attachments needed for matching (`file_redirect`, `variable_assignment`, comments).
   - It remains fail-closed for unsupported/unsafe constructs (substitutions/control-flow still reject).
2. Switch `core/src/exec_policy.rs` to use `parse_shell_lc_commands_for_exec_policy` in `commands_for_exec_policy`.
3. Add focused regression coverage in core + integration tests.

## Why This Is Safe
- The change only affects command extraction for execpolicy matching.
- If script structure is unsupported/ambiguous, behavior still falls back conservatively to existing prompt path.
- No broadening of execution permission outside existing prefix-rule semantics.

## Reproduction (Before vs After)
### Representative command
`/bin/zsh -lc "gh run view --help > /tmp/codex-gh-run-view-help.log && echo saved"`

### Before
- Select "Yes, and don't ask again for commands that start with `gh run view`".
- Same command shape triggers approval again because parser falls back to wrapper argv.

### After
- Same saved rule matches inner command extraction.
- No repeated approval prompt for the same command family.

## Tests Added
- `core/src/exec_policy.rs`
  - `evaluates_redirected_shell_script_against_prefix_rules`
  - `commands_for_exec_policy_parses_redirected_sequences`
- `shell-command/src/bash.rs`
  - `parse_shell_lc_commands_for_exec_policy_supports_redirects`
  - `parse_shell_lc_commands_for_exec_policy_rejects_substitutions`
- `core/tests/suite/approvals.rs`
  - `gh_run_view_prefix_rule_allows_redirected_command_without_prompt`

## Verification Performed
### Local bug reproduction
- Reproduced in this environment using redirected wrapped command + saved prefix rule.
- Verified fail-before/pass-after by temporarily restoring old parser call in `core/src/exec_policy.rs`:
  - without fix: integration test requests approval unexpectedly,
  - with fix restored: integration test passes.

### Local checks run
- `cargo test -p codex-core redirected -- --nocapture`
- `cargo test -p codex-core gh_run_view_prefix_rule_allows_redirected_command_without_prompt -- --nocapture`
- `just fix -p codex-core`

All passed.

## Related Reports
- Same root-cause pattern (redirection + repeated approvals): #10321
  - Issue example includes `xcodebuild ... 2>&1` and repeated approval despite prior allow.
- Potentially related but likely different root causes were also reviewed (for example env-var-prefix parsing reports such as #11298).

## Existing PRs Checked
- No open PR found that fixes this redirection-specific wrapper matching gap.
- Related prior work:
  - #10941 (wrapper canonicalization + heredoc prefix support)
  - #9565 (multiline quoted args parsing)

This PR complements those by covering non-heredoc redirection command extraction.
