### PR TITLE
chore(tui): reduce noisy key logging

### DIFF
--- a/codex-rs/tui/Cargo.toml
+++ b/codex-rs/tui/Cargo.toml
@@ -15,8 +15,6 @@ path = "src/lib.rs"
 [features]
 # Enable vt100-based tests (emulator) when running with `--features vt100-tests`.
 vt100-tests = []
-# Gate verbose debug logging inside the TUI implementation.
-debug-logs = []
 
 [lints]
 workspace = true

--- a/codex-rs/tui/src/bottom_pane/textarea.rs
+++ b/codex-rs/tui/src/bottom_pane/textarea.rs
@@ -487,8 +487,8 @@ impl TextArea {
                 self.move_cursor_to_end_of_line(true);
             }
             _o => {
-                #[cfg(feature = "debug-logs")]
-                tracing::debug!("Unhandled key event in TextArea: {:?}", _o);
+                #[cfg(debug_assertions)]
+                tracing::trace!("Unhandled key event in TextArea: {:?}", _o);
             }
         }
     }


### PR DESCRIPTION
### Why
`codex-tui` was logging unhandled key events in a way that was too noisy for normal debugging workflows, making it harder to focus on meaningful diagnostics.

### What changed
- Removed the now-unneeded `debug-logs` feature from `codex-rs/tui/Cargo.toml`.
- Changed the unhandled key event log in `codex-rs/tui/src/bottom_pane/textarea.rs` to:
  - use `tracing::trace!("Unhandled key event in TextArea: {:?}", _o)`
  - be gated by `#[cfg(debug_assertions)]`
- Kept the logging signal available for deep local debugging while significantly reducing default noise.

### Verification
- Confirmed no `debug-logs` references remain in `codex-rs/tui`.
