### PR TITLE
fix: js_repl reset hang by clearing exec tool calls without waiting

### DIFF
--- a/codex-rs/core/src/tools/js_repl/mod.rs
+++ b/codex-rs/core/src/tools/js_repl/mod.rs
@@ -327,9 +327,7 @@ impl JsReplManager {
         exec_id: &str,
     ) -> Option<CancellationToken> {
         let mut calls = exec_tool_calls.lock().await;
-        let Some(state) = calls.get_mut(exec_id) else {
-            return None;
-        };
+        let state = calls.get_mut(exec_id)?;
         state.in_flight += 1;
         Some(state.cancel.clone())
     }


### PR DESCRIPTION
Remove the waiting loop in `reset` so it no longer blocks on potentially hanging exec tool calls + add `clear_all_exec_tool_calls_map` to drain the map and notify waiters so `reset` completes immediately