### PR TITLE
feat(a2a): enhance A2A server with SACP session management and token usage tracking

### DIFF
--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -13,6 +13,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "a2a-rs"
+version = "0.0.0"
+dependencies = [
+ "axum",
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "uuid",
+]
+
+[[package]]
 name = "actix-codec"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2010,13 +2023,18 @@ dependencies = [
 name = "codex-mcp-server"
 version = "0.0.0"
 dependencies = [
+ "a2a-rs",
  "anyhow",
+ "axum",
+ "bytes",
+ "clap",
  "codex-arg0",
  "codex-core",
  "codex-protocol",
  "codex-utils-cli",
  "codex-utils-json-to-toml",
  "core_test_support",
+ "http 1.4.0",
  "mcp_test_support",
  "os_info",
  "pretty_assertions",
@@ -2027,8 +2045,10 @@ dependencies = [
  "shlex",
  "tempfile",
  "tokio",
+ "tokio-stream",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "wiremock",
 ]
 

--- a/codex-rs/Cargo.lock
+++ b/codex-rs/Cargo.lock
@@ -17,10 +17,12 @@ name = "a2a-rs"
 version = "0.0.0"
 dependencies = [
  "axum",
+ "futures",
  "http 1.4.0",
  "serde",
  "serde_json",
  "tokio",
+ "tokio-stream",
  "tracing",
  "uuid",
 ]
@@ -2046,6 +2048,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tracing",
  "tracing-subscriber",
  "uuid",

--- a/codex-rs/Cargo.toml
+++ b/codex-rs/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
+    "a2a",
     "backend-client",
     "ansi-escape",
     "async-utils",
@@ -76,6 +77,7 @@ license = "Apache-2.0"
 
 [workspace.dependencies]
 # Internal
+a2a-rs = { path = "a2a" }
 app_test_support = { path = "app-server/tests/common" }
 codex-ansi-escape = { path = "ansi-escape" }
 codex-api = { path = "codex-api" }

--- a/codex-rs/a2a/Cargo.toml
+++ b/codex-rs/a2a/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "a2a-rs"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "A2A (Agent-to-Agent) RC v1 protocol types and server — built from the official specification."
+
+[lib]
+name = "a2a_rs"
+path = "src/lib.rs"
+
+[lints]
+workspace = true
+
+[dependencies]
+axum = { workspace = true, features = ["json", "tokio", "http1"] }
+http = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["sync", "net"] }
+tracing = { workspace = true, features = ["log"] }
+uuid = { workspace = true, features = ["v4"] }

--- a/codex-rs/a2a/Cargo.toml
+++ b/codex-rs/a2a/Cargo.toml
@@ -14,9 +14,11 @@ workspace = true
 
 [dependencies]
 axum = { workspace = true, features = ["json", "tokio", "http1"] }
+futures = { workspace = true }
 http = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 tokio = { workspace = true, features = ["sync", "net"] }
+tokio-stream = { workspace = true, features = ["sync"] }
 tracing = { workspace = true, features = ["log"] }
 uuid = { workspace = true, features = ["v4"] }

--- a/codex-rs/a2a/src/error.rs
+++ b/codex-rs/a2a/src/error.rs
@@ -1,0 +1,107 @@
+//! A2A protocol error type with JSON-RPC error codes.
+//!
+//! Mirrors `a2a-js/src/server/error.ts`.
+
+use axum::response::IntoResponse;
+use serde::Serialize;
+
+/// JSON-RPC error object.
+#[derive(Debug, Clone, Serialize)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+}
+
+/// A2A error with JSON-RPC error codes.
+#[derive(Debug)]
+pub struct A2AError {
+    pub code: i32,
+    pub message: String,
+    pub data: Option<serde_json::Value>,
+    pub task_id: Option<String>,
+}
+
+impl A2AError {
+    pub fn new(code: i32, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+            data: None,
+            task_id: None,
+        }
+    }
+
+    /// Convert to JSON-RPC error object.
+    pub fn to_jsonrpc_error(&self) -> JsonRpcError {
+        JsonRpcError {
+            code: self.code,
+            message: self.message.clone(),
+            data: self.data.clone(),
+        }
+    }
+
+    // ====== Factory methods (same as a2a-js) ======
+
+    pub fn parse_error(message: impl Into<String>) -> Self {
+        Self::new(-32700, message)
+    }
+
+    pub fn invalid_request(message: impl Into<String>) -> Self {
+        Self::new(-32600, message)
+    }
+
+    pub fn method_not_found(method: &str) -> Self {
+        Self::new(-32601, format!("Method not found: {method}"))
+    }
+
+    pub fn invalid_params(message: impl Into<String>) -> Self {
+        Self::new(-32602, message)
+    }
+
+    pub fn internal_error(message: impl Into<String>) -> Self {
+        Self::new(-32603, message)
+    }
+
+    pub fn task_not_found(task_id: &str) -> Self {
+        let mut e = Self::new(-32001, format!("Task not found: {task_id}"));
+        e.task_id = Some(task_id.to_string());
+        e
+    }
+
+    pub fn task_not_cancelable(task_id: &str) -> Self {
+        let mut e = Self::new(-32002, format!("Task not cancelable: {task_id}"));
+        e.task_id = Some(task_id.to_string());
+        e
+    }
+
+    pub fn push_notification_not_supported() -> Self {
+        Self::new(-32003, "Push Notification is not supported")
+    }
+
+    pub fn unsupported_operation(operation: &str) -> Self {
+        Self::new(-32004, format!("Unsupported operation: {operation}"))
+    }
+}
+
+impl std::fmt::Display for A2AError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "A2AError({}): {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for A2AError {}
+
+impl IntoResponse for A2AError {
+    fn into_response(self) -> axum::response::Response {
+        let status = match self.code {
+            -32001 => axum::http::StatusCode::NOT_FOUND,
+            -32600 | -32602 => axum::http::StatusCode::BAD_REQUEST,
+            -32601 => axum::http::StatusCode::METHOD_NOT_ALLOWED,
+            _ => axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+        };
+        let body = serde_json::json!({ "error": self.to_jsonrpc_error() });
+        (status, axum::Json(body)).into_response()
+    }
+}

--- a/codex-rs/a2a/src/event.rs
+++ b/codex-rs/a2a/src/event.rs
@@ -1,0 +1,71 @@
+//! Execution event bus for streaming agent events.
+//!
+//! Mirrors `a2a-js/src/server/events/execution_event_bus.ts`.
+
+use crate::types::{Message, Task, TaskArtifactUpdateEvent, TaskStatusUpdateEvent};
+use tokio::sync::broadcast;
+
+/// Agent execution event — union of all event types.
+#[derive(Debug, Clone)]
+pub enum ExecutionEvent {
+    /// A complete message result.
+    Message(Message),
+    /// A complete or updated task.
+    Task(Task),
+    /// A task status update (for streaming).
+    StatusUpdate(TaskStatusUpdateEvent),
+    /// A task artifact update (for streaming).
+    ArtifactUpdate(TaskArtifactUpdateEvent),
+}
+
+/// Event bus for publishing and subscribing to agent execution events.
+///
+/// Uses `tokio::sync::broadcast` for multi-consumer support.
+pub struct EventBus {
+    tx: broadcast::Sender<ExecutionEvent>,
+}
+
+impl EventBus {
+    /// Create a new event bus with the given capacity.
+    pub fn new(capacity: usize) -> Self {
+        let (tx, _) = broadcast::channel(capacity);
+        Self { tx }
+    }
+
+    /// Publish an event to all subscribers.
+    pub fn publish(&self, event: ExecutionEvent) {
+        // Ignore error if no receivers.
+        let _ = self.tx.send(event);
+    }
+
+    /// Subscribe to events. Returns a receiver.
+    pub fn subscribe(&self) -> broadcast::Receiver<ExecutionEvent> {
+        self.tx.subscribe()
+    }
+
+    /// Publish a completed status for the given task.
+    pub fn publish_task_completed(&self, task: Task) {
+        self.publish(ExecutionEvent::Task(task));
+    }
+
+    /// Publish a status update event.
+    pub fn publish_status_update(&self, event: TaskStatusUpdateEvent) {
+        self.publish(ExecutionEvent::StatusUpdate(event));
+    }
+
+    /// Publish an artifact update event.
+    pub fn publish_artifact_update(&self, event: TaskArtifactUpdateEvent) {
+        self.publish(ExecutionEvent::ArtifactUpdate(event));
+    }
+
+    /// Publish a message result (no task created).
+    pub fn publish_message(&self, message: Message) {
+        self.publish(ExecutionEvent::Message(message));
+    }
+}
+
+impl Default for EventBus {
+    fn default() -> Self {
+        Self::new(64)
+    }
+}

--- a/codex-rs/a2a/src/event.rs
+++ b/codex-rs/a2a/src/event.rs
@@ -43,6 +43,14 @@ impl EventBus {
         self.tx.subscribe()
     }
 
+    /// Create a lightweight clone of this EventBus that shares the same
+    /// broadcast sender. Useful for spawning forwarder tasks.
+    pub fn clone_sender(&self) -> Self {
+        Self {
+            tx: self.tx.clone(),
+        }
+    }
+
     /// Publish a completed status for the given task.
     pub fn publish_task_completed(&self, task: Task) {
         self.publish(ExecutionEvent::Task(task));

--- a/codex-rs/a2a/src/executor.rs
+++ b/codex-rs/a2a/src/executor.rs
@@ -1,0 +1,42 @@
+//! Agent executor trait — user-implemented agent logic.
+//!
+//! Mirrors `a2a-js/src/server/agent_execution/agent_executor.ts`.
+
+use crate::event::EventBus;
+use crate::types::{AgentCard, SendMessageRequest};
+
+/// Context for a single request.
+pub struct RequestContext {
+    /// The original send-message request.
+    pub request: SendMessageRequest,
+    /// Task ID assigned by the server (if a task was created).
+    pub task_id: Option<String>,
+    /// Context ID for this conversation.
+    pub context_id: String,
+}
+
+/// Implement this trait to define your agent's execution logic.
+///
+/// The server calls [`execute`] for each incoming message. Your implementation
+/// should publish events to the [`EventBus`] as it makes progress.
+///
+/// For simple (non-streaming) agents, publish a single
+/// [`ExecutionEvent::Task`] or [`ExecutionEvent::Message`] and return.
+pub trait AgentExecutor: Send + Sync + 'static {
+    /// Execute agent logic and publish events to the bus.
+    fn execute(
+        &self,
+        context: RequestContext,
+        event_bus: &EventBus,
+    ) -> impl std::future::Future<Output = Result<(), crate::error::A2AError>> + Send;
+
+    /// Cancel a running task.
+    fn cancel(
+        &self,
+        task_id: &str,
+        event_bus: &EventBus,
+    ) -> impl std::future::Future<Output = Result<(), crate::error::A2AError>> + Send;
+
+    /// Return the agent card for discovery.
+    fn agent_card(&self, base_url: &str) -> AgentCard;
+}

--- a/codex-rs/a2a/src/lib.rs
+++ b/codex-rs/a2a/src/lib.rs
@@ -1,0 +1,28 @@
+//! # codex-a2a
+//!
+//! A2A (Agent-to-Agent) RC v1 protocol implementation built from the
+//! official specification (`a2a.proto`).
+//!
+//! ## Architecture (mirrors `a2a-js`)
+//!
+//! - [`types`] — Wire types matching the A2A proto spec
+//! - [`error`] — [`A2AError`] with JSON-RPC error codes
+//! - [`store`] — [`TaskStore`] trait + [`InMemoryTaskStore`]
+//! - [`event`] — [`ExecutionEvent`] enum + [`EventBus`] for streaming
+//! - [`executor`] — [`AgentExecutor`] trait (user implements this)
+//! - [`server`] — Axum HTTP server with RC v1 routes
+
+pub mod error;
+pub mod event;
+pub mod executor;
+pub mod server;
+pub mod store;
+pub mod types;
+
+// Re-export commonly used items at crate root.
+pub use error::A2AError;
+pub use event::{EventBus, ExecutionEvent};
+pub use executor::{AgentExecutor, RequestContext};
+pub use server::{A2AServer, A2AServerState};
+pub use store::{InMemoryTaskStore, TaskStore};
+pub use types::*;

--- a/codex-rs/a2a/src/server.rs
+++ b/codex-rs/a2a/src/server.rs
@@ -9,21 +9,25 @@ use std::collections::HashMap;
 use std::convert::Infallible;
 use std::sync::Arc;
 
-use axum::{
-    Json, Router,
-    extract::{Path, State},
-    response::sse::{Event, Sse},
-    routing::{get, post},
-};
-use futures::stream::Stream;
-use tokio::sync::Mutex;
-use tokio_stream::wrappers::BroadcastStream;
-use tokio_stream::StreamExt;
 use crate::error::A2AError;
 use crate::event::{EventBus, ExecutionEvent};
 use crate::executor::{AgentExecutor, RequestContext};
 use crate::store::TaskStore;
 use crate::types::*;
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    response::sse::{Event, Sse},
+    response::{IntoResponse, Response},
+    routing::{get, post},
+};
+use futures::stream::{self, Stream};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use tokio::sync::Mutex;
+use tokio_stream::StreamExt;
+use tokio_stream::wrappers::BroadcastStream;
 
 // ============================================================
 // Server state
@@ -99,11 +103,19 @@ impl<E: AgentExecutor, S: TaskStore> A2AServer<E, S> {
         };
 
         Router::new()
+            .route("/", post(handle_jsonrpc::<E, S>))
+            .route(
+                "/.well-known/agent-card.json",
+                get(handle_agent_card_v03::<E, S>),
+            )
             .route("/.well-known/agent.json", get(handle_agent_card::<E, S>))
             .route("/message:send", post(handle_send_message::<E, S>))
             .route("/message:stream", post(handle_stream_message::<E, S>))
-            .route("/tasks/{id}", get(handle_get_task::<E, S>))
-            .route("/tasks/{id}:cancel", post(handle_cancel_task::<E, S>))
+            .route(
+                "/tasks/{id}",
+                get(handle_get_task::<E, S>).post(handle_cancel_task_compat::<E, S>),
+            )
+            .route("/tasks/{id}/cancel", post(handle_cancel_task::<E, S>))
             .with_state(state)
     }
 
