### PR TITLE
chore: rename collab feature flag key to multi_agent

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -233,6 +233,9 @@
             "memory_tool": {
               "type": "boolean"
             },
+            "multi_agent": {
+              "type": "boolean"
+            },
             "personality": {
               "type": "boolean"
             },
@@ -1361,6 +1364,9 @@
           "type": "boolean"
         },
         "memory_tool": {
+          "type": "boolean"
+        },
+        "multi_agent": {
           "type": "boolean"
         },
         "personality": {

--- a/codex-rs/core/src/features.rs
+++ b/codex-rs/core/src/features.rs
@@ -552,7 +552,7 @@ pub const FEATURES: &[FeatureSpec] = &[
     },
     FeatureSpec {
         id: Feature::Collab,
-        key: "collab",
+        key: "multi_agent",
         stage: Stage::Experimental {
             name: "Sub-agents",
             menu_description: "Ask Codex to spawn multiple agents to parallelize the work and win in efficiency.",
@@ -737,5 +737,11 @@ mod tests {
             Stage::UnderDevelopment
         );
         assert_eq!(Feature::UseLinuxSandboxBwrap.default_enabled(), false);
+    }
+
+    #[test]
+    fn collab_is_legacy_alias_for_multi_agent() {
+        assert_eq!(feature_for_key("multi_agent"), Some(Feature::Collab));
+        assert_eq!(feature_for_key("collab"), Some(Feature::Collab));
     }
 }

--- a/codex-rs/core/src/features/legacy.rs
+++ b/codex-rs/core/src/features/legacy.rs
@@ -33,6 +33,10 @@ const ALIASES: &[Alias] = &[
         legacy_key: "web_search",
         feature: Feature::WebSearchRequest,
     },
+    Alias {
+        legacy_key: "collab",
+        feature: Feature::Collab,
+    },
 ];
 
 pub(crate) fn legacy_feature_keys() -> impl Iterator<Item = &'static str> {


### PR DESCRIPTION
Summary
- rename the collab feature key to multi_agent while keeping the Feature enum unchanged
- add legacy alias support so both "multi_agent" and "collab" map to the same feature
- cover the alias behavior with a new unit test