### PR TITLE
feat: integrate Specify (spec-kit) commands into Codex TUI

### DIFF
--- a/codex-rs/core/src/lib.rs
+++ b/codex-rs/core/src/lib.rs
@@ -103,6 +103,7 @@ pub mod shell;
 pub mod shell_snapshot;
 pub mod skills;
 pub mod spawn;
+pub mod specify;
 pub mod state_db;
 pub mod terminal;
 mod tools;

--- a/codex-rs/core/src/specify.rs
+++ b/codex-rs/core/src/specify.rs
@@ -1,0 +1,402 @@
+//! Specify (spec-kit) command discovery.
+//!
+//! Detects whether `specify init` has been run in the current project and
+//! discovers the available slash-command TOML/Markdown templates installed
+//! by spec-kit under the relevant AI agent directory.
+
+use std::path::Path;
+use std::path::PathBuf;
+
+use serde::Deserialize;
+
+// ---------------------------------------------------------------------------
+// Agent directory configurations
+// ---------------------------------------------------------------------------
+
+/// Agent directories that store commands as `.toml` files.
+const TOML_AGENT_DIRS: &[&str] = &[
+    ".codex/commands",
+    ".gemini/commands",
+    ".qwen/commands",
+];
+
+/// Agent directories that store commands as `.md` files.
+const MD_AGENT_DIRS: &[&str] = &[
+    ".claude/commands",
+    ".cursor/commands",
+    ".github/agents",
+];
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// A single Specify command discovered from a TOML or Markdown template file.
+#[derive(Debug, Clone)]
+pub struct SpecifyCommand {
+    /// Command name derived from the file stem (e.g. `"constitution"`).
+    pub name: String,
+    /// Human-readable description (from the TOML `description` field or MD
+    /// frontmatter).
+    pub description: String,
+    /// The prompt body that should be sent to the model.
+    pub prompt: String,
+    /// Absolute path to the template file.
+    pub path: PathBuf,
+}
+
+// ---------------------------------------------------------------------------
+// TOML schema (matches spec-kit `_render_toml_command` output)
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct TomlTemplate {
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    prompt: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if any known AI-agent commands directory exists under `cwd`.
+pub fn is_specify_initialized(cwd: &Path) -> bool {
+    for dir in TOML_AGENT_DIRS.iter().chain(MD_AGENT_DIRS.iter()) {
+        if cwd.join(dir).is_dir() {
+            return true;
+        }
+    }
+    false
+}
+
+/// Discover all Specify commands available under `cwd`.
+///
+/// The function scans known agent directories (TOML first, then Markdown),
+/// and returns the commands found in the **first** directory that exists.
+pub fn discover_specify_commands(cwd: &Path) -> Vec<SpecifyCommand> {
+    // Try TOML agent directories first.
+    for dir in TOML_AGENT_DIRS {
+        let commands_dir = cwd.join(dir);
+        if commands_dir.is_dir() {
+            return read_toml_commands(&commands_dir);
+        }
+    }
+
+    // Fall back to Markdown agent directories.
+    for dir in MD_AGENT_DIRS {
+        let commands_dir = cwd.join(dir);
+        if commands_dir.is_dir() {
+            return read_md_commands(&commands_dir);
+        }
+    }
+
+    Vec::new()
+}
+
+// ---------------------------------------------------------------------------
+// TOML parsing
+// ---------------------------------------------------------------------------
+
+fn read_toml_commands(dir: &Path) -> Vec<SpecifyCommand> {
+    let mut commands = Vec::new();
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return commands,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().map_or(true, |ext| ext != "toml") {
+            continue;
+        }
+        let name = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let template: TomlTemplate = match toml::from_str(&content) {
+            Ok(t) => t,
+            Err(_) => continue,
+        };
+
+        commands.push(SpecifyCommand {
+            name,
+            description: template.description.unwrap_or_default(),
+            prompt: template.prompt.unwrap_or_default(),
+            path,
+        });
+    }
+
+    commands.sort_by(|a, b| a.name.cmp(&b.name));
+    commands
+}
+
+// ---------------------------------------------------------------------------
+// Markdown parsing (YAML frontmatter)
+// ---------------------------------------------------------------------------
+
+fn read_md_commands(dir: &Path) -> Vec<SpecifyCommand> {
+    let mut commands = Vec::new();
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(_) => return commands,
+    };
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().map_or(true, |ext| ext != "md") {
+            continue;
+        }
+        let name = match path.file_stem().and_then(|s| s.to_str()) {
+            Some(n) => n.to_string(),
+            None => continue,
+        };
+
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+
+        let (description, body) = parse_md_frontmatter(&content);
+
+        commands.push(SpecifyCommand {
+            name,
+            description,
+            prompt: body,
+            path,
+        });
+    }
+
+    commands.sort_by(|a, b| a.name.cmp(&b.name));
+    commands
+}
+
+/// Extract YAML frontmatter `description` and the body from a Markdown file.
+fn parse_md_frontmatter(content: &str) -> (String, String) {
+    if !content.starts_with("---") {
+        return (String::new(), content.to_string());
+    }
+
+    let after_opening = &content[3..];
+    let end_marker = match after_opening.find("---") {
+        Some(pos) => pos,
+        None => return (String::new(), content.to_string()),
+    };
+
+    let frontmatter_str = &after_opening[..end_marker];
+    let body = after_opening[end_marker + 3..].trim().to_string();
+
+    // Extract `description:` value with basic YAML parsing.
+    let description = frontmatter_str
+        .lines()
+        .find_map(|line| {
+            let trimmed = line.trim();
+            if let Some(rest) = trimmed.strip_prefix("description:") {
+                Some(rest.trim().trim_matches('"').trim_matches('\'').to_string())
+            } else {
+                None
+            }
+        })
+        .unwrap_or_default();
+
+    (description, body)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_is_specify_initialized_with_codex_commands() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+
+        // Not initialized yet.
+        assert!(!is_specify_initialized(root));
+
+        // Create .codex/commands/
+        fs::create_dir_all(root.join(".codex/commands")).unwrap();
+        assert!(is_specify_initialized(root));
+    }
+
+    #[test]
+    fn test_is_specify_initialized_with_gemini_commands() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+
+        fs::create_dir_all(root.join(".gemini/commands")).unwrap();
+        assert!(is_specify_initialized(root));
+    }
+
+    #[test]
+    fn test_is_specify_initialized_with_claude_commands() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+
+        fs::create_dir_all(root.join(".claude/commands")).unwrap();
+        assert!(is_specify_initialized(root));
+    }
+
+    #[test]
+    fn test_discover_toml_commands() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let commands_dir = root.join(".codex/commands");
+        fs::create_dir_all(&commands_dir).unwrap();
+
+        fs::write(
+            commands_dir.join("constitution.toml"),
+            r#"
+description = "Create or update the project constitution"
+
+prompt = """
+You are a specification assistant.
+Update the constitution at .specify/memory/constitution.md.
+"""
+"#,
+        )
+        .unwrap();
+
+        fs::write(
+            commands_dir.join("plan.toml"),
+            r#"
+description = "Generate implementation plan"
+
+prompt = """
+Create a detailed plan.
+"""
+"#,
+        )
+        .unwrap();
+
+        let cmds = discover_specify_commands(root);
+        assert_eq!(cmds.len(), 2);
+
+        // Sorted alphabetically
+        assert_eq!(cmds[0].name, "constitution");
+        assert_eq!(
+            cmds[0].description,
+            "Create or update the project constitution"
+        );
+        assert!(cmds[0].prompt.contains("specification assistant"));
+
+        assert_eq!(cmds[1].name, "plan");
+        assert_eq!(cmds[1].description, "Generate implementation plan");
+    }
+
+    #[test]
+    fn test_discover_md_commands() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let commands_dir = root.join(".claude/commands");
+        fs::create_dir_all(&commands_dir).unwrap();
+
+        fs::write(
+            commands_dir.join("clarify.md"),
+            "---\ndescription: Clarify ambiguous requirements\n---\n\nAsk clarifying questions.\n",
+        )
+        .unwrap();
+
+        let cmds = discover_specify_commands(root);
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].name, "clarify");
+        assert_eq!(cmds[0].description, "Clarify ambiguous requirements");
+        assert!(cmds[0].prompt.contains("clarifying questions"));
+    }
+
+    #[test]
+    fn test_discover_empty_directory() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let commands_dir = root.join(".codex/commands");
+        fs::create_dir_all(&commands_dir).unwrap();
+
+        let cmds = discover_specify_commands(root);
+        assert!(cmds.is_empty());
+    }
+
+    #[test]
+    fn test_discover_ignores_invalid_toml() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+        let commands_dir = root.join(".codex/commands");
+        fs::create_dir_all(&commands_dir).unwrap();
+
+        fs::write(
+            commands_dir.join("broken.toml"),
+            "this is not valid toml {{{{",
+        )
+        .unwrap();
+
+        fs::write(
+            commands_dir.join("valid.toml"),
+            "description = \"A valid command\"\nprompt = \"Do something\"\n",
+        )
+        .unwrap();
+
+        let cmds = discover_specify_commands(root);
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].name, "valid");
+    }
+
+    #[test]
+    fn test_toml_dirs_take_priority_over_md() {
+        let tmp = tempdir().unwrap();
+        let root = tmp.path();
+
+        // Create both a TOML and MD commands directory.
+        let toml_dir = root.join(".codex/commands");
+        let md_dir = root.join(".claude/commands");
+        fs::create_dir_all(&toml_dir).unwrap();
+        fs::create_dir_all(&md_dir).unwrap();
+
+        fs::write(
+            toml_dir.join("a.toml"),
+            "description = \"from toml\"\nprompt = \"toml prompt\"\n",
+        )
+        .unwrap();
+        fs::write(
+            md_dir.join("b.md"),
+            "---\ndescription: from md\n---\nmd prompt\n",
+        )
+        .unwrap();
+
+        // TOML directory is found first.
+        let cmds = discover_specify_commands(root);
+        assert_eq!(cmds.len(), 1);
+        assert_eq!(cmds[0].name, "a");
+        assert_eq!(cmds[0].description, "from toml");
+    }
+
+    #[test]
+    fn test_parse_md_frontmatter() {
+        let content =
+            "---\ndescription: Create specification\nhandoffs:\n  - label: Next\n---\n\nBody content here.\n";
+        let (desc, body) = parse_md_frontmatter(content);
+        assert_eq!(desc, "Create specification");
+        assert!(body.contains("Body content here."));
+    }
+
+    #[test]
+    fn test_parse_md_frontmatter_no_frontmatter() {
+        let content = "Just plain markdown.\n";
+        let (desc, body) = parse_md_frontmatter(content);
+        assert!(desc.is_empty());
+        assert_eq!(body, content);
+    }
+}