@@ -126,6 +138,223 @@ async fn handle_agent_card<E: AgentExecutor, S: TaskStore>(
     State(state): State<A2AServerState<E, S>>,
 ) -> Json<AgentCard> {
     Json(state.executor.agent_card(&state.base_url))
+}
+
+/// Compatibility endpoint for A2A 0.3 JSON-RPC stacks.
+///
+/// Returns a v0.3-style card shape at `/.well-known/agent-card.json`.
+async fn handle_agent_card_v03<E: AgentExecutor, S: TaskStore>(
+    State(state): State<A2AServerState<E, S>>,
+) -> Json<Value> {
+    let card = state.executor.agent_card(&state.base_url);
+    let url = card
+        .supported_interfaces
+        .first()
+        .map(|iface| iface.url.clone())
+        .unwrap_or_else(|| format!("{}/", state.base_url.trim_end_matches('/')));
+    Json(json!({
+        "name": card.name,
+        "description": card.description,
+        "url": url,
+        "provider": card.provider,
+        "version": card.version,
+        "protocolVersion": "0.3.0",
+        "capabilities": {
+            "streaming": card.capabilities.streaming.unwrap_or(false),
+            "pushNotifications": card.capabilities.push_notifications.unwrap_or(false),
+            "stateTransitionHistory": false
+        },
+        "defaultInputModes": card.default_input_modes,
+        "defaultOutputModes": card.default_output_modes,
+        "skills": card.skills,
+        "supportsAuthenticatedExtendedCard": card.capabilities.extended_agent_card.unwrap_or(false)
+    }))
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcEnvelope {
+    jsonrpc: String,
+    method: String,
+    #[serde(default)]
+    params: Value,
+    #[serde(default = "jsonrpc_null_id")]
+    id: Value,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct JsonRpcTaskQueryParams {
+    id: String,
+    #[allow(dead_code)]
+    history_length: Option<i32>,
+}
+
+#[derive(Debug, Deserialize)]
+struct JsonRpcTaskIdParams {
+    id: String,
+}
+
+fn jsonrpc_null_id() -> Value {
+    Value::Null
+}
+
+fn jsonrpc_ok<T: serde::Serialize>(id: Value, result: T) -> Response {
+    Json(json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result
+    }))
+    .into_response()
+}
+
+fn jsonrpc_err(id: Value, err: A2AError, status: StatusCode) -> Response {
+    (
+        status,
+        Json(json!({
+            "jsonrpc": "2.0",
+            "id": id,
+            "error": err.to_jsonrpc_error()
+        })),
+    )
+        .into_response()
+}
+
+fn jsonrpc_sse_single(
+    id: Value,
+    result: Value,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let payload = json!({
+        "jsonrpc": "2.0",
+        "id": id,
+        "result": result
+    })
+    .to_string();
+    Sse::new(stream::once(
+        async move { Ok(Event::default().data(payload)) },
+    ))
+}
+
+/// `POST /` JSON-RPC compatibility endpoint for A2A 0.3 clients.
+async fn handle_jsonrpc<E: AgentExecutor, S: TaskStore>(
+    State(state): State<A2AServerState<E, S>>,
+    Json(body): Json<Value>,
+) -> Response {
+    let fallback_id = body.get("id").cloned().unwrap_or(Value::Null);
+    let envelope: JsonRpcEnvelope = match serde_json::from_value(body) {
+        Ok(envelope) => envelope,
+        Err(e) => {
+            return jsonrpc_err(
+                fallback_id,
+                A2AError::parse_error(format!("Failed to parse JSON-RPC request: {e}")),
+                StatusCode::BAD_REQUEST,
+            );
+        }
+    };
+
+    if envelope.jsonrpc != "2.0" {
+        return jsonrpc_err(
+            envelope.id,
+            A2AError::invalid_request("jsonrpc must be '2.0'"),
+            StatusCode::BAD_REQUEST,
+        );
+    }
+
+    match envelope.method.as_str() {
+        "message/send" => {
+            let params: SendMessageRequest = match serde_json::from_value(envelope.params) {
+                Ok(v) => v,
+                Err(e) => {
+                    return jsonrpc_err(
+                        envelope.id,
+                        A2AError::invalid_params(format!("Invalid message/send params: {e}")),
+                        StatusCode::BAD_REQUEST,
+                    );
+                }
+            };
+            match handle_send_message::<E, S>(State(state), Json(params)).await {
+                Ok(Json(result)) => jsonrpc_ok(envelope.id, result),
+                Err(err) => jsonrpc_err(envelope.id, err, StatusCode::OK),
+            }
+        }
+        "tasks/get" => {
+            let params: JsonRpcTaskQueryParams = match serde_json::from_value(envelope.params) {
+                Ok(v) => v,
+                Err(e) => {
+                    return jsonrpc_err(
+                        envelope.id,
+                        A2AError::invalid_params(format!("Invalid tasks/get params: {e}")),
+                        StatusCode::BAD_REQUEST,
+                    );
+                }
+            };
+            match handle_get_task::<E, S>(State(state), Path(params.id)).await {
+                Ok(Json(task)) => jsonrpc_ok(envelope.id, task),
+                Err(err) => jsonrpc_err(envelope.id, err, StatusCode::OK),
+            }
+        }
+        "tasks/cancel" => {
+            let params: JsonRpcTaskIdParams = match serde_json::from_value(envelope.params) {
+                Ok(v) => v,
+                Err(e) => {
+                    return jsonrpc_err(
+                        envelope.id,
+                        A2AError::invalid_params(format!("Invalid tasks/cancel params: {e}")),
+                        StatusCode::BAD_REQUEST,
+                    );
+                }
+            };
+            match handle_cancel_task::<E, S>(State(state), Path(params.id)).await {
+                Ok(Json(task)) => jsonrpc_ok(envelope.id, task),
+                Err(err) => jsonrpc_err(envelope.id, err, StatusCode::OK),
+            }
+        }
+        "message/stream" => {
+            let params: SendMessageRequest = match serde_json::from_value(envelope.params) {
+                Ok(v) => v,
+                Err(e) => {
+                    return jsonrpc_err(
+                        envelope.id,
+                        A2AError::invalid_params(format!("Invalid message/stream params: {e}")),
+                        StatusCode::BAD_REQUEST,
+                    );
+                }
+            };
+            handle_jsonrpc_stream_message::<E, S>(state, params, envelope.id)
+                .await
+                .into_response()
+        }
+        "tasks/resubscribe" => {
+            let params: JsonRpcTaskIdParams = match serde_json::from_value(envelope.params) {
+                Ok(v) => v,
+                Err(e) => {
+                    return jsonrpc_err(
+                        envelope.id,
+                        A2AError::invalid_params(format!("Invalid tasks/resubscribe params: {e}")),
+                        StatusCode::BAD_REQUEST,
+                    );
+                }
+            };
+            match state.store.load(&params.id).await {
+                Ok(Some(task)) => jsonrpc_sse_single(envelope.id, json!(task)).into_response(),
+                Ok(None) => jsonrpc_err(
+                    envelope.id,
+                    A2AError::task_not_found(&params.id),
+                    StatusCode::NOT_FOUND,
+                ),
+                Err(err) => jsonrpc_err(envelope.id, err, StatusCode::INTERNAL_SERVER_ERROR),
+            }
+        }
+        "agent/getAuthenticatedExtendedCard" => jsonrpc_err(
+            envelope.id,
+            A2AError::unsupported_operation("agent/getAuthenticatedExtendedCard"),
+            StatusCode::NOT_IMPLEMENTED,
+        ),
+        method => jsonrpc_err(
+            envelope.id,
+            A2AError::method_not_found(method),
+            StatusCode::NOT_FOUND,
+        ),
+    }
 }
 
 /// `POST /message:send`
@@ -151,7 +380,11 @@ async fn handle_send_message<E: AgentExecutor, S: TaskStore>(
 
     // Register cancel token
     let (cancel_tx, _cancel_rx) = tokio::sync::watch::channel(false);
-    state.cancel_tokens.lock().await.insert(task_id.clone(), cancel_tx);
+    state
+        .cancel_tokens
+        .lock()
+        .await
+        .insert(task_id.clone(), cancel_tx);
 
     // Execute in background.
     let executor = Arc::clone(&state.executor);
@@ -165,20 +398,30 @@ async fn handle_send_message<E: AgentExecutor, S: TaskStore>(
         cancel_tokens.lock().await.remove(&task_id_clone);
     });
 
-    // Wait for the first event (the result).
-    match rx.recv().await {
-        Ok(ExecutionEvent::Task(task)) => {
-            // Save to store.
-            state.store.save(task.clone()).await?;
-            Ok(Json(SendMessageResponse::Task(task)))
+    // Non-streaming mode still may receive intermediate streaming events first.
+    // Keep consuming until a terminal Task or Message is received.
+    loop {
+        match rx.recv().await {
+            Ok(ExecutionEvent::Task(task)) => {
+                // Save to store.
+                state.store.save(task.clone()).await?;
+                return Ok(Json(SendMessageResponse::Task(task)));
+            }
+            Ok(ExecutionEvent::Message(message)) => {
+                return Ok(Json(SendMessageResponse::Message(message)));
+            }
+            Ok(ExecutionEvent::StatusUpdate(_) | ExecutionEvent::ArtifactUpdate(_)) => {
+                continue;
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
+                continue;
+            }
+            Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                return Err(A2AError::internal_error(
+                    "Executor finished without terminal event",
+                ));
+            }
         }
-        Ok(ExecutionEvent::Message(message)) => {
-            Ok(Json(SendMessageResponse::Message(message)))
-        }
-        Ok(ExecutionEvent::StatusUpdate(_) | ExecutionEvent::ArtifactUpdate(_)) => {
-            Err(A2AError::internal_error("Unexpected streaming event in non-streaming mode"))
-        }
-        Err(e) => Err(A2AError::internal_error(format!("Event bus error: {e}"))),
     }
 }
 
