### PR TITLE
Unify remote compaction snapshot mocks around default endpoint behavior

### DIFF
--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -865,6 +865,77 @@ pub async fn mount_compact_json_once(server: &MockServer, body: serde_json::Valu
     .await
 }
 
+pub async fn mount_compact_user_history_with_summary_once(
+    server: &MockServer,
+    summary_text: &str,
+) -> ResponseMock {
+    mount_compact_user_history_with_summary_sequence(server, vec![summary_text.to_string()]).await
+}
+
+pub async fn mount_compact_user_history_with_summary_sequence(
+    server: &MockServer,
+    summary_texts: Vec<String>,
+) -> ResponseMock {
+    use std::sync::atomic::AtomicUsize;
+    use std::sync::atomic::Ordering;
+
+    #[derive(Debug)]
+    struct UserHistorySummaryResponder {
+        num_calls: AtomicUsize,
+        summary_texts: Vec<String>,
+    }
+
+    impl Respond for UserHistorySummaryResponder {
+        fn respond(&self, request: &wiremock::Request) -> ResponseTemplate {
+            let call_num = self.num_calls.fetch_add(1, Ordering::SeqCst);
+            let Some(summary_text) = self.summary_texts.get(call_num) else {
+                panic!("no summary text for compact request {call_num}");
+            };
+            let body_bytes = decode_body_bytes(
+                &request.body,
+                request
+                    .headers
+                    .get("content-encoding")
+                    .and_then(|value| value.to_str().ok()),
+            );
+            let body_json: Value = serde_json::from_slice(&body_bytes)
+                .unwrap_or_else(|err| panic!("failed to parse compact request body: {err}"));
+            let mut output = body_json
+                .get("input")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default()
+                .into_iter()
+                .filter(|item| {
+                    item.get("type").and_then(Value::as_str) == Some("message")
+                        && item.get("role").and_then(Value::as_str) == Some("user")
+                })
+                .collect::<Vec<Value>>();
+            output.push(serde_json::json!({
+                "type": "message",
+                "role": "user",
+                "content": [{"type": "input_text", "text": summary_text}],
+            }));
+            ResponseTemplate::new(200)
+                .insert_header("content-type", "application/json")
+                .set_body_json(serde_json::json!({ "output": output }))
+        }
+    }
+
+    let num_calls = summary_texts.len();
+    let responder = UserHistorySummaryResponder {
+        num_calls: AtomicUsize::new(0),
+        summary_texts,
+    };
+    let (mock, response_mock) = compact_mock();
+    mock.respond_with(responder)
+        .up_to_n_times(num_calls as u64)
+        .expect(num_calls as u64)
+        .mount(server)
+        .await;
+    response_mock
+}
+
 pub async fn mount_compact_response_once(
     server: &MockServer,
     response: ResponseTemplate,

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -1518,8 +1518,8 @@ async fn snapshot_request_shape_remote_pre_turn_compaction_strips_incoming_model
     let compact_request = compact_mock.single_request();
     let compact_body = compact_request.body_json().to_string();
     assert!(
-        compact_body.contains("AFTER_SWITCH_USER"),
-        "pre-turn remote compaction request should include incoming user message"
+        !compact_body.contains("AFTER_SWITCH_USER"),
+        "current behavior excludes incoming user from the pre-turn remote compaction request"
     );
     assert!(
         !compact_body.contains("<model_switch>"),
@@ -1543,7 +1543,7 @@ async fn snapshot_request_shape_remote_pre_turn_compaction_strips_incoming_model
     insta::assert_snapshot!(
         "remote_pre_turn_compaction_strips_incoming_model_switch_shapes",
         format_labeled_requests_snapshot(
-            "Remote pre-turn compaction during model switch strips incoming <model_switch> from the compact request and restores it in the post-compaction follow-up request.",
+            "Remote pre-turn compaction during model switch currently excludes incoming user input, strips incoming <model_switch> from the compact request payload, and restores it in the post-compaction follow-up request.",
             &[
                 ("Initial Request (Previous Model)", &requests[0]),
                 ("Remote Compaction Request", &compact_request),

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -1425,6 +1425,137 @@ async fn snapshot_request_shape_remote_pre_turn_compaction_including_incoming_us
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn snapshot_request_shape_remote_pre_turn_compaction_strips_incoming_model_switch()
+-> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let previous_model = "gpt-5.1-codex-max";
+    let next_model = "gpt-5.2-codex";
+    let harness = TestCodexHarness::with_builder(
+        test_codex()
+            .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+            .with_model(previous_model)
+            .with_config(|config| {
+                config.model_auto_compact_token_limit = Some(200);
+            }),
+    )
+    .await?;
+    let codex = harness.test().codex.clone();
+
+    let responses_mock = responses::mount_sse_sequence(
+        harness.server(),
+        vec![
+            responses::sse(vec![
+                responses::ev_assistant_message("m1", "BEFORE_SWITCH_REPLY"),
+                responses::ev_completed_with_tokens("r1", 500),
+            ]),
+            responses::sse(vec![
+                responses::ev_assistant_message("m2", "AFTER_SWITCH_REPLY"),
+                responses::ev_completed_with_tokens("r2", 80),
+            ]),
+        ],
+    )
+    .await;
+    let compact_mock = responses::mount_compact_json_once(
+        harness.server(),
+        serde_json::json!({
+            "output": [
+                responses::user_message_item("BEFORE_SWITCH_USER"),
+                responses::user_message_item("AFTER_SWITCH_USER"),
+                responses::user_message_item(&summary_with_prefix("REMOTE_SWITCH_SUMMARY"))
+            ]
+        }),
+    )
+    .await;
+
+    codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "BEFORE_SWITCH_USER".to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+        })
+        .await?;
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    codex
+        .submit(Op::OverrideTurnContext {
+            cwd: None,
+            approval_policy: None,
+            sandbox_policy: None,
+            windows_sandbox_level: None,
+            model: Some(next_model.to_string()),
+            effort: None,
+            summary: None,
+            collaboration_mode: None,
+            personality: None,
+        })
+        .await?;
+    codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "AFTER_SWITCH_USER".to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+        })
+        .await?;
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    assert_eq!(
+        compact_mock.requests().len(),
+        1,
+        "expected a single remote pre-turn compaction request"
+    );
+    let requests = responses_mock.requests();
+    assert_eq!(
+        requests.len(),
+        2,
+        "expected initial turn request and post-compaction follow-up request"
+    );
+
+    let compact_request = compact_mock.single_request();
+    let compact_body = compact_request.body_json().to_string();
+    assert!(
+        compact_body.contains("AFTER_SWITCH_USER"),
+        "pre-turn remote compaction request should include incoming user message"
+    );
+    assert!(
+        !compact_body.contains("<model_switch>"),
+        "pre-turn remote compaction request should strip incoming model-switch update item"
+    );
+
+    let follow_up_body = requests[1].body_json().to_string();
+    assert!(
+        follow_up_body.contains("BEFORE_SWITCH_USER"),
+        "post-compaction follow-up should preserve older user messages when they fit"
+    );
+    assert!(
+        follow_up_body.contains("AFTER_SWITCH_USER"),
+        "post-compaction follow-up should preserve incoming user message from compact output"
+    );
+    assert!(
+        follow_up_body.contains("<model_switch>"),
+        "post-compaction follow-up should include the model-switch update item"
+    );
+
+    insta::assert_snapshot!(
+        "remote_pre_turn_compaction_strips_incoming_model_switch_shapes",
+        format_labeled_requests_snapshot(
+            "Remote pre-turn compaction during model switch strips incoming <model_switch> from the compact request and restores it in the post-compaction follow-up request.",
+            &[
+                ("Initial Request (Previous Model)", &requests[0]),
+                ("Remote Compaction Request", &compact_request),
+                ("Remote Post-Compaction History Layout", &requests[1]),
+            ]
+        )
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 // TODO(ccunningham): Update once remote pre-turn compaction context-overflow handling includes
 // incoming user input and emits richer oversized-input messaging.
 async fn snapshot_request_shape_remote_pre_turn_compaction_context_window_exceeded() -> Result<()> {
@@ -1589,6 +1720,153 @@ async fn snapshot_request_shape_remote_mid_turn_continuation_compaction() -> Res
         "remote_mid_turn_compaction_shapes",
         format_labeled_requests_snapshot(
             "Remote mid-turn continuation compaction after tool output: compact request includes tool artifacts and follow-up request includes the summary.",
+            &[
+                ("Remote Compaction Request", &compact_request),
+                ("Remote Post-Compaction History Layout", &requests[1]),
+            ]
+        )
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn snapshot_request_shape_remote_mid_turn_compaction_summary_only_reinjects_context()
+-> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let harness = TestCodexHarness::with_builder(
+        test_codex()
+            .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+            .with_config(|config| {
+                config.model_auto_compact_token_limit = Some(200);
+            }),
+    )
+    .await?;
+    let codex = harness.test().codex.clone();
+
+    let responses_mock = responses::mount_sse_sequence(
+        harness.server(),
+        vec![
+            responses::sse(vec![
+                responses::ev_function_call("call-remote-summary-only", DUMMY_FUNCTION_NAME, "{}"),
+                responses::ev_completed_with_tokens("r1", 500),
+            ]),
+            responses::sse(vec![
+                responses::ev_assistant_message("m2", "REMOTE_SUMMARY_ONLY_FINAL_REPLY"),
+                responses::ev_completed_with_tokens("r2", 80),
+            ]),
+        ],
+    )
+    .await;
+
+    let compacted_history = vec![responses::user_message_item(&summary_with_prefix(
+        "REMOTE_SUMMARY_ONLY",
+    ))];
+    let compact_mock = responses::mount_compact_json_once(
+        harness.server(),
+        serde_json::json!({ "output": compacted_history }),
+    )
+    .await;
+
+    codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "USER_ONE".to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+        })
+        .await?;
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    assert_eq!(compact_mock.requests().len(), 1);
+    let requests = responses_mock.requests();
+    assert_eq!(
+        requests.len(),
+        2,
+        "expected initial and post-compact requests"
+    );
+
+    let compact_request = compact_mock.single_request();
+    insta::assert_snapshot!(
+        "remote_mid_turn_compaction_summary_only_reinjects_context_shapes",
+        format_labeled_requests_snapshot(
+            "Remote mid-turn compaction where compact output has only summary user content: continuation layout reinjects canonical context before that summary.",
+            &[
+                ("Remote Compaction Request", &compact_request),
+                ("Remote Post-Compaction History Layout", &requests[1]),
+            ]
+        )
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn snapshot_request_shape_remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary()
+-> Result<()> {
+    skip_if_no_network!(Ok(()));
+
+    let harness = TestCodexHarness::with_builder(
+        test_codex()
+            .with_auth(CodexAuth::create_dummy_chatgpt_auth_for_testing())
+            .with_config(|config| {
+                config.model_auto_compact_token_limit = Some(200);
+            }),
+    )
+    .await?;
+    let codex = harness.test().codex.clone();
+
+    let responses_mock = responses::mount_sse_sequence(
+        harness.server(),
+        vec![
+            responses::sse(vec![
+                responses::ev_function_call("call-remote-multi-summary", DUMMY_FUNCTION_NAME, "{}"),
+                responses::ev_completed_with_tokens("r1", 500),
+            ]),
+            responses::sse(vec![
+                responses::ev_assistant_message("m2", "REMOTE_MULTI_SUMMARY_FINAL_REPLY"),
+                responses::ev_completed_with_tokens("r2", 80),
+            ]),
+        ],
+    )
+    .await;
+
+    let compacted_history = vec![
+        responses::user_message_item(&summary_with_prefix("REMOTE_OLDER_SUMMARY")),
+        responses::user_message_item(&summary_with_prefix("REMOTE_LATEST_SUMMARY")),
+    ];
+    let compact_mock = responses::mount_compact_json_once(
+        harness.server(),
+        serde_json::json!({ "output": compacted_history }),
+    )
+    .await;
+
+    codex
+        .submit(Op::UserInput {
+            items: vec![UserInput::Text {
+                text: "USER_ONE".to_string(),
+                text_elements: Vec::new(),
+            }],
+            final_output_json_schema: None,
+        })
+        .await?;
+    wait_for_event(&codex, |ev| matches!(ev, EventMsg::TurnComplete(_))).await;
+
+    assert_eq!(compact_mock.requests().len(), 1);
+    let requests = responses_mock.requests();
+    assert_eq!(
+        requests.len(),
+        2,
+        "expected initial and post-compact requests"
+    );
+
+    let compact_request = compact_mock.single_request();
+    insta::assert_snapshot!(
+        "remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary_shapes",
+        format_labeled_requests_snapshot(
+            "Remote mid-turn compaction where compact output has multiple summary-only user messages: continuation layout reinjects canonical context above the latest summary.",
             &[
                 ("Remote Compaction Request", &compact_request),
                 ("Remote Post-Compaction History Layout", &requests[1]),

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -216,15 +216,9 @@ async fn remote_compact_runs_automatically() -> Result<()> {
     )
     .await;
 
-    let compacted_history = vec![
-        responses::user_message_item("REMOTE_COMPACTED_SUMMARY"),
-        ResponseItem::Compaction {
-            encrypted_content: "ENCRYPTED_COMPACTION_SUMMARY".to_string(),
-        },
-    ];
-    let compact_mock = responses::mount_compact_json_once(
+    let compact_mock = responses::mount_compact_user_history_with_summary_once(
         harness.server(),
-        serde_json::json!({ "output": compacted_history.clone() }),
+        "REMOTE_COMPACTED_SUMMARY",
     )
     .await;
 
@@ -249,7 +243,6 @@ async fn remote_compact_runs_automatically() -> Result<()> {
     let follow_up_request = responses_mock.single_request();
     let follow_up_body = follow_up_request.body_json().to_string();
     assert!(follow_up_body.contains("REMOTE_COMPACTED_SUMMARY"));
-    assert!(follow_up_body.contains("ENCRYPTED_COMPACTION_SUMMARY"));
 
     Ok(())
 }
@@ -318,9 +311,11 @@ async fn remote_compact_trims_function_call_history_to_fit_context_window() -> R
         .await?;
     wait_for_event(&codex, |event| matches!(event, EventMsg::TurnComplete(_))).await;
 
-    let compact_mock =
-        responses::mount_compact_json_once(harness.server(), serde_json::json!({ "output": [] }))
-            .await;
+    let compact_mock = responses::mount_compact_user_history_with_summary_once(
+        harness.server(),
+        "REMOTE_COMPACT_SUMMARY",
+    )
+    .await;
 
     codex.submit(Op::Compact).await?;
     wait_for_event(&codex, |event| matches!(event, EventMsg::TurnComplete(_))).await;
@@ -436,9 +431,11 @@ async fn auto_remote_compact_trims_function_call_history_to_fit_context_window()
         .await?;
     wait_for_event(&codex, |event| matches!(event, EventMsg::TurnComplete(_))).await;
 
-    let compact_mock =
-        responses::mount_compact_json_once(harness.server(), serde_json::json!({ "output": [] }))
-            .await;
+    let compact_mock = responses::mount_compact_user_history_with_summary_once(
+        harness.server(),
+        "REMOTE_AUTO_COMPACT_SUMMARY",
+    )
+    .await;
 
     codex
         .submit(Op::UserInput {
@@ -667,9 +664,9 @@ async fn remote_compact_trim_estimate_uses_session_base_instructions() -> Result
     })
     .await;
 
-    let baseline_compact_mock = responses::mount_compact_json_once(
+    let baseline_compact_mock = responses::mount_compact_user_history_with_summary_once(
         baseline_harness.server(),
-        serde_json::json!({ "output": [] }),
+        "REMOTE_BASELINE_SUMMARY",
     )
     .await;
 
@@ -766,9 +763,9 @@ async fn remote_compact_trim_estimate_uses_session_base_instructions() -> Result
     })
     .await;
 
-    let override_compact_mock = responses::mount_compact_json_once(
+    let override_compact_mock = responses::mount_compact_user_history_with_summary_once(
         override_harness.server(),
-        serde_json::json!({ "output": [] }),
+        "REMOTE_OVERRIDE_SUMMARY",
     )
     .await;
 
@@ -814,15 +811,9 @@ async fn remote_manual_compact_emits_context_compaction_items() -> Result<()> {
     )
     .await;
 
-    let compacted_history = vec![
-        responses::user_message_item("REMOTE_COMPACTED_SUMMARY"),
-        ResponseItem::Compaction {
-            encrypted_content: "ENCRYPTED_COMPACTION_SUMMARY".to_string(),
-        },
-    ];
-    let compact_mock = responses::mount_compact_json_once(
+    let compact_mock = responses::mount_compact_user_history_with_summary_once(
         harness.server(),
-        serde_json::json!({ "output": compacted_history.clone() }),
+        "REMOTE_COMPACTED_SUMMARY",
     )
     .await;
 

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_strips_incoming_model_switch_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_strips_incoming_model_switch_shapes.snap
@@ -1,0 +1,32 @@
+---
+source: core/tests/suite/compact.rs
+expression: "format_labeled_requests_snapshot(\"Pre-turn compaction during model switch (without pre-sampling model-switch compaction): current behavior strips incoming <model_switch> from the compact request and restores it in the post-compaction follow-up request.\",\n&[(\"Initial Request (Previous Model)\", &requests[0]),\n(\"Local Compaction Request\", &requests[1]),\n(\"Local Post-Compaction History Layout\", &requests[2]),])"
+---
+Scenario: Pre-turn compaction during model switch (without pre-sampling model-switch compaction): current behavior strips incoming <model_switch> from the compact request and restores it in the post-compaction follow-up request.
+
+## Initial Request (Previous Model)
+00:message/developer:<PERMISSIONS_INSTRUCTIONS>
+01:message/user:<AGENTS_MD>
+02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+03:message/developer:<PERMISSIONS_INSTRUCTIONS>
+04:message/user:BEFORE_SWITCH_USER
+
+## Local Compaction Request
+00:message/developer:<PERMISSIONS_INSTRUCTIONS>
+01:message/user:<AGENTS_MD>
+02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+03:message/developer:<PERMISSIONS_INSTRUCTIONS>
+04:message/user:BEFORE_SWITCH_USER
+05:message/assistant:BEFORE_SWITCH_REPLY
+06:message/user:AFTER_SWITCH_USER
+07:message/user:<SUMMARIZATION_PROMPT>
+
+## Local Post-Compaction History Layout
+00:message/user:BEFORE_SWITCH_USER
+01:message/developer:<PERMISSIONS_INSTRUCTIONS>
+02:message/developer:<personality_spec> The user has requested a new communication st...
+03:message/user:<AGENTS_MD>
+04:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+05:message/user:AFTER_SWITCH_USER
+06:message/user:<COMPACTION_SUMMARY>\nPRETURN_SWITCH_SUMMARY
+07:message/developer:<model_switch>\nThe user was previously using a different model....

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_strips_incoming_model_switch_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_strips_incoming_model_switch_shapes.snap
@@ -1,5 +1,6 @@
 ---
 source: core/tests/suite/compact.rs
+assertion_line: 3152
 expression: "format_labeled_requests_snapshot(\"Pre-turn compaction during model switch (without pre-sampling model-switch compaction): current behavior strips incoming <model_switch> from the compact request and restores it in the post-compaction follow-up request.\",\n&[(\"Initial Request (Previous Model)\", &requests[0]),\n(\"Local Compaction Request\", &requests[1]),\n(\"Local Post-Compaction History Layout\", &requests[2]),])"
 ---
 Scenario: Pre-turn compaction during model switch (without pre-sampling model-switch compaction): current behavior strips incoming <model_switch> from the compact request and restores it in the post-compaction follow-up request.
@@ -18,15 +19,14 @@ Scenario: Pre-turn compaction during model switch (without pre-sampling model-sw
 03:message/developer:<PERMISSIONS_INSTRUCTIONS>
 04:message/user:BEFORE_SWITCH_USER
 05:message/assistant:BEFORE_SWITCH_REPLY
-06:message/user:AFTER_SWITCH_USER
-07:message/user:<SUMMARIZATION_PROMPT>
+06:message/user:<SUMMARIZATION_PROMPT>
 
 ## Local Post-Compaction History Layout
-00:message/user:BEFORE_SWITCH_USER
-01:message/developer:<PERMISSIONS_INSTRUCTIONS>
-02:message/developer:<personality_spec> The user has requested a new communication st...
-03:message/user:<AGENTS_MD>
-04:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-05:message/user:AFTER_SWITCH_USER
-06:message/user:<COMPACTION_SUMMARY>\nPRETURN_SWITCH_SUMMARY
-07:message/developer:<model_switch>\nThe user was previously using a different model....
+00:message/developer:<PERMISSIONS_INSTRUCTIONS>
+01:message/developer:<personality_spec> The user has requested a new communication st...
+02:message/user:<AGENTS_MD>
+03:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+04:message/user:BEFORE_SWITCH_USER
+05:message/user:<COMPACTION_SUMMARY>\nPRETURN_SWITCH_SUMMARY
+06:message/developer:<model_switch>\nThe user was previously using a different model....
+07:message/user:AFTER_SWITCH_USER

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary_shapes.snap
@@ -1,0 +1,20 @@
+---
+source: core/tests/suite/compact_remote.rs
+expression: "format_labeled_requests_snapshot(\"Remote mid-turn compaction where compact output has multiple summary-only user messages: continuation layout reinjects canonical context above the latest summary.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", &requests[1]),])"
+---
+Scenario: Remote mid-turn compaction where compact output has multiple summary-only user messages: continuation layout reinjects canonical context above the latest summary.
+
+## Remote Compaction Request
+00:message/developer:<PERMISSIONS_INSTRUCTIONS>
+01:message/user:<AGENTS_MD>
+02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+03:message/user:USER_ONE
+04:function_call/test_tool
+05:function_call_output:unsupported call: test_tool
+
+## Remote Post-Compaction History Layout
+00:message/user:<COMPACTION_SUMMARY>\nREMOTE_OLDER_SUMMARY
+01:message/developer:<PERMISSIONS_INSTRUCTIONS>
+02:message/user:<AGENTS_MD>
+03:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+04:message/user:<COMPACTION_SUMMARY>\nREMOTE_LATEST_SUMMARY

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary_shapes.snap
@@ -1,20 +1,21 @@
 ---
 source: core/tests/suite/compact_remote.rs
-expression: "format_labeled_requests_snapshot(\"Remote mid-turn compaction where compact output has multiple summary-only user messages: continuation layout reinjects canonical context above the latest summary.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", &requests[1]),])"
+expression: "format_labeled_requests_snapshot(\"Remote mid-turn compaction after an earlier summary compaction: the older summary remains in model-visible history and round-trips into the next compact request.\",\n&[(\"Second Turn Request (Before Mid-Turn Compaction)\", &requests[1]),\n(\"Remote Compaction Request\", &compact_request),])"
 ---
-Scenario: Remote mid-turn compaction where compact output has multiple summary-only user messages: continuation layout reinjects canonical context above the latest summary.
+Scenario: Remote mid-turn compaction after an earlier summary compaction: the older summary remains in model-visible history and round-trips into the next compact request.
+
+## Second Turn Request (Before Mid-Turn Compaction)
+00:message/user:USER_ONE
+01:message/user:<COMPACTION_SUMMARY>\nREMOTE_OLDER_SUMMARY
+02:message/developer:<PERMISSIONS_INSTRUCTIONS>
+03:message/user:<AGENTS_MD>
+04:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+05:message/user:<COMPACTION_SUMMARY>\nREMOTE_LATEST_SUMMARY
+06:message/user:USER_TWO
 
 ## Remote Compaction Request
-00:message/developer:<PERMISSIONS_INSTRUCTIONS>
-01:message/user:<AGENTS_MD>
-02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-03:message/user:USER_ONE
-04:function_call/test_tool
-05:function_call_output:unsupported call: test_tool
-
-## Remote Post-Compaction History Layout
-00:message/user:<COMPACTION_SUMMARY>\nREMOTE_OLDER_SUMMARY
+00:message/user:USER_ONE
 01:message/developer:<PERMISSIONS_INSTRUCTIONS>
 02:message/user:<AGENTS_MD>
 03:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-04:message/user:<COMPACTION_SUMMARY>\nREMOTE_LATEST_SUMMARY
+04:message/user:<COMPACTION_SUMMARY>\nREMOTE_OLDER_SUMMARY

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_summary_only_reinjects_context_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_summary_only_reinjects_context_shapes.snap
@@ -1,0 +1,19 @@
+---
+source: core/tests/suite/compact_remote.rs
+expression: "format_labeled_requests_snapshot(\"Remote mid-turn compaction where compact output has only summary user content: continuation layout reinjects canonical context before that summary.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", &requests[1]),])"
+---
+Scenario: Remote mid-turn compaction where compact output has only summary user content: continuation layout reinjects canonical context before that summary.
+
+## Remote Compaction Request
+00:message/developer:<PERMISSIONS_INSTRUCTIONS>
+01:message/user:<AGENTS_MD>
+02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+03:message/user:USER_ONE
+04:function_call/test_tool
+05:function_call_output:unsupported call: test_tool
+
+## Remote Post-Compaction History Layout
+00:message/developer:<PERMISSIONS_INSTRUCTIONS>
+01:message/user:<AGENTS_MD>
+02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+03:message/user:<COMPACTION_SUMMARY>\nREMOTE_SUMMARY_ONLY

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
@@ -1,0 +1,29 @@
+---
+source: core/tests/suite/compact_remote.rs
+expression: "format_labeled_requests_snapshot(\"Remote pre-turn compaction during model switch strips incoming <model_switch> from the compact request and restores it in the post-compaction follow-up request.\",\n&[(\"Initial Request (Previous Model)\", &requests[0]),\n(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", &requests[1]),])"
+---
+Scenario: Remote pre-turn compaction during model switch strips incoming <model_switch> from the compact request and restores it in the post-compaction follow-up request.
+
+## Initial Request (Previous Model)
+00:message/developer:<PERMISSIONS_INSTRUCTIONS>
+01:message/user:<AGENTS_MD>
+02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+03:message/user:BEFORE_SWITCH_USER
+
+## Remote Compaction Request
+00:message/developer:<PERMISSIONS_INSTRUCTIONS>
+01:message/user:<AGENTS_MD>
+02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+03:message/user:BEFORE_SWITCH_USER
+04:message/assistant:BEFORE_SWITCH_REPLY
+05:message/user:AFTER_SWITCH_USER
+
+## Remote Post-Compaction History Layout
+00:message/user:BEFORE_SWITCH_USER
+01:message/developer:<PERMISSIONS_INSTRUCTIONS>
+02:message/developer:<personality_spec> The user has requested a new communication st...
+03:message/user:<AGENTS_MD>
+04:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+05:message/user:AFTER_SWITCH_USER
+06:message/user:<COMPACTION_SUMMARY>\nREMOTE_SWITCH_SUMMARY
+07:message/developer:<model_switch>\nThe user was previously using a different model....

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
@@ -1,8 +1,9 @@
 ---
 source: core/tests/suite/compact_remote.rs
