### PR TITLE
cloud-tasks: fall back to collect_git_info for branch detection

### DIFF
--- a/codex-rs/cloud-tasks/src/lib.rs
+++ b/codex-rs/cloud-tasks/src/lib.rs
@@ -123,7 +123,13 @@ impl GitInfoProvider for RealGitInfo {
     }
 
     async fn current_branch_name(&self, path: &std::path::Path) -> Option<String> {
-        codex_core::git_info::current_branch_name(path).await
+        if let Some(branch) = codex_core::git_info::current_branch_name(path).await {
+            Some(branch)
+        } else {
+            codex_core::git_info::collect_git_info(path)
+                .await
+                .and_then(|git_info| git_info.branch)
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #9111

## What changed
- In codex-rs/cloud-tasks/src/lib.rs, RealGitInfo::current_branch_name now falls back to codex_core::git_info::collect_git_info(path) when branch lookup via current_branch_name returns None.

## Why
- Prevents defaulting to main when current-branch detection fails in repositories that use another default branch (e.g. master).