### PR TITLE
Hide /debug slash commands from popup menu

### DIFF
--- a/codex-rs/tui/src/bottom_pane/slash_commands.rs
+++ b/codex-rs/tui/src/bottom_pane/slash_commands.rs
@@ -63,3 +63,15 @@ pub(crate) fn has_builtin_prefix(
     .into_iter()
     .any(|(command_name, _)| fuzzy_match(command_name, name).is_some())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn debug_command_still_resolves_for_dispatch() {
+        let cmd = find_builtin_command("debug-config", true, true, true, false);
+        assert_eq!(cmd, Some(SlashCommand::DebugConfig));
+    }
+}


### PR DESCRIPTION
Summary
- filter command popup builtins to remove any `/debug*` entries so they stay usable but are not listed
- added regression tests to ensure the popup hides debug commands while dispatch still resolves them