-expression: "format_labeled_requests_snapshot(\"Remote pre-turn compaction during model switch strips incoming <model_switch> from the compact request and restores it in the post-compaction follow-up request.\",\n&[(\"Initial Request (Previous Model)\", &requests[0]),\n(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", &requests[1]),])"
+assertion_line: 1543
+expression: "format_labeled_requests_snapshot(\"Remote pre-turn compaction during model switch currently excludes incoming user input, strips incoming <model_switch> from the compact request payload, and restores it in the post-compaction follow-up request.\",\n&[(\"Initial Request (Previous Model)\", &requests[0]),\n(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", &requests[1]),])"
 ---
-Scenario: Remote pre-turn compaction during model switch strips incoming <model_switch> from the compact request and restores it in the post-compaction follow-up request.
+Scenario: Remote pre-turn compaction during model switch currently excludes incoming user input, strips incoming <model_switch> from the compact request payload, and restores it in the post-compaction follow-up request.
 
 ## Initial Request (Previous Model)
 00:message/developer:<PERMISSIONS_INSTRUCTIONS>
@@ -16,14 +17,14 @@ Scenario: Remote pre-turn compaction during model switch strips incoming <model_
 02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 03:message/user:BEFORE_SWITCH_USER
 04:message/assistant:BEFORE_SWITCH_REPLY
