### PR TITLE
Increase Tokio worker stack for app-server runtime

### DIFF
--- a/codex-rs/app-server/tests/common/mcp_process.rs
+++ b/codex-rs/app-server/tests/common/mcp_process.rs
@@ -105,10 +105,6 @@ impl McpProcess {
         cmd.stderr(Stdio::piped());
         cmd.env("CODEX_HOME", codex_home);
         cmd.env("RUST_LOG", "debug");
-        // Bazel/Linux workers can run with smaller default thread stacks, which makes
-        // tokio-runtime-worker stack overflows more likely in app-server integration tests.
-        // Pin a larger minimum stack for the spawned test server process.
-        cmd.env("RUST_MIN_STACK", "4194304");
         cmd.env_remove(CODEX_INTERNAL_ORIGINATOR_OVERRIDE_ENV_VAR);
 
         for (k, v) in env_overrides {


### PR DESCRIPTION
## Summary
- set a non-Windows Tokio worker stack size in `codex-arg0` (4 MiB)
- keep Windows at the existing larger stack size (16 MiB)
- remove reliance on per-test `RUST_MIN_STACK` workarounds by fixing runtime construction directly

## Why
`//codex-rs/app-server:app-server-all-test` was consistently failing in Bazel on:
- `suite::v2::review::review_start_with_detached_delivery_returns_new_thread_id`
- `thread 'tokio-runtime-worker' has overflowed its stack`

Root cause is worker stack exhaustion in the detached-review thread startup path under the default Tokio worker stack size (2 MiB on Linux). This path is deeper than a normal thread start and can exceed that limit in Bazel workers.

## Validation
- `just fmt`
- `cargo test -p codex-arg0`
- `RUST_MIN_STACK=2031616 cargo test -q -p codex-app-server review_start_with_detached_delivery_returns_new_thread_id -- --nocapture`