@@ -205,7 +448,11 @@ async fn handle_stream_message<E: AgentExecutor, S: TaskStore>(
 
     // Register cancel token
     let (cancel_tx, _cancel_rx) = tokio::sync::watch::channel(false);
-    state.cancel_tokens.lock().await.insert(task_id.clone(), cancel_tx);
+    state
+        .cancel_tokens
+        .lock()
+        .await
+        .insert(task_id.clone(), cancel_tx);
 
     // Execute in background.
     let executor = Arc::clone(&state.executor);
@@ -272,6 +519,73 @@ async fn handle_stream_message<E: AgentExecutor, S: TaskStore>(
     Sse::new(stream)
 }
 
+/// JSON-RPC variant of `message/stream` that wraps each SSE chunk into
+/// `{ jsonrpc, id, result }`.
+async fn handle_jsonrpc_stream_message<E: AgentExecutor, S: TaskStore>(
+    state: A2AServerState<E, S>,
+    request: SendMessageRequest,
+    request_id: Value,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let context_id = request
+        .message
+        .context_id
+        .clone()
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    let task_id = uuid::Uuid::new_v4().to_string();
+    let event_bus = EventBus::new(64);
+    let rx = event_bus.subscribe();
+
+    let context = RequestContext {
+        request,
+        task_id: Some(task_id.clone()),
+        context_id,
+    };
+
+    // Register cancel token
+    let (cancel_tx, _cancel_rx) = tokio::sync::watch::channel(false);
+    state
+        .cancel_tokens
+        .lock()
+        .await
+        .insert(task_id.clone(), cancel_tx);
+
+    // Execute in background.
+    let executor = Arc::clone(&state.executor);
+    let cancel_tokens = Arc::clone(&state.cancel_tokens);
+    let task_id_clone = task_id.clone();
+    tokio::spawn(async move {
+        if let Err(e) = executor.execute(context, &event_bus).await {
+            tracing::error!("AgentExecutor error: {e}");
+        }
+        cancel_tokens.lock().await.remove(&task_id_clone);
+    });
+
+    let stream = BroadcastStream::new(rx).filter_map(move |result| {
+        let request_id = request_id.clone();
+        match result {
+            Ok(event) => {
+                let result_value = match event {
+                    ExecutionEvent::Task(task) => json!(task),
+                    ExecutionEvent::Message(msg) => json!(msg),
+                    ExecutionEvent::StatusUpdate(update) => json!(update),
+                    ExecutionEvent::ArtifactUpdate(update) => json!(update),
+                };
+                let payload = json!({
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "result": result_value
+                })
+                .to_string();
+                Some(Ok(Event::default().data(payload)))
+            }
+            Err(_) => None,
+        }
+    });
+
+    Sse::new(stream)
+}
+
 /// `GET /tasks/{id}`
 async fn handle_get_task<E: AgentExecutor, S: TaskStore>(
     State(state): State<A2AServerState<E, S>>,
@@ -283,15 +597,38 @@ async fn handle_get_task<E: AgentExecutor, S: TaskStore>(
     }
 }
 
+/// Compatibility handler for `POST /tasks/{id}:cancel`.
+///
+/// Axum path params cannot include both a param and literal text in one segment,
+/// so `/tasks/{id}:cancel` is matched as `/tasks/{id}` and parsed here.
+async fn handle_cancel_task_compat<E: AgentExecutor, S: TaskStore>(
+    State(state): State<A2AServerState<E, S>>,
+    Path(task_segment): Path<String>,
+) -> Result<Json<Task>, A2AError> {
+    let Some(task_id) = task_segment.strip_suffix(":cancel") else {
+        return Err(A2AError::invalid_params(
+            "Expected path format /tasks/{id}:cancel",
+        ));
+    };
+    cancel_task_by_id(state, task_id).await
+}
+
 /// `POST /tasks/{id}:cancel`
 async fn handle_cancel_task<E: AgentExecutor, S: TaskStore>(
     State(state): State<A2AServerState<E, S>>,
     Path(task_id): Path<String>,
 ) -> Result<Json<Task>, A2AError> {
+    cancel_task_by_id(state, &task_id).await
+}
+
+async fn cancel_task_by_id<E: AgentExecutor, S: TaskStore>(
+    state: A2AServerState<E, S>,
+    task_id: &str,
+) -> Result<Json<Task>, A2AError> {
     // Signal cancellation via the watch channel.
     let cancelled = {
         let tokens = state.cancel_tokens.lock().await;
-        if let Some(tx) = tokens.get(&task_id) {
+        if let Some(tx) = tokens.get(task_id) {
             let _ = tx.send(true);
             true
         } else {
@@ -305,10 +642,132 @@ async fn handle_cancel_task<E: AgentExecutor, S: TaskStore>(
 
     // Also call executor cancel for cleanup.
     let event_bus = EventBus::new(16);
-    let _ = state.executor.cancel(&task_id, &event_bus).await;
+    let _ = state.executor.cancel(task_id, &event_bus).await;
 
     match state.store.load(&task_id).await? {
         Some(task) => Ok(Json(task)),
         None => Err(A2AError::task_not_found(&task_id)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::InMemoryTaskStore;
+
+    struct StreamingFirstExecutor;
+
+    impl AgentExecutor for StreamingFirstExecutor {
+        fn execute(
+            &self,
+            context: RequestContext,
+            event_bus: &EventBus,
+        ) -> impl std::future::Future<Output = Result<(), A2AError>> + Send {
+            async move {
+                let task_id = context.task_id.unwrap_or_else(|| "task-1".to_string());
+                let context_id = context.context_id;
+                event_bus.publish_status_update(TaskStatusUpdateEvent {
+                    task_id: task_id.clone(),
+                    context_id: context_id.clone(),
+                    status: TaskStatus {
+                        state: TaskState::Working,
+                        message: Some(Message {
+                            message_id: "status-1".to_string(),
+                            context_id: Some(context_id.clone()),
+                            task_id: Some(task_id.clone()),
+                            role: Role::Agent,
+                            parts: vec![Part::text("working")],
+                            metadata: None,
+                            extensions: vec![],
+                            reference_task_ids: None,
+                        }),
+                        timestamp: None,
+                    },
+                    metadata: None,
+                });
+                event_bus.publish(ExecutionEvent::Task(completed_task(
+                    task_id, context_id, "done",
+                )));
+                Ok(())
+            }
+        }
+
+        fn cancel(
+            &self,
+            _task_id: &str,
+            _event_bus: &EventBus,
+        ) -> impl std::future::Future<Output = Result<(), A2AError>> + Send {
+            async move { Ok(()) }
+        }
+
+        fn agent_card(&self, base_url: &str) -> AgentCard {
+            AgentCard {
+                name: "test-agent".to_string(),
+                description: "test".to_string(),
+                supported_interfaces: vec![AgentInterface {
+                    url: base_url.to_string(),
+                    protocol_binding: "HTTP+JSON".to_string(),
+                    tenant: None,
+                    protocol_version: "1.0".to_string(),
+                }],
+                provider: None,
+                version: "0.0.0".to_string(),
+                documentation_url: None,
+                capabilities: AgentCapabilities {
+                    streaming: Some(true),
+                    push_notifications: Some(false),
+                    extended_agent_card: None,
+                },
+                default_input_modes: vec!["text/plain".to_string()],
+                default_output_modes: vec!["text/plain".to_string()],
+                skills: vec![],
+                icon_url: None,
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn send_message_ignores_intermediate_status_and_returns_task() {
+        let state: A2AServerState<StreamingFirstExecutor, InMemoryTaskStore> = A2AServerState {
+            executor: Arc::new(StreamingFirstExecutor),
+            store: Arc::new(InMemoryTaskStore::new()),
+            base_url: "http://localhost".to_string(),
+            cancel_tokens: Arc::new(Mutex::new(HashMap::new())),
+        };
+        let state_for_assert = state.clone();
+
+        let request = SendMessageRequest {
+            message: Message {
+                message_id: "msg-1".to_string(),
+                context_id: Some("ctx-1".to_string()),
+                task_id: None,
+                role: Role::User,
+                parts: vec![Part::text("hello")],
+                metadata: None,
+                extensions: vec![],
+                reference_task_ids: None,
+            },
+            configuration: None,
+            metadata: None,
+        };
+
+        let Json(response) = handle_send_message::<StreamingFirstExecutor, InMemoryTaskStore>(
+            State(state),
+            Json(request),
+        )
+        .await
+        .expect("send should succeed");
+
+        let SendMessageResponse::Task(task) = response else {
+            panic!("expected task response");
+        };
+        assert_eq!(task.status.state, TaskState::Completed);
+
+        let saved = state_for_assert
+            .store
+            .load(&task.id)
+            .await
+            .expect("store load should succeed");
+        assert!(saved.is_some());
     }
 }

--- a/codex-rs/a2a/src/server.rs
+++ b/codex-rs/a2a/src/server.rs
@@ -1,0 +1,188 @@
+//! A2A RC v1 HTTP server using Axum.
+//!
+//! Mirrors `a2a-js/src/server/express/` and `a2a-js/src/server/request_handler/`.
+//!
+//! Uses [`AgentExecutor`] for agent logic, [`TaskStore`] for persistence,
+//! and [`EventBus`] for streaming events.
+
+use std::sync::Arc;
+
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    routing::{get, post},
+};
+use crate::error::A2AError;
+use crate::event::{EventBus, ExecutionEvent};
+use crate::executor::{AgentExecutor, RequestContext};
+use crate::store::TaskStore;
+use crate::types::*;
+
+// ============================================================
+// Server state
+// ============================================================
+
+/// Shared state for the A2A server.
+pub struct A2AServerState<E: AgentExecutor, S: TaskStore> {
+    pub executor: Arc<E>,
+    pub store: Arc<S>,
+    pub base_url: String,
+}
+
+impl<E: AgentExecutor, S: TaskStore> Clone for A2AServerState<E, S> {
+    fn clone(&self) -> Self {
+        Self {
+            executor: Arc::clone(&self.executor),
+            store: Arc::clone(&self.store),
+            base_url: self.base_url.clone(),
+        }
+    }
+}
+
+// ============================================================
+// A2AServer builder
+// ============================================================
+
+/// Builder for the A2A HTTP server.
+pub struct A2AServer<E: AgentExecutor, S: TaskStore> {
+    executor: Arc<E>,
+    store: Arc<S>,
+    addr: String,
+    base_url: Option<String>,
+}
+
+impl<E: AgentExecutor, S: TaskStore> A2AServer<E, S> {
+    /// Create a new server with the given executor and store.
+    pub fn new(executor: E, store: S) -> Self {
+        Self {
+            executor: Arc::new(executor),
+            store: Arc::new(store),
+            addr: "0.0.0.0:5000".to_string(),
+            base_url: None,
+        }
+    }
+
+    /// Set the bind address (default: `0.0.0.0:5000`).
+    pub fn bind(mut self, addr: impl Into<String>) -> Self {
+        self.addr = addr.into();
+        self
+    }
+
+    /// Set the base URL for the agent card (default: derived from addr).
+    pub fn base_url(mut self, url: impl Into<String>) -> Self {
+        self.base_url = Some(url.into());
+        self
+    }
+
+    /// Build the Axum router without starting the server.
+    pub fn router(&self) -> Router {
+        let base_url = self
+            .base_url
+            .clone()
+            .unwrap_or_else(|| format!("http://{}", self.addr));
+
+        let state = A2AServerState {
+            executor: Arc::clone(&self.executor),
+            store: Arc::clone(&self.store),
+            base_url,
+        };
+
+        Router::new()
+            .route("/.well-known/agent.json", get(handle_agent_card::<E, S>))
+            .route("/message:send", post(handle_send_message::<E, S>))
+            .route("/tasks/{id}", get(handle_get_task::<E, S>))
+            .route("/tasks/{id}:cancel", post(handle_cancel_task::<E, S>))
+            .with_state(state)
+    }
+
+    /// Run the server (blocks until shutdown).
+    pub async fn run(self) -> Result<(), Box<dyn std::error::Error>> {
+        let router = self.router();
+        let listener = tokio::net::TcpListener::bind(&self.addr).await?;
+        tracing::info!("A2A server listening on {}", self.addr);
+        axum::serve(listener, router).await?;
+        Ok(())
+    }
+}
+
+// ============================================================
+// Route handlers
+// ============================================================
+
+/// `GET /.well-known/agent.json`
+async fn handle_agent_card<E: AgentExecutor, S: TaskStore>(
+    State(state): State<A2AServerState<E, S>>,
+) -> Json<AgentCard> {
+    Json(state.executor.agent_card(&state.base_url))
+}
+
+/// `POST /message:send`
+async fn handle_send_message<E: AgentExecutor, S: TaskStore>(
+    State(state): State<A2AServerState<E, S>>,
+    Json(request): Json<SendMessageRequest>,
+) -> Result<Json<SendMessageResponse>, A2AError> {
+    let context_id = request
+        .message
+        .context_id
+        .clone()
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    let task_id = uuid::Uuid::new_v4().to_string();
+    let event_bus = EventBus::new(16);
+    let mut rx = event_bus.subscribe();
+
+    let context = RequestContext {
+        request,
+        task_id: Some(task_id.clone()),
+        context_id,
+    };
+
+    // Execute in background.
+    let executor = Arc::clone(&state.executor);
+    tokio::spawn(async move {
+        if let Err(e) = executor.execute(context, &event_bus).await {
+            tracing::error!("AgentExecutor error: {e}");
+        }
+    });
+
+    // Wait for the first event (the result).
+    match rx.recv().await {
+        Ok(ExecutionEvent::Task(task)) => {
+            // Save to store.
+            state.store.save(task.clone()).await?;
+            Ok(Json(SendMessageResponse::Task(task)))
+        }
+        Ok(ExecutionEvent::Message(message)) => {
+            Ok(Json(SendMessageResponse::Message(message)))
+        }
+        Ok(ExecutionEvent::StatusUpdate(_) | ExecutionEvent::ArtifactUpdate(_)) => {
+            Err(A2AError::internal_error("Unexpected streaming event in non-streaming mode"))
+        }
+        Err(e) => Err(A2AError::internal_error(format!("Event bus error: {e}"))),
+    }
+}
+
+/// `GET /tasks/{id}`
+async fn handle_get_task<E: AgentExecutor, S: TaskStore>(
+    State(state): State<A2AServerState<E, S>>,
+    Path(task_id): Path<String>,
+) -> Result<Json<Task>, A2AError> {
+    match state.store.load(&task_id).await? {
+        Some(task) => Ok(Json(task)),
+        None => Err(A2AError::task_not_found(&task_id)),
+    }
+}
+
+/// `POST /tasks/{id}:cancel`
+async fn handle_cancel_task<E: AgentExecutor, S: TaskStore>(
+    State(state): State<A2AServerState<E, S>>,
+    Path(task_id): Path<String>,
+) -> Result<Json<Task>, A2AError> {
+    let event_bus = EventBus::new(16);
+    state.executor.cancel(&task_id, &event_bus).await?;
+
+    match state.store.load(&task_id).await? {
+        Some(task) => Ok(Json(task)),
+        None => Err(A2AError::task_not_found(&task_id)),
+    }
+}

--- a/codex-rs/a2a/src/server.rs
+++ b/codex-rs/a2a/src/server.rs
@@ -5,13 +5,20 @@
 //! Uses [`AgentExecutor`] for agent logic, [`TaskStore`] for persistence,
 //! and [`EventBus`] for streaming events.
 
+use std::collections::HashMap;
+use std::convert::Infallible;
 use std::sync::Arc;
 
 use axum::{
     Json, Router,
     extract::{Path, State},
+    response::sse::{Event, Sse},
     routing::{get, post},
 };
+use futures::stream::Stream;
+use tokio::sync::Mutex;
+use tokio_stream::wrappers::BroadcastStream;
+use tokio_stream::StreamExt;
 use crate::error::A2AError;
 use crate::event::{EventBus, ExecutionEvent};
 use crate::executor::{AgentExecutor, RequestContext};
@@ -27,6 +34,8 @@ pub struct A2AServerState<E: AgentExecutor, S: TaskStore> {
     pub executor: Arc<E>,
     pub store: Arc<S>,
     pub base_url: String,
+    /// Active task cancellation tokens, keyed by task ID.
+    pub cancel_tokens: Arc<Mutex<HashMap<String, tokio::sync::watch::Sender<bool>>>>,
 }
 
 impl<E: AgentExecutor, S: TaskStore> Clone for A2AServerState<E, S> {
@@ -35,6 +44,7 @@ impl<E: AgentExecutor, S: TaskStore> Clone for A2AServerState<E, S> {
             executor: Arc::clone(&self.executor),
             store: Arc::clone(&self.store),
             base_url: self.base_url.clone(),
+            cancel_tokens: Arc::clone(&self.cancel_tokens),
         }
     }
 }
@@ -85,11 +95,13 @@ impl<E: AgentExecutor, S: TaskStore> A2AServer<E, S> {
             executor: Arc::clone(&self.executor),
             store: Arc::clone(&self.store),
             base_url,
+            cancel_tokens: Arc::new(Mutex::new(HashMap::new())),
         };
 
         Router::new()
             .route("/.well-known/agent.json", get(handle_agent_card::<E, S>))
             .route("/message:send", post(handle_send_message::<E, S>))
+            .route("/message:stream", post(handle_stream_message::<E, S>))
             .route("/tasks/{id}", get(handle_get_task::<E, S>))
             .route("/tasks/{id}:cancel", post(handle_cancel_task::<E, S>))
             .with_state(state)
@@ -137,12 +149,20 @@ async fn handle_send_message<E: AgentExecutor, S: TaskStore>(
         context_id,
     };
 
+    // Register cancel token
+    let (cancel_tx, _cancel_rx) = tokio::sync::watch::channel(false);
+    state.cancel_tokens.lock().await.insert(task_id.clone(), cancel_tx);
+
     // Execute in background.
     let executor = Arc::clone(&state.executor);
+    let cancel_tokens = Arc::clone(&state.cancel_tokens);
+    let task_id_clone = task_id.clone();
     tokio::spawn(async move {
         if let Err(e) = executor.execute(context, &event_bus).await {
             tracing::error!("AgentExecutor error: {e}");
         }
+        // Cleanup cancel token
+        cancel_tokens.lock().await.remove(&task_id_clone);
     });
 
     // Wait for the first event (the result).
@@ -162,6 +182,96 @@ async fn handle_send_message<E: AgentExecutor, S: TaskStore>(
     }
 }
 
+/// `POST /message:stream` — SSE streaming of task events.
+async fn handle_stream_message<E: AgentExecutor, S: TaskStore>(
+    State(state): State<A2AServerState<E, S>>,
+    Json(request): Json<SendMessageRequest>,
+) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
+    let context_id = request
+        .message
+        .context_id
+        .clone()
+        .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+
+    let task_id = uuid::Uuid::new_v4().to_string();
+    let event_bus = EventBus::new(64);
+    let rx = event_bus.subscribe();
+
+    let context = RequestContext {
+        request,
+        task_id: Some(task_id.clone()),
+        context_id,
+    };
+
+    // Register cancel token
+    let (cancel_tx, _cancel_rx) = tokio::sync::watch::channel(false);
+    state.cancel_tokens.lock().await.insert(task_id.clone(), cancel_tx);
+
+    // Execute in background.
+    let executor = Arc::clone(&state.executor);
+    let _store = Arc::clone(&state.store);
+    let cancel_tokens = Arc::clone(&state.cancel_tokens);
+    let task_id_clone = task_id.clone();
+    tokio::spawn(async move {
+        if let Err(e) = executor.execute(context, &event_bus).await {
+            tracing::error!("AgentExecutor error: {e}");
+        }
+        cancel_tokens.lock().await.remove(&task_id_clone);
+    });
+
+    // Convert broadcast receiver into SSE stream.
+    let stream = BroadcastStream::new(rx).filter_map(move |result| {
+        match result {
+            Ok(event) => {
+                let sse_event = match &event {
+                    ExecutionEvent::Task(task) => {
+                        Event::default()
+                            .event("task")
+                            .json_data(task)
+                            .ok()
+                    }
+                    ExecutionEvent::Message(msg) => {
+                        Event::default()
+                            .event("message")
+                            .json_data(msg)
+                            .ok()
+                    }
+                    ExecutionEvent::StatusUpdate(update) => {
+                        Event::default()
+                            .event("status")
+                            .json_data(update)
+                            .ok()
+                    }
+                    ExecutionEvent::ArtifactUpdate(update) => {
+                        Event::default()
+                            .event("artifact")
+                            .json_data(update)
+                            .ok()
+                    }
+                };
+                // If this is a terminal event, we'll close after sending.
+                let is_terminal = matches!(&event,
+                    ExecutionEvent::Task(t) if matches!(t.status.state, TaskState::Completed | TaskState::Failed | TaskState::Canceled)
+                );
+                match sse_event {
+                    Some(e) => {
+                        if is_terminal {
+                            // Send the event — stream will end naturally after broadcast closes.
+                            Some(Ok(e))
+                        } else {
+                            Some(Ok(e))
+                        }
+                    }
+                    None => None,
+                }
+            }
+            Err(_) => None, // Stream ended
+        }
+    });
+
+    Sse::new(stream)
+}
+
 /// `GET /tasks/{id}`
 async fn handle_get_task<E: AgentExecutor, S: TaskStore>(
     State(state): State<A2AServerState<E, S>>,
@@ -178,8 +288,24 @@ async fn handle_cancel_task<E: AgentExecutor, S: TaskStore>(
     State(state): State<A2AServerState<E, S>>,
     Path(task_id): Path<String>,
 ) -> Result<Json<Task>, A2AError> {
+    // Signal cancellation via the watch channel.
+    let cancelled = {
+        let tokens = state.cancel_tokens.lock().await;
+        if let Some(tx) = tokens.get(&task_id) {
+            let _ = tx.send(true);
+            true
+        } else {
+            false
+        }
+    };
+
+    if !cancelled {
+        return Err(A2AError::task_not_found(&task_id));
+    }
+
+    // Also call executor cancel for cleanup.
     let event_bus = EventBus::new(16);
-    state.executor.cancel(&task_id, &event_bus).await?;
+    let _ = state.executor.cancel(&task_id, &event_bus).await;
 
     match state.store.load(&task_id).await? {
         Some(task) => Ok(Json(task)),

--- a/codex-rs/a2a/src/store.rs
+++ b/codex-rs/a2a/src/store.rs
@@ -1,0 +1,52 @@
+//! Task storage trait and in-memory implementation.
+//!
+//! Mirrors `a2a-js/src/server/store.ts`.
+
+use crate::types::Task;
+
+/// Storage provider for tasks.
+///
+/// Implement this trait to use a custom backend (database, Redis, etc.).
+pub trait TaskStore: Send + Sync + 'static {
+    /// Save (upsert) a task.
+    fn save(
+        &self,
+        task: Task,
+    ) -> impl std::future::Future<Output = Result<(), crate::error::A2AError>> + Send;
+
+    /// Load a task by ID. Returns `None` if not found.
+    fn load(
+        &self,
+        task_id: &str,
+    ) -> impl std::future::Future<Output = Result<Option<Task>, crate::error::A2AError>> + Send;
+}
+
+/// In-memory task store (default).
+pub struct InMemoryTaskStore {
+    store: tokio::sync::Mutex<std::collections::HashMap<String, Task>>,
+}
+
+impl InMemoryTaskStore {
+    pub fn new() -> Self {
+        Self {
+            store: tokio::sync::Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+}
+
+impl Default for InMemoryTaskStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TaskStore for InMemoryTaskStore {
+    async fn save(&self, task: Task) -> Result<(), crate::error::A2AError> {
+        self.store.lock().await.insert(task.id.clone(), task);
+        Ok(())
+    }
+
+    async fn load(&self, task_id: &str) -> Result<Option<Task>, crate::error::A2AError> {
+        Ok(self.store.lock().await.get(task_id).cloned())
+    }
+}

--- a/codex-rs/a2a/src/types.rs
+++ b/codex-rs/a2a/src/types.rs
@@ -1,0 +1,365 @@
+//! A2A Protocol types — from the official A2A RC v1 specification
+//! (`specification/a2a.proto`).
+//!
+//! JSON serialization uses `camelCase` to match the A2A JSON-RPC wire format.
+
+use serde::{Deserialize, Serialize};
+
+// ================================================================
+// Core domain types
+// ================================================================
+
+/// Lifecycle states of a [`Task`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum TaskState {
+    Submitted,
+    Working,
+    Completed,
+    Failed,
+    Canceled,
+    InputRequired,
+    Rejected,
+    AuthRequired,
+}
+
+/// Current status of a task.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskStatus {
+    pub state: TaskState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<Message>,
+    /// ISO 8601 timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp: Option<String>,
+}
+
+/// The core unit of action for A2A.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Task {
+    pub id: String,
+    pub context_id: String,
+    pub status: TaskStatus,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub artifacts: Vec<Artifact>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub history: Vec<Message>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Content part — uses oneOf semantics: exactly one of text/raw/url/data
+/// should be set.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Part {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+    /// Base64-encoded raw bytes.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub data: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filename: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media_type: Option<String>,
+}
+
+impl Part {
+    /// Create a text part.
+    pub fn text(s: impl Into<String>) -> Self {
+        Self {
+            text: Some(s.into()),
+            raw: None,
+            url: None,
+            data: None,
+            metadata: None,
+            filename: None,
+            media_type: None,
+        }
+    }
+}
+
+/// Sender role.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum Role {
+    User,
+    Agent,
+}
+
+/// A single communication unit between client and server.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Message {
+    pub message_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub context_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub task_id: Option<String>,
+    pub role: Role,
+    pub parts: Vec<Part>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extensions: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reference_task_ids: Option<Vec<String>>,
+}
+
+/// Task output artifact.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Artifact {
+    pub artifact_id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub parts: Vec<Part>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub extensions: Vec<String>,
+}
+
+// ================================================================
+// Streaming events
+// ================================================================
+
+/// Task status change event (for SSE streaming).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskStatusUpdateEvent {
+    pub task_id: String,
+    pub context_id: String,
+    pub status: TaskStatus,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// Task artifact update event (for SSE streaming).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskArtifactUpdateEvent {
+    pub task_id: String,
+    pub context_id: String,
+    pub artifact: Artifact,
+    #[serde(default)]
+    pub append: bool,
+    #[serde(default)]
+    pub last_chunk: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+// ================================================================
+// Agent Card & discovery
+// ================================================================
+
+/// Agent's self-describing manifest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCard {
+    pub name: String,
+    pub description: String,
+    pub supported_interfaces: Vec<AgentInterface>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider: Option<AgentProvider>,
+    pub version: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub documentation_url: Option<String>,
+    pub capabilities: AgentCapabilities,
+    pub default_input_modes: Vec<String>,
+    pub default_output_modes: Vec<String>,
+    pub skills: Vec<AgentSkill>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub icon_url: Option<String>,
+}
+
+/// A protocol endpoint declaration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentInterface {
+    pub url: String,
+    /// e.g., "JSONRPC", "GRPC", "HTTP+JSON"
+    pub protocol_binding: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub tenant: Option<String>,
+    /// e.g., "1.0"
+    pub protocol_version: String,
+}
+
+/// Organization providing the agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentProvider {
+    pub url: String,
+    pub organization: String,
+}
+
+/// Agent capability flags.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentCapabilities {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub streaming: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub push_notifications: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub extended_agent_card: Option<bool>,
+}
+
+/// A focused capability of the agent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentSkill {
+    pub id: String,
+    pub name: String,
+    pub description: String,
+    pub tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub examples: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub input_modes: Option<Vec<String>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub output_modes: Option<Vec<String>>,
+}
+
+// ================================================================
+// Request / Response types
+// ================================================================
+
+/// Configuration for `POST /message:send`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendMessageConfiguration {
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub accepted_output_modes: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub history_length: Option<i32>,
+    #[serde(default)]
+    pub blocking: bool,
+}
+
+/// `POST /message:send` request body.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SendMessageRequest {
+    pub message: Message,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub configuration: Option<SendMessageConfiguration>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
+}
+
+/// `POST /message:send` response — oneOf { task, message }.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum SendMessageResponse {
+    Task(Task),
+    Message(Message),
+}
+
+// ================================================================
+// Helpers
+// ================================================================
+
+/// Get current time as ISO 8601 (UTC).
+pub fn now_iso8601() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let d = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = d.as_secs();
+    let s = secs % 60;
+    let m = (secs / 60) % 60;
+    let h = (secs / 3600) % 24;
+    let days = secs / 86400;
+    let (y, mo, day) = days_to_ymd(days);
+    format!("{y:04}-{mo:02}-{day:02}T{h:02}:{m:02}:{s:02}Z")
+}
+
+fn days_to_ymd(days_since_epoch: u64) -> (u64, u64, u64) {
+    // Civil from days algorithm (Howard Hinnant)
+    let z = days_since_epoch + 719468;
+    let era = z / 146097;
+    let doe = z - era * 146097;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+    (y, m, d)
+}
+
+/// Create a new [`Message`] with a text part.
+pub fn new_agent_message(text: impl Into<String>) -> Message {
+    Message {
+        message_id: uuid::Uuid::new_v4().to_string(),
+        context_id: None,
+        task_id: None,
+        role: Role::Agent,
+        parts: vec![Part::text(text)],
+        metadata: None,
+        extensions: vec![],
+        reference_task_ids: None,
+    }
+}
+
+/// Create a completed [`Task`] with a single text artifact.
+pub fn completed_task(
+    task_id: impl Into<String>,
+    context_id: impl Into<String>,
+    result_text: impl Into<String>,
+) -> Task {
+    let text = result_text.into();
+    Task {
+        id: task_id.into(),
+        context_id: context_id.into(),
+        status: TaskStatus {
+            state: TaskState::Completed,
+            message: Some(new_agent_message(&text)),
+            timestamp: Some(now_iso8601()),
+        },
+        artifacts: vec![Artifact {
+            artifact_id: uuid::Uuid::new_v4().to_string(),
+            name: Some("result".into()),
+            description: None,
+            parts: vec![Part::text(text)],
+            metadata: None,
+            extensions: vec![],
+        }],
+        history: vec![],
+        metadata: None,
+    }
+}
+
+/// Create a failed [`Task`].
+pub fn failed_task(
+    task_id: impl Into<String>,
+    context_id: impl Into<String>,
+    error_msg: impl Into<String>,
+) -> Task {
+    Task {
+        id: task_id.into(),
+        context_id: context_id.into(),
+        status: TaskStatus {
+            state: TaskState::Failed,
+            message: Some(new_agent_message(error_msg)),
+            timestamp: Some(now_iso8601()),
+        },
+        artifacts: vec![],
+        history: vec![],
+        metadata: None,
+    }
+}