--- a/codex-rs/protocol/src/custom_prompts.rs
+++ b/codex-rs/protocol/src/custom_prompts.rs
@@ -10,6 +10,10 @@ use ts_rs::TS;
 /// - Full slash prefix: `"/{PROMPTS_CMD_PREFIX}:"`
 pub const PROMPTS_CMD_PREFIX: &str = "prompts";
 
+/// Base namespace for Specify (spec-kit) slash commands.
+/// Commands use the form `/specify.<command_name>`.
+pub const SPECIFY_CMD_PREFIX: &str = "specify";
+
 #[derive(Serialize, Deserialize, Debug, Clone, JsonSchema, TS)]
 pub struct CustomPrompt {
     pub name: String,

--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -733,6 +733,16 @@ impl BottomPane {
         self.request_redraw();
     }
 
+    /// Update Specify (spec-kit) commands available for the slash popup.
+    pub(crate) fn set_specify_commands(
+        &mut self,
+        commands: Vec<codex_core::specify::SpecifyCommand>,
+        initialized: bool,
+    ) {
+        self.composer.set_specify_commands(commands, initialized);
+        self.request_redraw();
+    }
+
     pub(crate) fn composer_is_empty(&self) -> bool {
         self.composer.is_empty()
     }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1057,6 +1057,14 @@ impl ChatWidget {
         }
         // Ask codex-core to enumerate custom prompts for this session.
         self.submit_op(Op::ListCustomPrompts);
+
+        // Discover Specify (spec-kit) commands from the project directory.
+        if let Some(cwd) = &self.current_cwd {
+            use codex_core::specify;
+            let initialized = specify::is_specify_initialized(cwd);
+            let commands = specify::discover_specify_commands(cwd);
+            self.bottom_pane.set_specify_commands(commands, initialized);
+        }
         self.submit_op(Op::ListSkills {
             cwds: Vec::new(),
             force_reload: true,


### PR DESCRIPTION
- Add specify.rs core module for command discovery (TOML + MD parsing)
- Add SPECIFY_CMD_PREFIX constant to protocol
- Extend CommandItem with SpecifyCommand variant for autocomplete
- Add Tab/Enter dispatch for /specify.* commands in chat_composer
- Wire discovery into chatwidget on session configured
- Support both {{args}} and $ARGUMENTS placeholders
- Scan .gemini/commands/, .codex/commands/, .claude/commands/ directories
- 10 unit tests for discovery, parsing, and init detection

# External (non-OpenAI) Pull Request Requirements

Before opening this Pull Request, please read the dedicated "Contributing" markdown file or your PR may be closed:
https://github.com/openai/codex/blob/main/docs/contributing.md

If your PR conforms to our contribution guidelines, replace this text with a detailed and high quality description of your changes.

Include a link to a bug report or enhancement request.
