### PR TITLE
Revert "Move previous turn context tracking into ContextManager history"

### DIFF
--- a/codex-rs/core/src/compact.rs
+++ b/codex-rs/core/src/compact.rs
@@ -118,7 +118,13 @@ async fn run_compact_task_inner(
     // Reuse one client session so turn-scoped state (sticky routing, websocket append tracking)
     // survives retries within this compact turn.
 
-    let rollout_item = RolloutItem::TurnContext(turn_context.to_turn_context_item());
+    // TODO: If we need to guarantee the persisted mode always matches the prompt used for this
+    // turn, capture it in TurnContext at creation time. Using SessionConfiguration here avoids
+    // duplicating model settings on TurnContext, but an Op after turn start could update the
+    // session config before this write occurs.
+    let collaboration_mode = sess.current_collaboration_mode().await;
+    let rollout_item =
+        RolloutItem::TurnContext(turn_context.to_turn_context_item(collaboration_mode));
     sess.persist_rollout_items(&[rollout_item]).await;
 
     loop {

--- a/codex-rs/core/src/context_manager/history.rs
+++ b/codex-rs/core/src/context_manager/history.rs
@@ -18,7 +18,6 @@ use codex_protocol::models::ResponseItem;
 use codex_protocol::openai_models::InputModality;
 use codex_protocol::protocol::TokenUsage;
 use codex_protocol::protocol::TokenUsageInfo;
-use codex_protocol::protocol::TurnContextItem;
 use std::ops::Deref;
 
 /// Transcript of thread history
@@ -27,12 +26,6 @@ pub(crate) struct ContextManager {
     /// The oldest items are at the beginning of the vector.
     items: Vec<ResponseItem>,
     token_info: Option<TokenUsageInfo>,
-    /// Previous turn context snapshot used for diffing context and producing
-    /// model-visible settings update items.
-    ///
-    /// When this is `None`, settings diffing treats the next turn as having no
-    /// baseline and emits a full reinjection of context state.
-    previous_context_item: Option<TurnContextItem>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -48,7 +41,6 @@ impl ContextManager {
         Self {
             items: Vec::new(),
             token_info: TokenUsageInfo::new_or_append(&None, &None, None),
-            previous_context_item: None,
         }
     }
 
@@ -58,14 +50,6 @@ impl ContextManager {
 
     pub(crate) fn set_token_info(&mut self, info: Option<TokenUsageInfo>) {
         self.token_info = info;
-    }
-
-    pub(crate) fn set_previous_context_item(&mut self, item: Option<TurnContextItem>) {
-        self.previous_context_item = item;
-    }
-
-    pub(crate) fn previous_context_item(&self) -> Option<TurnContextItem> {
-        self.previous_context_item.clone()
     }
 
     pub(crate) fn set_token_usage_full(&mut self, context_window: i64) {

--- a/codex-rs/core/src/context_manager/updates.rs
+++ b/codex-rs/core/src/context_manager/updates.rs
@@ -6,27 +6,26 @@ use codex_protocol::config_types::Personality;
 use codex_protocol::models::DeveloperInstructions;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::openai_models::ModelInfo;
-use codex_protocol::protocol::TurnContextItem;
 
 fn build_environment_update_item(
-    previous: Option<&TurnContextItem>,
+    previous: Option<&TurnContext>,
     next: &TurnContext,
     shell: &Shell,
 ) -> Option<ResponseItem> {
     let prev = previous?;
-    let prev_context = EnvironmentContext::from_turn_context_item(prev, shell);
+    let prev_context = EnvironmentContext::from_turn_context(prev, shell);
     let next_context = EnvironmentContext::from_turn_context(next, shell);
     if prev_context.equals_except_shell(&next_context) {
         return None;
     }
 
-    Some(ResponseItem::from(
-        EnvironmentContext::diff_from_turn_context_item(prev, next, shell),
-    ))
+    Some(ResponseItem::from(EnvironmentContext::diff(
+        prev, next, shell,
+    )))
 }
 
 fn build_permissions_update_item(
-    previous: Option<&TurnContextItem>,
+    previous: Option<&TurnContext>,
     next: &TurnContext,
     exec_policy: &Policy,
 ) -> Option<ResponseItem> {
@@ -47,11 +46,11 @@ fn build_permissions_update_item(
 }
 
 fn build_collaboration_mode_update_item(
-    previous: Option<&TurnContextItem>,
+    previous: Option<&TurnContext>,
     next: &TurnContext,
 ) -> Option<ResponseItem> {
     let prev = previous?;
-    if prev.collaboration_mode.as_ref() != Some(&next.collaboration_mode) {
+    if prev.collaboration_mode != next.collaboration_mode {
         // If the next mode has empty developer instructions, this returns None and we emit no
         // update, so prior collaboration instructions remain in the prompt history.
         Some(DeveloperInstructions::from_collaboration_mode(&next.collaboration_mode)?.into())
@@ -61,7 +60,7 @@ fn build_collaboration_mode_update_item(
 }
 
 fn build_personality_update_item(
-    previous: Option<&TurnContextItem>,
+    previous: Option<&TurnContext>,
     next: &TurnContext,
     personality_feature_enabled: bool,
 ) -> Option<ResponseItem> {
@@ -69,7 +68,7 @@ fn build_personality_update_item(
         return None;
     }
     let previous = previous?;
-    if next.model_info.slug != previous.model {
+    if next.model_info.slug != previous.model_info.slug {
         return None;
     }
 
@@ -97,11 +96,12 @@ pub(crate) fn personality_message_for(
 }
 
 pub(crate) fn build_model_instructions_update_item(
-    previous: Option<&TurnContextItem>,
+    previous: Option<&TurnContext>,
     resumed_model: Option<&str>,
     next: &TurnContext,
 ) -> Option<ResponseItem> {
-    let previous_model = resumed_model.or_else(|| previous.map(|prev| prev.model.as_str()))?;
+    let previous_model =
+        resumed_model.or_else(|| previous.map(|prev| prev.model_info.slug.as_str()))?;
     if previous_model == next.model_info.slug {
         return None;
     }
@@ -115,7 +115,7 @@ pub(crate) fn build_model_instructions_update_item(
 }
 
 pub(crate) fn build_settings_update_items(
-    previous: Option<&TurnContextItem>,
+    previous: Option<&TurnContext>,
     resumed_model: Option<&str>,
     next: &TurnContext,
     shell: &Shell,

--- a/codex-rs/core/src/environment_context.rs
+++ b/codex-rs/core/src/environment_context.rs
@@ -4,8 +4,6 @@ use codex_protocol::models::ContentItem;
 use codex_protocol::models::ResponseItem;
 use codex_protocol::protocol::ENVIRONMENT_CONTEXT_CLOSE_TAG;
 use codex_protocol::protocol::ENVIRONMENT_CONTEXT_OPEN_TAG;
-use codex_protocol::protocol::TurnContextItem;
-use codex_protocol::protocol::TurnContextNetworkItem;
 use serde::Deserialize;
 use serde::Serialize;
 use std::path::PathBuf;
@@ -46,12 +44,8 @@ impl EnvironmentContext {
         self.cwd == *cwd && self.network == *network
     }
 
-    pub fn diff_from_turn_context_item(
-        before: &TurnContextItem,
-        after: &TurnContext,
-        shell: &Shell,
-    ) -> Self {
-        let before_network = Self::network_from_turn_context_item(before);
+    pub fn diff(before: &TurnContext, after: &TurnContext, shell: &Shell) -> Self {
+        let before_network = Self::network_from_turn_context(before);
         let after_network = Self::network_from_turn_context(after);
         let cwd = if before.cwd != after.cwd {
             Some(after.cwd.clone())
@@ -74,14 +68,6 @@ impl EnvironmentContext {
         )
     }
 
-    pub fn from_turn_context_item(turn_context_item: &TurnContextItem, shell: &Shell) -> Self {
-        Self::new(
-            Some(turn_context_item.cwd.clone()),
-            shell.clone(),
-            Self::network_from_turn_context_item(turn_context_item),
-        )
-    }
-
     fn network_from_turn_context(turn_context: &TurnContext) -> Option<NetworkContext> {
         let network = turn_context
             .config
@@ -93,19 +79,6 @@ impl EnvironmentContext {
         Some(NetworkContext {
             allowed_domains: network.allowed_domains.clone().unwrap_or_default(),
             denied_domains: network.denied_domains.clone().unwrap_or_default(),
-        })
-    }
-
-    fn network_from_turn_context_item(
-        turn_context_item: &TurnContextItem,
-    ) -> Option<NetworkContext> {
-        let TurnContextNetworkItem {
-            allowed_domains,
-            denied_domains,
-        } = turn_context_item.network.as_ref()?;
-        Some(NetworkContext {
-            allowed_domains: allowed_domains.clone(),
-            denied_domains: denied_domains.clone(),
         })
     }
 }

--- a/codex-rs/core/src/state/session.rs
+++ b/codex-rs/core/src/state/session.rs
@@ -11,7 +11,6 @@ use crate::protocol::TokenUsage;
 use crate::protocol::TokenUsageInfo;
 use crate::tasks::RegularTask;
 use crate::truncate::TruncationPolicy;
-use codex_protocol::protocol::TurnContextItem;
 
 /// Persistent, session-scoped state previously stored directly on `Session`.
 pub(crate) struct SessionState {
@@ -79,14 +78,6 @@ impl SessionState {
 
     pub(crate) fn set_token_info(&mut self, info: Option<TokenUsageInfo>) {
         self.history.set_token_info(info);
-    }
-
-    pub(crate) fn set_previous_context_item(&mut self, item: Option<TurnContextItem>) {
-        self.history.set_previous_context_item(item);
-    }
-
-    pub(crate) fn previous_context_item(&self) -> Option<TurnContextItem> {
-        self.history.previous_context_item()
     }
 
     // Token/rate limit helpers


### PR DESCRIPTION
Reverts openai/codex#12179