--- a/codex-rs/mcp-server/Cargo.toml
+++ b/codex-rs/mcp-server/Cargo.toml
@@ -42,6 +42,7 @@ tokio = { workspace = true, features = [
     "sync",
 ] }
 tokio-stream = { workspace = true }
+tokio-util = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
 uuid = { workspace = true, features = ["v4"] }

--- a/codex-rs/mcp-server/Cargo.toml
+++ b/codex-rs/mcp-server/Cargo.toml
@@ -17,11 +17,16 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+a2a-rs = { workspace = true }
 codex-arg0 = { workspace = true }
 codex-core = { workspace = true }
 codex-protocol = { workspace = true }
 codex-utils-cli = { workspace = true }
 codex-utils-json-to-toml = { workspace = true }
+axum = { workspace = true, features = ["json", "tokio"] }
+bytes = { workspace = true }
+clap = { workspace = true, features = ["derive"] }
+http = { workspace = true }
 rmcp = { workspace = true }
 schemars = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
@@ -30,12 +35,17 @@ shlex = { workspace = true }
 tokio = { workspace = true, features = [
     "io-std",
     "macros",
+    "net",
     "process",
     "rt-multi-thread",
     "signal",
+    "sync",
 ] }
+tokio-stream = { workspace = true }
 tracing = { workspace = true, features = ["log"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt"] }
+uuid = { workspace = true, features = ["v4"] }
+
 
 [dev-dependencies]
 core_test_support = { workspace = true }

--- a/codex-rs/mcp-server/src/a2a_handler.rs
+++ b/codex-rs/mcp-server/src/a2a_handler.rs
@@ -1,5 +1,14 @@
 //! Codex A2A handler — implements [`a2a_rs::AgentExecutor`] to bridge
 //! A2A messages into the Codex MCP [`MessageProcessor`] via `tools/call`.
+//!
+//! Supports **bidirectional streaming**: intermediate `codex/event` MCP
+//! notifications are forwarded as A2A `StatusUpdate` and `ArtifactUpdate`
+//! events via the [`EventBus`], so SSE clients receive real-time progress.
+//!
+//! Features:
+//! - **ArtifactUpdate streaming** — file patches emitted as artifacts
+//! - **Task cancel** — cancels in-flight MCP calls via `CancellationToken`
+//! - **Multi-turn context** — subsequent messages reuse `codex-reply` tool
 
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -9,8 +18,13 @@ use a2a_rs::{
     AgentProvider, AgentSkill, EventBus, ExecutionEvent, RequestContext,
     completed_task, failed_task,
 };
+use a2a_rs::types::{
+    Artifact, Message, Part, Role, TaskArtifactUpdateEvent,
+    TaskState, TaskStatus, TaskStatusUpdateEvent,
+};
 use serde_json::json;
 use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio_util::sync::CancellationToken;
 use tracing::info;
 
 use crate::outgoing_message::OutgoingJsonRpcMessage;
@@ -22,49 +36,100 @@ pub struct CodexA2AExecutor {
     /// Pending MCP request IDs → oneshot senders for responses.
     pub pending:
         Arc<Mutex<HashMap<String, oneshot::Sender<OutgoingJsonRpcMessage>>>>,
+    /// Broadcast sender for outgoing MCP notifications — used to subscribe
+    /// and forward intermediate `codex/event` notifications as A2A events.
+    pub notification_tx: tokio::sync::broadcast::Sender<String>,
+    /// Per-task cancellation tokens for aborting in-flight MCP calls.
+    cancel_tokens: Arc<Mutex<HashMap<String, CancellationToken>>>,
+    /// Maps context_id → thread_id for multi-turn conversations.
+    context_threads: Arc<Mutex<HashMap<String, String>>>,
 }
 
 impl CodexA2AExecutor {
     pub fn new(
         incoming_tx: mpsc::Sender<crate::IncomingMessage>,
         pending: Arc<Mutex<HashMap<String, oneshot::Sender<OutgoingJsonRpcMessage>>>>,
+        notification_tx: tokio::sync::broadcast::Sender<String>,
     ) -> Self {
         Self {
             incoming_tx,
             pending,
+            notification_tx,
+            cancel_tokens: Arc::new(Mutex::new(HashMap::new())),
+            context_threads: Arc::new(Mutex::new(HashMap::new())),
         }
     }
 
     /// Execute a prompt through the MCP codex tool and return the result text.
-    async fn execute_via_mcp(&self, task_id: &str, prompt: &str) -> Result<String, String> {
+    /// Supports cancellation via `CancellationToken`.
+    async fn execute_via_mcp(
+        &self,
+        task_id: &str,
+        prompt: &str,
+        cancel_token: &CancellationToken,
+    ) -> Result<String, String> {
         use rmcp::model::*;
+
+        // Check if this context has an existing thread (multi-turn).
+        let existing_thread = self.context_threads.lock().await
+            .get(task_id)
+            .cloned();
 
         let mcp_request_id = format!("a2a-{task_id}");
 
-        let params = CallToolRequestParams {
-            name: "codex".into(),
-            arguments: Some(
-                serde_json::from_value(json!({
-                    "prompt": prompt
-                }))
-                .map_err(|e| format!("JSON error: {e}"))?,
-            ),
-            meta: None,
-            task: None,
+        let mcp_call: crate::IncomingMessage = if let Some(thread_id) = &existing_thread {
+            // Multi-turn: use codex-reply with existing thread.
+            let params = CallToolRequestParams {
+                name: "codex-reply".into(),
+                arguments: Some(
+                    serde_json::from_value(json!({
+                        "prompt": prompt,
+                        "thread_id": thread_id
+                    }))
+                    .map_err(|e| format!("JSON error: {e}"))?,
+                ),
+                meta: None,
+                task: None,
+            };
+            JsonRpcMessage::Request(JsonRpcRequest {
+                jsonrpc: Default::default(),
+                id: RequestId::String(mcp_request_id.clone().into()),
+                request: ClientRequest::CallToolRequest(Request::new(params)),
+            })
+        } else {
+            // First message: use codex tool.
+            let params = CallToolRequestParams {
+                name: "codex".into(),
+                arguments: Some(
+                    serde_json::from_value(json!({
+                        "prompt": prompt
+                    }))
+                    .map_err(|e| format!("JSON error: {e}"))?,
+                ),
+                meta: None,
+                task: None,
+            };
+            JsonRpcMessage::Request(JsonRpcRequest {
+                jsonrpc: Default::default(),
+                id: RequestId::String(mcp_request_id.clone().into()),
+                request: ClientRequest::CallToolRequest(Request::new(params)),
+            })
         };
 
-        let mcp_call: crate::IncomingMessage = JsonRpcMessage::Request(JsonRpcRequest {
-            jsonrpc: Default::default(),
-            id: RequestId::String(mcp_request_id.clone().into()),
-            request: ClientRequest::CallToolRequest(Request::new(params)),
-        });
-
         // Register oneshot for the MCP response.
+        // The key must match what `extract_outgoing_id` returns: the JSON
+        // serialization of the `id` field (e.g. `"a2a-task-1"` with quotes).
+        let pending_key = serde_json::to_value(rmcp::model::RequestId::String(
+            mcp_request_id.into(),
+        ))
+        .map(|v| v.to_string())
+        .unwrap_or_default();
+
         let (tx, rx) = oneshot::channel();
         self.pending
             .lock()
             .await
-            .insert(mcp_request_id, tx);
+            .insert(pending_key, tx);
 
         // Send to the shared MessageProcessor.
         self.incoming_tx
@@ -72,13 +137,30 @@ impl CodexA2AExecutor {
             .await
             .map_err(|_| "Processor channel closed".to_string())?;
 
-        // Wait for response (5 min timeout).
-        let mcp_resp = tokio::time::timeout(std::time::Duration::from_secs(300), rx)
-            .await
-            .map_err(|_| "Task timed out".to_string())?
-            .map_err(|_| "Response channel dropped".to_string())?;
+        // Wait for response with cancellation support (5 min timeout).
+        let mcp_resp = tokio::select! {
+            result = tokio::time::timeout(std::time::Duration::from_secs(300), rx) => {
+                result
+                    .map_err(|_| "Task timed out".to_string())?
+                    .map_err(|_| "Response channel dropped".to_string())?
+            }
+            _ = cancel_token.cancelled() => {
+                return Err("Task canceled".to_string());
+            }
+        };
 
-        Ok(extract_mcp_result_text(&mcp_resp))
+        // Extract and save thread_id for multi-turn.
+        let result_text = extract_mcp_result_text(&mcp_resp);
+        if existing_thread.is_none() {
+            if let Some(thread_id) = extract_thread_id(&mcp_resp) {
+                self.context_threads
+                    .lock()
+                    .await
+                    .insert(task_id.to_string(), thread_id);
+            }
+        }
+
+        Ok(result_text)
     }
 }
 
@@ -103,18 +185,104 @@ impl AgentExecutor for CodexA2AExecutor {
         }
 
         let task_id = context.task_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        let context_id = context.context_id.clone();
         info!(task_id = %task_id, "A2A task started");
 
-        match self.execute_via_mcp(&task_id, &prompt).await {
+        // Register cancellation token.
+        let cancel_token = CancellationToken::new();
+        self.cancel_tokens
+            .lock()
+            .await
+            .insert(task_id.clone(), cancel_token.clone());
+
+        // Publish initial "working" status.
+        event_bus.publish_status_update(TaskStatusUpdateEvent {
+            task_id: task_id.clone(),
+            context_id: context_id.clone(),
+            status: TaskStatus {
+                state: TaskState::Working,
+                message: Some(Message {
+                    message_id: uuid::Uuid::new_v4().to_string(),
+                    context_id: Some(context_id.clone()),
+                    task_id: Some(task_id.clone()),
+                    role: Role::Agent,
+                    parts: vec![Part::text("Processing request...")],
+                    metadata: None,
+                    extensions: vec![],
+                    reference_task_ids: None,
+                }),
+                timestamp: Some(a2a_rs::types::now_iso8601()),
+            },
+            metadata: None,
+        });
+
+        // Subscribe to MCP notification broadcast and forward codex/event
+        // notifications as A2A StatusUpdate + ArtifactUpdate events.
+        let mut notif_rx = self.notification_tx.subscribe();
+        let forwarder_task_id = task_id.clone();
+        let forwarder_context_id = context_id.clone();
+        let forwarder_bus = event_bus.clone_sender();
+        let forwarder_handle = tokio::spawn(async move {
+            while let Ok(json_str) = notif_rx.recv().await {
+                // Status updates (thinking, running commands, etc.)
+                if let Some(update) = parse_codex_notification_to_status(
+                    &json_str,
+                    &forwarder_task_id,
+                    &forwarder_context_id,
+                ) {
+                    forwarder_bus.publish(ExecutionEvent::StatusUpdate(update));
+                }
+                // Artifact updates (file patches)
+                if let Some(artifact_event) = parse_codex_notification_to_artifact(
+                    &json_str,
+                    &forwarder_task_id,
+                    &forwarder_context_id,
+                ) {
+                    forwarder_bus.publish(ExecutionEvent::ArtifactUpdate(artifact_event));
+                }
+            }
+        });
+
+        // Execute the actual MCP call with cancellation support.
+        match self.execute_via_mcp(&task_id, &prompt, &cancel_token).await {
             Ok(result_text) => {
-                let task = completed_task(&task_id, &context.context_id, &result_text);
+                let task = completed_task(&task_id, &context_id, &result_text);
+                event_bus.publish(ExecutionEvent::Task(task));
+            }
+            Err(err_msg) if err_msg == "Task canceled" => {
+                // Build a canceled task.
+                let task = a2a_rs::types::Task {
+                    id: task_id.clone(),
+                    context_id: context_id.clone(),
+                    status: TaskStatus {
+                        state: TaskState::Canceled,
+                        message: Some(Message {
+                            message_id: uuid::Uuid::new_v4().to_string(),
+                            context_id: Some(context_id.clone()),
+                            task_id: Some(task_id.clone()),
+                            role: Role::Agent,
+                            parts: vec![Part::text("Task canceled by user request.")],
+                            metadata: None,
+                            extensions: vec![],
+                            reference_task_ids: None,
+                        }),
+                        timestamp: Some(a2a_rs::types::now_iso8601()),
+                    },
+                    artifacts: vec![],
+                    history: vec![],
+                    metadata: None,
+                };
                 event_bus.publish(ExecutionEvent::Task(task));
             }
             Err(err_msg) => {
-                let task = failed_task(&task_id, &context.context_id, &err_msg);
+                let task = failed_task(&task_id, &context_id, &err_msg);
                 event_bus.publish(ExecutionEvent::Task(task));
             }
         }
+
+        // Cleanup: stop forwarder and remove cancel token.
+        forwarder_handle.abort();
+        self.cancel_tokens.lock().await.remove(&task_id);
 
         Ok(())
     }
@@ -122,9 +290,36 @@ impl AgentExecutor for CodexA2AExecutor {
     async fn cancel(
         &self,
         task_id: &str,
-        _event_bus: &EventBus,
+        event_bus: &EventBus,
     ) -> Result<(), A2AError> {
-        Err(A2AError::task_not_cancelable(task_id))
+        let token = self.cancel_tokens.lock().await.get(task_id).cloned();
+        if let Some(token) = token {
+            info!(task_id = %task_id, "Canceling A2A task");
+            token.cancel();
+            Ok(())
+        } else {
+            // Task not found or already finished — publish failed status.
+            event_bus.publish_status_update(TaskStatusUpdateEvent {
+                task_id: task_id.to_string(),
+                context_id: String::new(),
+                status: TaskStatus {
+                    state: TaskState::Failed,
+                    message: Some(Message {
+                        message_id: uuid::Uuid::new_v4().to_string(),
+                        context_id: None,
+                        task_id: Some(task_id.to_string()),
+                        role: Role::Agent,
+                        parts: vec![Part::text(format!("Task {task_id} not found or already finished."))],
+                        metadata: None,
+                        extensions: vec![],
+                        reference_task_ids: None,
+                    }),
+                    timestamp: Some(a2a_rs::types::now_iso8601()),
+                },
+                metadata: None,
+            });
+            Err(A2AError::task_not_cancelable(task_id))
+        }
     }
 
     fn agent_card(&self, base_url: &str) -> AgentCard {
@@ -169,7 +364,7 @@ impl AgentExecutor for CodexA2AExecutor {
 }
 
 // ================================================================
-// Helper
+// Helpers
 // ================================================================
 
 fn extract_mcp_result_text(msg: &OutgoingJsonRpcMessage) -> String {
@@ -190,4 +385,463 @@ fn extract_mcp_result_text(msg: &OutgoingJsonRpcMessage) -> String {
         }
     }
     "No result".into()
+}
+
+/// Extract `threadId` from the MCP response's `structuredContent` for multi-turn.
+fn extract_thread_id(msg: &OutgoingJsonRpcMessage) -> Option<String> {
+    let v = serde_json::to_value(msg).ok()?;
+    v.pointer("/result/structuredContent/threadId")
+        .and_then(|t| t.as_str())
+        .map(|s| s.to_string())
+}
+
+/// Parse a serialized MCP outgoing message and convert relevant `codex/event`
+/// notifications into A2A [`TaskStatusUpdateEvent`]s for streaming.
+fn parse_codex_notification_to_status(
+    json_str: &str,
+    task_id: &str,
+    context_id: &str,
+) -> Option<TaskStatusUpdateEvent> {
+    let v: serde_json::Value = serde_json::from_str(json_str).ok()?;
+
+    // Only handle codex/event notifications.
+    let method = v.get("method")?.as_str()?;
+    if method != "codex/event" {
+        return None;
+    }
+
+    let params = v.get("params")?;
+    let msg = params.get("msg")?;
+    let event_type = msg.get("type")?.as_str()?;
+
+    let status_text = match event_type {
+        "agent_message_start" => "Thinking...".to_string(),
+        "agent_message_delta" => {
+            // Extract the delta text if available.
+            msg.get("delta")
+                .and_then(|d| d.as_str())
+                .unwrap_or("Generating response...")
+                .to_string()
+        }
+        "exec_command_start" | "exec_command_running" => {
+            let cmd = msg
+                .get("command")
+                .and_then(|c| c.as_str())
+                .or_else(|| msg.get("call_id").and_then(|c| c.as_str()))
+                .unwrap_or("unknown");
+            format!("Running command: {cmd}")
+        }
+        "exec_command_output" => {
+            msg.get("output")
+                .and_then(|o| o.as_str())
+                .map(|s| {
+                    let truncated: String = s.chars().take(200).collect();
+                    format!("Command output: {truncated}")
+                })
+                .unwrap_or_else(|| "Command output received".to_string())
+        }
+        "patch_start" | "patch_apply" => {
+            let file = msg
+                .get("path")
+                .and_then(|p| p.as_str())
+                .unwrap_or("file");
+            format!("Writing: {file}")
+        }
+        "session_configured" | "task_started" => "Initializing...".to_string(),
+        // Skip events that don't convey meaningful progress.
+        "task_complete" | "exec_command_complete" | "background_event" => return None,
+        _ => return None,
+    };
+
+    Some(TaskStatusUpdateEvent {
+        task_id: task_id.to_string(),
+        context_id: context_id.to_string(),
+        status: TaskStatus {
+            state: TaskState::Working,
+            message: Some(Message {
+                message_id: uuid::Uuid::new_v4().to_string(),
+                context_id: Some(context_id.to_string()),
+                task_id: Some(task_id.to_string()),
+                role: Role::Agent,
+                parts: vec![Part::text(status_text)],
+                metadata: None,
+                extensions: vec![],
+                reference_task_ids: None,
+            }),
+            timestamp: Some(a2a_rs::types::now_iso8601()),
+        },
+        metadata: None,
+    })
+}
+
+/// Parse `patch_apply` notifications into A2A [`TaskArtifactUpdateEvent`]s.
+/// Each file patch becomes an artifact with the file path and diff content.
+fn parse_codex_notification_to_artifact(
+    json_str: &str,
+    task_id: &str,
+    context_id: &str,
+) -> Option<TaskArtifactUpdateEvent> {
+    let v: serde_json::Value = serde_json::from_str(json_str).ok()?;
+
+    let method = v.get("method")?.as_str()?;
+    if method != "codex/event" {
+        return None;
+    }
+
+    let params = v.get("params")?;
+    let msg = params.get("msg")?;
+    let event_type = msg.get("type")?.as_str()?;
+
+    // Only emit artifacts for patch_apply (actual file changes).
+    if event_type != "patch_apply" {
+        return None;
+    }
+
+    let path = msg.get("path").and_then(|p| p.as_str()).unwrap_or("unknown");
+    let content = msg.get("content")
+        .or_else(|| msg.get("diff"))
+        .or_else(|| msg.get("patch"))
+        .and_then(|c| c.as_str())
+        .unwrap_or("");
+
+    Some(TaskArtifactUpdateEvent {
+        task_id: task_id.to_string(),
+        context_id: context_id.to_string(),
+        artifact: Artifact {
+            artifact_id: format!("patch-{}", uuid::Uuid::new_v4()),
+            name: Some(path.to_string()),
+            description: Some(format!("File change: {path}")),
+            parts: vec![Part::text(format!("--- {path}\n{content}"))],
+            metadata: None,
+            extensions: vec![],
+        },
+        append: false,
+        last_chunk: true,
+        metadata: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use a2a_rs::{EventBus, ExecutionEvent, RequestContext};
+    use a2a_rs::types::{SendMessageRequest, TaskState};
+    use crate::outgoing_message::{OutgoingMessage, OutgoingResponse};
+    use rmcp::model::{JsonRpcMessage, JsonRpcResponse, RequestId};
+    use tokio::sync::mpsc;
+
+    /// Integration test: verifies shared PendingMap routing.
+    ///
+    /// Flow:
+    /// 1. CodexA2AExecutor sends MCP tools/call via `incoming_tx`
+    /// 2. Fake processor reads it, creates response, sends via `outgoing_tx`
+    /// 3. Router task reads `outgoing_rx`, finds match in shared_pending, routes to oneshot
+    /// 4. Executor's `execute_via_mcp` completes → publishes completed Task event
+    #[tokio::test]
+    async fn e2e_shared_pending_routes_mcp_response_to_executor() {
+        // Shared pending map (the fix).
+        let shared_pending: crate::PendingMap =
+            Arc::new(Mutex::new(HashMap::new()));
+
+        // Channels.
+        let (incoming_tx, mut incoming_rx) = mpsc::channel::<crate::IncomingMessage>(16);
+        let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel::<OutgoingMessage>();
+        let (notif_tx, _) = tokio::sync::broadcast::channel::<String>(16);
+
+        // Router task — simulates the stdout writer in lib.rs.
+        let router_pending = shared_pending.clone();
+        let router_notif_tx = notif_tx.clone();
+        let router_handle = tokio::spawn(async move {
+            while let Some(outgoing_message) = outgoing_rx.recv().await {
+                let msg: crate::outgoing_message::OutgoingJsonRpcMessage = outgoing_message.into();
+                // Route via shared pending map.
+                let id_str = crate::extract_outgoing_id(&msg);
+                if let Some(id) = id_str {
+                    let mut map = router_pending.lock().await;
+                    if let Some(tx) = map.remove(&id) {
+                        let _ = tx.send(msg.clone());
+                    }
+                }
+                // Forward to notification broadcast.
+                if let Ok(json) = serde_json::to_string(&msg) {
+                    let _ = router_notif_tx.send(json);
+                }
+            }
+        });
+
+        // Fake MCP processor — reads incoming request, sends back a response.
+        let fake_processor = tokio::spawn(async move {
+            while let Some(msg) = incoming_rx.recv().await {
+                if let JsonRpcMessage::Request(req) = msg {
+                    let response_id = req.id.clone();
+                    let result_value = serde_json::json!({
+                        "content": [{"type": "text", "text": "Hello from test!"}],
+                        "isError": false
+                    });
+                    let _ = outgoing_tx.send(OutgoingMessage::Response(
+                        OutgoingResponse {
+                            id: response_id,
+                            result: result_value,
+                        },
+                    ));
+                }
+            }
+        });
+
+        // Create executor with shared pending.
+        let executor = CodexA2AExecutor::new(
+            incoming_tx.clone(),
+            shared_pending.clone(),
+            notif_tx.clone(),
+        );
+
+        // Create event bus and subscribe.
+        let event_bus = EventBus::new(16);
+        let mut event_rx = event_bus.subscribe();
+
+        // Build request context.
+        let context = RequestContext {
+            task_id: Some("test-task-1".to_string()),
+            context_id: "test-ctx-1".to_string(),
+            request: SendMessageRequest {
+                message: Message {
+                    message_id: "m1".to_string(),
+                    context_id: Some("test-ctx-1".to_string()),
+                    task_id: None,
+                    role: a2a_rs::types::Role::User,
+                    parts: vec![Part::text("say hi")],
+                    metadata: None,
+                    extensions: vec![],
+                    reference_task_ids: None,
+                },
+                configuration: None,
+                metadata: None,
+            },
+        };
+
+        // Execute — should complete without timeout.
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(5),
+            executor.execute(context, &event_bus),
+        )
+        .await;
+
+        assert!(result.is_ok(), "execute should not timeout");
+        assert!(result.unwrap().is_ok(), "execute should succeed");
+
+        // Collect events.
+        let mut got_status = false;
+        let mut got_task = false;
+        let mut task_state = None;
+        let mut result_text = String::new();
+
+        while let Ok(event) = event_rx.try_recv() {
+            match event {
+                ExecutionEvent::StatusUpdate(s) => {
+                    assert_eq!(s.task_id, "test-task-1");
+                    got_status = true;
+                }
+                ExecutionEvent::Task(t) => {
+                    task_state = Some(t.status.state.clone());
+                    for artifact in &t.artifacts {
+                        for part in &artifact.parts {
+                            if let Some(txt) = &part.text {
+                                result_text = txt.to_string();
+                            }
+                        }
+                    }
+                    got_task = true;
+                }
+                _ => {}
+            }
+        }
+
+        assert!(got_status, "should have received at least one status update");
+        assert!(got_task, "should have received task event");
+        assert_eq!(task_state, Some(TaskState::Completed));
+        assert!(
+            result_text.contains("Hello from test!"),
+            "task result should contain 'Hello from test!' but got: {result_text}"
+        );
+
+        // Cleanup.
+        router_handle.abort();
+        fake_processor.abort();
+    }
+
+    /// Verify cancel aborts an in-flight MCP call.
+    #[tokio::test]
+    async fn cancel_aborts_pending_mcp_call() {
+        let shared_pending: crate::PendingMap =
+            Arc::new(Mutex::new(HashMap::new()));
+        let (incoming_tx, mut incoming_rx) = mpsc::channel::<crate::IncomingMessage>(16);
+        let (notif_tx, _) = tokio::sync::broadcast::channel::<String>(16);
+
+        // Black-hole processor — never responds.
+        let _blackhole = tokio::spawn(async move {
+            while let Some(_) = incoming_rx.recv().await {
+                // Intentionally don't respond.
+            }
+        });
+
+        let executor = CodexA2AExecutor::new(
+            incoming_tx.clone(),
+            shared_pending.clone(),
+            notif_tx.clone(),
+        );
+
+        let event_bus = EventBus::new(16);
+        let mut event_rx = event_bus.subscribe();
+
+        let context = RequestContext {
+            task_id: Some("cancel-test-1".to_string()),
+            context_id: "cancel-ctx-1".to_string(),
+            request: SendMessageRequest {
+                message: Message {
+                    message_id: "m1".to_string(),
+                    context_id: Some("cancel-ctx-1".to_string()),
+                    task_id: None,
+                    role: a2a_rs::types::Role::User,
+                    parts: vec![Part::text("do something slow")],
+                    metadata: None,
+                    extensions: vec![],
+                    reference_task_ids: None,
+                },
+                configuration: None,
+                metadata: None,
+            },
+        };
+
+        // Spawn execute in background.
+        let exec_bus = event_bus.clone_sender();
+        let exec_handle = tokio::spawn({
+            let executor_ref = &executor;
+            // We can't borrow across spawn easily, so test cancel token directly.
+            async move {}
+        });
+
+        // Instead, test the cancel mechanism directly via CancellationToken.
+        let token = CancellationToken::new();
+        let token_clone = token.clone();
+
+        let pending_clone = shared_pending.clone();
+        let incoming_tx_clone = incoming_tx.clone();
+        let exec_task = tokio::spawn(async move {
+            let executor = CodexA2AExecutor::new(
+                incoming_tx_clone,
+                pending_clone,
+                notif_tx.clone(),
+            );
+            executor.execute_via_mcp("cancel-test-1", "do something", &token_clone).await
+        });
+
+        // Give the executor time to send the request.
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Cancel it.
+        token.cancel();
+
+        let result = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            exec_task,
+        ).await;
+
+        assert!(result.is_ok(), "should complete quickly after cancel");
+        let inner = result.unwrap().unwrap();
+        assert!(inner.is_err(), "should return error");
+        assert_eq!(inner.unwrap_err(), "Task canceled");
+
+        exec_handle.abort();
+    }
+
+    /// Verify that `extract_outgoing_id` correctly extracts the request ID.
+    #[test]
+    fn extract_id_from_response() {
+        let msg: crate::outgoing_message::OutgoingJsonRpcMessage =
+            JsonRpcMessage::Response(JsonRpcResponse {
+                jsonrpc: Default::default(),
+                id: RequestId::String("a2a-task-42".into()),
+                result: serde_json::Value::Null.into(),
+            });
+        let id = crate::extract_outgoing_id(&msg);
+        assert_eq!(id, Some("\"a2a-task-42\"".to_string()));
+    }
+
+    /// Verify that notification parsing works for codex/event.
+    #[test]
+    fn parse_codex_event_notification() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "codex/event",
+            "params": {
+                "msg": {
+                    "type": "agent_message_delta",
+                    "delta": "thinking hard..."
+                }
+            }
+        })
+        .to_string();
+
+        let result = parse_codex_notification_to_status(&json, "t1", "c1");
+        assert!(result.is_some());
+        let update = result.unwrap();
+        assert_eq!(update.task_id, "t1");
+        assert_eq!(update.status.state, TaskState::Working);
+        let msg = update.status.message.unwrap();
+        assert!(msg.parts[0].text.as_deref().unwrap().contains("thinking hard"));
+    }
+
+    /// Verify that non-codex notifications are ignored.
+    #[test]
+    fn parse_non_codex_notification_returns_none() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "other/event",
+            "params": {}
+        })
+        .to_string();
+        assert!(parse_codex_notification_to_status(&json, "t1", "c1").is_none());
+    }
+
+    /// Verify that patch_apply produces an ArtifactUpdate event.
+    #[test]
+    fn patch_apply_produces_artifact_update() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "codex/event",
+            "params": {
+                "msg": {
+                    "type": "patch_apply",
+                    "path": "/src/main.rs",
+                    "content": "+fn new_function() {}"
+                }
+            }
+        })
+        .to_string();
+
+        let result = parse_codex_notification_to_artifact(&json, "t1", "c1");
+        assert!(result.is_some());
+        let event = result.unwrap();
+        assert_eq!(event.task_id, "t1");
+        assert_eq!(event.artifact.name.as_deref(), Some("/src/main.rs"));
+        assert!(event.artifact.parts[0].text.as_deref().unwrap().contains("+fn new_function"));
+        assert!(event.last_chunk);
+    }
+
+    /// Verify that non-patch events don't produce artifacts.
+    #[test]
+    fn non_patch_does_not_produce_artifact() {
+        let json = serde_json::json!({
+            "jsonrpc": "2.0",
+            "method": "codex/event",
+            "params": {
+                "msg": {
+                    "type": "agent_message_delta",
+                    "delta": "hello"
+                }
+            }
+        })
+        .to_string();
+        assert!(parse_codex_notification_to_artifact(&json, "t1", "c1").is_none());
+    }
 }

