### PR TITLE
Add configurable agent spawn depth

### DIFF
--- a/codex-rs/core/config.schema.json
+++ b/codex-rs/core/config.schema.json
@@ -29,6 +29,12 @@
         "$ref": "#/definitions/AgentRoleToml"
       },
       "properties": {
+        "max_depth": {
+          "description": "Maximum nesting depth allowed for spawned agent threads. Root sessions start at depth 0.",
+          "format": "int32",
+          "minimum": 1.0,
+          "type": "integer"
+        },
         "max_threads": {
           "description": "Maximum number of agent threads that can be open concurrently. When unset, no limit is enforced.",
           "format": "uint",

--- a/codex-rs/core/src/agent/guards.rs
+++ b/codex-rs/core/src/agent/guards.rs
@@ -21,9 +21,6 @@ pub(crate) struct Guards {
     total_count: AtomicUsize,
 }
 
-/// Initial agent is depth 0.
-pub(crate) const MAX_THREAD_SPAWN_DEPTH: i32 = 1;
-
 fn session_depth(session_source: &SessionSource) -> i32 {
     match session_source {
         SessionSource::SubAgent(SubAgentSource::ThreadSpawn { depth, .. }) => *depth,
@@ -36,8 +33,8 @@ pub(crate) fn next_thread_spawn_depth(session_source: &SessionSource) -> i32 {
     session_depth(session_source).saturating_add(1)
 }
 
-pub(crate) fn exceeds_thread_spawn_depth_limit(depth: i32) -> bool {
-    depth > MAX_THREAD_SPAWN_DEPTH
+pub(crate) fn exceeds_thread_spawn_depth_limit(depth: i32, max_depth: i32) -> bool {
+    depth > max_depth
 }
 
 impl Guards {
@@ -136,7 +133,7 @@ mod tests {
         });
         let child_depth = next_thread_spawn_depth(&session_source);
         assert_eq!(child_depth, 2);
-        assert!(exceeds_thread_spawn_depth_limit(child_depth));
+        assert!(exceeds_thread_spawn_depth_limit(child_depth, 1));
     }
 
     #[test]
@@ -144,7 +141,7 @@ mod tests {
         let session_source = SessionSource::SubAgent(SubAgentSource::Review);
         assert_eq!(session_depth(&session_source), 0);
         assert_eq!(next_thread_spawn_depth(&session_source), 1);
-        assert!(!exceeds_thread_spawn_depth_limit(1));
+        assert!(!exceeds_thread_spawn_depth_limit(1, 1));
     }
 
     #[test]

--- a/codex-rs/core/src/agent/mod.rs
+++ b/codex-rs/core/src/agent/mod.rs
@@ -5,7 +5,6 @@ pub(crate) mod status;
 
 pub(crate) use codex_protocol::protocol::AgentStatus;
 pub(crate) use control::AgentControl;
-pub(crate) use guards::MAX_THREAD_SPAWN_DEPTH;
 pub(crate) use guards::exceeds_thread_spawn_depth_limit;
 pub(crate) use guards::next_thread_spawn_depth;
 pub(crate) use status::agent_status_from_event;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -11,7 +11,6 @@ use crate::CodexAuth;
 use crate::SandboxState;
 use crate::agent::AgentControl;
 use crate::agent::AgentStatus;
-use crate::agent::MAX_THREAD_SPAWN_DEPTH;
 use crate::agent::agent_status_from_event;
 use crate::analytics_client::AnalyticsEventsClient;
 use crate::analytics_client::AppInvocation;
@@ -315,7 +314,7 @@ impl Codex {
         }
 
         if let SessionSource::SubAgent(SubAgentSource::ThreadSpawn { depth, .. }) = session_source
-            && depth >= MAX_THREAD_SPAWN_DEPTH
+            && depth >= config.agent_max_depth
         {
             config.features.disable(Feature::Collab);
         }


### PR DESCRIPTION
Summary
- expose `agents.max_depth` in config schema and toml parsing, with defaults and validation
- thread-spawn depth guards and multi-agent handler now respect the configured limit instead of a hardcoded value
- ensure documentation and helpers account for agent depth limits
