### PR TITLE
Remove collaboration_modes runtime feature gating

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2699,9 +2699,7 @@ impl ChatWidget {
                 .as_ref()
                 .is_some_and(|items| !items.is_empty()),
         );
-        widget.bottom_pane.set_collaboration_modes_enabled(
-            widget.config.features.enabled(Feature::CollaborationModes),
-        );
+        widget.bottom_pane.set_collaboration_modes_enabled(true);
         widget.sync_personality_command_enabled();
         #[cfg(target_os = "windows")]
         widget.bottom_pane.set_windows_degraded_sandbox_active(
@@ -2866,9 +2864,7 @@ impl ChatWidget {
                 .as_ref()
                 .is_some_and(|items| !items.is_empty()),
         );
-        widget.bottom_pane.set_collaboration_modes_enabled(
-            widget.config.features.enabled(Feature::CollaborationModes),
-        );
+        widget.bottom_pane.set_collaboration_modes_enabled(true);
         widget.sync_personality_command_enabled();
 
         widget
@@ -3022,9 +3018,7 @@ impl ChatWidget {
                 .as_ref()
                 .is_some_and(|items| !items.is_empty()),
         );
-        widget.bottom_pane.set_collaboration_modes_enabled(
-            widget.config.features.enabled(Feature::CollaborationModes),
-        );
+        widget.bottom_pane.set_collaboration_modes_enabled(true);
         widget.sync_personality_command_enabled();
         #[cfg(target_os = "windows")]
         widget.bottom_pane.set_windows_degraded_sandbox_active(
@@ -6027,22 +6021,6 @@ impl ChatWidget {
         if feature == Feature::Steer {
             self.bottom_pane.set_steer_enabled(enabled);
         }
-        if feature == Feature::CollaborationModes {
-            self.bottom_pane.set_collaboration_modes_enabled(enabled);
-            let settings = self.current_collaboration_mode.settings.clone();
-            self.current_collaboration_mode = CollaborationMode {
-                mode: ModeKind::Default,
-                settings,
-            };
-            self.active_collaboration_mask = if enabled {
-                collaboration_modes::default_mask(self.models_manager.as_ref())
-            } else {
-                None
-            };
-            self.update_collaboration_mode_indicator();
-            self.refresh_model_display();
-            self.request_redraw();
-        }
         if feature == Feature::Personality {
             self.sync_personality_command_enabled();
         }
@@ -6198,7 +6176,7 @@ impl ChatWidget {
     }
 
     fn collaboration_modes_enabled(&self) -> bool {
-        self.config.features.enabled(Feature::CollaborationModes)
+        true
     }
 
     fn initial_collaboration_mask(
@@ -6206,9 +6184,6 @@ impl ChatWidget {
         models_manager: &ModelsManager,
         model_override: Option<&str>,
     ) -> Option<CollaborationModeMask> {
-        if !config.features.enabled(Feature::CollaborationModes) {
-            return None;
-        }
         let mut mask = match config.experimental_mode {
             Some(kind) => collaboration_modes::mask_for_kind(models_manager, kind)?,
             None => collaboration_modes::default_mask(models_manager)?,


### PR DESCRIPTION
## Summary
- remove runtime gating for collaboration modes in TUI chat state
- always register the `request_user_input` tool in core tool specs
- update tests to assert that toggling `Feature::CollaborationModes` is now a compatibility no-op

## Testing
- `just fmt`
- `cargo test -p codex-core --test all suite::request_user_input::`
- `cargo test -p codex-tui`
- `cargo test -p codex-core` *(fails in this environment due pre-existing missing test binaries and unrelated integration suites; see output for `codex`/`test_stdio_server` missing and existing search-tool/grep-files failures)*
