### PR TITLE
Disable collab tools during review delegation

### DIFF
--- a/codex-rs/core/src/tasks/review.rs
+++ b/codex-rs/core/src/tasks/review.rs
@@ -19,6 +19,7 @@ use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::codex_delegate::run_codex_thread_one_shot;
 use crate::config::Constrained;
+use crate::features::Feature;
 use crate::review_format::format_review_findings_block;
 use crate::review_format::render_review_output_text;
 use crate::state::TaskKind;
@@ -87,13 +88,14 @@ async fn start_review_conversation(
     let config = ctx.config.clone();
     let mut sub_agent_config = config.as_ref().clone();
     // Carry over review-only feature restrictions so the delegate cannot
-    // re-enable blocked tools (web search, view image).
+    // re-enable blocked tools (web search, collab tools, view image).
     if let Err(err) = sub_agent_config
         .web_search_mode
         .set(WebSearchMode::Disabled)
     {
         panic!("by construction Constrained<WebSearchMode> must always support Disabled: {err}");
     }
+    sub_agent_config.features.disable(Feature::Collab);
 
     // Set explicit review rubric for the sub-agent
     sub_agent_config.base_instructions = Some(crate::REVIEW_PROMPT.to_string());


### PR DESCRIPTION
Summary
- prevent delegated review agents from re-enabling blocked tools by explicitly disabling the Collab feature alongside web search and view image controls

Testing
- Not run (not requested)