### PR TITLE
core: generate context diffs after pre-turn compaction

### DIFF
--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -118,13 +118,7 @@ async fn run_compact_task_inner(
     // Reuse one client session so turn-scoped state (sticky routing, websocket append tracking)
     // survives retries within this compact turn.
 
-    // TODO: If we need to guarantee the persisted mode always matches the prompt used for this
-    // turn, capture it in TurnContext at creation time. Using SessionConfiguration here avoids
-    // duplicating model settings on TurnContext, but an Op after turn start could update the
-    // session config before this write occurs.
-    let collaboration_mode = sess.current_collaboration_mode().await;
-    let rollout_item =
-        RolloutItem::TurnContext(turn_context.to_turn_context_item(collaboration_mode));
+    let rollout_item = RolloutItem::TurnContext(turn_context.to_turn_context_item());
     sess.persist_rollout_items(&[rollout_item]).await;
 
     loop {

--- a/codex-rs/core/src/context_manager/updates.rs
+++ b/codex-rs/core/src/context_manager/updates.rs
@@ -6,26 +6,27 @@ use codex_protocol::config_types::Personality;
 use codex_protocol::models::DeveloperInstructions;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::openai_models::ModelInfo;
+use codex_protocol::protocol::TurnContextItem;
 
 fn build_environment_update_item(
-    previous: Option<&TurnContext>,
+    previous: Option<&TurnContextItem>,
     next: &TurnContext,
     shell: &Shell,
 ) -> Option<ResponseItem> {
     let prev = previous?;
-    let prev_context = EnvironmentContext::from_turn_context(prev, shell);
+    let prev_context = EnvironmentContext::from_turn_context_item(prev, shell);
     let next_context = EnvironmentContext::from_turn_context(next, shell);
     if prev_context.equals_except_shell(&next_context) {
         return None;
     }
 
-    Some(ResponseItem::from(EnvironmentContext::diff(
-        prev, next, shell,
-    )))
+    Some(ResponseItem::from(
+        EnvironmentContext::diff_from_turn_context_item(prev, next, shell),
+    ))
 }
 
 fn build_permissions_update_item(
-    previous: Option<&TurnContext>,
+    previous: Option<&TurnContextItem>,
     next: &TurnContext,
     exec_policy: &Policy,
 ) -> Option<ResponseItem> {
@@ -46,11 +47,11 @@ fn build_permissions_update_item(
 }
 
 fn build_collaboration_mode_update_item(
-    previous: Option<&TurnContext>,
+    previous: Option<&TurnContextItem>,
     next: &TurnContext,
 ) -> Option<ResponseItem> {
     let prev = previous?;
-    if prev.collaboration_mode != next.collaboration_mode {
+    if prev.collaboration_mode.as_ref() != Some(&next.collaboration_mode) {
         // If the next mode has empty developer instructions, this returns None and we emit no
         // update, so prior collaboration instructions remain in the prompt history.
         Some(DeveloperInstructions::from_collaboration_mode(&next.collaboration_mode)?.into())
@@ -60,7 +61,7 @@ fn build_collaboration_mode_update_item(
 }
 
 fn build_personality_update_item(
-    previous: Option<&TurnContext>,
+    previous: Option<&TurnContextItem>,
     next: &TurnContext,
     personality_feature_enabled: bool,
 ) -> Option<ResponseItem> {
@@ -68,7 +69,7 @@ fn build_personality_update_item(
         return None;
     }
     let previous = previous?;
-    if next.model_info.slug != previous.model_info.slug {
+    if next.model_info.slug != previous.model {
         return None;
     }
 
@@ -96,12 +97,11 @@ pub(crate) fn personality_message_for(
 }
 
 pub(crate) fn build_model_instructions_update_item(
-    previous: Option<&TurnContext>,
+    previous: Option<&TurnContextItem>,
     resumed_model: Option<&str>,
     next: &TurnContext,
 ) -> Option<ResponseItem> {
-    let previous_model =
-        resumed_model.or_else(|| previous.map(|prev| prev.model_info.slug.as_str()))?;
+    let previous_model = resumed_model.or_else(|| previous.map(|prev| prev.model.as_str()))?;
     if previous_model == next.model_info.slug {
         return None;
     }
@@ -115,7 +115,7 @@ pub(crate) fn build_model_instructions_update_item(
 }
 
 pub(crate) fn build_settings_update_items(
-    previous: Option<&TurnContext>,
+    previous: Option<&TurnContextItem>,
     resumed_model: Option<&str>,
     next: &TurnContext,
     shell: &Shell,

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -11,6 +11,7 @@ use crate::protocol::TokenUsage;
 use crate::protocol::TokenUsageInfo;
 use crate::tasks::RegularTask;
 use crate::truncate::TruncationPolicy;
+use codex_protocol::protocol::TurnContextItem;
 
 /// Persistent, session-scoped state previously stored directly on `Session`.
 pub(crate) struct SessionState {
@@ -78,6 +79,14 @@ impl SessionState {
 
     pub(crate) fn set_token_info(&mut self, info: Option<TokenUsageInfo>) {
         self.history.set_token_info(info);
+    }
+
+    pub(crate) fn set_previous_context_item(&mut self, item: Option<TurnContextItem>) {
+        self.history.set_previous_context_item(item);
+    }
+
+    pub(crate) fn previous_context_item(&self) -> Option<TurnContextItem> {
+        self.history.previous_context_item()
     }
 
     // Token/rate limit helpers

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -1390,12 +1390,26 @@ async fn snapshot_request_shape_remote_pre_turn_compaction_including_incoming_us
     insta::assert_snapshot!(
         "remote_pre_turn_compaction_including_incoming_shapes",
         format_labeled_requests_snapshot(
-            "Remote pre-turn auto-compaction with a context override emits the context diff in the compact request while excluding the incoming user message.",
+            "Remote pre-turn auto-compaction with a context override excludes incoming-turn context diffs from the compact request, then appends those diffs immediately before the incoming user message after compaction.",
             &[
                 ("Remote Compaction Request", &compact_request),
                 ("Remote Post-Compaction History Layout", &requests[2]),
             ]
         )
+    );
+    assert!(
+        !compact_request
+            .body_json()
+            .to_string()
+            .contains(PRETURN_CONTEXT_DIFF_CWD),
+        "pre-turn remote compaction request should exclude incoming context diff items"
+    );
+    assert!(
+        requests[2]
+            .body_json()
+            .to_string()
+            .contains(PRETURN_CONTEXT_DIFF_CWD),
+        "post-compaction remote request should include incoming context diff items"
     );
     assert_eq!(
         requests[2]

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_including_incoming_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_including_incoming_shapes.snap
@@ -1,8 +1,8 @@
 ---
 source: core/tests/suite/compact.rs
-expression: "format_labeled_requests_snapshot(\"Pre-turn auto-compaction with a context override emits the context diff in the compact request while the incoming user message is still excluded.\",\n&[(\"Local Compaction Request\", &requests[2]),\n(\"Local Post-Compaction History Layout\", &requests[3]),])"
+expression: "format_labeled_requests_snapshot(\"Pre-turn auto-compaction with a context override excludes incoming-turn context diffs from the compact request, then appends those diffs immediately before the incoming user message after compaction.\",\n&[(\"Local Compaction Request\", &requests[2]),\n(\"Local Post-Compaction History Layout\", &requests[3]),])"
 ---
-Scenario: Pre-turn auto-compaction with a context override emits the context diff in the compact request while the incoming user message is still excluded.
+Scenario: Pre-turn auto-compaction with a context override excludes incoming-turn context diffs from the compact request, then appends those diffs immediately before the incoming user message after compaction.
 
 ## Local Compaction Request
 00:message/developer:<PERMISSIONS_INSTRUCTIONS>
@@ -12,8 +12,7 @@ Scenario: Pre-turn auto-compaction with a context override emits the context dif
 04:message/assistant:FIRST_REPLY
 05:message/user:USER_TWO
 06:message/assistant:SECOND_REPLY
-07:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
-08:message/user:<SUMMARIZATION_PROMPT>
+07:message/user:<SUMMARIZATION_PROMPT>
 
 ## Local Post-Compaction History Layout
 00:message/developer:<PERMISSIONS_INSTRUCTIONS>
@@ -22,4 +21,5 @@ Scenario: Pre-turn auto-compaction with a context override emits the context dif
 03:message/user:USER_ONE
 04:message/user:USER_TWO
 05:message/user:<COMPACTION_SUMMARY>\nPRE_TURN_SUMMARY
-06:message/user:<image> | <input_image:image_url> | </image> | USER_THREE
+06:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
+07:message/user:<image> | <input_image:image_url> | </image> | USER_THREE

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_including_incoming_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_including_incoming_shapes.snap
@@ -1,8 +1,8 @@
 ---
 source: core/tests/suite/compact_remote.rs
-expression: "format_labeled_requests_snapshot(\"Remote pre-turn auto-compaction with a context override emits the context diff in the compact request while excluding the incoming user message.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", &requests[2]),])"
+expression: "format_labeled_requests_snapshot(\"Remote pre-turn auto-compaction with a context override excludes incoming-turn context diffs from the compact request, then appends those diffs immediately before the incoming user message after compaction.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", &requests[2]),])"
 ---
-Scenario: Remote pre-turn auto-compaction with a context override emits the context diff in the compact request while excluding the incoming user message.
+Scenario: Remote pre-turn auto-compaction with a context override excludes incoming-turn context diffs from the compact request, then appends those diffs immediately before the incoming user message after compaction.
 
 ## Remote Compaction Request
 00:message/developer:<PERMISSIONS_INSTRUCTIONS>
@@ -12,7 +12,6 @@ Scenario: Remote pre-turn auto-compaction with a context override emits the cont
 04:message/assistant:REMOTE_FIRST_REPLY
 05:message/user:USER_TWO
 06:message/assistant:REMOTE_SECOND_REPLY
-07:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
 
 ## Remote Post-Compaction History Layout
 00:message/user:USER_ONE
@@ -21,4 +20,5 @@ Scenario: Remote pre-turn auto-compaction with a context override emits the cont
 03:message/user:<AGENTS_MD>
 04:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
 05:message/user:<COMPACTION_SUMMARY>\nREMOTE_PRE_TURN_SUMMARY
-06:message/user:USER_THREE
+06:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
+07:message/user:USER_THREE


### PR DESCRIPTION
## Summary
- move settings/context diff generation out of pre-spawn task setup and into `run_turn`
- generate and persist diff items only after pre-turn/model-switch compaction has run
- keep `previous_context_item` advancement in `run_turn` after diff persistence
- update pre-turn compaction snapshots to reflect that incoming context diffs are excluded from compaction input and appear immediately before the incoming user message afterward

## Testing
- `just fmt`
- `env -u CODEX_SANDBOX_NETWORK_DISABLED INSTA_UPDATE=always cargo test -p codex-core --test all snapshot_request_shape_pre_turn_compaction_including_incoming_user_message -- --nocapture`
- `env -u CODEX_SANDBOX_NETWORK_DISABLED INSTA_UPDATE=always cargo test -p codex-core --test all snapshot_request_shape_remote_pre_turn_compaction_including_incoming_user_message -- --nocapture`
- `env -u CODEX_SANDBOX_NETWORK_DISABLED cargo test -p codex-core --test all snapshot_request_shape_pre_turn_compaction_strips_incoming_model_switch -- --nocapture`
- `env -u CODEX_SANDBOX_NETWORK_DISABLED cargo test -p codex-core --test all snapshot_request_shape_remote_pre_turn_compaction_strips_incoming_model_switch -- --nocapture`
