### PR TITLE
skill-creator: lazy-load PyYAML in frontmatter parsing

### DIFF
--- a/codex-rs/core/src/skills/assets/samples/skill-creator/scripts/generate_openai_yaml.py
+++ b/codex-rs/core/src/skills/assets/samples/skill-creator/scripts/generate_openai_yaml.py
@@ -11,8 +11,6 @@ import re
 import sys
 from pathlib import Path
 
-import yaml
-
 ACRONYMS = {
     "GH",
     "MCP",
@@ -114,6 +112,9 @@ def read_frontmatter_name(skill_dir):
         print("[ERROR] Invalid SKILL.md frontmatter format.")
         return None
     frontmatter_text = match.group(1)
+
+    import yaml
+
     try:
         frontmatter = yaml.safe_load(frontmatter_text)
     except yaml.YAMLError as exc:


### PR DESCRIPTION
init-skill should work even without PyYAML
