### PR TITLE
Fix compaction context reinjection and model baselines

### DIFF
--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -5646,6 +5646,9 @@ async fn try_run_sampling_request(
     prompt: &Prompt,
     cancellation_token: CancellationToken,
 ) -> CodexResult<SamplingRequestResult> {
+    // Persist one TurnContext marker per sampling request (not just per user turn) so rollout
+    // analysis can reconstruct API-turn boundaries. `run_turn` persists model-visible context
+    // diffs/full reinjection earlier in the same regular turn before reaching this path.
     let rollout_item = RolloutItem::TurnContext(turn_context.to_turn_context_item());
 
     feedback_tags!(

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -6678,8 +6678,10 @@ mod tests {
             .await;
 
         assert_eq!(
-            session.reference_context_item().await,
-            Some(previous_context_item)
+            serde_json::to_value(session.reference_context_item().await)
+                .expect("serialize seeded reference context item"),
+            serde_json::to_value(Some(previous_context_item))
+                .expect("serialize expected reference context item")
         );
     }
 
@@ -6729,7 +6731,7 @@ mod tests {
             }))
             .await;
 
-        assert_eq!(session.reference_context_item().await, None);
+        assert!(session.reference_context_item().await.is_none());
     }
 
     #[tokio::test]

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1605,15 +1605,11 @@ impl Session {
                 let previous_model =
                     previous_regular_turn_context_item.map(|ctx| ctx.model.clone());
                 let curr = turn_context.model_info.slug.as_str();
-                let can_seed_reference_context_item = !crossed_compaction_after_turn
-                    && previous_regular_turn_context_item.is_some_and(|ctx| ctx.model == curr);
-                let reference_context_item = if can_seed_reference_context_item {
+                let reference_context_item = if !crossed_compaction_after_turn {
                     previous_regular_turn_context_item.cloned()
                 } else {
                     // Keep the baseline empty when compaction may have stripped the referenced
-                    // context diffs, or when resuming on a different model. The first resumed
-                    // turn will then do full reinjection (which also preserves personality spec
-                    // when the model changes).
+                    // context diffs so the first resumed regular turn fully reinjects context.
                     None
                 };
                 {
@@ -2798,6 +2794,9 @@ impl Session {
                     turn_context,
                 )
             {
+                // TODO(ccunningham): When a model switch changes the effective personality
+                // instructions, inject the updated personality spec alongside <model_switch>
+                // here so resume/model-switch paths can avoid forcing full reinjection.
                 initial_context.insert(0, model_switch_item);
             }
             initial_context

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1715,6 +1715,9 @@ impl Session {
     ///
     /// Returns `(None, false)` when no completed turn with a persisted
     /// `TurnContextItem` is present in the lifecycle-aware rollout view.
+    // TODO(ccunningham): Simplify this lookup by sharing rollout traversal/rollback application
+    // with `reconstruct_history_from_rollout` so resume/fork baseline hydration does not need a
+    // second bespoke rollout scan.
     fn last_rollout_regular_turn_context_lookup(
         rollout_items: &[RolloutItem],
     ) -> (Option<&TurnContextItem>, bool) {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2707,13 +2707,14 @@ impl Session {
         let context_items = if should_inject_full_context {
             let mut initial_context = self.build_initial_context(turn_context).await;
             // Full reinjection bypasses the pure diff item list, so explicitly preserve a
-            // model-switch instruction when one is needed this turn.
+            // model-switch instruction when one is needed this turn. Keep it before the rest
+            // of full context so model-specific guidance is read first.
             if let Some(model_switch_item) = settings_update_items
                 .iter()
                 .find(|item| Session::is_model_switch_developer_message(item))
                 .cloned()
             {
-                initial_context.push(model_switch_item);
+                initial_context.insert(0, model_switch_item);
             }
             initial_context
         } else {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2040,18 +2040,18 @@ impl Session {
     fn build_settings_update_items(
         &self,
         previous_context: Option<&TurnContextItem>,
-        resumed_model: Option<&str>,
+        previous_user_turn_model: Option<&str>,
         current_context: &TurnContext,
     ) -> Vec<ResponseItem> {
         // TODO: Make context updates a pure diff of persisted previous/current TurnContextItem
         // state so replay/backtracking is deterministic. Runtime inputs that affect model-visible
-        // context (shell, exec policy, feature gates, resumed model bridge) should be persisted
+        // context (shell, exec policy, feature gates, previous-model bridge) should be persisted
         // state or explicit non-state replay events.
         let shell = self.user_shell();
         let exec_policy = self.services.exec_policy.current();
         crate::context_manager::updates::build_settings_update_items(
             previous_context,
-            resumed_model,
+            previous_user_turn_model,
             current_context,
             shell.as_ref(),
             exec_policy.as_ref(),
@@ -2685,14 +2685,14 @@ impl Session {
     pub(crate) async fn record_context_updates_and_set_reference_context_item(
         &self,
         turn_context: &TurnContext,
-        resumed_model: Option<&str>,
+        previous_user_turn_model: Option<&str>,
         force_full_context_injection: bool,
         emit_raw_events: bool,
     ) {
         let reference_context_item = self.reference_context_item().await;
         let settings_update_items = self.build_settings_update_items(
             reference_context_item.as_ref(),
-            resumed_model,
+            previous_user_turn_model,
             turn_context,
         );
         let should_inject_full_context =

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2776,11 +2776,12 @@ impl Session {
             settings_update_items
         };
         if !context_items.is_empty() {
-            self.record_into_history(&context_items, turn_context).await;
-            self.persist_rollout_response_items(&context_items).await;
             if emit_raw_events {
-                self.send_raw_response_items(turn_context, &context_items)
+                self.record_conversation_items(turn_context, &context_items)
                     .await;
+            } else {
+                self.record_into_history(&context_items, turn_context).await;
+                self.persist_rollout_response_items(&context_items).await;
             }
         }
 

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2803,6 +2803,15 @@ impl Session {
         turn_context: &TurnContext,
         previous_user_turn_model: Option<&str>,
     ) {
+        let is_model_switch_developer_message = |item: &ResponseItem| match item {
+            ResponseItem::Message { role, content, .. } if role == "developer" => {
+                matches!(
+                    content.as_slice(),
+                    [ContentItem::InputText { text }] if text.starts_with("<model_switch>\n")
+                )
+            }
+            _ => false,
+        };
         let reference_context_item = self.reference_context_item().await;
         let should_inject_full_context = reference_context_item.is_none();
         let context_items = if should_inject_full_context {
@@ -2824,11 +2833,21 @@ impl Session {
             initial_context
         } else {
             // Steady-state path: append only context diffs to minimize token overhead.
-            self.build_settings_update_items(
+            let mut items = self.build_settings_update_items(
                 reference_context_item.as_ref(),
                 previous_user_turn_model,
                 turn_context,
-            )
+            );
+            if let Some(model_switch_item) =
+                crate::context_manager::updates::build_model_instructions_update_item(
+                    previous_user_turn_model,
+                    turn_context,
+                )
+            {
+                items.retain(|item| !is_model_switch_developer_message(item));
+                items.insert(0, model_switch_item);
+            }
+            items
         };
         if !context_items.is_empty() {
             self.record_conversation_items(turn_context, &context_items)

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4653,6 +4653,12 @@ pub(crate) async fn run_turn(
     last_agent_message
 }
 
+/// Runs pre-sampling compaction checks and returns whether compaction actually ran.
+///
+/// Returns:
+/// - `Ok(true)` when at least one pre-sampling compact path ran successfully.
+/// - `Ok(false)` when no pre-sampling compaction was needed.
+/// - `Err(_)` only when a pre-sampling compact path was attempted and failed.
 async fn run_pre_sampling_compact(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1589,7 +1589,7 @@ impl Session {
                 self.record_conversation_items(&turn_context, &items).await;
                 {
                     let mut state = self.state.lock().await;
-                    state.set_previous_context_item_raw(Some(turn_context.to_turn_context_item()));
+                    state.set_previous_context_item(Some(turn_context.to_turn_context_item()));
                 }
                 self.set_previous_model(None).await;
                 // Ensure initial items are visible to immediate readers (e.g., tests, forks).
@@ -1603,7 +1603,7 @@ impl Session {
                     .map(std::string::ToString::to_string);
                 {
                     let mut state = self.state.lock().await;
-                    state.set_previous_context_item_raw(None);
+                    state.set_previous_context_item(None);
                 }
                 self.set_previous_model(previous_model).await;
 
@@ -1685,7 +1685,7 @@ impl Session {
                     .await;
                 {
                     let mut state = self.state.lock().await;
-                    state.set_previous_context_item_raw(Some(turn_context.to_turn_context_item()));
+                    state.set_previous_context_item(Some(turn_context.to_turn_context_item()));
                 }
 
                 // Forked threads should remain file-backed immediately after startup.
@@ -2661,7 +2661,7 @@ impl Session {
 
     pub(crate) async fn clear_previous_context_item(&self) {
         let mut state = self.state.lock().await;
-        state.set_previous_context_item_raw(None);
+        state.set_previous_context_item(None);
     }
 
     /// Persist the latest turn context snapshot and emit any required model-visible context updates.
@@ -2717,7 +2717,7 @@ impl Session {
         }
 
         let mut state = self.state.lock().await;
-        state.set_previous_context_item_raw(Some(turn_context.to_turn_context_item()));
+        state.set_previous_context_item(Some(turn_context.to_turn_context_item()));
     }
 
     pub(crate) async fn update_token_usage_info(

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2102,7 +2102,7 @@ impl Session {
     }
     fn build_settings_update_items(
         &self,
-        previous_context: Option<&TurnContextItem>,
+        reference_context_item: Option<&TurnContextItem>,
         previous_user_turn_model: Option<&str>,
         current_context: &TurnContext,
     ) -> Vec<ResponseItem> {
@@ -2113,7 +2113,7 @@ impl Session {
         let shell = self.user_shell();
         let exec_policy = self.services.exec_policy.current();
         crate::context_manager::updates::build_settings_update_items(
-            previous_context,
+            reference_context_item,
             previous_user_turn_model,
             current_context,
             shell.as_ref(),

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4287,6 +4287,9 @@ async fn spawn_review_thread(
     }];
     let tc = Arc::new(review_turn_context);
     tc.turn_metadata_state.spawn_git_enrichment_task();
+    // TODO(ccunningham): Review turns currently rely on `spawn_task` for TurnComplete but do not
+    // emit a parent TurnStarted. Consider giving review a full parent turn lifecycle
+    // (TurnStarted + TurnComplete) for consistency with other standalone tasks.
     sess.spawn_task(tc.clone(), input, ReviewTask::new()).await;
 
     // Announce entering review mode so UIs can switch modes.

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1822,6 +1822,9 @@ impl Session {
             }
         }
 
+        // Legacy/minimal rollouts may only persist `TurnContextItem`/`Compacted` without turn
+        // lifecycle events. Fall back to the last `TurnContextItem` in rollout order so
+        // resume/fork can still hydrate `previous_model` and detect compaction-after-baseline.
         if !saw_turn_lifecycle_event {
             let mut saw_compaction_after_last_turn_context = false;
             for item in rollout_items.iter().rev() {

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -5533,8 +5533,6 @@ async fn try_run_sampling_request(
     prompt: &Prompt,
     cancellation_token: CancellationToken,
 ) -> CodexResult<SamplingRequestResult> {
-    // Persist a regular-turn context marker so resume/fork can recover the last
-    // user-turn model even when `reference_context_item` is intentionally cleared.
     let rollout_item = RolloutItem::TurnContext(turn_context.to_turn_context_item());
 
     feedback_tags!(

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2762,6 +2762,7 @@ impl Session {
         state.reference_context_item()
     }
 
+    #[cfg(test)]
     pub(crate) async fn clear_reference_context_item(&self) {
         let mut state = self.state.lock().await;
         state.set_reference_context_item(None);

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -4770,18 +4770,12 @@ pub(crate) async fn run_turn(
     last_agent_message
 }
 
-/// Runs pre-sampling compaction checks and returns whether compaction actually ran.
-///
-/// Returns:
-/// - `Ok(true)` when at least one pre-sampling compact path ran successfully.
-/// - `Ok(false)` when no pre-sampling compaction was needed.
-/// - `Err(_)` only when a pre-sampling compact path was attempted and failed.
 async fn run_pre_sampling_compact(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
-) -> CodexResult<bool> {
+) -> CodexResult<()> {
     let total_usage_tokens_before_compaction = sess.get_total_token_usage().await;
-    let mut compacted = maybe_run_previous_model_inline_compact(
+    maybe_run_previous_model_inline_compact(
         sess,
         turn_context,
         total_usage_tokens_before_compaction,
@@ -4795,9 +4789,8 @@ async fn run_pre_sampling_compact(
     // Compact if the total usage tokens are greater than the auto compact limit
     if total_usage_tokens >= auto_compact_limit {
         run_auto_compact(sess, turn_context, InitialContextInjection::DoNotInject).await?;
-        compacted = true;
     }
-    Ok(compacted)
+    Ok(())
 }
 
 /// Runs pre-sampling compaction against the previous model when switching to a smaller

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -3509,8 +3509,6 @@ mod handlers {
             UserShellCommandTask::new(command),
         )
         .await;
-        // Standalone shell tasks do not update `reference_context_item`; that
-        // baseline is owned by regular model turns only.
     }
 
     pub async fn resolve_elicitation(

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2674,19 +2674,55 @@ impl Session {
         state.previous_context_item()
     }
 
-    pub(crate) async fn full_context_reinjection_pending(&self) -> bool {
-        let state = self.state.lock().await;
-        state.full_context_reinjection_pending()
+    pub(crate) async fn seed_previous_context_item(&self, item: TurnContextItem) {
+        let mut state = self.state.lock().await;
+        state.set_previous_context_item(Some(item));
     }
 
-    pub(crate) async fn set_full_context_reinjection_pending(&self, pending: bool) {
+    pub(crate) async fn clear_previous_context_item(&self) {
         let mut state = self.state.lock().await;
-        state.set_full_context_reinjection_pending(pending);
+        state.set_previous_context_item(None);
     }
 
-    pub(crate) async fn set_previous_context_item(&self, item: Option<TurnContextItem>) {
+    pub(crate) async fn set_previous_context_item(
+        &self,
+        turn_context: &TurnContext,
+        resumed_model: Option<&str>,
+        force_full_context_injection: bool,
+        emit_raw_events: bool,
+    ) {
+        let previous_context_item = self.previous_context_item().await;
+        let settings_update_items = self.build_settings_update_items(
+            previous_context_item.as_ref(),
+            resumed_model,
+            turn_context,
+        );
+        let should_inject_full_context =
+            force_full_context_injection || previous_context_item.is_none();
+        let context_items = if should_inject_full_context {
+            let mut initial_context = self.build_initial_context(turn_context).await;
+            if let Some(model_switch_item) = settings_update_items
+                .iter()
+                .find(|item| Session::is_model_switch_developer_message(item))
+                .cloned()
+            {
+                initial_context.push(model_switch_item);
+            }
+            initial_context
+        } else {
+            settings_update_items
+        };
+        if !context_items.is_empty() {
+            self.record_into_history(&context_items, turn_context).await;
+            self.persist_rollout_response_items(&context_items).await;
+            if emit_raw_events {
+                self.send_raw_response_items(turn_context, &context_items)
+                    .await;
+            }
+        }
+
         let mut state = self.state.lock().await;
-        state.set_previous_context_item(item);
+        state.set_previous_context_item(Some(turn_context.to_turn_context_item()));
     }
 
     pub(crate) async fn update_token_usage_info(
@@ -3156,7 +3192,7 @@ impl Session {
 async fn submission_loop(sess: Arc<Session>, config: Arc<Config>, rx_sub: Receiver<Submission>) {
     // Seed with context in case there is an OverrideTurnContext first.
     let initial_context = sess.new_default_turn().await;
-    sess.set_previous_context_item(Some(initial_context.to_turn_context_item()))
+    sess.seed_previous_context_item(initial_context.to_turn_context_item())
         .await;
 
     // To break out of this loop, send Op::Shutdown.
@@ -3482,7 +3518,7 @@ mod handlers {
             UserShellCommandTask::new(command),
         )
         .await;
-        sess.set_previous_context_item(Some(turn_context.to_turn_context_item()))
+        sess.set_previous_context_item(turn_context.as_ref(), None, false, false)
             .await;
     }
 
@@ -4301,38 +4337,13 @@ pub(crate) async fn run_turn(
     };
 
     let previous_model = sess.previous_model().await;
-    let previous_context_item = sess.previous_context_item().await;
-    let full_context_reinjection_pending = sess.full_context_reinjection_pending().await;
-    let settings_update_items = sess.build_settings_update_items(
-        previous_context_item.as_ref(),
-        previous_model.as_deref(),
+    sess.set_previous_context_item(
         turn_context.as_ref(),
-    );
-    let should_inject_full_context = pre_sampling_compacted
-        || previous_context_item.is_none()
-        || full_context_reinjection_pending;
-    let context_items = if should_inject_full_context {
-        let mut initial_context = sess.build_initial_context(turn_context.as_ref()).await;
-        if let Some(model_switch_item) = settings_update_items
-            .iter()
-            .find(|item| Session::is_model_switch_developer_message(item))
-            .cloned()
-        {
-            initial_context.push(model_switch_item);
-        }
-        initial_context
-    } else {
-        settings_update_items
-    };
-    if !context_items.is_empty() {
-        sess.record_conversation_items(&turn_context, &context_items)
-            .await;
-    }
-    sess.set_previous_context_item(Some(turn_context.to_turn_context_item()))
-        .await;
-    if should_inject_full_context && full_context_reinjection_pending {
-        sess.set_full_context_reinjection_pending(false).await;
-    }
+        previous_model.as_deref(),
+        pre_sampling_compacted,
+        true,
+    )
+    .await;
 
     let skills_outcome = Some(
         sess.services
@@ -7826,17 +7837,51 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn full_context_reinjection_flag_survives_previous_context_updates() {
+    async fn set_previous_context_item_injects_full_context_when_baseline_missing() {
         let (session, turn_context) = make_session_and_context().await;
-
-        session.set_full_context_reinjection_pending(true).await;
         session
-            .set_previous_context_item(Some(turn_context.to_turn_context_item()))
+            .set_previous_context_item(&turn_context, None, false, false)
             .await;
-        assert!(session.full_context_reinjection_pending().await);
+        let history = session.clone_history().await;
+        let initial_context = session.build_initial_context(&turn_context).await;
+        assert_eq!(history.raw_items().to_vec(), initial_context);
 
-        session.set_full_context_reinjection_pending(false).await;
-        assert!(!session.full_context_reinjection_pending().await);
+        let current_context = session.previous_context_item().await;
+        assert_eq!(
+            serde_json::to_value(current_context).expect("serialize current context item"),
+            serde_json::to_value(Some(turn_context.to_turn_context_item()))
+                .expect("serialize expected context item")
+        );
+    }
+
+    #[tokio::test]
+    async fn set_previous_context_item_reinjects_full_context_after_clear() {
+        let (session, turn_context) = make_session_and_context().await;
+        let compacted_summary = ResponseItem::Message {
+            id: None,
+            role: "user".to_string(),
+            content: vec![ContentItem::InputText {
+                text: format!("{}\nsummary", crate::compact::SUMMARY_PREFIX),
+            }],
+            end_turn: None,
+            phase: None,
+        };
+        session
+            .record_into_history(std::slice::from_ref(&compacted_summary), &turn_context)
+            .await;
+        session
+            .seed_previous_context_item(turn_context.to_turn_context_item())
+            .await;
+        session.clear_previous_context_item().await;
+
+        session
+            .set_previous_context_item(&turn_context, None, false, false)
+            .await;
+
+        let history = session.clone_history().await;
+        let mut expected_history = vec![compacted_summary];
+        expected_history.extend(session.build_initial_context(&turn_context).await);
+        assert_eq!(history.raw_items().to_vec(), expected_history);
     }
 
     #[derive(Clone, Copy)]

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -2762,12 +2762,6 @@ impl Session {
         state.reference_context_item()
     }
 
-    #[cfg(test)]
-    pub(crate) async fn clear_reference_context_item(&self) {
-        let mut state = self.state.lock().await;
-        state.set_reference_context_item(None);
-    }
-
     /// Persist the latest turn context snapshot and emit any required model-visible context updates.
     ///
     /// When the reference snapshot is missing, this injects full initial context. Otherwise, it
@@ -8140,7 +8134,10 @@ mod tests {
         session
             .record_context_updates_and_set_reference_context_item(&turn_context, None)
             .await;
-        session.clear_reference_context_item().await;
+        {
+            let mut state = session.state.lock().await;
+            state.set_reference_context_item(None);
+        }
         session
             .replace_history(vec![compacted_summary.clone()], None)
             .await;
@@ -8158,7 +8155,10 @@ mod tests {
     #[tokio::test]
     async fn run_user_shell_command_does_not_set_reference_context_item() {
         let (session, _turn_context, rx) = make_session_and_context_with_rx().await;
-        session.clear_reference_context_item().await;
+        {
+            let mut state = session.state.lock().await;
+            state.set_reference_context_item(None);
+        }
 
         handlers::run_user_shell_command(&session, "sub-id".to_string(), "echo shell".to_string())
             .await;

--- a/codex-rs/core/src/codex.rs
+++ b/codex-rs/core/src/codex.rs
@@ -1606,13 +1606,11 @@ impl Session {
                     let mut state = self.state.lock().await;
                     state.set_reference_context_item(None);
                 }
-                self.set_previous_model(previous_model).await;
+                self.set_previous_model(previous_model.clone()).await;
 
                 // If resuming, warn when the last recorded model differs from the current one.
                 let curr = turn_context.model_info.slug.as_str();
-                if let Some(prev) = Self::last_rollout_regular_turn_model_name(&rollout_items)
-                    .filter(|p| *p != curr)
-                {
+                if let Some(prev) = previous_model.as_deref().filter(|p| *p != curr) {
                     warn!("resuming session with different model: previous={prev}, current={curr}");
                     self.send_event(
                         &turn_context,

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -127,9 +127,9 @@ async fn run_compact_task_inner(
     let mut client_session = sess.services.model_client.new_session();
     // Reuse one client session so turn-scoped state (sticky routing, websocket append tracking)
     // survives retries within this compact turn.
-
-    let rollout_item = RolloutItem::TurnContext(turn_context.to_turn_context_item());
-    sess.persist_rollout_items(&[rollout_item]).await;
+    // Intentionally do not persist `RolloutItem::TurnContext` for local compaction:
+    // that marker is reserved for regular sampling turns so resume/fork hydrates the
+    // previous user-turn model, not a `/compact` task model.
 
     loop {
         // Clone is required because of the loop

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -32,6 +32,15 @@ pub const SUMMARIZATION_PROMPT: &str = include_str!("../templates/compact/prompt
 pub const SUMMARY_PREFIX: &str = include_str!("../templates/compact/summary_prefix.md");
 const COMPACT_USER_MESSAGE_MAX_TOKENS: usize = 20_000;
 
+/// Controls whether compaction replacement history must include canonical initial context.
+///
+/// Pre-turn/manual compaction variants use `DoNotInject`: they replace history with a summary and
+/// clear `reference_context_item`, so the next regular turn will fully reinject canonical context
+/// after compaction.
+///
+/// Mid-turn compaction must use `BeforeLastUserMessage` because the model is trained to see the
+/// compaction summary as the last item in history after mid-turn compaction; we therefore inject
+/// canonical context into the replacement history just above the last real user message.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum InitialContextInjection {
     BeforeLastUserMessage,

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -32,15 +32,15 @@ pub const SUMMARIZATION_PROMPT: &str = include_str!("../templates/compact/prompt
 pub const SUMMARY_PREFIX: &str = include_str!("../templates/compact/summary_prefix.md");
 const COMPACT_USER_MESSAGE_MAX_TOKENS: usize = 20_000;
 
-/// Controls whether compaction replacement history must include canonical initial context.
+/// Controls whether compaction replacement history must include initial context.
 ///
 /// Pre-turn/manual compaction variants use `DoNotInject`: they replace history with a summary and
-/// clear `reference_context_item`, so the next regular turn will fully reinject canonical context
+/// clear `reference_context_item`, so the next regular turn will fully reinject initial context
 /// after compaction.
 ///
 /// Mid-turn compaction must use `BeforeLastUserMessage` because the model is trained to see the
 /// compaction summary as the last item in history after mid-turn compaction; we therefore inject
-/// canonical context into the replacement history just above the last real user message.
+/// initial context into the replacement history just above the last real user message.
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub(crate) enum InitialContextInjection {
     BeforeLastUserMessage,

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -140,8 +140,6 @@ async fn run_compact_task_inner(
     let mut client_session = sess.services.model_client.new_session();
     // Reuse one client session so turn-scoped state (sticky routing, websocket append tracking)
     // survives retries within this compact turn.
-    let rollout_item = RolloutItem::TurnContext(turn_context.to_turn_context_item());
-    sess.persist_rollout_items(&[rollout_item]).await;
 
     loop {
         // Clone is required because of the loop

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -127,6 +127,8 @@ async fn run_compact_task_inner(
     let mut client_session = sess.services.model_client.new_session();
     // Reuse one client session so turn-scoped state (sticky routing, websocket append tracking)
     // survives retries within this compact turn.
+    let rollout_item = RolloutItem::TurnContext(turn_context.to_turn_context_item());
+    sess.persist_rollout_items(&[rollout_item]).await;
 
     loop {
         // Clone is required because of the loop

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -237,6 +237,14 @@ async fn run_compact_task_inner(
         .collect();
     new_history.extend(ghost_snapshots);
     sess.replace_history(new_history.clone()).await;
+    if matches!(
+        initial_context_injection,
+        InitialContextInjection::DoNotInject
+    ) {
+        // Pre-turn/manual compaction replacement history strips prior context diffs, so the next
+        // regular turn must fully reinject canonical context.
+        sess.clear_reference_context_item().await;
+    }
     sess.recompute_token_usage(&turn_context).await;
 
     let rollout_item = RolloutItem::Compacted(CompactedItem {

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -127,9 +127,6 @@ async fn run_compact_task_inner(
     let mut client_session = sess.services.model_client.new_session();
     // Reuse one client session so turn-scoped state (sticky routing, websocket append tracking)
     // survives retries within this compact turn.
-    // Intentionally do not persist `RolloutItem::TurnContext` for local compaction:
-    // that marker is reserved for regular sampling turns so resume/fork hydrates the
-    // previous user-turn model, not a `/compact` task model.
 
     loop {
         // Clone is required because of the loop

--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -255,15 +255,12 @@ async fn run_compact_task_inner(
         .cloned()
         .collect();
     new_history.extend(ghost_snapshots);
-    sess.replace_history(new_history.clone()).await;
-    if matches!(
-        initial_context_injection,
-        InitialContextInjection::DoNotInject
-    ) {
-        // Pre-turn/manual compaction replacement history strips prior context diffs, so the next
-        // regular turn must fully reinject canonical context.
-        sess.clear_reference_context_item().await;
-    }
+    let reference_context_item = match initial_context_injection {
+        InitialContextInjection::DoNotInject => None,
+        InitialContextInjection::BeforeLastUserMessage => Some(turn_context.to_turn_context_item()),
+    };
+    sess.replace_history(new_history.clone(), reference_context_item)
+        .await;
     sess.recompute_token_usage(&turn_context).await;
 
     let rollout_item = RolloutItem::Compacted(CompactedItem {

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use crate::Prompt;
 use crate::codex::Session;
 use crate::codex::TurnContext;
-use crate::compact::CompactCallsite;
+use crate::compact::InjectTurnContextBeforeLastUserMessage;
 use crate::compact::extract_trailing_model_switch_update_for_compaction_request;
 use crate::context_manager::ContextManager;
 use crate::context_manager::TotalTokenUsageBreakdown;
@@ -26,9 +26,14 @@ use tracing::info;
 pub(crate) async fn run_inline_remote_auto_compact_task(
     sess: Arc<Session>,
     turn_context: Arc<TurnContext>,
-    callsite: CompactCallsite,
+    inject_turn_context_before_last_user_message: InjectTurnContextBeforeLastUserMessage,
 ) -> CodexResult<()> {
-    run_remote_compact_task_inner(&sess, &turn_context, callsite).await?;
+    run_remote_compact_task_inner(
+        &sess,
+        &turn_context,
+        inject_turn_context_before_last_user_message,
+    )
+    .await?;
     Ok(())
 }
 
@@ -43,15 +48,26 @@ pub(crate) async fn run_remote_compact_task(
     });
     sess.send_event(&turn_context, start_event).await;
 
-    run_remote_compact_task_inner(&sess, &turn_context, CompactCallsite::Manual).await
+    run_remote_compact_task_inner(
+        &sess,
+        &turn_context,
+        InjectTurnContextBeforeLastUserMessage::DontInjectTurnContext,
+    )
+    .await
 }
 
 async fn run_remote_compact_task_inner(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
-    callsite: CompactCallsite,
+    inject_turn_context_before_last_user_message: InjectTurnContextBeforeLastUserMessage,
 ) -> CodexResult<()> {
-    if let Err(err) = run_remote_compact_task_inner_impl(sess, turn_context, callsite).await {
+    if let Err(err) = run_remote_compact_task_inner_impl(
+        sess,
+        turn_context,
+        inject_turn_context_before_last_user_message,
+    )
+    .await
+    {
         let event = EventMsg::Error(
             err.to_error_event(Some("Error running remote compact task".to_string())),
         );
@@ -64,7 +80,7 @@ async fn run_remote_compact_task_inner(
 async fn run_remote_compact_task_inner_impl(
     sess: &Arc<Session>,
     turn_context: &Arc<TurnContext>,
-    callsite: CompactCallsite,
+    inject_turn_context_before_last_user_message: InjectTurnContextBeforeLastUserMessage,
 ) -> CodexResult<()> {
     let compaction_item = TurnItem::ContextCompaction(ContextCompactionItem::new());
     sess.emit_turn_item_started(turn_context, &compaction_item)
@@ -130,7 +146,7 @@ async fn run_remote_compact_task_inner_impl(
         sess.as_ref(),
         turn_context.as_ref(),
         new_history,
-        callsite,
+        inject_turn_context_before_last_user_message,
     )
     .await;
     // Reattach the stripped model-switch update only after successful compaction so the model

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -145,6 +145,14 @@ async fn run_remote_compact_task_inner_impl(
         new_history.extend(ghost_snapshots);
     }
     sess.replace_history(new_history.clone()).await;
+    if matches!(
+        initial_context_injection,
+        InitialContextInjection::DoNotInject
+    ) {
+        // Pre-turn/manual compaction replacement history strips prior context diffs, so the next
+        // regular turn must fully reinject canonical context.
+        sess.clear_reference_context_item().await;
+    }
     sess.recompute_token_usage(turn_context).await;
 
     let compacted_item = CompactedItem {

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -5,6 +5,7 @@ use crate::codex::Session;
 use crate::codex::TurnContext;
 use crate::compact::InitialContextInjection;
 use crate::compact::extract_trailing_model_switch_update_for_compaction_request;
+use crate::compact::insert_initial_context_before_last_real_user_or_summary;
 use crate::context_manager::ContextManager;
 use crate::context_manager::TotalTokenUsageBreakdown;
 use crate::context_manager::estimate_response_item_model_visible_bytes;
@@ -128,7 +129,7 @@ async fn run_remote_compact_task_inner_impl(
             Err(err)
         })
         .await?;
-    new_history = crate::compact::process_compacted_history(
+    new_history = process_compacted_history(
         sess.as_ref(),
         turn_context.as_ref(),
         new_history,
@@ -162,6 +163,52 @@ async fn run_remote_compact_task_inner_impl(
     sess.emit_turn_item_completed(turn_context, compaction_item)
         .await;
     Ok(())
+}
+
+pub(crate) async fn process_compacted_history(
+    sess: &Session,
+    turn_context: &TurnContext,
+    mut compacted_history: Vec<ResponseItem>,
+    initial_context_injection: InitialContextInjection,
+) -> Vec<ResponseItem> {
+    // Mid-turn compaction is the only path that must inject initial context above the last user
+    // message in the replacement history. Pre-turn compaction instead injects context after the
+    // compaction item, but mid-turn compaction keeps the compaction item last for model training.
+    let initial_context = if matches!(
+        initial_context_injection,
+        InitialContextInjection::BeforeLastUserMessage
+    ) {
+        sess.build_initial_context(turn_context).await
+    } else {
+        Vec::new()
+    };
+
+    compacted_history.retain(should_keep_compacted_history_item);
+    insert_initial_context_before_last_real_user_or_summary(compacted_history, initial_context)
+}
+
+/// Returns whether an item from remote compaction output should be preserved.
+///
+/// Called while processing the model-provided compacted transcript, before we
+/// append fresh canonical context from the current session.
+///
+/// We drop:
+/// - `developer` messages because remote output can include stale/duplicated
+///   instruction content.
+/// - non-user-content `user` messages (session prefix/instruction wrappers),
+///   keeping only real user messages as parsed by `parse_turn_item`.
+///
+/// This intentionally keeps `user`-role warnings and compaction-generated
+/// summary messages because they parse as `TurnItem::UserMessage`.
+fn should_keep_compacted_history_item(item: &ResponseItem) -> bool {
+    match item {
+        ResponseItem::Message { role, .. } if role == "developer" => false,
+        ResponseItem::Message { role, .. } if role == "user" => matches!(
+            crate::event_mapping::parse_turn_item(item),
+            Some(TurnItem::UserMessage(_))
+        ),
+        _ => true,
+    }
 }
 
 #[derive(Debug)]

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -210,7 +210,17 @@ fn should_keep_compacted_history_item(item: &ResponseItem) -> bool {
             Some(TurnItem::UserMessage(_))
         ),
         ResponseItem::Message { role, .. } if role == "assistant" => true,
-        _ => true,
+        ResponseItem::Message { .. } => false,
+        ResponseItem::Compaction { .. } => true,
+        ResponseItem::Reasoning { .. }
+        | ResponseItem::LocalShellCall { .. }
+        | ResponseItem::FunctionCall { .. }
+        | ResponseItem::FunctionCallOutput { .. }
+        | ResponseItem::CustomToolCall { .. }
+        | ResponseItem::CustomToolCallOutput { .. }
+        | ResponseItem::WebSearchCall { .. }
+        | ResponseItem::GhostSnapshot { .. }
+        | ResponseItem::Other => false,
     }
 }
 

--- a/codex-rs/core/src/compact_remote.rs
+++ b/codex-rs/core/src/compact_remote.rs
@@ -198,8 +198,10 @@ pub(crate) async fn process_compacted_history(
 /// - non-user-content `user` messages (session prefix/instruction wrappers),
 ///   keeping only real user messages as parsed by `parse_turn_item`.
 ///
-/// This intentionally keeps `user`-role warnings and compaction-generated
-/// summary messages because they parse as `TurnItem::UserMessage`.
+/// This intentionally keeps:
+/// - `assistant` messages (future remote compaction models may emit them)
+/// - `user`-role warnings and compaction-generated summary messages because
+///   they parse as `TurnItem::UserMessage`.
 fn should_keep_compacted_history_item(item: &ResponseItem) -> bool {
     match item {
         ResponseItem::Message { role, .. } if role == "developer" => false,
@@ -207,6 +209,7 @@ fn should_keep_compacted_history_item(item: &ResponseItem) -> bool {
             crate::event_mapping::parse_turn_item(item),
             Some(TurnItem::UserMessage(_))
         ),
+        ResponseItem::Message { role, .. } if role == "assistant" => true,
         _ => true,
     }
 }

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -62,8 +62,8 @@ impl ContextManager {
 
     /// Storage-only setter for the previous context snapshot.
     ///
-    /// Callers that want model-visible context updates should go through
-    /// `Session::record_context_updates_and_set_previous_context_item`.
+    /// When setting `Some(...)`, callers should take care to persist the
+    /// appropriate model-visible context diff items.
     pub(crate) fn set_previous_context_item_raw(&mut self, item: Option<TurnContextItem>) {
         self.previous_context_item = item;
     }

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -63,10 +63,6 @@ impl ContextManager {
         self.token_info = info;
     }
 
-    /// Storage-only setter for the reference context snapshot.
-    ///
-    /// When setting `Some(...)`, callers should take care to persist the
-    /// appropriate model-visible context diff items.
     pub(crate) fn set_reference_context_item(&mut self, item: Option<TurnContextItem>) {
         self.reference_context_item = item;
     }

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -64,7 +64,7 @@ impl ContextManager {
     ///
     /// When setting `Some(...)`, callers should take care to persist the
     /// appropriate model-visible context diff items.
-    pub(crate) fn set_previous_context_item_raw(&mut self, item: Option<TurnContextItem>) {
+    pub(crate) fn set_previous_context_item(&mut self, item: Option<TurnContextItem>) {
         self.previous_context_item = item;
     }
 

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -27,12 +27,15 @@ pub(crate) struct ContextManager {
     /// The oldest items are at the beginning of the vector.
     items: Vec<ResponseItem>,
     token_info: Option<TokenUsageInfo>,
-    /// Previous turn context snapshot used for diffing context and producing
-    /// model-visible settings update items.
+    /// Reference context snapshot used for diffing and producing model-visible
+    /// settings update items.
+    ///
+    /// This is the baseline for the next regular model turn, and may already
+    /// match the current turn after context updates are persisted.
     ///
     /// When this is `None`, settings diffing treats the next turn as having no
     /// baseline and emits a full reinjection of context state.
-    previous_context_item: Option<TurnContextItem>,
+    reference_context_item: Option<TurnContextItem>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -48,7 +51,7 @@ impl ContextManager {
         Self {
             items: Vec::new(),
             token_info: TokenUsageInfo::new_or_append(&None, &None, None),
-            previous_context_item: None,
+            reference_context_item: None,
         }
     }
 
@@ -60,16 +63,16 @@ impl ContextManager {
         self.token_info = info;
     }
 
-    /// Storage-only setter for the previous context snapshot.
+    /// Storage-only setter for the reference context snapshot.
     ///
     /// When setting `Some(...)`, callers should take care to persist the
     /// appropriate model-visible context diff items.
-    pub(crate) fn set_previous_context_item(&mut self, item: Option<TurnContextItem>) {
-        self.previous_context_item = item;
+    pub(crate) fn set_reference_context_item(&mut self, item: Option<TurnContextItem>) {
+        self.reference_context_item = item;
     }
 
-    pub(crate) fn previous_context_item(&self) -> Option<TurnContextItem> {
-        self.previous_context_item.clone()
+    pub(crate) fn reference_context_item(&self) -> Option<TurnContextItem> {
+        self.reference_context_item.clone()
     }
 
     pub(crate) fn set_token_usage_full(&mut self, context_window: i64) {

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -60,7 +60,11 @@ impl ContextManager {
         self.token_info = info;
     }
 
-    pub(crate) fn set_previous_context_item(&mut self, item: Option<TurnContextItem>) {
+    /// Storage-only setter for the previous context snapshot.
+    ///
+    /// Callers that want model-visible context updates should go through
+    /// `Session::record_context_updates_and_set_previous_context_item`.
+    pub(crate) fn set_previous_context_item_raw(&mut self, item: Option<TurnContextItem>) {
         self.previous_context_item = item;
     }
 

--- a/codex-rs/core/src/context_manager/updates.rs
+++ b/codex-rs/core/src/context_manager/updates.rs
@@ -97,11 +97,10 @@ pub(crate) fn personality_message_for(
 }
 
 pub(crate) fn build_model_instructions_update_item(
-    previous: Option<&TurnContextItem>,
-    resumed_model: Option<&str>,
+    previous_user_turn_model: Option<&str>,
     next: &TurnContext,
 ) -> Option<ResponseItem> {
-    let previous_model = resumed_model.or_else(|| previous.map(|prev| prev.model.as_str()))?;
+    let previous_model = previous_user_turn_model?;
     if previous_model == next.model_info.slug {
         return None;
     }
@@ -116,7 +115,7 @@ pub(crate) fn build_model_instructions_update_item(
 
 pub(crate) fn build_settings_update_items(
     previous: Option<&TurnContextItem>,
-    resumed_model: Option<&str>,
+    previous_user_turn_model: Option<&str>,
     next: &TurnContext,
     shell: &Shell,
     exec_policy: &Policy,
@@ -134,7 +133,7 @@ pub(crate) fn build_settings_update_items(
         update_items.push(collaboration_mode_item);
     }
     if let Some(model_instructions_item) =
-        build_model_instructions_update_item(previous, resumed_model, next)
+        build_model_instructions_update_item(previous_user_turn_model, next)
     {
         update_items.push(model_instructions_item);
     }

--- a/codex-rs/core/src/context_manager/updates.rs
+++ b/codex-rs/core/src/context_manager/updates.rs
@@ -123,6 +123,13 @@ pub(crate) fn build_settings_update_items(
 ) -> Vec<ResponseItem> {
     let mut update_items = Vec::new();
 
+    // Keep model-switch instructions first so model-specific guidance is read before
+    // any other context diffs on this turn.
+    if let Some(model_instructions_item) =
+        build_model_instructions_update_item(previous_user_turn_model, next)
+    {
+        update_items.push(model_instructions_item);
+    }
     if let Some(env_item) = build_environment_update_item(previous, next, shell) {
         update_items.push(env_item);
     }
@@ -131,11 +138,6 @@ pub(crate) fn build_settings_update_items(
     }
     if let Some(collaboration_mode_item) = build_collaboration_mode_update_item(previous, next) {
         update_items.push(collaboration_mode_item);
-    }
-    if let Some(model_instructions_item) =
-        build_model_instructions_update_item(previous_user_turn_model, next)
-    {
-        update_items.push(model_instructions_item);
     }
     if let Some(personality_item) =
         build_personality_update_item(previous, next, personality_feature_enabled)

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -28,6 +28,8 @@ pub(crate) struct SessionState {
     pub(crate) initial_context_seeded: bool,
     /// Previous model seen by the session, used for model-switch handling on task start.
     previous_model: Option<String>,
+    /// Forces the next user turn to inject full initial context regardless of context diff state.
+    full_context_reinjection_pending: bool,
     /// Startup regular task pre-created during session initialization.
     pub(crate) startup_regular_task: Option<RegularTask>,
     pub(crate) active_mcp_tool_selection: Option<Vec<String>>,
@@ -47,6 +49,7 @@ impl SessionState {
             mcp_dependency_prompted: HashSet::new(),
             initial_context_seeded: false,
             previous_model: None,
+            full_context_reinjection_pending: false,
             startup_regular_task: None,
             active_mcp_tool_selection: None,
             active_connector_selection: HashSet::new(),
@@ -67,6 +70,14 @@ impl SessionState {
     }
     pub(crate) fn set_previous_model(&mut self, previous_model: Option<String>) {
         self.previous_model = previous_model;
+    }
+
+    pub(crate) fn full_context_reinjection_pending(&self) -> bool {
+        self.full_context_reinjection_pending
+    }
+
+    pub(crate) fn set_full_context_reinjection_pending(&mut self, pending: bool) {
+        self.full_context_reinjection_pending = pending;
     }
 
     pub(crate) fn clone_history(&self) -> ContextManager {

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -28,8 +28,6 @@ pub(crate) struct SessionState {
     pub(crate) initial_context_seeded: bool,
     /// Previous model seen by the session, used for model-switch handling on task start.
     previous_model: Option<String>,
-    /// Forces the next user turn to inject full initial context regardless of context diff state.
-    full_context_reinjection_pending: bool,
     /// Startup regular task pre-created during session initialization.
     pub(crate) startup_regular_task: Option<RegularTask>,
     pub(crate) active_mcp_tool_selection: Option<Vec<String>>,
@@ -49,7 +47,6 @@ impl SessionState {
             mcp_dependency_prompted: HashSet::new(),
             initial_context_seeded: false,
             previous_model: None,
-            full_context_reinjection_pending: false,
             startup_regular_task: None,
             active_mcp_tool_selection: None,
             active_connector_selection: HashSet::new(),
@@ -70,14 +67,6 @@ impl SessionState {
     }
     pub(crate) fn set_previous_model(&mut self, previous_model: Option<String>) {
         self.previous_model = previous_model;
-    }
-
-    pub(crate) fn full_context_reinjection_pending(&self) -> bool {
-        self.full_context_reinjection_pending
-    }
-
-    pub(crate) fn set_full_context_reinjection_pending(&mut self, pending: bool) {
-        self.full_context_reinjection_pending = pending;
     }
 
     pub(crate) fn clone_history(&self) -> ContextManager {

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -69,8 +69,14 @@ impl SessionState {
         self.history.clone()
     }
 
-    pub(crate) fn replace_history(&mut self, items: Vec<ResponseItem>) {
+    pub(crate) fn replace_history(
+        &mut self,
+        items: Vec<ResponseItem>,
+        reference_context_item: Option<TurnContextItem>,
+    ) {
         self.history.replace(items);
+        self.history
+            .set_reference_context_item(reference_context_item);
     }
 
     pub(crate) fn set_token_info(&mut self, info: Option<TokenUsageInfo>) {

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -75,16 +75,16 @@ impl SessionState {
         self.history.set_token_info(info);
     }
 
-    /// Storage-only setter for the previous context snapshot.
+    /// Storage-only setter for the reference context snapshot.
     ///
     /// When setting `Some(...)`, callers should take care to persist the
     /// appropriate model-visible context diff items.
-    pub(crate) fn set_previous_context_item(&mut self, item: Option<TurnContextItem>) {
-        self.history.set_previous_context_item(item);
+    pub(crate) fn set_reference_context_item(&mut self, item: Option<TurnContextItem>) {
+        self.history.set_reference_context_item(item);
     }
 
-    pub(crate) fn previous_context_item(&self) -> Option<TurnContextItem> {
-        self.history.previous_context_item()
+    pub(crate) fn reference_context_item(&self) -> Option<TurnContextItem> {
+        self.history.reference_context_item()
     }
 
     // Token/rate limit helpers

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -81,8 +81,12 @@ impl SessionState {
         self.history.set_token_info(info);
     }
 
-    pub(crate) fn set_previous_context_item(&mut self, item: Option<TurnContextItem>) {
-        self.history.set_previous_context_item(item);
+    /// Storage-only setter for the previous context snapshot.
+    ///
+    /// Most callers should use
+    /// `Session::record_context_updates_and_set_previous_context_item`.
+    pub(crate) fn set_previous_context_item_raw(&mut self, item: Option<TurnContextItem>) {
+        self.history.set_previous_context_item_raw(item);
     }
 
     pub(crate) fn previous_context_item(&self) -> Option<TurnContextItem> {

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -77,10 +77,6 @@ impl SessionState {
         self.history.set_token_info(info);
     }
 
-    /// Storage-only setter for the reference context snapshot.
-    ///
-    /// When setting `Some(...)`, callers should take care to persist the
-    /// appropriate model-visible context diff items.
     pub(crate) fn set_reference_context_item(&mut self, item: Option<TurnContextItem>) {
         self.history.set_reference_context_item(item);
     }

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -21,11 +21,6 @@ pub(crate) struct SessionState {
     pub(crate) server_reasoning_included: bool,
     pub(crate) dependency_env: HashMap<String, String>,
     pub(crate) mcp_dependency_prompted: HashSet<String>,
-    /// Whether the session's initial context has been seeded into history.
-    ///
-    /// TODO(owen): This is a temporary solution to avoid updating a thread's updated_at
-    /// timestamp when resuming a session. Remove this once SQLite is in place.
-    pub(crate) initial_context_seeded: bool,
     /// Previous model seen by the session, used for model-switch handling on task start.
     previous_model: Option<String>,
     /// Startup regular task pre-created during session initialization.
@@ -45,7 +40,6 @@ impl SessionState {
             server_reasoning_included: false,
             dependency_env: HashMap::new(),
             mcp_dependency_prompted: HashSet::new(),
-            initial_context_seeded: false,
             previous_model: None,
             startup_regular_task: None,
             active_mcp_tool_selection: None,

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -21,7 +21,9 @@ pub(crate) struct SessionState {
     pub(crate) server_reasoning_included: bool,
     pub(crate) dependency_env: HashMap<String, String>,
     pub(crate) mcp_dependency_prompted: HashSet<String>,
-    /// Previous model seen by the session, used for model-switch handling on task start.
+    /// Model used by the latest regular user turn, used for model-switch handling
+    /// when the regular-turn context baseline is intentionally missing (e.g. resume
+    /// or post-`/compact` full-context reinjection).
     previous_model: Option<String>,
     /// Startup regular task pre-created during session initialization.
     pub(crate) startup_regular_task: Option<RegularTask>,

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -83,8 +83,8 @@ impl SessionState {
 
     /// Storage-only setter for the previous context snapshot.
     ///
-    /// Most callers should use
-    /// `Session::record_context_updates_and_set_previous_context_item`.
+    /// When setting `Some(...)`, callers should take care to persist the
+    /// appropriate model-visible context diff items.
     pub(crate) fn set_previous_context_item_raw(&mut self, item: Option<TurnContextItem>) {
         self.history.set_previous_context_item_raw(item);
     }

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -22,8 +22,8 @@ pub(crate) struct SessionState {
     pub(crate) dependency_env: HashMap<String, String>,
     pub(crate) mcp_dependency_prompted: HashSet<String>,
     /// Model used by the latest regular user turn, used for model-switch handling
-    /// when the regular-turn context baseline is intentionally missing (e.g. resume
-    /// or post-`/compact` full-context reinjection).
+    /// on subsequent regular turns (including full-context reinjection after
+    /// resume or `/compact`).
     previous_model: Option<String>,
     /// Startup regular task pre-created during session initialization.
     pub(crate) startup_regular_task: Option<RegularTask>,

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -79,8 +79,8 @@ impl SessionState {
     ///
     /// When setting `Some(...)`, callers should take care to persist the
     /// appropriate model-visible context diff items.
-    pub(crate) fn set_previous_context_item_raw(&mut self, item: Option<TurnContextItem>) {
-        self.history.set_previous_context_item_raw(item);
+    pub(crate) fn set_previous_context_item(&mut self, item: Option<TurnContextItem>) {
+        self.history.set_previous_context_item(item);
     }
 
     pub(crate) fn previous_context_item(&self) -> Option<TurnContextItem> {

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -25,20 +25,23 @@ impl SessionTask for CompactTask {
         _cancellation_token: CancellationToken,
     ) -> Option<String> {
         let session = session.clone_session();
-        if crate::compact::should_use_remote_compact_task(&ctx.provider) {
+        let compact_result = if crate::compact::should_use_remote_compact_task(&ctx.provider) {
             let _ = session.services.otel_manager.counter(
                 "codex.task.compact",
                 1,
                 &[("type", "remote")],
             );
-            let _ = crate::compact_remote::run_remote_compact_task(session, ctx).await;
+            crate::compact_remote::run_remote_compact_task(session.clone(), ctx).await
         } else {
             let _ = session.services.otel_manager.counter(
                 "codex.task.compact",
                 1,
                 &[("type", "local")],
             );
-            let _ = crate::compact::run_compact_task(session, ctx, input).await;
+            crate::compact::run_compact_task(session.clone(), ctx, input).await
+        };
+        if compact_result.is_ok() {
+            session.set_previous_context_item(None).await;
         }
 
         None

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -41,7 +41,7 @@ impl SessionTask for CompactTask {
             crate::compact::run_compact_task(session.clone(), ctx, input).await
         };
         if compact_result.is_ok() {
-            session.clear_previous_context_item().await;
+            session.clear_reference_context_item().await;
         }
 
         None

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -41,7 +41,7 @@ impl SessionTask for CompactTask {
             crate::compact::run_compact_task(session.clone(), ctx, input).await
         };
         if compact_result.is_ok() {
-            session.set_previous_context_item(None).await;
+            session.set_full_context_reinjection_pending(true).await;
         }
 
         None

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -41,7 +41,7 @@ impl SessionTask for CompactTask {
             crate::compact::run_compact_task(session.clone(), ctx, input).await
         };
         if compact_result.is_ok() {
-            session.set_full_context_reinjection_pending(true).await;
+            session.clear_previous_context_item().await;
         }
 
         None

--- a/codex-rs/core/src/tasks/compact.rs
+++ b/codex-rs/core/src/tasks/compact.rs
@@ -25,7 +25,7 @@ impl SessionTask for CompactTask {
         _cancellation_token: CancellationToken,
     ) -> Option<String> {
         let session = session.clone_session();
-        let compact_result = if crate::compact::should_use_remote_compact_task(&ctx.provider) {
+        let _ = if crate::compact::should_use_remote_compact_task(&ctx.provider) {
             let _ = session.services.otel_manager.counter(
                 "codex.task.compact",
                 1,
@@ -40,10 +40,6 @@ impl SessionTask for CompactTask {
             );
             crate::compact::run_compact_task(session.clone(), ctx, input).await
         };
-        if compact_result.is_ok() {
-            session.clear_reference_context_item().await;
-        }
-
         None
     }
 }

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -86,6 +86,16 @@ pub(crate) trait SessionTask: Send + Sync + 'static {
     /// surface it in telemetry and UI.
     fn kind(&self) -> TaskKind;
 
+    /// Whether this task records turn-context updates itself.
+    ///
+    /// Most tasks should use the default (`false`) so `spawn_task` persists
+    /// the appropriate context diffs before the task writes any transcript
+    /// items. `RegularTask` overrides this because `run_turn` must delay
+    /// reinjection until after pre-turn compaction.
+    fn records_context_updates_in_run(&self) -> bool {
+        false
+    }
+
     /// Executes the task until completion or cancellation.
     ///
     /// Implementations typically stream protocol events using `session` and
@@ -121,8 +131,16 @@ impl Session {
     ) {
         self.abort_all_tasks(TurnAbortReason::Replaced).await;
         self.clear_connector_selection().await;
-        self.seed_initial_context_if_needed(turn_context.as_ref())
+        if !task.records_context_updates_in_run() {
+            let previous_model = self.previous_model().await;
+            self.record_context_updates_and_set_previous_context_item(
+                turn_context.as_ref(),
+                previous_model.as_deref(),
+                false,
+                false,
+            )
             .await;
+        }
 
         let task: Arc<dyn SessionTask> = Arc::new(task);
         let task_kind = task.kind();

--- a/codex-rs/core/src/tasks/mod.rs
+++ b/codex-rs/core/src/tasks/mod.rs
@@ -136,6 +136,7 @@ impl Session {
             self.record_context_updates_and_set_previous_context_item(
                 turn_context.as_ref(),
                 previous_model.as_deref(),
+                // force_full_context_injection = false
                 false,
                 false,
             )

--- a/codex-rs/core/src/tasks/regular.rs
+++ b/codex-rs/core/src/tasks/regular.rs
@@ -83,10 +83,6 @@ impl SessionTask for RegularTask {
         TaskKind::Regular
     }
 
-    fn records_context_updates_in_run(&self) -> bool {
-        true
-    }
-
     async fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,

--- a/codex-rs/core/src/tasks/regular.rs
+++ b/codex-rs/core/src/tasks/regular.rs
@@ -83,6 +83,10 @@ impl SessionTask for RegularTask {
         TaskKind::Regular
     }
 
+    fn records_context_updates_in_run(&self) -> bool {
+        true
+    }
+
     async fn run(
         self: Arc<Self>,
         session: Arc<SessionTaskContext>,

--- a/codex-rs/core/src/tasks/undo.rs
+++ b/codex-rs/core/src/tasks/undo.rs
@@ -101,7 +101,8 @@ impl SessionTask for UndoTask {
         match restore_result {
             Ok(Ok(())) => {
                 items.remove(idx);
-                sess.replace_history(items).await;
+                let reference_context_item = sess.reference_context_item().await;
+                sess.replace_history(items, reference_context_item).await;
                 let short_id: String = commit_id.chars().take(7).collect();
                 info!(commit_id = commit_id, "Undo restored ghost snapshot");
                 completed.success = true;

--- a/codex-rs/core/src/tasks/user_shell.rs
+++ b/codex-rs/core/src/tasks/user_shell.rs
@@ -101,6 +101,10 @@ pub(crate) async fn execute_user_shell_command(
         // Auxiliary mode runs within an existing active turn. That turn already
         // emitted TurnStarted, so emitting another TurnStarted here would create
         // duplicate turn lifecycle events and confuse clients.
+        // TODO(ccunningham): After TurnStarted, emit model-visible turn context diffs for
+        // standalone lifecycle tasks (for example /shell, and review once it emits TurnStarted).
+        // `/compact` is an intentional exception because compaction requests should not include
+        // freshly reinjected context before the summary/replacement history is applied.
         let event = EventMsg::TurnStarted(TurnStartedEvent {
             turn_id: turn_context.sub_id.clone(),
             model_context_window: turn_context.model_context_window(),

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -867,7 +867,7 @@ pub async fn mount_compact_json_once(server: &MockServer, body: serde_json::Valu
 
 /// Mount a `/responses/compact` mock that mirrors the default remote compaction shape:
 /// keep user+developer messages from the request, drop assistant/tool artifacts, and append one
-/// summary user message.
+/// compaction item carrying the provided summary text.
 pub async fn mount_compact_user_history_with_summary_once(
     server: &MockServer,
     summary_text: &str,
@@ -921,11 +921,10 @@ pub async fn mount_compact_user_history_with_summary_sequence(
                         )
                 })
                 .collect::<Vec<Value>>();
-            // Append the synthetic summary message as the newest user item.
+            // Append a synthetic compaction item as the newest item.
             output.push(serde_json::json!({
-                "type": "message",
-                "role": "user",
-                "content": [{"type": "input_text", "text": summary_text}],
+                "type": "compaction",
+                "encrypted_content": summary_text,
             }));
             ResponseTemplate::new(200)
                 .insert_header("content-type", "application/json")

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -911,7 +911,7 @@ pub async fn mount_compact_user_history_with_summary_sequence(
                 .cloned()
                 .unwrap_or_default()
                 .into_iter()
-                // TODO(ccunningham): Update this mock to match remote compact 5.4 behavior:
+                // TODO(ccunningham): Update this mock to match future compaction model behavior:
                 // return user/developer/assistant messages since the last compaction item, then
                 // append a single newest compaction item.
                 // Match current remote compaction behavior: keep user/developer messages and

--- a/codex-rs/core/tests/common/responses.rs
+++ b/codex-rs/core/tests/common/responses.rs
@@ -911,6 +911,9 @@ pub async fn mount_compact_user_history_with_summary_sequence(
                 .cloned()
                 .unwrap_or_default()
                 .into_iter()
+                // TODO(ccunningham): Update this mock to match remote compact 5.4 behavior:
+                // return user/developer/assistant messages since the last compaction item, then
+                // append a single newest compaction item.
                 // Match current remote compaction behavior: keep user/developer messages and
                 // omit assistant/tool history entries.
                 .filter(|item| {

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -1893,13 +1893,13 @@ async fn snapshot_request_shape_remote_mid_turn_compaction_multi_summary_reinjec
     insta::assert_snapshot!(
         "remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary_shapes",
         format_labeled_requests_snapshot(
-            "Remote mid-turn compaction after an earlier summary compaction: the older summary remains in model-visible history and round-trips into the next compact request.",
+            "After a prior manual /compact produced REMOTE_OLDER_SUMMARY, the next turn hits remote auto-compaction before the next sampling request. The compact request keeps only user-visible history (including the older summary), and the next sampling request shows the new summary plus canonical context reinjected before USER_TWO.",
             &[
+                ("Remote Compaction Request", &compact_request),
                 (
-                    "Second Turn Request (Before Mid-Turn Compaction)",
+                    "Second Turn Request (After Compaction)",
                     &second_turn_request
                 ),
-                ("Remote Compaction Request", &compact_request),
             ]
         )
     );

--- a/codex-rs/core/tests/suite/compact_remote.rs
+++ b/codex-rs/core/tests/suite/compact_remote.rs
@@ -93,12 +93,9 @@ async fn remote_compact_replaces_history_for_followups() -> Result<()> {
     )
     .await;
 
-    let compacted_history = vec![
-        responses::user_message_item("REMOTE_COMPACTED_SUMMARY"),
-        ResponseItem::Compaction {
-            encrypted_content: "ENCRYPTED_COMPACTION_SUMMARY".to_string(),
-        },
-    ];
+    let compacted_history = vec![ResponseItem::Compaction {
+        encrypted_content: "ENCRYPTED_COMPACTION_SUMMARY".to_string(),
+    }];
     let compact_mock = responses::mount_compact_json_once(
         harness.server(),
         serde_json::json!({ "output": compacted_history.clone() }),
@@ -159,7 +156,7 @@ async fn remote_compact_replaces_history_for_followups() -> Result<()> {
     let follow_up_request = response_requests.last().expect("follow-up request missing");
     let follow_up_body = follow_up_request.body_json().to_string();
     assert!(
-        follow_up_body.contains("REMOTE_COMPACTED_SUMMARY"),
+        follow_up_body.contains("\"type\":\"compaction\""),
         "expected follow-up request to use compacted history"
     );
     assert!(
@@ -178,7 +175,7 @@ async fn remote_compact_replaces_history_for_followups() -> Result<()> {
     insta::assert_snapshot!(
         "remote_manual_compact_with_history_shapes",
         format_labeled_requests_snapshot(
-            "Remote manual /compact where remote compact output is summary-only: follow-up layout uses returned summary plus new user message.",
+            "Remote manual /compact where remote compact output is compaction-only: follow-up layout uses the returned compaction item plus new user message.",
             &[
                 ("Remote Compaction Request", &compact_request),
                 ("Remote Post-Compaction History Layout", follow_up_request),
@@ -958,7 +955,6 @@ async fn remote_compact_persists_replacement_history_in_rollout() -> Result<()> 
     .await;
 
     let compacted_history = vec![
-        responses::user_message_item("COMPACTED_USER_SUMMARY"),
         ResponseItem::Compaction {
             encrypted_content: "ENCRYPTED_COMPACTION_SUMMARY".to_string(),
         },
@@ -1012,17 +1008,6 @@ async fn remote_compact_persists_replacement_history_in_rollout() -> Result<()> 
             && compacted.message.is_empty()
             && let Some(replacement_history) = compacted.replacement_history.as_ref()
         {
-            let has_compacted_user_summary = replacement_history.iter().any(|item| {
-                matches!(
-                    item,
-                    ResponseItem::Message { role, content, .. }
-                        if role == "user"
-                            && content.iter().any(|part| matches!(
-                                part,
-                                ContentItem::InputText { text } if text == "COMPACTED_USER_SUMMARY"
-                            ))
-                )
-            });
             let has_compaction_item = replacement_history.iter().any(|item| {
                 matches!(
                     item,
@@ -1054,7 +1039,7 @@ async fn remote_compact_persists_replacement_history_in_rollout() -> Result<()> 
                 )
             });
 
-            if has_compacted_user_summary && has_compaction_item && has_compacted_assistant_note {
+            if has_compaction_item && has_compacted_assistant_note {
                 assert!(
                     !has_permissions_developer_message,
                     "manual remote compact rollout replacement history should not inject permissions context"
@@ -1110,7 +1095,6 @@ async fn remote_compact_and_resume_refresh_stale_developer_instructions() -> Res
     .await;
 
     let compacted_history = vec![
-        responses::user_message_item("REMOTE_COMPACTED_SUMMARY"),
         ResponseItem::Message {
             id: None,
             role: "developer".to_string(),
@@ -1196,8 +1180,8 @@ async fn remote_compact_and_resume_refresh_stale_developer_instructions() -> Res
         "fresh developer instructions should be present after compaction"
     );
     assert!(
-        after_compact_body.contains("REMOTE_COMPACTED_SUMMARY"),
-        "compacted summary should be present after compaction"
+        after_compact_body.contains("ENCRYPTED_COMPACTION_SUMMARY"),
+        "compaction item should be present after compaction"
     );
 
     let after_resume_body = after_resume_request.body_json().to_string();
@@ -1210,8 +1194,8 @@ async fn remote_compact_and_resume_refresh_stale_developer_instructions() -> Res
         "fresh developer instructions should be present after resume"
     );
     assert!(
-        after_resume_body.contains("REMOTE_COMPACTED_SUMMARY"),
-        "compacted summary should persist after resume"
+        after_resume_body.contains("ENCRYPTED_COMPACTION_SUMMARY"),
+        "compaction item should persist after resume"
     );
 
     Ok(())
@@ -1243,7 +1227,6 @@ async fn remote_compact_refreshes_stale_developer_instructions_without_resume() 
     .await;
 
     let compacted_history = vec![
-        responses::user_message_item("REMOTE_COMPACTED_SUMMARY"),
         ResponseItem::Message {
             id: None,
             role: "developer".to_string(),
@@ -1302,8 +1285,8 @@ async fn remote_compact_refreshes_stale_developer_instructions_without_resume() 
         "fresh developer instructions should be present after compaction"
     );
     assert!(
-        after_compact_body.contains("REMOTE_COMPACTED_SUMMARY"),
-        "compacted summary should be present after compaction"
+        after_compact_body.contains("ENCRYPTED_COMPACTION_SUMMARY"),
+        "compaction item should be present after compaction"
     );
 
     Ok(())
@@ -1706,7 +1689,7 @@ async fn snapshot_request_shape_remote_mid_turn_continuation_compaction() -> Res
     insta::assert_snapshot!(
         "remote_mid_turn_compaction_shapes",
         format_labeled_requests_snapshot(
-            "Remote mid-turn continuation compaction after tool output: compact request includes tool artifacts and follow-up request includes the summary.",
+            "Remote mid-turn continuation compaction after tool output: compact request includes tool artifacts and the follow-up request includes the returned compaction item.",
             &[
                 ("Remote Compaction Request", &compact_request),
                 ("Remote Post-Compaction History Layout", &requests[1]),
@@ -1749,9 +1732,9 @@ async fn snapshot_request_shape_remote_mid_turn_compaction_summary_only_reinject
     )
     .await;
 
-    let compacted_history = vec![responses::user_message_item(&summary_with_prefix(
-        "REMOTE_SUMMARY_ONLY",
-    ))];
+    let compacted_history = vec![ResponseItem::Compaction {
+        encrypted_content: summary_with_prefix("REMOTE_SUMMARY_ONLY"),
+    }];
     let compact_mock = responses::mount_compact_json_once(
         harness.server(),
         serde_json::json!({ "output": compacted_history }),
@@ -1786,7 +1769,7 @@ async fn snapshot_request_shape_remote_mid_turn_compaction_summary_only_reinject
     insta::assert_snapshot!(
         "remote_mid_turn_compaction_summary_only_reinjects_context_shapes",
         format_labeled_requests_snapshot(
-            "Remote mid-turn compaction where compact output has only summary user content: continuation layout reinjects canonical context before that summary.",
+            "Remote mid-turn compaction where compact output has only a compaction item: continuation layout reinjects context before that compaction item.",
             &[
                 ("Remote Compaction Request", &compact_request),
                 (
@@ -1893,7 +1876,7 @@ async fn snapshot_request_shape_remote_mid_turn_compaction_multi_summary_reinjec
     insta::assert_snapshot!(
         "remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary_shapes",
         format_labeled_requests_snapshot(
-            "After a prior manual /compact produced REMOTE_OLDER_SUMMARY, the next turn hits remote auto-compaction before the next sampling request. The compact request keeps only user-visible history (including the older summary), and the next sampling request shows the new summary plus canonical context reinjected before USER_TWO.",
+            "After a prior manual /compact produced an older remote compaction item, the next turn hits remote auto-compaction before the next sampling request. The compact request carries forward that earlier compaction item, and the next sampling request shows the latest compaction item with context reinjected before USER_TWO.",
             &[
                 ("Remote Compaction Request", &compact_request),
                 (

--- a/codex-rs/core/tests/suite/compact_resume_fork.rs
+++ b/codex-rs/core/tests/suite/compact_resume_fork.rs
@@ -81,25 +81,32 @@ fn normalize_line_endings_str(text: &str) -> String {
     }
 }
 
-fn extract_summary_message(request: &Value, summary_text: &str) -> Value {
+fn extract_summary_user_text(request: &Value, summary_text: &str) -> String {
+    json_message_input_texts(request, "user")
+        .into_iter()
+        .find(|text| text.contains(summary_text))
+        .unwrap_or_else(|| panic!("expected summary message {summary_text}"))
+}
+
+fn json_message_input_texts(request: &Value, role: &str) -> Vec<String> {
     request
         .get("input")
         .and_then(Value::as_array)
-        .and_then(|items| {
-            items.iter().find(|item| {
-                item.get("type").and_then(Value::as_str) == Some("message")
-                    && item.get("role").and_then(Value::as_str) == Some("user")
-                    && item
-                        .get("content")
-                        .and_then(Value::as_array)
-                        .and_then(|arr| arr.first())
-                        .and_then(|entry| entry.get("text"))
-                        .and_then(Value::as_str)
-                        .is_some_and(|text| text.contains(summary_text))
-            })
+        .into_iter()
+        .flatten()
+        .filter(|item| {
+            item.get("type").and_then(Value::as_str) == Some("message")
+                && item.get("role").and_then(Value::as_str) == Some(role)
         })
-        .cloned()
-        .unwrap_or_else(|| panic!("expected summary message {summary_text}"))
+        .filter_map(|item| {
+            item.get("content")
+                .and_then(Value::as_array)
+                .and_then(|content| content.first())
+                .and_then(|entry| entry.get("text"))
+                .and_then(Value::as_str)
+                .map(str::to_string)
+        })
+        .collect()
 }
 
 fn normalize_compact_prompts(requests: &mut [Value]) {
@@ -200,459 +207,50 @@ async fn compact_resume_and_fork_preserve_model_history_view() {
         &fork_arr[..compact_arr.len()]
     );
 
-    let expected_model = requests[0]["model"]
-        .as_str()
-        .unwrap_or_default()
-        .to_string();
-    let prompt = requests[0]["instructions"]
-        .as_str()
-        .unwrap_or_default()
-        .to_string();
-    let permissions_message = requests[0]["input"][0].clone();
-    let user_instructions = requests[0]["input"][1]["content"][0]["text"]
-        .as_str()
-        .unwrap_or_default()
-        .to_string();
-    let environment_context = requests[0]["input"][2]["content"][0]["text"]
-        .as_str()
-        .unwrap_or_default()
-        .to_string();
-    let tool_calls = json!(requests[0]["tools"].as_array());
-    let prompt_cache_key = requests[0]["prompt_cache_key"]
-        .as_str()
-        .unwrap_or_default()
-        .to_string();
-    let fork_prompt_cache_key = requests[requests.len() - 1]["prompt_cache_key"]
-        .as_str()
-        .unwrap_or_default()
-        .to_string();
-    let summary_after_compact = extract_summary_message(&requests[2], SUMMARY_TEXT);
-    let summary_after_resume = extract_summary_message(&requests[3], SUMMARY_TEXT);
-    let summary_after_fork = extract_summary_message(&requests[4], SUMMARY_TEXT);
-    let user_turn_1 = json!(
-    {
-      "model": expected_model,
-      "instructions": prompt,
-      "input": [
-        permissions_message,
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": user_instructions
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": environment_context
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": "hello world"
-            }
-          ]
-        }
-      ],
-      "tools": tool_calls,
-      "tool_choice": "auto",
-      "parallel_tool_calls": false,
-      "reasoning": {
-        "effort": "medium",
-        "summary": "auto"
-      },
-      "store": false,
-      "stream": true,
-      "include": [
-        "reasoning.encrypted_content"
-      ],
-      "prompt_cache_key": prompt_cache_key
-    });
-    let compact_1 = json!(
-    {
-      "model": expected_model,
-      "instructions": prompt,
-      "input": [
-        permissions_message,
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": user_instructions
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": environment_context
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": "hello world"
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "assistant",
-          "content": [
-            {
-              "type": "output_text",
-              "text": "FIRST_REPLY"
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": SUMMARIZATION_PROMPT
-            }
-          ]
-        }
-      ],
-      "tools": [],
-      "tool_choice": "auto",
-      "parallel_tool_calls": false,
-      "reasoning": {
-        "effort": "medium",
-        "summary": "auto"
-      },
-      "store": false,
-      "stream": true,
-      "include": [
-        "reasoning.encrypted_content"
-      ],
-      "prompt_cache_key": prompt_cache_key
-    });
-    let user_turn_2_after_compact = json!(
-    {
-      "model": expected_model,
-      "instructions": prompt,
-      "input": [
-        permissions_message,
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": user_instructions
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": environment_context
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": "hello world"
-            }
-          ]
-        },
-        summary_after_compact,
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": "AFTER_COMPACT"
-            }
-          ]
-        }
-      ],
-      "tools": tool_calls,
-      "tool_choice": "auto",
-      "parallel_tool_calls": false,
-      "reasoning": {
-        "effort": "medium",
-        "summary": "auto"
-      },
-      "store": false,
-      "stream": true,
-      "include": [
-        "reasoning.encrypted_content"
-      ],
-      "prompt_cache_key": prompt_cache_key
-    });
-    let usert_turn_3_after_resume = json!(
-    {
-      "model": expected_model,
-      "instructions": prompt,
-      "input": [
-        permissions_message,
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": user_instructions
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": environment_context
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": "hello world"
-            }
-          ]
-        },
-        summary_after_resume,
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": "AFTER_COMPACT"
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "assistant",
-          "content": [
-            {
-              "type": "output_text",
-              "text": "AFTER_COMPACT_REPLY"
-            }
-          ]
-        },
-        permissions_message,
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": user_instructions
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": environment_context
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": "AFTER_RESUME"
-            }
-          ]
-        }
-      ],
-      "tools": tool_calls,
-      "tool_choice": "auto",
-      "parallel_tool_calls": false,
-      "reasoning": {
-        "effort": "medium",
-        "summary": "auto"
-      },
-      "store": false,
-      "stream": true,
-      "include": [
-        "reasoning.encrypted_content"
-      ],
-      "prompt_cache_key": prompt_cache_key
-    });
-    let user_turn_3_after_fork = json!(
-    {
-      "model": expected_model,
-      "instructions": prompt,
-      "input": [
-        permissions_message,
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": user_instructions
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": environment_context
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": "hello world"
-            }
-          ]
-        },
-        summary_after_fork,
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": "AFTER_COMPACT"
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "assistant",
-          "content": [
-            {
-              "type": "output_text",
-              "text": "AFTER_COMPACT_REPLY"
-            }
-          ]
-        },
-        permissions_message,
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": user_instructions
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": environment_context
-            }
-          ]
-        },
-        permissions_message,
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": user_instructions
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": environment_context
-            }
-          ]
-        },
-        {
-          "type": "message",
-          "role": "user",
-          "content": [
-            {
-              "type": "input_text",
-              "text": "AFTER_FORK"
-            }
-          ]
-        }
-      ],
-      "tools": tool_calls,
-      "tool_choice": "auto",
-      "parallel_tool_calls": false,
-      "reasoning": {
-        "effort": "medium",
-        "summary": "auto"
-      },
-      "store": false,
-      "stream": true,
-      "include": [
-        "reasoning.encrypted_content"
-      ],
-      "prompt_cache_key": fork_prompt_cache_key
-    });
-    let mut expected = json!([
-        user_turn_1,
-        compact_1,
-        user_turn_2_after_compact,
-        usert_turn_3_after_resume,
-        user_turn_3_after_fork
-    ]);
-    normalize_line_endings(&mut expected);
-    if let Some(arr) = expected.as_array_mut() {
-        normalize_compact_prompts(arr);
-    }
+    let first_request_user_texts = json_message_input_texts(&requests[0], "user");
+    let first_turn_user_index = first_request_user_texts
+        .len()
+        .checked_sub(1)
+        .unwrap_or_else(|| panic!("first turn request missing user messages"));
+    assert_eq!(
+        first_request_user_texts[first_turn_user_index],
+        "hello world"
+    );
+    let seeded_user_prefix = &first_request_user_texts[..first_turn_user_index];
+    let summary_after_compact = extract_summary_user_text(&requests[2], SUMMARY_TEXT);
+    let summary_after_resume = extract_summary_user_text(&requests[3], SUMMARY_TEXT);
+    let summary_after_fork = extract_summary_user_text(&requests[4], SUMMARY_TEXT);
+    let mut expected_after_compact_user_texts =
+        vec!["hello world".to_string(), summary_after_compact];
+    expected_after_compact_user_texts.extend_from_slice(seeded_user_prefix);
+    expected_after_compact_user_texts.push("AFTER_COMPACT".to_string());
+    assert_eq!(
+        json_message_input_texts(&requests[2], "user"),
+        expected_after_compact_user_texts
+    );
+
+    let mut expected_after_resume_user_texts =
+        vec!["hello world".to_string(), summary_after_resume];
+    expected_after_resume_user_texts.extend_from_slice(seeded_user_prefix);
+    expected_after_resume_user_texts.push("AFTER_COMPACT".to_string());
+    expected_after_resume_user_texts.extend_from_slice(seeded_user_prefix);
+    expected_after_resume_user_texts.push("AFTER_RESUME".to_string());
+    assert_eq!(
+        json_message_input_texts(&requests[3], "user"),
+        expected_after_resume_user_texts
+    );
+
+    let mut expected_after_fork_user_texts = vec!["hello world".to_string(), summary_after_fork];
+    expected_after_fork_user_texts.extend_from_slice(seeded_user_prefix);
+    expected_after_fork_user_texts.push("AFTER_COMPACT".to_string());
+    expected_after_fork_user_texts.extend_from_slice(seeded_user_prefix);
+    expected_after_fork_user_texts.extend_from_slice(seeded_user_prefix);
+    expected_after_fork_user_texts.push("AFTER_FORK".to_string());
+    assert_eq!(
+        json_message_input_texts(&requests[4], "user"),
+        expected_after_fork_user_texts
+    );
     assert_eq!(requests.len(), 5);
-    assert_eq!(json!(requests), expected);
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -725,118 +323,28 @@ async fn compact_resume_after_second_compaction_preserves_history() {
         compact_filtered.as_slice(),
         &resume_filtered[..compact_filtered.len()]
     );
-    // hard coded test
-    let prompt = requests[0]["instructions"]
-        .as_str()
-        .unwrap_or_default()
-        .to_string();
-    let permissions_message = requests[0]["input"][0].clone();
-    let user_instructions = requests[0]["input"][1]["content"][0]["text"]
-        .as_str()
-        .unwrap_or_default()
-        .to_string();
-    let environment_instructions = requests[0]["input"][2]["content"][0]["text"]
-        .as_str()
-        .unwrap_or_default()
-        .to_string();
-
-    // Build expected final request input: initial context + forked user message +
-    // compacted summary + post-compact user message + resumed user message.
+    let first_request_user_texts = json_message_input_texts(&requests[0], "user");
+    let first_turn_user_index = first_request_user_texts
+        .len()
+        .checked_sub(1)
+        .unwrap_or_else(|| panic!("first turn request missing user messages"));
+    assert_eq!(
+        first_request_user_texts[first_turn_user_index],
+        "hello world"
+    );
+    let seeded_user_prefix = &first_request_user_texts[..first_turn_user_index];
     let summary_after_second_compact =
-        extract_summary_message(&requests[requests.len() - 3], SUMMARY_TEXT);
-
-    let mut expected = json!([
-      {
-        "instructions": prompt,
-        "input": [
-          permissions_message,
-          {
-            "type": "message",
-            "role": "user",
-            "content": [
-              {
-                "type": "input_text",
-                "text": user_instructions
-              }
-            ]
-          },
-          {
-            "type": "message",
-            "role": "user",
-            "content": [
-              {
-                "type": "input_text",
-                "text": environment_instructions
-              }
-            ]
-          },
-          {
-            "type": "message",
-            "role": "user",
-            "content": [
-              {
-                "type": "input_text",
-                "text": "AFTER_FORK"
-              }
-            ]
-          },
-          summary_after_second_compact,
-          {
-            "type": "message",
-            "role": "user",
-            "content": [
-              {
-                "type": "input_text",
-                "text": "AFTER_COMPACT_2"
-              }
-            ]
-          },
-          permissions_message,
-          {
-            "type": "message",
-            "role": "user",
-            "content": [
-              {
-                "type": "input_text",
-                "text": user_instructions
-              }
-            ]
-          },
-          {
-            "type": "message",
-            "role": "user",
-            "content": [
-              {
-                "type": "input_text",
-                "text": environment_instructions
-              }
-            ]
-          },
-          {
-            "type": "message",
-            "role": "user",
-            "content": [
-              {
-                "type": "input_text",
-                "text": "AFTER_SECOND_RESUME"
-              }
-            ]
-          }
-        ],
-      }
-    ]);
-    normalize_line_endings(&mut expected);
-    let mut last_request_after_2_compacts = json!([{
-        "instructions": requests[requests.len() -1]["instructions"],
-        "input": requests[requests.len() -1]["input"],
-    }]);
-    if let Some(arr) = expected.as_array_mut() {
-        normalize_compact_prompts(arr);
-    }
-    if let Some(arr) = last_request_after_2_compacts.as_array_mut() {
-        normalize_compact_prompts(arr);
-    }
-    assert_eq!(expected, last_request_after_2_compacts);
+        extract_summary_user_text(&requests[requests.len() - 3], SUMMARY_TEXT);
+    let mut expected_final_user_texts =
+        vec!["AFTER_FORK".to_string(), summary_after_second_compact];
+    expected_final_user_texts.extend_from_slice(seeded_user_prefix);
+    expected_final_user_texts.push("AFTER_COMPACT_2".to_string());
+    expected_final_user_texts.extend_from_slice(seeded_user_prefix);
+    expected_final_user_texts.push(AFTER_SECOND_RESUME.to_string());
+    assert_eq!(
+        json_message_input_texts(&requests[requests.len() - 1], "user"),
+        expected_final_user_texts
+    );
 }
 
 fn normalize_line_endings(value: &mut Value) {

--- a/codex-rs/core/tests/suite/model_visible_layout.rs
+++ b/codex-rs/core/tests/suite/model_visible_layout.rs
@@ -308,6 +308,8 @@ async fn snapshot_model_visible_layout_resume_with_personality_change() -> Resul
         config.personality = Some(Personality::Pragmatic);
     });
     let resumed = resume_builder.resume(&server, home, rollout_path).await?;
+    let resume_override_cwd = resumed.cwd_path().join(PRETURN_CONTEXT_DIFF_CWD);
+    fs::create_dir_all(&resume_override_cwd)?;
     resumed
         .codex
         .submit(Op::UserTurn {
@@ -316,7 +318,7 @@ async fn snapshot_model_visible_layout_resume_with_personality_change() -> Resul
                 text_elements: Vec::new(),
             }],
             final_output_json_schema: None,
-            cwd: resumed.cwd_path().to_path_buf(),
+            cwd: resume_override_cwd,
             approval_policy: AskForApproval::Never,
             sandbox_policy: SandboxPolicy::new_read_only_policy(),
             model: resumed.session_configured.model.clone(),
@@ -398,10 +400,12 @@ async fn snapshot_model_visible_layout_resume_override_matches_rollout_model() -
         config.model = Some("gpt-5.2-codex".to_string());
     });
     let resumed = resume_builder.resume(&server, home, rollout_path).await?;
+    let resume_override_cwd = resumed.cwd_path().join(PRETURN_CONTEXT_DIFF_CWD);
+    fs::create_dir_all(&resume_override_cwd)?;
     resumed
         .codex
         .submit(Op::OverrideTurnContext {
-            cwd: None,
+            cwd: Some(resume_override_cwd),
             approval_policy: None,
             sandbox_policy: None,
             windows_sandbox_level: None,

--- a/codex-rs/core/tests/suite/prompt_caching.rs
+++ b/codex-rs/core/tests/suite/prompt_caching.rs
@@ -672,12 +672,7 @@ async fn per_turn_overrides_keep_cached_prefix_and_key_constant() -> anyhow::Res
     });
     let expected_permissions_msg = body1["input"][0].clone();
     let body1_input = body1["input"].as_array().expect("input array");
-    let expected_permissions_msg_2 = body2["input"][body1_input.len() + 1].clone();
-    assert_ne!(
-        expected_permissions_msg_2, expected_permissions_msg,
-        "expected updated permissions message after per-turn override"
-    );
-    let expected_model_switch_msg = body2["input"][body1_input.len() + 2].clone();
+    let expected_model_switch_msg = body2["input"][body1_input.len()].clone();
     assert_eq!(
         expected_model_switch_msg["role"].as_str(),
         Some("developer")
@@ -688,10 +683,15 @@ async fn per_turn_overrides_keep_cached_prefix_and_key_constant() -> anyhow::Res
             .is_some_and(|text| text.contains("<model_switch>")),
         "expected model switch message after model override: {expected_model_switch_msg:?}"
     );
+    let expected_permissions_msg_2 = body2["input"][body1_input.len() + 2].clone();
+    assert_ne!(
+        expected_permissions_msg_2, expected_permissions_msg,
+        "expected updated permissions message after per-turn override"
+    );
     let mut expected_body2 = body1_input.to_vec();
+    expected_body2.push(expected_model_switch_msg);
     expected_body2.push(expected_env_msg_2);
     expected_body2.push(expected_permissions_msg_2);
-    expected_body2.push(expected_model_switch_msg);
     expected_body2.push(expected_user_message_2);
     assert_eq!(body2["input"], serde_json::Value::Array(expected_body2));
 
@@ -900,12 +900,7 @@ async fn send_user_turn_with_changes_sends_environment_context() -> anyhow::Resu
     assert_eq!(body1["input"], expected_input_1);
 
     let body1_input = body1["input"].as_array().expect("input array");
-    let expected_permissions_msg_2 = body2["input"][body1_input.len()].clone();
-    assert_ne!(
-        expected_permissions_msg_2, expected_permissions_msg,
-        "expected updated permissions message after policy change"
-    );
-    let expected_model_switch_msg = body2["input"][body1_input.len() + 1].clone();
+    let expected_model_switch_msg = body2["input"][body1_input.len()].clone();
     assert_eq!(
         expected_model_switch_msg["role"].as_str(),
         Some("developer")
@@ -916,14 +911,19 @@ async fn send_user_turn_with_changes_sends_environment_context() -> anyhow::Resu
             .is_some_and(|text| text.contains("<model_switch>")),
         "expected model switch message after model override: {expected_model_switch_msg:?}"
     );
+    let expected_permissions_msg_2 = body2["input"][body1_input.len() + 1].clone();
+    assert_ne!(
+        expected_permissions_msg_2, expected_permissions_msg,
+        "expected updated permissions message after policy change"
+    );
     let expected_user_message_2 = text_user_input("hello 2".to_string());
     let expected_input_2 = serde_json::Value::Array(vec![
         expected_permissions_msg,
         expected_ui_msg,
         expected_env_msg_1,
         expected_user_message_1,
-        expected_permissions_msg_2,
         expected_model_switch_msg,
+        expected_permissions_msg_2,
         expected_user_message_2,
     ]);
     assert_eq!(body2["input"], expected_input_2);

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact__manual_compact_with_history_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact__manual_compact_with_history_shapes.snap
@@ -13,9 +13,9 @@ Scenario: Manual /compact with prior user history compacts existing history and 
 05:message/user:<SUMMARIZATION_PROMPT>
 
 ## Local Post-Compaction History Layout
-00:message/developer:<PERMISSIONS_INSTRUCTIONS>
-01:message/user:<AGENTS_MD>
-02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-03:message/user:first manual turn
-04:message/user:<COMPACTION_SUMMARY>\nFIRST_MANUAL_SUMMARY
+00:message/user:first manual turn
+01:message/user:<COMPACTION_SUMMARY>\nFIRST_MANUAL_SUMMARY
+02:message/developer:<PERMISSIONS_INSTRUCTIONS>
+03:message/user:<AGENTS_MD>
+04:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 05:message/user:second manual turn

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact__manual_compact_without_prev_user_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact__manual_compact_without_prev_user_shapes.snap
@@ -11,8 +11,8 @@ Scenario: Manual /compact with no prior user turn currently still issues a compa
 03:message/user:<SUMMARIZATION_PROMPT>
 
 ## Local Post-Compaction History Layout
-00:message/developer:<PERMISSIONS_INSTRUCTIONS>
-01:message/user:<AGENTS_MD>
-02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-03:message/user:<COMPACTION_SUMMARY>\nMANUAL_EMPTY_SUMMARY
+00:message/user:<COMPACTION_SUMMARY>\nMANUAL_EMPTY_SUMMARY
+01:message/developer:<PERMISSIONS_INSTRUCTIONS>
+02:message/user:<AGENTS_MD>
+03:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 04:message/user:AFTER_MANUAL_EMPTY_COMPACT

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_sampling_model_switch_compaction_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_sampling_model_switch_compaction_shapes.snap
@@ -1,6 +1,5 @@
 ---
 source: core/tests/suite/compact.rs
-assertion_line: 1773
 expression: "format_labeled_requests_snapshot(\"Pre-sampling compaction on model switch to a smaller context window: current behavior compacts using prior-turn history only (incoming user message excluded), and the follow-up request carries compacted history plus the new user message.\",\n&[(\"Initial Request (Previous Model)\", &requests[0]),\n(\"Pre-sampling Compaction Request\", &requests[1]),\n(\"Post-Compaction Follow-up Request (Next Model)\", &requests[2]),])"
 ---
 Scenario: Pre-sampling compaction on model switch to a smaller context window: current behavior compacts using prior-turn history only (incoming user message excluded), and the follow-up request carries compacted history plus the new user message.
@@ -22,10 +21,10 @@ Scenario: Pre-sampling compaction on model switch to a smaller context window: c
 06:message/user:<SUMMARIZATION_PROMPT>
 
 ## Post-Compaction Follow-up Request (Next Model)
-00:message/developer:<PERMISSIONS_INSTRUCTIONS>
-01:message/user:<AGENTS_MD>
-02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-03:message/user:before switch
-04:message/user:<COMPACTION_SUMMARY>\nPRE_SAMPLING_SUMMARY
-05:message/developer:<model_switch>\nThe user was previously using a different model....
+00:message/user:before switch
+01:message/user:<COMPACTION_SUMMARY>\nPRE_SAMPLING_SUMMARY
+02:message/developer:<model_switch>\nThe user was previously using a different model....
+03:message/developer:<PERMISSIONS_INSTRUCTIONS>
+04:message/user:<AGENTS_MD>
+05:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 06:message/user:after switch

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_including_incoming_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_including_incoming_shapes.snap
@@ -12,14 +12,13 @@ Scenario: Pre-turn auto-compaction with a context override emits the context dif
 04:message/assistant:FIRST_REPLY
 05:message/user:USER_TWO
 06:message/assistant:SECOND_REPLY
-07:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
-08:message/user:<SUMMARIZATION_PROMPT>
+07:message/user:<SUMMARIZATION_PROMPT>
 
 ## Local Post-Compaction History Layout
-00:message/developer:<PERMISSIONS_INSTRUCTIONS>
-01:message/user:<AGENTS_MD>
-02:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
-03:message/user:USER_ONE
-04:message/user:USER_TWO
-05:message/user:<COMPACTION_SUMMARY>\nPRE_TURN_SUMMARY
+00:message/user:USER_ONE
+01:message/user:USER_TWO
+02:message/user:<COMPACTION_SUMMARY>\nPRE_TURN_SUMMARY
+03:message/developer:<PERMISSIONS_INSTRUCTIONS>
+04:message/user:<AGENTS_MD>
+05:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
 06:message/user:<image> | <input_image:image_url> | </image> | USER_THREE

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_strips_incoming_model_switch_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_strips_incoming_model_switch_shapes.snap
@@ -21,15 +21,11 @@ Scenario: Pre-turn compaction during model switch (without pre-sampling model-sw
 06:message/user:<SUMMARIZATION_PROMPT>
 
 ## Local Post-Compaction History Layout
-00:message/developer:<PERMISSIONS_INSTRUCTIONS>
-01:message/developer:<personality_spec> The user has requested a new communication st...
-02:message/user:<AGENTS_MD>
-03:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-04:message/user:BEFORE_SWITCH_USER
-05:message/user:<COMPACTION_SUMMARY>\nPRETURN_SWITCH_SUMMARY
-06:message/developer:<PERMISSIONS_INSTRUCTIONS>
-07:message/developer:<personality_spec> The user has requested a new communication st...
-08:message/user:<AGENTS_MD>
-09:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-10:message/developer:<model_switch>\nThe user was previously using a different model....
-11:message/user:AFTER_SWITCH_USER
+00:message/user:BEFORE_SWITCH_USER
+01:message/user:<COMPACTION_SUMMARY>\nPRETURN_SWITCH_SUMMARY
+02:message/developer:<PERMISSIONS_INSTRUCTIONS>
+03:message/developer:<personality_spec> The user has requested a new communication st...
+04:message/user:<AGENTS_MD>
+05:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+06:message/developer:<model_switch>\nThe user was previously using a different model....
+07:message/user:AFTER_SWITCH_USER

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_strips_incoming_model_switch_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_strips_incoming_model_switch_shapes.snap
@@ -23,9 +23,9 @@ Scenario: Pre-turn compaction during model switch (without pre-sampling model-sw
 ## Local Post-Compaction History Layout
 00:message/user:BEFORE_SWITCH_USER
 01:message/user:<COMPACTION_SUMMARY>\nPRETURN_SWITCH_SUMMARY
-02:message/developer:<PERMISSIONS_INSTRUCTIONS>
-03:message/developer:<personality_spec> The user has requested a new communication st...
-04:message/user:<AGENTS_MD>
-05:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-06:message/developer:<model_switch>\nThe user was previously using a different model....
+02:message/developer:<model_switch>\nThe user was previously using a different model....
+03:message/developer:<PERMISSIONS_INSTRUCTIONS>
+04:message/developer:<personality_spec> The user has requested a new communication st...
+05:message/user:<AGENTS_MD>
+06:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 07:message/user:AFTER_SWITCH_USER

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_strips_incoming_model_switch_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact__pre_turn_compaction_strips_incoming_model_switch_shapes.snap
@@ -1,6 +1,5 @@
 ---
 source: core/tests/suite/compact.rs
-assertion_line: 3152
 expression: "format_labeled_requests_snapshot(\"Pre-turn compaction during model switch (without pre-sampling model-switch compaction): current behavior strips incoming <model_switch> from the compact request and restores it in the post-compaction follow-up request.\",\n&[(\"Initial Request (Previous Model)\", &requests[0]),\n(\"Local Compaction Request\", &requests[1]),\n(\"Local Post-Compaction History Layout\", &requests[2]),])"
 ---
 Scenario: Pre-turn compaction during model switch (without pre-sampling model-switch compaction): current behavior strips incoming <model_switch> from the compact request and restores it in the post-compaction follow-up request.
@@ -28,5 +27,9 @@ Scenario: Pre-turn compaction during model switch (without pre-sampling model-sw
 03:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 04:message/user:BEFORE_SWITCH_USER
 05:message/user:<COMPACTION_SUMMARY>\nPRETURN_SWITCH_SUMMARY
-06:message/developer:<model_switch>\nThe user was previously using a different model....
-07:message/user:AFTER_SWITCH_USER
+06:message/developer:<PERMISSIONS_INSTRUCTIONS>
+07:message/developer:<personality_spec> The user has requested a new communication st...
+08:message/user:<AGENTS_MD>
+09:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+10:message/developer:<model_switch>\nThe user was previously using a different model....
+11:message/user:AFTER_SWITCH_USER

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_with_history_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_with_history_shapes.snap
@@ -1,6 +1,5 @@
 ---
 source: core/tests/suite/compact_remote.rs
-assertion_line: 178
 expression: "format_labeled_requests_snapshot(\"Remote manual /compact where remote compact output is summary-only: follow-up layout uses returned summary plus new user message.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", follow_up_request),])"
 ---
 Scenario: Remote manual /compact where remote compact output is summary-only: follow-up layout uses returned summary plus new user message.
@@ -13,9 +12,9 @@ Scenario: Remote manual /compact where remote compact output is summary-only: fo
 04:message/assistant:FIRST_REMOTE_REPLY
 
 ## Remote Post-Compaction History Layout
-00:message/developer:<PERMISSIONS_INSTRUCTIONS>
-01:message/user:<AGENTS_MD>
-02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-03:message/user:REMOTE_COMPACTED_SUMMARY
-04:compaction:encrypted=true
+00:message/user:REMOTE_COMPACTED_SUMMARY
+01:compaction:encrypted=true
+02:message/developer:<PERMISSIONS_INSTRUCTIONS>
+03:message/user:<AGENTS_MD>
+04:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 05:message/user:after compact

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_with_history_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_manual_compact_with_history_shapes.snap
@@ -1,8 +1,8 @@
 ---
 source: core/tests/suite/compact_remote.rs
-expression: "format_labeled_requests_snapshot(\"Remote manual /compact where remote compact output is summary-only: follow-up layout uses returned summary plus new user message.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", follow_up_request),])"
+expression: "format_labeled_requests_snapshot(\"Remote manual /compact where remote compact output is compaction-only: follow-up layout uses the returned compaction item plus new user message.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", follow_up_request),])"
 ---
-Scenario: Remote manual /compact where remote compact output is summary-only: follow-up layout uses returned summary plus new user message.
+Scenario: Remote manual /compact where remote compact output is compaction-only: follow-up layout uses the returned compaction item plus new user message.
 
 ## Remote Compaction Request
 00:message/developer:<PERMISSIONS_INSTRUCTIONS>
@@ -12,9 +12,8 @@ Scenario: Remote manual /compact where remote compact output is summary-only: fo
 04:message/assistant:FIRST_REMOTE_REPLY
 
 ## Remote Post-Compaction History Layout
-00:message/user:REMOTE_COMPACTED_SUMMARY
-01:compaction:encrypted=true
-02:message/developer:<PERMISSIONS_INSTRUCTIONS>
-03:message/user:<AGENTS_MD>
-04:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-05:message/user:after compact
+00:compaction:encrypted=true
+01:message/developer:<PERMISSIONS_INSTRUCTIONS>
+02:message/user:<AGENTS_MD>
+03:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+04:message/user:after compact

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary_shapes.snap
@@ -1,5 +1,6 @@
 ---
 source: core/tests/suite/compact_remote.rs
+assertion_line: 1876
 expression: "format_labeled_requests_snapshot(\"After a prior manual /compact produced an older remote compaction item, the next turn hits remote auto-compaction before the next sampling request. The compact request carries forward that earlier compaction item, and the next sampling request shows the latest compaction item with context reinjected before USER_TWO.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Second Turn Request (After Compaction)\", &second_turn_request),])"
 ---
 Scenario: After a prior manual /compact produced an older remote compaction item, the next turn hits remote auto-compaction before the next sampling request. The compact request carries forward that earlier compaction item, and the next sampling request shows the latest compaction item with context reinjected before USER_TWO.
@@ -11,8 +12,7 @@ Scenario: After a prior manual /compact produced an older remote compaction item
 ## Second Turn Request (After Compaction)
 00:message/user:USER_ONE
 01:compaction:encrypted=true
-02:compaction:encrypted=true
-03:message/developer:<PERMISSIONS_INSTRUCTIONS>
-04:message/user:<AGENTS_MD>
-05:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-06:message/user:USER_TWO
+02:message/developer:<PERMISSIONS_INSTRUCTIONS>
+03:message/user:<AGENTS_MD>
+04:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+05:message/user:USER_TWO

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary_shapes.snap
@@ -1,21 +1,18 @@
 ---
 source: core/tests/suite/compact_remote.rs
-expression: "format_labeled_requests_snapshot(\"Remote mid-turn compaction after an earlier summary compaction: the older summary remains in model-visible history and round-trips into the next compact request.\",\n&[(\"Second Turn Request (Before Mid-Turn Compaction)\", &requests[1]),\n(\"Remote Compaction Request\", &compact_request),])"
+expression: "format_labeled_requests_snapshot(\"Remote mid-turn compaction after an earlier summary compaction: the older summary remains in model-visible history and round-trips into the next compact request.\",\n&[(\"Second Turn Request (Before Mid-Turn Compaction)\", &second_turn_request),\n(\"Remote Compaction Request\", &compact_request),])"
 ---
 Scenario: Remote mid-turn compaction after an earlier summary compaction: the older summary remains in model-visible history and round-trips into the next compact request.
 
 ## Second Turn Request (Before Mid-Turn Compaction)
 00:message/user:USER_ONE
 01:message/user:<COMPACTION_SUMMARY>\nREMOTE_OLDER_SUMMARY
-02:message/developer:<PERMISSIONS_INSTRUCTIONS>
-03:message/user:<AGENTS_MD>
-04:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-05:message/user:<COMPACTION_SUMMARY>\nREMOTE_LATEST_SUMMARY
+02:message/user:<COMPACTION_SUMMARY>\nREMOTE_LATEST_SUMMARY
+03:message/developer:<PERMISSIONS_INSTRUCTIONS>
+04:message/user:<AGENTS_MD>
+05:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 06:message/user:USER_TWO
 
 ## Remote Compaction Request
 00:message/user:USER_ONE
-01:message/developer:<PERMISSIONS_INSTRUCTIONS>
-02:message/user:<AGENTS_MD>
-03:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-04:message/user:<COMPACTION_SUMMARY>\nREMOTE_OLDER_SUMMARY
+01:message/user:<COMPACTION_SUMMARY>\nREMOTE_OLDER_SUMMARY

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary_shapes.snap
@@ -1,17 +1,17 @@
 ---
 source: core/tests/suite/compact_remote.rs
-expression: "format_labeled_requests_snapshot(\"After a prior manual /compact produced REMOTE_OLDER_SUMMARY, the next turn hits remote auto-compaction before the next sampling request. The compact request keeps only user-visible history (including the older summary), and the next sampling request shows the new summary plus canonical context reinjected before USER_TWO.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Second Turn Request (After Compaction)\", &second_turn_request),])"
+expression: "format_labeled_requests_snapshot(\"After a prior manual /compact produced an older remote compaction item, the next turn hits remote auto-compaction before the next sampling request. The compact request carries forward that earlier compaction item, and the next sampling request shows the latest compaction item with context reinjected before USER_TWO.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Second Turn Request (After Compaction)\", &second_turn_request),])"
 ---
-Scenario: After a prior manual /compact produced REMOTE_OLDER_SUMMARY, the next turn hits remote auto-compaction before the next sampling request. The compact request keeps only user-visible history (including the older summary), and the next sampling request shows the new summary plus canonical context reinjected before USER_TWO.
+Scenario: After a prior manual /compact produced an older remote compaction item, the next turn hits remote auto-compaction before the next sampling request. The compact request carries forward that earlier compaction item, and the next sampling request shows the latest compaction item with context reinjected before USER_TWO.
 
 ## Remote Compaction Request
 00:message/user:USER_ONE
-01:message/user:<COMPACTION_SUMMARY>\nREMOTE_OLDER_SUMMARY
+01:compaction:encrypted=true
 
 ## Second Turn Request (After Compaction)
 00:message/user:USER_ONE
-01:message/user:<COMPACTION_SUMMARY>\nREMOTE_OLDER_SUMMARY
-02:message/user:<COMPACTION_SUMMARY>\nREMOTE_LATEST_SUMMARY
+01:compaction:encrypted=true
+02:compaction:encrypted=true
 03:message/developer:<PERMISSIONS_INSTRUCTIONS>
 04:message/user:<AGENTS_MD>
 05:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_multi_summary_reinjects_above_last_summary_shapes.snap
@@ -1,10 +1,14 @@
 ---
 source: core/tests/suite/compact_remote.rs
-expression: "format_labeled_requests_snapshot(\"Remote mid-turn compaction after an earlier summary compaction: the older summary remains in model-visible history and round-trips into the next compact request.\",\n&[(\"Second Turn Request (Before Mid-Turn Compaction)\", &second_turn_request),\n(\"Remote Compaction Request\", &compact_request),])"
+expression: "format_labeled_requests_snapshot(\"After a prior manual /compact produced REMOTE_OLDER_SUMMARY, the next turn hits remote auto-compaction before the next sampling request. The compact request keeps only user-visible history (including the older summary), and the next sampling request shows the new summary plus canonical context reinjected before USER_TWO.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Second Turn Request (After Compaction)\", &second_turn_request),])"
 ---
-Scenario: Remote mid-turn compaction after an earlier summary compaction: the older summary remains in model-visible history and round-trips into the next compact request.
+Scenario: After a prior manual /compact produced REMOTE_OLDER_SUMMARY, the next turn hits remote auto-compaction before the next sampling request. The compact request keeps only user-visible history (including the older summary), and the next sampling request shows the new summary plus canonical context reinjected before USER_TWO.
 
-## Second Turn Request (Before Mid-Turn Compaction)
+## Remote Compaction Request
+00:message/user:USER_ONE
+01:message/user:<COMPACTION_SUMMARY>\nREMOTE_OLDER_SUMMARY
+
+## Second Turn Request (After Compaction)
 00:message/user:USER_ONE
 01:message/user:<COMPACTION_SUMMARY>\nREMOTE_OLDER_SUMMARY
 02:message/user:<COMPACTION_SUMMARY>\nREMOTE_LATEST_SUMMARY
@@ -12,7 +16,3 @@ Scenario: Remote mid-turn compaction after an earlier summary compaction: the ol
 04:message/user:<AGENTS_MD>
 05:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 06:message/user:USER_TWO
-
-## Remote Compaction Request
-00:message/user:USER_ONE
-01:message/user:<COMPACTION_SUMMARY>\nREMOTE_OLDER_SUMMARY

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_shapes.snap
@@ -13,8 +13,8 @@ Scenario: Remote mid-turn continuation compaction after tool output: compact req
 05:function_call_output:unsupported call: test_tool
 
 ## Remote Post-Compaction History Layout
-00:message/user:USER_ONE
-01:message/developer:<PERMISSIONS_INSTRUCTIONS>
-02:message/user:<AGENTS_MD>
-03:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+00:message/developer:<PERMISSIONS_INSTRUCTIONS>
+01:message/user:<AGENTS_MD>
+02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+03:message/user:USER_ONE
 04:message/user:<COMPACTION_SUMMARY>\nREMOTE_MID_TURN_SUMMARY

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_shapes.snap
@@ -1,8 +1,8 @@
 ---
 source: core/tests/suite/compact_remote.rs
-expression: "format_labeled_requests_snapshot(\"Remote mid-turn continuation compaction after tool output: compact request includes tool artifacts and follow-up request includes the summary.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", &requests[1]),])"
+expression: "format_labeled_requests_snapshot(\"Remote mid-turn continuation compaction after tool output: compact request includes tool artifacts and the follow-up request includes the returned compaction item.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", &requests[1]),])"
 ---
-Scenario: Remote mid-turn continuation compaction after tool output: compact request includes tool artifacts and follow-up request includes the summary.
+Scenario: Remote mid-turn continuation compaction after tool output: compact request includes tool artifacts and the follow-up request includes the returned compaction item.
 
 ## Remote Compaction Request
 00:message/developer:<PERMISSIONS_INSTRUCTIONS>
@@ -17,4 +17,4 @@ Scenario: Remote mid-turn continuation compaction after tool output: compact req
 01:message/user:<AGENTS_MD>
 02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 03:message/user:USER_ONE
-04:message/user:<COMPACTION_SUMMARY>\nREMOTE_MID_TURN_SUMMARY
+04:compaction:encrypted=true

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_summary_only_reinjects_context_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_mid_turn_compaction_summary_only_reinjects_context_shapes.snap
@@ -1,8 +1,8 @@
 ---
 source: core/tests/suite/compact_remote.rs
-expression: "format_labeled_requests_snapshot(\"Remote mid-turn compaction where compact output has only summary user content: continuation layout reinjects canonical context before that summary.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", &requests[1]),])"
+expression: "format_labeled_requests_snapshot(\"Remote mid-turn compaction where compact output has only a compaction item: continuation layout reinjects context before that compaction item.\",\n&[(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", &requests[1]),])"
 ---
-Scenario: Remote mid-turn compaction where compact output has only summary user content: continuation layout reinjects canonical context before that summary.
+Scenario: Remote mid-turn compaction where compact output has only a compaction item: continuation layout reinjects context before that compaction item.
 
 ## Remote Compaction Request
 00:message/developer:<PERMISSIONS_INSTRUCTIONS>
@@ -16,4 +16,4 @@ Scenario: Remote mid-turn compaction where compact output has only summary user 
 00:message/developer:<PERMISSIONS_INSTRUCTIONS>
 01:message/user:<AGENTS_MD>
 02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-03:message/user:<COMPACTION_SUMMARY>\nREMOTE_SUMMARY_ONLY
+03:compaction:encrypted=true

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_including_incoming_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_including_incoming_shapes.snap
@@ -16,7 +16,7 @@ Scenario: Remote pre-turn auto-compaction with a context override emits the cont
 ## Remote Post-Compaction History Layout
 00:message/user:USER_ONE
 01:message/user:USER_TWO
-02:message/user:<COMPACTION_SUMMARY>\nREMOTE_PRE_TURN_SUMMARY
+02:compaction:encrypted=true
 03:message/developer:<PERMISSIONS_INSTRUCTIONS>
 04:message/user:<AGENTS_MD>
 05:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_including_incoming_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_including_incoming_shapes.snap
@@ -12,13 +12,12 @@ Scenario: Remote pre-turn auto-compaction with a context override emits the cont
 04:message/assistant:REMOTE_FIRST_REPLY
 05:message/user:USER_TWO
 06:message/assistant:REMOTE_SECOND_REPLY
-07:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
 
 ## Remote Post-Compaction History Layout
 00:message/user:USER_ONE
 01:message/user:USER_TWO
-02:message/developer:<PERMISSIONS_INSTRUCTIONS>
-03:message/user:<AGENTS_MD>
-04:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
-05:message/user:<COMPACTION_SUMMARY>\nREMOTE_PRE_TURN_SUMMARY
+02:message/user:<COMPACTION_SUMMARY>\nREMOTE_PRE_TURN_SUMMARY
+03:message/developer:<PERMISSIONS_INSTRUCTIONS>
+04:message/user:<AGENTS_MD>
+05:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
 06:message/user:USER_THREE

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
@@ -20,9 +20,9 @@ Scenario: Remote pre-turn compaction during model switch currently excludes inco
 ## Remote Post-Compaction History Layout
 00:message/user:BEFORE_SWITCH_USER
 01:message/user:<COMPACTION_SUMMARY>\nREMOTE_SWITCH_SUMMARY
-02:message/developer:<PERMISSIONS_INSTRUCTIONS>
-03:message/developer:<personality_spec> The user has requested a new communication st...
-04:message/user:<AGENTS_MD>
-05:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-06:message/developer:<model_switch>\nThe user was previously using a different model....
+02:message/developer:<model_switch>\nThe user was previously using a different model....
+03:message/developer:<PERMISSIONS_INSTRUCTIONS>
+04:message/developer:<personality_spec> The user has requested a new communication st...
+05:message/user:<AGENTS_MD>
+06:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 07:message/user:AFTER_SWITCH_USER

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
@@ -1,6 +1,6 @@
 ---
 source: core/tests/suite/compact_remote.rs
-expression: "format_labeled_requests_snapshot(\"Remote pre-turn compaction during model switch currently excludes incoming user input, strips incoming <model_switch> from the compact request payload, and restores it in the post-compaction follow-up request.\",\n&[(\"Initial Request (Previous Model)\", &requests[0]),\n(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", &requests[1]),])"
+expression: "format_labeled_requests_snapshot(\"Remote pre-turn compaction during model switch currently excludes incoming user input, strips incoming <model_switch> from the compact request payload, and restores it in the post-compaction follow-up request.\",\n&[(\"Initial Request (Previous Model)\", &initial_turn_request),\n(\"Remote Compaction Request\", &compact_request),\n(\"Remote Post-Compaction History Layout\", &post_compact_turn_request),])"
 ---
 Scenario: Remote pre-turn compaction during model switch currently excludes incoming user input, strips incoming <model_switch> from the compact request payload, and restores it in the post-compaction follow-up request.
 
@@ -24,5 +24,9 @@ Scenario: Remote pre-turn compaction during model switch currently excludes inco
 03:message/user:<AGENTS_MD>
 04:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 05:message/user:<COMPACTION_SUMMARY>\nREMOTE_SWITCH_SUMMARY
-06:message/developer:<model_switch>\nThe user was previously using a different model....
-07:message/user:AFTER_SWITCH_USER
+06:message/developer:<PERMISSIONS_INSTRUCTIONS>
+07:message/developer:<personality_spec> The user has requested a new communication st...
+08:message/user:<AGENTS_MD>
+09:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+10:message/developer:<model_switch>\nThe user was previously using a different model....
+11:message/user:AFTER_SWITCH_USER

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
@@ -19,7 +19,7 @@ Scenario: Remote pre-turn compaction during model switch currently excludes inco
 
 ## Remote Post-Compaction History Layout
 00:message/user:BEFORE_SWITCH_USER
-01:message/user:<COMPACTION_SUMMARY>\nREMOTE_SWITCH_SUMMARY
+01:compaction:encrypted=true
 02:message/developer:<model_switch>\nThe user was previously using a different model....
 03:message/developer:<PERMISSIONS_INSTRUCTIONS>
 04:message/developer:<personality_spec> The user has requested a new communication st...

--- a/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__compact_remote__remote_pre_turn_compaction_strips_incoming_model_switch_shapes.snap
@@ -19,14 +19,10 @@ Scenario: Remote pre-turn compaction during model switch currently excludes inco
 
 ## Remote Post-Compaction History Layout
 00:message/user:BEFORE_SWITCH_USER
-01:message/developer:<PERMISSIONS_INSTRUCTIONS>
-02:message/developer:<personality_spec> The user has requested a new communication st...
-03:message/user:<AGENTS_MD>
-04:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-05:message/user:<COMPACTION_SUMMARY>\nREMOTE_SWITCH_SUMMARY
-06:message/developer:<PERMISSIONS_INSTRUCTIONS>
-07:message/developer:<personality_spec> The user has requested a new communication st...
-08:message/user:<AGENTS_MD>
-09:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-10:message/developer:<model_switch>\nThe user was previously using a different model....
-11:message/user:AFTER_SWITCH_USER
+01:message/user:<COMPACTION_SUMMARY>\nREMOTE_SWITCH_SUMMARY
+02:message/developer:<PERMISSIONS_INSTRUCTIONS>
+03:message/developer:<personality_spec> The user has requested a new communication st...
+04:message/user:<AGENTS_MD>
+05:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+06:message/developer:<model_switch>\nThe user was previously using a different model....
+07:message/user:AFTER_SWITCH_USER

--- a/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_resume_override_matches_rollout_model.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_resume_override_matches_rollout_model.snap
@@ -1,6 +1,6 @@
 ---
 source: core/tests/suite/model_visible_layout.rs
-assertion_line: 431
+assertion_line: 435
 expression: "format_labeled_requests_snapshot(\"First post-resume turn where pre-turn override sets model to rollout model; no model-switch update should appear.\",\n&[(\"Last Request Before Resume\", &initial_request),\n(\"First Request After Resume + Override\", &resumed_request),])"
 ---
 Scenario: First post-resume turn where pre-turn override sets model to rollout model; no model-switch update should appear.
@@ -17,5 +17,5 @@ Scenario: First post-resume turn where pre-turn override sets model to rollout m
 02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 03:message/user:seed resume history
 04:message/assistant:recorded before resume
-05:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+05:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
 06:message/user:first resumed turn after model override

--- a/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_resume_override_matches_rollout_model.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_resume_override_matches_rollout_model.snap
@@ -1,5 +1,6 @@
 ---
 source: core/tests/suite/model_visible_layout.rs
+assertion_line: 431
 expression: "format_labeled_requests_snapshot(\"First post-resume turn where pre-turn override sets model to rollout model; no model-switch update should appear.\",\n&[(\"Last Request Before Resume\", &initial_request),\n(\"First Request After Resume + Override\", &resumed_request),])"
 ---
 Scenario: First post-resume turn where pre-turn override sets model to rollout model; no model-switch update should appear.
@@ -16,7 +17,5 @@ Scenario: First post-resume turn where pre-turn override sets model to rollout m
 02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 03:message/user:seed resume history
 04:message/assistant:recorded before resume
-05:message/developer:<PERMISSIONS_INSTRUCTIONS>
-06:message/user:<AGENTS_MD>
-07:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-08:message/user:first resumed turn after model override
+05:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+06:message/user:first resumed turn after model override

--- a/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_resume_with_personality_change.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_resume_with_personality_change.snap
@@ -1,5 +1,6 @@
 ---
 source: core/tests/suite/model_visible_layout.rs
+assertion_line: 335
 expression: "format_labeled_requests_snapshot(\"First post-resume turn where resumed config model differs from rollout and personality changes.\",\n&[(\"Last Request Before Resume\", &initial_request),\n(\"First Request After Resume\", &resumed_request),])"
 ---
 Scenario: First post-resume turn where resumed config model differs from rollout and personality changes.
@@ -17,8 +18,6 @@ Scenario: First post-resume turn where resumed config model differs from rollout
 03:message/user:seed resume history
 04:message/assistant:recorded before resume
 05:message/developer:<model_switch>\nThe user was previously using a different model. Please continue the conversatio...
-06:message/developer:<PERMISSIONS_INSTRUCTIONS>
-07:message/developer:<personality_spec> The user has requested a new communication style. Future messages should adhe...
-08:message/user:<AGENTS_MD>
-09:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-10:message/user:resume and change personality
+06:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+07:message/developer:<PERMISSIONS_INSTRUCTIONS>
+08:message/user:resume and change personality

--- a/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_resume_with_personality_change.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_resume_with_personality_change.snap
@@ -1,6 +1,6 @@
 ---
 source: core/tests/suite/model_visible_layout.rs
-assertion_line: 335
+assertion_line: 337
 expression: "format_labeled_requests_snapshot(\"First post-resume turn where resumed config model differs from rollout and personality changes.\",\n&[(\"Last Request Before Resume\", &initial_request),\n(\"First Request After Resume\", &resumed_request),])"
 ---
 Scenario: First post-resume turn where resumed config model differs from rollout and personality changes.
@@ -18,6 +18,6 @@ Scenario: First post-resume turn where resumed config model differs from rollout
 03:message/user:seed resume history
 04:message/assistant:recorded before resume
 05:message/developer:<model_switch>\nThe user was previously using a different model. Please continue the conversatio...
-06:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+06:message/user:<ENVIRONMENT_CONTEXT:cwd=PRETURN_CONTEXT_DIFF_CWD>
 07:message/developer:<PERMISSIONS_INSTRUCTIONS>
 08:message/user:resume and change personality

--- a/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_resume_with_personality_change.snap
+++ b/codex-rs/core/tests/suite/snapshots/all__suite__model_visible_layout__model_visible_layout_resume_with_personality_change.snap
@@ -16,11 +16,9 @@ Scenario: First post-resume turn where resumed config model differs from rollout
 02:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
 03:message/user:seed resume history
 04:message/assistant:recorded before resume
-05:message/developer:<PERMISSIONS_INSTRUCTIONS>
-06:message/developer:<personality_spec> The user has requested a new communication style. Future messages should adhe...
-07:message/user:<AGENTS_MD>
-08:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
-09:message/developer:<PERMISSIONS_INSTRUCTIONS>
-10:message/developer:<model_switch>\nThe user was previously using a different model. Please continue the conversatio...
-11:message/developer:<personality_spec> The user has requested a new communication style. Future messages should adhe...
-12:message/user:resume and change personality
+05:message/developer:<model_switch>\nThe user was previously using a different model. Please continue the conversatio...
+06:message/developer:<PERMISSIONS_INSTRUCTIONS>
+07:message/developer:<personality_spec> The user has requested a new communication style. Future messages should adhe...
+08:message/user:<AGENTS_MD>
+09:message/user:<ENVIRONMENT_CONTEXT:cwd=<CWD>>
+10:message/user:resume and change personality

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -1952,6 +1952,9 @@ pub enum RolloutItem {
     SessionMeta(SessionMetaLine),
     ResponseItem(ResponseItem),
     Compacted(CompactedItem),
+    /// Regular-turn sampling marker. Persist only when the same turn also persists the
+    /// corresponding model-visible context updates (diffs or full reinjection), so resume/fork
+    /// does not hydrate a context baseline that was never recorded in history.
     TurnContext(TurnContextItem),
     EventMsg(EventMsg),
 }

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -1952,9 +1952,6 @@ pub enum RolloutItem {
     SessionMeta(SessionMetaLine),
     ResponseItem(ResponseItem),
     Compacted(CompactedItem),
-    /// Regular-turn sampling marker. Persist only when the same turn also persists the
-    /// corresponding model-visible context updates (diffs or full reinjection), so resume/fork
-    /// does not hydrate a context baseline that was never recorded in history.
     TurnContext(TurnContextItem),
     EventMsg(EventMsg),
 }
@@ -1986,6 +1983,9 @@ pub struct TurnContextNetworkItem {
     pub denied_domains: Vec<String>,
 }
 
+/// Persist TurnContextItem only when the same turn also persists the
+/// corresponding model-visible context updates (diffs or full reinjection), so resume/fork
+/// does not hydrate a context baseline that was never recorded in history.
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, TS)]
 pub struct TurnContextItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/codex-rs/protocol/src/protocol.rs
+++ b/codex-rs/protocol/src/protocol.rs
@@ -1983,9 +1983,10 @@ pub struct TurnContextNetworkItem {
     pub denied_domains: Vec<String>,
 }
 
-/// Persist TurnContextItem only when the same turn also persists the
-/// corresponding model-visible context updates (diffs or full reinjection), so resume/fork
-/// does not hydrate a context baseline that was never recorded in history.
+/// Persist only when the same turn also persists the corresponding
+/// model-visible context updates (diffs or full reinjection), so
+/// resume/fork does not use a `reference_context_item` whose context
+/// was never actually visible to the model.
 #[derive(Serialize, Deserialize, Clone, Debug, JsonSchema, TS)]
 pub struct TurnContextItem {
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Summary
- move regular-turn context diff/full-context persistence into `run_turn` so pre-turn compaction runs before incoming context updates are recorded
- after successful pre-turn compaction, rely on a cleared `reference_context_item` to trigger full context reinjection on the follow-up regular turn (manual `/compact` keeps replacement history summary-only and also clears the baseline)
- preserve `<model_switch>` when full context is reinjected, and inject it *before* the rest of the full-context items
- scope `reference_context_item` and `previous_model` to regular user turns only so standalone tasks (`/compact`, shell, review, undo) cannot suppress future reinjection or `<model_switch>` behavior
- make context-diff persistence + `reference_context_item` updates explicit in the regular-turn path, with clearer docs/comments around the invariant
- stop persisting local `/compact` `RolloutItem::TurnContext` snapshots (only regular turns persist `TurnContextItem` now)
- simplify resume/fork previous-model/reference-baseline hydration by looking up the last surviving turn context from rollout lifecycle events, including rollback and compaction-crossing handling
- remove the legacy fallback that guessed from bare `TurnContext` rollouts without lifecycle events
- update compaction/remote-compaction/model-visible snapshots and compact test assertions (including remote compaction mock response shape)

## Why
We were persisting incoming context items before spawning the regular turn task, which let pre-turn compaction requests accidentally include incoming context diffs without the new user message. Fixing that exposed follow-on baseline issues around `/compact`, resume/fork, and standalone tasks that could cause duplicate context injection or suppress `<model_switch>` instructions.

This PR re-centers the invariants around regular turns:
- regular turns persist model-visible context diffs/full reinjection and update the `reference_context_item`
- standalone tasks do not advance those regular-turn baselines
- compaction clears the baseline when replacement history may have stripped the referenced context diffs

## Follow-ups (TODOs left in code)
- `TODO(ccunningham)`: fix rollback/backtracking baseline handling more comprehensively
- `TODO(ccunningham)`: include pending incoming context items in pre-turn compaction threshold estimation
- `TODO(ccunningham)`: inject updated personality spec alongside `<model_switch>` so some model-switch paths can avoid forced full reinjection
- `TODO(ccunningham)`: review task turn lifecycle (`TurnStarted`/`TurnComplete`) behavior and emit task-start context diffs for task types that should have them (excluding `/compact`)

## Validation
- `just fmt`
- CI should cover the updated compaction/resume/model-visible snapshot expectations and rollout-hydration behavior
- I did **not** rerun the full local test suite after the latest resume-lookup / rollout-persistence simplifications
