### PR TITLE
fix(tui): support Option-key shortcuts across terminal encodings

### DIFF
--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3098,6 +3098,8 @@ impl ChatWidget {
             {
                 self.cycle_collaboration_mode();
             }
+            // Terminals can encode Option+Up as Alt+Up or Ctrl+Up (e.g. CSI 1;5A),
+            // so accept either modifier for queued-message restore.
             KeyEvent {
                 code: KeyCode::Up,
                 modifiers,

--- a/codex-rs/tui/src/chatwidget.rs
+++ b/codex-rs/tui/src/chatwidget.rs
@@ -3100,10 +3100,12 @@ impl ChatWidget {
             }
             KeyEvent {
                 code: KeyCode::Up,
-                modifiers: KeyModifiers::ALT,
+                modifiers,
                 kind: KeyEventKind::Press,
                 ..
-            } if !self.queued_user_messages.is_empty() => {
+            } if modifiers.intersects(KeyModifiers::ALT | KeyModifiers::CONTROL)
+                && !self.queued_user_messages.is_empty() =>
+            {
                 // Prefer the most recently queued item.
                 if let Some(user_message) = self.queued_user_messages.pop_back() {
                     self.restore_user_message_to_composer(user_message);

--- a/codex-rs/tui/src/chatwidget/tests.rs
+++ b/codex-rs/tui/src/chatwidget/tests.rs
@@ -2807,6 +2807,30 @@ async fn alt_up_edits_most_recent_queued_message() {
     );
 }
 
+#[tokio::test]
+async fn control_up_edits_most_recent_queued_message() {
+    let (mut chat, _rx, _op_rx) = make_chatwidget_manual(None).await;
+
+    chat.bottom_pane.set_task_running(true);
+    chat.queued_user_messages
+        .push_back(UserMessage::from("first queued".to_string()));
+    chat.queued_user_messages
+        .push_back(UserMessage::from("second queued".to_string()));
+    chat.refresh_queued_user_messages();
+
+    chat.handle_key_event(KeyEvent::new(KeyCode::Up, KeyModifiers::CONTROL));
+
+    assert_eq!(
+        chat.bottom_pane.composer_text(),
+        "second queued".to_string()
+    );
+    assert_eq!(chat.queued_user_messages.len(), 1);
+    assert_eq!(
+        chat.queued_user_messages.front().unwrap().text,
+        "first queued"
+    );
+}
+
 /// Pressing Up to recall the most recent history entry and immediately queuing
 /// it while a task is running should always enqueue the same text, even when it
 /// is queued repeatedly.


### PR DESCRIPTION
## Summary
- fix terminal-encoding compatibility for Option-key shortcuts used in chat input
- ensure queued-message edit works when `Option+Up` is delivered as `Ctrl+Up` (e.g. `CSI 1;5A`)
- ensure word-delete shortcuts work when terminals deliver Option as Control:
  - `Option+Backspace` -> accept `Ctrl+Backspace`
  - `Option+Delete` -> accept `Ctrl+Delete`
- add regression coverage for the control-encoded variants

## Why
Some terminals/settings (including macOS Terminal in certain setups) encode Option-modified keys as control-modified sequences, so strict Alt-only matching misses the intended shortcut.

## Shortcut compatibility
- no dedicated `Ctrl+Up`, `Ctrl+Backspace`, or `Ctrl+Delete` binding is overridden by these aliases
- intentionally did **not** remap `Option+b` / `Option+f` to control aliases because `Ctrl+b` / `Ctrl+f` already mean single-character cursor movement

## Codex author
`codex resume 019c73a1-aac6-7a11-9500-95388ad319ff`
