### PR TITLE
ci(bazel): install Node from node-version.txt in remote image

### DIFF
--- a/.github/workflows/Dockerfile.bazel
+++ b/.github/workflows/Dockerfile.bazel
@@ -8,8 +8,24 @@ FROM ubuntu:24.04
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    curl git python3 ca-certificates && \
+    curl git python3 ca-certificates xz-utils && \
     rm -rf /var/lib/apt/lists/*
+
+COPY codex-rs/node-version.txt /tmp/node-version.txt
+
+RUN set -eux; \
+    node_arch="$(dpkg --print-architecture)"; \
+    case "${node_arch}" in \
+      amd64) node_dist_arch="x64" ;; \
+      arm64) node_dist_arch="arm64" ;; \
+      *) echo "unsupported architecture: ${node_arch}"; exit 1 ;; \
+    esac; \
+    node_version="$(tr -d '[:space:]' </tmp/node-version.txt)"; \
+    curl -fsSLO "https://nodejs.org/dist/v${node_version}/node-v${node_version}-linux-${node_dist_arch}.tar.xz"; \
+    tar -xJf "node-v${node_version}-linux-${node_dist_arch}.tar.xz" -C /usr/local --strip-components=1; \
+    rm "node-v${node_version}-linux-${node_dist_arch}.tar.xz" /tmp/node-version.txt; \
+    node --version; \
+    npm --version
 
 # Install dotslash.
 RUN curl -LSfs "https://github.com/facebook/dotslash/releases/download/v0.5.8/dotslash-ubuntu-22.04.$(uname -m).tar.gz" | tar fxz - -C /usr/local/bin


### PR DESCRIPTION
## Summary
Install Node in the Bazel remote execution image using the version pinned in `codex-rs/node-version.txt`.

## Why
`js_repl` tests run under Bazel remote execution and require a modern Node runtime. Runner-level `setup-node` does not guarantee Node is available (or recent enough) inside the remote worker container.

## What changed
- Updated `.github/workflows/Dockerfile.bazel` to install Node from official tarballs at image build time.
- Added `xz-utils` for extracting `.tar.xz` archives.
- Copied `codex-rs/node-version.txt` into the image build context and used it as the single source of truth for Node version.
- Added architecture mapping for multi-arch builds:
  - `amd64 -> x64`
  - `arm64 -> arm64`
- Verified install during image build with:
  - `node --version`
  - `npm --version`

## Impact
- Bazel remote workers should now have the required Node version available for `js_repl` tests.
- Keeps Node version synchronized with repo policy via `codex-rs/node-version.txt`.

## Testing
- Verified Dockerfile changes and build steps locally (build-time commands are deterministic and fail fast on unsupported arch/version fetch issues).

## Follow-up
- Rebuild and publish the Bazel runner image for both `linux/amd64` and `linux/arm64`.
- Update image digests in `rbe.bzl` to roll out this runtime update in CI.


#### [git stack](https://github.com/magus/git-stack-cli)
- ✅ `1` https://github.com/openai/codex/pull/12300
- ✅ `2` https://github.com/openai/codex/pull/12275
- 👉 `3` https://github.com/openai/codex/pull/12205
- ⏳ `4` https://github.com/openai/codex/pull/12185
- ⏳ `5` https://github.com/openai/codex/pull/10673