### PR TITLE
Protect workspace .agents directory in Windows sandbox

### DIFF
--- a/codex-rs/windows-sandbox-rs/src/lib.rs
+++ b/codex-rs/windows-sandbox-rs/src/lib.rs
@@ -127,6 +127,8 @@ pub use winutil::to_wide;
 #[cfg(target_os = "windows")]
 pub use workspace_acl::is_command_cwd_root;
 #[cfg(target_os = "windows")]
+pub use workspace_acl::protect_workspace_agents_dir;
+#[cfg(target_os = "windows")]
 pub use workspace_acl::protect_workspace_codex_dir;
 
 #[cfg(not(target_os = "windows"))]
@@ -165,6 +167,7 @@ mod windows_impl {
     use super::winutil::quote_windows_arg;
     use super::winutil::to_wide;
     use super::workspace_acl::is_command_cwd_root;
+    use super::workspace_acl::protect_workspace_agents_dir;
     use super::workspace_acl::protect_workspace_codex_dir;
     use anyhow::Result;
     use std::collections::HashMap;
@@ -344,6 +347,7 @@ mod windows_impl {
             if let Some(psid) = psid_workspace {
                 allow_null_device(psid);
                 let _ = protect_workspace_codex_dir(&current_dir, psid);
+                let _ = protect_workspace_agents_dir(&current_dir, psid);
             }
         }
 
@@ -552,6 +556,7 @@ mod windows_impl {
             allow_null_device(psid_generic);
             allow_null_device(psid_workspace);
             let _ = protect_workspace_codex_dir(&current_dir, psid_workspace);
+            let _ = protect_workspace_agents_dir(&current_dir, psid_workspace);
         }
 
         Ok(())

--- a/codex-rs/windows-sandbox-rs/src/workspace_acl.rs
+++ b/codex-rs/windows-sandbox-rs/src/workspace_acl.rs
@@ -11,9 +11,19 @@ pub fn is_command_cwd_root(root: &Path, canonical_command_cwd: &Path) -> bool {
 /// # Safety
 /// Caller must ensure `psid` is a valid SID pointer.
 pub unsafe fn protect_workspace_codex_dir(cwd: &Path, psid: *mut c_void) -> Result<bool> {
-    let cwd_codex = cwd.join(".codex");
-    if cwd_codex.is_dir() {
-        add_deny_write_ace(&cwd_codex, psid)
+    protect_workspace_subdir(cwd, psid, ".codex")
+}
+
+/// # Safety
+/// Caller must ensure `psid` is a valid SID pointer.
+pub unsafe fn protect_workspace_agents_dir(cwd: &Path, psid: *mut c_void) -> Result<bool> {
+    protect_workspace_subdir(cwd, psid, ".agents")
+}
+
+unsafe fn protect_workspace_subdir(cwd: &Path, psid: *mut c_void, subdir: &str) -> Result<bool> {
+    let path = cwd.join(subdir);
+    if path.is_dir() {
+        add_deny_write_ace(&path, psid)
     } else {
         Ok(false)
     }


### PR DESCRIPTION
The Mac and Linux implementations of the sandbox recently added write protections for `.codex` and `.agents` subdirectories in all writable roots. When adding documentation for this, I noticed that this change was never made for the Windows sandbox.

Summary
- make compute_allow_paths treat .codex/.agents as protected alongside .git, and cover their behavior in new tests
- wire protect_workspace_agents_dir through the sandbox lib and setup path to apply deny ACEs when `.agents` exists
- factor shared ACL logic for workspace subdirectories
