### PR TITLE
docs(mcp): document how to pass environment variables to MCP servers

### DIFF
--- a/docs/config.md
+++ b/docs/config.md
@@ -12,6 +12,38 @@ Codex can connect to MCP servers configured in `~/.codex/config.toml`. See the c
 
 - https://developers.openai.com/codex/config-reference
 
+### Passing environment variables to MCP servers
+
+MCP server arguments (`args`) are passed directly to the process — they are **not** interpreted by a shell, so `$VAR` or `${VAR}` in an `args` value will be passed literally, not expanded.
+
+To securely supply API keys or secrets to an MCP server, use one of two approaches:
+
+**Option 1 – static value in `[mcp_servers.NAME.env]`:**
+
+```toml
+[mcp_servers.my-server]
+command = "npx"
+args = ["-y", "my-mcp-package"]
+
+[mcp_servers.my-server.env]
+MY_API_KEY = "sk-..."
+```
+
+**Option 2 – inherit a variable from the host environment via `env_vars`:**
+
+```toml
+[mcp_servers.my-server]
+command = "npx"
+args    = ["-y", "my-mcp-package"]
+env_vars = ["MY_API_KEY"]
+```
+
+With `env_vars`, Codex reads `MY_API_KEY` from its own environment and passes it to the MCP server process. This avoids storing secrets in `config.toml`.
+
+> **Note:** If Codex is not started from a shell that already exports the variable (e.g. it is launched from a GUI), the variable may not be present. In that case, consider setting it in `~/.codex/config.toml` under `[env]`, or exporting it in the shell that launches Codex.
+
+> **Note on `shell_environment_policy`:** By default, Codex restricts which variables are forwarded to subprocesses. If a variable exported by your shell is not reaching the MCP server, check your `shell_environment_policy` settings — you may need to add the variable name to the allowlist or set `ignore_default_excludes = true`. See [#3064](https://github.com/openai/codex/issues/3064) for context.
+
 ## Apps (Connectors)
 
 Use `$` in the composer to insert a ChatGPT connector; the popover lists accessible


### PR DESCRIPTION
## What

Add a new subsection under "Connecting to MCP servers" in `docs/config.md` that explains how to securely supply API keys and other environment variables to MCP server processes.

## Why

Closes #7521. This is a frequently asked question — users want to pass API keys like `$MY_API_KEY` in MCP server `args`, but those aren't shell-expanded. The two correct approaches (`[mcp_servers.NAME.env]` table and `env_vars` list) were undocumented.

## How

Documents:
1. That `args` values are passed literally to the process (no shell expansion)
2. **Option 1**: Static values in `[mcp_servers.NAME.env]`
3. **Option 2**: Inheriting host env vars via the `env_vars` list
4. A note about `shell_environment_policy` potentially blocking variable forwarding (with reference to #3064)

## Testing

Documentation-only change, no code changes.

## Checklist

- [x] Documentation only
- [x] Verified against the source code (`rmcp-client/src/rmcp_client.rs` and `rmcp-client/src/utils.rs`)