### PR TITLE
feat: add configurable write_stdin timeout

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -1296,7 +1296,7 @@
       "description": "Settings for app-specific controls."
     },
     "background_terminal_timeout": {
-      "description": "Maximum poll window for background terminal output (`write_stdin`), in milliseconds. Default: `30000`.",
+      "description": "Maximum poll window for background terminal output (`write_stdin`), in milliseconds. Default: `300000` (5 minutes).",
       "format": "uint64",
       "minimum": 0.0,
       "type": "integer"

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -1295,6 +1295,12 @@
       "default": null,
       "description": "Settings for app-specific controls."
     },
+    "background_terminal_timeout": {
+      "description": "Maximum poll window for background terminal output (`write_stdin`), in milliseconds. Default: `30000`.",
+      "format": "uint64",
+      "minimum": 0.0,
+      "type": "integer"
+    },
     "chatgpt_base_url": {
       "description": "Base URL for requests to ChatGPT (as opposed to the OpenAI API).",
       "type": "string"

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -1298,7 +1298,7 @@
     "background_terminal_timeout": {
       "description": "Maximum poll window for background terminal output (`write_stdin`), in milliseconds. Default: `300000` (5 minutes).",
       "format": "uint64",
-      "minimum": 5000.0,
+      "minimum": 0.0,
       "type": "integer"
     },
     "chatgpt_base_url": {

--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -1298,7 +1298,7 @@
     "background_terminal_timeout": {
       "description": "Maximum poll window for background terminal output (`write_stdin`), in milliseconds. Default: `300000` (5 minutes).",
       "format": "uint64",
-      "minimum": 0.0,
+      "minimum": 5000.0,
       "type": "integer"
     },
     "chatgpt_base_url": {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1287,7 +1287,9 @@ impl Session {
         let services = SessionServices {
             mcp_connection_manager: Arc::new(RwLock::new(McpConnectionManager::default())),
             mcp_startup_cancellation_token: Mutex::new(CancellationToken::new()),
-            unified_exec_manager: UnifiedExecProcessManager::default(),
+            unified_exec_manager: UnifiedExecProcessManager::new(
+                config.background_terminal_timeout,
+            ),
             zsh_exec_bridge,
             analytics_events_client: AnalyticsEventsClient::new(
                 Arc::clone(&config),
@@ -7376,7 +7378,9 @@ mod tests {
         let services = SessionServices {
             mcp_connection_manager: Arc::new(RwLock::new(McpConnectionManager::default())),
             mcp_startup_cancellation_token: Mutex::new(CancellationToken::new()),
-            unified_exec_manager: UnifiedExecProcessManager::default(),
+            unified_exec_manager: UnifiedExecProcessManager::new(
+                config.background_terminal_timeout,
+            ),
             zsh_exec_bridge: ZshExecBridge::default(),
             analytics_events_client: AnalyticsEventsClient::new(
                 Arc::clone(&config),
@@ -7525,7 +7529,9 @@ mod tests {
         let services = SessionServices {
             mcp_connection_manager: Arc::new(RwLock::new(McpConnectionManager::default())),
             mcp_startup_cancellation_token: Mutex::new(CancellationToken::new()),
-            unified_exec_manager: UnifiedExecProcessManager::default(),
+            unified_exec_manager: UnifiedExecProcessManager::new(
+                config.background_terminal_timeout,
+            ),
             zsh_exec_bridge: ZshExecBridge::default(),
             analytics_events_client: AnalyticsEventsClient::new(
                 Arc::clone(&config),

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1288,7 +1288,7 @@ impl Session {
             mcp_connection_manager: Arc::new(RwLock::new(McpConnectionManager::default())),
             mcp_startup_cancellation_token: Mutex::new(CancellationToken::new()),
             unified_exec_manager: UnifiedExecProcessManager::new(
-                config.background_terminal_timeout,
+                config.background_terminal_max_timeout,
             ),
             zsh_exec_bridge,
             analytics_events_client: AnalyticsEventsClient::new(
@@ -7379,7 +7379,7 @@ mod tests {
             mcp_connection_manager: Arc::new(RwLock::new(McpConnectionManager::default())),
             mcp_startup_cancellation_token: Mutex::new(CancellationToken::new()),
             unified_exec_manager: UnifiedExecProcessManager::new(
-                config.background_terminal_timeout,
+                config.background_terminal_max_timeout,
             ),
             zsh_exec_bridge: ZshExecBridge::default(),
             analytics_events_client: AnalyticsEventsClient::new(
@@ -7530,7 +7530,7 @@ mod tests {
             mcp_connection_manager: Arc::new(RwLock::new(McpConnectionManager::default())),
             mcp_startup_cancellation_token: Mutex::new(CancellationToken::new()),
             unified_exec_manager: UnifiedExecProcessManager::new(
-                config.background_terminal_timeout,
+                config.background_terminal_max_timeout,
             ),
             zsh_exec_bridge: ZshExecBridge::default(),
             analytics_events_client: AnalyticsEventsClient::new(

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -51,6 +51,8 @@ use crate::protocol::ReadOnlyAccess;
 use crate::protocol::SandboxPolicy;
 #[cfg(target_os = "macos")]
 use crate::seatbelt_permissions::MacOsSeatbeltProfileExtensions;
+use crate::unified_exec::DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS;
+use crate::unified_exec::MIN_EMPTY_YIELD_TIME_MS;
 use crate::windows_sandbox::WindowsSandboxLevelExt;
 use crate::windows_sandbox::resolve_windows_sandbox_mode;
 use codex_app_server_protocol::Tools;
@@ -379,6 +381,10 @@ pub struct Config {
 
     /// If set to `true`, used only the experimental unified exec tool.
     pub use_experimental_unified_exec_tool: bool,
+
+    /// Maximum poll window for background terminal output (`write_stdin`), in milliseconds.
+    /// Default: `30000`.
+    pub background_terminal_timeout: u64,
 
     /// Settings for ghost snapshots (used for undo).
     pub ghost_snapshot: GhostSnapshotConfig,
@@ -981,6 +987,10 @@ pub struct ConfigToml {
 
     /// Token budget applied when storing tool/function outputs in the context manager.
     pub tool_output_token_limit: Option<usize>,
+
+    /// Maximum poll window for background terminal output (`write_stdin`), in milliseconds.
+    /// Default: `30000`.
+    pub background_terminal_timeout: Option<u64>,
 
     /// Optional absolute path to the Node runtime used by `js_repl`.
     pub js_repl_node_path: Option<AbsolutePathBuf>,
@@ -1675,6 +1685,10 @@ impl Config {
             })
             .transpose()?
             .unwrap_or_default();
+        let background_terminal_timeout = cfg
+            .background_terminal_timeout
+            .unwrap_or(DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS)
+            .max(MIN_EMPTY_YIELD_TIME_MS);
 
         let ghost_snapshot = {
             let mut config = GhostSnapshotConfig::default();
@@ -1925,6 +1939,7 @@ impl Config {
             include_apply_patch_tool: include_apply_patch_tool_flag,
             web_search_mode: constrained_web_search_mode.value,
             use_experimental_unified_exec_tool,
+            background_terminal_timeout,
             ghost_snapshot,
             features,
             suppress_unstable_features_warning: cfg
@@ -4346,6 +4361,7 @@ model_verbosity = "high"
                 include_apply_patch_tool: false,
                 web_search_mode: Constrained::allow_any(WebSearchMode::Cached),
                 use_experimental_unified_exec_tool: !cfg!(windows),
+                background_terminal_timeout: DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS,
                 ghost_snapshot: GhostSnapshotConfig::default(),
                 features: Features::with_defaults(),
                 suppress_unstable_features_warning: false,
@@ -4460,6 +4476,7 @@ model_verbosity = "high"
             include_apply_patch_tool: false,
             web_search_mode: Constrained::allow_any(WebSearchMode::Cached),
             use_experimental_unified_exec_tool: !cfg!(windows),
+            background_terminal_timeout: DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS,
             ghost_snapshot: GhostSnapshotConfig::default(),
             features: Features::with_defaults(),
             suppress_unstable_features_warning: false,
@@ -4572,6 +4589,7 @@ model_verbosity = "high"
             include_apply_patch_tool: false,
             web_search_mode: Constrained::allow_any(WebSearchMode::Cached),
             use_experimental_unified_exec_tool: !cfg!(windows),
+            background_terminal_timeout: DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS,
             ghost_snapshot: GhostSnapshotConfig::default(),
             features: Features::with_defaults(),
             suppress_unstable_features_warning: false,
@@ -4670,6 +4688,7 @@ model_verbosity = "high"
             include_apply_patch_tool: false,
             web_search_mode: Constrained::allow_any(WebSearchMode::Cached),
             use_experimental_unified_exec_tool: !cfg!(windows),
+            background_terminal_timeout: DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS,
             ghost_snapshot: GhostSnapshotConfig::default(),
             features: Features::with_defaults(),
             suppress_unstable_features_warning: false,

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -384,7 +384,7 @@ pub struct Config {
 
     /// Maximum poll window for background terminal output (`write_stdin`), in milliseconds.
     /// Default: `300000` (5 minutes).
-    pub background_terminal_timeout: u64,
+    pub background_terminal_max_timeout: u64,
 
     /// Settings for ghost snapshots (used for undo).
     pub ghost_snapshot: GhostSnapshotConfig,
@@ -1685,7 +1685,7 @@ impl Config {
             })
             .transpose()?
             .unwrap_or_default();
-        let background_terminal_timeout = cfg
+        let background_terminal_max_timeout = cfg
             .background_terminal_timeout
             .unwrap_or(DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS)
             .max(MIN_EMPTY_YIELD_TIME_MS);
@@ -1939,7 +1939,7 @@ impl Config {
             include_apply_patch_tool: include_apply_patch_tool_flag,
             web_search_mode: constrained_web_search_mode.value,
             use_experimental_unified_exec_tool,
-            background_terminal_timeout,
+            background_terminal_max_timeout,
             ghost_snapshot,
             features,
             suppress_unstable_features_warning: cfg
@@ -4361,7 +4361,7 @@ model_verbosity = "high"
                 include_apply_patch_tool: false,
                 web_search_mode: Constrained::allow_any(WebSearchMode::Cached),
                 use_experimental_unified_exec_tool: !cfg!(windows),
-                background_terminal_timeout: DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS,
+                background_terminal_max_timeout: DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS,
                 ghost_snapshot: GhostSnapshotConfig::default(),
                 features: Features::with_defaults(),
                 suppress_unstable_features_warning: false,
@@ -4476,7 +4476,7 @@ model_verbosity = "high"
             include_apply_patch_tool: false,
             web_search_mode: Constrained::allow_any(WebSearchMode::Cached),
             use_experimental_unified_exec_tool: !cfg!(windows),
-            background_terminal_timeout: DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS,
+            background_terminal_max_timeout: DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS,
             ghost_snapshot: GhostSnapshotConfig::default(),
             features: Features::with_defaults(),
             suppress_unstable_features_warning: false,
@@ -4589,7 +4589,7 @@ model_verbosity = "high"
             include_apply_patch_tool: false,
             web_search_mode: Constrained::allow_any(WebSearchMode::Cached),
             use_experimental_unified_exec_tool: !cfg!(windows),
-            background_terminal_timeout: DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS,
+            background_terminal_max_timeout: DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS,
             ghost_snapshot: GhostSnapshotConfig::default(),
             features: Features::with_defaults(),
             suppress_unstable_features_warning: false,
@@ -4688,7 +4688,7 @@ model_verbosity = "high"
             include_apply_patch_tool: false,
             web_search_mode: Constrained::allow_any(WebSearchMode::Cached),
             use_experimental_unified_exec_tool: !cfg!(windows),
-            background_terminal_timeout: DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS,
+            background_terminal_max_timeout: DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS,
             ghost_snapshot: GhostSnapshotConfig::default(),
             features: Features::with_defaults(),
             suppress_unstable_features_warning: false,

--- a/codex-rs/core/src/config/mod.rs
+++ b/codex-rs/core/src/config/mod.rs
@@ -51,7 +51,7 @@ use crate::protocol::ReadOnlyAccess;
 use crate::protocol::SandboxPolicy;
 #[cfg(target_os = "macos")]
 use crate::seatbelt_permissions::MacOsSeatbeltProfileExtensions;
-use crate::unified_exec::DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS;
+use crate::unified_exec::DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS;
 use crate::unified_exec::MIN_EMPTY_YIELD_TIME_MS;
 use crate::windows_sandbox::WindowsSandboxLevelExt;
 use crate::windows_sandbox::resolve_windows_sandbox_mode;
@@ -383,7 +383,7 @@ pub struct Config {
     pub use_experimental_unified_exec_tool: bool,
 
     /// Maximum poll window for background terminal output (`write_stdin`), in milliseconds.
-    /// Default: `30000`.
+    /// Default: `300000` (5 minutes).
     pub background_terminal_timeout: u64,
 
     /// Settings for ghost snapshots (used for undo).
@@ -989,7 +989,7 @@ pub struct ConfigToml {
     pub tool_output_token_limit: Option<usize>,
 
     /// Maximum poll window for background terminal output (`write_stdin`), in milliseconds.
-    /// Default: `30000`.
+    /// Default: `300000` (5 minutes).
     pub background_terminal_timeout: Option<u64>,
 
     /// Optional absolute path to the Node runtime used by `js_repl`.
@@ -1687,7 +1687,7 @@ impl Config {
             .unwrap_or_default();
         let background_terminal_timeout = cfg
             .background_terminal_timeout
-            .unwrap_or(DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS)
+            .unwrap_or(DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS)
             .max(MIN_EMPTY_YIELD_TIME_MS);
 
         let ghost_snapshot = {
@@ -4361,7 +4361,7 @@ model_verbosity = "high"
                 include_apply_patch_tool: false,
                 web_search_mode: Constrained::allow_any(WebSearchMode::Cached),
                 use_experimental_unified_exec_tool: !cfg!(windows),
-                background_terminal_timeout: DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS,
+                background_terminal_timeout: DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS,
                 ghost_snapshot: GhostSnapshotConfig::default(),
                 features: Features::with_defaults(),
                 suppress_unstable_features_warning: false,
@@ -4476,7 +4476,7 @@ model_verbosity = "high"
             include_apply_patch_tool: false,
             web_search_mode: Constrained::allow_any(WebSearchMode::Cached),
             use_experimental_unified_exec_tool: !cfg!(windows),
-            background_terminal_timeout: DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS,
+            background_terminal_timeout: DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS,
             ghost_snapshot: GhostSnapshotConfig::default(),
             features: Features::with_defaults(),
             suppress_unstable_features_warning: false,
@@ -4589,7 +4589,7 @@ model_verbosity = "high"
             include_apply_patch_tool: false,
             web_search_mode: Constrained::allow_any(WebSearchMode::Cached),
             use_experimental_unified_exec_tool: !cfg!(windows),
-            background_terminal_timeout: DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS,
+            background_terminal_timeout: DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS,
             ghost_snapshot: GhostSnapshotConfig::default(),
             features: Features::with_defaults(),
             suppress_unstable_features_warning: false,
@@ -4688,7 +4688,7 @@ model_verbosity = "high"
             include_apply_patch_tool: false,
             web_search_mode: Constrained::allow_any(WebSearchMode::Cached),
             use_experimental_unified_exec_tool: !cfg!(windows),
-            background_terminal_timeout: DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS,
+            background_terminal_timeout: DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS,
             ghost_snapshot: GhostSnapshotConfig::default(),
             features: Features::with_defaults(),
             suppress_unstable_features_warning: false,

--- a/codex-rs/core/src/unified_exec/mod.rs
+++ b/codex-rs/core/src/unified_exec/mod.rs
@@ -53,7 +53,7 @@ pub(crate) use process::UnifiedExecProcess;
 pub(crate) const MIN_YIELD_TIME_MS: u64 = 250;
 // Minimum yield time for an empty `write_stdin`.
 pub(crate) const MIN_EMPTY_YIELD_TIME_MS: u64 = 5_000;
-pub(crate) const MAX_YIELD_TIME_MS: u64 = 30_000;
+pub(crate) const DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS: u64 = 30_000;
 pub(crate) const DEFAULT_MAX_OUTPUT_TOKENS: usize = 10_000;
 pub(crate) const UNIFIED_EXEC_OUTPUT_MAX_BYTES: usize = 1024 * 1024; // 1 MiB
 pub(crate) const UNIFIED_EXEC_OUTPUT_MAX_TOKENS: usize = UNIFIED_EXEC_OUTPUT_MAX_BYTES / 4;
@@ -129,13 +129,22 @@ impl ProcessStore {
 
 pub(crate) struct UnifiedExecProcessManager {
     process_store: Mutex<ProcessStore>,
+    max_write_stdin_yield_time_ms: u64,
+}
+
+impl UnifiedExecProcessManager {
+    pub(crate) fn new(max_write_stdin_yield_time_ms: u64) -> Self {
+        Self {
+            process_store: Mutex::new(ProcessStore::default()),
+            max_write_stdin_yield_time_ms: max_write_stdin_yield_time_ms
+                .max(MIN_EMPTY_YIELD_TIME_MS),
+        }
+    }
 }
 
 impl Default for UnifiedExecProcessManager {
     fn default() -> Self {
-        Self {
-            process_store: Mutex::new(ProcessStore::default()),
-        }
+        Self::new(DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS)
     }
 }
 
@@ -151,7 +160,7 @@ struct ProcessEntry {
 }
 
 pub(crate) fn clamp_yield_time(yield_time_ms: u64) -> u64 {
-    yield_time_ms.clamp(MIN_YIELD_TIME_MS, MAX_YIELD_TIME_MS)
+    yield_time_ms.clamp(MIN_YIELD_TIME_MS, DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS)
 }
 
 pub(crate) fn resolve_max_tokens(max_tokens: Option<usize>) -> usize {

--- a/codex-rs/core/src/unified_exec/mod.rs
+++ b/codex-rs/core/src/unified_exec/mod.rs
@@ -53,7 +53,8 @@ pub(crate) use process::UnifiedExecProcess;
 pub(crate) const MIN_YIELD_TIME_MS: u64 = 250;
 // Minimum yield time for an empty `write_stdin`.
 pub(crate) const MIN_EMPTY_YIELD_TIME_MS: u64 = 5_000;
-pub(crate) const DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS: u64 = 30_000;
+pub(crate) const MAX_YIELD_TIME_MS: u64 = 30_000;
+pub(crate) const DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS: u64 = 300_000;
 pub(crate) const DEFAULT_MAX_OUTPUT_TOKENS: usize = 10_000;
 pub(crate) const UNIFIED_EXEC_OUTPUT_MAX_BYTES: usize = 1024 * 1024; // 1 MiB
 pub(crate) const UNIFIED_EXEC_OUTPUT_MAX_TOKENS: usize = UNIFIED_EXEC_OUTPUT_MAX_BYTES / 4;
@@ -144,7 +145,7 @@ impl UnifiedExecProcessManager {
 
 impl Default for UnifiedExecProcessManager {
     fn default() -> Self {
-        Self::new(DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS)
+        Self::new(DEFAULT_MAX_BACKGROUND_TERMINAL_TIMEOUT_MS)
     }
 }
 
@@ -160,7 +161,7 @@ struct ProcessEntry {
 }
 
 pub(crate) fn clamp_yield_time(yield_time_ms: u64) -> u64 {
-    yield_time_ms.clamp(MIN_YIELD_TIME_MS, DEFAULT_BACKGROUND_TERMINAL_TIMEOUT_MS)
+    yield_time_ms.clamp(MIN_YIELD_TIME_MS, MAX_YIELD_TIME_MS)
 }
 
 pub(crate) fn resolve_max_tokens(max_tokens: Option<usize>) -> usize {

--- a/codex-rs/core/src/unified_exec/process_manager.rs
+++ b/codex-rs/core/src/unified_exec/process_manager.rs
@@ -31,8 +31,8 @@ use crate::truncate::approx_token_count;
 use crate::truncate::formatted_truncate_text;
 use crate::unified_exec::ExecCommandRequest;
 use crate::unified_exec::MAX_UNIFIED_EXEC_PROCESSES;
-use crate::unified_exec::MAX_YIELD_TIME_MS;
 use crate::unified_exec::MIN_EMPTY_YIELD_TIME_MS;
+use crate::unified_exec::MIN_YIELD_TIME_MS;
 use crate::unified_exec::ProcessEntry;
 use crate::unified_exec::ProcessStore;
 use crate::unified_exec::UnifiedExecContext;
@@ -351,11 +351,13 @@ impl UnifiedExecProcessManager {
 
         let max_tokens = resolve_max_tokens(request.max_output_tokens);
         let yield_time_ms = {
-            let time_ms = clamp_yield_time(request.yield_time_ms);
+            // Keep `write_stdin` responsive with a minimum poll window while
+            // still honoring the configured background terminal timeout cap.
+            let time_ms = request.yield_time_ms.max(MIN_YIELD_TIME_MS);
             if request.input.is_empty() {
-                time_ms.clamp(MIN_EMPTY_YIELD_TIME_MS, MAX_YIELD_TIME_MS)
+                time_ms.clamp(MIN_EMPTY_YIELD_TIME_MS, self.max_write_stdin_yield_time_ms)
             } else {
-                time_ms
+                time_ms.min(self.max_write_stdin_yield_time_ms)
             }
         };
         let start = Instant::now();


### PR DESCRIPTION
Add max timeout as config for `write_stdin`. This is only used for empty `write_stdin`. 

Also increased the default value from 30s to 5mins.