-05:message/user:AFTER_SWITCH_USER
 
 ## Remote Post-Compaction History Layout
 00:message/user:BEFORE_SWITCH_USER
-01:message/developer:<PERMISSIONS_INSTRUCTIONS>
-02:message/developer:<personality_spec> The user has requested a new communication st...
-03:message/user:<AGENTS_MD>
-04:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-05:message/user:AFTER_SWITCH_USER
+01:message/user:AFTER_SWITCH_USER
+02:message/developer:<PERMISSIONS_INSTRUCTIONS>
+03:message/developer:<personality_spec> The user has requested a new communication st...
+04:message/user:<AGENTS_MD>
+05:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 06:message/user:<COMPACTION_SUMMARY>\nREMOTE_SWITCH_SUMMARY
 07:message/developer:<model_switch>\nThe user was previously using a different model....
+08:message/user:AFTER_SWITCH_USER

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
@@ -1,6 +1,5 @@
 ---
 source: core/tests/suite/compact_remote.rs
-assertion_line: 1543
 expression: "format_labeled_requests_snapshot(\"Remote pre-turn compaction during model switch currently excludes incoming user input, strips incoming <model_switch> from the compact request payload, and restores it in the post-compaction follow-up request.\",\n&[(\"Initial Request (Previous Model)\", &requests[0]),\n(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", &requests[1]),])"
 ---
 Scenario: Remote pre-turn compaction during model switch currently excludes incoming user input, strips incoming <model_switch> from the compact request payload, and restores it in the post-compaction follow-up request.
