### PR TITLE
Enforce errors on overriding built-in model providers

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -2223,7 +2223,7 @@
         "$ref": "#/definitions/ModelProviderInfo"
       },
       "default": {},
-      "description": "User-defined provider entries that extend/override the built-in list.",
+      "description": "User-defined provider entries that extend the built-in list. Built-in IDs cannot be overridden.",
       "type": "object"
     },
     "model_reasoning_effort": {

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -160,35 +160,6 @@ consolidation_model = "gpt-5"
 }
 
 #[test]
-fn test_toml_parsing_rejects_reserved_model_provider_override_openai() {
-    let cfg = r#"
-[model_providers.openai]
-name = "OpenAI Custom"
-"#;
-
-    let err = toml::from_str::<ConfigToml>(cfg).expect_err("should reject reserved provider");
-    let message = err.to_string();
-    assert!(message.contains("reserved built-in provider IDs"));
-    assert!(message.contains("`openai`"));
-}
-
-#[test]
-fn test_toml_parsing_rejects_multiple_reserved_model_provider_overrides() {
-    let cfg = r#"
-[model_providers.ollama]
-name = "Ollama Override"
-
-[model_providers.openai]
-name = "OpenAI Override"
-"#;
-
-    let err = toml::from_str::<ConfigToml>(cfg).expect_err("should reject reserved providers");
-    let message = err.to_string();
-    assert!(message.contains("`openai`"));
-    assert!(message.contains("`ollama`"));
-}
-
-#[test]
 fn parses_bundled_skills_config() {
     let cfg: ConfigToml = toml::from_str(
         r#"

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -4973,29 +4973,6 @@ fn test_load_config_rejects_legacy_ollama_chat_provider_with_helpful_error() -> 
 }
 
 #[test]
-fn test_load_config_rejects_programmatic_reserved_model_provider_override() -> std::io::Result<()> {
-    let codex_home = TempDir::new()?;
-    let mut cfg = ConfigToml::default();
-    cfg.model_providers.insert(
-        "openai".to_string(),
-        ModelProviderInfo::create_openai_provider(None),
-    );
-
-    let result = Config::load_from_base_config_with_overrides(
-        cfg,
-        ConfigOverrides::default(),
-        codex_home.path().to_path_buf(),
-    );
-    assert!(result.is_err());
-    let error = result.unwrap_err();
-    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
-    assert!(error.to_string().contains("reserved built-in provider IDs"));
-    assert!(error.to_string().contains("`openai`"));
-
-    Ok(())
-}
-
-#[test]
 fn test_untrusted_project_gets_workspace_write_sandbox() -> anyhow::Result<()> {
     let config_with_untrusted = r#"
 [projects."/tmp/test"]

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -160,6 +160,49 @@ consolidation_model = "gpt-5"
 }
 
 #[test]
+fn test_toml_parsing_rejects_reserved_model_provider_override_openai() {
+    let cfg = r#"
+[model_providers.openai]
+name = "OpenAI Custom"
+"#;
+
+    let err = toml::from_str::<ConfigToml>(cfg).expect_err("should reject reserved provider");
+    let message = err.to_string();
+    assert!(message.contains("reserved built-in provider IDs"));
+    assert!(message.contains("`openai`"));
+}
+
+#[test]
+fn test_toml_parsing_rejects_multiple_reserved_model_provider_overrides() {
+    let cfg = r#"
+[model_providers.ollama]
+name = "Ollama Override"
+
+[model_providers.openai]
+name = "OpenAI Override"
+"#;
+
+    let err = toml::from_str::<ConfigToml>(cfg).expect_err("should reject reserved providers");
+    let message = err.to_string();
+    assert!(message.contains("`openai`"));
+    assert!(message.contains("`ollama`"));
+}
+
+#[test]
+fn test_toml_parsing_allows_non_reserved_model_provider() {
+    let cfg = r#"
+[model_providers.openai-custom]
+name = "OpenAI Custom"
+base_url = "https://example.com/v1"
+env_key = "OPENAI_API_KEY"
+"#;
+
+    let parsed =
+        toml::from_str::<ConfigToml>(cfg).expect("non-reserved provider should deserialize");
+    assert!(parsed.model_providers.contains_key("openai-custom"));
+}
+
+#[test]
 fn parses_bundled_skills_config() {
     let cfg: ConfigToml = toml::from_str(
         r#"
@@ -4925,6 +4968,29 @@ fn test_load_config_rejects_legacy_ollama_chat_provider_with_helpful_error() -> 
             .to_string()
             .contains(OLLAMA_CHAT_PROVIDER_REMOVED_ERROR)
     );
+
+    Ok(())
+}
+
+#[test]
+fn test_load_config_rejects_programmatic_reserved_model_provider_override() -> std::io::Result<()> {
+    let codex_home = TempDir::new()?;
+    let mut cfg = ConfigToml::default();
+    cfg.model_providers.insert(
+        "openai".to_string(),
+        ModelProviderInfo::create_openai_provider(None),
+    );
+
+    let result = Config::load_from_base_config_with_overrides(
+        cfg,
+        ConfigOverrides::default(),
+        codex_home.path().to_path_buf(),
+    );
+    assert!(result.is_err());
+    let error = result.unwrap_err();
+    assert_eq!(error.kind(), std::io::ErrorKind::InvalidInput);
+    assert!(error.to_string().contains("reserved built-in provider IDs"));
+    assert!(error.to_string().contains("`openai`"));
 
     Ok(())
 }

--- a/codex-rs/core/src/config/config_tests.rs
+++ b/codex-rs/core/src/config/config_tests.rs
@@ -189,20 +189,6 @@ name = "OpenAI Override"
 }
 
 #[test]
