### PR TITLE
memories: bump rollout summary slug cap to 60

### DIFF
--- a/codex-rs/core/src/memories/storage.rs
+++ b/codex-rs/core/src/memories/storage.rs
@@ -194,7 +194,7 @@ pub(super) fn rollout_summary_file_stem_from_parts(
     source_updated_at: chrono::DateTime<chrono::Utc>,
     rollout_slug: Option<&str>,
 ) -> String {
-    const ROLLOUT_SLUG_MAX_LEN: usize = 20;
+    const ROLLOUT_SLUG_MAX_LEN: usize = 60;
     const SHORT_HASH_ALPHABET: &[u8; 62] =
         b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
     const SHORT_HASH_SPACE: u32 = 14_776_336;
@@ -318,12 +318,17 @@ mod tests {
         let thread_id = fixed_thread_id();
         let memory = stage1_output_with_slug(
             thread_id,
-            Some("Unsafe Slug/With Spaces & Symbols + EXTRA_LONG_12345"),
+            Some("Unsafe Slug/With Spaces & Symbols + EXTRA_LONG_12345_67890_ABCDE_fghij_klmno"),
         );
 
+        let stem = rollout_summary_file_stem(&memory);
+        let slug = stem
+            .strip_prefix(&format!("{FIXED_PREFIX}-"))
+            .expect("slug suffix should be present");
+        assert_eq!(slug.len(), 60);
         assert_eq!(
-            rollout_summary_file_stem(&memory),
-            format!("{FIXED_PREFIX}-unsafe_slug_with_spa")
+            slug,
+            "unsafe_slug_with_spaces___symbols___extra_long_12345_67890_a"
         );
     }
 

--- a/codex-rs/core/src/memories/tests.rs
+++ b/codex-rs/core/src/memories/tests.rs
@@ -203,7 +203,7 @@ async fn sync_rollout_summaries_uses_timestamp_hash_and_sanitized_slug_filename(
         short_hash.chars().all(|ch| ch.is_ascii_alphanumeric()),
         "short hash should use only alphanumeric chars"
     );
-    assert!(slug.len() <= 20, "slug should be capped at 20 chars");
+    assert!(slug.len() <= 60, "slug should be capped at 60 chars");
     assert!(
         slug.chars()
             .all(|ch| ch.is_ascii_lowercase() || ch.is_ascii_digit() || ch == '_'),


### PR DESCRIPTION
## Summary
Increase the rollout summary filename slug cap from 20 to 60 characters in memory storage.

## What changed
- Updated `ROLLOUT_SLUG_MAX_LEN` from `20` to `60` in:
  - `codex-rs/core/src/memories/storage.rs`
- Updated slug truncation test to verify 60-char behavior.

## Why
This preserves more semantic context in rollout summary filenames while keeping existing normalization behavior unchanged.

## Testing
- `just fmt`
- `cargo test -p codex-core memories::storage::tests::rollout_summary_file_stem_sanitizes_and_truncates_slug -- --exact`