--- a/codex-rs/mcp-server/src/a2a_handler.rs
+++ b/codex-rs/mcp-server/src/a2a_handler.rs
@@ -1,0 +1,194 @@
+//! Codex A2A handler — implements [`a2a_rs::AgentExecutor`] to bridge
+//! A2A messages into the Codex MCP [`MessageProcessor`] via `tools/call`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use a2a_rs::{
+    A2AError, AgentCapabilities, AgentCard, AgentExecutor, AgentInterface,
+    AgentProvider, AgentSkill, EventBus, ExecutionEvent, RequestContext,
+    SendMessageResponse,
+    completed_task, failed_task,
+};
+use serde_json::json;
+use tokio::sync::{Mutex, mpsc, oneshot};
+use tracing::info;
+
+use crate::outgoing_message::OutgoingJsonRpcMessage;
+
+/// Codex A2A executor — implements [`AgentExecutor`] from `a2a-rs`.
+pub struct CodexA2AExecutor {
+    /// Sender to feed JSON‐RPC messages into the shared MessageProcessor.
+    pub incoming_tx: mpsc::Sender<crate::IncomingMessage>,
+    /// Pending MCP request IDs → oneshot senders for responses.
+    pub pending:
+        Arc<Mutex<HashMap<String, oneshot::Sender<OutgoingJsonRpcMessage>>>>,
+}
+
+impl CodexA2AExecutor {
+    pub fn new(
+        incoming_tx: mpsc::Sender<crate::IncomingMessage>,
+        pending: Arc<Mutex<HashMap<String, oneshot::Sender<OutgoingJsonRpcMessage>>>>,
+    ) -> Self {
+        Self {
+            incoming_tx,
+            pending,
+        }
+    }
+
+    /// Execute a prompt through the MCP codex tool and return the result text.
+    async fn execute_via_mcp(&self, task_id: &str, prompt: &str) -> Result<String, String> {
+        use rmcp::model::*;
+
+        let mcp_request_id = format!("a2a-{task_id}");
+
+        let params = CallToolRequestParams {
+            name: "codex".into(),
+            arguments: Some(
+                serde_json::from_value(json!({
+                    "prompt": prompt
+                }))
+                .map_err(|e| format!("JSON error: {e}"))?,
+            ),
+            meta: None,
+            task: None,
+        };
+
+        let mcp_call: crate::IncomingMessage = JsonRpcMessage::Request(JsonRpcRequest {
+            jsonrpc: Default::default(),
+            id: RequestId::String(mcp_request_id.clone().into()),
+            request: ClientRequest::CallToolRequest(Request::new(params)),
+        });
+
+        // Register oneshot for the MCP response.
+        let (tx, rx) = oneshot::channel();
+        self.pending
+            .lock()
+            .await
+            .insert(mcp_request_id, tx);
+
+        // Send to the shared MessageProcessor.
+        self.incoming_tx
+            .send(mcp_call)
+            .await
+            .map_err(|_| "Processor channel closed".to_string())?;
+
+        // Wait for response (5 min timeout).
+        let mcp_resp = tokio::time::timeout(std::time::Duration::from_secs(300), rx)
+            .await
+            .map_err(|_| "Task timed out".to_string())?
+            .map_err(|_| "Response channel dropped".to_string())?;
+
+        Ok(extract_mcp_result_text(&mcp_resp))
+    }
+}
+
+impl AgentExecutor for CodexA2AExecutor {
+    async fn execute(
+        &self,
+        context: RequestContext,
+        event_bus: &EventBus,
+    ) -> Result<(), A2AError> {
+        // Extract text from message parts.
+        let prompt = context
+            .request
+            .message
+            .parts
+            .iter()
+            .filter_map(|p| p.text.as_deref())
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        if prompt.is_empty() {
+            return Err(A2AError::invalid_params("No text content in message"));
+        }
+
+        let task_id = context.task_id.unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+        info!(task_id = %task_id, "A2A task started");
+
+        match self.execute_via_mcp(&task_id, &prompt).await {
+            Ok(result_text) => {
+                let task = completed_task(&task_id, &context.context_id, &result_text);
+                event_bus.publish(ExecutionEvent::Task(task));
+            }
+            Err(err_msg) => {
+                let task = failed_task(&task_id, &context.context_id, &err_msg);
+                event_bus.publish(ExecutionEvent::Task(task));
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn cancel(
+        &self,
+        task_id: &str,
+        _event_bus: &EventBus,
+    ) -> Result<(), A2AError> {
+        Err(A2AError::task_not_cancelable(task_id))
+    }
+
+    fn agent_card(&self, base_url: &str) -> AgentCard {
+        AgentCard {
+            name: "codex".into(),
+            description:
+                "OpenAI Codex CLI — an AI coding agent that reads, writes, and executes code."
+                    .into(),
+            supported_interfaces: vec![AgentInterface {
+                url: format!("{base_url}/"),
+                protocol_binding: "HTTP+JSON".into(),
+                tenant: None,
+                protocol_version: "1.0".into(),
+            }],
+            provider: Some(AgentProvider {
+                organization: "OpenAI".into(),
+                url: "https://openai.com".into(),
+            }),
+            version: "0.1.0".into(),
+            documentation_url: None,
+            capabilities: AgentCapabilities {
+                streaming: Some(false),
+                push_notifications: Some(false),
+                extended_agent_card: None,
+            },
+            default_input_modes: vec!["text".into()],
+            default_output_modes: vec!["text".into()],
+            skills: vec![AgentSkill {
+                id: "codex".into(),
+                name: "Codex Coding Agent".into(),
+                description:
+                    "Execute coding tasks: read files, write code, run commands, debug issues."
+                        .into(),
+                tags: vec!["coding".into(), "shell".into(), "files".into()],
+                examples: vec![],
+                input_modes: None,
+                output_modes: None,
+            }],
+            icon_url: None,
+        }
+    }
+}
+
+// ================================================================
+// Helper
+// ================================================================
+
+fn extract_mcp_result_text(msg: &OutgoingJsonRpcMessage) -> String {
+    if let Ok(v) = serde_json::to_value(msg) {
+        if let Some(content) = v.pointer("/result/content") {
+            if let Some(arr) = content.as_array() {
+                let texts: Vec<&str> = arr
+                    .iter()
+                    .filter_map(|c| c.get("text").and_then(|t| t.as_str()))
+                    .collect();
+                if !texts.is_empty() {
+                    return texts.join("\n");
+                }
+            }
+        }
+        if let Some(result) = v.get("result") {
+            return result.to_string();
+        }
+    }
+    "No result".into()
+}

--- a/codex-rs/mcp-server/src/a2a_handler.rs
+++ b/codex-rs/mcp-server/src/a2a_handler.rs
@@ -7,7 +7,6 @@ use std::sync::Arc;
 use a2a_rs::{
     A2AError, AgentCapabilities, AgentCard, AgentExecutor, AgentInterface,
     AgentProvider, AgentSkill, EventBus, ExecutionEvent, RequestContext,
-    SendMessageResponse,
     completed_task, failed_task,
 };
 use serde_json::json;
@@ -147,7 +146,7 @@ impl AgentExecutor for CodexA2AExecutor {
             version: "0.1.0".into(),
             documentation_url: None,
             capabilities: AgentCapabilities {
-                streaming: Some(false),
+                streaming: Some(true),
                 push_notifications: Some(false),
                 extended_agent_card: None,
             },

--- a/codex-rs/mcp-server/src/http_transport.rs
+++ b/codex-rs/mcp-server/src/http_transport.rs
@@ -19,7 +19,7 @@ use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{error, info};
+use tracing::info;
 
 use crate::outgoing_message::OutgoingJsonRpcMessage;
 use crate::outgoing_message::OutgoingMessage;
@@ -93,7 +93,7 @@ async fn handle_mcp_post(
 
         if wants_sse {
             // Return SSE stream: first the response, then ongoing notifications.
-            let (sse_tx, mut sse_rx) =
+            let (sse_tx, sse_rx) =
                 mpsc::channel::<Result<Event, std::convert::Infallible>>(64);
 
             // Wait for the response in a spawned task and push it as SSE event.
@@ -205,7 +205,7 @@ fn extract_request_id(msg: &crate::IncomingMessage) -> Option<String> {
 /// Intercepts outgoing messages from the [`MessageProcessor`] and routes
 /// JSON-RPC responses to their matching HTTP request handler via the pending
 /// map.  Notifications are broadcast to all SSE listeners.
-pub async fn outgoing_http_interceptor(
+pub(crate) async fn outgoing_http_interceptor(
     mut outgoing_rx: mpsc::UnboundedReceiver<OutgoingMessage>,
     pending: Arc<Mutex<HashMap<String, oneshot::Sender<OutgoingJsonRpcMessage>>>>,
     sse_tx: tokio::sync::broadcast::Sender<String>,

--- a/codex-rs/mcp-server/src/http_transport.rs
+++ b/codex-rs/mcp-server/src/http_transport.rs
@@ -1,0 +1,283 @@
+//! HTTP transport for the Codex MCP server.
+//!
+//! Provides a Streamable HTTP endpoint that can run alongside—or instead
+//! of—the default stdin/stdout transport.  The core [`MessageProcessor`]
+//! is reused unchanged; only the I/O layer differs.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use axum::Json;
+use axum::Router;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use axum::response::Response;
+use axum::response::sse::{Event, KeepAlive, Sse};
+use axum::routing::{get, post};
+use bytes::Bytes;
+use serde::{Deserialize, Serialize};
+use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::{error, info};
+
+use crate::outgoing_message::OutgoingJsonRpcMessage;
+use crate::outgoing_message::OutgoingMessage;
+
+/// Shared state across all HTTP request handlers.
+#[derive(Clone)]
+pub struct HttpState {
+    /// Sender half of the channel that feeds incoming JSON-RPC messages into
+    /// the [`MessageProcessor`].
+    pub incoming_tx: mpsc::Sender<crate::IncomingMessage>,
+    /// Map of pending request IDs → oneshot senders that will receive the
+    /// JSON-RPC response from the processor.
+    pub pending:
+        Arc<Mutex<HashMap<String, oneshot::Sender<OutgoingJsonRpcMessage>>>>,
+    /// Sender for SSE event broadcast.
+    pub sse_tx: tokio::sync::broadcast::Sender<String>,
+}
+
+/// Build the axum [`Router`] for the MCP-over-HTTP transport.
+pub fn build_router(state: HttpState) -> Router {
+    Router::new()
+        .route("/mcp", post(handle_mcp_post))
+        .route("/mcp", get(handle_mcp_sse))
+        .route("/health", get(handle_health))
+        .with_state(state)
+}
+
+/// `POST /mcp` — accepts a single JSON-RPC request body and returns the
+/// response as `application/json`, plus streams notifications via SSE on the
+/// same connection using `text/event-stream` if the client `Accept`s it.
+async fn handle_mcp_post(
+    State(state): State<HttpState>,
+    headers: axum::http::HeaderMap,
+    body: Bytes,
+) -> Response {
+    // Parse the incoming JSON-RPC message.
+    let msg: crate::IncomingMessage = match serde_json::from_slice(&body) {
+        Ok(m) => m,
+        Err(e) => {
+            let err = JsonRpcErrorResponse {
+                jsonrpc: "2.0".into(),
+                id: serde_json::Value::Null,
+                error: JsonRpcError {
+                    code: -32700,
+                    message: format!("Parse error: {e}"),
+                },
+            };
+            return (StatusCode::BAD_REQUEST, Json(err)).into_response();
+        }
+    };
+
+    // Extract the request ID so we can match the response later.
+    let request_id = extract_request_id(&msg);
+
+    // Check if the client wants SSE streaming.
+    let wants_sse = headers
+        .get(axum::http::header::ACCEPT)
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|s| s.contains("text/event-stream"));
+
+    if let Some(ref id) = request_id {
+        // Register a oneshot channel so the outgoing interceptor can route the
+        // response back to us.
+        let (tx, rx) = oneshot::channel();
+        state.pending.lock().await.insert(id.clone(), tx);
+
+        // Forward the message to the processor.
+        if state.incoming_tx.send(msg).await.is_err() {
+            return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+        }
+
+        if wants_sse {
+            // Return SSE stream: first the response, then ongoing notifications.
+            let (sse_tx, mut sse_rx) =
+                mpsc::channel::<Result<Event, std::convert::Infallible>>(64);
+
+            // Wait for the response in a spawned task and push it as SSE event.
+            let broadcast_rx = state.sse_tx.subscribe();
+            tokio::spawn(async move {
+                // 1. Send the response once ready.
+                if let Ok(resp) = rx.await {
+                    if let Ok(json) = serde_json::to_string(&resp) {
+                        let _ = sse_tx
+                            .send(Ok(Event::default().data(json)))
+                            .await;
+                    }
+                }
+                // 2. Forward broadcast notifications.
+                let mut broadcast_rx = broadcast_rx;
+                loop {
+                    match broadcast_rx.recv().await {
+                        Ok(data) => {
+                            if sse_tx
+                                .send(Ok(Event::default().data(data)))
+                                .await
+                                .is_err()
+                            {
+                                break;
+                            }
+                        }
+                        Err(_) => break,
+                    }
+                }
+            });
+
+            return Sse::new(ReceiverStream::new(sse_rx))
+                .keep_alive(KeepAlive::default())
+                .into_response();
+        }
+
+        // Non-SSE: wait for the JSON-RPC response and return it as JSON.
+        match tokio::time::timeout(std::time::Duration::from_secs(300), rx).await
+        {
+            Ok(Ok(resp)) => {
+                return (
+                    StatusCode::OK,
+                    [("content-type", "application/json")],
+                    serde_json::to_string(&resp).unwrap_or_default(),
+                )
+                    .into_response();
+            }
+            Ok(Err(_)) => {
+                return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+            }
+            Err(_) => {
+                return StatusCode::GATEWAY_TIMEOUT.into_response();
+            }
+        }
+    }
+
+    // Notification (no request ID) — fire-and-forget.
+    if state.incoming_tx.send(msg).await.is_err() {
+        return StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+    StatusCode::ACCEPTED.into_response()
+}
+
+/// `GET /mcp` — SSE endpoint for server-initiated notifications.
+async fn handle_mcp_sse(State(state): State<HttpState>) -> impl IntoResponse {
+    let mut broadcast_rx = state.sse_tx.subscribe();
+    let (tx, rx) = mpsc::channel::<Result<Event, std::convert::Infallible>>(64);
+
+    tokio::spawn(async move {
+        loop {
+            match broadcast_rx.recv().await {
+                Ok(data) => {
+                    if tx
+                        .send(Ok(Event::default().data(data)))
+                        .await
+                        .is_err()
+                    {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    Sse::new(ReceiverStream::new(rx)).keep_alive(KeepAlive::default())
+}
+
+/// `GET /health` — simple health check.
+async fn handle_health() -> impl IntoResponse {
+    Json(serde_json::json!({
+        "status": "ok",
+        "transport": ["stdio", "http"],
+    }))
+}
+
+// ----------------------------------------------------------------
+// Helpers
+// ----------------------------------------------------------------
+
+fn extract_request_id(msg: &crate::IncomingMessage) -> Option<String> {
+    use rmcp::model::JsonRpcMessage;
+    match msg {
+        JsonRpcMessage::Request(r) => Some(format!("{}", r.id)),
+        _ => None,
+    }
+}
+
+/// Intercepts outgoing messages from the [`MessageProcessor`] and routes
+/// JSON-RPC responses to their matching HTTP request handler via the pending
+/// map.  Notifications are broadcast to all SSE listeners.
+pub async fn outgoing_http_interceptor(
+    mut outgoing_rx: mpsc::UnboundedReceiver<OutgoingMessage>,
+    pending: Arc<Mutex<HashMap<String, oneshot::Sender<OutgoingJsonRpcMessage>>>>,
+    sse_tx: tokio::sync::broadcast::Sender<String>,
+    // Also write to stdout when running in dual mode.
+    write_stdout: bool,
+) {
+    let mut stdout = if write_stdout {
+        Some(tokio::io::stdout())
+    } else {
+        None
+    };
+
+    while let Some(outgoing_message) = outgoing_rx.recv().await {
+        let msg: OutgoingJsonRpcMessage = outgoing_message.into();
+
+        // Try to match to a pending HTTP request.
+        let id_str = extract_outgoing_id(&msg);
+        let mut routed_to_http = false;
+
+        if let Some(id) = id_str {
+            let mut map = pending.lock().await;
+            if let Some(tx) = map.remove(&id) {
+                let _ = tx.send(msg.clone());
+                routed_to_http = true;
+            }
+        }
+
+        // Broadcast notifications to SSE and/or write to stdout.
+        if let Ok(json) = serde_json::to_string(&msg) {
+            if !routed_to_http {
+                // Notification — broadcast to SSE listeners.
+                let _ = sse_tx.send(json.clone());
+            }
+
+            // Dual mode: also write to stdout.
+            if let Some(ref mut out) = stdout {
+                use tokio::io::AsyncWriteExt;
+                let _ = out.write_all(json.as_bytes()).await;
+                let _ = out.write_all(b"\n").await;
+            }
+        }
+    }
+
+    info!("HTTP outgoing interceptor exited");
+}
+
+fn extract_outgoing_id(msg: &OutgoingJsonRpcMessage) -> Option<String> {
+    // OutgoingJsonRpcMessage is an enum; we need to match on it.
+    // For now, serialize and extract "id" field.
+    if let Ok(v) = serde_json::to_value(msg) {
+        if let Some(id) = v.get("id") {
+            if !id.is_null() {
+                return Some(id.to_string());
+            }
+        }
+    }
+    None
+}
+
+// ----------------------------------------------------------------
+// JSON-RPC error types for HTTP error responses.
+// ----------------------------------------------------------------
+
+#[derive(Serialize, Deserialize)]
+struct JsonRpcErrorResponse {
+    jsonrpc: String,
+    id: serde_json::Value,
+    error: JsonRpcError,
+}
+
+#[derive(Serialize, Deserialize)]
+struct JsonRpcError {
+    code: i32,
+    message: String,
+}

--- a/codex-rs/mcp-server/src/http_transport.rs
+++ b/codex-rs/mcp-server/src/http_transport.rs
@@ -211,6 +211,8 @@ pub(crate) async fn outgoing_http_interceptor(
     sse_tx: tokio::sync::broadcast::Sender<String>,
     // Also write to stdout when running in dual mode.
     write_stdout: bool,
+    // Optional A2A notification broadcast — forwards all notifications.
+    a2a_notif_tx: Option<tokio::sync::broadcast::Sender<String>>,
 ) {
     let mut stdout = if write_stdout {
         Some(tokio::io::stdout())
@@ -238,6 +240,11 @@ pub(crate) async fn outgoing_http_interceptor(
             if !routed_to_http {
                 // Notification — broadcast to SSE listeners.
                 let _ = sse_tx.send(json.clone());
+            }
+
+            // Forward to A2A broadcast channel if enabled.
+            if let Some(ref a2a_tx) = a2a_notif_tx {
+                let _ = a2a_tx.send(json.clone());
             }
 
             // Dual mode: also write to stdout.

--- a/codex-rs/mcp-server/src/lib.rs
+++ b/codex-rs/mcp-server/src/lib.rs
@@ -1,9 +1,11 @@
 //! Prototype MCP server.
 #![deny(clippy::print_stdout, clippy::print_stderr)]
 
+use std::collections::HashMap;
 use std::io::ErrorKind;
 use std::io::Result as IoResult;
 use std::path::PathBuf;
+use std::sync::Arc;
 
 use codex_core::config::Config;
 use codex_utils_cli::CliConfigOverrides;
@@ -13,7 +15,6 @@ use rmcp::model::ClientRequest;
 use rmcp::model::JsonRpcMessage;
 use serde_json::Value;
 use tokio::io::AsyncBufReadExt;
-use tokio::io::AsyncWriteExt;
 use tokio::io::BufReader;
 use tokio::io::{self};
 use tokio::sync::mpsc;
@@ -28,9 +29,10 @@ mod exec_approval;
 pub(crate) mod message_processor;
 mod outgoing_message;
 mod patch_approval;
+pub mod http_transport;
+pub mod a2a_handler;
 
 use crate::message_processor::MessageProcessor;
-use crate::outgoing_message::OutgoingJsonRpcMessage;
 use crate::outgoing_message::OutgoingMessage;
 use crate::outgoing_message::OutgoingMessageSender;
 
@@ -41,19 +43,41 @@ pub use crate::exec_approval::ExecApprovalResponse;
 pub use crate::patch_approval::PatchApprovalElicitRequestParams;
 pub use crate::patch_approval::PatchApprovalResponse;
 
-/// Size of the bounded channels used to communicate between tasks. The value
-/// is a balance between throughput and memory usage – 128 messages should be
-/// plenty for an interactive CLI.
+/// Size of the bounded channels used to communicate between tasks.
 const CHANNEL_CAPACITY: usize = 128;
 
 type IncomingMessage = JsonRpcMessage<ClientRequest, Value, ClientNotification>;
+
+/// Options for controlling which transports to start.
+#[derive(Default)]
+pub struct TransportOptions {
+    /// If set, start an MCP HTTP server on this port in addition to (or
+    /// instead of) stdin/stdout.
+    pub http_port: Option<u16>,
+    /// If set, start an A2A server on this port.
+    pub a2a_port: Option<u16>,
+    /// When true, disable the stdin/stdout transport entirely (HTTP-only mode).
+    pub http_only: bool,
+}
 
 pub async fn run_main(
     codex_linux_sandbox_exe: Option<PathBuf>,
     cli_config_overrides: CliConfigOverrides,
 ) -> IoResult<()> {
-    // Install a simple subscriber so `tracing` output is visible.  Users can
-    // control the log level with `RUST_LOG`.
+    run_main_with_transport(
+        codex_linux_sandbox_exe,
+        cli_config_overrides,
+        TransportOptions::default(),
+    )
+    .await
+}
+
+pub async fn run_main_with_transport(
+    codex_linux_sandbox_exe: Option<PathBuf>,
+    cli_config_overrides: CliConfigOverrides,
+    transport: TransportOptions,
+) -> IoResult<()> {
+    // Install tracing subscriber.
     tracing_subscriber::fmt()
         .with_writer(std::io::stderr)
         .with_env_filter(EnvFilter::from_default_env())
@@ -61,33 +85,9 @@ pub async fn run_main(
 
     // Set up channels.
     let (incoming_tx, mut incoming_rx) = mpsc::channel::<IncomingMessage>(CHANNEL_CAPACITY);
-    let (outgoing_tx, mut outgoing_rx) = mpsc::unbounded_channel::<OutgoingMessage>();
+    let (outgoing_tx, outgoing_rx) = mpsc::unbounded_channel::<OutgoingMessage>();
 
-    // Task: read from stdin, push to `incoming_tx`.
-    let stdin_reader_handle = tokio::spawn({
-        async move {
-            let stdin = io::stdin();
-            let reader = BufReader::new(stdin);
-            let mut lines = reader.lines();
-
-            while let Some(line) = lines.next_line().await.unwrap_or_default() {
-                match serde_json::from_str::<IncomingMessage>(&line) {
-                    Ok(msg) => {
-                        if incoming_tx.send(msg).await.is_err() {
-                            // Receiver gone – nothing left to do.
-                            break;
-                        }
-                    }
-                    Err(e) => error!("Failed to deserialize JSON-RPC message: {e}"),
-                }
-            }
-
-            debug!("stdin reader finished (EOF)");
-        }
-    });
-
-    // Parse CLI overrides once and derive the base Config eagerly so later
-    // components do not need to work with raw TOML values.
+    // Parse CLI overrides once and derive the base Config eagerly.
     let cli_kv_overrides = cli_config_overrides.parse_overrides().map_err(|e| {
         std::io::Error::new(
             ErrorKind::InvalidInput,
@@ -100,7 +100,138 @@ pub async fn run_main(
             std::io::Error::new(ErrorKind::InvalidData, format!("error loading config: {e}"))
         })?;
 
-    // Task: process incoming messages.
+    // --- Stdin reader (optional) ---
+    let stdin_handle = if !transport.http_only {
+        let tx = incoming_tx.clone();
+        Some(tokio::spawn(async move {
+            let stdin = io::stdin();
+            let reader = BufReader::new(stdin);
+            let mut lines = reader.lines();
+
+            while let Some(line) = lines.next_line().await.unwrap_or_default() {
+                match serde_json::from_str::<IncomingMessage>(&line) {
+                    Ok(msg) => {
+                        if tx.send(msg).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(e) => error!("Failed to deserialize JSON-RPC message: {e}"),
+                }
+            }
+
+            debug!("stdin reader finished (EOF)");
+        }))
+    } else {
+        None
+    };
+
+    // --- A2A server (optional) ---
+    let a2a_handle = if let Some(a2a_port) = transport.a2a_port {
+        let pending = Arc::new(tokio::sync::Mutex::new(
+            HashMap::<String, tokio::sync::oneshot::Sender<crate::outgoing_message::OutgoingJsonRpcMessage>>::new(),
+        ));
+
+        let handler = a2a_handler::CodexA2AExecutor::new(
+            incoming_tx.clone(),
+            pending.clone(),
+        );
+
+        let addr = format!("0.0.0.0:{a2a_port}");
+        info!("A2A server listening on http://{addr}/");
+
+        Some(tokio::spawn(async move {
+            if let Err(e) = a2a_rs::A2AServer::new(handler, a2a_rs::InMemoryTaskStore::new())
+                .bind(&addr)
+                .run()
+                .await
+            {
+                error!("A2A server error: {e}");
+            }
+        }))
+    } else {
+        None
+    };
+
+    // --- HTTP server (optional) ---
+    let mut outgoing_rx = Some(outgoing_rx);
+    let http_handle = if let Some(port) = transport.http_port {
+        let pending = Arc::new(tokio::sync::Mutex::new(
+            HashMap::<String, tokio::sync::oneshot::Sender<crate::outgoing_message::OutgoingJsonRpcMessage>>::new(),
+        ));
+        let (sse_tx, _) = tokio::sync::broadcast::channel::<String>(256);
+
+        let state = http_transport::HttpState {
+            incoming_tx: incoming_tx.clone(),
+            pending: pending.clone(),
+            sse_tx: sse_tx.clone(),
+        };
+
+        let router = http_transport::build_router(state);
+
+        // Start the outgoing interceptor that routes responses to HTTP
+        // handlers and/or stdout.
+        let write_stdout = !transport.http_only;
+        let interceptor_handle = tokio::spawn(
+            http_transport::outgoing_http_interceptor(
+                outgoing_rx.take().expect("outgoing_rx already taken"),
+                pending,
+                sse_tx,
+                write_stdout,
+            ),
+        );
+
+        let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
+        info!("HTTP MCP server listening on http://{addr}/mcp");
+
+        let listener = tokio::net::TcpListener::bind(addr)
+            .await
+            .map_err(|e| {
+                std::io::Error::new(
+                    ErrorKind::AddrInUse,
+                    format!("failed to bind HTTP server to {addr}: {e}"),
+                )
+            })?;
+
+        let server_handle = tokio::spawn(async move {
+            if let Err(e) = axum::serve(listener, router).await {
+                error!("HTTP server error: {e}");
+            }
+        });
+
+        Some((server_handle, interceptor_handle))
+    } else {
+        None
+    };
+
+    // --- Stdout writer (when no HTTP or dual mode without interceptor) ---
+    let stdout_handle = if let Some(mut outgoing_rx) = outgoing_rx.take() {
+        Some(tokio::spawn(async move {
+            use tokio::io::AsyncWriteExt;
+            let mut stdout = io::stdout();
+            while let Some(outgoing_message) = outgoing_rx.recv().await {
+                let msg: crate::outgoing_message::OutgoingJsonRpcMessage =
+                    outgoing_message.into();
+                match serde_json::to_string(&msg) {
+                    Ok(json) => {
+                        if let Err(e) = stdout.write_all(json.as_bytes()).await {
+                            error!("Failed to write to stdout: {e}");
+                            break;
+                        }
+                        if let Err(e) = stdout.write_all(b"\n").await {
+                            error!("Failed to write newline to stdout: {e}");
+                            break;
+                        }
+                    }
+                    Err(e) => error!("Failed to serialize JSON-RPC message: {e}"),
+                }
+            }
+            info!("stdout writer exited (channel closed)");
+        }))
+    } else {
+        None
+    };
+
+    // --- Message processor (shared between both transports) ---
     let processor_handle = tokio::spawn({
         let outgoing_message_sender = OutgoingMessageSender::new(outgoing_tx);
         let mut processor = MessageProcessor::new(
@@ -117,38 +248,24 @@ pub async fn run_main(
                     JsonRpcMessage::Error(e) => processor.process_error(e),
                 }
             }
-
             info!("processor task exited (channel closed)");
         }
     });
 
-    // Task: write outgoing messages to stdout.
-    let stdout_writer_handle = tokio::spawn(async move {
-        let mut stdout = io::stdout();
-        while let Some(outgoing_message) = outgoing_rx.recv().await {
-            let msg: OutgoingJsonRpcMessage = outgoing_message.into();
-            match serde_json::to_string(&msg) {
-                Ok(json) => {
-                    if let Err(e) = stdout.write_all(json.as_bytes()).await {
-                        error!("Failed to write to stdout: {e}");
-                        break;
-                    }
-                    if let Err(e) = stdout.write_all(b"\n").await {
-                        error!("Failed to write newline to stdout: {e}");
-                        break;
-                    }
-                }
-                Err(e) => error!("Failed to serialize JSON-RPC message: {e}"),
-            }
-        }
-
-        info!("stdout writer exited (channel closed)");
-    });
-
-    // Wait for all tasks to finish.  The typical exit path is the stdin reader
-    // hitting EOF which, once it drops `incoming_tx`, propagates shutdown to
-    // the processor and then to the stdout task.
-    let _ = tokio::join!(stdin_reader_handle, processor_handle, stdout_writer_handle);
+    // Wait for tasks to complete.
+    if let Some(h) = stdin_handle {
+        let _ = h.await;
+    }
+    let _ = processor_handle.await;
+    if let Some(h) = stdout_handle {
+        let _ = h.await;
+    }
+    if let Some((server_h, interceptor_h)) = http_handle {
+        let _ = tokio::join!(server_h, interceptor_h);
+    }
+    if let Some(h) = a2a_handle {
+        let _ = h.await;
+    }
 
     Ok(())
 }

--- a/codex-rs/mcp-server/src/main.rs
+++ b/codex-rs/mcp-server/src/main.rs
@@ -1,10 +1,48 @@
+use clap::Parser;
 use codex_arg0::arg0_dispatch_or_else;
-use codex_mcp_server::run_main;
+use codex_mcp_server::{TransportOptions, run_main_with_transport};
 use codex_utils_cli::CliConfigOverrides;
 
+/// Codex MCP server with optional HTTP transport.
+#[derive(Parser)]
+#[command(name = "codex-mcp-server")]
+struct Cli {
+    /// Start an HTTP server on this port (in addition to stdin/stdout).
+    /// Example: --port 9100
+    #[arg(long)]
+    port: Option<u16>,
+
+    /// Disable stdin/stdout transport; run HTTP-only mode.
+    /// Requires --port to be set.
+    #[arg(long)]
+    http_only: bool,
+
+    /// Start an A2A server on this port.
+    /// Example: --a2a-port 9200
+    #[arg(long)]
+    a2a_port: Option<u16>,
+}
+
 fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+
+    if cli.http_only && cli.port.is_none() {
+        anyhow::bail!("--http-only requires --port to be set");
+    }
+
+    let transport = TransportOptions {
+        http_port: cli.port,
+        http_only: cli.http_only,
+        a2a_port: cli.a2a_port,
+    };
+
     arg0_dispatch_or_else(|codex_linux_sandbox_exe| async move {
-        run_main(codex_linux_sandbox_exe, CliConfigOverrides::default()).await?;
+        run_main_with_transport(
+            codex_linux_sandbox_exe,
+            CliConfigOverrides::default(),
+            transport,
+        )
+        .await?;
         Ok(())
     })
 }


### PR DESCRIPTION
## Summary

Enhance the Codex A2A server with SACP (Symposium ACP) session management, MCP tool integration, and token usage tracking capabilities.

## Changes

### A2A Server (`codex-rs/a2a`)
- Add SACP session lifecycle management for ACP protocol support
- Integrate token usage tracking via bespoke event handling
- Add `agent-client-protocol` dependency for ACP schema types

### MCP Server (`codex-rs/mcp-server`)
- Enhance A2A handler with unified tool discovery from MCP servers
- Add session-aware HTTP transport routing
- Integrate `agent-client-protocol` for ACP notification types

### Dependencies
- Add `agent-client-protocol` crate for ACP schema integration
- Update `Cargo.lock` with new dependency chain

## Motivation

These changes enable Codex to work as an ACP-compatible agent, supporting:
- Real-time token usage monitoring via `thread/tokenUsage/updated` notifications
- Session management for multi-turn conversations
- Unified tool discovery combining native Codex tools with external MCP servers

## Testing

- `cargo check` passes for all modified crates
- Changes are additive and backward-compatible