### PR TITLE
Revert "chore(deps): bump rust-toolchain from 1.93.0 to 1.93.1 in /co…dex-rs (#11886)"

### DIFF
--- a/codex-rs/rust-toolchain.toml
+++ b/codex-rs/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.93.1"
+channel = "1.93.0"
 components = ["clippy", "rustfmt", "rust-src"]


### PR DESCRIPTION

This reverts commit af3b1ae6cb1d31b8985e8f87e18bc98cd524d4b5 which is breaking CI.