-fn test_toml_parsing_allows_non_reserved_model_provider() {
-    let cfg = r#"
-[model_providers.openai-custom]
-name = "OpenAI Custom"
-base_url = "https://example.com/v1"
-env_key = "OPENAI_API_KEY"
-"#;
-
-    let parsed =
-        toml::from_str::<ConfigToml>(cfg).expect("non-reserved provider should deserialize");
-    assert!(parsed.model_providers.contains_key("openai-custom"));
-}
-
-#[test]
 fn parses_bundled_skills_config() {
     let cfg: ConfigToml = toml::from_str(
         r#"

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -139,6 +139,8 @@ pub(crate) const DEFAULT_AGENT_JOB_MAX_RUNTIME_SECONDS: Option<u64> = None;
 
 pub const CONFIG_TOML_FILE: &str = "config.toml";
 const OPENAI_BASE_URL_ENV_VAR: &str = "OPENAI_BASE_URL";
+const RESERVED_MODEL_PROVIDER_IDS: [&str; 3] =
+    ["openai", OLLAMA_OSS_PROVIDER_ID, LMSTUDIO_OSS_PROVIDER_ID];
 
 fn resolve_sqlite_home_env(resolved_cwd: &Path) -> Option<PathBuf> {
     let raw = std::env::var(codex_state::SQLITE_HOME_ENV).ok()?;
@@ -367,7 +369,7 @@ pub struct Config {
     /// to 127.0.0.1 (using `mcp_oauth_callback_port` when provided).
     pub mcp_oauth_callback_url: Option<String>,
 
-    /// Combined provider map (defaults merged with user-defined overrides).
+    /// Combined provider map (defaults plus user-defined providers).
     pub model_providers: HashMap<String, ModelProviderInfo>,
 
     /// Maximum number of bytes to include from an AGENTS.md project doc file.
@@ -1262,8 +1264,9 @@ pub struct ConfigToml {
     /// to 127.0.0.1 (using `mcp_oauth_callback_port` when provided).
     pub mcp_oauth_callback_url: Option<String>,
 
-    /// User-defined provider entries that extend/override the built-in list.
-    #[serde(default)]
+    /// User-defined provider entries that extend the built-in list. Built-in
+    /// IDs cannot be overridden.
+    #[serde(default, deserialize_with = "deserialize_model_providers")]
     pub model_providers: HashMap<String, ModelProviderInfo>,
 
     /// Maximum number of bytes to include from an AGENTS.md project doc file.
@@ -1890,6 +1893,37 @@ pub struct ConfigOverrides {
     pub additional_writable_roots: Vec<PathBuf>,
 }
 
+fn validate_reserved_model_provider_ids(
+    model_providers: &HashMap<String, ModelProviderInfo>,
+) -> Result<(), String> {
+    let mut conflicts = model_providers
+        .keys()
+        .filter(|key| RESERVED_MODEL_PROVIDER_IDS.contains(&key.as_str()))
+        .map(|key| format!("`{key}`"))
+        .collect::<Vec<_>>();
+    conflicts.sort_unstable();
+    if conflicts.is_empty() {
+        Ok(())
+    } else {
+        Err(format!(
+            "model_providers contains reserved built-in provider IDs: {}. \
+Built-in providers cannot be overridden. Rename your custom provider (for example, `openai-custom`).",
+            conflicts.join(", ")
+        ))
+    }
+}
+
+fn deserialize_model_providers<'de, D>(
+    deserializer: D,
+) -> Result<HashMap<String, ModelProviderInfo>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let model_providers = HashMap::<String, ModelProviderInfo>::deserialize(deserializer)?;
+    validate_reserved_model_provider_ids(&model_providers).map_err(serde::de::Error::custom)?;
+    Ok(model_providers)
+}
+
 /// Resolves the OSS provider from CLI override, profile config, or global config.
 /// Returns `None` if no provider is configured at any level.
 pub fn resolve_oss_provider(
@@ -2011,6 +2045,8 @@ impl Config {
         codex_home: PathBuf,
         config_layer_stack: ConfigLayerStack,
     ) -> std::io::Result<Self> {
+        validate_reserved_model_provider_ids(&cfg.model_providers)
+            .map_err(|message| std::io::Error::new(std::io::ErrorKind::InvalidInput, message))?;
         // Ensure that every field of ConfigRequirements is applied to the final
         // Config.
         let ConfigRequirements {

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -47,6 +47,7 @@ use crate::model_provider_info::LMSTUDIO_OSS_PROVIDER_ID;
 use crate::model_provider_info::ModelProviderInfo;
 use crate::model_provider_info::OLLAMA_CHAT_PROVIDER_REMOVED_ERROR;
 use crate::model_provider_info::OLLAMA_OSS_PROVIDER_ID;
+use crate::model_provider_info::OPENAI_PROVIDER_ID;
 use crate::model_provider_info::built_in_model_providers;
 use crate::path_utils::normalize_for_native_workdir;
 use crate::project_doc::DEFAULT_PROJECT_DOC_FILENAME;
@@ -139,8 +140,11 @@ pub(crate) const DEFAULT_AGENT_JOB_MAX_RUNTIME_SECONDS: Option<u64> = None;
 
 pub const CONFIG_TOML_FILE: &str = "config.toml";
 const OPENAI_BASE_URL_ENV_VAR: &str = "OPENAI_BASE_URL";
-const RESERVED_MODEL_PROVIDER_IDS: [&str; 3] =
-    ["openai", OLLAMA_OSS_PROVIDER_ID, LMSTUDIO_OSS_PROVIDER_ID];
+const RESERVED_MODEL_PROVIDER_IDS: [&str; 3] = [
+    OPENAI_PROVIDER_ID,
+    OLLAMA_OSS_PROVIDER_ID,
+    LMSTUDIO_OSS_PROVIDER_ID,
+];
 
 fn resolve_sqlite_home_env(resolved_cwd: &Path) -> Option<PathBuf> {
     let raw = std::env::var(codex_state::SQLITE_HOME_ENV).ok()?;

--- a/codex-rs/core/src/config/service_tests.rs
+++ b/codex-rs/core/src/config/service_tests.rs
@@ -387,6 +387,34 @@ async fn invalid_user_value_rejected_even_if_overridden_by_managed() {
 }
 
 #[tokio::test]
+async fn reserved_builtin_provider_override_rejected() {
+    let tmp = tempdir().expect("tempdir");
+    std::fs::write(tmp.path().join(CONFIG_TOML_FILE), "model = \"user\"\n").unwrap();
+
+    let service = ConfigService::new_with_defaults(tmp.path().to_path_buf());
+    let error = service
+        .write_value(ConfigValueWriteParams {
+            file_path: Some(tmp.path().join(CONFIG_TOML_FILE).display().to_string()),
+            key_path: "model_providers.openai.name".to_string(),
+            value: serde_json::json!("OpenAI Override"),
+            merge_strategy: MergeStrategy::Replace,
+            expected_version: None,
+        })
+        .await
+        .expect_err("should reject reserved provider override");
+
+    assert_eq!(
+        error.write_error_code(),
+        Some(ConfigWriteErrorCode::ConfigValidationError)
+    );
+    assert!(error.to_string().contains("reserved built-in provider IDs"));
+    assert!(error.to_string().contains("`openai`"));
+
+    let contents = std::fs::read_to_string(tmp.path().join(CONFIG_TOML_FILE)).expect("read config");
+    assert_eq!(contents, "model = \"user\"\n");
+}
+
+#[tokio::test]
 async fn write_value_rejects_feature_requirement_conflict() {
     let tmp = tempdir().expect("tempdir");
     std::fs::write(tmp.path().join(CONFIG_TOML_FILE), "").unwrap();


### PR DESCRIPTION
We receive bug reports from users who attempt to override one of the three built-in model providers (openai, ollama, or lmstuio). Currently, these overrides are silently ignored. This PR makes it an error to override them.

## Summary
- add validation for `model_providers` so `openai`, `ollama`, and `lmstudio` keys now produce clear configuration errors instead of being silently ignored
