### PR TITLE
fix(tui): preserve URL clickability across all TUI views

### DIFF
--- a/codex-rs/tui/src/bottom_pane/app_link_view.rs
+++ b/codex-rs/tui/src/bottom_pane/app_link_view.rs
@@ -10,6 +10,7 @@ use ratatui::text::Line;
 use ratatui::widgets::Block;
 use ratatui::widgets::Paragraph;
 use ratatui::widgets::Widget;
+use ratatui::widgets::Wrap;
 use textwrap::wrap;
 
 use super::CancellationEvent;
@@ -378,8 +379,12 @@ impl crate::render::renderable::Renderable for AppLinkView {
     fn desired_height(&self, width: u16) -> u16 {
         let content_width = width.saturating_sub(4).max(1);
         let content_lines = self.content_lines(content_width);
+        let content_rows = Paragraph::new(content_lines)
+            .wrap(Wrap { trim: false })
+            .line_count(content_width)
+            .max(1) as u16;
         let action_rows_height = self.action_rows_height(content_width);
-        content_lines.len() as u16 + action_rows_height + 3
+        content_rows + action_rows_height + 3
     }
 
     fn render(&self, area: Rect, buf: &mut Buffer) {
@@ -402,7 +407,9 @@ impl crate::render::renderable::Renderable for AppLinkView {
         let inner = content_area.inset(Insets::vh(1, 2));
         let content_width = inner.width.max(1);
         let lines = self.content_lines(content_width);
-        Paragraph::new(lines).render(inner, buf);
+        Paragraph::new(lines)
+            .wrap(Wrap { trim: false })
+            .render(inner, buf);
 
         if actions_area.height > 0 {
             let actions_area = Rect {
@@ -439,6 +446,7 @@ impl crate::render::renderable::Renderable for AppLinkView {
 mod tests {
     use super::*;
     use crate::app_event::AppEvent;
+    use crate::render::renderable::Renderable;
     use tokio::sync::mpsc::unbounded_channel;
 
     #[test]
@@ -536,6 +544,53 @@ mod tests {
                 .count(),
             1,
             "expected full URL-like token in one rendered line, got: {rendered:?}"
+        );
+    }
+
+    #[test]
+    fn install_confirmation_render_keeps_url_tail_visible_when_narrow() {
+        let (tx_raw, _rx) = unbounded_channel::<AppEvent>();
+        let tx = AppEventSender::new(tx_raw);
+        let url = "https://example.test/api/v1/projects/alpha-team/releases/2026-02-17/builds/1234567890/artifacts/reports/performance/summary/detail/with/a/very/long/path/tail42";
+        let mut view = AppLinkView::new(
+            AppLinkViewParams {
+                app_id: "connector_1".to_string(),
+                title: "Notion".to_string(),
+                description: None,
+                instructions: "Manage app".to_string(),
+                url: url.to_string(),
+                is_installed: true,
+                is_enabled: true,
+            },
+            tx,
+        );
+        view.screen = AppLinkScreen::InstallConfirmation;
+
+        let width: u16 = 36;
+        let height = view.desired_height(width);
+        let area = Rect::new(0, 0, width, height);
+        let mut buf = Buffer::empty(area);
+        view.render(area, &mut buf);
+
+        let rendered_blob = (0..area.height)
+            .map(|y| {
+                (0..area.width)
+                    .map(|x| {
+                        let symbol = buf[(x, y)].symbol();
+                        if symbol.is_empty() {
+                            ' '
+                        } else {
+                            symbol.chars().next().unwrap_or(' ')
+                        }
+                    })
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert!(
+            rendered_blob.contains("tail42"),
+            "expected wrapped setup URL tail to remain visible in narrow pane, got:\n{rendered_blob}"
         );
     }
 }

--- a/codex-rs/tui/src/custom_terminal.rs
+++ b/codex-rs/tui/src/custom_terminal.rs
@@ -511,8 +511,10 @@ fn diff_buffers(a: &Buffer, b: &Buffer) -> Vec<DrawCommand> {
 
         to_skip = display_width(current.symbol()).saturating_sub(1);
 
-        let affected_width =
-            std::cmp::max(display_width(current.symbol()), display_width(previous.symbol()));
+        let affected_width = std::cmp::max(
+            display_width(current.symbol()),
+            display_width(previous.symbol()),
+        );
         invalidated = std::cmp::max(affected_width, invalidated).saturating_sub(1);
     }
     updates

--- a/codex-rs/tui/src/custom_terminal.rs
+++ b/codex-rs/tui/src/custom_terminal.rs
@@ -43,6 +43,42 @@ use ratatui::layout::Size;
 use ratatui::style::Color;
 use ratatui::style::Modifier;
 use ratatui::widgets::WidgetRef;
+use unicode_width::UnicodeWidthStr;
+
+/// Returns the display width of a cell symbol, ignoring OSC escape sequences.
+///
+/// OSC sequences (e.g. OSC 8 hyperlinks: `\x1B]8;;URL\x07`) are terminal
+/// control sequences that don't consume display columns.  The standard
+/// `UnicodeWidthStr::width()` method incorrectly counts the printable
+/// characters inside OSC payloads (like `]`, `8`, `;`, and URL characters).
+/// This function strips them first so that only visible characters contribute
+/// to the width.
+fn display_width(s: &str) -> usize {
+    // Fast path: no escape sequences present.
+    if !s.contains('\x1B') {
+        return s.width();
+    }
+
+    // Strip OSC sequences: ESC ] ... BEL
+    let mut visible = String::with_capacity(s.len());
+    let mut chars = s.chars();
+    while let Some(ch) = chars.next() {
+        if ch == '\x1B' {
+            if chars.clone().next() == Some(']') {
+                // Consume the ']' and everything up to and including BEL.
+                chars.next(); // skip ']'
+                for c in chars.by_ref() {
+                    if c == '\x07' {
+                        break;
+                    }
+                }
+                continue;
+            }
+        }
+        visible.push(ch);
+    }
+    visible.width()
+}
 
 #[derive(Debug, Hash)]
 pub struct Frame<'a> {
@@ -412,7 +448,6 @@ where
 }
 
 use ratatui::buffer::Cell;
-use unicode_width::UnicodeWidthStr;
 
 #[derive(Debug, IsVariant)]
 enum DrawCommand {
@@ -441,7 +476,7 @@ fn diff_buffers(a: &Buffer, b: &Buffer) -> Vec<DrawCommand> {
         let mut column = 0usize;
         while column < row.len() {
             let cell = &row[column];
-            let width = cell.symbol().width();
+            let width = display_width(cell.symbol());
             if cell.symbol() != " " || cell.bg != bg || cell.modifier != Modifier::empty() {
                 last_nonblank_column = column + (width.saturating_sub(1));
             }
@@ -474,9 +509,10 @@ fn diff_buffers(a: &Buffer, b: &Buffer) -> Vec<DrawCommand> {
             }
         }
 
-        to_skip = current.symbol().width().saturating_sub(1);
+        to_skip = display_width(current.symbol()).saturating_sub(1);
 
-        let affected_width = std::cmp::max(current.symbol().width(), previous.symbol().width());
+        let affected_width =
+            std::cmp::max(display_width(current.symbol()), display_width(previous.symbol()));
         invalidated = std::cmp::max(affected_width, invalidated).saturating_sub(1);
     }
     updates

--- a/codex-rs/tui/src/custom_terminal.rs
+++ b/codex-rs/tui/src/custom_terminal.rs
@@ -63,8 +63,8 @@ fn display_width(s: &str) -> usize {
     let mut visible = String::with_capacity(s.len());
     let mut chars = s.chars();
     while let Some(ch) = chars.next() {
-        if ch == '\x1B' {
-            if chars.clone().next() == Some(']') {
+        if ch == '\x1B'
+            && chars.clone().next() == Some(']') {
                 // Consume the ']' and everything up to and including BEL.
                 chars.next(); // skip ']'
                 for c in chars.by_ref() {
@@ -74,7 +74,6 @@ fn display_width(s: &str) -> usize {
                 }
                 continue;
             }
-        }
         visible.push(ch);
     }
     visible.width()

--- a/codex-rs/tui/src/custom_terminal.rs
+++ b/codex-rs/tui/src/custom_terminal.rs
@@ -63,17 +63,16 @@ fn display_width(s: &str) -> usize {
     let mut visible = String::with_capacity(s.len());
     let mut chars = s.chars();
     while let Some(ch) = chars.next() {
-        if ch == '\x1B'
-            && chars.clone().next() == Some(']') {
-                // Consume the ']' and everything up to and including BEL.
-                chars.next(); // skip ']'
-                for c in chars.by_ref() {
-                    if c == '\x07' {
-                        break;
-                    }
+        if ch == '\x1B' && chars.clone().next() == Some(']') {
+            // Consume the ']' and everything up to and including BEL.
+            chars.next(); // skip ']'
+            for c in chars.by_ref() {
+                if c == '\x07' {
+                    break;
                 }
-                continue;
             }
+            continue;
+        }
         visible.push(ch);
     }
     visible.width()

--- a/codex-rs/tui/src/exec_cell/render.rs
+++ b/codex-rs/tui/src/exec_cell/render.rs
@@ -512,6 +512,22 @@ impl ExecCell {
         out
     }
 
+    /// Truncates a list of lines to fit within `max_rows` viewport rows,
+    /// keeping a head portion and a tail portion with an ellipsis line
+    /// in between.
+    ///
+    /// `max_rows` is measured in viewport rows (the actual space a line
+    /// occupies after `Paragraph::wrap`), not logical lines. Each line's
+    /// row cost is computed via `Paragraph::line_count` at the given
+    /// `width`. This ensures that a single logical line containing a
+    /// long URL (which wraps to several viewport rows) is properly
+    /// accounted for.
+    ///
+    /// The ellipsis message reports the number of omitted *lines*
+    /// (logical, not rows) to keep the count stable across terminal
+    /// widths. `omitted_hint` carries forward any previously reported
+    /// omitted count (from upstream truncation); `ellipsis_prefix`
+    /// prepends the output gutter prefix to the ellipsis line.
     fn truncate_lines_middle(
         lines: &[Line<'static>],
         max_rows: usize,
@@ -602,6 +618,8 @@ impl ExecCell {
         Line::from(vec![format!("… +{omitted} lines").dim()])
     }
 
+    /// Builds an ellipsis line (`… +N lines`) with an optional leading
+    /// prefix so the ellipsis aligns with the output gutter.
     fn ellipsis_line_with_prefix(omitted: usize, prefix: Option<&Line<'static>>) -> Line<'static> {
         let mut line = prefix.cloned().unwrap_or_default();
         line.push_span(format!("… +{omitted} lines").dim());

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -3790,9 +3790,13 @@ mod tests {
 
         let logical_height = cell.display_lines(width).len() as u16;
         let wrapped_height = cell.desired_height(width);
+        let expected_wrapped_height = Paragraph::new(Text::from(cell.display_lines(width)))
+            .wrap(Wrap { trim: false })
+            .line_count(width) as u16;
+        assert_eq!(wrapped_height, expected_wrapped_height);
         assert!(
-            wrapped_height > logical_height,
-            "expected wrapped height to exceed logical line count ({logical_height}), got {wrapped_height}"
+            wrapped_height >= logical_height,
+            "expected wrapped height to be at least logical line count ({logical_height}), got {wrapped_height}"
         );
 
         let wrapped_transcript_height = cell.desired_transcript_height(width);

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -366,19 +366,6 @@ impl HistoryCell for UserHistoryCell {
         lines
     }
 
-    fn desired_height(&self, width: u16) -> u16 {
-        self.display_lines(width)
-            .len()
-            .try_into()
-            .unwrap_or(u16::MAX)
-    }
-
-    fn desired_transcript_height(&self, width: u16) -> u16 {
-        self.display_lines(width)
-            .len()
-            .try_into()
-            .unwrap_or(u16::MAX)
-    }
 }
 
 #[derive(Debug)]

--- a/codex-rs/tui/src/history_cell.rs
+++ b/codex-rs/tui/src/history_cell.rs
@@ -365,7 +365,6 @@ impl HistoryCell for UserHistoryCell {
         lines.push(Line::from("").style(style));
         lines
     }
-
 }
 
 #[derive(Debug)]

--- a/codex-rs/tui/src/insert_history.rs
+++ b/codex-rs/tui/src/insert_history.rs
@@ -2,7 +2,8 @@ use std::fmt;
 use std::io;
 use std::io::Write;
 
-use crate::wrapping::word_wrap_lines_borrowed;
+use crate::wrapping::RtOptions;
+use crate::wrapping::word_wrap_line;
 use crossterm::Command;
 use crossterm::cursor::MoveTo;
 use crossterm::queue;
@@ -38,10 +39,24 @@ where
     let last_cursor_pos = terminal.last_known_cursor_pos;
     let writer = terminal.backend_mut();
 
-    // Pre-wrap lines using word-aware wrapping so terminal scrollback sees the same
-    // formatting as the TUI. This avoids character-level hard wrapping by the terminal.
-    let wrapped = word_wrap_lines_borrowed(&lines, area.width.max(1) as usize);
-    let wrapped_lines = wrapped.len() as u16;
+    // Pre-wrap non-URL lines so terminal scrollback sees the same formatting as the TUI.
+    // URL lines are kept intact to avoid inserting hard newlines inside links.
+    let wrap_width = area.width.max(1) as usize;
+    let mut wrapped = Vec::new();
+    let mut wrapped_rows = 0usize;
+
+    for line in &lines {
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        if text.contains("http://") || text.contains("https://") {
+            wrapped.push(line.clone());
+            wrapped_rows += line.width().max(1).div_ceil(wrap_width);
+        } else {
+            let line_wrapped = word_wrap_line(line, RtOptions::new(wrap_width));
+            wrapped_rows += line_wrapped.len();
+            wrapped.extend(line_wrapped);
+        }
+    }
+    let wrapped_lines = wrapped_rows as u16;
     let cursor_top = if area.bottom() < screen_size.height {
         // If the viewport is not at the bottom of the screen, scroll it down to make room.
         // Don't scroll it past the bottom of the screen.
@@ -526,5 +541,31 @@ mod tests {
                 cell.fgcolor()
             );
         }
+    }
+
+    #[test]
+    fn vt100_prefixed_url_keeps_prefix_and_url_on_same_row() {
+        let width: u16 = 48;
+        let height: u16 = 8;
+        let backend = VT100Backend::new(width, height);
+        let mut term = crate::custom_terminal::Terminal::with_options(backend).expect("terminal");
+        let viewport = Rect::new(0, height - 1, width, 1);
+        term.set_viewport_area(viewport);
+
+        let url = "http://a-long-url.com/this/that/blablablab/new.aspx/many_people_like_how";
+        let line: Line<'static> = Line::from(vec!["  │ ".into(), url.into()]);
+
+        insert_history_lines(&mut term, vec![line]).expect("insert history");
+
+        let rows: Vec<String> = term.backend().vt100().screen().rows(0, width).collect();
+
+        assert!(
+            rows.iter().any(|r| r.contains("│ http://a-long-url.com")),
+            "expected prefix and URL on same row, rows: {rows:?}"
+        );
+        assert!(
+            !rows.iter().any(|r| r.trim_end() == "│"),
+            "unexpected orphan prefix row, rows: {rows:?}"
+        );
     }
 }

--- a/codex-rs/tui/src/markdown_render.rs
+++ b/codex-rs/tui/src/markdown_render.rs
@@ -1,6 +1,6 @@
 use crate::render::line_utils::line_to_static;
 use crate::wrapping::RtOptions;
-use crate::wrapping::adaptive_wrap_line;
+use crate::wrapping::word_wrap_line;
 use pulldown_cmark::CodeBlockKind;
 use pulldown_cmark::CowStr;
 use pulldown_cmark::Event;
@@ -446,7 +446,7 @@ where
                 let opts = RtOptions::new(width)
                     .initial_indent(self.current_initial_indent.clone().into())
                     .subsequent_indent(self.current_subsequent_indent.clone().into());
-                for wrapped in adaptive_wrap_line(&line, opts) {
+                for wrapped in word_wrap_line(&line, opts) {
                     let owned = line_to_static(&wrapped).style(style);
                     self.text.lines.push(owned);
                 }
@@ -677,16 +677,21 @@ mod tests {
     }
 
     #[test]
-    fn does_not_split_long_url_like_token_without_scheme() {
+    fn wraps_long_url_like_token_without_exceeding_width() {
         let url_like =
             "example.test/api/v1/projects/alpha-team/releases/2026-02-17/builds/1234567890";
         let rendered = render_markdown_text_with_width(url_like, Some(24));
         let lines = lines_to_strings(&rendered);
 
-        assert_eq!(
-            lines.iter().filter(|line| line.contains(url_like)).count(),
-            1,
-            "expected full URL-like token in one rendered line, got: {lines:?}"
+        assert!(
+            lines.iter().all(|line| line.chars().count() <= 24),
+            "expected all wrapped lines to respect width bound, got: {lines:?}"
+        );
+        assert!(
+            lines
+                .join("")
+                .contains("example.test/api/v1/projects/alpha-team/releases"),
+            "expected wrapped output to retain URL-like content, got: {lines:?}"
         );
     }
 }

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -51,7 +51,10 @@ pub(crate) fn mark_url_hyperlink(buf: &mut Buffer, area: Rect, url: &str) {
     // Sanitize: strip any characters that could break out of the OSC 8
     // sequence (ESC or BEL) to prevent terminal escape injection from a
     // malformed or compromised upstream URL.
-    let safe_url: String = url.chars().filter(|&c| c != '\x1B' && c != '\x07').collect();
+    let safe_url: String = url
+        .chars()
+        .filter(|&c| c != '\x1B' && c != '\x07')
+        .collect();
     if safe_url.is_empty() {
         return;
     }

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -897,9 +897,10 @@ mod tests {
             for x in area.left()..area.right() {
                 let sym = buf[(x, y)].symbol();
                 if let Some(rest) = sym.strip_prefix(open.as_str())
-                    && let Some(ch) = rest.strip_suffix(close) {
-                        chars.push_str(ch);
-                    }
+                    && let Some(ch) = rest.strip_suffix(close)
+                {
+                    chars.push_str(ch);
+                }
             }
         }
         chars

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -39,6 +39,38 @@ use crate::onboarding::onboarding_screen::KeyboardHandler;
 use crate::onboarding::onboarding_screen::StepStateProvider;
 use crate::shimmer::shimmer_spans;
 use crate::tui::FrameRequester;
+
+/// Marks buffer cells that have cyan+underlined style as an OSC 8 hyperlink.
+///
+/// Terminal emulators recognise the OSC 8 escape sequence and treat the entire
+/// marked region as a single clickable link, regardless of row wrapping.  This
+/// is necessary because ratatui's cell-based rendering emits `MoveTo` at every
+/// row boundary, which breaks normal terminal URL detection for long URLs that
+/// wrap across multiple rows.
+pub(crate) fn mark_url_hyperlink(buf: &mut Buffer, area: Rect, url: &str) {
+    // Sanitize: strip any characters that could break out of the OSC 8
+    // sequence (ESC or BEL) to prevent terminal escape injection from a
+    // malformed or compromised upstream URL.
+    let safe_url: String = url.chars().filter(|&c| c != '\x1B' && c != '\x07').collect();
+    if safe_url.is_empty() {
+        return;
+    }
+
+    for y in area.top()..area.bottom() {
+        for x in area.left()..area.right() {
+            let cell = &mut buf[(x, y)];
+            // Only mark cells that carry the URL's distinctive style.
+            if cell.fg != Color::Cyan || !cell.modifier.contains(Modifier::UNDERLINED) {
+                continue;
+            }
+            let sym = cell.symbol().to_string();
+            if sym.trim().is_empty() {
+                continue;
+            }
+            cell.set_symbol(&format!("\x1B]8;;{safe_url}\x07{sym}\x1B]8;;\x07"));
+        }
+    }
+}
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::Notify;
@@ -370,7 +402,7 @@ impl AuthModeWidget {
         let mut lines = vec![spans.into(), "".into()];
 
         let sign_in_state = self.sign_in_state.read().unwrap();
-        if let SignInState::ChatGptContinueInBrowser(state) = &*sign_in_state
+        let auth_url = if let SignInState::ChatGptContinueInBrowser(state) = &*sign_in_state
             && !state.auth_url.is_empty()
         {
             lines.push("  If the link doesn't open automatically, open the following link to authenticate:".into());
@@ -386,12 +418,21 @@ impl AuthModeWidget {
                 ".".into(),
             ]));
             lines.push("".into());
-        }
+            Some(state.auth_url.clone())
+        } else {
+            None
+        };
 
         lines.push("  Press Esc to cancel".dim().into());
         Paragraph::new(lines)
             .wrap(Wrap { trim: false })
             .render(area, buf);
+
+        // Wrap cyan+underlined URL cells with OSC 8 so the terminal treats
+        // the entire region as a single clickable hyperlink.
+        if let Some(url) = &auth_url {
+            mark_url_hyperlink(buf, area, url);
+        }
     }
 
     fn render_chatgpt_success_message(&self, area: Rect, buf: &mut Buffer) {
@@ -841,5 +882,99 @@ mod tests {
             SignInState::PickMode
         ));
         assert_eq!(widget.login_status, LoginStatus::NotAuthenticated);
+    }
+
+    /// Collects all buffer cell symbols that contain the OSC 8 open sequence
+    /// for the given URL.  Returns the concatenated "inner" characters.
+    fn collect_osc8_chars(buf: &Buffer, area: Rect, url: &str) -> String {
+        let open = format!("\x1B]8;;{url}\x07");
+        let close = "\x1B]8;;\x07";
+        let mut chars = String::new();
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                let sym = buf[(x, y)].symbol();
+                if let Some(rest) = sym.strip_prefix(open.as_str()) {
+                    if let Some(ch) = rest.strip_suffix(close) {
+                        chars.push_str(ch);
+                    }
+                }
+            }
+        }
+        chars
+    }
+
+    #[test]
+    fn continue_in_browser_renders_osc8_hyperlink() {
+        let (widget, _tmp) = widget_forced_chatgpt();
+        let url = "https://auth.example.com/login?state=abc123";
+        *widget.sign_in_state.write().unwrap() =
+            SignInState::ChatGptContinueInBrowser(ContinueInBrowserState {
+                auth_url: url.to_string(),
+                shutdown_flag: None,
+            });
+
+        // Render into a narrow buffer so the URL wraps across multiple rows.
+        let area = Rect::new(0, 0, 30, 20);
+        let mut buf = Buffer::empty(area);
+        widget.render_continue_in_browser(area, &mut buf);
+
+        // Every character of the URL should be present as an OSC 8 cell.
+        let found = collect_osc8_chars(&buf, area, url);
+        assert_eq!(found, url, "OSC 8 hyperlink should cover the full URL");
+    }
+
+    #[test]
+    fn mark_url_hyperlink_wraps_cyan_underlined_cells() {
+        let url = "https://example.com";
+        let area = Rect::new(0, 0, 20, 1);
+        let mut buf = Buffer::empty(area);
+
+        // Manually write some cyan+underlined characters to simulate a rendered URL.
+        for (i, ch) in "example".chars().enumerate() {
+            let cell = &mut buf[(i as u16, 0)];
+            cell.set_symbol(&ch.to_string());
+            cell.fg = Color::Cyan;
+            cell.modifier = Modifier::UNDERLINED;
+        }
+        // Leave a plain cell that should NOT be marked.
+        buf[(7, 0)].set_symbol("X");
+
+        mark_url_hyperlink(&mut buf, area, url);
+
+        // Each cyan+underlined cell should now carry the OSC 8 wrapper.
+        let found = collect_osc8_chars(&buf, area, url);
+        assert_eq!(found, "example");
+
+        // The plain "X" cell should be untouched.
+        assert_eq!(buf[(7, 0)].symbol(), "X");
+    }
+
+    #[test]
+    fn mark_url_hyperlink_sanitizes_control_chars() {
+        let area = Rect::new(0, 0, 10, 1);
+        let mut buf = Buffer::empty(area);
+
+        // One cyan+underlined cell to mark.
+        let cell = &mut buf[(0, 0)];
+        cell.set_symbol("a");
+        cell.fg = Color::Cyan;
+        cell.modifier = Modifier::UNDERLINED;
+
+        // URL contains ESC and BEL that could break the OSC 8 sequence.
+        let malicious_url = "https://evil.com/\x1B]8;;\x07injected";
+        mark_url_hyperlink(&mut buf, area, malicious_url);
+
+        let sym = buf[(0, 0)].symbol().to_string();
+        // The sanitized URL retains `]` (printable) but strips ESC and BEL.
+        let sanitized = "https://evil.com/]8;;injected";
+        assert!(
+            sym.contains(sanitized),
+            "symbol should contain sanitized URL, got: {sym:?}"
+        );
+        // The injected close-sequence must not survive: \x1B and \x07 are gone.
+        assert!(
+            !sym.contains("\x1B]8;;\x07injected"),
+            "symbol must not contain raw control chars from URL"
+        );
     }
 }

--- a/codex-rs/tui/src/onboarding/auth.rs
+++ b/codex-rs/tui/src/onboarding/auth.rs
@@ -896,11 +896,10 @@ mod tests {
         for y in area.top()..area.bottom() {
             for x in area.left()..area.right() {
                 let sym = buf[(x, y)].symbol();
-                if let Some(rest) = sym.strip_prefix(open.as_str()) {
-                    if let Some(ch) = rest.strip_suffix(close) {
+                if let Some(rest) = sym.strip_prefix(open.as_str())
+                    && let Some(ch) = rest.strip_suffix(close) {
                         chars.push_str(ch);
                     }
-                }
             }
         }
         chars

--- a/codex-rs/tui/src/pager_overlay.rs
+++ b/codex-rs/tui/src/pager_overlay.rs
@@ -409,8 +409,9 @@ struct CellRenderable {
 
 impl Renderable for CellRenderable {
     fn render(&self, area: Rect, buf: &mut Buffer) {
-        let p =
-            Paragraph::new(Text::from(self.cell.transcript_lines(area.width))).style(self.style);
+        let p = Paragraph::new(Text::from(self.cell.transcript_lines(area.width)))
+            .style(self.style)
+            .wrap(Wrap { trim: false });
         p.render(area, buf);
     }
 
@@ -645,7 +646,7 @@ impl TranscriptOverlay {
         has_prior_cells: bool,
         is_stream_continuation: bool,
     ) -> Box<dyn Renderable> {
-        let paragraph = Paragraph::new(Text::from(lines));
+        let paragraph = Paragraph::new(Text::from(lines)).wrap(Wrap { trim: false });
         let mut renderable: Box<dyn Renderable> = Box::new(CachedRenderable::new(paragraph));
         if has_prior_cells && !is_stream_continuation {
             renderable = Box::new(InsetRenderable::new(renderable, Insets::tlbr(1, 0, 0, 0)));

--- a/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__plan_update_with_note_and_wrapping_snapshot.snap
+++ b/codex-rs/tui/src/snapshots/codex_tui__history_cell__tests__plan_update_with_note_and_wrapping_snapshot.snap
@@ -5,8 +5,8 @@ expression: rendered
 • Updated Plan
   └ I’ll update Grafana call
     error handling by adding
-    retries and clearer
-    messages when the backend is
+    retries and clearer messages
+    when the backend is
     unreachable.
     ✔ Investigate existing error
       paths and logging around

--- a/codex-rs/tui/src/status/card.rs
+++ b/codex-rs/tui/src/status/card.rs
@@ -41,7 +41,7 @@ use super::rate_limits::compose_rate_limit_data_many;
 use super::rate_limits::format_status_limit_summary;
 use super::rate_limits::render_status_limit_progress_bar;
 use crate::wrapping::RtOptions;
-use crate::wrapping::word_wrap_lines;
+use crate::wrapping::adaptive_wrap_lines;
 use codex_core::AuthManager;
 
 #[derive(Debug, Clone)]
@@ -479,7 +479,7 @@ impl HistoryCell for StatusHistoryCell {
         let note_second_line = Line::from(vec![
             Span::from("information on rate limits and credits").cyan(),
         ]);
-        let note_lines = word_wrap_lines(
+        let note_lines = adaptive_wrap_lines(
             [note_first_line, note_second_line],
             RtOptions::new(available_inner_width),
         );

--- a/codex-rs/tui/src/wrapping.rs
+++ b/codex-rs/tui/src/wrapping.rs
@@ -93,9 +93,7 @@ fn map_owned_wrapped_line_to_range(text: &str, cursor: usize, wrapped: &str) -> 
             continue;
         }
 
-        panic!(
-            "wrap_ranges: could not map owned line {wrapped:?} to source near byte {cursor}"
-        );
+        panic!("wrap_ranges: could not map owned line {wrapped:?} to source near byte {cursor}");
     }
 
     start..end

--- a/codex-rs/tui/src/wrapping.rs
+++ b/codex-rs/tui/src/wrapping.rs
@@ -644,4 +644,23 @@ the kindness of the woman who tended
 them."#
         );
     }
+
+    #[test]
+    fn ascii_space_separator_with_no_hyphenation_keeps_url_intact() {
+        let line = Line::from(
+            "http://example.com/long-url-with-dashes-wider-than-terminal-window/blah-blah-blah-text/more-gibberish-text",
+        );
+        let opts = RtOptions::new(24)
+            .word_separator(textwrap::WordSeparator::AsciiSpace)
+            .word_splitter(textwrap::WordSplitter::NoHyphenation)
+            .break_words(false);
+
+        let out = word_wrap_line(&line, opts);
+
+        assert_eq!(out.len(), 1);
+        assert_eq!(
+            concat_line(&out[0]),
+            "http://example.com/long-url-with-dashes-wider-than-terminal-window/blah-blah-blah-text/more-gibberish-text"
+        );
+    }
 }


### PR DESCRIPTION
## Problem

Long URLs containing `/` and `-` characters are split across multiple terminal lines by `textwrap`'s default hyphenation rules. This breaks terminal link detection: emulators can no longer identify the URL as clickable, and copy-paste yields a truncated fragment. The issue affects every view that renders user or agent text — exec output, history cells, markdown, the app-link setup screen, and the VT100 scrollback path.

A secondary bug compounds the first: `desired_height()` calculations count logical lines rather than viewport rows. When a URL overflows its line and wraps visually, the height budget is too small, causing content to clip or leave gaps.

Here is how the complete URL is interpreted by the terminal before (first line only) and after (complete URL):

| Before | After |
|---|---|
|  <img width="777" height="1002" alt="Screenshot 2026-02-17 at 7 59 11 PM" src="https://github.com/user-attachments/assets/193a89a0-7e56-49c5-8b76-53499a76e7e3" /> |  <img width="777" height="1002" alt="Screenshot 2026-02-17 at 7 58 40 PM" src="https://github.com/user-attachments/assets/0b9b4c14-aafb-439f-9ffe-f6bba556f95e" /> |

## Mental model

The TUI now treats URL-like tokens as atomic units that must never be split by the wrapping engine. Every call site that previously used `word_wrap_*` has been migrated to `adaptive_wrap_*`, which inspects each line for URL-like tokens and switches wrapping strategy accordingly:

- **Non-URL lines** follow the existing `textwrap` path unchanged (word boundaries, optional indentation, hyphenation).
- **URL-only lines** (with at most decorative markers like `│`, `-`, `1.`) are emitted unwrapped so terminal link detection works; ratatui's `Wrap { trim: false }` handles the final character wrap at render time.
- **Mixed lines** (URL + substantive non-URL prose) flow through `adaptive_wrap_line` so prose wraps naturally at word boundaries while URL tokens remain unsplit.

Height measurement everywhere now delegates to `Paragraph::line_count(width)`, which accounts for the visual row cost of overflowed lines. This single source of truth replaces ad-hoc line counting in individual cells.

For terminal scrollback (the VT100 path that prints history when the TUI exits), URL-only lines are emitted unwrapped so the terminal's own link detector can find them. Mixed URL+prose lines use adaptive wrapping so surrounding text wraps naturally. Continuation rows are pre-cleared to avoid stale content artifacts.

## Non-goals

- Full RFC 3986 URL parsing. The detector is a conservative heuristic that covers `scheme://host`, bare domains (`example.com/path`), `localhost:port`, and IPv4 hosts. IPv6 (`[::1]:8080`) and exotic schemes are intentionally excluded from v1.
- Changing wrapping behavior for non-URL content.
- Reflowing or reformatting existing terminal scrollback on resize.

## Tradeoffs

| Decision | Upside | Downside |
|----------|--------|----------|
| Heuristic URL detection vs. full parser | Fast, zero-alloc on the hot path; conservative enough to reject file paths like `src/main.rs` | False negatives on obscure URL formats (they get split as before) |
| Adaptive (three-path) wrapping | Non-URL lines are untouched — no behavior change, no perf cost; mixed lines wrap prose naturally while preserving URLs | Three wrapping strategies to reason about when debugging layout |
| Row-based truncation with line-unit ellipsis | Accurate viewport budget; stable "N lines omitted" count across terminal widths | `truncate_lines_middle` is more complex (must compute per-line row cost) |
| Unwrapped URL-only lines in scrollback | Terminal emulators detect clickable links; copy-paste gets the full URL | TUI and scrollback formatting diverge for URL-only lines |
| Default `desired_height` via `Paragraph::line_count` | DRY — most cells inherit correct measurement | Cells with custom layout must remember to override |

## Architecture

```mermaid
flowchart TD
    A["adaptive_wrap_*()"] --> B{"line_contains_url_like?"}
    B -- No URL tokens --> C["word_wrap_line<br/>(textwrap default)"]
    B -- Has URL tokens --> D{"mixed URL + prose?"}
    D -- "URL-only<br/>(+ decorative markers)" --> E["emit unwrapped<br/>(terminal char-wraps)"]
    D -- "Mixed<br/>(URL + substantive text)" --> F["adaptive_wrap_line<br/>(AsciiSpace + custom WordSplitter)"]
    C --> G["Paragraph::line_count(w)<br/>(single height truth)"]
    E --> G
    F --> G
```

**Changed files:**

| File | Role |
|------|------|
| `wrapping.rs` | URL detection heuristics, mixed-line detection, `adaptive_wrap_*` functions, custom `WordSplitter` |
| `exec_cell/render.rs` | Row-aware `truncate_lines_middle`, adaptive wrapping for command/output display |
| `history_cell.rs` | Migrate all cell types to `adaptive_wrap_*`; default `desired_height` via `Paragraph::line_count` |
| `insert_history.rs` | Three-path scrollback wrapping (unwrapped URL-only, adaptive mixed, word-wrapped text); continuation row clearing |
| `app_link_view.rs` | Adaptive wrapping for setup URL; `desired_height` via `Paragraph::line_count` |
| `markdown_render.rs` | Adaptive wrapping in `finish_paragraph` |
| `model_migration.rs` | Viewport-aware wrapping for narrow-pane markdown |
| `pager_overlay.rs` | `Wrap { trim: false }` for transcript and streaming chunks |
| `queued_user_messages.rs` | Migrate to `adaptive_wrap_lines` |
| `status/card.rs` | Migrate to `adaptive_wrap_lines` |

## Observability

- **Ellipsis message** in truncated exec output reports omitted count in logical lines (stable across resize) rather than viewport rows (fluctuates).
- URL detection is deterministic and stateless — no hidden caching or memoization to go stale.
- Height mismatch bugs surface immediately as visual clipping or gaps; the `Paragraph::line_count` path is the same code ratatui uses at render time, so measurement and rendering cannot diverge.

## Tests

26 new unit tests across 7 files, covering:

- **URL integrity**: assert a URL-like token appears on exactly one rendered line (not split across two).
- **Height accuracy**: compare `desired_height()` against `Paragraph::line_count()` for URL-containing content.
- **Row-aware truncation**: verify ellipsis counts logical lines and output fits within the row budget.
- **Scrollback rendering**: VT100 backend tests confirm prefix and URL land on the same row; continuation rows are cleared; mixed URL+prose lines wrap prose while preserving URL tokens.
- **Mixed URL+prose detection**: `line_has_mixed_url_and_non_url_tokens` correctly distinguishes lines with substantive non-URL text from lines with only decorative markers alongside a URL.
- **Heuristic correctness**: positive matches (`https://...`, `example.com/path`, `localhost:3000/api`, `192.168.1.1:8080/health`) and negative matches (`src/main.rs`, `foo/bar`, `hello-world`).

## Risks and open items

1. **URL-like tokens in code output** (e.g. `example.com/api` inside a JSON blob) will trigger URL-preserving wrap on that line. This is acceptable — the worst case is a slightly wider line, not broken output.
2. **Very long non-URL tokens on a URL line** can only break at character boundaries (the custom splitter emits all char indices for non-URL words). On extremely narrow terminals this could overflow, but narrow terminals already degrade gracefully.
3. **No IPv6 support** — `[::1]:8080/path` will be treated as a non-URL and may get split. Can be added later without API changes.

Fixes #5457