### PR TITLE
fix(tui) remove config check for trusted setting

### DIFF
--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -219,10 +219,6 @@ pub struct Config {
     /// using backend-specific headers or URLs to enforce this.
     pub enforce_residency: Constrained<Option<ResidencyRequirement>>,
 
-    /// True if the user passed in an override or set a value in config.toml
-    /// for either of approval_policy or sandbox_mode.
-    pub did_user_set_custom_approval_policy_or_sandbox_mode: bool,
-
     /// When `true`, `AgentReasoning` events emitted by the backend will be
     /// suppressed from the frontend output. This can reduce visual noise when
     /// users are only interested in the final agent responses.
@@ -1789,9 +1785,6 @@ impl Config {
         let active_project = cfg
             .get_active_project(&resolved_cwd)
             .unwrap_or(ProjectConfig { trust_level: None });
-        let sandbox_mode_was_explicit = sandbox_mode.is_some()
-            || config_profile.sandbox_mode.is_some()
-            || cfg.sandbox_mode.is_some();
 
         let windows_sandbox_level = match windows_sandbox_mode {
             Some(WindowsSandboxModeToml::Elevated) => WindowsSandboxLevel::Elevated,
@@ -1821,9 +1814,6 @@ impl Config {
                 }
             }
         }
-        let approval_policy_was_explicit = approval_policy_override.is_some()
-            || config_profile.approval_policy.is_some()
-            || cfg.approval_policy.is_some();
         let mut approval_policy = approval_policy_override
             .or(config_profile.approval_policy)
             .or(cfg.approval_policy)
@@ -1836,9 +1826,7 @@ impl Config {
                     AskForApproval::default()
                 }
             });
-        if !approval_policy_was_explicit
-            && let Err(err) = constrained_approval_policy.can_set(&approval_policy)
-        {
+        if let Err(err) = constrained_approval_policy.can_set(&approval_policy) {
             tracing::warn!(
                 error = %err,
                 "default approval policy is disallowed by requirements; falling back to required default"
@@ -1847,10 +1835,6 @@ impl Config {
         }
         let web_search_mode = resolve_web_search_mode(&cfg, &config_profile, &features)
             .unwrap_or(WebSearchMode::Cached);
-        // TODO(dylan): We should be able to leverage ConfigLayerStack so that
-        // we can reliably check this at every config level.
-        let did_user_set_custom_approval_policy_or_sandbox_mode =
-            approval_policy_was_explicit || sandbox_mode_was_explicit;
 
         let mut model_providers = built_in_model_providers();
         // Merge user-defined providers into the built-in list.
@@ -2155,7 +2139,6 @@ impl Config {
                 macos_seatbelt_profile_extensions: None,
             },
             enforce_residency: enforce_residency.value,
-            did_user_set_custom_approval_policy_or_sandbox_mode,
             notify: cfg.notify,
             user_instructions,
             base_instructions,
@@ -3489,7 +3472,6 @@ profile = "project"
             config.permissions.sandbox_policy.get(),
             &SandboxPolicy::DangerFullAccess
         ));
-        assert!(config.did_user_set_custom_approval_policy_or_sandbox_mode);
 
         Ok(())
     }
@@ -5195,7 +5177,6 @@ model_verbosity = "high"
                     macos_seatbelt_profile_extensions: None,
                 },
                 enforce_residency: Constrained::allow_any(None),
-                did_user_set_custom_approval_policy_or_sandbox_mode: true,
                 user_instructions: None,
                 notify: None,
                 cwd: fixture.cwd(),
@@ -5325,7 +5306,6 @@ model_verbosity = "high"
                 macos_seatbelt_profile_extensions: None,
             },
             enforce_residency: Constrained::allow_any(None),
-            did_user_set_custom_approval_policy_or_sandbox_mode: true,
             user_instructions: None,
             notify: None,
             cwd: fixture.cwd(),
@@ -5453,7 +5433,6 @@ model_verbosity = "high"
                 macos_seatbelt_profile_extensions: None,
             },
             enforce_residency: Constrained::allow_any(None),
-            did_user_set_custom_approval_policy_or_sandbox_mode: true,
             user_instructions: None,
             notify: None,
             cwd: fixture.cwd(),
@@ -5567,7 +5546,6 @@ model_verbosity = "high"
                 macos_seatbelt_profile_extensions: None,
             },
             enforce_residency: Constrained::allow_any(None),
-            did_user_set_custom_approval_policy_or_sandbox_mode: true,
             user_instructions: None,
             notify: None,
             cwd: fixture.cwd(),
@@ -5645,24 +5623,6 @@ model_verbosity = "high"
         };
 
         assert_eq!(expected_gpt5_profile_config, gpt5_profile_config);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_did_user_set_custom_approval_policy_or_sandbox_mode_defaults_no() -> anyhow::Result<()>
-    {
-        let fixture = create_test_fixture()?;
-
-        let config = Config::load_from_base_config_with_overrides(
-            fixture.cfg.clone(),
-            ConfigOverrides {
-                ..Default::default()
-            },
-            fixture.codex_home(),
-        )?;
-
-        assert!(config.did_user_set_custom_approval_policy_or_sandbox_mode);
 
         Ok(())
     }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -1148,15 +1148,8 @@ async fn load_config_or_exit_with_fallback_cwd(
     }
 }
 
-/// Determine if user has configured a sandbox / approval policy,
-/// or if the current cwd project is already trusted. If not, we need to
-/// show the trust screen.
+/// Determine if the user has decided whether to trust the current directory.
 fn should_show_trust_screen(config: &Config) -> bool {
-    if config.did_user_set_custom_approval_policy_or_sandbox_mode {
-        // Respect explicit approval/sandbox overrides made by the user.
-        return false;
-    }
-    // otherwise, show only if no trust decision has been made
     config.active_project.trust_level.is_none()
 }
 
@@ -1212,7 +1205,6 @@ mod tests {
     async fn windows_shows_trust_prompt_without_sandbox() -> std::io::Result<()> {
         let temp_dir = TempDir::new()?;
         let mut config = build_config(&temp_dir).await?;
-        config.did_user_set_custom_approval_policy_or_sandbox_mode = false;
         config.active_project = ProjectConfig { trust_level: None };
         config.set_windows_sandbox_enabled(false);
 
@@ -1228,7 +1220,6 @@ mod tests {
     async fn windows_shows_trust_prompt_with_sandbox() -> std::io::Result<()> {
         let temp_dir = TempDir::new()?;
         let mut config = build_config(&temp_dir).await?;
-        config.did_user_set_custom_approval_policy_or_sandbox_mode = false;
         config.active_project = ProjectConfig { trust_level: None };
         config.set_windows_sandbox_enabled(true);
 
@@ -1251,7 +1242,6 @@ mod tests {
         use codex_protocol::config_types::TrustLevel;
         let temp_dir = TempDir::new()?;
         let mut config = build_config(&temp_dir).await?;
-        config.did_user_set_custom_approval_policy_or_sandbox_mode = false;
         config.active_project = ProjectConfig {
             trust_level: Some(TrustLevel::Untrusted),
         };


### PR DESCRIPTION
## Summary
Simplify the trusted directory flow. This logic was originally designed several months ago, to determine if codex should start in read-only or workspace-write mode. However, that's no longer the purpose of directory trust - and therefore we should get rid of this logic.

## Testing
- [x] Unit tests pass