### PR TITLE
bazel: fix snapshot parity for tests/*.rs rust_test targets

### DIFF
--- a/codex-rs/core/tests/common/lib.rs
+++ b/codex-rs/core/tests/common/lib.rs
@@ -26,6 +26,26 @@ fn enable_deterministic_unified_exec_process_ids_for_tests() {
     codex_core::test_support::set_deterministic_process_ids(true);
 }
 
+#[ctor]
+fn configure_insta_workspace_root_for_snapshot_tests() {
+    if std::env::var_os("INSTA_WORKSPACE_ROOT").is_some() {
+        return;
+    }
+
+    let workspace_root = codex_utils_cargo_bin::repo_root()
+        .ok()
+        .map(|root| root.join("codex-rs"));
+
+    if let Some(workspace_root) = workspace_root
+        && let Ok(workspace_root) = workspace_root.canonicalize()
+    {
+        // Safety: this ctor runs at process startup before test threads begin.
+        unsafe {
+            std::env::set_var("INSTA_WORKSPACE_ROOT", workspace_root);
+        }
+    }
+}
+
 #[track_caller]
 pub fn assert_regex_match<'s>(pattern: &str, actual: &'s str) -> regex_lite::Captures<'s> {
     let regex = Regex::new(pattern).unwrap_or_else(|err| {


### PR DESCRIPTION
## Summary
- make `rust_test` targets generated from `tests/*.rs` use Cargo-style crate names (file stem) so snapshot names match Cargo (`all__...` instead of Bazel-derived names)
- split lib vs `tests/*.rs` test env wiring in `codex_rust_crate` to keep existing lib snapshot behavior while applying Bazel runfiles-compatible workspace root for `tests/*.rs`
- compute the `tests/*.rs` snapshot workspace root from package depth so `insta` resolves committed snapshots under Bazel `--noenable_runfiles`

## Validation
- `bazelisk test //codex-rs/core:core-all-test --test_arg=suite::compact:: --cache_test_results=no`
- `bazelisk test //codex-rs/core:core-all-test --test_arg=suite::compact_remote:: --cache_test_results=no`

