### PR TITLE
Infer Codex updater source from install context

### DIFF
--- a/codex-cli/bin/codex.js
+++ b/codex-cli/bin/codex.js
@@ -166,11 +166,12 @@ if (existsSync(pathDir)) {
 const updatedPath = getUpdatedPath(additionalDirs);
 
 const env = { ...process.env, PATH: updatedPath };
-const packageManagerEnvVar =
-  detectPackageManager() === "bun"
-    ? "CODEX_MANAGED_BY_BUN"
-    : "CODEX_MANAGED_BY_NPM";
-env[packageManagerEnvVar] = "1";
+const packageManager = detectPackageManager();
+if (packageManager === "bun") {
+  env.CODEX_MANAGED_BY_BUN = "1";
+} else if (packageManager === "npm") {
+  env.CODEX_MANAGED_BY_NPM = "1";
+}
 
 const child = spawn(binaryPath, process.argv.slice(2), {
   stdio: "inherit",


### PR DESCRIPTION
## Summary
- infer update action from runtime executable path when `CODEX_MANAGED_BY_*` env vars are missing, so Bun-installed binaries choose Bun updates and npm-managed binaries choose npm updates
- avoid setting `CODEX_MANAGED_BY_NPM` by default in the Node launcher when package manager detection is unknown
- add cross-platform tests for Bun and npm path-based inference in `update_action`

## Verification
- `node --check codex-cli/bin/codex.js`
- added unit coverage in `codex-rs/tui/src/update_action.rs` (cargo tests not runnable in this environment)

## Why
- in mixed environments (e.g. both Bun binary and npm shims on PATH), updater prompts can target the wrong package manager and leave the active binary unchanged
- this makes updater behavior deterministic without hardcoding machine-specific install paths