### PR TITLE
Stabilize app-server detached review and running-resume tests

### DIFF
--- a/codex-rs/app-server/tests/common/mcp_process.rs
+++ b/codex-rs/app-server/tests/common/mcp_process.rs
@@ -105,6 +105,10 @@ impl McpProcess {
         cmd.stderr(Stdio::piped());
         cmd.env("CODEX_HOME", codex_home);
         cmd.env("RUST_LOG", "debug");
+        // Bazel/Linux workers can run with smaller default thread stacks, which makes
+        // tokio-runtime-worker stack overflows more likely in app-server integration tests.
+        // Pin a larger minimum stack for the spawned test server process.
+        cmd.env("RUST_MIN_STACK", "4194304");
         cmd.env_remove(CODEX_INTERNAL_ORIGINATOR_OVERRIDE_ENV_VAR);
 
         for (k, v) in env_overrides {


### PR DESCRIPTION
## Summary
- stabilize `thread_resume_rejoins_running_thread_even_with_override_mismatch` by using a valid delayed second SSE response instead of an intentionally truncated stream
- set `RUST_MIN_STACK=4194304` for spawned app-server test processes in `McpProcess` to avoid stack-sensitive CI overflows in detached review tests

## Why
- the thread-resume assertion could race with a mocked stream-disconnect error and intermittently observe `systemError`
- detached review startup is stack-sensitive in some CI environments; pinning a larger stack in the test harness removes that flake without changing product behavior

## Validation
- `just fmt`
- `cargo test -p codex-app-server --test all suite::v2::thread_resume::thread_resume_rejoins_running_thread_even_with_override_mismatch`
- `cargo test -p codex-app-server --test all suite::v2::review::review_start_with_detached_delivery_returns_new_thread_id`
