### PR TITLE
fix(tui): restore Read Only mode in /approvals on non-Windows

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3319,7 +3319,7 @@ impl ChatWidget {
                 self.app_event_tx.send(AppEvent::OpenAgentPicker);
             }
             SlashCommand::Approvals => {
-                self.open_permissions_popup();
+                self.open_approvals_popup();
             }
             SlashCommand::Permissions => {
                 self.open_permissions_popup();
@@ -5325,14 +5325,18 @@ impl ChatWidget {
         );
     }
 
-    /// Open the permissions popup (alias for /permissions).
+    /// Open a popup to choose the approvals mode (ask for approval policy + sandbox policy).
     pub(crate) fn open_approvals_popup(&mut self) {
-        self.open_permissions_popup();
+        self.open_approval_mode_popup(true);
     }
 
     /// Open a popup to choose the permissions mode (approval policy + sandbox policy).
     pub(crate) fn open_permissions_popup(&mut self) {
         let include_read_only = cfg!(target_os = "windows");
+        self.open_approval_mode_popup(include_read_only);
+    }
+
+    fn open_approval_mode_popup(&mut self, include_read_only: bool) {
         let current_approval = self.config.permissions.approval_policy.value();
         let current_sandbox = self.config.permissions.sandbox_policy.get();
         let mut items: Vec<SelectionItem> = Vec::new();

--- a/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approvals_selection_popup.snap
+++ b/codex-rs/tui/src/chatwidget/snapshots/codex_tui__chatwidget__tests__approvals_selection_popup.snap
@@ -1,15 +1,18 @@
 ---
 source: tui/src/chatwidget/tests.rs
-assertion_line: 3092
+assertion_line: 4990
 expression: popup
 ---
   Update Model Permissions
 
-› 1. Default      Codex can read and edit files in the current workspace, and
-                  run commands. Approval is required to access the internet or
-                  edit other files.
-  2. Full Access  Codex can edit files outside this workspace and access the
-                  internet without asking for approval. Exercise caution when
-                  using.
+› 1. Read Only (current)  Codex can read files in the current workspace.
+                          Approval is required to edit files or access the
+                          internet.
+  2. Default              Codex can read and edit files in the current
+                          workspace, and run commands. Approval is required to
+                          access the internet or edit other files.
+  3. Full Access          Codex can edit files outside this workspace and
+                          access the internet without asking for approval.
+                          Exercise caution when using.
 
   Press enter to confirm or esc to go back


### PR DESCRIPTION
## Summary
Restore `/approvals` to show `Read Only`, `Default`, and `Full Access` on non-Windows by routing `/approvals` through the dedicated approvals popup, while keeping `/permissions` behavior unchanged.

## Testing
- cargo test -p codex-tui

Fixes #11915