### PR TITLE
Remove /collab and make /plan a toggle

### DIFF
--- a/codex-rs/tui/src/bottom_pane/command_popup.rs
+++ b/codex-rs/tui/src/bottom_pane/command_popup.rs
@@ -464,7 +464,7 @@ mod tests {
     }
 
     #[test]
-    fn collab_command_hidden_when_collaboration_modes_disabled() {
+    fn plan_command_hidden_when_collaboration_modes_disabled() {
         let mut popup = CommandPopup::new(Vec::new(), CommandPopupFlags::default());
         popup.on_composer_text_change("/".to_string());
 
@@ -477,32 +477,9 @@ mod tests {
             })
             .collect();
         assert!(
-            !cmds.contains(&"collab"),
-            "expected '/collab' to be hidden when collaboration modes are disabled, got {cmds:?}"
-        );
-        assert!(
             !cmds.contains(&"plan"),
             "expected '/plan' to be hidden when collaboration modes are disabled, got {cmds:?}"
         );
-    }
-
-    #[test]
-    fn collab_command_visible_when_collaboration_modes_enabled() {
-        let mut popup = CommandPopup::new(
-            Vec::new(),
-            CommandPopupFlags {
-                collaboration_modes_enabled: true,
-                connectors_enabled: false,
-                personality_command_enabled: true,
-                windows_degraded_sandbox_active: false,
-            },
-        );
-        popup.on_composer_text_change("/collab".to_string());
-
-        match popup.selected_item() {
-            Some(CommandItem::Builtin(cmd)) => assert_eq!(cmd.command(), "collab"),
-            other => panic!("expected collab to be selected for exact match, got {other:?}"),
-        }
     }
 
     #[test]

--- a/codex-rs/tui/src/bottom_pane/slash_commands.rs
+++ b/codex-rs/tui/src/bottom_pane/slash_commands.rs
@@ -20,7 +20,7 @@ pub(crate) fn builtins_for_input(
         .filter(|(_, cmd)| allow_elevate_sandbox || *cmd != SlashCommand::ElevateSandbox)
         .filter(|(_, cmd)| {
             collaboration_modes_enabled
-                || !matches!(*cmd, SlashCommand::Collab | SlashCommand::Plan)
+                || *cmd != SlashCommand::Plan
         })
         .filter(|(_, cmd)| connectors_enabled || *cmd != SlashCommand::Apps)
         .filter(|(_, cmd)| personality_command_enabled || *cmd != SlashCommand::Personality)

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3299,21 +3299,17 @@ impl ChatWidget {
                     );
                     return;
                 }
-                if let Some(mask) = collaboration_modes::plan_mask(self.models_manager.as_ref()) {
+                if self.active_mode_kind() == ModeKind::Plan {
+                    let Some(mask) = collaboration_modes::default_mask(self.models_manager.as_ref()) else {
+                        self.add_info_message("Default mode unavailable right now.".to_string(), None);
+                        return;
+                    };
+                    self.set_collaboration_mask(mask);
+                } else if let Some(mask) = collaboration_modes::plan_mask(self.models_manager.as_ref()) {
                     self.set_collaboration_mask(mask);
                 } else {
                     self.add_info_message("Plan mode unavailable right now.".to_string(), None);
                 }
-            }
-            SlashCommand::Collab => {
-                if !self.collaboration_modes_enabled() {
-                    self.add_info_message(
-                        "Collaboration modes are disabled.".to_string(),
-                        Some("Enable collaboration modes to use /collab.".to_string()),
-                    );
-                    return;
-                }
-                self.open_collaboration_modes_popup();
             }
             SlashCommand::Agent => {
                 self.app_event_tx.send(AppEvent::OpenAgentPicker);

--- a/codex-rs/tui/src/slash_command.rs
+++ b/codex-rs/tui/src/slash_command.rs
@@ -29,7 +29,6 @@ pub enum SlashCommand {
     Init,
     Compact,
     Plan,
-    Collab,
     Agent,
     // Undo,
     Diff,
@@ -82,7 +81,6 @@ impl SlashCommand {
             SlashCommand::Model => "choose what model and reasoning effort to use",
             SlashCommand::Personality => "choose a communication style for Codex",
             SlashCommand::Plan => "switch to Plan mode",
-            SlashCommand::Collab => "change collaboration mode (experimental)",
             SlashCommand::Agent => "switch the active agent thread",
             SlashCommand::Approvals => "choose what Codex is allowed to do",
             SlashCommand::Permissions => "choose what Codex is allowed to do",
@@ -152,7 +150,6 @@ impl SlashCommand {
             | SlashCommand::Exit => true,
             SlashCommand::Rollout => true,
             SlashCommand::TestApproval => true,
-            SlashCommand::Collab => true,
             SlashCommand::Agent => true,
             SlashCommand::Statusline => false,
         }


### PR DESCRIPTION
## Summary
- Remove the legacy /collab slash command.
- Make /plan toggle between Plan and default collaboration modes.
- Update slash command filtering and popup tests.