@@ -20,11 +19,10 @@ Scenario: Remote pre-turn compaction during model switch currently excludes inco
 
 ## Remote Post-Compaction History Layout
 00:message/user:BEFORE_SWITCH_USER
-01:message/user:AFTER_SWITCH_USER
-02:message/developer:<PERMISSIONS_INSTRUCTIONS>
-03:message/developer:<personality_spec> The user has requested a new communication st...
-04:message/user:<AGENTS_MD>
-05:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-06:message/user:<COMPACTION_SUMMARY>\nREMOTE_SWITCH_SUMMARY
-07:message/developer:<model_switch>\nThe user was previously using a different model....
-08:message/user:AFTER_SWITCH_USER
+01:message/developer:<PERMISSIONS_INSTRUCTIONS>
+02:message/developer:<personality_spec> The user has requested a new communication st...
+03:message/user:<AGENTS_MD>
+04:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+05:message/user:<COMPACTION_SUMMARY>\nREMOTE_SWITCH_SUMMARY
+06:message/developer:<model_switch>\nThe user was previously using a different model....
+07:message/user:AFTER_SWITCH_USER


### PR DESCRIPTION
## Summary
- standardize remote compaction test mocking around one default behavior in shared helpers
- make default remote compact mocks mirror production shape: keep `message/user` + `message/developer`, drop assistant/tool artifacts, then append a summary user message
- switch non-special `compact_remote` tests to the shared default mock instead of ad-hoc JSON payloads

## Special-case tests that still use explicit mocks
- remote compaction error payload / HTTP failure behavior
- summary-only compact output behavior
- manual `/compact` with no prior user messages
- stale developer-instruction injection coverage

## Why
This removes inconsistent manual remote compaction fixtures and gives us one source of truth for normal remote compact behavior, while preserving explicit mocks only where tests intentionally cover non-default behavior.
