### PR TITLE
tui: make Cmd+Shift+V paste text inline without placeholder

### DIFF
--- a/codex-rs/tui/src/bottom_pane/mod.rs
+++ b/codex-rs/tui/src/bottom_pane/mod.rs
@@ -427,6 +427,23 @@ impl BottomPane {
         }
     }
 
+    pub fn handle_verbatim_paste(&mut self, pasted: String) {
+        if let Some(view) = self.view_stack.last_mut() {
+            let needs_redraw = view.handle_paste(pasted);
+            if view.is_complete() {
+                self.on_active_view_complete();
+            }
+            if needs_redraw {
+                self.request_redraw();
+            }
+        } else {
+            let needs_redraw = self.composer.handle_verbatim_paste(pasted);
+            if needs_redraw {
+                self.request_redraw();
+            }
+        }
+    }
+
     pub(crate) fn insert_str(&mut self, text: &str) {
         self.composer.insert_str(text);
         self.request_redraw();

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -184,6 +184,7 @@ use crate::bottom_pane::SelectionViewParams;
 use crate::bottom_pane::custom_prompt_view::CustomPromptView;
 use crate::bottom_pane::popup_consts::standard_popup_hint_line;
 use crate::clipboard_paste::paste_image_to_temp_png;
+use crate::clipboard_paste::paste_text;
 use crate::collaboration_modes;
 use crate::diff_render::display_path_for;
 use crate::exec_cell::CommandOutput;
@@ -3085,6 +3086,27 @@ impl ChatWidget {
                         tracing::warn!("failed to paste image: {err}");
                         self.add_to_history(history_cell::new_error_event(format!(
                             "Failed to paste image: {err}",
+                        )));
+                    }
+                }
+                return;
+            }
+            KeyEvent {
+                code: KeyCode::Char(c),
+                modifiers,
+                kind: KeyEventKind::Press,
+                ..
+            } if modifiers.contains(KeyModifiers::SUPER)
+                && modifiers.contains(KeyModifiers::SHIFT)
+                && !modifiers.intersects(KeyModifiers::CONTROL | KeyModifiers::ALT)
+                && c.eq_ignore_ascii_case(&'v') =>
+            {
+                match paste_text() {
+                    Ok(text) => self.bottom_pane.handle_verbatim_paste(text),
+                    Err(err) => {
+                        tracing::warn!("failed to paste text: {err}");
+                        self.add_to_history(history_cell::new_error_event(format!(
+                            "Failed to paste text: {err}",
                         )));
                     }
                 }

--- a/codex-rs/tui/src/clipboard_paste.rs
+++ b/codex-rs/tui/src/clipboard_paste.rs
@@ -22,6 +22,23 @@ impl std::fmt::Display for PasteImageError {
 }
 impl std::error::Error for PasteImageError {}
 
+#[derive(Debug, Clone)]
+pub enum PasteTextError {
+    ClipboardUnavailable(String),
+    NoText(String),
+}
+
+impl std::fmt::Display for PasteTextError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PasteTextError::ClipboardUnavailable(msg) => write!(f, "clipboard unavailable: {msg}"),
+            PasteTextError::NoText(msg) => write!(f, "no text on clipboard: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for PasteTextError {}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum EncodedImageFormat {
     Png,
@@ -147,6 +164,22 @@ pub fn paste_image_to_temp_png() -> Result<(PathBuf, PastedImageInfo), PasteImag
             }
         }
     }
+}
+
+#[cfg(not(target_os = "android"))]
+pub fn paste_text() -> Result<String, PasteTextError> {
+    let mut cb = arboard::Clipboard::new()
+        .map_err(|e| PasteTextError::ClipboardUnavailable(e.to_string()))?;
+    cb.get()
+        .text()
+        .map_err(|e| PasteTextError::NoText(e.to_string()))
+}
+
+#[cfg(target_os = "android")]
+pub fn paste_text() -> Result<String, PasteTextError> {
+    Err(PasteTextError::ClipboardUnavailable(
+        "clipboard text paste is unsupported on Android".into(),
+    ))
 }
 
 /// Attempt WSL fallback for clipboard image paste.


### PR DESCRIPTION
## Summary
- add clipboard text paste helper for explicit text-only paste handling
- bind `Cmd+Shift+V` to verbatim text paste in TUI
- bypass large pending-paste placeholder generation for this shortcut
- keep existing regular paste behavior unchanged

## Codex author
`codex resume 019c6d7e-5a93-7723-8b19-9b7532f694b3`