### PR TITLE
feat(tui): render markdown tables with Unicode box-drawing borders

### DIFF
--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -123,6 +123,10 @@ pub(crate) enum AppEvent {
 
     InsertHistoryCell(Box<dyn HistoryCell>),
 
+    /// Replace the contiguous run of streaming `AgentMessageCell`s at the end of the transcript
+    /// with a single `AgentMarkdownCell` that re-renders from the raw markdown source on resize.
+    ConsolidateAgentMessage(String),
+
     /// Apply rollback semantics to local transcript cells.
     ///
     /// This is emitted when rollback was not initiated by the current

--- a/codex-rs/tui/src/app_event.rs
+++ b/codex-rs/tui/src/app_event.rs
@@ -123,8 +123,14 @@ pub(crate) enum AppEvent {
 
     InsertHistoryCell(Box<dyn HistoryCell>),
 
-    /// Replace the contiguous run of streaming `AgentMessageCell`s at the end of the transcript
-    /// with a single `AgentMarkdownCell` that re-renders from the raw markdown source on resize.
+    /// Replace the contiguous run of streaming `AgentMessageCell`s at the end of
+    /// the transcript with a single `AgentMarkdownCell` that stores the raw
+    /// markdown source.
+    ///
+    /// Emitted by `ChatWidget::flush_answer_stream_with_separator` after stream
+    /// finalization. The `App` handler walks backward through `transcript_cells`
+    /// to find the `AgentMessageCell` run and splices in the consolidated cell.
+    /// If `reflow_ran_during_stream` is set, a follow-up reflow is scheduled.
     ConsolidateAgentMessage(String),
 
     /// Apply rollback semantics to local transcript cells.

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -136,7 +136,6 @@ use crossterm::event::KeyCode;
 use crossterm::event::KeyEvent;
 use crossterm::event::KeyEventKind;
 use crossterm::event::KeyModifiers;
-use crossterm::terminal;
 use rand::Rng;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect;
@@ -2347,18 +2346,15 @@ impl ChatWidget {
     }
 
     fn current_stream_width(&self, reserved_cols: usize) -> Option<usize> {
-        self.last_rendered_width
-            .get()
-            .or_else(|| terminal::size().ok().map(|(w, _)| usize::from(w)))
-            .and_then(|w| {
-                if w == 0 {
-                    None
-                } else {
-                    // Keep a 1-column minimum for active stream controllers so they can
-                    // continue accepting deltas on ultra-narrow layouts.
-                    Some(crate::width::usable_content_width(w, reserved_cols).unwrap_or(1))
-                }
-            })
+        self.last_rendered_width.get().and_then(|w| {
+            if w == 0 {
+                None
+            } else {
+                // Keep a 1-column minimum for active stream controllers so they can
+                // continue accepting deltas on ultra-narrow layouts.
+                Some(crate::width::usable_content_width(w, reserved_cols).unwrap_or(1))
+            }
+        })
     }
 
     pub(crate) fn on_terminal_resize(&mut self, width: u16) {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -837,7 +837,7 @@ impl ChatWidget {
             }
         }
         self.adaptive_chunking.reset();
-        if had_stream_controller {
+        if had_stream_controller && self.stream_controllers_idle() {
             self.app_event_tx.send(AppEvent::StopCommitAnimation);
         }
     }

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -458,6 +458,28 @@ fn rate_limit_error_kind(info: &CodexErrorInfo) -> Option<RateLimitErrorKind> {
     }
 }
 
+fn is_interrupt_droppable_stream_event(msg: &EventMsg) -> bool {
+    match msg {
+        EventMsg::AgentMessage(_)
+        | EventMsg::AgentMessageDelta(_)
+        | EventMsg::PlanDelta(_)
+        | EventMsg::AgentReasoning(_)
+        | EventMsg::AgentReasoningDelta(_)
+        | EventMsg::AgentReasoningRawContent(_)
+        | EventMsg::AgentReasoningRawContentDelta(_)
+        | EventMsg::AgentReasoningSectionBreak(_)
+        | EventMsg::AgentMessageContentDelta(_)
+        | EventMsg::ReasoningContentDelta(_)
+        | EventMsg::ReasoningRawContentDelta(_) => true,
+        EventMsg::ItemCompleted(event) => matches!(
+            &event.item,
+            codex_protocol::items::TurnItem::AgentMessage(_)
+                | codex_protocol::items::TurnItem::Plan(_)
+        ),
+        _ => false,
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
 pub(crate) enum ExternalEditorState {
     #[default]
@@ -536,6 +558,11 @@ pub(crate) struct ChatWidget {
     /// bottom pane is treated as "running" while this is populated, even if no agent turn is
     /// currently executing.
     mcp_startup_status: Option<HashMap<String, McpStartupStatus>>,
+    /// True once an interrupt was requested for the active turn.
+    ///
+    /// While this is set, inbound stream deltas are dropped locally so a large
+    /// queued backlog cannot keep rendering stale content after user interrupt.
+    interrupt_requested_for_turn: bool,
     connectors_cache: ConnectorsCacheState,
     connectors_prefetch_in_flight: bool,
     // Queue of interruptive UI events deferred during an active write cycle
@@ -1302,6 +1329,7 @@ impl ChatWidget {
     fn on_task_started(&mut self) {
         self.agent_turn_running = true;
         self.turn_sleep_inhibitor.set_turn_running(true);
+        self.interrupt_requested_for_turn = false;
         self.saw_plan_update_this_turn = false;
         self.saw_plan_item_this_turn = false;
         self.plan_delta_buffer.clear();
@@ -1360,6 +1388,7 @@ impl ChatWidget {
         self.pending_status_indicator_restore = false;
         self.agent_turn_running = false;
         self.turn_sleep_inhibitor.set_turn_running(false);
+        self.interrupt_requested_for_turn = false;
         self.update_task_running_state();
         self.running_commands.clear();
         self.suppressed_exec_calls.clear();
@@ -1600,6 +1629,7 @@ impl ChatWidget {
         // Reset running state and clear streaming buffers.
         self.agent_turn_running = false;
         self.turn_sleep_inhibitor.set_turn_running(false);
+        self.interrupt_requested_for_turn = false;
         self.update_task_running_state();
         self.running_commands.clear();
         self.suppressed_exec_calls.clear();
@@ -2688,6 +2718,7 @@ impl ChatWidget {
             unified_exec_processes: Vec::new(),
             agent_turn_running: false,
             mcp_startup_status: None,
+            interrupt_requested_for_turn: false,
             connectors_cache: ConnectorsCacheState::default(),
             connectors_prefetch_in_flight: false,
             interrupts: InterruptManager::new(),
@@ -2855,6 +2886,7 @@ impl ChatWidget {
             unified_exec_processes: Vec::new(),
             agent_turn_running: false,
             mcp_startup_status: None,
+            interrupt_requested_for_turn: false,
             connectors_cache: ConnectorsCacheState::default(),
             connectors_prefetch_in_flight: false,
             interrupts: InterruptManager::new(),
@@ -3011,6 +3043,7 @@ impl ChatWidget {
             unified_exec_processes: Vec::new(),
             agent_turn_running: false,
             mcp_startup_status: None,
+            interrupt_requested_for_turn: false,
             connectors_cache: ConnectorsCacheState::default(),
             connectors_prefetch_in_flight: false,
             interrupts: InterruptManager::new(),
@@ -4074,6 +4107,14 @@ impl ChatWidget {
     /// `replay_initial_messages()`. Callers should treat `None` as a "fake" id
     /// that must not be used to correlate follow-up actions.
     fn dispatch_event_msg(&mut self, id: Option<String>, msg: EventMsg, from_replay: bool) {
+        if !from_replay
+            && self.interrupt_requested_for_turn
+            && is_interrupt_droppable_stream_event(&msg)
+        {
+            tracing::trace!("dropping stream event while interrupt is pending");
+            return;
+        }
+
         let is_stream_error = matches!(&msg, EventMsg::StreamError(_));
         if !is_stream_error {
             self.restore_retry_status_header_if_present();
@@ -6891,6 +6932,9 @@ impl ChatWidget {
     }
     /// Forward an `Op` directly to codex.
     pub(crate) fn submit_op(&mut self, op: Op) {
+        if matches!(&op, Op::Interrupt) && self.agent_turn_running {
+            self.interrupt_requested_for_turn = true;
+        }
         // Record outbound operation for session replay fidelity.
         crate::session_log::log_outbound_op(&op);
         if matches!(&op, Op::Review { .. }) && !self.bottom_pane.is_task_running() {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -1592,6 +1592,9 @@ impl ChatWidget {
     /// This does not clear MCP startup tracking, because MCP startup can overlap with turn cleanup
     /// and should continue to drive the bottom-pane running indicator while it is in progress.
     fn finalize_turn(&mut self) {
+        // Drop preview-only stream tail content on any termination path before
+        // failed-cell finalization, so transient tail cells are never persisted.
+        self.clear_active_stream_tail();
         // Ensure any spinner is replaced by a red ✗ and flushed into history.
         self.finalize_active_cell_as_failed();
         // Reset running state and clear streaming buffers.

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2320,7 +2320,13 @@ impl ChatWidget {
         self.last_rendered_width
             .get()
             .or_else(|| terminal::size().ok().map(|(w, _)| usize::from(w)))
-            .and_then(|w| crate::width::usable_content_width(w, reserved_cols))
+            .and_then(|w| {
+                if w == 0 {
+                    None
+                } else {
+                    Some(crate::width::usable_content_width(w, reserved_cols).unwrap_or(1))
+                }
+            })
     }
 
     pub(crate) fn on_terminal_resize(&mut self, width: u16) {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2317,7 +2317,7 @@ impl ChatWidget {
         self.last_rendered_width
             .get()
             .or_else(|| terminal::size().ok().map(|(w, _)| usize::from(w)))
-            .map(|w| w.saturating_sub(reserved_cols))
+            .and_then(|w| crate::width::usable_content_width(w, reserved_cols))
     }
 
     pub(crate) fn on_terminal_resize(&mut self, width: u16) {

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3687,12 +3687,17 @@ impl ChatWidget {
     }
 
     fn flush_active_cell(&mut self) {
-        if self.stream_controller.is_some()
-            && self
-                .active_cell
-                .as_ref()
-                .is_some_and(|cell| cell.as_any().is::<history_cell::StreamingAgentTailCell>())
+        if self
+            .active_cell
+            .as_ref()
+            .is_some_and(|cell| cell.as_any().is::<history_cell::StreamingAgentTailCell>())
         {
+            if self.stream_controller.is_some() {
+                return;
+            }
+            // If stream cleanup already cleared the controller, drop the transient tail instead
+            // of committing preview-only content to transcript history.
+            self.active_cell.take();
             return;
         }
 

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -2354,12 +2354,15 @@ impl ChatWidget {
                 if w == 0 {
                     None
                 } else {
+                    // Keep a 1-column minimum for active stream controllers so they can
+                    // continue accepting deltas on ultra-narrow layouts.
                     Some(crate::width::usable_content_width(w, reserved_cols).unwrap_or(1))
                 }
             })
     }
 
     pub(crate) fn on_terminal_resize(&mut self, width: u16) {
+        let had_rendered_width = self.last_rendered_width.get().is_some();
         self.last_rendered_width.set(Some(width as usize));
         let stream_width = self.current_stream_width(2);
         let plan_stream_width = self.current_stream_width(4);
@@ -2370,6 +2373,9 @@ impl ChatWidget {
             controller.set_width(plan_stream_width);
         }
         self.sync_active_stream_tail();
+        if !had_rendered_width {
+            self.request_redraw();
+        }
     }
 
     fn worked_elapsed_from(&mut self, current_elapsed: u64) -> u64 {

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1749,6 +1749,9 @@ async fn make_chatwidget_manual(
 async fn current_stream_width_clamps_to_minimum_when_reserved_columns_exhaust_width() {
     let (chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
 
+    chat.last_rendered_width.set(None);
+    assert_eq!(chat.current_stream_width(2), None);
+
     chat.last_rendered_width.set(Some(2));
     assert_eq!(chat.current_stream_width(2), Some(1));
 

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -3145,6 +3145,36 @@ async fn steer_enter_submits_when_plan_stream_is_not_active() {
 }
 
 #[tokio::test]
+async fn flush_answer_stream_does_not_stop_animation_while_plan_stream_is_active() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+
+    let mut plan_controller = PlanStreamController::new(Some(80));
+    assert!(plan_controller.push("- Step 1\n"));
+    assert!(
+        plan_controller.queued_lines() > 0,
+        "expected plan stream to have queued lines for this repro",
+    );
+    chat.plan_stream_controller = Some(plan_controller);
+    chat.stream_controller = Some(StreamController::new(Some(80)));
+
+    while rx.try_recv().is_ok() {}
+
+    chat.flush_answer_stream_with_separator();
+
+    let mut saw_stop = false;
+    while let Ok(event) = rx.try_recv() {
+        if matches!(event, AppEvent::StopCommitAnimation) {
+            saw_stop = true;
+        }
+    }
+
+    assert!(
+        !saw_stop,
+        "did not expect StopCommitAnimation while plan stream still has queued lines",
+    );
+}
+
+#[tokio::test]
 async fn ctrl_c_shutdown_works_with_caps_lock() {
     let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
 

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1669,6 +1669,20 @@ async fn make_chatwidget_manual(
     (widget, rx, op_rx)
 }
 
+#[tokio::test]
+async fn current_stream_width_returns_none_when_reserved_columns_exhaust_width() {
+    let (chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
+
+    chat.last_rendered_width.set(Some(2));
+    assert_eq!(chat.current_stream_width(2), None);
+
+    chat.last_rendered_width.set(Some(4));
+    assert_eq!(chat.current_stream_width(4), None);
+
+    chat.last_rendered_width.set(Some(5));
+    assert_eq!(chat.current_stream_width(4), Some(1));
+}
+
 // ChatWidget may emit other `Op`s (e.g. history/logging updates) on the same channel; this helper
 // filters until we see a submission op.
 fn next_submit_op(op_rx: &mut tokio::sync::mpsc::UnboundedReceiver<Op>) -> Op {

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1745,14 +1745,14 @@ async fn make_chatwidget_manual(
 }
 
 #[tokio::test]
-async fn current_stream_width_returns_none_when_reserved_columns_exhaust_width() {
+async fn current_stream_width_clamps_to_minimum_when_reserved_columns_exhaust_width() {
     let (chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
 
     chat.last_rendered_width.set(Some(2));
-    assert_eq!(chat.current_stream_width(2), None);
+    assert_eq!(chat.current_stream_width(2), Some(1));
 
     chat.last_rendered_width.set(Some(4));
-    assert_eq!(chat.current_stream_width(4), None);
+    assert_eq!(chat.current_stream_width(4), Some(1));
 
     chat.last_rendered_width.set(Some(5));
     assert_eq!(chat.current_stream_width(4), Some(1));

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -6095,6 +6095,94 @@ async fn interrupt_drops_stream_deltas_until_turn_aborted() {
 }
 
 #[tokio::test]
+async fn interrupt_remains_responsive_during_resized_table_stream() {
+    let (mut chat, mut rx, mut op_rx) = make_chatwidget_manual(None).await;
+
+    chat.last_rendered_width.set(Some(120));
+    chat.handle_codex_event(Event {
+        id: "turn-resize".into(),
+        msg: EventMsg::TurnStarted(TurnStartedEvent {
+            turn_id: "turn-resize".to_string(),
+            model_context_window: None,
+            collaboration_mode_kind: ModeKind::Default,
+        }),
+    });
+
+    chat.handle_codex_event(Event {
+        id: "table-head".into(),
+        msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
+            delta:
+                "| Row | Initiative Summary | Extended Notes | URL |\n| --- | --- | --- | --- |\n"
+                    .to_string(),
+        }),
+    });
+
+    for idx in 0..40 {
+        chat.handle_codex_event(Event {
+            id: format!("table-row-{idx}"),
+            msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
+                delta: format!(
+                    "| {idx:03} | Workstream {idx:03} provides a long narrative about scope boundaries, sequencing assumptions, contingency paths, stakeholder dependencies, and quality criteria to keep complex coordination readable under pressure. | Record {idx:03} stores extended execution commentary including risk signals, approvals, rollback conditions, evidence links, and checkpoint outcomes so auditors and new contributors can understand context without reopening old threads. | https://example.com/program/workstream-{idx:03}-detailed-governance-and-delivery-context |\n",
+                ),
+            }),
+        });
+        chat.on_terminal_resize(if idx % 2 == 0 { 72 } else { 116 });
+        chat.on_commit_tick();
+        let _ = drain_insert_history(&mut rx);
+    }
+
+    assert!(
+        chat.stream_controller.is_some(),
+        "expected active stream during table tail stress",
+    );
+
+    chat.handle_key_event(KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+    let mut saw_interrupt = false;
+    while let Ok(op) = op_rx.try_recv() {
+        if matches!(op, Op::Interrupt) {
+            saw_interrupt = true;
+            break;
+        }
+    }
+    assert!(saw_interrupt, "expected Ctrl+C to submit Op::Interrupt");
+
+    chat.on_terminal_resize(64);
+    let resized_tail = {
+        let controller = chat
+            .stream_controller
+            .as_ref()
+            .expect("expected stream controller after resize");
+        lines_to_single_string(&controller.current_tail_lines())
+    };
+
+    chat.handle_codex_event(Event {
+        id: "table-row-stale-after-interrupt".into(),
+        msg: EventMsg::AgentMessageDelta(AgentMessageDeltaEvent {
+            delta: "| 999 | INTERRUPT_STALE_SENTINEL | INTERRUPT_STALE_SENTINEL | https://example.com/stale |\n"
+                .to_string(),
+        }),
+    });
+
+    let tail_after_stale_delta = {
+        let controller = chat
+            .stream_controller
+            .as_ref()
+            .expect("expected stream controller after stale delta");
+        lines_to_single_string(&controller.current_tail_lines())
+    };
+    assert_eq!(
+        tail_after_stale_delta, resized_tail,
+        "expected stale table delta to be dropped while interrupt is pending",
+    );
+    assert!(
+        !tail_after_stale_delta.contains("INTERRUPT_STALE_SENTINEL"),
+        "stale sentinel should never reach the active stream tail",
+    );
+
+    let _ = drain_insert_history(&mut rx);
+}
+
+#[tokio::test]
 async fn interrupt_prepends_queued_messages_before_existing_composer_text() {
     let (mut chat, mut rx, mut op_rx) = make_chatwidget_manual(None).await;
 

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -1250,6 +1250,39 @@ async fn add_to_history_does_not_commit_transient_stream_tail_after_controller_c
 }
 
 #[tokio::test]
+async fn on_error_does_not_persist_transient_stream_tail_during_finalize_turn() {
+    let (mut chat, mut rx, _op_rx) = make_chatwidget_manual(None).await;
+
+    chat.stream_controller = Some(StreamController::new(Some(80)));
+    chat.active_cell = Some(Box::new(history_cell::StreamingAgentTailCell::new(
+        vec![ratatui::text::Line::from("transient stream tail preview")],
+        true,
+    )));
+
+    chat.on_error("stream failed".to_string());
+
+    let mut saw_transient_tail = false;
+    let mut saw_error = false;
+    while let Ok(event) = rx.try_recv() {
+        if let AppEvent::InsertHistoryCell(cell) = event {
+            if cell.as_any().is::<history_cell::StreamingAgentTailCell>() {
+                saw_transient_tail = true;
+            }
+            let rendered = lines_to_single_string(&cell.display_lines(80));
+            if rendered.contains("stream failed") {
+                saw_error = true;
+            }
+        }
+    }
+
+    assert!(saw_error, "expected error history cell to be emitted");
+    assert!(
+        !saw_transient_tail,
+        "did not expect transient stream-tail cell to be committed during finalize_turn",
+    );
+}
+
+#[tokio::test]
 async fn remap_placeholders_uses_attachment_labels() {
     let placeholder_one = "[Image #1]";
     let placeholder_two = "[Image #2]";

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -3843,6 +3843,7 @@ mod tests {
             message: "tiny width coverage for wrapped user history".to_string(),
             text_elements: Vec::new(),
             local_image_paths: Vec::new(),
+            remote_image_urls: Vec::new(),
         };
         let agent_message_cell = AgentMessageCell::new(vec!["tiny width agent line".into()], true);
         let reasoning_cell = ReasoningSummaryCell::new(
@@ -3979,6 +3980,7 @@ mod tests {
             message: "hello".to_string(),
             text_elements: Vec::new(),
             local_image_paths: Vec::new(),
+            remote_image_urls: Vec::new(),
         }) as Arc<dyn HistoryCell>;
         let head = Arc::new(AgentMessageCell::new(vec![Line::from("line 1")], true))
             as Arc<dyn HistoryCell>;

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -457,6 +457,76 @@ impl HistoryCell for AgentMessageCell {
     }
 }
 
+/// A consolidated agent message cell taht stores raw markdown source and re-renders from it at any
+/// width. This replaces the run of `AgentMessageCell`s after a stream finalizes, so tables and
+/// other width-sensitive content review correctly on terminal resize.
+#[derive(Debug)]
+pub(crate) struct AgentMarkdownCell {
+    markdown_source: String,
+}
+
+impl AgentMarkdownCell {
+    pub(crate) fn new(markdown_source: String) -> Self {
+        Self { markdown_source }
+    }
+}
+
+impl HistoryCell for AgentMarkdownCell {
+    fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
+        let mut lines: Vec<Line<'static>> = Vec::new();
+        // Re-render markdown from source at the current width. Reserve 2 columns for the "• " /
+        // " " prefix prepended below.
+        let wrap_width = (width as usize).saturating_sub(2);
+        crate::markdown::append_markdown_agent(&self.markdown_source, Some(wrap_width), &mut lines);
+        // Use prefix_lines (not word_wrap_lines) so table rows with box-drawing characters are not
+        // broken by word-wrapping. The markdown renderer already output to wrap_width.
+        prefix_lines(lines, "• ".dim(), "  ".into())
+    }
+}
+
+/// Transient active-cell representation of the mutable tail of an agent stream.
+///
+/// During streaming, lines that have not yet been committed to scrollback (because they belong to
+/// an in-progress table or are the last incomplete line) are displayed via this cell in the
+/// `active_cell` slot.  It is replaced on every delta and cleared when the stream finalizes.
+///
+/// Unlike `AgentMessageCell`, this cell is never committed to the transcript. It exists only as a
+/// live preview of content that will eventually be emitted as stable `AgentMessageCell`s or
+/// consolidated into an `AgentMarkdownCell`.
+#[derive(Debug)]
+pub(crate) struct StreamingAgentTailCell {
+    lines: Vec<Line<'static>>,
+    is_first_line: bool,
+}
+
+impl StreamingAgentTailCell {
+    pub(crate) fn new(lines: Vec<Line<'static>>, is_first_line: bool) -> Self {
+        Self {
+            lines,
+            is_first_line,
+        }
+    }
+}
+
+impl HistoryCell for StreamingAgentTailCell {
+    fn display_lines(&self, width: u16) -> Vec<Line<'static>> {
+        word_wrap_lines(
+            &self.lines,
+            RtOptions::new(width as usize)
+                .initial_indent(if self.is_first_line {
+                    "• ".dim().into()
+                } else {
+                    "  ".into()
+                })
+                .subsequent_indent("  ".into()),
+        )
+    }
+
+    fn is_stream_continuation(&self) -> bool {
+        !self.is_first_line
+    }
+}
+
 #[derive(Debug)]
 pub(crate) struct PlainHistoryCell {
     lines: Vec<Line<'static>>,
@@ -3699,6 +3769,170 @@ mod tests {
                 "⚠ Feature flag `foo`".to_string(),
                 "Use flag `bar` instead.".to_string(),
             ]
+        );
+    }
+
+    #[test]
+    fn agent_markdown_cell_renders_table_at_different_widths() {
+        let source = "| Name | Role |\n|------|------|\n| Alice | Engineer |\n| Bob | Designer |\n";
+        let cell = AgentMarkdownCell::new(source.to_string());
+
+        // At width 80 the table should render with box-drawing characters.
+        let lines_80 = render_lines(&cell.display_lines(80));
+        assert!(
+            lines_80.iter().any(|l| l.contains('┌')),
+            "expected box-drawing table at width 80: {lines_80:?}"
+        );
+        // Verify the "• " leader is present on the first line.
+        assert!(
+            lines_80[0].starts_with("• "),
+            "first line should start with bullet prefix: {:?}",
+            lines_80[0]
+        );
+
+        // At width 40 the table should also render correctly (re-rendered from
+        // source, not just word-wrapped).
+        let lines_40 = render_lines(&cell.display_lines(40));
+        assert!(
+            lines_40.iter().any(|l| l.contains('┌')),
+            "expected box-drawing table at width 40: {lines_40:?}"
+        );
+
+        // Verify table borders are intact (not broken by naive word-wrapping).
+        // Every line with a box char should have matching left/right borders.
+        for line in &lines_40 {
+            let trimmed = line.trim();
+            if trimmed.starts_with('│') {
+                assert!(
+                    trimmed.ends_with('│'),
+                    "table row should have matching right border: {line:?}"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn agent_markdown_cell_survives_insert_history_rewrap() {
+        let source = "\
+  | Milestone | Target Date | Outcome | Extended Context |
+  |-----------|-------------|---------|------------------|
+  | Canary Rollout | 2026-01-15 | Completed | Canary remained at limited traffic longer than planned because p95 latency briefly regressed during
+  cold-cache periods |
+  | Regional Expansion | 2026-01-29 | Completed | Expansion succeeded with stable error rates, though internal analytics lagged temporarily |
+  ";
+        let cell = AgentMarkdownCell::new(source.to_string());
+        let width: u16 = 80;
+        let lines = cell.display_lines(width);
+
+        // Simulate what insert_history_lines does: word_wrap_lines with
+        // the terminal width and no indent.
+        let rewrapped = word_wrap_lines(&lines, width as usize);
+        let before = render_lines(&lines);
+        let after = render_lines(&rewrapped);
+        assert_eq!(
+            before, after,
+            "word_wrap_lines should not alter lines that already fit within width"
+        );
+    }
+
+    #[test]
+    fn agent_markdown_cell_table_fits_within_narrow_width() {
+        let source = "\
+  | Milestone | Target Date | Outcome | Extended Context |
+  |-----------|-------------|---------|------------------|
+  | Canary Rollout | 2026-01-15 | Completed | Canary remained at limited traffic longer than planned because p95 latency briefly regressed during
+  cold-cache periods |
+  | Regional Expansion | 2026-01-29 | Completed | Expansion succeeded with stable error rates, though internal analytics lagged temporarily |
+  | Legacy Decommission | 2026-02-10 | In Progress | Most legacy jobs are drained, but final shutdown is blocked by one compliance export workflow |
+  ";
+        let cell = AgentMarkdownCell::new(source.to_string());
+
+        // Render at a narrow width (simulating terminal resize).
+        let narrow_width: u16 = 80;
+        let lines = cell.display_lines(narrow_width);
+        let rendered = render_lines(&lines);
+
+        // Every rendered line must fit within the target width.
+        for line in &rendered {
+            let display_width = unicode_width::UnicodeWidthStr::width(line.as_str());
+            assert!(
+                display_width <= narrow_width as usize,
+                "line exceeds width {narrow_width}: ({display_width} chars) {line:?}"
+            );
+        }
+
+        // Table should still have box-drawing characters.
+        assert!(
+            rendered.iter().any(|l| l.contains('┌')),
+            "expected box-drawing table: {rendered:?}"
+        );
+    }
+
+    /// Simulate the consolidation backward-walk logic from `App::handle_event`
+    /// to verify it correctly identifies and replaces `AgentMessageCell` runs.
+    #[test]
+    fn consolidation_walker_replaces_agent_message_cells() {
+        use std::sync::Arc;
+
+        // Build a transcript with: [UserCell, AgentMsg(head), AgentMsg(cont), AgentMsg(cont)]
+        let user = Arc::new(UserHistoryCell {
+            message: "hello".to_string(),
+            text_elements: Vec::new(),
+            local_image_paths: Vec::new(),
+        }) as Arc<dyn HistoryCell>;
+        let head = Arc::new(AgentMessageCell::new(vec![Line::from("line 1")], true))
+            as Arc<dyn HistoryCell>;
+        let cont1 = Arc::new(AgentMessageCell::new(vec![Line::from("line 2")], false))
+            as Arc<dyn HistoryCell>;
+        let cont2 = Arc::new(AgentMessageCell::new(vec![Line::from("line 3")], false))
+            as Arc<dyn HistoryCell>;
+
+        let mut transcript_cells: Vec<Arc<dyn HistoryCell>> =
+            vec![user.clone(), head, cont1, cont2];
+
+        // Run the same consolidation logic as the handler.
+        let source = "line 1\nline 2\nline 3\n".to_string();
+        let end = transcript_cells.len();
+        let mut start = end;
+        while start > 0
+            && transcript_cells[start - 1].is_stream_continuation()
+            && transcript_cells[start - 1]
+                .as_any()
+                .is::<AgentMessageCell>()
+        {
+            start -= 1;
+        }
+        if start > 0
+            && transcript_cells[start - 1]
+                .as_any()
+                .is::<AgentMessageCell>()
+            && !transcript_cells[start - 1].is_stream_continuation()
+        {
+            start -= 1;
+        }
+
+        assert_eq!(
+            start, 1,
+            "should find all 3 agent cells starting at index 1"
+        );
+        assert_eq!(end, 4);
+
+        // Splice.
+        let consolidated: Arc<dyn HistoryCell> = Arc::new(AgentMarkdownCell::new(source));
+        transcript_cells.splice(start..end, std::iter::once(consolidated));
+
+        assert_eq!(transcript_cells.len(), 2, "should be [user, consolidated]");
+
+        // Verify first cell is still the user cell.
+        assert!(
+            transcript_cells[0].as_any().is::<UserHistoryCell>(),
+            "first cell should be UserHistoryCell"
+        );
+
+        // Verify second cell is AgentMarkdownCell.
+        assert!(
+            transcript_cells[1].as_any().is::<AgentMarkdownCell>(),
+            "second cell should be AgentMarkdownCell"
         );
     }
 }

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -457,9 +457,17 @@ impl HistoryCell for AgentMessageCell {
     }
 }
 
-/// A consolidated agent message cell taht stores raw markdown source and re-renders from it at any
-/// width. This replaces the run of `AgentMessageCell`s after a stream finalizes, so tables and
-/// other width-sensitive content review correctly on terminal resize.
+/// A consolidated agent message cell that stores raw markdown source and
+/// re-renders from it at any width.
+///
+/// After a stream finalizes, the `ConsolidateAgentMessage` handler in `App`
+/// replaces the contiguous run of `AgentMessageCell`s with a single
+/// `AgentMarkdownCell`. On terminal resize, `display_lines(width)` re-renders
+/// from source via `append_markdown_agent`, producing correctly-sized tables
+/// with box-drawing borders.
+///
+/// Uses `prefix_lines` (not `word_wrap_lines`) so table rows with box-drawing
+/// characters pass through without re-wrapping.
 #[derive(Debug)]
 pub(crate) struct AgentMarkdownCell {
     markdown_source: String,

--- a/codex-rs/tui/src/insert_history.rs
+++ b/codex-rs/tui/src/insert_history.rs
@@ -92,8 +92,15 @@ where
     // fetch/restore the cursor position. insert_history_lines should be cursor-position-neutral :)
     queue!(writer, MoveTo(0, cursor_top))?;
 
+    let scroll_bottom = area.top().saturating_sub(1);
+    let mut advance_row = cursor_top;
     for line in wrapped {
-        queue!(writer, Print("\r\n"))?;
+        // Explicitly anchor before each line advance to avoid terminal wrap-pending drift when
+        // prior content reached the right edge.
+        queue!(writer, MoveTo(0, advance_row), Print("\n"))?;
+        if advance_row < scroll_bottom {
+            advance_row += 1;
+        }
         queue!(
             writer,
             SetColors(Colors::new(
@@ -524,6 +531,60 @@ mod tests {
                 vt100::Color::Default,
                 "expected default color for 3rd-level content at row {row_idx} col {content_col}, got {:?}",
                 cell.fgcolor()
+            );
+        }
+    }
+
+    #[test]
+    fn vt100_exact_width_rows_keep_stable_line_progression() {
+        let width: u16 = 10;
+        let height: u16 = 7;
+        let backend = VT100Backend::new(width, height);
+        let mut term = crate::custom_terminal::Terminal::with_options(backend).expect("terminal");
+        let viewport = Rect::new(0, height - 1, width, 1);
+        term.set_viewport_area(viewport);
+
+        let lines = vec![
+            Line::from("1234567890"),
+            Line::from("abcdefghij"),
+            Line::from("KLMNOPQRST"),
+        ];
+        insert_history_lines(&mut term, lines).expect("insert_history_lines should succeed");
+
+        let screen = term.backend().vt100().screen();
+        let mut non_empty_rows: Vec<(u16, String)> = Vec::new();
+        for row in 0..height.saturating_sub(1) {
+            let row_text = (0..width)
+                .map(|col| {
+                    screen
+                        .cell(row, col)
+                        .map(|cell| cell.contents().to_string())
+                        .unwrap_or_default()
+                })
+                .collect::<String>();
+            if !row_text.trim().is_empty() {
+                non_empty_rows.push((row, row_text));
+            }
+        }
+
+        assert_eq!(
+            non_empty_rows.len(),
+            3,
+            "expected exactly three populated rows, got {non_empty_rows:?}",
+        );
+
+        let expected = ["1234567890", "abcdefghij", "KLMNOPQRST"];
+        for (idx, (row, row_text)) in non_empty_rows.iter().enumerate() {
+            assert_eq!(
+                row_text, expected[idx],
+                "unexpected row content at y={row}: {row_text:?}",
+            );
+        }
+        for pair in non_empty_rows.windows(2) {
+            assert_eq!(
+                pair[1].0,
+                pair[0].0 + 1,
+                "expected contiguous row progression, got {non_empty_rows:?}",
             );
         }
     }

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -115,6 +115,7 @@ mod version;
 
 mod wrapping;
 
+mod table_detect;
 #[cfg(test)]
 pub mod test_backend;
 

--- a/codex-rs/tui/src/lib.rs
+++ b/codex-rs/tui/src/lib.rs
@@ -112,6 +112,7 @@ pub mod update_action;
 mod update_prompt;
 mod updates;
 mod version;
+mod width;
 
 mod wrapping;
 

--- a/codex-rs/tui/src/markdown.rs
+++ b/codex-rs/tui/src/markdown.rs
@@ -1,13 +1,24 @@
 //! Markdown-to-ratatui rendering entry points.
 //!
-//! This module provides the public API surface that the rest of the TUI uses to turn markdown
-//! source into `Vec<Line<'static>>`.  Three variants exist:
+//! This module provides the public API surface that the rest of the TUI uses
+//! to turn markdown source into `Vec<Line<'static>>`.  Two variants exist:
 //!
-//! - [`append_markdown`] -- general-purpose, used for plan blocks and history cells that already
-//!   hold pre-processed markdown.
-//! - [`append_markdown_agent`] -- for agent responses.  Runs [`unwrap_markdown_fences`] first so
-//!   that `` ```md ``/`` ```markdown `` fences containing tables are stripped and the table
-//!   parser sees raw markdown instead of fenced code.
+//! - [`append_markdown`] -- general-purpose, used for plan blocks and history
+//!   cells that already hold pre-processed markdown (no fence unwrapping).
+//! - [`append_markdown_agent`] -- for agent responses.  Runs
+//!   [`unwrap_markdown_fences`] first so that `` ```md ``/`` ```markdown ``
+//!   fences containing tables are stripped and `pulldown-cmark` sees raw
+//!   table syntax instead of fenced code.
+//!
+//! ## Why fence unwrapping exists
+//!
+//! LLM agents frequently wrap tables in `` ```markdown `` fences, treating
+//! them as code.  Without unwrapping, `pulldown-cmark` parses those lines
+//! as a fenced code block and renders them as monospace code rather than a
+//! structured table.  The unwrapper is intentionally conservative: it
+//! buffers the entire fence body before deciding, only unwraps fences whose
+//! info string is `md` or `markdown` AND whose body contains a
+//! header+delimiter pair, and degrades gracefully on unclosed fences.
 use ratatui::text::Line;
 
 use crate::table_detect;

--- a/codex-rs/tui/src/markdown.rs
+++ b/codex-rs/tui/src/markdown.rs
@@ -20,8 +20,14 @@
 //! info string is `md` or `markdown` AND whose body contains a
 //! header+delimiter pair, and degrades gracefully on unclosed fences.
 use ratatui::text::Line;
+use std::ops::Range;
 
 use crate::table_detect;
+
+pub(crate) struct AgentRenderedWithSourceMap {
+    pub(crate) lines: Vec<Line<'static>>,
+    pub(crate) line_end_source_bytes: Vec<usize>,
+}
 
 /// Render markdown source to styled ratatui lines and append them to `lines`.
 ///
@@ -47,8 +53,29 @@ pub(crate) fn append_markdown_agent(
     width: Option<usize>,
     lines: &mut Vec<Line<'static>>,
 ) {
-    let normalized = unwrap_markdown_fences(markdown_source);
-    append_markdown(&normalized, width, lines);
+    let rendered = render_markdown_agent_with_source_map(markdown_source, width);
+    lines.extend(rendered.lines);
+}
+
+pub(crate) fn render_markdown_agent_with_source_map(
+    markdown_source: &str,
+    width: Option<usize>,
+) -> AgentRenderedWithSourceMap {
+    let normalized = unwrap_markdown_fences_with_mapping(markdown_source);
+    let rendered = crate::markdown_render::render_markdown_text_with_width_and_source_map(
+        &normalized.text,
+        width,
+    );
+    let lines = rendered.text.lines;
+    let line_end_source_bytes = rendered
+        .line_end_input_bytes
+        .into_iter()
+        .map(|offset| normalized.raw_source_offset(offset))
+        .collect();
+    AgentRenderedWithSourceMap {
+        lines,
+        line_end_source_bytes,
+    }
 }
 
 /// Strip `` ```md ``/`` ```markdown `` fences that contain tables, emitting their content as bare
@@ -62,7 +89,64 @@ pub(crate) fn append_markdown_agent(
 /// The fence unwrapping is intentionally conservative: it buffers the entire fence body before
 /// deciding, and an unclosed fence at end-of-input is re-emitted with its opening line so partial
 /// streams degrade to code display.
+#[cfg(test)]
 fn unwrap_markdown_fences(markdown_source: &str) -> String {
+    unwrap_markdown_fences_with_mapping(markdown_source).text
+}
+
+#[derive(Clone, Debug)]
+struct NormalizedToRawSegment {
+    normalized_start: usize,
+    raw_start: usize,
+}
+
+struct NormalizedMarkdown {
+    text: String,
+    raw_source_len: usize,
+    segments: Vec<NormalizedToRawSegment>,
+}
+
+impl NormalizedMarkdown {
+    fn new(raw_source_len: usize, capacity: usize) -> Self {
+        Self {
+            text: String::with_capacity(capacity),
+            raw_source_len,
+            segments: Vec::new(),
+        }
+    }
+
+    fn push_source_range(&mut self, source: &str, range: Range<usize>) {
+        if range.is_empty() {
+            return;
+        }
+        let out_start = self.text.len();
+        let out_text = &source[range.clone()];
+        self.text.push_str(out_text);
+        self.segments.push(NormalizedToRawSegment {
+            normalized_start: out_start,
+            raw_start: range.start,
+        });
+    }
+
+    fn raw_source_offset(&self, normalized_offset: usize) -> usize {
+        if normalized_offset == 0 {
+            return 0;
+        }
+        if normalized_offset >= self.text.len() {
+            return self.raw_source_len;
+        }
+        let idx = self
+            .segments
+            .partition_point(|segment| segment.normalized_start < normalized_offset);
+        if idx == 0 {
+            return 0;
+        }
+        let segment = &self.segments[idx - 1];
+        segment.raw_start + normalized_offset.saturating_sub(segment.normalized_start)
+    }
+}
+
+fn unwrap_markdown_fences_with_mapping(markdown_source: &str) -> NormalizedMarkdown {
     #[derive(Clone, Copy)]
     struct Fence {
         marker: char,
@@ -142,46 +226,66 @@ fn unwrap_markdown_fences(markdown_source: &str) -> String {
         false
     }
 
+    fn content_from_ranges(source: &str, ranges: &[Range<usize>]) -> String {
+        let mut content = String::new();
+        for range in ranges {
+            content.push_str(&source[range.clone()]);
+        }
+        content
+    }
+
     enum ActiveFence {
         Passthrough(Fence),
         MarkdownCandidate {
             fence: Fence,
-            opening_line: String,
-            content: String,
+            opening_range: Range<usize>,
+            content_ranges: Vec<Range<usize>>,
         },
     }
 
-    let mut out = String::with_capacity(markdown_source.len());
+    let mut out = NormalizedMarkdown::new(markdown_source.len(), markdown_source.len());
     let mut active_fence: Option<ActiveFence> = None;
+    let mut source_offset = 0usize;
 
     for line in markdown_source.split_inclusive('\n') {
+        let line_start = source_offset;
+        source_offset += line.len();
+        let line_range = line_start..source_offset;
+
         if let Some(active) = active_fence.take() {
             match active {
                 ActiveFence::Passthrough(fence) => {
-                    out.push_str(line);
+                    out.push_source_range(markdown_source, line_range);
                     if !is_close_fence(line, fence) {
                         active_fence = Some(ActiveFence::Passthrough(fence));
                     }
                 }
                 ActiveFence::MarkdownCandidate {
                     fence,
-                    opening_line,
-                    mut content,
+                    opening_range,
+                    mut content_ranges,
                 } => {
                     if is_close_fence(line, fence) {
-                        if markdown_fence_contains_table(&content) {
-                            out.push_str(&content);
+                        if markdown_fence_contains_table(&content_from_ranges(
+                            markdown_source,
+                            &content_ranges,
+                        )) {
+                            for range in content_ranges {
+                                out.push_source_range(markdown_source, range);
+                            }
                         } else {
-                            out.push_str(&opening_line);
-                            out.push_str(&content);
-                            out.push_str(line);
+                            out.push_source_range(markdown_source, opening_range);
+                            for range in content_ranges {
+                                out.push_source_range(markdown_source, range);
+                            }
+                            out.push_source_range(markdown_source, line_range);
                         }
                     } else {
-                        content.push_str(line);
+                        content_ranges.push(line_range);
                         active_fence = Some(ActiveFence::MarkdownCandidate {
                             fence,
-                            opening_line,
-                            content,
+                            opening_range,
+                            content_ranges,
                         });
                     }
                 }
@@ -193,29 +297,31 @@ fn unwrap_markdown_fences(markdown_source: &str) -> String {
             if fence.is_markdown {
                 active_fence = Some(ActiveFence::MarkdownCandidate {
                     fence,
-                    opening_line: line.to_string(),
-                    content: String::new(),
+                    opening_range: line_range,
+                    content_ranges: Vec::new(),
                 });
             } else {
-                out.push_str(line);
+                out.push_source_range(markdown_source, line_range);
                 active_fence = Some(ActiveFence::Passthrough(fence));
             }
             continue;
         }
 
-        out.push_str(line);
+        out.push_source_range(markdown_source, line_range);
     }
 
     if let Some(active) = active_fence {
         match active {
             ActiveFence::Passthrough(_) => {}
             ActiveFence::MarkdownCandidate {
-                opening_line,
-                content,
+                opening_range,
+                content_ranges,
                 ..
             } => {
-                out.push_str(&opening_line);
-                out.push_str(&content);
+                out.push_source_range(markdown_source, opening_range);
+                for range in content_ranges {
+                    out.push_source_range(markdown_source, range);
+                }
             }
         }
     }
@@ -398,5 +504,49 @@ mod tests {
         let src = "```markdown\n| A | B |\nnot a delimiter row\n| --- | --- |\n# Heading\n```\n";
         let normalized = unwrap_markdown_fences(src);
         assert_eq!(normalized, src);
+    }
+
+    #[test]
+    fn render_markdown_agent_with_source_map_offsets_align_with_line_count() {
+        let src = "alpha\n\n```md\n| A | B |\n|---|---|\n| 1 | 2 |\n```\nomega\n";
+        let rendered = render_markdown_agent_with_source_map(src, Some(80));
+        assert_eq!(rendered.lines.len(), rendered.line_end_source_bytes.len());
+
+        let mut prev = 0usize;
+        for offset in rendered.line_end_source_bytes {
+            assert!(
+                offset <= src.len(),
+                "line-end offset must stay within source bounds: {offset} > {}",
+                src.len()
+            );
+            assert!(
+                offset >= prev,
+                "line-end offsets must be non-decreasing: {offset} < {prev}"
+            );
+            prev = offset;
+        }
+    }
+
+    #[test]
+    fn unwrap_markdown_fences_mapping_preserves_raw_offsets_across_removed_fence_lines() {
+        let src = "before\n```md\n| A | B |\n|---|---|\n| 1 | 2 |\n```\nafter\n";
+        let normalized = unwrap_markdown_fences_with_mapping(src);
+        assert!(
+            !normalized.text.contains("```"),
+            "markdown table fence should be removed in normalized text"
+        );
+        let after_in_normalized = normalized
+            .text
+            .find("after")
+            .expect("expected 'after' in normalized text");
+        let after_in_raw = src.find("after").expect("expected 'after' in raw source");
+        assert_eq!(
+            normalized.raw_source_offset(after_in_normalized + 1),
+            after_in_raw + 1
+        );
+        assert_eq!(
+            normalized.raw_source_offset(normalized.text.len()),
+            src.len()
+        );
     }
 }

--- a/codex-rs/tui/src/markdown.rs
+++ b/codex-rs/tui/src/markdown.rs
@@ -1,4 +1,21 @@
+//! Markdown-to-ratatui rendering entry points.
+//!
+//! This module provides the public API surface that the rest of the TUI uses to turn markdown
+//! source into `Vec<Line<'static>>`.  Three variants exist:
+//!
+//! - [`append_markdown`] -- general-purpose, used for plan blocks and history cells that already
+//!   hold pre-processed markdown.
+//! - [`append_markdown_agent`] -- for agent responses.  Runs [`unwrap_markdown_fences`] first so
+//!   that `` ```md ``/`` ```markdown `` fences containing tables are stripped and the table
+//!   parser sees raw markdown instead of fenced code.
 use ratatui::text::Line;
+
+use crate::table_detect;
+
+/// Render markdown source to styled ratatui lines and append them to `lines`.
+///
+/// This is the general-purpose entry point used for plan blocks and history cells that already
+/// hold pre-processed markdown (no fence unwrapping).
 pub(crate) fn append_markdown(
     markdown_source: &str,
     width: Option<usize>,
@@ -6,6 +23,191 @@ pub(crate) fn append_markdown(
 ) {
     let rendered = crate::markdown_render::render_markdown_text_with_width(markdown_source, width);
     crate::render::line_utils::push_owned_lines(&rendered.lines, lines);
+}
+
+/// Render an agent message to styled ratatui lines.
+///
+/// Before rendering, the source is passed through [`unwrap_markdown_fences`] so that tables
+/// wrapped in `` ```md `` fences are rendered as native tables rather than code blocks.
+/// Non-markdown fences (e.g. `rust`, `sh`) are left
+/// intact.
+pub(crate) fn append_markdown_agent(
+    markdown_source: &str,
+    width: Option<usize>,
+    lines: &mut Vec<Line<'static>>,
+) {
+    let normalized = unwrap_markdown_fences(markdown_source);
+    append_markdown(&normalized, width, lines);
+}
+
+/// Strip `` ```md ``/`` ```markdown `` fences that contain tables, emitting their content as bare
+/// markdown so `pulldown-cmark` parses the tables natively.
+///
+/// Fences whose info string is not `md` or `markdown` are passed through unchanged.  Markdown
+/// fences that do *not* contain a table (detected by checking for a header row + delimiter row)
+/// are also passed through so that non-table markdown inside a fence still renders as a code
+/// block.
+///
+/// The fence unwrapping is intentionally conservative: it buffers the entire fence body before
+/// deciding, and an unclosed fence at end-of-input is re-emitted with its opening line so partial
+/// streams degrade to code display.
+fn unwrap_markdown_fences(markdown_source: &str) -> String {
+    #[derive(Clone, Copy)]
+    struct Fence {
+        marker: char,
+        len: usize,
+        is_markdown: bool,
+    }
+
+    fn parse_open_fence(line: &str) -> Option<Fence> {
+        let without_newline = line.strip_suffix('\n').unwrap_or(line);
+        let leading_ws = without_newline
+            .as_bytes()
+            .iter()
+            .take_while(|byte| **byte == b' ')
+            .count();
+        if leading_ws > 3 {
+            return None;
+        }
+        let trimmed = &without_newline[leading_ws..];
+        let marker = trimmed.chars().next()?;
+        if marker != '`' && marker != '~' {
+            return None;
+        }
+        let len = trimmed.chars().take_while(|ch| *ch == marker).count();
+        if len < 3 {
+            return None;
+        }
+        let rest = trimmed[len..].trim();
+        let info = rest.split_whitespace().next().unwrap_or_default();
+        let is_markdown = info.eq_ignore_ascii_case("md") || info.eq_ignore_ascii_case("markdown");
+        Some(Fence {
+            marker,
+            len,
+            is_markdown,
+        })
+    }
+
+    fn is_close_fence(line: &str, fence: Fence) -> bool {
+        let without_newline = line.strip_suffix('\n').unwrap_or(line);
+        let leading_ws = without_newline
+            .as_bytes()
+            .iter()
+            .take_while(|byte| **byte == b' ')
+            .count();
+        if leading_ws > 3 {
+            return false;
+        }
+        let trimmed = &without_newline[leading_ws..];
+        if !trimmed.starts_with(fence.marker) {
+            return false;
+        }
+        let len = trimmed.chars().take_while(|ch| *ch == fence.marker).count();
+        if len < fence.len {
+            return false;
+        }
+        trimmed[len..].trim().is_empty()
+    }
+
+    fn markdown_fence_contains_table(content: &str) -> bool {
+        let mut saw_candidate = false;
+        let mut saw_delimiter = false;
+        for line in content.lines() {
+            let trimmed = line.trim();
+            if trimmed.is_empty() {
+                continue;
+            }
+            if !table_detect::is_table_header_line(trimmed) {
+                continue;
+            }
+            if table_detect::is_table_delimiter_line(trimmed) {
+                saw_delimiter = true;
+            } else {
+                saw_candidate = true;
+            }
+        }
+        saw_candidate && saw_delimiter
+    }
+
+    enum ActiveFence {
+        Passthrough(Fence),
+        MarkdownCandidate {
+            fence: Fence,
+            opening_line: String,
+            content: String,
+        },
+    }
+
+    let mut out = String::with_capacity(markdown_source.len());
+    let mut active_fence: Option<ActiveFence> = None;
+
+    for line in markdown_source.split_inclusive('\n') {
+        if let Some(active) = active_fence.take() {
+            match active {
+                ActiveFence::Passthrough(fence) => {
+                    out.push_str(line);
+                    if !is_close_fence(line, fence) {
+                        active_fence = Some(ActiveFence::Passthrough(fence));
+                    }
+                }
+                ActiveFence::MarkdownCandidate {
+                    fence,
+                    opening_line,
+                    mut content,
+                } => {
+                    if is_close_fence(line, fence) {
+                        if markdown_fence_contains_table(&content) {
+                            out.push_str(&content);
+                        } else {
+                            out.push_str(&opening_line);
+                            out.push_str(&content);
+                            out.push_str(line);
+                        }
+                    } else {
+                        content.push_str(line);
+                        active_fence = Some(ActiveFence::MarkdownCandidate {
+                            fence,
+                            opening_line,
+                            content,
+                        });
+                    }
+                }
+            }
+            continue;
+        }
+
+        if let Some(fence) = parse_open_fence(line) {
+            if fence.is_markdown {
+                active_fence = Some(ActiveFence::MarkdownCandidate {
+                    fence,
+                    opening_line: line.to_string(),
+                    content: String::new(),
+                });
+            } else {
+                out.push_str(line);
+                active_fence = Some(ActiveFence::Passthrough(fence));
+            }
+            continue;
+        }
+
+        out.push_str(line);
+    }
+
+    if let Some(active) = active_fence {
+        match active {
+            ActiveFence::Passthrough(_) => {}
+            ActiveFence::MarkdownCandidate {
+                opening_line,
+                content,
+                ..
+            } => {
+                out.push_str(&opening_line);
+                out.push_str(&content);
+            }
+        }
+    }
+
+    out
 }
 
 #[cfg(test)]
@@ -101,5 +303,70 @@ mod tests {
                 .any(|w| w[0].trim_end() == "1." && w[1] == "Tight item"),
             "did not expect a split into ['1.', 'Tight item']; got: {lines:?}"
         );
+    }
+
+    #[test]
+    fn append_markdown_agent_unwraps_markdown_fences_for_table_rendering() {
+        let src = "```markdown\n| A | B |\n|---|---|\n| 1 | 2 |\n```\n";
+        let mut out = Vec::new();
+        append_markdown_agent(src, None, &mut out);
+        let rendered = lines_to_strings(&out);
+        assert!(rendered.iter().any(|line| line.contains("┌")));
+        assert!(rendered.iter().any(|line| line.contains("│ 1   │ 2   │")));
+    }
+
+    #[test]
+    fn append_markdown_agent_unwraps_markdown_fences_for_no_outer_table_rendering() {
+        let src = "```md\nCol A | Col B | Col C\n--- | --- | ---\nx | y | z\n10 | 20 | 30\n```\n";
+        let mut out = Vec::new();
+        append_markdown_agent(src, None, &mut out);
+        let rendered = lines_to_strings(&out);
+        assert!(rendered.iter().any(|line| line.contains("┌")));
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line.contains("│ Col A │ Col B │ Col C │"))
+        );
+        assert!(
+            !rendered
+                .iter()
+                .any(|line| line.trim() == "Col A | Col B | Col C")
+        );
+    }
+
+    #[test]
+    fn append_markdown_agent_unwraps_markdown_fences_for_two_column_no_outer_table() {
+        let src = "```md\nA | B\n--- | ---\nleft | right\n```\n";
+        let mut out = Vec::new();
+        append_markdown_agent(src, None, &mut out);
+        let rendered = lines_to_strings(&out);
+        assert!(rendered.iter().any(|line| line.contains("┌")));
+        assert!(rendered.iter().any(|line| line.contains("│ A")));
+        assert!(!rendered.iter().any(|line| line.trim() == "A | B"));
+    }
+
+    #[test]
+    fn append_markdown_agent_keeps_non_markdown_fences_as_code() {
+        let src = "```rust\n| A | B |\n|---|---|\n| 1 | 2 |\n```\n";
+        let mut out = Vec::new();
+        append_markdown_agent(src, None, &mut out);
+        let rendered = lines_to_strings(&out);
+        assert_eq!(
+            rendered,
+            vec![
+                "| A | B |".to_string(),
+                "|---|---|".to_string(),
+                "| 1 | 2 |".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn append_markdown_agent_keeps_markdown_fence_when_content_is_not_table() {
+        let src = "```markdown\n**bold**\n```\n";
+        let mut out = Vec::new();
+        append_markdown_agent(src, None, &mut out);
+        let rendered = lines_to_strings(&out);
+        assert_eq!(rendered, vec!["**bold**".to_string()]);
     }
 }

--- a/codex-rs/tui/src/markdown.rs
+++ b/codex-rs/tui/src/markdown.rs
@@ -147,6 +147,12 @@ impl NormalizedMarkdown {
 }
 
 fn unwrap_markdown_fences_with_mapping(markdown_source: &str) -> NormalizedMarkdown {
+    if !markdown_source.contains("```") && !markdown_source.contains("~~~") {
+        let mut out = NormalizedMarkdown::new(markdown_source.len(), markdown_source.len());
+        out.push_source_range(markdown_source, 0..markdown_source.len());
+        return out;
+    }
+
     #[derive(Clone, Copy)]
     struct Fence {
         marker: char,

--- a/codex-rs/tui/src/markdown.rs
+++ b/codex-rs/tui/src/markdown.rs
@@ -348,6 +348,16 @@ mod tests {
     }
 
     #[test]
+    fn append_markdown_agent_unwraps_markdown_fences_for_single_column_table() {
+        let src = "```md\n| Only |\n|---|\n| value |\n```\n";
+        let mut out = Vec::new();
+        append_markdown_agent(src, None, &mut out);
+        let rendered = lines_to_strings(&out);
+        assert!(rendered.iter().any(|line| line.contains("┌")));
+        assert!(!rendered.iter().any(|line| line.trim() == "| Only |"));
+    }
+
+    #[test]
     fn append_markdown_agent_keeps_non_markdown_fences_as_code() {
         let src = "```rust\n| A | B |\n|---|---|\n| 1 | 2 |\n```\n";
         let mut out = Vec::new();

--- a/codex-rs/tui/src/markdown.rs
+++ b/codex-rs/tui/src/markdown.rs
@@ -155,7 +155,7 @@ fn unwrap_markdown_fences_with_mapping(markdown_source: &str) -> NormalizedMarkd
 
     #[derive(Clone, Copy)]
     struct Fence {
-        marker: char,
+        marker: u8,
         len: usize,
         is_markdown: bool,
     }
@@ -171,11 +171,15 @@ fn unwrap_markdown_fences_with_mapping(markdown_source: &str) -> NormalizedMarkd
             return None;
         }
         let trimmed = &without_newline[leading_ws..];
-        let marker = trimmed.chars().next()?;
-        if marker != '`' && marker != '~' {
+        let marker = *trimmed.as_bytes().first()?;
+        if marker != b'`' && marker != b'~' {
             return None;
         }
-        let len = trimmed.chars().take_while(|ch| *ch == marker).count();
+        let len = trimmed
+            .as_bytes()
+            .iter()
+            .take_while(|byte| **byte == marker)
+            .count();
         if len < 3 {
             return None;
         }
@@ -200,10 +204,14 @@ fn unwrap_markdown_fences_with_mapping(markdown_source: &str) -> NormalizedMarkd
             return false;
         }
         let trimmed = &without_newline[leading_ws..];
-        if !trimmed.starts_with(fence.marker) {
+        if !trimmed.as_bytes().starts_with(&[fence.marker]) {
             return false;
         }
-        let len = trimmed.chars().take_while(|ch| *ch == fence.marker).count();
+        let len = trimmed
+            .as_bytes()
+            .iter()
+            .take_while(|byte| **byte == fence.marker)
+            .count();
         if len < fence.len {
             return false;
         }

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -1,6 +1,8 @@
 use crate::render::line_utils::line_to_static;
+use crate::render::line_utils::push_owned_lines;
 use crate::wrapping::RtOptions;
 use crate::wrapping::word_wrap_line;
+use pulldown_cmark::Alignment;
 use pulldown_cmark::CodeBlockKind;
 use pulldown_cmark::CowStr;
 use pulldown_cmark::Event;
@@ -10,9 +12,11 @@ use pulldown_cmark::Parser;
 use pulldown_cmark::Tag;
 use pulldown_cmark::TagEnd;
 use ratatui::style::Style;
+use ratatui::style::Stylize;
 use ratatui::text::Line;
 use ratatui::text::Span;
 use ratatui::text::Text;
+use unicode_width::UnicodeWidthStr;
 
 struct MarkdownStyles {
     h1: Style,
@@ -71,6 +75,113 @@ impl IndentContext {
     }
 }
 
+/// Styled content of a single cell in the table being parsed.
+///
+/// A cell can contain multiple lines (hard breaks inside the cell) and rich inline spans (bold,
+/// code, links).  The `plain_text()` projection is used for column-width measurement; the styled
+/// `lines` are used for final rendering.
+#[derive(Clone, Debug, Default)]
+struct TableCell {
+    lines: Vec<Line<'static>>,
+}
+
+impl TableCell {
+    fn ensure_line(&mut self) {
+        if self.lines.is_empty() {
+            self.lines.push(Line::default());
+        }
+    }
+
+    fn push_span(&mut self, span: Span<'static>) {
+        self.ensure_line();
+        if let Some(line) = self.lines.last_mut() {
+            line.push_span(span);
+        }
+    }
+
+    fn hard_break(&mut self) {
+        self.lines.push(Line::default());
+    }
+
+    fn plain_text(&self) -> String {
+        self.lines
+            .iter()
+            .map(|line| {
+                line.spans
+                    .iter()
+                    .map(|span| span.content.clone())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join(" ")
+    }
+}
+
+/// Accumulates pulldown-cmark table events into a structured representation.
+///
+/// `TableState` is created on `Tag::Table` and consumed on `TagEnd::Table`. Between those events,
+/// the Writer delegates cell content (text, code, html, breaks) into the `current_cell`, which is
+/// flushed into `current_row` on `TagEnd::TableCell`, then into `header`/`rows` on row/head end
+/// events.
+#[derive(Debug)]
+struct TableState {
+    alignments: Vec<Alignment>,
+    header: Option<Vec<TableCell>>,
+    rows: Vec<Vec<TableCell>>,
+    current_row: Option<Vec<TableCell>>,
+    current_cell: Option<TableCell>,
+    in_header: bool,
+}
+
+impl TableState {
+    fn new(alignments: Vec<Alignment>) -> Self {
+        Self {
+            alignments,
+            header: None,
+            rows: Vec::new(),
+            current_row: None,
+            current_cell: None,
+            in_header: false,
+        }
+    }
+}
+
+/// Classification of a table column for width-allocation priority.
+///
+/// Narrative columns (long prose, many words per cell) are shrunk first when the table exceeds
+/// available width.  Structured columns (short tokens like dates, status words, numbers) are
+/// preserved as long as possible to keep their content on a single line.
+///
+/// The heuristic is simple: >= 4 average words per cell OR >= 28 average character width →
+/// Narrative. Everything else → Structured.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TableColumnKind {
+    /// Long-form prose content (>= 4 avg words/cell or >= 28 avg char width).
+    Narrative,
+    /// Short, token-like content that should resist wrapping.
+    Structured,
+}
+
+/// Per-column statistics used to drive the width-allocation algorithm.
+///
+/// Collected in a single pass over the header and body rows before any
+/// shrinking decisions are made.
+#[derive(Clone, Debug)]
+struct TableColumnMetrics {
+    /// Widest cell content (display width) across header and all body rows.
+    max_width: usize,
+    /// Display width of the longest whitespace-delimited token in the header.
+    header_token_width: usize,
+    /// Display width of the longest whitespace-delimited token across body rows.
+    body_token_width: usize,
+    /// Average number of whitespace-delimited words per non-empty body cell.
+    avg_words_per_cell: f64,
+    /// Average display width of non-empty body cells.
+    avg_cell_width: f64,
+    /// Classification derived from `avg_words_per_cell` and `avg_cell_width`.
+    kind: TableColumnKind,
+}
+
 pub fn render_markdown_text(input: &str) -> Text<'static> {
     render_markdown_text_with_width(input, None)
 }
@@ -78,6 +189,7 @@ pub fn render_markdown_text(input: &str) -> Text<'static> {
 pub(crate) fn render_markdown_text_with_width(input: &str, width: Option<usize>) -> Text<'static> {
     let mut options = Options::empty();
     options.insert(Options::ENABLE_STRIKETHROUGH);
+    options.insert(Options::ENABLE_TABLES);
     let parser = Parser::new_ext(input, options);
     let mut w = Writer::new(parser, width);
     w.run();
@@ -105,6 +217,7 @@ where
     current_subsequent_indent: Vec<Span<'static>>,
     current_line_style: Style,
     current_line_in_code_block: bool,
+    table_state: Option<TableState>,
 }
 
 impl<'a, I> Writer<'a, I>
@@ -130,6 +243,7 @@ where
             current_subsequent_indent: Vec::new(),
             current_line_style: Style::default(),
             current_line_in_code_block: false,
+            table_state: None,
         }
     }
 
@@ -185,12 +299,12 @@ where
             Tag::Strong => self.push_inline_style(self.styles.strong),
             Tag::Strikethrough => self.push_inline_style(self.styles.strikethrough),
             Tag::Link { dest_url, .. } => self.push_link(dest_url.to_string()),
+            Tag::Table(alignments) => self.start_table(alignments),
+            Tag::TableHead => self.start_table_head(),
+            Tag::TableRow => self.start_table_row(),
+            Tag::TableCell => self.start_table_cell(),
             Tag::HtmlBlock
             | Tag::FootnoteDefinition(_)
-            | Tag::Table(_)
-            | Tag::TableHead
-            | Tag::TableRow
-            | Tag::TableCell
             | Tag::Image { .. }
             | Tag::MetadataBlock(_) => {}
         }
@@ -209,18 +323,21 @@ where
             }
             TagEnd::Emphasis | TagEnd::Strong | TagEnd::Strikethrough => self.pop_inline_style(),
             TagEnd::Link => self.pop_link(),
+            TagEnd::Table => self.end_table(),
+            TagEnd::TableHead => self.end_table_head(),
+            TagEnd::TableRow => self.end_table_row(),
+            TagEnd::TableCell => self.end_table_cell(),
             TagEnd::HtmlBlock
             | TagEnd::FootnoteDefinition
-            | TagEnd::Table
-            | TagEnd::TableHead
-            | TagEnd::TableRow
-            | TagEnd::TableCell
             | TagEnd::Image
             | TagEnd::MetadataBlock(_) => {}
         }
     }
 
     fn start_paragraph(&mut self) {
+        if self.in_table_cell() {
+            return;
+        }
         if self.needs_newline {
             self.push_blank_line();
         }
@@ -230,12 +347,18 @@ where
     }
 
     fn end_paragraph(&mut self) {
+        if self.in_table_cell() {
+            return;
+        }
         self.needs_newline = true;
         self.in_paragraph = false;
         self.pending_marker_line = false;
     }
 
     fn start_heading(&mut self, level: HeadingLevel) {
+        if self.in_table_cell() {
+            return;
+        }
         if self.needs_newline {
             self.push_line(Line::default());
             self.needs_newline = false;
@@ -255,11 +378,17 @@ where
     }
 
     fn end_heading(&mut self) {
+        if self.in_table_cell() {
+            return;
+        }
         self.needs_newline = true;
         self.pop_inline_style();
     }
 
     fn start_blockquote(&mut self) {
+        if self.in_table_cell() {
+            return;
+        }
         if self.needs_newline {
             self.push_blank_line();
             self.needs_newline = false;
@@ -269,11 +398,19 @@ where
     }
 
     fn end_blockquote(&mut self) {
+        if self.in_table_cell() {
+            return;
+        }
         self.indent_stack.pop();
         self.needs_newline = true;
     }
 
     fn text(&mut self, text: CowStr<'a>) {
+        if self.in_table_cell() {
+            self.push_text_to_table_cell(&text);
+            return;
+        }
+
         if self.pending_marker_line {
             self.push_line(Line::default());
         }
@@ -313,6 +450,11 @@ where
     }
 
     fn code(&mut self, code: CowStr<'a>) {
+        if self.in_table_cell() {
+            self.push_span_to_table_cell(Span::from(code.into_string()).style(self.styles.code));
+            return;
+        }
+
         if self.pending_marker_line {
             self.push_line(Line::default());
             self.pending_marker_line = false;
@@ -322,6 +464,19 @@ where
     }
 
     fn html(&mut self, html: CowStr<'a>, inline: bool) {
+        if self.in_table_cell() {
+            let style = self.inline_styles.last().copied().unwrap_or_default();
+            for (i, line) in html.lines().enumerate() {
+                if i > 0 {
+                    self.push_table_cell_hard_break();
+                }
+                self.push_span_to_table_cell(Span::styled(line.to_string(), style));
+            }
+            if !inline {
+                self.push_table_cell_hard_break();
+            }
+            return;
+        }
         self.pending_marker_line = false;
         for (i, line) in html.lines().enumerate() {
             if self.needs_newline {
@@ -338,10 +493,19 @@ where
     }
 
     fn hard_break(&mut self) {
+        if self.in_table_cell() {
+            self.push_table_cell_hard_break();
+            return;
+        }
         self.push_line(Line::default());
     }
 
     fn soft_break(&mut self) {
+        if self.in_table_cell() {
+            let style = self.inline_styles.last().copied().unwrap_or_default();
+            self.push_span_to_table_cell(Span::styled(" ".to_string(), style));
+            return;
+        }
         self.push_line(Line::default());
     }
 
@@ -414,6 +578,593 @@ where
         self.indent_stack.pop();
     }
 
+    fn start_table(&mut self, alignments: Vec<Alignment>) {
+        self.flush_current_line();
+        if self.needs_newline {
+            self.push_blank_line();
+            self.needs_newline = false;
+        }
+        self.table_state = Some(TableState::new(alignments));
+    }
+
+    fn end_table(&mut self) {
+        let Some(table_state) = self.table_state.take() else {
+            return;
+        };
+
+        let table_lines = self.render_table_lines(table_state);
+        let mut pending_marker_line = self.pending_marker_line;
+        for line in table_lines {
+            self.push_prewrapped_line(line, pending_marker_line);
+            pending_marker_line = false;
+        }
+        self.pending_marker_line = false;
+        self.needs_newline = true;
+    }
+
+    fn start_table_head(&mut self) {
+        if let Some(table_state) = self.table_state.as_mut() {
+            table_state.in_header = true;
+            table_state.current_row = Some(Vec::new());
+        }
+    }
+
+    fn end_table_head(&mut self) {
+        let Some(table_state) = self.table_state.as_mut() else {
+            return;
+        };
+        if let Some(current_cell) = table_state.current_cell.take() {
+            table_state
+                .current_row
+                .get_or_insert_with(Vec::new)
+                .push(current_cell);
+        }
+        if let Some(row) = table_state.current_row.take() {
+            table_state.header = Some(row);
+        }
+        table_state.in_header = false;
+    }
+
+    fn start_table_row(&mut self) {
+        if let Some(table_state) = self.table_state.as_mut() {
+            table_state.current_row = Some(Vec::new());
+        }
+    }
+
+    fn end_table_row(&mut self) {
+        let Some(table_state) = self.table_state.as_mut() else {
+            return;
+        };
+
+        if let Some(current_cell) = table_state.current_cell.take() {
+            table_state
+                .current_row
+                .get_or_insert_with(Vec::new)
+                .push(current_cell);
+        }
+
+        let Some(row) = table_state.current_row.take() else {
+            return;
+        };
+
+        if table_state.in_header {
+            table_state.header = Some(row);
+        } else {
+            table_state.rows.push(row);
+        }
+    }
+
+    fn start_table_cell(&mut self) {
+        if let Some(table_state) = self.table_state.as_mut() {
+            table_state.current_cell = Some(TableCell::default());
+        }
+    }
+
+    fn end_table_cell(&mut self) {
+        let Some(table_state) = self.table_state.as_mut() else {
+            return;
+        };
+
+        if let Some(cell) = table_state.current_cell.take() {
+            table_state
+                .current_row
+                .get_or_insert_with(Vec::new)
+                .push(cell);
+        }
+    }
+
+    fn in_table_cell(&self) -> bool {
+        self.table_state
+            .as_ref()
+            .and_then(|table_state| table_state.current_cell.as_ref())
+            .is_some()
+    }
+
+    fn push_span_to_table_cell(&mut self, span: Span<'static>) {
+        if let Some(table_state) = self.table_state.as_mut()
+            && let Some(cell) = table_state.current_cell.as_mut()
+        {
+            cell.push_span(span);
+        }
+    }
+
+    fn push_table_cell_hard_break(&mut self) {
+        if let Some(table_state) = self.table_state.as_mut()
+            && let Some(cell) = table_state.current_cell.as_mut()
+        {
+            cell.hard_break();
+        }
+    }
+
+    fn push_text_to_table_cell(&mut self, text: &str) {
+        let style = self.inline_styles.last().copied().unwrap_or_default();
+        for (i, line) in text.lines().enumerate() {
+            if i > 0 {
+                self.push_table_cell_hard_break();
+            }
+            self.push_span_to_table_cell(Span::styled(line.to_string(), style));
+        }
+    }
+
+    /// Convert a completed `TableState` into styled `Line`s with Unicode box-drawing borders.
+    ///
+    /// The pipeline is: filter spillover rows -> normalize column counts -> compute column widths
+    /// -> render box grid (or fall back to pipe format if widths can't fit). Spillover rows are
+    /// appended after the table grid.
+    fn render_table_lines(&self, mut table_state: TableState) -> Vec<Line<'static>> {
+        let column_count = table_state.alignments.len();
+        if column_count == 0 {
+            return Vec::new();
+        }
+
+        let mut spillover_rows: Vec<TableCell> = Vec::new();
+        let mut rows: Vec<Vec<TableCell>> = Vec::new();
+        for (row_idx, row) in table_state.rows.iter().enumerate() {
+            let next_row = table_state.rows.get(row_idx + 1);
+            // pulldown-cmark accepts body rows without pipes, which can turn a following paragraph
+            // into a one-cell table row. For multi-column tables, treat those as spillover text
+            // rendered after the table.
+            if column_count > 1 && Self::is_spillover_row(row, next_row) {
+                if let Some(cell) = row.first().cloned() {
+                    spillover_rows.push(cell);
+                }
+            } else {
+                rows.push(row.clone());
+            }
+        }
+
+        let mut header = table_state
+            .header
+            .take()
+            .unwrap_or_else(|| vec![TableCell::default(); column_count]);
+        Self::normalize_row(&mut header, column_count);
+        for row in &mut rows {
+            Self::normalize_row(row, column_count);
+        }
+
+        let available_width = self.available_table_width(column_count);
+        let widths =
+            self.compute_column_widths(&header, &rows, &table_state.alignments, available_width);
+
+        let Some(column_widths) = widths else {
+            let mut fallback =
+                self.render_table_pipe_fallback(&header, &rows, &table_state.alignments);
+            for spillover in spillover_rows {
+                fallback.extend(spillover.lines);
+            }
+            return fallback;
+        };
+
+        let border_style = Style::new().dim();
+        let mut out = Vec::new();
+        out.push(self.render_border_line('┌', '┬', '┐', &column_widths, border_style));
+        out.extend(self.render_table_row(
+            &header,
+            &column_widths,
+            &table_state.alignments,
+            border_style,
+        ));
+        out.push(self.render_border_line('├', '┼', '┤', &column_widths, border_style));
+        for row in &rows {
+            out.extend(self.render_table_row(
+                row,
+                &column_widths,
+                &table_state.alignments,
+                border_style,
+            ));
+        }
+        out.push(self.render_border_line('└', '┴', '┘', &column_widths, border_style));
+        for spillover in spillover_rows {
+            out.extend(spillover.lines);
+        }
+        out
+    }
+
+    fn normalize_row(row: &mut Vec<TableCell>, column_count: usize) {
+        if row.len() > column_count {
+            row.truncate(column_count);
+        }
+        if row.len() < column_count {
+            row.resize(column_count, TableCell::default());
+        }
+    }
+
+    /// subtracts the space eaten by border characters
+    fn available_table_width(&self, column_count: usize) -> Option<usize> {
+        self.wrap_width.map(|wrap_width| {
+            let prefix_width =
+                Self::spans_display_width(&self.prefix_spans(self.pending_marker_line));
+            let reserved = prefix_width + 1 + (column_count * 3);
+            wrap_width.saturating_sub(reserved)
+        })
+    }
+
+    fn compute_column_widths(
+        &self,
+        header: &[TableCell],
+        rows: &[Vec<TableCell>],
+        alignments: &[Alignment],
+        available_width: Option<usize>,
+    ) -> Option<Vec<usize>> {
+        let min_column_width = 3usize;
+        let metrics = Self::collect_table_column_metrics(header, rows, alignments.len());
+        let mut widths: Vec<usize> = metrics
+            .iter()
+            .map(|col| col.max_width.max(min_column_width))
+            .collect();
+
+        let Some(max_width) = available_width else {
+            return Some(widths);
+        };
+        let minimum_total = alignments.len() * min_column_width;
+        if max_width < minimum_total {
+            return None;
+        }
+
+        let mut floors: Vec<usize> = metrics
+            .iter()
+            .map(|col| Self::preferred_column_floor(col, min_column_width))
+            .collect();
+        let mut floor_total: usize = floors.iter().sum();
+        if floor_total > max_width {
+            // Relax preferred floors (starting with narrative columns) until we can satisfy the
+            // width budget. We still keep hard minimums.
+            while floor_total > max_width {
+                let Some((idx, _)) = floors
+                    .iter()
+                    .enumerate()
+                    .filter(|(_, floor)| **floor > min_column_width)
+                    .min_by_key(|(idx, floor)| {
+                        let kind_priority = match metrics[*idx].kind {
+                            TableColumnKind::Narrative => 0,
+                            TableColumnKind::Structured => 1,
+                        };
+                        (kind_priority, *floor)
+                    })
+                else {
+                    break;
+                };
+
+                floors[idx] -= 1;
+                floor_total -= 1;
+            }
+        }
+
+        let mut total_width: usize = widths.iter().sum();
+
+        while total_width > max_width {
+            let Some(idx) = Self::next_column_to_shrink(&widths, &floors, &metrics) else {
+                break;
+            };
+            widths[idx] -= 1;
+            total_width -= 1;
+        }
+
+        if total_width > max_width {
+            return None;
+        }
+
+        Some(widths)
+    }
+
+    fn collect_table_column_metrics(
+        header: &[TableCell],
+        rows: &[Vec<TableCell>],
+        column_count: usize,
+    ) -> Vec<TableColumnMetrics> {
+        let mut metrics = Vec::with_capacity(column_count);
+        for column in 0..column_count {
+            let header_cell = &header[column];
+            let header_plain = header_cell.plain_text();
+            let header_token_width = Self::longest_token_width(&header_plain);
+            let mut max_width = Self::cell_display_width(header_cell);
+            let mut body_token_width = 0usize;
+            let mut total_words = 0usize;
+            let mut total_cells = 0usize;
+            let mut total_cell_width = 0usize;
+
+            for row in rows {
+                let cell = &row[column];
+                max_width = max_width.max(Self::cell_display_width(cell));
+                let plain = cell.plain_text();
+                body_token_width = body_token_width.max(Self::longest_token_width(&plain));
+                let word_count = plain.split_whitespace().count();
+                if word_count > 0 {
+                    total_words += word_count;
+                    total_cells += 1;
+                    total_cell_width += plain.width();
+                }
+            }
+
+            let avg_words_per_cell = if total_cells == 0 {
+                header_plain.split_whitespace().count() as f64
+            } else {
+                total_words as f64 / total_cells as f64
+            };
+            let avg_cell_width = if total_cells == 0 {
+                header_plain.width() as f64
+            } else {
+                total_cell_width as f64 / total_cells as f64
+            };
+            let kind = if avg_words_per_cell >= 4.0 || avg_cell_width >= 28.0 {
+                TableColumnKind::Narrative
+            } else {
+                TableColumnKind::Structured
+            };
+
+            metrics.push(TableColumnMetrics {
+                max_width,
+                header_token_width,
+                body_token_width,
+                avg_words_per_cell,
+                avg_cell_width,
+                kind,
+            });
+        }
+
+        metrics
+    }
+
+    fn preferred_column_floor(metrics: &TableColumnMetrics, min_column_width: usize) -> usize {
+        let token_target = match metrics.kind {
+            TableColumnKind::Narrative => metrics.header_token_width.min(10),
+            TableColumnKind::Structured => metrics
+                .header_token_width
+                .max(metrics.body_token_width.min(16)),
+        };
+        token_target.max(min_column_width).min(metrics.max_width)
+    }
+
+    fn next_column_to_shrink(
+        widths: &[usize],
+        floors: &[usize],
+        metrics: &[TableColumnMetrics],
+    ) -> Option<usize> {
+        widths
+            .iter()
+            .enumerate()
+            .filter(|(idx, width)| **width > floors[*idx])
+            .min_by_key(|(idx, width)| {
+                let slack = width.saturating_sub(floors[*idx]);
+                let kind_cost = match metrics[*idx].kind {
+                    TableColumnKind::Narrative => 0i32,
+                    TableColumnKind::Structured => 2i32,
+                };
+                let header_guard = if **width <= metrics[*idx].header_token_width {
+                    3i32
+                } else {
+                    0i32
+                };
+                let density_guard = if metrics[*idx].avg_words_per_cell >= 4.0
+                    || metrics[*idx].avg_cell_width >= 24.0
+                {
+                    0i32
+                } else {
+                    1i32
+                };
+                (
+                    kind_cost + header_guard + density_guard,
+                    usize::MAX.saturating_sub(slack),
+                )
+            })
+            .map(|(idx, _)| idx)
+    }
+
+    fn render_border_line(
+        &self,
+        left: char,
+        sep: char,
+        right: char,
+        column_widths: &[usize],
+        style: Style,
+    ) -> Line<'static> {
+        let mut spans = Vec::with_capacity(column_widths.len() * 2 + 1);
+        spans.push(Span::styled(left.to_string(), style));
+        for (idx, width) in column_widths.iter().enumerate() {
+            spans.push(Span::styled("─".repeat(*width + 2), style));
+            if idx + 1 == column_widths.len() {
+                spans.push(Span::styled(right.to_string(), style));
+            } else {
+                spans.push(Span::styled(sep.to_string(), style));
+            }
+        }
+        Line::from(spans)
+    }
+
+    fn render_table_row(
+        &self,
+        row: &[TableCell],
+        column_widths: &[usize],
+        alignments: &[Alignment],
+        border_style: Style,
+    ) -> Vec<Line<'static>> {
+        let wrapped_cells: Vec<Vec<Line<'static>>> = row
+            .iter()
+            .zip(column_widths)
+            .map(|(cell, width)| self.wrap_cell(cell, *width))
+            .collect();
+        let row_height = wrapped_cells.iter().map(Vec::len).max().unwrap_or(1).max(1);
+
+        let mut out = Vec::with_capacity(row_height);
+        for row_line in 0..row_height {
+            let mut spans = Vec::new();
+            spans.push(Span::styled("│".to_string(), border_style));
+            for (column, width) in column_widths.iter().enumerate() {
+                spans.push(Span::raw(" "));
+                let line = wrapped_cells[column]
+                    .get(row_line)
+                    .cloned()
+                    .unwrap_or_default();
+                let line_width = Self::line_display_width(&line);
+                let remaining = width.saturating_sub(line_width);
+                let (left_padding, right_padding) = match alignments[column] {
+                    Alignment::Left | Alignment::None => (0, remaining),
+                    Alignment::Center => (remaining / 2, remaining - (remaining / 2)),
+                    Alignment::Right => (remaining, 0),
+                };
+                if left_padding > 0 {
+                    spans.push(Span::raw(" ".repeat(left_padding)));
+                }
+                spans.extend(line.spans);
+                if right_padding > 0 {
+                    spans.push(Span::raw(" ".repeat(right_padding)));
+                }
+                spans.push(Span::raw(" "));
+                spans.push(Span::styled("│".to_string(), border_style));
+            }
+            out.push(Line::from(spans));
+        }
+        out
+    }
+
+    fn render_table_pipe_fallback(
+        &self,
+        header: &[TableCell],
+        rows: &[Vec<TableCell>],
+        alignments: &[Alignment],
+    ) -> Vec<Line<'static>> {
+        let mut out = Vec::new();
+        out.push(Line::from(Self::row_to_pipe_string(header)));
+        out.push(Line::from(Self::alignments_to_pipe_delimiter(alignments)));
+        out.extend(
+            rows.iter()
+                .map(|row| Line::from(Self::row_to_pipe_string(row))),
+        );
+        out
+    }
+
+    fn row_to_pipe_string(row: &[TableCell]) -> String {
+        let mut out = String::new();
+        out.push('|');
+        for cell in row {
+            out.push(' ');
+            out.push_str(&cell.plain_text());
+            out.push(' ');
+            out.push('|');
+        }
+        out
+    }
+
+    fn alignments_to_pipe_delimiter(alignments: &[Alignment]) -> String {
+        let mut out = String::new();
+        out.push('|');
+        for alignment in alignments {
+            let segment = match alignment {
+                Alignment::Left => ":---",
+                Alignment::Center => ":---:",
+                Alignment::Right => "---:",
+                Alignment::None => "---",
+            };
+            out.push_str(segment);
+            out.push('|');
+        }
+        out
+    }
+
+    fn wrap_cell(&self, cell: &TableCell, width: usize) -> Vec<Line<'static>> {
+        if cell.lines.is_empty() {
+            return vec![Line::default()];
+        }
+        let mut wrapped = Vec::new();
+        for source_line in &cell.lines {
+            let rendered = word_wrap_line(source_line, RtOptions::new(width.max(1)));
+            if rendered.is_empty() {
+                wrapped.push(Line::default());
+            } else {
+                push_owned_lines(&rendered, &mut wrapped);
+            };
+        }
+        if wrapped.is_empty() {
+            wrapped.push(Line::default());
+        }
+        wrapped
+    }
+
+    /// Detect rows that are artifacts of pulldown-cmark's lenient table parsing rather than real
+    /// table data. These "spillover" rows -- typically trailing paragraphs absorbed into the table
+    /// because they lack leading pipes -- are extracted and rendered as plain text after the table
+    /// grid.
+    fn is_spillover_row(row: &[TableCell], next_row: Option<&Vec<TableCell>>) -> bool {
+        let Some(first_text) = Self::first_non_empty_only_text(row) else {
+            return false;
+        };
+
+        if row.len() == 1 {
+            return true;
+        }
+
+        if Self::looks_like_html_content(&first_text) {
+            return true;
+        }
+
+        // Keep common intro + html-block spillover together:
+        // "HTML block:" followed by "<div ...>".
+        first_text.trim_end().ends_with(':')
+            && (next_row
+                .and_then(|row| Self::first_non_empty_only_text(row))
+                .is_some_and(|text| Self::looks_like_html_content(&text))
+                || Self::looks_like_label_line(&first_text))
+    }
+
+    fn first_non_empty_only_text(row: &[TableCell]) -> Option<String> {
+        let first = row.first()?.plain_text();
+        if first.trim().is_empty() {
+            return None;
+        }
+        let rest_empty = row[1..]
+            .iter()
+            .all(|cell| cell.plain_text().trim().is_empty());
+        rest_empty.then_some(first)
+    }
+
+    fn looks_like_html_content(text: &str) -> bool {
+        text.contains('<') && text.contains('>')
+    }
+
+    fn looks_like_label_line(text: &str) -> bool {
+        text.trim_end().ends_with(':') && text.split_whitespace().count() <= 3
+    }
+
+    fn spans_display_width(spans: &[Span<'_>]) -> usize {
+        spans.iter().map(|span| span.content.width()).sum()
+    }
+
+    fn line_display_width(line: &Line<'_>) -> usize {
+        line.spans.iter().map(|span| span.content.width()).sum()
+    }
+
+    fn cell_display_width(cell: &TableCell) -> usize {
+        cell.lines
+            .iter()
+            .map(Self::line_display_width)
+            .max()
+            .unwrap_or(0)
+    }
+
+    fn longest_token_width(text: &str) -> usize {
+        text.split_whitespace().map(str::width).max().unwrap_or(0)
+    }
+
     fn push_inline_style(&mut self, style: Style) {
         let current = self.inline_styles.last().copied().unwrap_or_default();
         let merged = current.patch(style);
@@ -460,6 +1211,30 @@ where
             self.current_subsequent_indent.clear();
             self.current_line_in_code_block = false;
         }
+    }
+
+    // Like push_line, but skips word wrapping.
+    //
+    // It just prepends the indent prefix in case blockquote is active and pushed directly to the
+    // output.
+    //
+    // Table lines are already laid out with the exact column widths. We don't want word wrapping
+    // to break the box-drawing borders.
+    fn push_prewrapped_line(&mut self, line: Line<'static>, pending_marker_line: bool) {
+        self.flush_current_line();
+        let blockquote_active = self
+            .indent_stack
+            .iter()
+            .any(|ctx| ctx.prefix.iter().any(|p| p.content.contains('>')));
+        let style = if blockquote_active {
+            self.styles.blockquote.patch(line.style)
+        } else {
+            line.style
+        };
+
+        let mut spans = self.prefix_spans(pending_marker_line);
+        spans.extend(line.spans);
+        self.text.lines.push(Line::from(spans).style(style));
     }
 
     fn push_line(&mut self, line: Line<'static>) {

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -1207,9 +1207,15 @@ where
 
     fn pop_link(&mut self) {
         if let Some(link) = self.link.take() {
-            self.push_span(" (".into());
-            self.push_span(Span::styled(link, self.styles.link));
-            self.push_span(")".into());
+            if self.in_table_cell() {
+                self.push_span_to_table_cell(" (".into());
+                self.push_span_to_table_cell(Span::styled(link, self.styles.link));
+                self.push_span_to_table_cell(")".into());
+            } else {
+                self.push_span(" (".into());
+                self.push_span(Span::styled(link, self.styles.link));
+                self.push_span(")".into());
+            }
         }
     }
 

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -1083,7 +1083,7 @@ where
         out.push('|');
         for cell in row {
             out.push(' ');
-            out.push_str(&cell.plain_text());
+            out.push_str(&cell.plain_text().replace('|', "\\|"));
             out.push(' ');
             out.push('|');
         }

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -1151,10 +1151,9 @@ where
         // Keep common intro + html-block spillover together:
         // "HTML block:" followed by "<div ...>".
         first_text.trim_end().ends_with(':')
-            && (next_row
+            && next_row
                 .and_then(|row| Self::first_non_empty_only_text(row))
                 .is_some_and(|text| Self::looks_like_html_content(&text))
-                || Self::looks_like_label_line(&first_text))
     }
 
     fn first_non_empty_only_text(row: &[TableCell]) -> Option<String> {
@@ -1170,10 +1169,6 @@ where
 
     fn looks_like_html_content(text: &str) -> bool {
         text.contains('<') && text.contains('>')
-    }
-
-    fn looks_like_label_line(text: &str) -> bool {
-        text.trim_end().ends_with(':') && text.split_whitespace().count() <= 3
     }
 
     fn spans_display_width(spans: &[Span<'_>]) -> usize {

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -1270,7 +1270,25 @@ where
     }
 
     fn looks_like_html_content(text: &str) -> bool {
-        text.contains('<') && text.contains('>')
+        let bytes = text.as_bytes();
+        for idx in 0..bytes.len() {
+            if bytes[idx] != b'<' {
+                continue;
+            }
+
+            let mut tag_start = idx + 1;
+            if tag_start < bytes.len() && (bytes[tag_start] == b'/' || bytes[tag_start] == b'!') {
+                tag_start += 1;
+            }
+
+            if tag_start < bytes.len()
+                && bytes[tag_start].is_ascii_alphabetic()
+                && bytes[tag_start + 1..].contains(&b'>')
+            {
+                return true;
+            }
+        }
+        false
     }
 
     fn looks_like_html_label_line(text: &str) -> bool {

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -1314,9 +1314,7 @@ where
                 tag_start += 1;
             }
 
-            if bytes
-                .get(tag_start)
-                .is_some_and(u8::is_ascii_alphabetic)
+            if bytes.get(tag_start).is_some_and(u8::is_ascii_alphabetic)
                 && bytes
                     .get(tag_start + 1..)
                     .is_some_and(|suffix| suffix.contains(&b'>'))

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -70,8 +70,6 @@ struct MarkdownStyles {
 
 impl Default for MarkdownStyles {
     fn default() -> Self {
-        use ratatui::style::Stylize;
-
         Self {
             h1: Style::new().bold().underlined(),
             h2: Style::new().bold(),
@@ -1316,9 +1314,12 @@ where
                 tag_start += 1;
             }
 
-            if tag_start < bytes.len()
-                && bytes[tag_start].is_ascii_alphabetic()
-                && bytes[tag_start + 1..].contains(&b'>')
+            if bytes
+                .get(tag_start)
+                .is_some_and(u8::is_ascii_alphabetic)
+                && bytes
+                    .get(tag_start + 1..)
+                    .is_some_and(|suffix| suffix.contains(&b'>'))
             {
                 return true;
             }

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -1087,6 +1087,20 @@ fn table_falls_back_to_pipe_rendering_if_it_cannot_fit() {
 }
 
 #[test]
+fn table_pipe_fallback_escapes_literal_pipes_in_cell_content() {
+    let md = "| c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 | c9 | c10 |\n|---|---|---|---|---|---|---|---|---|---|\n| keep | keep | keep | keep | keep | keep | keep | keep | a \\| b | keep |\n";
+    let text = crate::markdown_render::render_markdown_text_with_width(md, Some(20));
+    let lines: Vec<String> = text
+        .lines
+        .iter()
+        .map(|line| line.spans.iter().map(|span| span.content.clone()).collect())
+        .collect();
+
+    assert!(lines.first().is_some_and(|line| line.starts_with('|')));
+    assert!(lines.iter().any(|line| line.contains("a \\| b")));
+}
+
+#[test]
 fn table_keeps_sparse_rows_with_empty_trailing_cells() {
     let md = "| A | B | C |\n|---|---|---|\n| a | | |\n";
     let text = render_markdown_text(md);

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -1168,6 +1168,28 @@ fn table_spillover_prose_wraps_in_narrow_width() {
 }
 
 #[test]
+fn table_keeps_sparse_comparison_row_inside_grid() {
+    let md = "| A | B | C |\n|---|---|---|\n| x < y > z | | |\n";
+    let text = render_markdown_text(md);
+    let lines: Vec<String> = text
+        .lines
+        .iter()
+        .map(|line| line.spans.iter().map(|span| span.content.clone()).collect())
+        .collect();
+
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("│ x < y > z") && line.ends_with('│')),
+        "expected sparse comparison row to remain inside table grid: {lines:?}"
+    );
+    assert!(
+        !lines.iter().any(|line| line.trim() == "x < y > z"),
+        "did not expect sparse comparison row to spill outside table: {lines:?}"
+    );
+}
+
+#[test]
 fn table_keeps_sparse_rows_with_empty_trailing_cells() {
     let md = "| A | B | C |\n|---|---|---|\n| a | | |\n";
     let text = render_markdown_text(md);

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -1087,6 +1087,23 @@ fn table_falls_back_to_pipe_rendering_if_it_cannot_fit() {
 }
 
 #[test]
+fn table_pipe_fallback_rows_wrap_in_narrow_width() {
+    let md = "| c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 | c9 | c10 |\n|---|---|---|---|---|---|---|---|---|---|\n| 111111 | 222222 | 333333 | 444444 | 555555 | 666666 | 777777 | 888888 | 999999 | 101010 |\n";
+    let text = crate::markdown_render::render_markdown_text_with_width(md, Some(20));
+    let lines: Vec<String> = text
+        .lines
+        .iter()
+        .map(|line| line.spans.iter().map(|span| span.content.clone()).collect())
+        .collect();
+
+    assert!(lines.first().is_some_and(|line| line.starts_with('|')));
+    assert!(
+        lines.len() > 3,
+        "expected wrapped pipe-fallback rows at narrow width, got {lines:?}"
+    );
+}
+
+#[test]
 fn table_pipe_fallback_escapes_literal_pipes_in_cell_content() {
     let md = "| c1 | c2 | c3 | c4 | c5 | c6 | c7 | c8 | c9 | c10 |\n|---|---|---|---|---|---|---|---|---|---|\n| keep | keep | keep | keep | keep | keep | keep | keep | a \\| b | keep |\n";
     let text = crate::markdown_render::render_markdown_text_with_width(md, Some(20));
@@ -1097,7 +1114,10 @@ fn table_pipe_fallback_escapes_literal_pipes_in_cell_content() {
         .collect();
 
     assert!(lines.first().is_some_and(|line| line.starts_with('|')));
-    assert!(lines.iter().any(|line| line.contains("a \\| b")));
+    assert!(
+        lines.iter().any(|line| line.contains("\\|")),
+        "expected escaped pipe marker to be preserved in wrapped fallback rows: {lines:?}"
+    );
 }
 
 #[test]

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -1101,6 +1101,28 @@ fn table_pipe_fallback_escapes_literal_pipes_in_cell_content() {
 }
 
 #[test]
+fn table_link_keeps_url_suffix_inside_cell() {
+    let md = "| Site |\n|---|\n| [OpenAI](https://openai.com) |\n";
+    let text = render_markdown_text(md);
+    let lines: Vec<String> = text
+        .lines
+        .iter()
+        .map(|line| line.spans.iter().map(|span| span.content.clone()).collect())
+        .collect();
+
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("OpenAI (https://openai.com)")),
+        "expected link suffix inside table cell: {lines:?}"
+    );
+    assert!(
+        !lines.iter().any(|line| line.trim() == "(https://openai.com)"),
+        "did not expect stray url suffix line outside table: {lines:?}"
+    );
+}
+
+#[test]
 fn table_keeps_sparse_rows_with_empty_trailing_cells() {
     let md = "| A | B | C |\n|---|---|---|\n| a | | |\n";
     let text = render_markdown_text(md);

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -1131,6 +1131,28 @@ fn table_keeps_sparse_sentence_row_inside_grid() {
 }
 
 #[test]
+fn table_keeps_label_only_sparse_row_inside_grid() {
+    let md = "| A | B | C |\n|---|---|---|\n| Status: | | |\n| ok | | |\n";
+    let text = render_markdown_text(md);
+    let lines: Vec<String> = text
+        .lines
+        .iter()
+        .map(|line| line.spans.iter().map(|span| span.content.clone()).collect())
+        .collect();
+
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("│ Status:") && line.ends_with('│')),
+        "expected label-only sparse row to remain inside table grid: {lines:?}"
+    );
+    assert!(
+        !lines.iter().any(|line| line.trim() == "Status:"),
+        "did not expect label-only sparse row to spill outside table: {lines:?}"
+    );
+}
+
+#[test]
 fn table_preserves_structured_leading_columns_when_last_column_is_long() {
     let md = "| Milestone | Planned Date | Outcome | Retrospective Summary |\n|---|---|---|---|\n| Canary rollout | 2026-01-10 | Completed | Canary
   traffic was held at 5% longer than planned due to latency regressions tied to cold cache behavior; after pre-warming and query plan hints, p95

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -1233,6 +1233,28 @@ fn table_keeps_single_word_label_row_at_end_inside_grid() {
 }
 
 #[test]
+fn table_keeps_multi_word_label_row_at_end_inside_grid() {
+    let md = "| A | B | C |\n|---|---|---|\n| Build status: | | |\n";
+    let text = render_markdown_text(md);
+    let lines: Vec<String> = text
+        .lines
+        .iter()
+        .map(|line| line.spans.iter().map(|span| span.content.clone()).collect())
+        .collect();
+
+    assert!(
+        lines
+            .iter()
+            .any(|line| line.contains("│ Build status:") && line.ends_with('│')),
+        "expected multi-word trailing label row to remain inside table grid: {lines:?}"
+    );
+    assert!(
+        !lines.iter().any(|line| line.trim() == "Build status:"),
+        "did not expect multi-word trailing label row to spill outside table: {lines:?}"
+    );
+}
+
+#[test]
 fn table_preserves_structured_leading_columns_when_last_column_is_long() {
     let md = "| Milestone | Planned Date | Outcome | Retrospective Summary |\n|---|---|---|---|\n| Canary rollout | 2026-01-10 | Completed | Canary
   traffic was held at 5% longer than planned due to latency regressions tied to cold cache behavior; after pre-warming and query plan hints, p95

--- a/codex-rs/tui/src/markdown_render_tests.rs
+++ b/codex-rs/tui/src/markdown_render_tests.rs
@@ -1145,6 +1145,29 @@ fn table_does_not_absorb_trailing_html_block_label_line() {
 }
 
 #[test]
+fn table_spillover_prose_wraps_in_narrow_width() {
+    let long_label = "This html spillover prose line should wrap on narrow widths to avoid clipping:";
+    let md = format!(
+        "| Left | Center | Right |\n|:-----|:------:|------:|\n| a    |   b    |     c |\n{long_label}\n<div style=\"border:1px solid #ccc;padding:2px\">inline block</div>\n"
+    );
+    let text = crate::markdown_render::render_markdown_text_with_width(&md, Some(40));
+    let lines: Vec<String> = text
+        .lines
+        .iter()
+        .map(|line| line.spans.iter().map(|span| span.content.clone()).collect())
+        .collect();
+
+    assert!(
+        lines.iter().any(|line| line.contains("This html spillover prose")),
+        "expected spillover prose to be present: {lines:?}"
+    );
+    assert!(
+        !lines.iter().any(|line| line.contains(long_label)),
+        "did not expect spillover prose to remain as one long clipped line: {lines:?}"
+    );
+}
+
+#[test]
 fn table_keeps_sparse_rows_with_empty_trailing_cells() {
     let md = "| A | B | C |\n|---|---|---|\n| a | | |\n";
     let text = render_markdown_text(md);

--- a/codex-rs/tui/src/markdown_stream.rs
+++ b/codex-rs/tui/src/markdown_stream.rs
@@ -1,11 +1,30 @@
+//! Newline-gated streaming accumulator for markdown source.
+//!
+//! `MarkdownStreamCollector` buffers incoming token deltas and exposes a commit boundary at each
+//! newline.  The stream controllers (`streaming/controller.rs`) call `commit_complete_source()`
+//! after each newline-bearing delta to obtain the completed prefix for re-rendering, leaving the
+//! trailing incomplete line in the buffer for the next delta.
+//!
+//! On finalization, `finalize_and_drain_source()` flushes whatever remains (the last line, which
+//! may lack a trailing newline).
+
+#[cfg(test)]
 use ratatui::text::Line;
 
+#[cfg(test)]
 use crate::markdown;
 
-/// Newline-gated accumulator that renders markdown and commits only fully
-/// completed logical lines.
+/// Newline-gated accumulator that buffers raw markdown source and commits only completed lines
+/// (terminated by `\n`).
+///
+/// The buffer tracks how many source bytes have already been committed via
+/// `committed_source_len`, so each `commit_complete_source()` call returns only the newly
+/// completed portion.  This design lets the stream controller re-render the entire accumulated
+/// source while only appending new content.
 pub(crate) struct MarkdownStreamCollector {
     buffer: String,
+    committed_source_len: usize,
+    #[cfg(test)]
     committed_line_count: usize,
     width: Option<usize>,
 }
@@ -14,14 +33,24 @@ impl MarkdownStreamCollector {
     pub fn new(width: Option<usize>) -> Self {
         Self {
             buffer: String::new(),
+            committed_source_len: 0,
+            #[cfg(test)]
             committed_line_count: 0,
             width,
         }
     }
 
+    pub fn set_width(&mut self, width: Option<usize>) {
+        self.width = width;
+    }
+
     pub fn clear(&mut self) {
         self.buffer.clear();
-        self.committed_line_count = 0;
+        self.committed_source_len = 0;
+        #[cfg(test)]
+        {
+            self.committed_line_count = 0;
+        }
     }
 
     pub fn push_delta(&mut self, delta: &str) {
@@ -29,17 +58,48 @@ impl MarkdownStreamCollector {
         self.buffer.push_str(delta);
     }
 
+    /// Commit newly completed raw markdown source up to the last newline.
+    pub fn commit_complete_source(&mut self) -> Option<String> {
+        let commit_end = self.buffer.rfind('\n').map(|idx| idx + 1)?;
+        if commit_end <= self.committed_source_len {
+            return None;
+        }
+
+        let out = self.buffer[self.committed_source_len..commit_end].to_string();
+        self.committed_source_len = commit_end;
+        Some(out)
+    }
+
+    /// Finalize the stream and return any remaining raw source.
+    ///
+    /// Ensures the returned source chunk is newline-terminated when non-empty so callers can
+    /// safely run markdown block parsing on the final chunk.
+    pub fn finalize_and_drain_source(&mut self) -> String {
+        if self.committed_source_len >= self.buffer.len() {
+            self.clear();
+            return String::new();
+        }
+
+        let mut out = self.buffer[self.committed_source_len..].to_string();
+        if !out.ends_with('\n') {
+            out.push('\n');
+        }
+        self.clear();
+        out
+    }
+
     /// Render the full buffer and return only the newly completed logical lines
     /// since the last commit. When the buffer does not end with a newline, the
     /// final rendered line is considered incomplete and is not emitted.
+    #[cfg(test)]
     pub fn commit_complete_lines(&mut self) -> Vec<Line<'static>> {
-        let source = self.buffer.clone();
-        let last_newline_idx = source.rfind('\n');
-        let source = if let Some(last_newline_idx) = last_newline_idx {
-            source[..=last_newline_idx].to_string()
-        } else {
+        let Some(commit_end) = self.buffer.rfind('\n').map(|idx| idx + 1) else {
             return Vec::new();
         };
+        if commit_end <= self.committed_source_len {
+            return Vec::new();
+        }
+        let source = self.buffer[..commit_end].to_string();
         let mut rendered: Vec<Line<'static>> = Vec::new();
         markdown::append_markdown(&source, self.width, &mut rendered);
         let mut complete_line_count = rendered.len();
@@ -58,6 +118,7 @@ impl MarkdownStreamCollector {
         let out_slice = &rendered[self.committed_line_count..complete_line_count];
 
         let out = out_slice.to_vec();
+        self.committed_source_len = commit_end;
         self.committed_line_count = complete_line_count;
         out
     }
@@ -66,17 +127,21 @@ impl MarkdownStreamCollector {
     /// If the buffer does not end with a newline, a temporary one is appended
     /// for rendering. Optionally unwraps ```markdown language fences in
     /// non-test builds.
+    #[cfg(test)]
     pub fn finalize_and_drain(&mut self) -> Vec<Line<'static>> {
-        let raw_buffer = self.buffer.clone();
-        let mut source: String = raw_buffer.clone();
+        let mut source = self.buffer.clone();
+        if source.is_empty() {
+            self.clear();
+            return Vec::new();
+        }
         if !source.ends_with('\n') {
             source.push('\n');
-        }
+        };
         tracing::debug!(
-            raw_len = raw_buffer.len(),
+            raw_len = self.buffer.len(),
             source_len = source.len(),
             "markdown finalize (raw length: {}, rendered length: {})",
-            raw_buffer.len(),
+            self.buffer.len(),
             source.len()
         );
         tracing::trace!("markdown finalize (raw source):\n---\n{source}\n---");
@@ -386,6 +451,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn table_header_commits_without_holdback() {
+        let mut c = super::MarkdownStreamCollector::new(None);
+        c.push_delta("| A | B |\n");
+        let out1 = c.commit_complete_lines();
+        let out1_str = lines_to_plain_strings(&out1);
+        assert_eq!(out1_str, vec!["| A | B |".to_string()]);
+
+        c.push_delta("| --- | --- |\n");
+        let out = c.commit_complete_lines();
+        let out_str = lines_to_plain_strings(&out);
+        assert!(
+            !out_str.is_empty(),
+            "expected output to continue committing after delimiter: {out_str:?}"
+        );
+
+        c.push_delta("| 1 | 2 |\n");
+        let out2 = c.commit_complete_lines();
+        assert!(
+            !out2.is_empty(),
+            "expected output to continue committing after body row"
+        );
+
+        c.push_delta("\n");
+        let _ = c.commit_complete_lines();
+    }
+
+    #[tokio::test]
+    async fn pipe_text_without_table_prefix_is_not_delayed() {
+        let mut c = super::MarkdownStreamCollector::new(None);
+        c.push_delta("Escaped pipe in text: a | b | c\n");
+        let out = c.commit_complete_lines();
+        let out_str = lines_to_plain_strings(&out);
+        assert_eq!(out_str, vec!["Escaped pipe in text: a | b | c".to_string()]);
+    }
+
+    #[tokio::test]
     async fn lists_and_fences_commit_without_duplication() {
         // List case
         assert_streamed_equals_full(&["- a\n- ", "b\n- c\n"]).await;
@@ -666,5 +767,10 @@ mod tests {
             "more stuff\n",
         ])
         .await;
+    }
+
+    #[tokio::test]
+    async fn table_like_lines_inside_fenced_code_are_not_held() {
+        assert_streamed_equals_full(&["```\n", "| a | b |\n", "```\n"]).await;
     }
 }

--- a/codex-rs/tui/src/markdown_stream.rs
+++ b/codex-rs/tui/src/markdown_stream.rs
@@ -30,6 +30,10 @@ pub(crate) struct MarkdownStreamCollector {
 }
 
 impl MarkdownStreamCollector {
+    /// Create a collector that accumulates raw markdown deltas.
+    ///
+    /// `width` is only used by test-only rendering helpers; production stream
+    /// commits operate on raw source boundaries.
     pub fn new(width: Option<usize>) -> Self {
         Self {
             buffer: String::new(),
@@ -40,10 +44,12 @@ impl MarkdownStreamCollector {
         }
     }
 
+    /// Update the rendering width used by test-only line-commit helpers.
     pub fn set_width(&mut self, width: Option<usize>) {
         self.width = width;
     }
 
+    /// Reset all buffered source and commit bookkeeping.
     pub fn clear(&mut self) {
         self.buffer.clear();
         self.committed_source_len = 0;
@@ -53,6 +59,7 @@ impl MarkdownStreamCollector {
         }
     }
 
+    /// Append a raw streaming delta to the internal source buffer.
     pub fn push_delta(&mut self, delta: &str) {
         tracing::trace!("push_delta: {delta:?}");
         self.buffer.push_str(delta);

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -559,10 +559,13 @@ impl TranscriptOverlay {
         }
     }
 
-    ///  Replace a range of committed cells with a single consolidated cell.
+    /// Replace a range of committed cells with a single consolidated cell.
     ///
-    ///  This mirros the splice performed on `App::transcript_cells` during `ConsolidateAgentMessage`
-    ///  so the overlay stays in sync with the main transcript.
+    /// Mirrors the splice performed on `App::transcript_cells` during
+    /// `ConsolidateAgentMessage` so the Ctrl+T overlay stays in sync with the
+    /// main transcript. The range is clamped defensively: cells may have been
+    /// inserted after the overlay opened, leaving it with fewer entries than
+    /// the main transcript.
     pub(crate) fn consolidate_cells(
         &mut self,
         range: std::ops::Range<usize>,

--- a/codex-rs/tui/src/render/line_utils.rs
+++ b/codex-rs/tui/src/render/line_utils.rs
@@ -26,6 +26,7 @@ pub fn push_owned_lines<'a>(src: &[Line<'a>], out: &mut Vec<Line<'static>>) {
 
 /// Consider a line blank if it has no spans or only spans whose contents are
 /// empty or consist solely of spaces (no tabs/newlines).
+#[cfg(test)]
 pub fn is_blank_line_spaces_only(line: &Line<'_>) -> bool {
     if line.spans.is_empty() {
         return true;

--- a/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_complex_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_complex_snapshot.snap
@@ -29,13 +29,13 @@ Image: alt text
 
 Table below (alignment test):
 
-┌─────────────┬────────┬───────┐
-│ Left        │ Center │ Right │
-├─────────────┼────────┼───────┤
-│ a           │   b    │     c │
-│ HTML block: │        │       │
-└─────────────┴────────┴───────┘
+┌──────┬────────┬───────┐
+│ Left │ Center │ Right │
+├──────┼────────┼───────┤
+│ a    │   b    │     c │
+└──────┴────────┴───────┘
 Inline HTML: <sup>sup</sup> and <sub>sub</sub>.
+HTML block:
 <div style="border:1px solid #ccc;padding:2px">inline block</div>
 Escapes: \_underscores\_, backslash \\, ticks ``code with `backtick` inside``.
 Emoji shortcodes: :sparkles: :tada: (if supported).

--- a/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_complex_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_complex_snapshot.snap
@@ -29,13 +29,13 @@ Image: alt text
 
 Table below (alignment test):
 
-┌──────┬────────┬───────┐
-│ Left │ Center │ Right │
-├──────┼────────┼───────┤
-│ a    │   b    │     c │
-└──────┴────────┴───────┘
+┌─────────────┬────────┬───────┐
+│ Left        │ Center │ Right │
+├─────────────┼────────┼───────┤
+│ a           │   b    │     c │
+│ HTML block: │        │       │
+└─────────────┴────────┴───────┘
 Inline HTML: <sup>sup</sup> and <sub>sub</sub>.
-HTML block:
 <div style="border:1px solid #ccc;padding:2px">inline block</div>
 Escapes: \_underscores\_, backslash \\, ticks ``code with `backtick` inside``.
 Emoji shortcodes: :sparkles: :tada: (if supported).

--- a/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_complex_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__markdown_render__markdown_render_tests__markdown_render_complex_snapshot.snap
@@ -28,9 +28,12 @@ Image: alt text
 ———
 
 Table below (alignment test):
-| Left | Center | Right |
-|:-----|:------:|------:|
-| a    |   b    |     c |
+
+┌──────┬────────┬───────┐
+│ Left │ Center │ Right │
+├──────┼────────┼───────┤
+│ a    │   b    │     c │
+└──────┴────────┴───────┘
 Inline HTML: <sup>sup</sup> and <sub>sub</sub>.
 HTML block:
 <div style="border:1px solid #ccc;padding:2px">inline block</div>

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -1313,6 +1313,15 @@ mod tests {
     }
 
     #[test]
+    fn table_holdback_state_detects_single_column_header_plus_delimiter() {
+        let source = "| Only |\n| --- |\n";
+        assert!(matches!(
+            table_holdback_state(source),
+            TableHoldbackState::Confirmed
+        ));
+    }
+
+    #[test]
     fn table_holdback_state_ignores_table_like_lines_inside_unclosed_long_fence() {
         let source = "````sh\n```cmd\n| Key | Description |\n| --- | --- |\n````\n";
         assert!(

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -1,5 +1,21 @@
+//! Two-region streaming controllers for agent messages and proposed plans.
+//!
+//! Each stream partitions rendered markdown into a *stable region* (committed
+//! to scrollback via the animation queue in `StreamState`) and a *tail region*
+//! (mutable, displayed in the active-cell slot as `StreamingAgentTailCell`).
+//!
+//! `StreamCore` owns the shared bookkeeping: source accumulation, re-rendering,
+//! stable/tail partitioning, commit-animation queue management, and terminal
+//! resize handling.  `StreamController` and `PlanStreamController` are thin
+//! wrappers that add only their `emit()` styling and finalize return types.
+//!
+//! Table-aware holdback (`table_holdback_state`) keeps the entire buffer as
+//! tail while a table is being streamed, because each new row can change column
+//! widths and reshape every prior line.
+
 use crate::history_cell::HistoryCell;
 use crate::history_cell::{self};
+use crate::markdown::append_markdown_agent;
 use crate::render::line_utils::prefix_lines;
 use crate::style::proposed_plan_style;
 use ratatui::prelude::Stylize;
@@ -7,92 +23,299 @@ use ratatui::text::Line;
 use std::time::Duration;
 use std::time::Instant;
 
+use crate::table_detect::is_table_delimiter_line;
+use crate::table_detect::is_table_header_line;
+use crate::table_detect::parse_table_segments;
+
 use super::StreamState;
 
-/// Controller that manages newline-gated streaming, header emission, and
-/// commit animation across streams.
-pub(crate) struct StreamController {
+// ---------------------------------------------------------------------------
+// StreamCore — shared bookkeeping for both stream controllers
+// ---------------------------------------------------------------------------
+
+/// Shared state and logic for the two-region streaming model.
+///
+/// Both [`StreamController`] (agent messages) and [`PlanStreamController`]
+/// (proposed plans) delegate their core bookkeeping here: source
+/// accumulation, re-rendering, stable/tail partitioning, commit-animation
+/// queue management, and terminal resize handling.
+///
+/// The wrapping controllers add only their own `emit()` styling and
+/// finalize return types.
+struct StreamCore {
     state: StreamState,
-    finishing_after_drain: bool,
+    /// Current rendering width (columns available for markdown content).
+    width: Option<usize>,
+    /// Accumulated raw markdown source for the current stream.
+    raw_source: String,
+    /// Full re-render of `raw_source` at `width`. Rebuilt on every committed delta.
+    rendered_lines: Vec<Line<'static>>,
+    /// Lines enqueued into the commit-animation queue.
+    enqueued_stable_len: usize,
+    /// Lines actually emitted to scrollback.
+    emitted_stable_len: usize,
+}
+
+impl StreamCore {
+    fn new(width: Option<usize>) -> Self {
+        Self {
+            state: StreamState::new(width),
+            width,
+            raw_source: String::new(),
+            rendered_lines: Vec::new(),
+            enqueued_stable_len: 0,
+            emitted_stable_len: 0,
+        }
+    }
+
+    /// Push a delta; if it contains a newline, commit completed lines and enqueue newly-stable
+    /// lines. Returns `true` if new lines were enqueued.
+    fn push_delta(&mut self, delta: &str) -> bool {
+        if !delta.is_empty() {
+            self.state.has_seen_delta = true;
+        }
+        self.state.collector.push_delta(delta);
+
+        let mut enqueued = false;
+        if delta.contains('\n')
+            && let Some(committed_source) = self.state.collector.commit_complete_source()
+        {
+            self.raw_source.push_str(&committed_source);
+            self.recompute_streaming_render();
+            enqueued = self.sync_stable_queue();
+        }
+        enqueued
+    }
+
+    /// Drain the collector, re-render, and return lines not yet emitted.
+    /// Does NOT reset state - the caller must call `reset()` afterward.
+    fn finalize_remaining(&mut self) -> Vec<Line<'static>> {
+        let remainder_source = self.state.collector.finalize_and_drain_source();
+        if !remainder_source.is_empty() {
+            self.raw_source.push_str(&remainder_source);
+        }
+        let mut rendered = Vec::new();
+        append_markdown_agent(&self.raw_source, self.width, &mut rendered);
+        if self.emitted_stable_len >= rendered.len() {
+            Vec::new()
+        } else {
+            rendered[self.emitted_stable_len..].to_vec()
+        }
+    }
+
+    /// Step animation: dequeue one line, update the emitted count.
+    fn tick(&mut self) -> Vec<Line<'static>> {
+        let step = self.state.step();
+        self.emitted_stable_len += step.len();
+        step
+    }
+
+    /// Batch drain: dequeue up to `max_lines`, update the emitted count.
+    fn tick_batch(&mut self, max_lines: usize) -> Vec<Line<'static>> {
+        let step = self.state.drain_n(max_lines.max(1));
+        self.emitted_stable_len += step.len();
+        step
+    }
+
+    fn is_idle(&self) -> bool {
+        self.state.is_idle()
+    }
+
+    fn queued_lines(&self) -> usize {
+        self.state.queued_len()
+    }
+
+    fn oldest_queued_age(&self, now: Instant) -> Option<Duration> {
+        self.state.oldest_queued_age(now)
+    }
+
+    /// Mutable tail lines not yet queued into the stable region.
+    fn current_tail_lines(&self) -> Vec<Line<'static>> {
+        let start = self.enqueued_stable_len.min(self.rendered_lines.len());
+        self.rendered_lines[start..].to_vec()
+    }
+
+    /// Update rendering width and rebuild queued stable lines for the new layout.
+    fn set_width(&mut self, width: Option<usize>) {
+        if self.width == width {
+            return;
+        }
+        let old_width = self.width;
+        self.width = width;
+        self.state.collector.set_width(width);
+        if self.raw_source.is_empty() {
+            return;
+        }
+
+        // Recalculate emitted_stabe_len for the new width so we don't re-queue lines that were
+        // already emitted at the old width.
+        if self.emitted_stable_len > 0 {
+            let emitted_bytes = source_bytes_for_rendered_count(
+                &self.raw_source,
+                old_width,
+                self.emitted_stable_len,
+            );
+            let mut emitted_at_new = Vec::new();
+            append_markdown_agent(
+                &self.raw_source[..emitted_bytes],
+                self.width,
+                &mut emitted_at_new,
+            );
+            self.emitted_stable_len = emitted_at_new.len();
+        }
+
+        self.recompute_streaming_render();
+        self.rebuild_stable_queue_from_render();
+    }
+
+    /// Clear all accumulated state for current stream.
+    fn reset(&mut self) {
+        self.state.clear();
+        self.raw_source.clear();
+        self.rendered_lines.clear();
+        self.enqueued_stable_len = 0;
+        self.emitted_stable_len = 0;
+    }
+
+    /// Re-render the full `raw_source` at current `width`.
+    fn recompute_streaming_render(&mut self) {
+        let mut rendered = Vec::new();
+        append_markdown_agent(&self.raw_source, self.width, &mut rendered);
+        self.rendered_lines = rendered;
+    }
+
+    /// Advance `enqueued_stable_len` toward the target stable boundary and enqueue any
+    /// newly-stable lines. Returns `true` if new lines were enqueued.
+    fn sync_stable_queue(&mut self) -> bool {
+        let tail_budget = self.active_tail_budget_lines();
+        let target_stable_len = self
+            .rendered_lines
+            .len()
+            .saturating_sub(tail_budget)
+            .max(self.emitted_stable_len);
+
+        // A structural rewrite moved the stable boundary backward into enqueue-but-unemitted
+        // lines. Rebuild queue from the latest snapshot.
+        if target_stable_len < self.enqueued_stable_len {
+            self.state.clear_queue();
+            if self.emitted_stable_len < target_stable_len {
+                self.state.enqueue(
+                    self.rendered_lines[self.emitted_stable_len..target_stable_len].to_vec(),
+                );
+            }
+            self.enqueued_stable_len = target_stable_len;
+            return self.state.queued_len() > 0;
+        }
+
+        if target_stable_len == self.enqueued_stable_len {
+            return false;
+        }
+
+        self.state
+            .enqueue(self.rendered_lines[self.enqueued_stable_len..target_stable_len].to_vec());
+        self.enqueued_stable_len = target_stable_len;
+        true
+    }
+
+    /// Rebuild the stable queue from the current render snapshot. Used after `set_width()` where
+    /// the old queue is stale.
+    fn rebuild_stable_queue_from_render(&mut self) {
+        let tail_budget = self.active_tail_budget_lines();
+        let target_stable_len = self
+            .rendered_lines
+            .len()
+            .saturating_sub(tail_budget)
+            .max(self.emitted_stable_len);
+        self.state.clear_queue();
+        if self.emitted_stable_len < target_stable_len {
+            self.state
+                .enqueue(self.rendered_lines[self.emitted_stable_len..target_stable_len].to_vec());
+        }
+        self.enqueued_stable_len = target_stable_len;
+    }
+
+    /// How many rendered lines to withhold as mutable tail. When a table is detected, the entire
+    /// buffer is tail; otherwise zero.
+    fn active_tail_budget_lines(&self) -> usize {
+        match table_holdback_state(&self.raw_source) {
+            TableHoldbackState::Confirmed => self.rendered_lines.len(),
+            TableHoldbackState::PendingHeader => self.rendered_lines.len(),
+            TableHoldbackState::None => 0,
+        }
+    }
+}
+
+/// Controller for streaming agent message content with table-aware holdback.
+///
+/// Wraps [`StreamCore`] and adds `AgentMessageCell` emission styling.
+pub(crate) struct StreamController {
+    core: StreamCore,
     header_emitted: bool,
 }
 
 impl StreamController {
     pub(crate) fn new(width: Option<usize>) -> Self {
         Self {
-            state: StreamState::new(width),
-            finishing_after_drain: false,
+            core: StreamCore::new(width),
             header_emitted: false,
         }
     }
 
-    /// Push a delta; if it contains a newline, commit completed lines and start animation.
     pub(crate) fn push(&mut self, delta: &str) -> bool {
-        let state = &mut self.state;
-        if !delta.is_empty() {
-            state.has_seen_delta = true;
-        }
-        state.collector.push_delta(delta);
-        if delta.contains('\n') {
-            let newly_completed = state.collector.commit_complete_lines();
-            if !newly_completed.is_empty() {
-                state.enqueue(newly_completed);
-                return true;
-            }
-        }
-        false
+        self.core.push_delta(delta)
     }
 
-    /// Finalize the active stream. Drain and emit now.
-    pub(crate) fn finalize(&mut self) -> Option<Box<dyn HistoryCell>> {
-        // Finalize collector first.
-        let remaining = {
-            let state = &mut self.state;
-            state.collector.finalize_and_drain()
-        };
-        // Collect all output first to avoid emitting headers when there is no content.
-        let mut out_lines = Vec::new();
-        {
-            let state = &mut self.state;
-            if !remaining.is_empty() {
-                state.enqueue(remaining);
-            }
-            let step = state.drain_all();
-            out_lines.extend(step);
+    /// Finalize the active stream. Returns the final cell (if any remaining lines) and the raw
+    /// markdown source for consolidation.
+    pub(crate) fn finalize(&mut self) -> (Option<Box<dyn HistoryCell>>, Option<String>) {
+        let remaining = self.core.finalize_remaining();
+        if self.core.raw_source.is_empty() {
+            self.core.reset();
+            return (None, None);
         }
 
-        // Cleanup
-        self.state.clear();
-        self.finishing_after_drain = false;
-        self.emit(out_lines)
+        // Capture the source before reset clears it.
+        let source = self.core.raw_source.clone();
+        let out = self.emit(remaining);
+        self.core.reset();
+        (out, Some(source))
     }
 
-    /// Step animation: commit at most one queued line and handle end-of-drain cleanup.
     pub(crate) fn on_commit_tick(&mut self) -> (Option<Box<dyn HistoryCell>>, bool) {
-        let step = self.state.step();
-        (self.emit(step), self.state.is_idle())
+        let step = self.core.tick();
+        (self.emit(step), self.core.is_idle())
     }
 
-    /// Step animation: commit at most `max_lines` queued lines.
-    ///
-    /// This is intended for adaptive catch-up drains. Callers should keep `max_lines` bounded; a
-    /// very large value can collapse perceived animation into a single jump.
     pub(crate) fn on_commit_tick_batch(
         &mut self,
         max_lines: usize,
     ) -> (Option<Box<dyn HistoryCell>>, bool) {
-        let step = self.state.drain_n(max_lines.max(1));
-        (self.emit(step), self.state.is_idle())
+        let step = self.core.tick_batch(max_lines);
+        (self.emit(step), self.core.is_idle())
     }
 
-    /// Returns the current number of queued lines waiting to be displayed.
     pub(crate) fn queued_lines(&self) -> usize {
-        self.state.queued_len()
+        self.core.queued_lines()
     }
 
-    /// Returns the age of the oldest queued line.
     pub(crate) fn oldest_queued_age(&self, now: Instant) -> Option<Duration> {
-        self.state.oldest_queued_age(now)
+        self.core.oldest_queued_age(now)
+    }
+
+    pub(crate) fn current_tail_lines(&self) -> Vec<Line<'static>> {
+        self.core.current_tail_lines()
+    }
+
+    pub(crate) fn tail_starts_stream(&self) -> bool {
+        !self.header_emitted && self.core.enqueued_stable_len == 0
+    }
+
+    pub(crate) fn has_live_tail(&self) -> bool {
+        !self.current_tail_lines().is_empty()
+    }
+
+    pub(crate) fn set_width(&mut self, width: Option<usize>) {
+        self.core.set_width(width);
     }
 
     fn emit(&mut self, lines: Vec<Line<'static>>) -> Option<Box<dyn HistoryCell>> {
@@ -106,10 +329,16 @@ impl StreamController {
         })))
     }
 }
+// ---------------------------------------------------------------------------
+// PlanStreamController — proposed plan streams
+// ---------------------------------------------------------------------------
 
 /// Controller that streams proposed plan markdown into a styled plan block.
+///
+/// Wraps [`StreamCore`] and adds plan-specific header, indentation, and
+/// background styling.
 pub(crate) struct PlanStreamController {
-    state: StreamState,
+    core: StreamCore,
     header_emitted: bool,
     top_padding_emitted: bool,
 }
@@ -117,75 +346,47 @@ pub(crate) struct PlanStreamController {
 impl PlanStreamController {
     pub(crate) fn new(width: Option<usize>) -> Self {
         Self {
-            state: StreamState::new(width),
+            core: StreamCore::new(width),
             header_emitted: false,
             top_padding_emitted: false,
         }
     }
 
-    /// Push a delta; if it contains a newline, commit completed lines and start animation.
     pub(crate) fn push(&mut self, delta: &str) -> bool {
-        let state = &mut self.state;
-        if !delta.is_empty() {
-            state.has_seen_delta = true;
-        }
-        state.collector.push_delta(delta);
-        if delta.contains('\n') {
-            let newly_completed = state.collector.commit_complete_lines();
-            if !newly_completed.is_empty() {
-                state.enqueue(newly_completed);
-                return true;
-            }
-        }
-        false
+        self.core.push_delta(delta)
     }
 
     /// Finalize the active stream. Drain and emit now.
     pub(crate) fn finalize(&mut self) -> Option<Box<dyn HistoryCell>> {
-        let remaining = {
-            let state = &mut self.state;
-            state.collector.finalize_and_drain()
-        };
-        let mut out_lines = Vec::new();
-        {
-            let state = &mut self.state;
-            if !remaining.is_empty() {
-                state.enqueue(remaining);
-            }
-            let step = state.drain_all();
-            out_lines.extend(step);
-        }
-
-        self.state.clear();
-        self.emit(out_lines, true)
+        let remaining = self.core.finalize_remaining();
+        let out = self.emit(remaining, true);
+        self.core.reset();
+        out
     }
 
-    /// Step animation: commit at most one queued line and handle end-of-drain cleanup.
     pub(crate) fn on_commit_tick(&mut self) -> (Option<Box<dyn HistoryCell>>, bool) {
-        let step = self.state.step();
-        (self.emit(step, false), self.state.is_idle())
+        let step = self.core.tick();
+        (self.emit(step, false), self.core.is_idle())
     }
 
-    /// Step animation: commit at most `max_lines` queued lines.
-    ///
-    /// This is intended for adaptive catch-up drains. Callers should keep `max_lines` bounded; a
-    /// very large value can collapse perceived animation into a single jump.
     pub(crate) fn on_commit_tick_batch(
         &mut self,
         max_lines: usize,
     ) -> (Option<Box<dyn HistoryCell>>, bool) {
-        let step = self.state.drain_n(max_lines.max(1));
-        (self.emit(step, false), self.state.is_idle())
+        let step = self.core.tick_batch(max_lines);
+        (self.emit(step, false), self.core.is_idle())
     }
 
-    /// Returns the current number of queued plan lines waiting to be displayed.
     pub(crate) fn queued_lines(&self) -> usize {
-        self.state.queued_len()
+        self.core.queued_lines()
     }
 
-    /// Returns the age of the oldest queued plan line.
     pub(crate) fn oldest_queued_age(&self, now: Instant) -> Option<Duration> {
-        self.state.oldest_queued_age(now)
+        self.core.oldest_queued_age(now)
+    }
+
+    pub(crate) fn set_width(&mut self, width: Option<usize>) {
+        self.core.set_width(width);
     }
 
     fn emit(
@@ -229,6 +430,202 @@ impl PlanStreamController {
     }
 }
 
+// ---------------------------------------------------------------------------
+// source_bytes_for_rendered_count — resize remapping helper
+// ---------------------------------------------------------------------------
+
+/// Find the largest newline-terminated prefix of `raw_source` whose
+/// rendering at `width` produces at most `target_count` lines.
+///
+/// When the target falls exactly on a source-line boundary, the returned
+/// offset covers that line. When it falls in the middle of a wrapped
+/// source line (partial drain), the offset stops at the *previous*
+/// newline to avoid overshooting — this may re-queue a few already-emitted
+/// wrapped lines as duplicates, but never drops un-emitted content.
+///
+/// For non-table content (the only case where `emitted_stable_len > 0`),
+/// rendering a newline-terminated prefix produces a prefix of the full
+/// rendering, so this converges correctly.
+fn source_bytes_for_rendered_count(
+    raw_source: &str,
+    width: Option<usize>,
+    target_count: usize,
+) -> usize {
+    if target_count == 0 {
+        return 0;
+    }
+    let mut best_offset = 0;
+    for (i, _) in raw_source.match_indices('\n') {
+        let prefix = &raw_source[..=i];
+        let mut lines = Vec::new();
+        crate::markdown::append_markdown_agent(prefix, width, &mut lines);
+        if lines.len() <= target_count {
+            best_offset = i + 1;
+        }
+        if lines.len() >= target_count {
+            break;
+        }
+    }
+    best_offset
+}
+
+// ---------------------------------------------------------------------------
+// Table holdback infrastructure
+// ---------------------------------------------------------------------------
+
+fn parse_fence_marker(line: &str) -> Option<(char, usize)> {
+    let mut chars = line.chars();
+    let first = chars.next()?;
+    if first != '`' && first != '~' {
+        return None;
+    }
+    let mut len = 1usize;
+    for ch in chars {
+        if ch == first {
+            len += 1;
+        } else {
+            break;
+        }
+    }
+    if len < 3 {
+        return None;
+    }
+    Some((first, len))
+}
+
+/// A source line annotated with whether it falls inside a fenced code block.
+struct ParsedLine<'a> {
+    text: &'a str,
+    fence_context: FenceContext,
+}
+
+/// Where a source line sits relative to fenced code blocks.
+///
+/// Table holdback only applies to lines that are `Outside` or inside a
+/// `Markdown` fence. Lines inside `Other` fences (e.g. `sh`, `rust`) are
+/// ignored by the table scanner because their pipe characters are code, not
+/// table syntax.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum FenceContext {
+    /// Not inside any fenced code block.
+    Outside,
+    /// Inside a `` ```md `` or `` ```markdown `` fence.
+    Markdown,
+    /// Inside a fence with a non-markdown info string.
+    Other,
+}
+
+fn is_markdown_fence(trimmed_line: &str, marker_len: usize) -> bool {
+    let info = trimmed_line[marker_len..]
+        .split_whitespace()
+        .next()
+        .unwrap_or_default();
+    info.eq_ignore_ascii_case("md") || info.eq_ignore_ascii_case("markdown")
+}
+
+fn parse_lines_with_fence_state(source: &str) -> Vec<ParsedLine<'_>> {
+    let mut in_fence = false;
+    let mut fence_char = '\0';
+    let mut fence_context = FenceContext::Other;
+    let mut lines = Vec::new();
+
+    for raw_line in source.split('\n') {
+        lines.push(ParsedLine {
+            text: raw_line,
+            fence_context: if in_fence {
+                fence_context
+            } else {
+                FenceContext::Outside
+            },
+        });
+
+        let trimmed = raw_line.trim_start();
+        if let Some((marker, len)) = parse_fence_marker(trimmed) {
+            if !in_fence {
+                in_fence = true;
+                fence_char = marker;
+                fence_context = if is_markdown_fence(trimmed, len) {
+                    FenceContext::Markdown
+                } else {
+                    FenceContext::Other
+                };
+            } else if marker == fence_char && len >= 3 {
+                in_fence = false;
+                fence_context = FenceContext::Other;
+            }
+        }
+    }
+
+    lines
+}
+
+fn strip_blockquote_prefix(line: &str) -> &str {
+    let mut rest = line.trim_start();
+    loop {
+        let Some(stripped) = rest.strip_prefix('>') else {
+            return rest;
+        };
+        rest = stripped.strip_prefix(' ').unwrap_or(stripped).trim_start();
+    }
+}
+
+fn table_candidate_text(line: &str) -> Option<&str> {
+    let stripped = strip_blockquote_prefix(line).trim();
+    parse_table_segments(stripped).map(|_| stripped)
+}
+
+/// Whether the accumulated raw source contains a markdown table that requires
+/// holdback of the mutable tail to prevent partial-table commits.
+enum TableHoldbackState {
+    /// No table detected -- all rendered lines can flow into the stable queue.
+    None,
+    /// The last non-blank line looks like a table header row but no delimiter
+    /// row has followed yet. Hold back in case the next delta is a delimiter.
+    PendingHeader,
+    /// A header + delimiter pair was found -- the source contains a confirmed
+    /// table. The entire rendered buffer is held as mutable tail.
+    Confirmed,
+}
+
+/// Scan `source` for pipe-table patterns (header row followed by delimiter row)
+/// outside of non-markdown fenced code blocks. Used by the stream controllers
+/// to decide the tail budget.
+fn table_holdback_state(source: &str) -> TableHoldbackState {
+    let lines = parse_lines_with_fence_state(source);
+    for pair in lines.windows(2) {
+        let [header_line, delimiter_line] = pair else {
+            continue;
+        };
+        if header_line.fence_context == FenceContext::Other
+            || delimiter_line.fence_context == FenceContext::Other
+        {
+            continue;
+        }
+
+        let Some(header_text) = table_candidate_text(header_line.text) else {
+            continue;
+        };
+        let Some(delimiter_text) = table_candidate_text(delimiter_line.text) else {
+            continue;
+        };
+
+        if is_table_header_line(header_text) && is_table_delimiter_line(delimiter_text) {
+            return TableHoldbackState::Confirmed;
+        }
+    }
+
+    let pending_header = lines.iter().rev().find(|line| !line.text.trim().is_empty());
+    let pending_header = pending_header.is_some_and(|line| {
+        line.fence_context != FenceContext::Other
+            && table_candidate_text(line.text).is_some_and(is_table_header_line)
+    });
+    if pending_header {
+        TableHoldbackState::PendingHeader
+    } else {
+        TableHoldbackState::None
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -246,12 +643,154 @@ mod tests {
             .collect()
     }
 
+    fn collect_streamed_lines(deltas: &[&str], width: Option<usize>) -> Vec<String> {
+        let mut ctrl = StreamController::new(width);
+        let mut lines = Vec::new();
+        for d in deltas {
+            ctrl.push(d);
+            while let (Some(cell), idle) = ctrl.on_commit_tick() {
+                lines.extend(cell.transcript_lines(u16::MAX));
+                if idle {
+                    break;
+                }
+            }
+        }
+        if let (Some(cell), _source) = ctrl.finalize() {
+            lines.extend(cell.transcript_lines(u16::MAX));
+        }
+        lines_to_plain_strings(&lines)
+            .into_iter()
+            .map(|s| s.chars().skip(2).collect::<String>())
+            .collect()
+    }
+
+    fn collect_plan_streamed_lines(deltas: &[&str], width: Option<usize>) -> Vec<String> {
+        let mut ctrl = PlanStreamController::new(width);
+        let mut lines = Vec::new();
+        for d in deltas {
+            ctrl.push(d);
+            while let (Some(cell), idle) = ctrl.on_commit_tick() {
+                lines.extend(cell.transcript_lines(u16::MAX));
+                if idle {
+                    break;
+                }
+            }
+        }
+        if let Some(cell) = ctrl.finalize() {
+            lines.extend(cell.transcript_lines(u16::MAX));
+        }
+        lines_to_plain_strings(&lines)
+    }
+
+    #[test]
+    fn controller_set_width_rebuilds_queued_lines() {
+        let mut ctrl = StreamController::new(Some(120));
+        let delta = "This is a long line that should wrap into multiple rows when resized.\n";
+        assert!(ctrl.push(delta));
+        assert_eq!(ctrl.queued_lines(), 1);
+
+        ctrl.set_width(Some(24));
+        let (cell, idle) = ctrl.on_commit_tick_batch(usize::MAX);
+        let rendered = lines_to_plain_strings(
+            &cell
+                .expect("expected resized queued lines")
+                .transcript_lines(u16::MAX),
+        );
+
+        assert!(idle);
+        assert!(
+            rendered.len() > 1,
+            "expected resized content to occupy multiple lines, got {rendered:?}",
+        );
+    }
+
+    #[test]
+    fn controller_set_width_no_duplicate_after_emit() {
+        let mut ctrl = StreamController::new(Some(120));
+        let line =
+            "This is a long line that definitely wraps when the terminal shrinks to 24 columns.\n";
+        ctrl.push(line);
+        let (cell, _) = ctrl.on_commit_tick_batch(usize::MAX);
+        assert!(cell.is_some(), "expected emitted cell");
+        assert_eq!(ctrl.queued_lines(), 0);
+
+        ctrl.set_width(Some(24));
+
+        assert_eq!(
+            ctrl.queued_lines(),
+            0,
+            "already-emitted content must not be re-queued after resize",
+        );
+    }
+
+    #[test]
+    fn controller_set_width_partial_drain_no_lost_lines() {
+        let mut ctrl = StreamController::new(Some(40));
+        ctrl.push("AAAA BBBB CCCC DDDD EEEE FFFF GGGG HHHH IIII JJJJ\n");
+        ctrl.push("second line\n");
+
+        let (cell, idle) = ctrl.on_commit_tick();
+        assert!(cell.is_some(), "expected 1 emitted line");
+        assert!(!idle, "queue should still have lines");
+        let remaining_before = ctrl.queued_lines();
+        assert!(remaining_before > 0, "should have queued lines left");
+
+        ctrl.set_width(Some(20));
+
+        let (cell, source) = ctrl.finalize();
+        let final_lines = cell
+            .map(|c| lines_to_plain_strings(&c.transcript_lines(u16::MAX)))
+            .unwrap_or_default();
+
+        assert!(
+            final_lines.iter().any(|l| l.contains("second line")),
+            "un-emitted 'second line' was lost after resize; got: {final_lines:?}",
+        );
+        assert!(source.is_some(), "expected source from finalize");
+    }
+
+    #[test]
+    fn controller_set_width_preserves_in_flight_tail() {
+        let mut ctrl = StreamController::new(Some(80));
+        ctrl.push("tail without newline");
+        ctrl.set_width(Some(24));
+
+        let (cell, _source) = ctrl.finalize();
+        let rendered = lines_to_plain_strings(
+            &cell
+                .expect("expected finalized tail")
+                .transcript_lines(u16::MAX),
+        );
+
+        assert_eq!(rendered, vec!["• tail without newline".to_string()]);
+    }
+
+    #[test]
+    fn plan_controller_set_width_preserves_in_flight_tail() {
+        let mut ctrl = PlanStreamController::new(Some(80));
+        ctrl.push("1. Item without newline");
+        ctrl.set_width(Some(24));
+
+        let rendered = lines_to_plain_strings(
+            &ctrl
+                .finalize()
+                .expect("expected finalized tail")
+                .transcript_lines(u16::MAX),
+        );
+
+        assert!(
+            rendered
+                .iter()
+                .any(|line| line.contains("Item without newline")),
+            "expected finalized plan content after resize, got {rendered:?}",
+        );
+    }
+
     #[tokio::test]
     async fn controller_loose_vs_tight_with_commit_ticks_matches_full() {
         let mut ctrl = StreamController::new(None);
         let mut lines = Vec::new();
 
-        // Exact deltas from the session log (section: Loose vs. tight list items)
         let deltas = vec![
             "\n\n",
             "Loose",
@@ -322,7 +861,6 @@ mod tests {
             "\n\n",
         ];
 
-        // Simulate streaming with a commit tick attempt after each delta.
         for d in deltas.iter() {
             ctrl.push(d);
             while let (Some(cell), idle) = ctrl.on_commit_tick() {
@@ -332,26 +870,22 @@ mod tests {
                 }
             }
         }
-        // Finalize and flush remaining lines now.
-        if let Some(cell) = ctrl.finalize() {
+        if let (Some(cell), _source) = ctrl.finalize() {
             lines.extend(cell.transcript_lines(u16::MAX));
         }
 
         let streamed: Vec<_> = lines_to_plain_strings(&lines)
             .into_iter()
-            // skip • and 2-space indentation
             .map(|s| s.chars().skip(2).collect::<String>())
             .collect();
 
-        // Full render of the same source
         let source: String = deltas.iter().copied().collect();
         let mut rendered: Vec<ratatui::text::Line<'static>> = Vec::new();
-        crate::markdown::append_markdown(&source, None, &mut rendered);
+        crate::markdown::append_markdown_agent(&source, None, &mut rendered);
         let rendered_strs = lines_to_plain_strings(&rendered);
 
         assert_eq!(streamed, rendered_strs);
 
-        // Also assert exact expected plain strings for clarity.
         let expected = vec![
             "Loose vs. tight list items:".to_string(),
             "".to_string(),
@@ -367,6 +901,436 @@ mod tests {
         assert_eq!(
             streamed, expected,
             "expected exact rendered lines for loose/tight section"
+        );
+    }
+
+    #[tokio::test]
+    async fn controller_streamed_table_matches_full_render_widths() {
+        let deltas = vec![
+            "| Key | Description |\n",
+            "| --- | --- |\n",
+            "| -v | Enable very verbose logging output for debugging |\n",
+            "\n",
+        ];
+
+        let streamed = collect_streamed_lines(&deltas, Some(80));
+
+        let source: String = deltas.iter().copied().collect();
+        let mut rendered = Vec::new();
+        crate::markdown::append_markdown_agent(&source, Some(80), &mut rendered);
+        let expected = lines_to_plain_strings(&rendered);
+
+        assert_eq!(streamed, expected);
+    }
+
+    #[tokio::test]
+    async fn controller_holds_blockquoted_table_tail_until_stable() {
+        let deltas = vec![
+            "> | A | B |\n",
+            "> | --- | --- |\n",
+            "> | longvalue | ok |\n",
+            "\n",
+        ];
+
+        let streamed = collect_streamed_lines(&deltas, Some(80));
+
+        let source: String = deltas.iter().copied().collect();
+        let mut rendered = Vec::new();
+        crate::markdown::append_markdown_agent(&source, Some(80), &mut rendered);
+        let expected = lines_to_plain_strings(&rendered);
+
+        assert_eq!(streamed, expected);
+    }
+
+    #[tokio::test]
+    async fn controller_does_not_hold_back_pipe_prose_without_table_delimiter() {
+        let mut ctrl = StreamController::new(Some(80));
+
+        ctrl.push("status | owner | note\n");
+        let (_first_commit, first_idle) = ctrl.on_commit_tick();
+        assert!(first_idle);
+
+        ctrl.push("next line\n");
+        let (second_commit, _second_idle) = ctrl.on_commit_tick();
+        assert!(
+            second_commit.is_some(),
+            "expected prose lines to be released once no table delimiter follows"
+        );
+    }
+
+    #[tokio::test]
+    async fn controller_handles_table_immediately_after_heading() {
+        let deltas = vec![
+            "### 1) Basic table\n",
+            "| Name | Role | Status |\n",
+            "|---|---|---|\n",
+            "| Alice | Admin | Active |\n",
+            "| Bob | Editor | Pending |\n",
+            "\n",
+        ];
+
+        let streamed = collect_streamed_lines(&deltas, Some(100));
+
+        let source: String = deltas.iter().copied().collect();
+        let mut rendered = Vec::new();
+        crate::markdown::append_markdown_agent(&source, Some(100), &mut rendered);
+        let expected = lines_to_plain_strings(&rendered);
+
+        assert_eq!(streamed, expected);
+    }
+
+    #[tokio::test]
+    async fn controller_renders_unicode_for_multi_table_response_shape() {
+        let source = "Absolutely. Here are several different Markdown table patterns you can use for rendering tests.\n\n| Name  | Role      |
+  Location |\n|-------|-----------|----------|\n| Ava   | Engineer  | NYC      |\n| Malik | Designer  | Berlin   |\n| Priya | PM        | Remote
+  |\n\n| Item        | Qty | Price | In Stock |\n|:------------|----:|------:|:--------:|\n| Keyboard    |   2 | 49.99 |    Yes   |\n| Mouse       |  10
+   | 19.50 |    Yes   |\n| Monitor     |   1 | 219.0 |    No    |\n\n| Field         | Example                         | Notes
+  |\n|---------------|----------------------------------|--------------------------|\n| Escaped pipe  | `foo \\| bar`                    | Should stay
+  in one cell  |\n| Inline code   | `let x = value;`                | Monospace inline content |\n| Link          | [OpenAI](https://openai.com)    |
+  Standard markdown link   |\n";
+
+        let chunked = source
+            .split_inclusive('\n')
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        let deltas = chunked.iter().map(String::as_str).collect::<Vec<_>>();
+        let streamed = collect_streamed_lines(&deltas, Some(120));
+        assert!(
+            streamed.iter().any(|line| line.contains('┌')),
+            "expected unicode table border in streamed output: {streamed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn controller_renders_unicode_for_no_outer_pipes_table_shape() {
+        let source = "### 1) Basic\n\n| Name | Role | Active |\n|---|---|---|\n| Alice | Engineer | Yes |\n| Bob | Designer | No |\n\n### 2) No outer
+  pipes\n\nCol A | Col B | Col C\n--- | --- | ---\nx | y | z\n10 | 20 | 30\n\n### 3) Another table\n\n| Key | Value |\n|---|---|\n| a | b |\n";
+
+        let chunked = source
+            .split_inclusive('\n')
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        let deltas = chunked.iter().map(String::as_str).collect::<Vec<_>>();
+        let streamed = collect_streamed_lines(&deltas, Some(100));
+
+        let mut rendered = Vec::new();
+        crate::markdown::append_markdown_agent(source, Some(100), &mut rendered);
+        let expected = lines_to_plain_strings(&rendered);
+
+        assert_eq!(streamed, expected);
+        let has_raw_no_outer_header = streamed
+            .iter()
+            .any(|line| line.trim() == "Col A | Col B | Col C");
+        assert!(
+            !has_raw_no_outer_header,
+            "no-outer-pipes header should not remain raw in final streamed output: {streamed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn controller_stabilizes_first_no_outer_pipes_table_in_response() {
+        let deltas = vec![
+            "### No outer pipes first\n\n",
+            "Col A | Col B | Col C\n",
+            "--- | --- | ---\n",
+            "x | y | z\n",
+            "10 | 20 | 30\n",
+            "\n",
+            "After table paragraph.\n",
+        ];
+        let streamed = collect_streamed_lines(&deltas, Some(100));
+
+        let source: String = deltas.iter().copied().collect();
+        let mut rendered = Vec::new();
+        crate::markdown::append_markdown_agent(&source, Some(100), &mut rendered);
+        let expected = lines_to_plain_strings(&rendered);
+
+        assert_eq!(streamed, expected);
+        assert!(
+            streamed.iter().any(|line| line.contains('┌')),
+            "expected unicode table border for no-outer-pipes streaming: {streamed:?}"
+        );
+        assert!(
+            !streamed
+                .iter()
+                .any(|line| line.trim() == "Col A | Col B | Col C"),
+            "did not expect raw no-outer-pipes header in final streamed output: {streamed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn controller_stabilizes_two_column_no_outer_table_in_response() {
+        let deltas = vec![
+            "A | B\n",
+            "--- | ---\n",
+            "left | right\n",
+            "\n",
+            "After table paragraph.\n",
+        ];
+        let streamed = collect_streamed_lines(&deltas, Some(80));
+
+        let source: String = deltas.iter().copied().collect();
+        let mut rendered = Vec::new();
+        crate::markdown::append_markdown_agent(&source, Some(80), &mut rendered);
+        let expected = lines_to_plain_strings(&rendered);
+
+        assert_eq!(streamed, expected);
+        assert!(
+            streamed.iter().any(|line| line.contains('┌')),
+            "expected unicode table border for two-column no-outer table: {streamed:?}"
+        );
+        assert!(
+            !streamed.iter().any(|line| line.trim() == "A | B"),
+            "did not expect raw two-column no-outer header in final streamed output: {streamed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn controller_converts_no_outer_table_between_preboxed_sections() {
+        let source = "  ┌───────┬──────────┬────────┐\n  │ Name  │ Role     │ Active │\n  ├───────┼──────────┼────────┤\n  │ Alice │ Engineer │ Yes    │\n  │ Bob   │ Designer │ No     │\n  │ Cara  │ PM       │ Yes    │\n  └───────┴──────────┴────────┘\n\n  ### 3) No outer pipes\n\n  Col A | Col B | Col C\n  --- | --- | ---\n  x | y | z\n  10 | 20 | 30\n\n  ┌─────────────────┬────────┬────────────────────────┐\n  │ Example         │ Output │ Notes                  │\n  ├─────────────────┼────────┼────────────────────────┤\n  │ a | b           │ `a     │ b`                     │\n  │ npm run test    │ ok     │ Inline code formatting │\n  │ SELECT * FROM t │ 3 rows │ SQL snippet            │\n  └─────────────────┴────────┴────────────────────────┘\n";
+
+        let deltas = source
+            .split_inclusive('\n')
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        let streamed = collect_streamed_lines(
+            &deltas.iter().map(String::as_str).collect::<Vec<_>>(),
+            Some(100),
+        );
+
+        let has_raw_no_outer_header = streamed
+            .iter()
+            .any(|line| line.trim() == "Col A | Col B | Col C");
+        assert!(
+            !has_raw_no_outer_header,
+            "no-outer table header remained raw in streamed output: {streamed:?}"
+        );
+        assert!(
+            streamed
+                .iter()
+                .any(|line| line.contains("┌───────┬───────┬───────┐")),
+            "expected converted no-outer table border in streamed output: {streamed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn controller_keeps_markdown_fenced_tables_mutable_until_finalize() {
+        let source = "```md\n| A | B |\n|---|---|\n| 1 | 2 |\n```\n";
+        let deltas = vec![
+            "```md\n",
+            "| A | B |\n",
+            "|---|---|\n",
+            "| 1 | 2 |\n",
+            "```\n",
+        ];
+        let streamed = collect_streamed_lines(&deltas, Some(80));
+
+        let mut rendered = Vec::new();
+        crate::markdown::append_markdown_agent(source, Some(80), &mut rendered);
+        let expected = lines_to_plain_strings(&rendered);
+
+        assert_eq!(streamed, expected);
+        assert!(
+            streamed.iter().any(|line| line.contains('┌')),
+            "expected unicode table border in streamed output: {streamed:?}"
+        );
+        assert!(
+            !streamed.iter().any(|line| line.trim() == "| A | B |"),
+            "did not expect raw table header line after finalize: {streamed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn controller_keeps_markdown_fenced_no_outer_tables_mutable_until_finalize() {
+        let source =
+            "```md\nCol A | Col B | Col C\n--- | --- | ---\nx | y | z\n10 | 20 | 30\n```\n";
+        let deltas = vec![
+            "```md\n",
+            "Col A | Col B | Col C\n",
+            "--- | --- | ---\n",
+            "x | y | z\n",
+            "10 | 20 | 30\n",
+            "```\n",
+        ];
+        let streamed = collect_streamed_lines(&deltas, Some(100));
+
+        let mut rendered = Vec::new();
+        crate::markdown::append_markdown_agent(source, Some(100), &mut rendered);
+        let expected = lines_to_plain_strings(&rendered);
+
+        assert_eq!(streamed, expected);
+        assert!(
+            streamed.iter().any(|line| line.contains('┌')),
+            "expected unicode table border in streamed output: {streamed:?}"
+        );
+        assert!(
+            !streamed
+                .iter()
+                .any(|line| line.trim() == "Col A | Col B | Col C"),
+            "did not expect raw no-outer-pipes header line after finalize: {streamed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn controller_keeps_non_markdown_fenced_tables_as_code() {
+        let source = "```sh\n| A | B |\n|---|---|\n| 1 | 2 |\n```\n";
+        let deltas = vec![
+            "```sh\n",
+            "| A | B |\n",
+            "|---|---|\n",
+            "| 1 | 2 |\n",
+            "```\n",
+        ];
+        let streamed = collect_streamed_lines(&deltas, Some(80));
+
+        let mut rendered = Vec::new();
+        crate::markdown::append_markdown_agent(source, Some(80), &mut rendered);
+        let expected = lines_to_plain_strings(&rendered);
+
+        assert_eq!(streamed, expected);
+        assert!(
+            streamed.iter().any(|line| line.trim() == "| A | B |"),
+            "expected code-fenced pipe line to remain raw: {streamed:?}"
+        );
+        assert!(
+            !streamed.iter().any(|line| line.contains('┌')),
+            "did not expect unicode table border for non-markdown fence: {streamed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn plan_controller_streamed_table_matches_finalize_render() {
+        let deltas = vec![
+            "## Build plan\n\n",
+            "| Step | Owner |\n",
+            "|---|---|\n",
+            "| Write tests | Agent |\n",
+            "| Verify output | User |\n",
+            "\n",
+        ];
+        let streamed = collect_plan_streamed_lines(&deltas, Some(80));
+
+        let source: String = deltas.iter().copied().collect();
+        let baseline = collect_plan_streamed_lines(&[source.as_str()], Some(80));
+
+        assert_eq!(streamed, baseline);
+        assert!(
+            streamed.iter().any(|line| line.contains('┌')),
+            "expected unicode table border in plan streamed output: {streamed:?}"
+        );
+        assert!(
+            !streamed
+                .iter()
+                .any(|line| line.trim() == "| Step | Owner |"),
+            "did not expect raw table header line in plan output: {streamed:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn plan_controller_streamed_markdown_fenced_table_matches_finalize_render() {
+        let deltas = vec![
+            "## Build plan\n\n",
+            "```md\n",
+            "| Step | Owner |\n",
+            "|---|---|\n",
+            "| Write tests | Agent |\n",
+            "| Verify output | User |\n",
+            "```\n",
+            "\n",
+        ];
+        let streamed = collect_plan_streamed_lines(&deltas, Some(80));
+
+        let source: String = deltas.iter().copied().collect();
+        let baseline = collect_plan_streamed_lines(&[source.as_str()], Some(80));
+
+        assert_eq!(streamed, baseline);
+        assert!(
+            streamed.iter().any(|line| line.contains('┌')),
+            "expected unicode table border in fenced plan output: {streamed:?}"
+        );
+    }
+
+    #[test]
+    fn table_holdback_state_detects_header_plus_delimiter() {
+        let source = "| Key | Description |\n| --- | --- |\n";
+        assert!(matches!(
+            table_holdback_state(source),
+            TableHoldbackState::Confirmed
+        ));
+    }
+
+    // -----------------------------------------------------------------------
+    // source_bytes_for_rendered_count — prefix-stability tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn source_bytes_plain_paragraphs() {
+        let src = "Alpha\n\nBravo\n\nCharlie\n";
+        let width = Some(80);
+
+        let mut full = Vec::new();
+        crate::markdown::append_markdown_agent(src, width, &mut full);
+        let total = full.len();
+        assert!(
+            total >= 3,
+            "expected at least 3 rendered lines, got {total}"
+        );
+
+        assert_eq!(source_bytes_for_rendered_count(src, width, 0), 0);
+        assert_eq!(
+            source_bytes_for_rendered_count(src, width, total),
+            src.len()
+        );
+
+        let off = source_bytes_for_rendered_count(src, width, 1);
+        assert!(off > 0 && off <= src.len());
+        let mut partial = Vec::new();
+        crate::markdown::append_markdown_agent(&src[..off], width, &mut partial);
+        assert!(
+            partial.len() <= 1,
+            "expected <=1 line, got {}",
+            partial.len()
+        );
+    }
+
+    #[test]
+    fn source_bytes_wrapped_lines() {
+        let src = "The quick brown fox jumps over the lazy dog near the riverbank.\n";
+        let width = Some(20);
+
+        let mut full = Vec::new();
+        crate::markdown::append_markdown_agent(src, width, &mut full);
+        let total = full.len();
+        assert!(
+            total > 1,
+            "expected wrapping at width 20, got {total} lines"
+        );
+
+        let off = source_bytes_for_rendered_count(src, width, 1);
+        assert_eq!(off, 0, "single wrapped source line should not be split");
+    }
+
+    #[test]
+    fn source_bytes_list_items() {
+        let src = "- First item\n- Second item\n- Third item\n";
+        let width = Some(80);
+
+        let mut full = Vec::new();
+        crate::markdown::append_markdown_agent(src, width, &mut full);
+        let total = full.len();
+        assert!(
+            total >= 3,
+            "expected at least 3 rendered lines, got {total}"
+        );
+
+        let off = source_bytes_for_rendered_count(src, width, 2);
+        assert!(off > 0);
+        let mut partial = Vec::new();
+        crate::markdown::append_markdown_agent(&src[..off], width, &mut partial);
+        assert!(
+            partial.len() <= 2,
+            "expected <=2 lines from prefix, got {}",
+            partial.len()
         );
     }
 }

--- a/codex-rs/tui/src/streaming/controller.rs
+++ b/codex-rs/tui/src/streaming/controller.rs
@@ -505,6 +505,7 @@ fn source_bytes_for_rendered_count(
 // Table holdback infrastructure
 // ---------------------------------------------------------------------------
 
+/// Return fence marker character and run length for a potential fence line.
 fn parse_fence_marker(line: &str) -> Option<(char, usize)> {
     let mut chars = line.chars();
     let first = chars.next()?;
@@ -555,6 +556,11 @@ fn is_markdown_fence(trimmed_line: &str, marker_len: usize) -> bool {
     info.eq_ignore_ascii_case("md") || info.eq_ignore_ascii_case("markdown")
 }
 
+/// Parse source into lines tagged with fenced-code context for table scanning.
+///
+/// Fence close markers must use the same marker character and at least the
+/// opening marker length, with no trailing content. This avoids accidentally
+/// closing on shorter markers that appear inside longer fences.
 fn parse_lines_with_fence_state(source: &str) -> Vec<ParsedLine<'_>> {
     let mut in_fence = false;
     let mut fence_char = '\0';

--- a/codex-rs/tui/src/streaming/mod.rs
+++ b/codex-rs/tui/src/streaming/mod.rs
@@ -66,12 +66,9 @@ impl StreamState {
             .map(|queued| queued.line)
             .collect()
     }
-    /// Drains all queued lines from the front of the queue.
-    pub(crate) fn drain_all(&mut self) -> Vec<Line<'static>> {
-        self.queued_lines
-            .drain(..)
-            .map(|queued| queued.line)
-            .collect()
+    /// Clears queued lines while keeping collector/turn lifecycle state intact.
+    pub(crate) fn clear_queue(&mut self) {
+        self.queued_lines.clear();
     }
     /// Returns whether no lines are queued for commit.
     pub(crate) fn is_idle(&self) -> bool {

--- a/codex-rs/tui/src/table_detect.rs
+++ b/codex-rs/tui/src/table_detect.rs
@@ -1,9 +1,23 @@
-//! Shared pipe-table detection helpers.
+//! Canonical pipe-table structure detection for raw markdown source.
 //!
 //! Both the streaming controller (`streaming/controller.rs`) and the
 //! markdown-fence unwrapper (`markdown.rs`) need to identify pipe-table
-//! structure in raw markdown source. This module provides the canonical
+//! structure in raw markdown source.  This module provides the canonical
 //! implementations so fixes only need to happen in one place.
+//!
+//! ## Concepts
+//!
+//! A GFM pipe table is a sequence of lines where:
+//! - A **header line** contains pipe-separated segments with at least one
+//!   non-empty cell.
+//! - A **delimiter line** immediately follows the header and contains only
+//!   alignment markers (`---`, `:---`, `---:`, `:---:`), each with at least
+//!   three dashes.
+//! - **Body rows** follow the delimiter.
+//!
+//! The functions here operate on single lines and do not maintain cross-line
+//! state.  Callers (the streaming controller and fence unwrapper) are
+//! responsible for pairing consecutive lines to confirm a table.
 
 /// Split a pipe-delimited line into trimmed segments.
 ///

--- a/codex-rs/tui/src/table_detect.rs
+++ b/codex-rs/tui/src/table_detect.rs
@@ -1,0 +1,139 @@
+//! Shared pipe-table detection helpers.
+//!
+//! Both the streaming controller (`streaming/controller.rs`) and the
+//! markdown-fence unwrapper (`markdown.rs`) need to identify pipe-table
+//! structure in raw markdown source. This module provides the canonical
+//! implementations so fixes only need to happen in one place.
+
+/// Split a pipe-delimited line into trimmed segments.
+///
+/// Returns `None` if the line is empty or has fewer than two segments.
+/// Leading/trailing pipes are stripped before splitting.
+pub(crate) fn parse_table_segments(line: &str) -> Option<Vec<&str>> {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    let mut content = trimmed;
+    if let Some(without_leading) = content.strip_prefix('|') {
+        content = without_leading;
+    }
+    if let Some(without_trailing) = content.strip_suffix('|') {
+        content = without_trailing;
+    }
+
+    let segments: Vec<&str> = content.split('|').map(str::trim).collect();
+    (segments.len() >= 2).then_some(segments)
+}
+
+/// Whether `line` looks like a table header row (has pipe-separated
+/// segments with at least one non-empty cell).
+pub(crate) fn is_table_header_line(line: &str) -> bool {
+    parse_table_segments(line).is_some_and(|segments| segments.iter().any(|s| !s.is_empty()))
+}
+
+/// Whether a single segment matches the `---`, `:---`, `---:`, or `:---:`
+/// alignment-colon syntax used in markdown table delimiter rows.
+pub(crate) fn is_table_delimiter_segment(segment: &str) -> bool {
+    let trimmed = segment.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    let without_leading = trimmed.strip_prefix(':').unwrap_or(trimmed);
+    let without_ends = without_leading.strip_suffix(':').unwrap_or(without_leading);
+    without_ends.len() >= 3 && without_ends.chars().all(|c| c == '-')
+}
+
+/// Whether `line` is a valid table delimiter row (every segment passes
+/// [`is_table_delimiter_segment`]).
+pub(crate) fn is_table_delimiter_line(line: &str) -> bool {
+    parse_table_segments(line)
+        .is_some_and(|segments| segments.into_iter().all(is_table_delimiter_segment))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_table_segments_basic() {
+        assert_eq!(
+            parse_table_segments("| A | B | C |"),
+            Some(vec!["A", "B", "C"])
+        );
+    }
+
+    #[test]
+    fn parse_table_segments_no_outer_pipes() {
+        assert_eq!(parse_table_segments("A | B | C"), Some(vec!["A", "B", "C"]));
+    }
+
+    #[test]
+    fn parse_table_segments_no_leading_pipe() {
+        assert_eq!(
+            parse_table_segments("A | B | C |"),
+            Some(vec!["A", "B", "C"])
+        );
+    }
+
+    #[test]
+    fn parse_table_segments_no_trailing_pipe() {
+        assert_eq!(
+            parse_table_segments("| A | B | C"),
+            Some(vec!["A", "B", "C"])
+        );
+    }
+
+    #[test]
+    fn parse_table_segments_single_segment_returns_none() {
+        assert_eq!(parse_table_segments("| only |"), None);
+    }
+
+    #[test]
+    fn parse_table_segments_empty_returns_none() {
+        assert_eq!(parse_table_segments(""), None);
+        assert_eq!(parse_table_segments("   "), None);
+    }
+
+    #[test]
+    fn is_table_delimiter_segment_valid() {
+        assert!(is_table_delimiter_segment("---"));
+        assert!(is_table_delimiter_segment(":---"));
+        assert!(is_table_delimiter_segment("---:"));
+        assert!(is_table_delimiter_segment(":---:"));
+        assert!(is_table_delimiter_segment(":-------:"));
+    }
+
+    #[test]
+    fn is_table_delimiter_segment_invalid() {
+        assert!(!is_table_delimiter_segment(""));
+        assert!(!is_table_delimiter_segment("--"));
+        assert!(!is_table_delimiter_segment("abc"));
+        assert!(!is_table_delimiter_segment(":--"));
+    }
+
+    #[test]
+    fn is_table_delimiter_line_valid() {
+        assert!(is_table_delimiter_line("| --- | --- |"));
+        assert!(is_table_delimiter_line("|:---:|---:|"));
+        assert!(is_table_delimiter_line("--- | --- | ---"));
+    }
+
+    #[test]
+    fn is_table_delimiter_line_invalid() {
+        assert!(!is_table_delimiter_line("| A | B |"));
+        assert!(!is_table_delimiter_line("| -- | -- |"));
+    }
+
+    #[test]
+    fn is_table_header_line_valid() {
+        assert!(is_table_header_line("| A | B |"));
+        assert!(is_table_header_line("Name | Value"));
+    }
+
+    #[test]
+    fn is_table_header_line_all_empty_segments() {
+        assert!(!is_table_header_line("| | |"));
+    }
+}

--- a/codex-rs/tui/src/table_detect.rs
+++ b/codex-rs/tui/src/table_detect.rs
@@ -7,11 +7,11 @@
 
 /// Split a pipe-delimited line into trimmed segments.
 ///
-/// Returns `None` if the line is empty or has fewer than two segments.
+/// Returns `None` if the line is empty or has no `|` marker.
 /// Leading/trailing pipes are stripped before splitting.
 pub(crate) fn parse_table_segments(line: &str) -> Option<Vec<&str>> {
     let trimmed = line.trim();
-    if trimmed.is_empty() {
+    if trimmed.is_empty() || !trimmed.contains('|') {
         return None;
     }
 
@@ -24,7 +24,7 @@ pub(crate) fn parse_table_segments(line: &str) -> Option<Vec<&str>> {
     }
 
     let segments: Vec<&str> = content.split('|').map(str::trim).collect();
-    (segments.len() >= 2).then_some(segments)
+    (!segments.is_empty()).then_some(segments)
 }
 
 /// Whether `line` looks like a table header row (has pipe-separated
@@ -86,8 +86,13 @@ mod tests {
     }
 
     #[test]
-    fn parse_table_segments_single_segment_returns_none() {
-        assert_eq!(parse_table_segments("| only |"), None);
+    fn parse_table_segments_single_segment_is_allowed() {
+        assert_eq!(parse_table_segments("| only |"), Some(vec!["only"]));
+    }
+
+    #[test]
+    fn parse_table_segments_without_pipe_returns_none() {
+        assert_eq!(parse_table_segments("just text"), None);
     }
 
     #[test]

--- a/codex-rs/tui/src/tui.rs
+++ b/codex-rs/tui/src/tui.rs
@@ -445,6 +445,11 @@ impl Tui {
         self.frame_requester().schedule_frame();
     }
 
+    /// Drop any queued history lines that have not yet been flushed to the terminal.
+    pub fn clear_pending_history_lines(&mut self) {
+        self.pending_history_lines.clear();
+    }
+
     pub fn draw(
         &mut self,
         height: u16,

--- a/codex-rs/tui/src/width.rs
+++ b/codex-rs/tui/src/width.rs
@@ -1,8 +1,15 @@
-//! Shared width guards for transcript rendering.
+//! Width guards for transcript rendering with fixed prefix columns.
 //!
-//! Callers use these helpers when they reserve fixed prefix columns (for
-//! bullets, gutters, or labels) and need to know whether any content width
-//! remains.
+//! Several rendering paths reserve a fixed number of columns for bullets,
+//! gutters, or labels before laying out content.  When the terminal is very
+//! narrow, those reserved columns can consume the entire width, leaving zero
+//! or negative space for content.
+//!
+//! These helpers centralise the subtraction and enforce a strict-positive
+//! contract: they return `Some(n)` where `n > 0`, or `None` when no usable
+//! content width remains.  Callers treat `None` as "render prefix-only
+//! fallback" rather than attempting wrapped rendering at zero width, which
+//! would produce empty or unstable output.
 
 /// Returns usable content width after reserving fixed columns.
 ///

--- a/codex-rs/tui/src/width.rs
+++ b/codex-rs/tui/src/width.rs
@@ -1,7 +1,17 @@
+//! Shared width guards for transcript rendering.
+//!
+//! Callers use these helpers when they reserve fixed prefix columns (for
+//! bullets, gutters, or labels) and need to know whether any content width
+//! remains.
+
 /// Returns usable content width after reserving fixed columns.
 ///
 /// Guarantees a strict positive width (`Some(n)` where `n > 0`) or `None` when
 /// the reserved columns consume the full width.
+///
+/// Treat `None` as "render prefix-only fallback". Coercing it to `0` and still
+/// attempting wrapped rendering often produces empty or unstable output at very
+/// narrow terminal widths.
 pub(crate) fn usable_content_width(total_width: usize, reserved_cols: usize) -> Option<usize> {
     total_width
         .checked_sub(reserved_cols)
@@ -9,6 +19,9 @@ pub(crate) fn usable_content_width(total_width: usize, reserved_cols: usize) -> 
 }
 
 /// `u16` convenience wrapper around [`usable_content_width`].
+///
+/// This keeps width math at callsites that receive terminal dimensions as
+/// `u16` while preserving the same `None` contract for exhausted width.
 pub(crate) fn usable_content_width_u16(total_width: u16, reserved_cols: u16) -> Option<usize> {
     usable_content_width(usize::from(total_width), usize::from(reserved_cols))
 }

--- a/codex-rs/tui/src/width.rs
+++ b/codex-rs/tui/src/width.rs
@@ -1,0 +1,34 @@
+/// Returns usable content width after reserving fixed columns.
+///
+/// Guarantees a strict positive width (`Some(n)` where `n > 0`) or `None` when
+/// the reserved columns consume the full width.
+pub(crate) fn usable_content_width(total_width: usize, reserved_cols: usize) -> Option<usize> {
+    total_width
+        .checked_sub(reserved_cols)
+        .filter(|remaining| *remaining > 0)
+}
+
+/// `u16` convenience wrapper around [`usable_content_width`].
+pub(crate) fn usable_content_width_u16(total_width: u16, reserved_cols: u16) -> Option<usize> {
+    usable_content_width(usize::from(total_width), usize::from(reserved_cols))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn usable_content_width_returns_none_when_reserved_exhausts_width() {
+        assert_eq!(usable_content_width(0, 0), None);
+        assert_eq!(usable_content_width(2, 2), None);
+        assert_eq!(usable_content_width(3, 4), None);
+        assert_eq!(usable_content_width(5, 4), Some(1));
+    }
+
+    #[test]
+    fn usable_content_width_u16_matches_usize_variant() {
+        assert_eq!(usable_content_width_u16(2, 2), None);
+        assert_eq!(usable_content_width_u16(5, 4), Some(1));
+    }
+}


### PR DESCRIPTION
## Problem

Agent responses containing Markdown tables render as raw pipe-delimited text in the TUI transcript. Tables are one of the most common structured output formats from LLMs, and rendering them as `| A | B |` lines wastes horizontal space, obscures alignment, and makes multi-column data hard to scan - especially when columns contain prose or mixed-width content.

**Before** - raw pipe-delimited table on `main`:

<img width="1552" height="1012" alt="image" src="https://github.com/user-attachments/assets/ef36827d-971c-43b5-86e8-950f853154b4" />

**After** - Unicode box table that adapts to terminal width:

| Wide terminal | Narrow terminal |
|---|---|
|  <img width="1552" height="1012" alt="image" src="https://github.com/user-attachments/assets/0a49311a-35e6-4c95-aa44-2cb8db2bd79b" />  |  <img width="1552" height="1012" alt="image" src="https://github.com/user-attachments/assets/6e17cc9f-37b2-41ac-bd90-4e33db56d89b" /> |

And a demonstration of the table rendering flow:

https://github.com/user-attachments/assets/f0f153e3-0f05-4dc1-b941-9f49773ff46f

A second, subtler problem: agents frequently wrap tables in ` ```markdown ` fences (treating them as code), which causes `pulldown-cmark` to parse the table as a fenced code block rather than a native table. Both problems need solving together.

**Side benefit:** The resize reflow infrastructure built for table width adaptation also fixes terminal resize for all markdown content. On `main`, widening the terminal wastes space and narrowing it causes visual corruption (see [Resize handling](#resize-handling-new-in-this-pr) for screenshots and details).

## Mental model

The change introduces a **two-region streaming model with table-aware holdback**:

1. **Stable region** - rendered lines committed to scrollback via a commit-animation queue. Once emitted, these lines are immutable.
2. **Tail region** - mutable rendered lines displayed in the active-cell slot. When a table is detected in the accumulated source, content from the table header onward is held as tail because adding a single row can reshape every column width. Pre-table prose flows to stable normally.

The holdback decision is the core architectural choice: rather than trying to incrementally patch table renders, the system re-renders the entire accumulated markdown source on every committed delta and decides per-delta whether lines flow to stable or stay as mutable tail.

**How lines are allocated between regions:**

- **No table** (`None`): lines progressively flow from tail to stable as new deltas arrive. Only the most recent not-yet-committed lines stay in tail.
- **Table confirmed** (`Confirmed { table_start }`): content from the table header onward is held as tail until the stream ends, because a single new row can reshape every column width. Pre-table prose continues flowing to stable.
- **Pending header** (`PendingHeader { header_start }`): transitional — a header row was seen but not yet confirmed by a delimiter row. Content from the speculative header onward is kept mutable.

The holdback decision is maintained by an **incremental scanner** over append-only source chunks (`TableHoldbackScanner`), with a stateless full-source scan retained in tests for parity checks.

A parallel fence-unwrapping pass (`unwrap_markdown_fences`) strips ` ```md `/` ```markdown ` wrappers when the fence body contains a header+delimiter pair, so `pulldown-cmark` sees raw table syntax instead of fenced code.

## Non-goals

- **Incremental table rendering.** The system does not attempt to patch prior lines when a new row arrives. It re-renders from source. This is intentional: markdown rendering is non-monotonic (a new row can change every column width), so incremental updates would require diffing rendered output, which is complex and error-prone.
- **Table editing or interaction.** Tables are display-only transcript content.
- **Arbitrary markdown extensions.** Only standard pipe tables (GFM) are supported. No grid tables, CSV, or custom formats.
- **Horizontal scrolling.** When a table cannot fit the terminal width, it falls back to pipe-delimited format rather than implementing horizontal scroll.

## Tradeoffs

| Decision | Upside | Downside |
|---|---|---|
| Full re-render on each committed source chunk (newline-gated) | Correct by construction; no incremental diffing bugs | O(n) in source size per committed chunk; acceptable for typical agent messages (hundreds of lines) |
| Hold table region as tail during table streaming | No flickering or duplicated partial table rows in scrollback; pre-table prose streams normally | Long tables delay scrollback commit of table content until stream ends |
| Source-map resize remapping (`rendered_line_end_source_bytes` + `remap_emitted_len_from_source_boundary`) | Correct width transition without dropping content; one re-render per resize | O(N) boundary scan per resize (one re-render + linear scan of stored source-byte boundaries) |
| Fence unwrapping before parsing | Handles the common ` ```markdown ` pattern transparently | Buffers entire fence body before deciding; adds a preprocessing pass |
| Narrative/Structured column classification | Intelligent shrinking prioritizes preserving short-token columns | Heuristic thresholds (4 avg words, 28 avg char width) may misclassify edge cases |
| Spillover row detection | Prevents pulldown-cmark's lenient parsing from producing malformed single-cell rows | Heuristic-based; may occasionally miscategorize intentional sparse rows |

## Architecture

```mermaid
flowchart TD
    delta["Token delta from agent"]
    collector["MarkdownStreamCollector
    *(newline-gated raw source accumulator)*"]

    delta --> collector
    collector -- "commit_complete_source()" --> raw

    subgraph StreamCore["StreamCore — two-region streaming engine"]
        raw["raw_source
        *(append-only markdown accumulator)*"]

        raw --> recompute["recompute_streaming_render()"]

        subgraph pipeline["Render pipeline"]
            unwrap["unwrap_markdown_fences()"]
            pulldown["pulldown-cmark"]
            writer["Writer"]
            table_render["render_table_lines()"]
            unwrap --> pulldown --> writer --> table_render
        end

        recompute --> unwrap
        writer --> rendered["rendered_lines
        *(full re-render at current width)*"]
        table_render --> boxgrid["Unicode box grid
        or pipe fallback"]

        rendered --> holdback["holdback_scanner.state()"]
        holdback --> state["TableHoldbackState
        {None | PendingHeader | Confirmed}"]
        state --> sync["sync_stable_queue()"]
    end

    sync -- "Stable lines" --> commit["commit-animation queue"]
    commit --> agent["AgentMessageCell *(scrollback)*"]
    sync -- "Tail lines" --> tail["StreamingAgentTailCell *(active-cell slot, mutable)*"]
```

**New modules:**

- `table_detect` - canonical pipe-table detection shared by streaming controller and fence unwrapper
- `width` - usable-width guards for prefix-column reservation
- `markdown` - public entry points with fence unwrapping (`append_markdown_agent`)

**Key types:**

- `StreamCore` - shared bookkeeping for two-region streaming
- `TableHoldbackState` - None / PendingHeader { header_start } / Confirmed { table_start }
- `FenceContext` - Outside / Markdown / Other (for holdback scanning)
- `TableState` / `TableCell` - pulldown-cmark event accumulator
- `TableColumnKind` / `TableColumnMetrics` - width-allocation classification
- `RenderedMarkdownWithSourceMap` - render artifact carrying lines + per-line input byte offsets (`line_end_input_bytes`); converted to source byte offsets by `AgentRenderedWithSourceMap` after fence-unwrapping adjustment
- `StreamingAgentTailCell` / `AgentMessageCell` - history cell types for tail and committed content

## Resize handling (new in this PR)

On `main`, terminal resize is essentially ignored for transcript content. History cells store pre-rendered `Vec<Line>` and are never reflowed — growing the terminal wastes horizontal space (text stays wrapped at the old width), and shrinking it causes visual corruption as pre-rendered lines are hard-clipped mid-word.

**`main` — paragraph at half width, then after resize (no reflow):**

<img width="1552" height="1012" alt="SCR-20260217-shfw" src="https://github.com/user-attachments/assets/190aa994-22df-494b-a28b-93dbe9507e32" />
<img width="1552" height="1012" alt="SCR-20260217-shha" src="https://github.com/user-attachments/assets/038b0d7a-8f27-44cb-a097-0546dbe6a134" />

**This branch — prose reflows cleanly at any width:**

<img width="1552" height="1012" alt="SCR-20260217-shmc" src="https://github.com/user-attachments/assets/43401d08-2429-4602-b264-49b71aee59ed" />

This PR adds a resize reflow system, motivated by tables (whose column widths must adapt to available space) but benefiting all markdown content:

1. **Width-change detection.** `App` tracks `last_transcript_render_width` and fires `ChatWidget::on_terminal_resize()` when it changes.

2. **Active stream updates immediately.** `StreamController::set_width()` re-renders once at the new width, then remaps `emitted_stable_len` via stored source-byte boundaries (`emitted_stable_source_bytes`). The `remap_emitted_len_from_source_boundary` function walks `rendered_line_end_source_bytes` with a tie-break counter for wrapped lines sharing the same source offset, avoiding duplicated or dropped content across the width transition.

3. **Committed scrollback reflowed on a 75ms debounce.** `maybe_run_resize_reflow()` clears the terminal and re-inserts every transcript cell at the new width. The debounce (`RESIZE_REFLOW_DEBOUNCE`) prevents expensive re-renders on every pixel of a drag resize.

4. **Source-based history cells.** `AgentMarkdownCell` stores raw markdown source instead of pre-rendered lines, so it can re-render at any width during reflow. This replaces the run of `AgentMessageCell`s emitted during streaming once the stream is consolidated.

5. **Stream-time reflow coordination.** If a reflow runs while a stream is still active (cells are still `AgentMessageCell`, not yet consolidated), the `reflow_ran_during_stream` flag triggers a second reflow after `ConsolidateAgentMessage` to pick up the `AgentMarkdownCell` rendering at the current width.

## Observability

- `tracing::trace!` on every `push_delta` call in `MarkdownStreamCollector`
- `tracing::debug!` on finalization with raw/rendered lengths (test-only `finalize_and_drain`; production `finalize_and_drain_source` has no tracing)
- Table holdback state is updated incrementally per committed source chunk; tests verify parity against a stateless full-source scanner
- Resize reflow is debounced at 75ms (`RESIZE_REFLOW_DEBOUNCE`); `reflow_ran_during_stream` flag triggers a re-reflow on stream consolidation to pick up the final `AgentMarkdownCell` rendering

## Tests

- **Streaming/full-render parity:** Multiple tests assert that streaming token-by-token through `StreamController` produces identical output to a single full `append_markdown_agent` call. Covers: basic tables, blockquoted tables, no-outer-pipes tables, two-column tables, markdown-fenced tables, multi-table responses.
- **Table holdback:** Confirms `Confirmed` state for header+delimiter pairs, `PendingHeader` for lone headers, `None` for prose with pipes, and fence-awareness (non-markdown fences suppress holdback).
- **Resize correctness:** `set_width` tests verify no duplicate lines after emit, no lost lines on partial drain, preserved in-flight tails for both agent and plan controllers, and correct output when resizing during an active confirmed-table stream.
- **Fence unwrapping:** Tests confirm markdown fences with tables are unwrapped, non-markdown fences are preserved, markdown fences without tables stay as code blocks, and unclosed fences degrade gracefully.
- **Column width allocation:** Direct unit tests assert `TableColumnKind` classification, `preferred_column_floor` caps, and `next_column_to_shrink` priority. End-to-end parity tests provide additional coverage.
- **Spillover detection:** Direct unit tests for `is_spillover_row` cover each heuristic branch (single-cell, HTML content, label+HTML, trailing HTML label) and negative cases. End-to-end tests provide additional coverage.
- **Source-boundary resize remap:** Tests verify no duplicate lines after partial emit + resize, and that un-emitted content survives width changes. Fence-unwrapping mapping invariants tested separately.